### PR TITLE
WIN32 is not necessarily defined _WIN32 should be

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg-v2/libopenjpeg/opj_malloc.h
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg-v2/libopenjpeg/opj_malloc.h
@@ -64,7 +64,7 @@ Allocate memory aligned to a 16 byte boundry
 @return Returns a void pointer to the allocated space, or NULL if there is insufficient memory available
 */
 /* FIXME: These should be set with cmake tests, but we're currently not requiring use of cmake */
-#ifdef WIN32
+#ifdef _WIN32
   /* Someone should tell the mingw people that their malloc.h ought to provide _mm_malloc() */
   #ifdef __GNUC__
     #include <mm_malloc.h>


### PR DESCRIPTION
Typo or intentional? 
_WIN32 is described in https://msdn.microsoft.com/en-us/library/b0084kay(v=vs.140).aspx for all editions WIN32 is not defined for any. Thus the reason to not change this, would be to somehow take into account windows c++ compilers that does not define this flag by default. However, on my combination of cmake flags WIN32 were not defined at compile-time. 
(On Windows 8.1 with Visual studio v140, v120 and the Intel C++ Compiler 17.0 - Using ExternalProject_Add almost the same way Slicer do, but without the VTK dependency)