### PR TITLE
COMP: Install a newer version of CMake on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,8 @@ dependencies:
     cache_directories:
         - "~/.ExternalData"
     override:
+        - pip install --upgrade pip
+        - pip install cmake
         - mkdir -p ${CTEST_BINARY_DIRECTORY}
         - git clone --single-branch ${CIRCLE_REPOSITORY_URL} -b dashboard ${DASHBOARD_BRANCH_DIRECTORY}
         - mkdir -p "${DISTCC_DIR}" && printf -- "--randomize localhost/2 --localslots=2\n" > "${DISTCC_DIR}/hosts" && for ((i=1;i<CIRCLE_NODE_TOTAL;i++)); do printf "ubuntu@node$i/${DISTCC_SLOTS}\n" >> "${DISTCC_DIR}/hosts"; done


### PR DESCRIPTION
Use the Python CMake wheel, which currently provides CMake 3.7.0.

This avoids the warning:

  Source FileModules/Numerics/FEM/src/dsrc2c.c
  Command
  [+] "/usr/bin/distcc"
  Directory/home/ubuntu/ITK-build/Modules/Numerics/FEM/src
  Standard Error
  cc1: warning: command line option '-fvisibility-inlines-hidden' is valid for
  C++/ObjC++ but not for C [enabled by default]

That has been addressed on newer CMake.

Change-Id: I95c166f8b5592ad385bd165d3253788d80934f17