### PR TITLE
Add ITKCommon_EXPORT macro in the declaration of inlined Zero in NumericTraits

### DIFF
--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -965,8 +965,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR ValueType Zero = 0LL;
-  static ITK_CONSTEXPR ValueType One = 1LL;
+  static ITK_CONSTEXPR ValueType ITKCommon_EXPORT Zero = 0LL;
+  static ITK_CONSTEXPR ValueType ITKCommon_EXPORT One = 1LL;
 
   itkNUMERIC_TRAITS_MIN_MAX_MACRO();
   static ITK_CONSTEXPR_FUNC ValueType NonpositiveMin() { return std::numeric_limits< ValueType >::min(); }
@@ -1019,8 +1019,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR ValueType Zero = 0ULL;
-  static ITK_CONSTEXPR ValueType One = 1ULL;
+  static ITK_CONSTEXPR ValueType ITKCommon_EXPORT Zero = 0ULL;
+  static ITK_CONSTEXPR ValueType ITKCommon_EXPORT One = 1ULL;
 
   itkNUMERIC_TRAITS_MIN_MAX_MACRO();
   static ITK_CONSTEXPR_FUNC ValueType NonpositiveMin() { return std::numeric_limits< ValueType >::min(); }

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -302,8 +302,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR char Zero = 0;
-  static ITK_CONSTEXPR char One = 1;
+  static ITK_CONSTEXPR char ITKCommon_EXPORT Zero = 0;
+  static ITK_CONSTEXPR char ITKCommon_EXPORT One = 1;
 
   static ITK_CONSTEXPR_FUNC char min() { return char(255) < char(0) ? char(-128) : char(0); }
   static ITK_CONSTEXPR_FUNC char max() { return char(255) < char(0) ? char(127) : char(255); }
@@ -366,8 +366,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR signed char Zero = 0;
-  static ITK_CONSTEXPR signed char One = 1;
+  static ITK_CONSTEXPR signed char ITKCommon_EXPORT Zero = 0;
+  static ITK_CONSTEXPR signed char ITKCommon_EXPORT One = 1;
 
   static ITK_CONSTEXPR_FUNC signed char min() { return -128; }
   static ITK_CONSTEXPR_FUNC signed char max() { return 127; }
@@ -422,8 +422,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR unsigned char Zero = 0;
-  static ITK_CONSTEXPR unsigned char One = 1;
+  static ITK_CONSTEXPR unsigned char ITKCommon_EXPORT Zero = 0;
+  static ITK_CONSTEXPR unsigned char ITKCommon_EXPORT One = 1;
 
   itkNUMERIC_TRAITS_MIN_MAX_MACRO();
 
@@ -475,8 +475,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR short Zero = 0;
-  static ITK_CONSTEXPR short One = 1;
+  static ITK_CONSTEXPR short ITKCommon_EXPORT Zero = 0;
+  static ITK_CONSTEXPR short ITKCommon_EXPORT One = 1;
 
   itkNUMERIC_TRAITS_MIN_MAX_MACRO();
   static ITK_CONSTEXPR_FUNC short NonpositiveMin() { return std::numeric_limits< ValueType >::min(); }
@@ -528,8 +528,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR unsigned short Zero = 0;
-  static ITK_CONSTEXPR unsigned short One = 1;
+  static ITK_CONSTEXPR unsigned short ITKCommon_EXPORT Zero = 0;
+  static ITK_CONSTEXPR unsigned short ITKCommon_EXPORT One = 1;
 
   itkNUMERIC_TRAITS_MIN_MAX_MACRO();
   static ITK_CONSTEXPR_FUNC unsigned short NonpositiveMin() { return std::numeric_limits< ValueType >::min(); }
@@ -580,8 +580,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR int Zero = 0;
-  static ITK_CONSTEXPR int One = 1;
+  static ITK_CONSTEXPR int ITKCommon_EXPORT Zero = 0;
+  static ITK_CONSTEXPR int ITKCommon_EXPORT One = 1;
 
   itkNUMERIC_TRAITS_MIN_MAX_MACRO();
   static ITK_CONSTEXPR_FUNC int NonpositiveMin() { return std::numeric_limits< ValueType >::min(); }
@@ -633,8 +633,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR unsigned int Zero = 0;
-  static ITK_CONSTEXPR unsigned int One = 1;
+  static ITK_CONSTEXPR unsigned int ITKCommon_EXPORT Zero = 0;
+  static ITK_CONSTEXPR unsigned int ITKCommon_EXPORT One = 1;
 
   static ITK_CONSTEXPR_FUNC unsigned int min(void) { return 0; }
   static ITK_CONSTEXPR_FUNC unsigned int max(void) { return static_cast< unsigned int >( -1 ); }
@@ -689,8 +689,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR long Zero = 0L;
-  static ITK_CONSTEXPR long One = 1L;
+  static ITK_CONSTEXPR long ITKCommon_EXPORT Zero = 0L;
+  static ITK_CONSTEXPR long ITKCommon_EXPORT One = 1L;
 
   itkNUMERIC_TRAITS_MIN_MAX_MACRO();
   static ITK_CONSTEXPR_FUNC long NonpositiveMin() { return std::numeric_limits< ValueType >::min(); }
@@ -742,8 +742,8 @@ public:
   typedef float                    FloatType;
   typedef FixedArray<ValueType, 1> MeasurementVectorType;
 
-  static ITK_CONSTEXPR unsigned long Zero = 0UL;
-  static ITK_CONSTEXPR unsigned long One = 1UL;
+  static ITK_CONSTEXPR unsigned long ITKCommon_EXPORT Zero = 0UL;
+  static ITK_CONSTEXPR unsigned long ITKCommon_EXPORT One = 1UL;
 
   itkNUMERIC_TRAITS_MIN_MAX_MACRO();
   static ITK_CONSTEXPR_FUNC unsigned long NonpositiveMin() { return std::numeric_limits< ValueType >::min(); }


### PR DESCRIPTION
commit 3ed8e8a  in itk NumericTraits leads to compilation error in orfeo toolbox.

I was able to solve them adding ITKCommon_EXPORT macro in the declaration. Not sure to understand why it is necessary as the related commit in ITK seems to handle linkage resolution.

The link error related to new declaration of inlined Zero for integers type can be seen on otb dashboard:

http://dash.orfeo-toolbox.org/viewBuildError.php?buildid=225288

Configurations for ITK and OTB which leads to the linking issue can also be found on otb git repositories:

itk configuration:

https://git.orfeo-toolbox.org/otb-devutils.git/blob/HEAD:/Config/pc-christophe/pc-christophe-ITK-trunk.cmake

otb configuration:

https://git.orfeo-toolbox.org/otb-devutils.git/blob/HEAD:/Config/pc-christophe/pc-christophe-OTB-Nightly-clang-ThirdPartyTrunk.cmake