### PR TITLE
BUG: CMake build errors

### DIFF
--- a/CMake/itkExternal_FFTW.cmake
+++ b/CMake/itkExternal_FFTW.cmake
@@ -95,7 +95,7 @@ else()
       itk_download_attempt_check(FFTW)
       ExternalProject_add(fftwf
         PREFIX fftwf
-        URL "${_fftw_url}"
+        URL ${_fftw_url}
         URL_HASH SHA512=${_fftw_url_hash}
         DOWNLOAD_NAME "fftw-${_fftw_target_version}.tar.gz"
         CONFIGURE_COMMAND
@@ -123,7 +123,7 @@ else()
       itk_download_attempt_check(FFTW)
       ExternalProject_add(fftwd
         PREFIX fftwd
-        URL "${_fftw_url}"
+        URL ${_fftw_url}
         URL_HASH SHA512=${_fftw_url_hash}
         DOWNLOAD_NAME "fftw-${_fftw_target_version}.tar.gz"
         CONFIGURE_COMMAND


### PR DESCRIPTION
Removed quotes from URL and URL_HASH commands that were causing build errors.