### PR TITLE
STYLE: Replace integer literals which are cast to bool.

### DIFF
--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -234,7 +234,7 @@ VertexCell< TCellInterface >
       {
       pcoord[0] = -10.0;
       }
-    return 0;
+    return false;
     }
 }
 } // end namespace itk

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -411,7 +411,7 @@ void
 DataObject
 ::DataHasBeenGenerated()
 {
-  this->m_DataReleased = 0;
+  this->m_DataReleased = false;
   this->Modified();
   this->m_UpdateMTime.Modified();
 }

--- a/Modules/Core/Common/src/itkLightProcessObject.cxx
+++ b/Modules/Core/Common/src/itkLightProcessObject.cxx
@@ -75,7 +75,7 @@ LightProcessObject
    * GenerateData this object - we have not aborted yet, and our progress
    * before we start to execute is 0.0.
    */
-  m_AbortGenerateData = 0;
+  m_AbortGenerateData = false;
   m_Progress = 0.0f;
 
   this->GenerateData();

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -908,7 +908,7 @@ ObjectFactoryBase
       return ( *i ).second.m_EnabledFlag;
       }
     }
-  return 0;
+  return false;
 }
 
 /**
@@ -923,7 +923,7 @@ ObjectFactoryBase
 
   for ( auto i = start; i != end; ++i )
     {
-    ( *i ).second.m_EnabledFlag = 0;
+    ( *i ).second.m_EnabledFlag = false;
     }
 }
 

--- a/Modules/Core/Common/src/itkOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkOutputWindow.cxx
@@ -38,7 +38,7 @@ OutputWindow::Pointer OutputWindow:: m_Instance = nullptr;
 OutputWindow
 ::OutputWindow()
 {
-  m_PromptUser = 0;
+  m_PromptUser = false;
 }
 
 OutputWindow

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1383,7 +1383,7 @@ ProcessObject
   // Reset this object.
   //
   // Clear the updating flag.
-  m_Updating = 0;
+  m_Updating = false;
 
   //
   // Loop through the inputs

--- a/Modules/Core/Common/test/itkFloodFilledSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFilledSpatialFunctionTest.cxx
@@ -80,7 +80,7 @@ int itkFloodFilledSpatialFunctionTest(int, char* [])
 
     for(it.GoToBegin(); !it.IsAtEnd(); ++it)
       {
-      it.Set(0);
+      it.Set(false);
       }
 
     // Create and initialize a spatial function
@@ -130,7 +130,7 @@ int itkFloodFilledSpatialFunctionTest(int, char* [])
     // Iterate through the entire image and set interior pixels to 1
     for( sfi.GoToBegin(); !( sfi.IsAtEnd() ); ++sfi)
       {
-      sfi.Set(1);
+      sfi.Set(true);
       }
 
     } // end loop over iterator strategies

--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -259,7 +259,7 @@ int itkAffineTransformTest(int, char *[])
     }
 
   /* Compose with an isotropic scaling */
-  aff2->Scale(.3, 1);
+  aff2->Scale(.3, true);
   std::cout << "Result of isotropic scaling:" << std::endl;
   aff2->Print( std::cout );
 
@@ -301,7 +301,7 @@ int itkAffineTransformTest(int, char *[])
     }
 
   /* Compose with a general N-D rotation */
-  aff2->Rotate(0, 1, 0.57, 1);
+  aff2->Rotate(0, 1, 0.57, true);
   std::cout << "Result of general rotation:" << std::endl;
   aff2->Print( std::cout );
 
@@ -321,7 +321,7 @@ int itkAffineTransformTest(int, char *[])
     }
 
   /* Compose with a 2-D rotation */
-  aff2->Rotate(0, 1, -0.57, 1);
+  aff2->Rotate(0, 1, -0.57, true);
   std::cout << "Result of 2-D rotation:" << std::endl;
   aff2->Print( std::cout );
 
@@ -501,7 +501,7 @@ int itkAffineTransformTest(int, char *[])
   axis[0] = .707;
   axis[1] = .707;
   axis[2] = .707;
-  aff3->Rotate3D(axis, 1.0, 1);
+  aff3->Rotate3D(axis, 1.0, true);
   std::cout << "Create and rotate a 3D transform:" << std::endl;
   aff3->Print( std::cout );
 

--- a/Modules/Core/Transform/test/itkCenteredAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredAffineTransformTest.cxx
@@ -128,7 +128,7 @@ int itkCenteredAffineTransformTest(int, char *[])
   aff2->Print( std::cout );
 
   /* Compose with an isotropic scaling */
-  aff2->Scale(.3, 1);
+  aff2->Scale(.3, true);
   std::cout << "Result of isotropic scaling:" << std::endl;
   aff2->Print( std::cout );
 
@@ -141,12 +141,12 @@ int itkCenteredAffineTransformTest(int, char *[])
   aff2->Print( std::cout );
 
   /* Compose with a general N-D rotation */
-  aff2->Rotate(0, 1, 0.57, 1);
+  aff2->Rotate(0, 1, 0.57, true);
   std::cout << "Result of general rotation:" << std::endl;
   aff2->Print( std::cout );
 
   /* Compose with a 2-D rotation */
-  aff2->Rotate(0, 1, -0.57, 1);
+  aff2->Rotate(0, 1, -0.57, true);
   std::cout << "Result of 2-D rotation:" << std::endl;
   aff2->Print( std::cout );
 
@@ -214,7 +214,7 @@ int itkCenteredAffineTransformTest(int, char *[])
   axis[0] = .707;
   axis[1] = .707;
   axis[2] = .707;
-  aff3->Rotate3D(axis, 1.0, 1);
+  aff3->Rotate3D(axis, 1.0, true);
   std::cout << "Create and rotate a 3D transform:" << std::endl;
   aff3->Print( std::cout );
 

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -25,7 +25,7 @@ namespace itk
 /** Constructor */
 BMPImageIO::BMPImageIO() :
   m_BitMapOffset( 0 ),
-  m_FileLowerLeft( 0 ),
+  m_FileLowerLeft( false ),
   m_Depth( 8 ),
   m_NumberOfColors( 0 ),
   m_ColorPaletteSize( 0 ),
@@ -463,11 +463,11 @@ void BMPImageIO::ReadImageInformation()
   if ( ysize < 0 )
     {
     ysize = -ysize;
-    m_FileLowerLeft = 0;
+    m_FileLowerLeft = false;
     }
   else
     {
-    m_FileLowerLeft = 1;
+    m_FileLowerLeft = true;
     }
 
   this->SetNumberOfDimensions(2);

--- a/Modules/IO/BMP/src/itkBMPImageIOFactory.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIOFactory.cxx
@@ -26,7 +26,7 @@ BMPImageIOFactory::BMPImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkBMPImageIO",
                           "BMP Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< BMPImageIO >::New() );
 }
 

--- a/Modules/IO/BioRad/src/itkBioRadImageIOFactory.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIOFactory.cxx
@@ -36,7 +36,7 @@ BioRadImageIOFactory::BioRadImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkBioRadImageIO",
                           "BioRad Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< BioRadImageIO >::New() );
 }
 

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIOFactory.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIOFactory.cxx
@@ -35,7 +35,7 @@ Bruker2dseqImageIOFactory::Bruker2dseqImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkBruker2dseqImageIO",
                           "Bruker2dseq Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< Bruker2dseqImageIO >::New() );
 }
 

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -1022,7 +1022,7 @@ DCMTKFileReader
                    << "," << entry);
     }
   OFString ofString;
-  if(uiItem->getOFStringArray(ofString,0) != EC_Normal)
+  if(uiItem->getOFStringArray(ofString,false) != EC_Normal)
     {
     DCMTKExceptionOrErrorReturn(<< "Can't get UID Value at tag "
                    << std::hex << group << " " << std::hex

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -49,7 +49,7 @@ DCMTKImageIO::DCMTKImageIO()
   m_UseJPEGCodec = false;
   m_UseJPLSCodec = false;
   m_UseRLECodec  = false;
-  m_DicomImageSetByUser = 0;
+  m_DicomImageSetByUser = false;
 
 
   const char *readExtensions[] =

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIOFactory.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIOFactory.cxx
@@ -26,7 +26,7 @@ DCMTKImageIOFactory::DCMTKImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkDCMTKImageIO",
                           "DICOM Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< DCMTKImageIO >::New() );
 }
 

--- a/Modules/IO/GDCM/src/itkGDCMImageIOFactory.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIOFactory.cxx
@@ -26,7 +26,7 @@ GDCMImageIOFactory::GDCMImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkGDCMImageIO",
                           "GDCM Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< GDCMImageIO >::New() );
 }
 

--- a/Modules/IO/GE/src/itkGE4ImageIOFactory.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIOFactory.cxx
@@ -29,7 +29,7 @@ GE4ImageIOFactory::GE4ImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkGE4ImageIO",
                           "GE4 Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< GE4ImageIO >::New() );
 }
 

--- a/Modules/IO/GE/src/itkGE5ImageIOFactory.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIOFactory.cxx
@@ -29,7 +29,7 @@ GE5ImageIOFactory::GE5ImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkGE5ImageIO",
                           "GE5 Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< GE5ImageIO >::New() );
 }
 

--- a/Modules/IO/GE/src/itkGEAdwImageIOFactory.cxx
+++ b/Modules/IO/GE/src/itkGEAdwImageIOFactory.cxx
@@ -29,7 +29,7 @@ GEAdwImageIOFactory::GEAdwImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkGEAdwImageIO",
                           "GEAdw Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< GEAdwImageIO >::New() );
 }
 

--- a/Modules/IO/GIPL/src/itkGiplImageIOFactory.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIOFactory.cxx
@@ -26,7 +26,7 @@ GiplImageIOFactory::GiplImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkGiplImageIO",
                           "Gipl Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< GiplImageIO >::New() );
 }
 

--- a/Modules/IO/HDF5/src/itkHDF5ImageIOFactory.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIOFactory.cxx
@@ -29,7 +29,7 @@ HDF5ImageIOFactory::HDF5ImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkHDF5ImageIO",
                           "HDF5 Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< HDF5ImageIO >::New() );
 }
 

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -528,7 +528,7 @@ ImageFileReader< TOutputImage, ConvertPixelTraits >
       }                                                                 \
     }
 
-  if(0) {}
+  if(false) {}
   ITK_CONVERT_BUFFER_IF_BLOCK(ImageIOBase::UCHAR,unsigned char)
   ITK_CONVERT_BUFFER_IF_BLOCK(ImageIOBase::CHAR,char)
   ITK_CONVERT_BUFFER_IF_BLOCK(ImageIOBase::USHORT,unsigned short)

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
@@ -48,7 +48,7 @@ FileFreeImageIOFactory::FileFreeImageIOFactory()
   this->RegisterOverride("itkImageIOBase",
                          "itkFileFreeImageIO",
                          "ImageIO that creates an in-memory file from a text description",
-                         1,
+                         true,
                          CreateObjectFunction<FileFreeImageIO>::New());
 }
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
@@ -262,14 +262,14 @@ int itkImageFileWriterStreamingPastingCompressingTest1(int argc, char* argv[])
 
   i = 0;
 
-  int retValue =                                         ActualTest(argv[1], argv[2], argv[3], 0, 0, 0, expectException[i++]);
-  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], 0, 0, 1, expectException[i++]);
-  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], 0, 1, 0, expectException[i++]);
-  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], 0, 1, 1, expectException[i++]);
-  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], 1, 0, 0, expectException[i++]);
-  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], 1, 0, 1, expectException[i++]);
-  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], 1, 1, 0, expectException[i++]);
-  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], 1, 1, 1, expectException[i++]);
+  int retValue =                                         ActualTest(argv[1], argv[2], argv[3], false, false, false, expectException[i++]);
+  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], false, false, true, expectException[i++]);
+  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], false, true, false, expectException[i++]);
+  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], false, true, true, expectException[i++]);
+  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], true, false, false, expectException[i++]);
+  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], true, false, true, expectException[i++]);
+  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], true, true, false, expectException[i++]);
+  retValue = (retValue == EXIT_FAILURE) ? EXIT_FAILURE : ActualTest(argv[1], argv[2], argv[3], true, true, true, expectException[i++]);
 
 
   return retValue;

--- a/Modules/IO/JPEG/src/itkJPEGImageIOFactory.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIOFactory.cxx
@@ -26,7 +26,7 @@ JPEGImageIOFactory::JPEGImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkJPEGImageIO",
                           "JPEG Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< JPEGImageIO >::New() );
 }
 

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIOFactory.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIOFactory.cxx
@@ -26,7 +26,7 @@ JPEG2000ImageIOFactory::JPEG2000ImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkJPEG2000ImageIO",
                           "JPEG2000 Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< JPEG2000ImageIO >::New() );
 }
 

--- a/Modules/IO/LSM/src/itkLSMImageIOFactory.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIOFactory.cxx
@@ -36,7 +36,7 @@ LSMImageIOFactory::LSMImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkLSMImageIO",
                           "LSM Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< LSMImageIO >::New() );
 }
 

--- a/Modules/IO/MINC/src/itkMINCImageIOFactory.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIOFactory.cxx
@@ -26,7 +26,7 @@ MINCImageIOFactory::MINCImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkMINCImageIO",
                           "MINC Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< MINCImageIO >::New() );
 }
 

--- a/Modules/IO/MRC/src/itkMRCImageIOFactory.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIOFactory.cxx
@@ -36,7 +36,7 @@ MRCImageIOFactory::MRCImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkMRCImageIO",
                           "MRC Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< MRCImageIO >::New() );
 }
 

--- a/Modules/IO/Mesh/src/itkFreeSurferAsciiMeshIOFactory.cxx
+++ b/Modules/IO/Mesh/src/itkFreeSurferAsciiMeshIOFactory.cxx
@@ -34,7 +34,7 @@ FreeSurferAsciiMeshIOFactory
   this->RegisterOverride( "itkMeshIOBase",
                          "itkFreeSurferAsciiMeshIO",
                          "Freesurfer Mesh IO",
-                         1,
+                         true,
                          CreateObjectFunction< FreeSurferAsciiMeshIO >::New() );
 }
 

--- a/Modules/IO/Mesh/src/itkFreeSurferBinaryMeshIOFactory.cxx
+++ b/Modules/IO/Mesh/src/itkFreeSurferBinaryMeshIOFactory.cxx
@@ -34,7 +34,7 @@ FreeSurferBinaryMeshIOFactory
   this->RegisterOverride( "itkMeshIOBase",
                          "itkFreeSurferBinaryMeshIO",
                          "Freesurfer Binary Mesh IO",
-                         1,
+                         true,
                          CreateObjectFunction< FreeSurferBinaryMeshIO >::New() );
 }
 

--- a/Modules/IO/Mesh/src/itkGiftiMeshIOFactory.cxx
+++ b/Modules/IO/Mesh/src/itkGiftiMeshIOFactory.cxx
@@ -34,7 +34,7 @@ GiftiMeshIOFactory
   this->RegisterOverride( "itkMeshIOBase",
                          "itkGiftiMeshIO",
                          "Gifti Mesh IO",
-                         1,
+                         true,
                          CreateObjectFunction< GiftiMeshIO >::New() );
 }
 

--- a/Modules/IO/Mesh/src/itkOBJMeshIOFactory.cxx
+++ b/Modules/IO/Mesh/src/itkOBJMeshIOFactory.cxx
@@ -34,7 +34,7 @@ OBJMeshIOFactory
   this->RegisterOverride( "itkMeshIOBase",
                          "itkOBJMeshIO",
                          "OBJ Mesh IO",
-                         1,
+                         true,
                          CreateObjectFunction< OBJMeshIO >::New() );
 }
 

--- a/Modules/IO/Mesh/src/itkOFFMeshIOFactory.cxx
+++ b/Modules/IO/Mesh/src/itkOFFMeshIOFactory.cxx
@@ -34,7 +34,7 @@ OFFMeshIOFactory
   this->RegisterOverride( "itkMeshIOBase",
                          "itkOFFMeshIO",
                          "OFF Mesh IO",
-                         1,
+                         true,
                          CreateObjectFunction< OFFMeshIO >::New() );
 }
 

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
@@ -35,7 +35,7 @@ BYUMeshIOFactory
   this->RegisterOverride( "itkMeshIOBase",
                          "itkBYUMeshIO",
                          "BYU Mesh IO",
-                         1,
+                         true,
                          CreateObjectFunction< BYUMeshIO >::New() );
 }
 

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -839,7 +839,7 @@ MeshFileReader< TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits >
       numberOfPixels);                                                 \
     }
 
-  if ( 0 )
+  if ( false )
      {}
   ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(MeshIOBase::UCHAR, unsigned char)
   ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(MeshIOBase::CHAR, char)
@@ -916,7 +916,7 @@ MeshFileReader< TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits >
       numberOfPixels);                                                 \
     }
 
-  if ( 0 )
+  if ( false )
      {}
   ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(MeshIOBase::UCHAR, unsigned char)
   ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(MeshIOBase::CHAR, char)

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
@@ -36,7 +36,7 @@ VTKPolyDataMeshIOFactory
   this->RegisterOverride("itkMeshIOBase",
                          "itkVTKPolyDataMeshIO",
                          "VTK Polydata IO",
-                         1,
+                         true,
                          CreateObjectFunction< VTKPolyDataMeshIO >::New() );
 }
 

--- a/Modules/IO/Meta/src/itkMetaImageIOFactory.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIOFactory.cxx
@@ -26,7 +26,7 @@ MetaImageIOFactory::MetaImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkMetaImageIO",
                           "Meta Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< MetaImageIO >::New() );
 }
 

--- a/Modules/IO/NIFTI/src/itkNiftiImageIOFactory.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIOFactory.cxx
@@ -29,7 +29,7 @@ NiftiImageIOFactory::NiftiImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkNiftiImageIO",
                           "Nifti Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< NiftiImageIO >::New() );
 }
 

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -225,7 +225,7 @@ void NrrdImageIO::ReadImageInformation()
   try
     {
     // nrrd causes exceptions on purpose, so mask them
-    bool saveFPEState(0);
+    bool saveFPEState(false);
     if ( FloatingPointExceptions::HasFloatingPointExceptionsSupport() )
       {
       saveFPEState = FloatingPointExceptions::GetEnabled();

--- a/Modules/IO/NRRD/src/itkNrrdImageIOFactory.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIOFactory.cxx
@@ -26,7 +26,7 @@ NrrdImageIOFactory::NrrdImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkNrrdImageIO",
                           "Nrrd Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< NrrdImageIO >::New() );
 }
 

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -48,9 +48,9 @@ bool wrapSetjmp( png_structp & png_ptr )
 {
   if( setjmp( png_jmpbuf( png_ptr ) ) )
     {
-    return 1;
+    return true;
     }
-  return 0;
+  return false;
 }
 }
 

--- a/Modules/IO/PNG/src/itkPNGImageIOFactory.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIOFactory.cxx
@@ -26,7 +26,7 @@ PNGImageIOFactory::PNGImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkPNGImageIO",
                           "PNG Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< PNGImageIO >::New() );
 }
 

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIOFactory.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIOFactory.cxx
@@ -37,7 +37,7 @@ PhilipsRECImageIOFactory::PhilipsRECImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkPhilipsRECImageIO",
                           "Philips REC Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< PhilipsRECImageIO >::New() );
 }
 

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIOFactory.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIOFactory.cxx
@@ -29,7 +29,7 @@ SiemensVisionImageIOFactory::SiemensVisionImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkSiemensVisionImageIO",
                           "SiemensVision Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< SiemensVisionImageIO >::New() );
 }
 

--- a/Modules/IO/Stimulate/src/itkStimulateImageIOFactory.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIOFactory.cxx
@@ -36,7 +36,7 @@ StimulateImageIOFactory::StimulateImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkStimulateImageIO",
                           "Stimulate Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< StimulateImageIO >::New() );
 }
 

--- a/Modules/IO/TIFF/src/itkTIFFImageIOFactory.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIOFactory.cxx
@@ -26,7 +26,7 @@ TIFFImageIOFactory::TIFFImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkTIFFImageIO",
                           "TIFF Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< TIFFImageIO >::New() );
 }
 

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIOFactory.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIOFactory.cxx
@@ -30,13 +30,13 @@ HDF5TransformIOFactory::HDF5TransformIOFactory()
   this->RegisterOverride( "itkTransformIOBaseTemplate",
                           "itkHDF5TransformIO",
                           "HD5 Transform float IO",
-                          1,
+                          true,
                           CreateObjectFunction< HDF5TransformIOTemplate< float > >::New() );
 
   this->RegisterOverride( "itkTransformIOBaseTemplate",
                           "itkHDF5TransformIO",
                           "HD5 Transform double IO",
-                          1,
+                          true,
                           CreateObjectFunction< HDF5TransformIOTemplate< double > >::New() );
 }
 

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIOFactory.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIOFactory.cxx
@@ -30,12 +30,12 @@ TxtTransformIOFactory::TxtTransformIOFactory()
   this->RegisterOverride( "itkTransformIOBaseTemplate",
                           "itkTxtTransformIO",
                           "Txt Transform float IO",
-                          1,
+                          true,
                           CreateObjectFunction< TxtTransformIOTemplate< float > >::New() );
   this->RegisterOverride( "itkTransformIOBaseTemplate",
                           "itkTxtTransformIO",
                           "Txt Transform double IO",
-                          1,
+                          true,
                           CreateObjectFunction< TxtTransformIOTemplate< double > >::New() );
 }
 

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIOFactory.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIOFactory.cxx
@@ -32,13 +32,13 @@ MINCTransformIOFactory::MINCTransformIOFactory()
   this->RegisterOverride( "itkTransformIOBaseTemplate",
                           "itkMINCTransformIO",
                           "MINC XFM Transform float IO",
-                          1,
+                          true,
                           CreateObjectFunction< MINCTransformIOTemplate< float > >::New() );
 
   this->RegisterOverride( "itkTransformIOBaseTemplate",
                           "itkMINCTransformIO",
                           "MINC XFM Transform double IO",
-                          1,
+                          true,
                           CreateObjectFunction< MINCTransformIOTemplate< double > >::New() );
 }
 

--- a/Modules/IO/TransformMatlab/src/itkMatlabTransformIOFactory.cxx
+++ b/Modules/IO/TransformMatlab/src/itkMatlabTransformIOFactory.cxx
@@ -30,12 +30,12 @@ MatlabTransformIOFactory::MatlabTransformIOFactory()
   this->RegisterOverride( "itkTransformIOBaseTemplate",
                           "itkMatlabTransformIO",
                           "Matlab Transform float IO",
-                          1,
+                          true,
                           CreateObjectFunction< MatlabTransformIOTemplate< float > >::New() );
   this->RegisterOverride( "itkTransformIOBaseTemplate",
                           "itkMatlabTransformIO",
                           "Matlab Transform double IO",
-                          1,
+                          true,
                           CreateObjectFunction< MatlabTransformIOTemplate< double >  >::New() );
 }
 

--- a/Modules/IO/VTK/src/itkVTKImageIOFactory.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIOFactory.cxx
@@ -36,7 +36,7 @@ VTKImageIOFactory::VTKImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkVTKImageIO",
                           "VTK Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< VTKImageIO >::New() );
 }
 

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIOFactory.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIOFactory.cxx
@@ -35,7 +35,7 @@ VoxBoCUBImageIOFactory::VoxBoCUBImageIOFactory()
   this->RegisterOverride( "itkImageIOBase",
                           "itkVoxBoCUBImageIO",
                           "VoxBo CUB Image IO",
-                          1,
+                          true,
                           CreateObjectFunction< VoxBoCUBImageIO >::New() );
 }
 

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest2.cxx
@@ -80,7 +80,7 @@ int itkScalarChanAndVeseDenseLevelSetImageFilterTest2( int argc, char * argv [] 
   levelSetFilter->SetLevelSet( 0, levelSetReader1->GetOutput() );
   levelSetFilter->SetNumberOfIterations( nb_iteration );
   levelSetFilter->SetMaximumRMSError( rms );
-  levelSetFilter->SetUseImageSpacing( 0 );
+  levelSetFilter->SetUseImageSpacing( false );
   levelSetFilter->SetInPlace( false );
 
   MultiLevelSetType::FunctionType * function = levelSetFilter->GetDifferenceFunction(0);

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest4.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest4.cxx
@@ -90,7 +90,7 @@ int itkScalarChanAndVeseDenseLevelSetImageFilterTest4( int argc, char * argv [] 
   levelSetFilter->SetLevelSet( 0, levelSetReader1->GetOutput() );
   levelSetFilter->SetNumberOfIterations( nb_iteration );
   levelSetFilter->SetMaximumRMSError( rms );
-  levelSetFilter->SetUseImageSpacing( 0 );
+  levelSetFilter->SetUseImageSpacing( false );
   levelSetFilter->SetInPlace( false );
 
   levelSetFilter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseSparseLevelSetImageFilterTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseSparseLevelSetImageFilterTest2.cxx
@@ -84,7 +84,7 @@ int itkScalarChanAndVeseSparseLevelSetImageFilterTest2( int argc, char * argv []
   levelSetFilter->SetLevelSet( 0, levelSetReader1->GetOutput() );
   levelSetFilter->SetNumberOfIterations( nb_iteration );
   levelSetFilter->SetMaximumRMSError( rms );
-  levelSetFilter->SetUseImageSpacing( 0 );
+  levelSetFilter->SetUseImageSpacing( false );
   levelSetFilter->SetInPlace( false );
 
   levelSetFilter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedron.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedron.cxx
@@ -293,7 +293,7 @@ Element3DC0LinearHexahedron
         pc[i] = localPt[i];
         }
       }
-    return 0;
+    return false;
     }
 }
 

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -34,7 +34,7 @@ CumulativeGaussianOptimizer::CumulativeGaussianOptimizer()
   m_LowerAsymptote = 0;
   m_OffsetForMean = 0;
   m_DifferenceTolerance = 1e-10;
-  m_Verbose = 0;
+  m_Verbose = false;
   m_FitError = 0;
   m_FinalSampledArray = nullptr;
   m_CumulativeGaussianArray = nullptr;

--- a/Modules/Numerics/Optimizers/test/itkCumulativeGaussianOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkCumulativeGaussianOptimizerTest.cxx
@@ -75,7 +75,7 @@ int itkCumulativeGaussianOptimizerTest(int, char* [] )
   optimizer->SetDifferenceTolerance(differenceTolerance);
 
   // Print results after each iteration.
-  optimizer->SetVerbose(1);
+  optimizer->SetVerbose(true);
 
   // Set the data array.
   optimizer->SetDataArray(cumGaussianArray);

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
@@ -307,7 +307,7 @@ int itkJointHistogramMutualInformationImageToImageRegistrationTest(int argc, cha
   RegistrationParameterScalesFromShiftType::ScalesType
     displacementScales( displacementTransform->GetNumberOfLocalParameters() );
   displacementScales.Fill(1);
-  if( 0 )
+  if( false )
     {
     optimizer->SetScales( displacementScales );
     }

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
@@ -202,7 +202,7 @@ int itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char *argv[])
   // Optimizer
   RegistrationParameterScalesFromShiftType::ScalesType displacementScales( displacementTransform->GetNumberOfLocalParameters() );
   displacementScales.Fill(1);
-  if( 0 )
+  if( false )
     {
     optimizer->SetScales( displacementScales );
     }

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest2.cxx
@@ -137,7 +137,7 @@ int itkMeanSquaresImageToImageMetricv4RegistrationTest2(int argc, char *argv[])
   for( it.GoToBegin(); !it.IsAtEnd(); ++it )
     {
     // take every N^th point
-    if ( 1 /*ct % 4 == 0*/  )
+    if ( true /*ct % 4 == 0*/  )
       {
         PointType pt;
         fixedImage->TransformIndexToPhysicalPoint( it.GetIndex(), pt);

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -209,7 +209,7 @@ int itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char *arg
   // Optimizer
   RegistrationParameterScalesFromShiftType::ScalesType displacementScales( displacementTransform->GetNumberOfLocalParameters() );
   displacementScales.Fill(1);
-  if( 0 )
+  if( false )
     {
     optimizer->SetScales( displacementScales );
     }

--- a/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
@@ -114,7 +114,7 @@ int itkMultiGradientImageToImageMetricv4RegistrationTest(int argc, char *argv[])
   metric->SetNumberOfHistogramBins(20);
   MetricType2::Pointer metric2 = MetricType2::New();
 
-  if( 0 )
+  if( false )
     {
     std::cout << "Dense sampling." << std::endl;
     metric->SetUseSampledPointSet( false );

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -238,7 +238,7 @@ FastSymmetricForcesDemonsRegistrationFunction< TFixedImage, TMovingImage, TDispl
 
   // update the squared change value
   PointType newMappedCenterPoint;
-  bool      IsOutsideRegion = 0;
+  bool      IsOutsideRegion = false;
   for ( unsigned int j = 0; j < ImageDimension; j++ )
     {
     if ( globalData )
@@ -247,7 +247,7 @@ FastSymmetricForcesDemonsRegistrationFunction< TFixedImage, TMovingImage, TDispl
       newMappedCenterPoint[j] = mappedCenterPoint[j] + update[j];
       if ( index[j] < ( FirstIndex[j] + 2 ) || index[j] > ( LastIndex[j] - 3 ) )
         {
-        IsOutsideRegion = 1;
+        IsOutsideRegion = true;
         }
       }
     }

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -265,7 +265,7 @@ SymmetricForcesDemonsRegistrationFunction< TFixedImage, TMovingImage, TDisplacem
 
   // update the squared change value
   PointType newMappedCenterPoint;
-  bool      IsOutsideRegion = 0;
+  bool      IsOutsideRegion = false;
   for ( unsigned int j = 0; j < ImageDimension; j++ )
     {
     if ( globalData )
@@ -274,7 +274,7 @@ SymmetricForcesDemonsRegistrationFunction< TFixedImage, TMovingImage, TDisplacem
       newMappedCenterPoint[j] = mappedCenterPoint[j] + update[j];
       if ( index[j] < ( FirstIndex[j] + 2 ) || index[j] > ( LastIndex[j] - 3 ) )
         {
-        IsOutsideRegion = 1;
+        IsOutsideRegion = true;
         }
       }
     }

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
@@ -91,7 +91,7 @@ int itkSLICImageFilterTest(int argc, char *argv[])
     }
 
 
-  const bool enforceConnectivity = (argc > 4) ? std::stoi(argv[4]) : 1;
+  const bool enforceConnectivity = (argc > 4) ? std::stoi(argv[4]) : true;
   const unsigned int gridSize = (argc > 3) ? std::stoi(argv[3] ) : 20;
   const char *inFileName = argv[1];
   const char *outFileName = argv[2];

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -110,25 +110,25 @@ VoronoiDiagram2DGenerator< TCoordRepType >::comp(PointType arg1, PointType arg2)
 {
   if ( arg1[1] < arg2[1] )
     {
-    return 1;
+    return true;
     }
   else if ( arg1[1] > arg2[1] )
     {
-    return 0;
+    return false;
     }
   // arg1[1] == arg2[1]
   else if ( arg1[0] < arg2[0] )
     {
-    return 1;
+    return true;
     }
   else if ( arg1[0] > arg2[0] )
     {
-    return 0;
+    return false;
     }
   // arg1[0] == arg2[0]
   else
     {
-    return 0;
+    return false;
     }
 }
 
@@ -448,15 +448,15 @@ VoronoiDiagram2DGenerator< TCoordRepType >::right_of(FortuneHalfEdge *el, PointT
 
   bool right_of_site = ( ( ( *p )[0] ) > ( topsite->m_Coord[0] ) );
 
-  if ( right_of_site && ( !( el->m_RorL ) ) ) { return ( 1 ); }
-  if ( ( !right_of_site ) && ( el->m_RorL ) ) { return ( 0 ); }
+  if ( right_of_site && ( !( el->m_RorL ) ) ) { return ( true ); }
+  if ( ( !right_of_site ) && ( el->m_RorL ) ) { return ( false ); }
   bool above;
   bool fast;
   if ( e->m_A == 1.0 )
     {
     double dyp = ( ( *p )[1] ) - ( topsite->m_Coord[1] );
     double dxp = ( ( *p )[0] ) - ( topsite->m_Coord[0] );
-    fast = 0;
+    fast = false;
     if ( ( ( !right_of_site ) && ( ( e->m_B ) < 0.0 ) )
          || ( right_of_site && ( ( e->m_B ) >= 0.0 ) ) )
       {
@@ -467,7 +467,7 @@ VoronoiDiagram2DGenerator< TCoordRepType >::right_of(FortuneHalfEdge *el, PointT
       {
       above = ( ( ( ( *p )[0] ) + ( ( *p )[1] ) * ( e->m_B ) ) > e->m_C );
       if ( e->m_B < 0.0 ) { above = !above; }
-      if ( !above ) { fast = 1; }
+      if ( !above ) { fast = true; }
       }
     if ( !fast )
       {
@@ -635,7 +635,7 @@ VoronoiDiagram2DGenerator< TCoordRepType >::findLeftHE(PointType *p)
   FortuneHalfEdge *he = ELgethash(bucket);
   if ( he == nullptr )
     {
-    for ( i = 1; 1; i++ )
+    for ( i = 1; true; i++ )
       {
       if ( ( he = ELgethash(bucket - i) ) != nullptr ) { break; }
       if ( ( he = ELgethash(bucket + i) ) != nullptr ) { break; }
@@ -1110,7 +1110,7 @@ VoronoiDiagram2DGenerator< TCoordRepType >::GenerateVDFortune()
   int Siteid = 0;
 
   i = 2;
-  bool ok = 1;
+  bool ok = true;
   while ( ok )
     {
     if ( m_PQcount != 0 )
@@ -1187,13 +1187,13 @@ VoronoiDiagram2DGenerator< TCoordRepType >::GenerateVDFortune()
       deletePQ(rightHalfEdge);
       deleteEdgeList(rightHalfEdge);
 
-      saveBool = 0;
+      saveBool = false;
       if ( ( findSite->m_Coord[1] ) > ( topSite->m_Coord[1] ) )
         {
         saveSite = findSite;
         findSite = topSite;
         topSite = saveSite;
-        saveBool = 1;
+        saveBool = true;
         }
 
       bisect(&( Edgepool[Edgeid] ), findSite, topSite);
@@ -1227,7 +1227,7 @@ VoronoiDiagram2DGenerator< TCoordRepType >::GenerateVDFortune()
       }
     else
       {
-      ok = 0;
+      ok = false;
       }
     }
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -101,11 +101,11 @@ VoronoiSegmentationImageFilter< TInputImage, TOutputImage, TBinaryPriorImage >
   if ( ( savemean > -m_MeanTolerance ) && ( savemean < m_MeanTolerance )
        && ( saveSTD < m_STDTolerance ) )
     {
-    return 1;
+    return true;
     }
   else
     {
-    return 0;
+    return false;
     }
 }
 
@@ -128,7 +128,7 @@ VoronoiSegmentationImageFilter< TInputImage, TOutputImage, TBinaryPriorImage >
 
   unsigned int i, j;
   unsigned int minx = 0, miny = 0, maxx = 0, maxy = 0;
-  bool         status = 0;
+  bool         status = false;
   for ( i = 0; i < this->m_Size[1]; i++ )
     {
     for ( j = 0; j < this->m_Size[0]; j++ )
@@ -139,7 +139,7 @@ VoronoiSegmentationImageFilter< TInputImage, TOutputImage, TBinaryPriorImage >
         minx = j;
         maxy = i;
         maxx = j;
-        status = 1;
+        status = true;
         }
       else if ( ( status == 1 ) && ( ait.Get() ) )
         {

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
@@ -253,7 +253,7 @@ protected:
   void GetPixelIndexFromPolygon(PointTypeDeque VertList, IndexList *PixelPool);
 
   virtual bool TestHomogeneity(IndexList &)
-  { return 1; }
+  { return true; }
 
   void FillPolygon(PointTypeDeque vertlist, OutputPixelType color = 1);
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -143,12 +143,12 @@ VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage
   int    i;
   if ( leftendy > rightendy )
     {
-    RorL = 1;
+    RorL = true;
     endy = rightendy;
     }
   else
     {
-    RorL = 0;
+    RorL = false;
     endy = leftendy;
     }
   if ( Math::AlmostEquals(leftP[1], beginy) )
@@ -262,12 +262,12 @@ VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage
     rightendy = rightP[1];
     if ( leftendy > rightendy )
       {
-      RorL = 1;
+      RorL = true;
       endy = rightendy;
       }
     else
       {
-      RorL = 0;
+      RorL = false;
       endy = leftendy;
       }
 
@@ -399,7 +399,7 @@ VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage
       {
       auto itend = m_WorkingVD->NeighborIdsEnd(i);
       auto it = m_WorkingVD->NeighborIdsBegin(i);
-      bool               bnd = 0;
+      bool               bnd = false;
       // and any adjacent region is homogeneous
       while ( ( it != itend ) && ( !bnd ) )
         {
@@ -473,7 +473,7 @@ void
 VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage >
 ::RunSegment()
 {
-  bool ok = 1;
+  bool ok = true;
 
   if ( m_Steps == 0 )
     {
@@ -484,7 +484,7 @@ VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage
                           / static_cast< float >( NumericTraits< SizeValueType >::max() ) );
     if ( m_NumberOfBoundary == 0 )
       {
-      ok = 0;
+      ok = false;
       }
     while ( ( m_NumberOfSeedsToAdded != 0 ) && ok )
       {
@@ -516,7 +516,7 @@ VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage
       }
     if ( m_NumberOfBoundary == 0 )
       {
-      ok = 0;
+      ok = false;
       }
     int i = 1;
     while ( ( i < m_Steps ) && ok )
@@ -707,12 +707,12 @@ VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage
   int    i;
   if ( leftendy > rightendy )
     {
-    RorL = 1;
+    RorL = true;
     endy = rightendy;
     }
   else
     {
-    RorL = 0;
+    RorL = false;
     endy = leftendy;
     }
   if (Math::AlmostEquals( leftP[1], beginy ))
@@ -824,12 +824,12 @@ VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage
     rightendy = rightP[1];
     if ( leftendy > rightendy )
       {
-      RorL = 1;
+      RorL = true;
       endy = rightendy;
       }
     else
       {
-      RorL = 0;
+      RorL = false;
       endy = leftendy;
       }
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -192,7 +192,7 @@ VoronoiSegmentationRGBImageFilter< TInputImage, TOutputImage >::TestHomogeneity(
       }
     }
 
-  bool ok = 1;
+  bool ok = true;
   j = 0;
   double savem, savev;
   while ( ok && ( j < 3 ) )
@@ -202,23 +202,23 @@ VoronoiSegmentationRGBImageFilter< TInputImage, TOutputImage >::TestHomogeneity(
     if ( ( savem < -m_MeanTolerance[m_TestMean[j]] )
          || ( savem > m_MeanTolerance[m_TestMean[j]] ) )
       {
-      ok = 0;
+      ok = false;
       }
     if ( ( savev < -m_STDTolerance[m_TestSTD[j]] )
          || ( savev > m_STDTolerance[m_TestSTD[j]] ) )
       {
-      ok = 0;
+      ok = false;
       }
     j++;
     }
 
   if ( ok )
     {
-    return 1;
+    return true;
     }
   else
     {
-    return 0;
+    return false;
     }
 }
 
@@ -232,7 +232,7 @@ VoronoiSegmentationRGBImageFilter< TInputImage, TOutputImage >::TakeAPrior(const
   itk::ImageRegionIteratorWithIndex< RGBHCVImage >            iit(m_WorkingImage, region);
 
   unsigned int minx = 0, miny = 0, maxx = 0, maxy = 0;
-  bool         status = 0;
+  bool         status = false;
   for ( unsigned int i = 0; i < this->GetSize()[1]; i++ )
     {
     for ( unsigned int j = 0; j < this->GetSize()[0]; j++ )
@@ -243,7 +243,7 @@ VoronoiSegmentationRGBImageFilter< TInputImage, TOutputImage >::TakeAPrior(const
         minx = j;
         maxy = i;
         maxx = j;
-        status = 1;
+        status = true;
         }
       else if ( ( status == 1 ) && ( ait.Get() ) )
         {

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -312,7 +312,7 @@ DoConvertBuffer(void* inputData, FrameOffsetType frameNumber)
       }                                                                 \
     }
 
-  if(0) {}
+  if(false) {}
   ITK_CONVERT_BUFFER_IF_BLOCK(ImageIOBase::UCHAR,unsigned char)
   ITK_CONVERT_BUFFER_IF_BLOCK(ImageIOBase::CHAR,char)
   ITK_CONVERT_BUFFER_IF_BLOCK(ImageIOBase::USHORT,unsigned short)

--- a/Modules/Video/IO/src/itkFileListVideoIOFactory.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIOFactory.cxx
@@ -26,7 +26,7 @@ FileListVideoIOFactory::FileListVideoIOFactory()
   this->RegisterOverride( "itkVideoIOBase",
                           "itkFileListVideoIO",
                           "FileList Video IO",
-                          1,
+                          true,
                           CreateObjectFunction< FileListVideoIO >::New() );
 }
 

--- a/Utilities/ITKv5Preparation/modernize-use-bool-literals.sh
+++ b/Utilities/ITKv5Preparation/modernize-use-bool-literals.sh
@@ -46,7 +46,7 @@ export CC=/Users/johnsonhj/local/ccache/bin/clang_ccache
 export CXX=/Users/johnsonhj/local/ccache/bin/clang++11_ccache
 export PATH=~/local/llvm/llvm_trunk-build/bin:$PATH
 cd ${BLDDIR}
-/Users/johnsonhj/Dashboard/src/scripts/run-clang-tidy.py -checks=-*,modernize-use-bool-literals  -header-filter=.* -fix
+/Users/johnsonhj/Dashboard/src/scripts/run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-bool-literals  -header-filter=.* -fix
 
 cd ${SRCDIR}
 git add -A && git commit --file ${CMTMSG}


### PR DESCRIPTION
Finds and replaces integer literals which are cast to bool.

SRCDIR=/Users/johnsonhj/Dashboard/src/ITK #My local SRC
BLDDIR=/Users/johnsonhj/Dashboard/src/ITK-clang/ #My local BLD

cd /Users/johnsonhj/Dashboard/src/ITK-clang/
run-clang-tidy.py -checks=-*,modernize-use-bool-literals  -header-filter=.* -fix