### PR TITLE
COMP: Suppress warning on CircleCI about itkIndex out of bounds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,9 @@ jobs:
           command: |
             export PATH=/usr/lib/ccache:${PATH}
             mkdir -p ${CTEST_BINARY_DIRECTORY}
-            ctest -V -Ddashboard_no_clean:BOOL=1 -S "${DASHBOARD_BRANCH_DIRECTORY}/circleci.cmake"
+            ctest -V -Ddashboard_no_clean:BOOL=1 \
+              -DCTEST_CUSTOM_WARNING_EXCEPTION:STRING="itkIndex.h:.*warning: array subscript is above array bounds" \
+              -S "${DASHBOARD_BRANCH_DIRECTORY}/circleci.cmake"
       - run:
           name: ccache stats
           when: always


### PR DESCRIPTION
This suppresses warnings of the following form:
ITK/Modules/Core/Common/include/itkIndex.h:391:27: warning: array
subscript is above array bounds [-Warray-bounds]

It has been determined that this warning is coming from access of an
index variable in ImageAlgorithm::DispatchedCopy. Specifically, when
done like this "++outCurrentIndex[i + 1]". This is a false positive
warning as the code is correct.

Change-Id: Ic763930b6872f78ad51a28b9fc519a4b7aa1dd0b
