### PR TITLE
BUG: prevent crash when TransformFileReader transform list is empty

### DIFF
--- a/Modules/IO/TransformBase/include/itkTransformFileReader.hxx
+++ b/Modules/IO/TransformBase/include/itkTransformFileReader.hxx
@@ -139,6 +139,14 @@ void TransformFileReaderTemplate<TParametersValueType>
   m_TransformIO->SetFileName(m_FileName);
   m_TransformIO->Read();
 
+  if (ioTransformList.empty())
+    {
+    std::ostringstream msg;
+    msg <<  "Transform IO: " << m_TransformIO->GetNameOfClass() << std::endl
+        <<  "   failed to read file: " << this->GetFileName() << std::endl;
+    itkExceptionMacro( << msg.str() );
+    }
+
   // Clear old results.
   this->m_TransformList.clear();
   // If the transform is derived from itk::KernelTransform, the internal matrices


### PR DESCRIPTION
Fixes segfault reported here: https://discourse.slicer.org/t/loading-mat-matrix/2226
while reading MATLAB .mat file (into Slicer, but replicated independently) because ioTransformList is empty.

```
frame #0: 0x00000001148d4209 libITKIOTransformBase-4.13d.1.dylib`itk::TransformFileReaderTemplate<double>::Update(this=0x0000000146741000) at itkTransformFileReader.hxx:149
   146 	  // need to be initialized using the transform parameters.
   147 	  // kernelTransform->ComputeWMatrix() has to be called after the transform is read but
   148 	  // before the transform is used.
-> 149 	  std::string transformTypeName = ioTransformList.front()->GetNameOfClass();
   150 	  const size_t len = strlen("KernelTransform");// Computed at compile time in most cases
   151 	  if (transformTypeName.size() >= len
   152 	      && !transformTypeName.compare(transformTypeName.size()-len , len, "KernelTransform"))
```