### PR TITLE
For cicleci, only update the version information in the update state

### DIFF
--- a/circleci.cmake
+++ b/circleci.cmake
@@ -33,12 +33,12 @@ set_from_env(CTEST_SOURCE_DIRECTORY "CTEST_SOURCE_DIRECTORY" )
 set_from_env(CTEST_BINARY_DIRECTORY "CTEST_BINARY_DIRECTORY")
 set_from_env(dashboard_model "DASHBOARD_MODEL")
 
-if (DEFINED ENV{CONFIGURATION})
-  set(CTEST_BUILD_CONFIGURATION "$ENV{CTEST_BUILD_CONFIGURATION}")
+if (DEFINED ENV{CTEST_CONFIGURATION_TYPE})
+  set(CTEST_CONFIGURATION_TYPE "$ENV{CTEST_CONFIGURATION_TYPE}")
 endif()
 
-# CircleCI already has the repository check out to the hash to be tested.
-set(dashboard_no_update 1)
+
+set(CTEST_UPDATE_VERSION_ONLY 1)
 
 set(dashboard_loop 0)
 


### PR DESCRIPTION
Use the newer >3.1 CTest variable, CTEST_UPDATE_VERSION_ONLY, to
specify that the git repo should not be updated, instead of skipping
the step.

Also the configuration type variable is fixed to match the CTest name
and what is set in circleci yml.

Change-Id: Id7488520599dce5a8a3ef4b49d88ca038a182b24