### PR TITLE
vnl_sparse_matrix::mult - size of q buffer should actually be (this->rows())*pcols.

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_sparse_matrix.txx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_sparse_matrix.txx
@@ -157,7 +157,7 @@ void vnl_sparse_matrix<T>::mult(unsigned int prows, unsigned int pcols,
   assert(prows == columns());
 
   // Clear q matrix.
-  int size = prows*pcols;
+  int size = rows()*pcols;
   for (int temp=0; temp<size; temp++)
     q[temp] = T(0);
 


### PR DESCRIPTION
I ran into a subtle bug in vnl_sparse_matrix::mult(), where the code assumes the p and q buffers are the same size (prows_pcols).  However the size of q should really be (this->rows())_pcols.

ie, in matrix multiplication an (a,b) size matrix multiplied with a (b,c) size matrix results in a (a,c) size matrix, not (b,c). 
