### PR TITLE
50-GerritCTestConfig: Fix detection of multiple Remote Modules changes

### DIFF
--- a/50-GerritCTestConfig.cmake
+++ b/50-GerritCTestConfig.cmake
@@ -7,16 +7,17 @@ set(dashboard_no_clean 1)
 
 find_package(Git)
 if(GIT_EXECUTABLE)
-  execute_process(COMMAND ${GIT_EXECUTABLE} diff-tree --no-commit-id --name-only -r HEAD
+  execute_process(COMMAND ${GIT_EXECUTABLE} diff-tree --no-commit-id --name-only --diff-filter=ACMRT -r HEAD
     WORKING_DIRECTORY "${CTEST_DASHBOARD_ROOT}/${dashboard_source_name}"
     RESULT_VARIABLE result
     OUTPUT_VARIABLE output)
   if(${result} EQUAL 0 AND "${output}" MATCHES "Modules/Remote")
     string(REGEX MATCHALL "Modules/Remote/.*[.]remote[.]cmake" remote_paths "${output}")
+    string(REGEX REPLACE "\n" ";" remote_paths ${remote_paths})
     foreach(remote ${remote_paths})
       string(REGEX REPLACE "Modules/Remote/(.*)[.]remote[.]cmake" "Module_\\1:BOOL=ON" module_enable "${remote}")
       message(STATUS "Remote module change detected. Adding: ${module_enable}")
-      set(dashboard_cache "${dashboard_cache} ${module_enable}")
+      set(dashboard_cache "${dashboard_cache}\n${module_enable}")
     endforeach()
   endif()
 endif()


### PR DESCRIPTION
This commit plays two roles:

(1) updates the "diff-tree" call to ensure only added, modified
or changed files are considered when generating the list of remote
modules to enabled.

(2) ensures the output of "execute_process" is treated as a list of remotes.

Co-authored-by: Lucas Gandel <lucas.gandel@kitware.com>

Change-Id: I7340fdbbe4a50985d39b630d7bd7fa0e9a8897c0