### PR TITLE
ENH: Adding initial CircleCi configuration file

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -119,6 +119,9 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
 
   # KWStyle's internal utilities
   ".*KWStyle/Utilities.*"
+
+  # CircleCI distcc warning
+  ".*WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED.*"
   )
 
 if(APPLE)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,42 @@
+machine:
+    environment:
+        CTEST_DASHBOARD_ROOT: ${HOME}
+        CTEST_SOURCE_DIRECTORY: ${HOME}/ITK
+        CTEST_BINARY_DIRECTORY: ${HOME}/ITK-build
+        DASHBOARD_BRANCH_DIRECTORY: ${HOME}/ITK-dashboard
+        ITK_DATA_TAR: InsightData-4.10.1.tar.gz
+        ITK_DATA_TAR_URL: "https://sourceforge.net/projects/itk/files/itk/4.10/${ITK_DATA_TAR}"
+        ExternalData_OBJECT_STORES: ${HOME}/.ExternalData
+        DISTCC_TCP_CORK: "0"
+        DISTCC_DIR: ${HOME}/.distcc
+        DISTCC_SLOTS: 3
+        MAKEJ: $(expr $CIRCLE_NODE_TOTAL \* $DISTCC_SLOTS + 1)
+        CC: "distcc gcc"
+        CXX: "distcc g++"
+    post:
+        - env
+        - sudo apt-get install distcc
+        - sudo sed -i.bak s/STARTDISTCC=\"false\"/STARTDISTCC=\"true\"/g /etc/default/distcc && sudo /etc/init.d/distcc start
+        - sudo sed -i "s/false/true/g" /etc/default/sysstat && sudo sed -i "s/[0-9]*-[0-9]*\/[0-9]*/\*\/2/g" /etc/cron.d/sysstat && sudo service sysstat restart
+        - if [ ! -x "$ExternalData_OBJECT_STORES" ]; then wget --progress=dot:binary ${ITK_DATA_TAR_URL} && tar -zxf ${ITK_DATA_TAR} --strip-components=1 -C ${HOME} ; fi
+
+dependencies:
+    cache_directories:
+        - "~/.ExternalData"
+    override:
+        - mkdir -p ${CTEST_BINARY_DIRECTORY}
+        - git clone --single-branch ${CIRCLE_REPOSITORY_URL} -b dashboard ${DASHBOARD_BRANCH_DIRECTORY}
+        - mkdir -p "${DISTCC_DIR}" && printf -- "--randomize localhost/2 --localslots=2\n" > "${DISTCC_DIR}/hosts" && for ((i=1;i<CIRCLE_NODE_TOTAL;i++)); do printf "ubuntu@node$i/${DISTCC_SLOTS}\n" >> "${DISTCC_DIR}/hosts"; done
+        - if [ $CIRCLE_NODE_INDEX -eq 0 ]; then mkdir -p ~/.ssh_tmp && printf -- "Host *\nControlMaster auto\nControlPath ~/.ssh_tmp/master-%%r@%%h:%%p\n" >> ~/.ssh/config ; fi
+
+
+test:
+    override:
+        - ctest -V -S "${DASHBOARD_BRANCH_DIRECTORY}/circleci.cmake":
+            timeout: 1200
+            environment:
+                CTEST_OUTPUT_ON_FAILURE: 1
+                DASHBOARD_MODEL:  $( [[ "$CIRCLE_BRANCH" = "master" ]] && echo Continuous || echo Experimental )
+                CTEST_CONFIGURATION_TYPE: "Release"
+        - sar:
+            parallel: true


### PR DESCRIPTION
This configuration features:
 Using distcc to compile on multiple containers
 Saving the ExternalData directory cache

Change-Id: I8cb489fa84ab2fa1d1dc4d3776a651b9a717ae69
