### PR TITLE
Update itkNaryFunctorImageFilter

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.hxx
@@ -30,7 +30,7 @@ NaryFunctorImageFilter< TInputImage, TOutputImage, TFunction >
 {
   // This number will be incremented each time an image
   // is added over the two minimum required
-  this->SetNumberOfRequiredInputs(2);
+  this->SetNumberOfRequiredInputs(1);
   this->InPlaceOff();
   this->DynamicMultiThreadingOn();
 }


### PR DESCRIPTION
In the context of my work, I need a itk::NaryFunctorImageFilter because I can have a different number of input images depending on the context. Specifically, I can have 1 to 3 input images. I realized that the filter itk::NaryFunctorImageFilter has a required number of inputs equal to 2 and I do not understand why. Above all, when I check the method DynamicThreadedGenerateData I see the following check: numberOfValidInputImages == 0 and I am wondering why it is not numberOfValidInputImages < 2. Therefore I suggest the following change by setting the number of required inputs to 1.
Kind regards,
Pierre Lassalle

See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as the PR message.

A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)

[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.

Thanks for contributing to ITK!