### PR TITLE
ENH: Enable writing scl_slope and scl_inter in NIfTI header

### DIFF
--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -120,6 +120,10 @@ public:
   ImageIORegion
   GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requestedRegion) const override;
 
+  /** Set the slope and intercept for voxel value rescaling. */
+  itkSetMacro(RescaleSlope, double);
+  itkSetMacro(RescaleIntercept, double);
+
   /** A mode to allow the Nifti filter to read and write to the LegacyAnalyze75 format as interpreted by
     * the nifti library maintainers.  This format does not properly respect the file orientation fields.
     * By default this is set to true.

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1707,8 +1707,8 @@ NiftiImageIO
   //     -----------------------------------------------------
   //     magic         must be "ni1\0" or "n+1\0"
   //     -----------------------------------------------------
-  this->m_NiftiImage->scl_slope = 1.0f;
-  this->m_NiftiImage->scl_inter = 0.0f;
+  this->m_NiftiImage->scl_slope = static_cast< float >( m_RescaleSlope );
+  this->m_NiftiImage->scl_inter = static_cast< float >( m_RescaleIntercept );
   //TODO: Note both arguments are the same, no need to distinguish between them.
   this->SetNIfTIOrientationFromImageIO( this->GetNumberOfDimensions(), this->GetNumberOfDimensions() );
 }


### PR DESCRIPTION
This is useful when writing image data that are stored in integers.

Change-Id: I72caaf4565a195b2d603b95a01eb1ff5ccfddbda
