### PR TITLE
BUG: make sure the palette is empty when IsReadAsScalarPlusPalette is false

### DIFF
--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -429,6 +429,11 @@ void PNGImageIO::ReadImageInformation()
 
       }
     }
+  if( !m_IsReadAsScalarPlusPalette )
+    {
+    // make sure not palette is left
+    m_ColorPalette.resize(0);
+    }
 
   // minimum of a byte per pixel
   if ( colorType == PNG_COLOR_TYPE_GRAY && bitDepth < 8 )

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -454,6 +454,11 @@ void TIFFImageIO::ReadImageInformation()
         }
       }
     }
+  if( !m_IsReadAsScalarPlusPalette )
+    {
+    // make sure the palette is empty
+    m_ColorPalette.resize(0);
+    }
 
 
   if ( !m_InternalImage->CanRead() )
@@ -960,8 +965,13 @@ void TIFFImageIO::ReadTIFFTags()
 
   this->InitializeColors();
   if ( m_TotalColors > -1 )
-    {// if a palette have been found
+    {// if a palette have been found store it in m_ColorPalette
     PopulateColorPalette();
+    }
+  else
+    {
+    // otherwise make sure that the stored palette is empty in the case it was already set
+    m_ColorPalette.resize(0);
     }
 
   for (int i = 0; i < tagCount; ++i)


### PR DESCRIPTION
This is a proposal to force the palette to be empty when the palette is expended. It seems to be the most expected behavior, also uniform across the two classes. It should avoid also problem when a instance is reused, and a palette was already read.

Change-Id: Ie12910c8ebdd70f47afff12fdfacca08134a8856
