### PR TITLE
WIP: Fix clearing build tree failure.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,7 @@ dependencies:
 
 test:
     override:
-        - ctest -V -S "${DASHBOARD_BRANCH_DIRECTORY}/circleci.cmake":
+        - ctest -V -Ddashboard_no_clean:BOOL=1 -S "${DASHBOARD_BRANCH_DIRECTORY}/circleci.cmake":
             timeout: 1200
             environment:
                 ITK_GLOBAL_DEFAULT_NUMBER_OF_THREAD: 2


### PR DESCRIPTION
The CircleCI build ctest script is returning a failure to CircleCI
even though the ctest build and testing is successful. This patch
addresses are CMake Error message produced:

Clearing build tree...
CMake Error at /home/ubuntu/ITK-dashboard/itk_common.cmake:371
(ctest_empty_binary_directory):
  ctest_empty_binary_directory problem removing the binary directory:
  /home/ubuntu/ITK-build
Call Stack (most recent call first):
  /home/ubuntu/ITK-dashboard/circleci.cmake:65 (include)

Change-Id: Ib16bcfe7b99b280614344d1d5add6f173400e304