### PR TITLE
ENH: Update CircleCI external data cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,16 @@
+referenced:
+  generate-hash-step: &generate-hash-step
+    run:
+      name: Generate external data hash
+      command: |
+        cd ITK
+        find . -name \*.md5 -o -name \*.sha512 -print0 | xargs -d "\n" git log -n 1 | tee /home/circleci/external-data.hashable
+  restore-data-step: &restore-data-step
+     restore_cache:
+       keys:
+         - 'v1-external-data-{{ checksum "/home/circleci/external-data.hashable" }}'
+         - 'v1-external-data'
+
 version: 2
 jobs:
   build:
@@ -19,9 +32,8 @@ jobs:
     steps:
       - checkout:
           path : ~/ITK
-      - restore_cache:
-          keys:
-            - external-data
+      - *generate-hash-step
+      - *restore-data-step
       - restore_cache:
           keys:
             - ccache-{{ arch }}-{{ .Branch }}
@@ -78,5 +90,5 @@ jobs:
           key: 'ccache-{{ arch }}-{{ .Branch }}-{{ epoch }}'
           paths: [ "/home/circleci/.ccache" ]
       - save_cache:
-          key: 'external-data'
+          key: 'v1-external-data-{{ checksum "/home/circleci/external-data.hashable" }}'
           paths: [ "/home/circleci/.ExternalData" ]


### PR DESCRIPTION
Introduce Yaml anchors to enable reuse of common steps.

The previous external data circleci cache was never being updated.

Obtain the most recent commit to modify a md5 or sha512 file. The hash
of this commit message is used for the hash key of the external data
CircleCI cache.

Change-Id: I29e35b15bfd3c3d2799ce835bd4a8dedd371f49a

See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as the PR message.

A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)

[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.

Thanks for contributing to ITK!