### PR TITLE
BUG: Use pip to install cmake for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,7 @@ jobs:
           command: |
             sudo apt-get install -y  rsync ninja-build ccache
             sudo pip install --upgrade pip
-            sudo pip install scikit-ci-addons
-            ci_addons circle/install_cmake.py 3.7.2
+            sudo pip install cmake==3.7.2 scikit-ci-addons
       - run:
           name: CCache initialization
           command: |


### PR DESCRIPTION
scikit-ci-addons intall_cmake explicitly fails with CircleCI
2.0. Revert to `pip install cmake`.

ref: scikit-build/scikit-ci-addons#69