### PR TITLE
Update CTest driver for 2.0

### DIFF
--- a/circleci.cmake
+++ b/circleci.cmake
@@ -48,9 +48,18 @@ set_from_env(dashboard_git_branch "CIRCLE_BRANCH")
 set_from_env(dashboard_model "DASHBOARD_MODEL" DEFAULT "Continuous" )
 set(dashboard_loop 0)
 
-list(APPEND CTEST_NOTES_FILES
-  "${CTEST_SOURCE_DIRECTORY}/circle.yml"
-  )
+if ( EXISTS "${CTEST_SOURCE_DIRECTORY}/circle.yml")
+  list(APPEND CTEST_NOTES_FILES
+    "${CTEST_SOURCE_DIRECTORY}/circle.yml"
+    )
+endif()
+
+if ( EXISTS  "${CTEST_SOURCE_DIRECTORY}/.circleci/config.yml")
+  list(APPEND CTEST_NOTES_FILES
+    "${CTEST_SOURCE_DIRECTORY}/.circleci/config.yml"
+    )
+endif()
+
 
 SET (dashboard_cache "
     BUILD_DOCUMENTATION:BOOL=OFF

--- a/circleci.cmake
+++ b/circleci.cmake
@@ -23,7 +23,9 @@ endfunction()
 
 set(CTEST_SITE "CircleCI")
 set(CTEST_UPDATE_VERSION_ONLY 1)
-set( CTEST_TEST_ARGS ${CTEST_TEST_ARGS} PARALLEL_LEVEL 2 )
+
+set_from_env(PARALLEL_LEVEL "PARALLEL_LEVEL" DEFAULT 2 )
+set( CTEST_TEST_ARGS ${CTEST_TEST_ARGS} PARALLEL_LEVEL  ${PARALLEL_LEVEL})
 
 
 # Make environment variables to CMake variables for CTest
@@ -57,9 +59,16 @@ SET (dashboard_cache "
     BUILD_TESTING:BOOL=ON
     ITK_USE_KWSTYLE:BOOL=OFF
     ITK_BUILD_DEFAULT_MODULES:BOOL=ON
+" )
+
+
+if (DEFINED ENV{DISTCC_DIR})
+  SET (dashboard_cache "${dashboard_cache}
     CMAKE_CXX_COMPILER_LAUNCHER:STRING=distcc
     CMAKE_C_COMPILER_LAUNCHER:STRING=distcc
-" )
+")
+endif()
+
 
 
 include("${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake")


### PR DESCRIPTION
This maintains compatibility with older 1.0 CircleCI utilization.