### PR TITLE
WIP: Added HoughTransform2D Circle class, simplified GetCircles() ret…

### DIFF
--- a/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
@@ -215,9 +215,9 @@ int main( int argc, char *argv[] )
   while( itCircles != circles.end() )
     {
     std::cout << "Center: ";
-    std::cout << (*itCircles)->GetObjectToParentTransform()->GetOffset()
+    std::cout << itCircles->GetCenter()
               << std::endl;
-    std::cout << "Radius: " << (*itCircles)->GetRadius()[0] << std::endl;
+    std::cout << "Radius: " << itCircles->GetRadius() << std::endl;
     // Software Guide : EndCodeSnippet
 
     //  Software Guide : BeginLatex
@@ -231,16 +231,14 @@ int main( int argc, char *argv[] )
          angle <= itk::Math::twopi;
          angle += itk::Math::pi/60.0 )
       {
-      using TransformType = HoughTransformFilterType::CircleType::TransformType;
-      using OffsetType = TransformType::OutputVectorType;
-      const OffsetType offset =
-        (*itCircles)->GetObjectToParentTransform()->GetOffset();
+      const HoughTransformFilterType::Circle::CenterType center = itCircles->GetCenter();
+      using IndexValueType = HoughTransformFilterType::IndexType::IndexValueType;
       localIndex[0] =
-         itk::Math::Round<long int>(offset[0]
-                    + (*itCircles)->GetRadius()[0]*std::cos(angle));
+         itk::Math::Round<IndexValueType>(center[0]
+                    + itCircles->GetRadius()*std::cos(angle));
       localIndex[1] =
-         itk::Math::Round<long int>(offset[1]
-                    + (*itCircles)->GetRadius()[0]*std::sin(angle));
+         itk::Math::Round<IndexValueType>(center[1]
+                    + itCircles->GetRadius()*std::sin(angle));
       OutputImageType::RegionType outputRegion =
                                   localOutputImage->GetLargestPossibleRegion();
 

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -21,6 +21,9 @@
 
 #include "itkImageToImageFilter.h"
 #include "itkEllipseSpatialObject.h"
+#include "itkIndex.h"
+#include <ostream>
+#include <vector>
 
 namespace itk
 {
@@ -66,6 +69,42 @@ class ITK_TEMPLATE_EXPORT HoughTransform2DCirclesImageFilter:
 {
 public:
 
+  /**
+  * \class Circle
+  * \brief Represents a circle by its center and its radius.
+  *
+  * \ingroup ITKImageFeature
+  */
+  class Circle
+  {
+  public:
+    using CenterType = Index<2>;
+    using RadiusType = TRadiusPixelType;
+
+    Circle();
+
+    Circle(const CenterType&, RadiusType);
+
+    RadiusType GetRadius() const;
+
+    void SetRadius(RadiusType);
+
+    CenterType GetCenter() const;
+
+    void SetCenter(const CenterType&);
+
+    void ToEllipseSpatialObject(EllipseSpatialObject<2>&) const;
+
+  private:
+    CenterType m_Center;
+    RadiusType m_Radius;
+
+    friend std::ostream & operator<<(std::ostream & os, const Circle & circle)
+    {
+      return os << circle.m_Center << ' ' << circle.m_Radius;
+    }
+  };
+
   /** Standard class type aliases. */
   using Self = HoughTransform2DCirclesImageFilter;
   using Superclass = ImageToImageFilter< Image< TInputPixelType, 2 >,
@@ -96,9 +135,7 @@ public:
   using OutputImageRegionType = typename InputImageType::RegionType;
 
   /** Circle type alias. */
-  using CircleType = EllipseSpatialObject< 2 >;
-  using CirclePointer = typename CircleType::Pointer;
-  using CirclesListType = std::list< CirclePointer >;
+  using CirclesListType = std::vector< Circle >;
 
   using CirclesListSizeType = typename CirclesListType::size_type;
 

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -168,10 +168,8 @@ namespace
       return false;
     }
 
-    using CirclesListType = FilterType1::CirclesListType;
-
-    const CirclesListType& circles1 = filter1->GetCircles();
-    const CirclesListType& circles2 = filter2->GetCircles();
+    const auto& circles1 = filter1->GetCircles();
+    const auto& circles2 = filter2->GetCircles();
 
     if ( circles1.empty() || circles2.empty() )
     {
@@ -187,30 +185,13 @@ namespace
       return false;
     }
 
-    using CircleType = FilterType1::CircleType;
-
-    const CircleType* const circle1 = circles1.front().GetPointer();
-    const CircleType* const circle2 = circles2.front().GetPointer();
-
-    if ( (circle1 == nullptr) || (circle2 == nullptr) )
-    {
-      std::cout << "A Circle pointer appears to be incorrect!" << std::endl;
-      return false;
-    }
-
-    const CircleType::TransformType* const transform1 = circle1->GetObjectToParentTransform();
-    const CircleType::TransformType* const transform2 = circle2->GetObjectToParentTransform();
-
-    if ( (transform1 == nullptr) || (transform2 == nullptr) )
-    {
-      std::cout << "A GetObjectToParentTransform() call appears to be incorrect!" << std::endl;
-      return false;
-    }
+    const auto circle1 = circles1.front();
+    const auto circle2 = circles2.front();
 
     bool success = true;
 
-    const itk::Vector<double, 2>& center1 = transform1->GetOffset();
-    const itk::Vector<double, 2>& center2 = transform2->GetOffset();
+    const auto center1 = circle1.GetCenter();
+    const auto center2 = circle2.GetCenter();
 
     if (center1 != center2)
     {
@@ -220,8 +201,8 @@ namespace
       success = false;
     }
 
-    const double radius1 = circle1->GetRadius()[0];
-    const double radius2 = circle2->GetRadius()[0];
+    const double radius1 = circle1.GetRadius();
+    const double radius2 = circle2.GetRadius();
 
     if ( radius2 < radius1 )
     {
@@ -381,18 +362,18 @@ int itkHoughTransform2DCirclesImageTest( int, char* [] )
   unsigned int i = 0;
   while( it != circleList.end() )
     {
-      if( !itk::Math::FloatAlmostEqual( (double)( it->GetPointer()->GetRadius()[0] ),
+      if( !itk::Math::FloatAlmostEqual( (double)( it->GetRadius() ),
         radius[i], 10, radiusTolerance ) &&
-        !itk::Math::FloatAlmostEqual( (double)( it->GetPointer()->GetRadius()[0] ),
+        !itk::Math::FloatAlmostEqual( (double)( it->GetRadius() ),
         radius[i] * discRadiusRatio, 10, radiusTolerance ) )
       {
       std::cout << "Failure for circle #" << i << std::endl;
-      std::cout << "Expected radius: " << radius[i] << ", found " << it->GetPointer()->GetRadius() << std::endl;
+      std::cout << "Expected radius: " << radius[i] << ", found " << it->GetRadius() << std::endl;
       success = false;
       }
     else
       {
-      std::cout << "Circle #" << i << " radius: " << it->GetPointer()->GetRadius() << std::endl;
+      std::cout << "Circle #" << i << " radius: " << it->GetRadius() << std::endl;
       }
     ++it;
     ++i;


### PR DESCRIPTION
…urn type

Added a very simple Circle class to represent a circle, detected by
itk::HoughTransform2DCirclesImageFilter. Changed the return type of
HoughTransform2DCirclesImageFilter::GetCircles() from
std::list<EllipseSpatialObject<2>::Pointer>& to std::vector<Circle>&,
to ease retrieval of the center and the radius of detected circles.

Added convenience conversion function from Circle to EllipseSpatialObject<2>,
to ease upgrading legacy code that depended on the old (<= ITK 4.13) interface.

Removed redundant local variable 'circles' (equal to m_CirclesList.size())
from GetCircles().

Triggered by comments from Tim Evain, starting at:
https://discourse.itk.org/t/hough-transform-2d-circles-image-filter-getcircles-patch/350/46
