### PR TITLE
ENH: Improve coverage for itk::FastMarchingImageFilterBase.

### DIFF
--- a/Modules/Filtering/FastMarching/include/itkFastMarchingBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingBase.h
@@ -108,9 +108,12 @@ public:
   using SuperclassType = typename Traits::SuperclassType;
 
   using Self = FastMarchingBase;
-  using Superclass = SuperclassType;
+  using Superclass = typename FastMarchingTraits<TInput, TOutput>::SuperclassType;
   using Pointer = SmartPointer< Self >;
   using ConstPointer = SmartPointer< const Self >;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(FastMarchingBase, FastMarchingTraits);
 
   /** Input Domain related definitions */
   using InputDomainType = typename Traits::InputDomainType;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -114,7 +114,7 @@ public:
 
   /** Standard class typdedefs. */
   using Self = FastMarchingImageFilter;
-  using Superclass = ImageSource< TLevelSet >;
+  using Superclass = ImageToImageFilter< TSpeedImage, TLevelSet >;
   using Pointer = SmartPointer< Self >;
   using ConstPointer = SmartPointer< const Self >;
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
@@ -107,7 +107,7 @@ int itkFastMarchingExtensionImageFilterTest(int, char* [] )
   index[1] -= 1;
   TrialPoints->push_back( NodePairType( index, 1. ) );
 
-  index.Fill( 300 ); // this node is out of ranage
+  index.Fill( 300 ); // this node is out of range
   TrialPoints->push_back( NodePairType( index, 42. ) );
 
   marcher->SetTrialPoints( TrialPoints );

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
@@ -18,57 +18,100 @@
 
 #include "itkFastMarchingImageFilterBase.h"
 #include "itkFastMarchingThresholdStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
+/*
+ * This function ONLY tests basic getters/setters for the base class
+ * and does not exercise the base class filter. The process of testing
+ * the running of the filter is delegated to other tests.
+ * @tparam VDimension
+ * @return EXIT_SUCCESS if all test passs, EXIT_FAILURE otherwise
+ */
 template< unsigned int VDimension >
-int FastMarchingImageFilterBase( )
-  {
+static int FastMarchingImageFilterBaseTestFunction()
+{
   using PixelType = float;
 
   using ImageType = itk::Image< PixelType, VDimension >;
   typename ImageType::Pointer input = ImageType::New();
 
-  using FMMType =
+  using FastMarchingImageFilterType =
       itk::FastMarchingImageFilterBase< ImageType, ImageType >;
-  typename FMMType::Pointer fmm = FMMType::New();
-  fmm->SetInput( input );
+  typename FastMarchingImageFilterType::Pointer fastMarchingFilter =
+      FastMarchingImageFilterType::New();
 
-  bool exception_caught = false;
+  bool overrideOutputInformation = true;
+  TEST_SET_GET_BOOLEAN( fastMarchingFilter, OverrideOutputInformation,
+    overrideOutputInformation );
 
-  try
-    {
-    fmm->Update();
-    }
-  catch( itk::ExceptionObject & excep )
-    {
-    std::cerr << "Exception caught !" << std::endl;
-    std::cerr << excep << std::endl;
-    exception_caught = true;
-    }
+  typename FastMarchingImageFilterType::OutputSizeType outputSize;
+  outputSize.Fill( 32 );
+  fastMarchingFilter->SetOutputSize( outputSize );
+  TEST_SET_GET_VALUE( outputSize, fastMarchingFilter->GetOutputSize() );
 
-  if( !exception_caught )
-    {
-    std::cout <<"Exception is not caught!" <<std::endl;
-    return EXIT_FAILURE;
-    }
+  typename FastMarchingImageFilterType::OutputRegionType outputRegion;
+  outputRegion.SetSize( outputSize );
+  fastMarchingFilter->SetOutputRegion( outputRegion );
+  TEST_SET_GET_VALUE( outputRegion, fastMarchingFilter->GetOutputRegion() );
 
-  typename ImageType::Pointer output = fmm->GetOutput();
+  typename FastMarchingImageFilterType::OutputSpacingType outputSpacing;
+  outputSpacing.Fill( 1.0 );
+  fastMarchingFilter->SetOutputSpacing( outputSpacing );
+  TEST_SET_GET_VALUE( outputSpacing, fastMarchingFilter->GetOutputSpacing() );
+
+  typename FastMarchingImageFilterType::OutputDirectionType outputDirection;
+  outputDirection.SetIdentity();
+  fastMarchingFilter->SetOutputDirection( outputDirection );
+  TEST_SET_GET_VALUE( outputDirection, fastMarchingFilter->GetOutputDirection() );
+
+  typename FastMarchingImageFilterType::OutputPointType outputOrigin;
+  outputOrigin.Fill( 0.0 );
+  fastMarchingFilter->SetOutputOrigin( outputOrigin );
+  TEST_SET_GET_VALUE( outputOrigin, fastMarchingFilter->GetOutputOrigin() );
+
+  // DO NOT ATTEMPT TO UPDATE the base class filter.
+  // the base class filter is not sufficiently configured
+  // with trial point, stopping criteria, normalization factors, or speed constants.
+  // or given a valid image.
+  //
+  // DO NOT ADD TRY_EXPECT_NO_EXCEPTION( fastMarchingFilter->Update() );
+  // DO NOT ADD typename ImageType::Pointer output = fastMarchingFilter->GetOutput();
 
   return EXIT_SUCCESS;
-  }
+}
 
 
-// ----------------------------------------------------------------------------
 int itkFastMarchingImageFilterBaseTest( int , char * [] )
-  {
-  if( FastMarchingImageFilterBase< 2 >() == EXIT_FAILURE )
+{
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  const unsigned int Dimension = 2;
+  typedef float                               PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+
+  typedef itk::FastMarchingImageFilterBase< ImageType, ImageType >
+    FastMarchingImageFilterType;
+
+  FastMarchingImageFilterType::Pointer fastMarchingFilter =
+    FastMarchingImageFilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( fastMarchingFilter,
+    FastMarchingImageFilterBase, FastMarchingBase );
+
+
+  if(FastMarchingImageFilterBaseTestFunction<2>() == EXIT_FAILURE )
     {
-    std::cerr << "2D Fails" <<std::endl;
+    std::cerr << "Test failed!" << std::endl;
     return EXIT_FAILURE;
     }
-  if( FastMarchingImageFilterBase< 3 >() == EXIT_FAILURE )
+  if(FastMarchingImageFilterBaseTestFunction<3>() == EXIT_FAILURE )
     {
-    std::cerr << "3D Fails" <<std::endl;
+    std::cerr << "Test failed!" << std::endl;
     return EXIT_FAILURE;
     }
+
+
+  std::cout << "Test finished." <<std::endl;
   return EXIT_SUCCESS;
-  }
+}

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
@@ -122,7 +122,7 @@ int itkFastMarchingImageFilterRealTest1(int argc, char* argv[] )
   trial->push_back( node_pair );
 
   node_pair.SetValue( 42.0 );
-  index.Fill( 300 ); // this node is out of ranage
+  index.Fill( 300 ); // this node is out of range
   node_pair.SetNode( index );
   trial->push_back( node_pair );
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkFastMarchingThresholdStoppingCriterion.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkTextOutput.h"
+#include "itkTestingMacros.h"
 #include "itkCommand.h"
 
 
@@ -31,22 +32,19 @@ namespace{
 class ShowProgressObject
 {
 public:
-  ShowProgressObject(itk::ProcessObject* o)
-    {m_Process = o;}
+  ShowProgressObject( itk::ProcessObject* o )
+    { m_Process = o; }
   void ShowProgress()
-    {std::cout << "Progress " << m_Process->GetProgress() << std::endl;}
+    { std::cout << "Progress " << m_Process->GetProgress() << std::endl; }
   itk::ProcessObject::Pointer m_Process;
 };
 }
 
-int itkFastMarchingImageFilterRealTest2(int argc, char* argv[] )
+int itkFastMarchingImageFilterRealTest2( int itkNotUsed( argc ), char* itkNotUsed( argv )[] )
 {
-  (void) argc;
-  (void) argv;
+  itk::OutputWindow::SetInstance( itk::TextOutput::New().GetPointer() );
 
-  itk::OutputWindow::SetInstance(itk::TextOutput::New().GetPointer());
-
-  // create a fastmarching object
+  // Create a Fast Marching image filter object
   using PixelType = float;
   constexpr unsigned Dimension  = 2;
 
@@ -62,20 +60,25 @@ int itkFastMarchingImageFilterRealTest2(int argc, char* argv[] )
   criterion->SetThreshold( 100. );
 
   FastMarchingType::Pointer marcher = FastMarchingType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( marcher, FastMarchingImageFilterBase,
+    FastMarchingBase );
+
+
   marcher->SetStoppingCriterion( criterion );
 
-  ShowProgressObject progressWatch(marcher);
-  itk::SimpleMemberCommand<ShowProgressObject>::Pointer command;
-  command = itk::SimpleMemberCommand<ShowProgressObject>::New();
-  command->SetCallbackFunction(&progressWatch,
-                               &ShowProgressObject::ShowProgress);
-  marcher->AddObserver( itk::ProgressEvent(), command);
+  ShowProgressObject progressWatch( marcher );
+  itk::SimpleMemberCommand< ShowProgressObject >::Pointer command =
+    itk::SimpleMemberCommand< ShowProgressObject >::New();
+  command->SetCallbackFunction( &progressWatch,
+                               &ShowProgressObject::ShowProgress );
+  marcher->AddObserver( itk::ProgressEvent(), command );
 
-  // specify the size of the output image
-  FloatImageType::SizeType size = {{64,64}};
+  // Specify the size of the output image
+  FloatImageType::SizeType size = {{64, 64}};
   marcher->SetOutputSize( size );
 
-  // setup a speed image of ones
+  // Set up a speed image of ones
   FloatImageType::Pointer speedImage = FloatImageType::New();
   FloatImageType::RegionType region;
   region.SetSize( size );
@@ -83,53 +86,53 @@ int itkFastMarchingImageFilterRealTest2(int argc, char* argv[] )
   speedImage->SetBufferedRegion( region );
   speedImage->Allocate();
 
-  // setup a 'alive image'
-  FloatImageType::Pointer AliveImage = FloatImageType::New();
-  AliveImage->SetLargestPossibleRegion( region );
-  AliveImage->SetBufferedRegion( region );
-  AliveImage->Allocate();
-  AliveImage->FillBuffer( 0.0 );
+  // Set up an 'alive image'
+  FloatImageType::Pointer aliveImage = FloatImageType::New();
+  aliveImage->SetLargestPossibleRegion( region );
+  aliveImage->SetBufferedRegion( region );
+  aliveImage->Allocate();
+  aliveImage->FillBuffer( 0.0 );
 
-  FloatImageType::OffsetType offset0 = {{28,35}};
+  FloatImageType::OffsetType offset0 = {{28, 35}};
 
-  itk::Index<2> index;
-  index.Fill(0);
+  itk::Index< Dimension > index;
+  index.Fill( 0 );
   index += offset0;
 
-  AliveImage->SetPixel( index, 1.0 );
+  aliveImage->SetPixel( index, 1.0 );
 
-  // setup a 'trial image'
-  FloatImageType::Pointer TrialImage = FloatImageType::New();
-  TrialImage->SetLargestPossibleRegion( region );
-  TrialImage->SetBufferedRegion( region );
-  TrialImage->Allocate();
-  TrialImage->FillBuffer( 0.0 );
+  // Set up a 'trial image'
+  FloatImageType::Pointer trialImage = FloatImageType::New();
+  trialImage->SetLargestPossibleRegion( region );
+  trialImage->SetBufferedRegion( region );
+  trialImage->Allocate();
+  trialImage->FillBuffer( 0.0 );
 
   index[0] += 1;
-  TrialImage->SetPixel( index, 1.0 );
+  trialImage->SetPixel( index, 1.0 );
 
   index[0] -= 1;
   index[1] += 1;
-  TrialImage->SetPixel( index, 1.0 );
+  trialImage->SetPixel( index, 1.0 );
 
   index[0] -= 1;
   index[1] -= 1;
-  TrialImage->SetPixel( index, 1.0 );
+  trialImage->SetPixel( index, 1.0 );
 
   index[0] += 1;
   index[1] -= 1;
-  TrialImage->SetPixel( index, 1.0 );
+  trialImage->SetPixel( index, 1.0 );
 
-  // setup a binary mask image in float (to make sure it works with float)
-  FloatImageType::Pointer MaskImage = FloatImageType::New();
-  MaskImage->SetLargestPossibleRegion( region );
-  MaskImage->SetBufferedRegion( region );
-  MaskImage->Allocate();
+  // Set up a binary mask image in float (to make sure it works with float)
+  FloatImageType::Pointer maskImage = FloatImageType::New();
+  maskImage->SetLargestPossibleRegion( region );
+  maskImage->SetBufferedRegion( region );
+  maskImage->Allocate();
 
-  itk::ImageRegionIterator<FloatImageType>
+  itk::ImageRegionIterator< FloatImageType >
     speedIter( speedImage, speedImage->GetBufferedRegion() );
   itk::ImageRegionIteratorWithIndex<FloatImageType>
-    maskIter( MaskImage, MaskImage->GetBufferedRegion() );
+    maskIter( maskImage, maskImage->GetBufferedRegion() );
   while ( !speedIter.IsAtEnd() )
     {
     speedIter.Set( 1.0 );
@@ -148,7 +151,6 @@ int itkFastMarchingImageFilterRealTest2(int argc, char* argv[] )
     ++speedIter;
     }
 
-  speedImage->Print( std::cout );
   marcher->SetInput( speedImage );
 
   using AdaptorType = itk::FastMarchingImageToNodePairContainerAdaptor< FloatImageType,
@@ -157,32 +159,35 @@ int itkFastMarchingImageFilterRealTest2(int argc, char* argv[] )
   AdaptorType::Pointer adaptor = AdaptorType::New();
   adaptor->SetIsForbiddenImageBinaryMask( true );
 
-  adaptor->SetAliveImage( AliveImage );
+  adaptor->SetAliveImage( aliveImage.GetPointer() );
   adaptor->SetAliveValue( 0.0 );
 
-  adaptor->SetTrialImage( TrialImage );
+  adaptor->SetTrialImage( trialImage.GetPointer() );
   adaptor->SetTrialValue( 1.0 );
 
-  adaptor->SetForbiddenImage( MaskImage );
+  adaptor->SetForbiddenImage( maskImage.GetPointer() );
   adaptor->Update();
 
   marcher->SetForbiddenPoints( adaptor->GetForbiddenPoints() );
   marcher->SetAlivePoints( adaptor->GetAlivePoints() );
   marcher->SetTrialPoints( adaptor->GetTrialPoints() );
 
-  // turn on debugging
+  // Turn on debugging
   marcher->DebugOn();
 
-  // update the marcher
-  marcher->Update();
+  // Update the Fast Marching filter
+  TRY_EXPECT_NO_EXCEPTION( marcher->Update() );
 
-  // check the results
+
+  // Check the results
   FloatImageType::Pointer output = marcher->GetOutput();
-  itk::ImageRegionIterator<FloatImageType>
+
+  itk::ImageRegionIterator< FloatImageType >
     iterator( output, output->GetBufferedRegion() );
 
   bool passed = true;
 
+  double threshold = 1.42;
   while( !iterator.IsAtEnd() )
     {
     FloatImageType::IndexType tempIndex = iterator.GetIndex();
@@ -193,19 +198,22 @@ int itkFastMarchingImageFilterRealTest2(int argc, char* argv[] )
       {
       tempIndex -= offset0;
       double distance = 0.0;
-      for ( int j = 0; j < 2; j++ )
+      for ( unsigned int j = 0; j < Dimension; j++ )
         {
         distance += tempIndex[j] * tempIndex[j];
         }
       distance = std::sqrt( distance );
 
-      if (distance > itk::NumericTraits< double >::epsilon() )
+      if ( distance > itk::NumericTraits< double >::epsilon() )
         {
-        if ( itk::Math::abs( outputValue ) / distance > 1.42 )
+        if ( itk::Math::abs( outputValue ) / distance > threshold )
           {
-          std::cout << iterator.GetIndex() << " ";
-          std::cout << itk::Math::abs( outputValue ) / distance << " ";
-          std::cout << itk::Math::abs( outputValue ) << " " << distance << std::endl;
+          std::cout << "Error at index [" << iterator.GetIndex() << "]"
+            << std::endl;
+          std::cout << "Expected scaled output value be less than: " << threshold
+            <<", but got: " << itk::Math::abs( outputValue ) / distance
+            << ", where output: " << itk::Math::abs( outputValue )
+            << "; scale factor: " << distance << std::endl;
           passed = false;
           }
         }
@@ -214,38 +222,25 @@ int itkFastMarchingImageFilterRealTest2(int argc, char* argv[] )
       {
       if( outputValue != 0. )
         {
-        std::cout << iterator.GetIndex() << " ";
-        std::cout << outputValue << " " << 0.;
-        std::cout << std::endl;
+        std::cout << "Error at index [" << iterator.GetIndex() << "]"
+          << std::endl;
+        std::cout << "Expected output value: " << 0. << ", but got: "
+          << outputValue << std::endl;
         passed = false;
         }
       }
     ++iterator;
     }
 
-  // Exercise other member functions
-  /*
-  std::cout << "SpeedConstant: " << marcher->GetSpeedConstant() << std::endl;
-  std::cout << "StoppingValue: " << marcher->GetStoppingValue() << std::endl;
-  std::cout << "CollectPoints: " << marcher->GetCollectPoints() << std::endl;
-
-  marcher->SetNormalizationFactor( 2.0 );
-  std::cout << "NormalizationFactor: " << marcher->GetNormalizationFactor();
-  std::cout << std::endl;
-
-  std::cout << "SpeedImage: " << marcher->GetInput();
-  std::cout << std::endl;*/
-
-  marcher->Print( std::cout );
 
   if ( passed )
     {
-    std::cout << "Fast Marching test passed" << std::endl;
+    std::cout << "Test passed!" << std::endl;
     return EXIT_SUCCESS;
     }
   else
     {
-    std::cout << "Fast Marching test failed" << std::endl;
+    std::cout << "Test failed!" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
@@ -97,7 +97,7 @@ int itkFastMarchingImageFilterRealWithNumberOfElementsTest(int , char* [] )
   trial->push_back( node_pair );
 
   node_pair.SetValue( 42.0 );
-  index.Fill( 300 ); // this node is out of ranage
+  index.Fill( 300 ); // this node is out of range
   node_pair.SetNode( index );
   trial->push_back( node_pair );
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -108,7 +108,7 @@ int itkFastMarchingTest(int, char* [] )
   trialPoints->InsertElement(3, node);
 
   node.SetValue( 42.0 );
-  index.Fill( 300 ); // this node is out of ranage
+  index.Fill( 300 ); // this node is out of range
   node.SetIndex( index );
   trialPoints->InsertElement(4, node);
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
@@ -108,7 +108,7 @@ int itkFastMarchingTest2(int, char* [] )
   trialPoints->InsertElement(3, node);
 
   node.SetValue( 42.0 );
-  index.Fill( 300 ); // this node is out of ranage
+  index.Fill( 300 ); // this node is out of range
   node.SetIndex( index );
   trialPoints->InsertElement(4, node);
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -106,7 +106,7 @@ int itkFastMarchingUpwindGradientBaseTest(int, char* [] )
   index[1] -= 1;
   TrialPoints->push_back( NodePairType( index, 1. ) );
 
-  index.Fill( 300 ); // this node is out of ranage
+  index.Fill( 300 ); // this node is out of range
   TrialPoints->push_back( NodePairType( index, 42. ) );
 
   marcher->SetTrialPoints( TrialPoints );

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
@@ -111,7 +111,7 @@ int itkFastMarchingUpwindGradientTest(int, char* [] )
   trialPoints->InsertElement(3, node);
 
   node.SetValue( 42.0 );
-  index.Fill( 300 ); // this node is out of ranage
+  index.Fill( 300 ); // this node is out of range
   node.SetIndex( index );
   trialPoints->InsertElement(4, node);
 


### PR DESCRIPTION
Exercise basic object methods.

Test all Set/Get methods using the TEST_SET_GET_VALUE macro, and all
On/Off methods corresponding to boolean members usign the
TEST_SET_GET_BOOLEAN macro.

Use the TRY_EXPECT_NO_EXCEPTION macro to update the filter and save
tryping the try/catch blocks.

Prefer initialization over assignment in variables.

Use the itkNotUsed macro for test input arguments and hence avoid
casting argc and argv to void to avoid compiler warnings.

Remove printing the input (speed) image.

Remove the calls to the Get* methods corresponding to base class
members (specifically: m_SpeedConstant, m_TargetReachedValue, and
m_NormalizationFactor should be tested for itk::FastMarchingBase in
itkFastMarchingBaseTest.cxx; and m_StoppingValue and GetCollectPoints
should be tested for itk::FastMarchingImageFilter in
itkFastMarchingTest.cxx).

Start comments with capital letters.

Minor style changes (such as white spaces between operators and
arguments, improvement of type names and error messages).
