### PR TITLE
WIP: BUG: The Z spacing was set using thickness

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -1326,7 +1326,16 @@ DCMTKFileReader
     // slice thickness
     spacing[0] = _spacing[1];
     spacing[1] = _spacing[0];
-    if(this->GetElementDS<double>(0x0018,0x0050,1,&_spacing[2],false) == EXIT_SUCCESS)
+    /*
+     * According Dicom standard (DICOM PS3.6 2016b - Data Dictionary)
+     * (0028, 0030) indicates physical X,Y spacing inside a slice;
+     * (0018, 0088) indicates physical Z spacing between slices;
+     *  which above are also consistent with Dcom2iix software.
+     *  when we can not get (0018, 0088),we will revert to previous
+     *  behavior and use (0018, 0050) thickness as a proxy to spacing.
+     * */
+    if(GetElementDS<double>(0x0018,0x0088,1,&_spacing[2], false) == EXIT_SUCCESS
+       || GetElementDS<double>(0x0018,0x0050,1,&_spacing[2],false) == EXIT_SUCCESS)
       {
       spacing[2] = _spacing[2];
       }
@@ -1359,12 +1368,27 @@ DCMTKFileReader
         rval = item.GetElementSQ(0x0028,0x9110,subSequence,false);
         if(rval == EXIT_SUCCESS)
           {
-          if(subSequence.GetElementDS<double>(0x0028,0x0030,2,_spacing,false) == EXIT_SUCCESS
-             && subSequence.GetElementDS<double>(0x0018,0x0050,1,&_spacing[2]) == EXIT_SUCCESS)
-            {
-            spacing[0] = _spacing[1];
-            spacing[1] = _spacing[0];
-            spacing[2] = _spacing[2];
+           /*
+            * According Dicom standard (DICOM PS3.6 2016b - Data Dictionary)
+            * (0028, 0030) indicates physical X,Y spacing inside a slice;
+            * (0018, 0088) indicates physical Z spacing between slices;
+            *  which above are also consistent with Dcom2iix software.
+            *  when we can not get (0018, 0088),we will revert to previous
+            *  behavior and use (0018, 0050) thickness as a proxy to spacing.
+            * */
+           if(subSequence.GetElementDS<double>(0x0028,0x0030,2,_spacing,false) == EXIT_SUCCESS)
+           {
+               spacing[0] = _spacing[1];
+               spacing[1] = _spacing[0];
+               if (subSequence.GetElementDS<double>(0x0018,0x0088,1,&_spacing[2], false) == EXIT_SUCCESS
+                   || subSequence.GetElementDS<double>(0x0018,0x0050,1,&_spacing[2], false) == EXIT_SUCCESS){
+                   spacing[2] = _spacing[2];
+               }
+               else
+               {
+                   // punt, zSpace of 1
+                   spacing[2] = 1.0;
+               }
             break;
             }
           }


### PR DESCRIPTION
This addresses https://issues.itk.org/jira/browse/ITK-3527

According Dicom standard (DICOM PS3.6 2016b - Data Dictionary)
(0028, 0030) indicates physical X,Y spacing inside a slice;
(0018, 0088) indicates physical Z spacing between slices;
which above are also consistent with Dcom2iix software.

In current code, the zSpace is get from (0x0018,0x0050) which
actually is the thickness from which the signal is created,
not the separation of signal samplings.

This patch set resolves the problem by updating the Z get
spacing method by using (0018, 0088) when it is available.

If (0018, 0088) is not available, then the code reverts to
the previous behavior of using (0x0018,0x0050).
