### PR TITLE
ENH: Support of VectorImage as template parameters for WarpImageFilter

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -240,7 +240,7 @@ public:
   itkConceptMacro( SameDimensionCheck2,
                    ( Concept::SameDimension< ImageDimension, DisplacementFieldDimension > ) );
   itkConceptMacro( InputHasNumericTraitsCheck,
-                   ( Concept::HasNumericTraits< typename TInputImage::PixelType > ) );
+                   ( Concept::HasNumericTraits< typename TInputImage::InternalPixelType > ) );
   itkConceptMacro( DisplacementFieldHasNumericTraitsCheck,
                    ( Concept::HasNumericTraits< typename TDisplacementField::PixelType::ValueType > ) );
   // End concept checking

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -43,7 +43,7 @@ WarpImageFilter< TInputImage, TOutputImage, TDisplacementField >
   m_OutputOrigin.Fill(0.0);
   m_OutputDirection.SetIdentity();
   m_OutputSize.Fill(0);
-  m_EdgePaddingValue = NumericTraits< PixelType >::ZeroValue();
+  m_EdgePaddingValue = NumericTraits< typename OutputImageType::InternalPixelType >::ZeroValue();
   m_OutputStartIndex.Fill(0);
   // Setup default interpolator
   typename DefaultInterpolatorType::Pointer interp =
@@ -179,6 +179,16 @@ WarpImageFilter< TInputImage, TOutputImage, TDisplacementField >
     }
   DisplacementFieldPointer fieldPtr = this->GetDisplacementField();
 
+
+  if (NumericTraits<PixelType>::GetLength(m_EdgePaddingValue)
+      != this->GetInput()->GetNumberOfComponentsPerPixel() )
+    {
+    // Assume EdgePaddingValue has not been set externally
+    // initialize it here with ZeroValue, when we know the number of components
+    const PixelType& pixel = this->GetInput()->GetPixel( this->GetInput()->GetBufferedRegion().GetIndex() );
+    m_EdgePaddingValue = NumericTraits<PixelType>::ZeroValue( pixel );
+    }
+
   // Connect input image to interpolator
   m_Interpolator->SetInputImage( this->GetInput() );
 
@@ -292,7 +302,7 @@ WarpImageFilter< TInputImage, TOutputImage, TDisplacementField >
       {
       const DisplacementType input =
         fieldPtr->GetPixel(neighIndex);
-      for ( unsigned int k = 0; k < ImageDimension; k++ )
+      for ( unsigned int k = 0; k < NumericTraits<DisplacementType>::GetLength(input); k++ )
         {
         output[k] += overlap * static_cast< double >( input[k] );
         }

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkWarpImageFilter.h"
 #include "itkVectorCastImageFilter.h"
 #include "itkStreamingImageFilter.h"
+#include "itkVectorImage.h"
 #include "itkMath.h"
 
 // class to produce a linear image pattern
@@ -97,8 +98,8 @@ int itkWarpImageFilterTest(int, char* [] )
   typedef float PixelType;
   enum { ImageDimension = 2 };
   typedef itk::Image<PixelType,ImageDimension> ImageType;
-
-  typedef itk::Vector<float,ImageDimension>     VectorType;
+  typedef itk::VectorImage<PixelType,ImageDimension> VectorImageType;
+  typedef itk::Vector<float,ImageDimension> VectorType;
   typedef itk::Image<VectorType,ImageDimension> FieldType;
 
   bool testPassed = true;
@@ -169,7 +170,13 @@ int itkWarpImageFilterTest(int, char* [] )
     }
 
   //=============================================================
+  std::cout << "Instanciate WarpImageFilter with VectorImage.";
+  std::cout << std::endl;
 
+  typedef itk::WarpImageFilter<VectorImageType,VectorImageType,VectorImageType> WarpVectorImageFilterType;
+  WarpVectorImageFilterType::Pointer warpVectorImageFilter = WarpVectorImageFilterType::New();
+
+  //=============================================================
   std::cout << "Run WarpImageFilter in standalone mode with progress.";
   std::cout << std::endl;
   typedef itk::WarpImageFilter<ImageType,ImageType,FieldType> WarperType;


### PR DESCRIPTION
This patch relates to issue #2895 ( https://issues.itk.org/jira/browse/ITK-2895#comment-27056 )

It is a straigthforward port of OTB patch provided by Julien Malik on his github page (see first comment)

Patch summary:
- In itkWarpImageFilter.h:
  - Replace HasNumericTraits concept checking on TInputImage::PixelType by checking on TInputImage::InternalPixelType, since HasNumericTraits will fail with VariableLengthVector as PixelType

- In itkWarpImageFilter.txx:
  - Changed instanciation of m_EdgePaddingValue member to avoid calling NumericTraits< PixelType >::Zero, which does not exist for VariableLengthVector
  - Add further initialization of m_EdgePaddingValue in BeforeThreadedGenerateData, so that it will generate a VariableLenghtVector of appropriate length if needed
  - Avoid calling DisplacementType::Dimension and use the GetLength method from NumericTraits instead, which will support both static and dynamic (VariableLengthVector) length

- In itkWarpImageFilterTest.cxx:
  - Added a simple test for template instanciation of WarpImageFilter using VectorImage for all three template parameters

Change-Id: I44fb183dd6a684a23312446b2bc2d62e7f8eff7b