### PR TITLE
BUG: IsReadAsScalarPlusPalette already printed in parent class

### DIFF
--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -314,10 +314,6 @@ void PNGImageIO::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 
   os << indent << "CompressionLevel: " << m_CompressionLevel << std::endl;
-  if ( m_IsReadAsScalarPlusPalette )
-    {
-    os << "Read as Scalar Image plus palette" << "\n";
-    }
   if( m_ColorPalette.size() > 0  )
     {
     os << indent << "ColorPalette:" << std::endl;


### PR DESCRIPTION
The parent class of itkPNGImageIO, itkImageIOBase, already cares about print printing m_IsReadAsScalarPlusPalette