### PR TITLE
BUG: unnecessary call to GetExpandRGBPalette

### DIFF
--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -138,7 +138,6 @@ unsigned int TIFFImageIO::GetFormat()
            m_ImageFormat = TIFFImageIO::PALETTE_RGB;
            return m_ImageFormat;
           }
-
         }
     }
   m_ImageFormat = TIFFImageIO::OTHER;
@@ -1311,7 +1310,7 @@ void TIFFImageIO::ReadGenericImage(void *_out,
           }
         break;
       case TIFFImageIO::PALETTE_RGB:
-        if ( this->GetExpandRGBPalette() || (!this->GetIsReadAsScalarPlusPalette()) )
+        if ( !this->GetIsReadAsScalarPlusPalette() )
           {
           switch ( m_InternalImage->m_BitsPerSample )
             {


### PR DESCRIPTION
It is needed to check if the image is actually read as palette or not, not if the user asked for it

Change-Id: Idd996005c8ac18739025a485697fb8c56cd8cdab