### PR TITLE
BUG: Fix CircleCI command to upload test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,6 @@ jobs:
       DASHBOARD_BRANCH_DIRECTORY: /home/circleci/ITK-dashboard
       ExternalData_OBJECT_STORES: /home/circleci/.ExternalData
     steps:
-      - store_test_results:
-          path: /tmp/test-results
       - checkout:
           path : ~/ITK
       - run:
@@ -51,4 +49,7 @@ jobs:
           command: |
             env
             mkdir -p /tmp/test-results/CTest
-            ci_addons ctest_junit_formatter ${CTEST_BINARY_DIRECTORY} > /tmp/test-results/CTest/JUnit-${CIRCLE_NODE_INDEX}.xml
+            ci_addons ctest_junit_formatter ${CTEST_BINARY_DIRECTORY} > /tmp/test-results/JUnit-${CIRCLE_NODE_INDEX}.xml
+      - store_test_results:
+          path: /tmp/test-results
+          destination: ctest


### PR DESCRIPTION
The store_test_results command specifies a path to upload at that
time, so the step must occur after the juint tests formatter is run.

Change-Id: Idaaf68c9213981c8babcb21319d957d6075a491a