### PR TITLE
fix bug in itk.GetVnlMatrixFromArray python wrapping

### DIFF
--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -325,7 +325,7 @@ def _GetVnlObjectFromArray(arr, function):
     import itk
     PixelType = _get_itk_pixelid(arr)
     templatedFunction = getattr(itk.PyVnl[PixelType], function)
-    return templatedFunction(vnlObject)
+    return templatedFunction(arr)
 
 def GetVnlVectorFromArray(arr):
     """Get a vnl vector from a Python array.


### PR DESCRIPTION
`vnlObject` is supposed to be `arr`.. seems like a copy-paste error. 

```python
>>> import itk
>>> import numpy as np
>>> itk.GetVnlMatrixFromArray(np.ones((3,3))) # doesnt work
```
```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-696-efd313fbd347> in <module>()
----> 1 itk.GetVnlMatrixFromArray(np.ones((3,3)))

/Users/ncullen/anaconda/lib/python3.6/site-packages/itkExtras.py in GetVnlMatrixFromArray(arr)
    341     """Get a vnl matrix from a Python array.
    342     """
--> 343     return _GetVnlObjectFromArray(arr, "GetVnlMatrixFromArray")
    344 
    345 def GetVnlMatrixViewFromArray(arr):

/Users/ncullen/anaconda/lib/python3.6/site-packages/itkExtras.py in _GetVnlObjectFromArray(arr, function)
    326     PixelType = _get_itk_pixelid(arr)
    327     templatedFunction = getattr(itk.PyVnl[PixelType], function)
--> 328     return templatedFunction(vnlObject)
    329 
    330 def GetVnlVectorFromArray(arr):

NameError: name 'vnlObject' is not defined
```