### PR TITLE
BUG: Use pip to install cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,7 @@ jobs:
           command: |
             sudo apt-get install -y  rsync ninja-build ccache
             sudo pip install --upgrade pip
-            sudo pip install scikit-ci-addons
-            ci_addons circle/install_cmake.py 3.11.2
+            sudo pip install cmake==3.11.4 scikit-ci-addons
       - run:
           name: CCache initialization
           command: |


### PR DESCRIPTION
scikit-ci-addons intall_cmake explicitly fails with CircleCI
2.0. Revert to `pip install cmake`.

ref: scikit-build/scikit-ci-addons#69