### PR TITLE
BUG: Support ITK transform files with corrected group names

### DIFF
--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
@@ -62,6 +62,8 @@ struct ITKIOTransformHDF5_EXPORT HDF5CommonPathNames
   static const std::string transformTypeName;
   static const std::string transformFixedName;
   static const std::string transformParamsName;
+  static const std::string transformFixedNameCorrected;
+  static const std::string transformParamsNameCorrected;
   static const std::string ItkVersion;
   static const std::string HDFVersion;
   static const std::string OSName;

--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.hxx
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.hxx
@@ -335,13 +335,28 @@ HDF5TransformIOTemplate<TParametersValueType>
       // Composite transform doesn't store its own parameters
       if(transformType.find("CompositeTransform") == std::string::npos)
         {
-        std::string fixedParamsName(transformName);
-        fixedParamsName += transformFixedName;
+        std::string fixedParamsName(transformName + transformFixedName);
+
+        // check if group exists
+        htri_t exists = H5Lexists( this->m_H5File->getId(),
+                                   fixedParamsName.c_str(),
+                                   H5P_DEFAULT);
+        if ( exists == 0 )
+           {
+           fixedParamsName = transformName + transformFixedNameCorrected;
+           }
         FixedParametersType fixedparams(this->ReadFixedParameters(fixedParamsName));
         transform->SetFixedParameters(fixedparams);
 
-        std::string paramsName(transformName);
-        paramsName += transformParamsName;
+        std::string paramsName(transformName + transformParamsName);
+
+        exists = H5Lexists( this->m_H5File->getId(),
+                            paramsName.c_str(),
+                            H5P_DEFAULT);
+        if ( exists == 0 )
+          {
+          paramsName = transformName + transformParamsNameCorrected;
+          }
         ParametersType params = this->ReadParameters(paramsName);
         transform->SetParametersByValue(params);
         }

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -30,6 +30,9 @@ const std::string HDF5CommonPathNames::transformGroupName(std::string("/Transfor
 const std::string HDF5CommonPathNames::transformTypeName("/TransformType");
 const std::string HDF5CommonPathNames::transformFixedName("/TranformFixedParameters");
 const std::string HDF5CommonPathNames::transformParamsName("/TranformParameters");
+
+const std::string HDF5CommonPathNames::transformFixedNameCorrected("/TransformFixedParameters");
+const std::string HDF5CommonPathNames::transformParamsNameCorrected("/TransformParameters");
 const std::string HDF5CommonPathNames::ItkVersion("/ITKVersion");
 const std::string HDF5CommonPathNames::HDFVersion("/HDFVersion");
 const std::string HDF5CommonPathNames::OSName("/OSName");


### PR DESCRIPTION
Add overlapping support for generated ITK HDF5 transform files.

Closes #64 

Change-Id: Ie7edaad2734117277e7a0bca219e13ebfab9fc23