### PR TITLE
PERF: improve DCMTKFileReader::CanReadFile perf

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -34,6 +34,7 @@
 #include "dcmtk/dcmdata/dcvrobow.h"        /* for DcmOtherByteOtherWord */
 #include "dcmtk/dcmdata/dcvrui.h"          /* for DcmUniqueIdentifier */
 #include "dcmtk/dcmdata/dcfilefo.h"        /* for DcmFileFormat */
+#include "dcmtk/dcmdata/dcmetinf.h"        /* for DcmMetaInfo */
 #include "dcmtk/dcmdata/dcdeftag.h"        /* for DCM_NumberOfFrames */
 #include "dcmtk/dcmdata/dcvrlo.h"          /* for DcmLongString */
 #include "dcmtk/dcmdata/dcvrtm.h"          /* for DCMTime */
@@ -373,17 +374,17 @@ bool
 DCMTKFileReader
 ::CanReadFile(const std::string &filename)
 {
-  auto * DFile = new DcmFileFormat();
+  auto *MInfo = new DcmMetaInfo();
   bool rval = false;
-  if( DFile &&
-      DFile->loadFile(filename.c_str(),
+  if( MInfo &&
+      MInfo->loadFile(filename.c_str(),
                       EXS_Unknown,
                       EGL_noChange,
                       65536) == EC_Normal)
     {
     rval = true;
     }
-  delete DFile;
+  delete MInfo;
   return rval;
 }
 


### PR DESCRIPTION
Using DcmMetaInfo avoids loading full dataset into memory, which
can be very expensive for large files.
For example, in Slicer, DCMTK is one of the first ITK readers tested.
Without this change, attempting to read a multi-gigabyte NIfTI file
will hang for many minutes in the ::CanReadFile code path. With this
change, the test path completes in under 50ms.