### PR TITLE
WIP: Tweak FixedArray and derived constructors

### DIFF
--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -108,18 +108,14 @@ public:
   CovariantVector & operator=(const CovariantVector &) = default;
   CovariantVector & operator=(CovariantVector &&) = default;
   ~CovariantVector() = default;
-
-  /**
-  * Constructor to initialize entire vector to one value.
-  */
-  explicit CovariantVector(const ValueType & r);
+  /* Inherit constructors from base class */
+  using Superclass::Superclass;
 
   /** Pass-through constructor for the Array base class. Implicit casting is
    * performed to initialize constructor from any another one of datatype. */
   template< typename TVectorValueType >
   CovariantVector(const CovariantVector< TVectorValueType,
                                          NVectorDimension > & r):BaseArray(r) {}
-  CovariantVector(const ValueType r[Dimension]):BaseArray(r) {}
 
   /** Assignment operator with implicit casting from another data type */
   template< typename TCovariantVectorValueType >
@@ -128,9 +124,6 @@ public:
     BaseArray::operator=(r);
     return *this;
   }
-
-  /** Pass-through assignment operator for the Array base class. */
-  CovariantVector & operator=(const ValueType r[NVectorDimension]);
 
   /** Scalar operator*=.  Scales elements by a scalar. */
   template< typename Tt >

--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -24,24 +24,6 @@
 
 namespace itk
 {
-template< typename T, unsigned int TVectorDimension >
-CovariantVector< T, TVectorDimension >
-::CovariantVector(const ValueType & r)
-{
-  for ( typename BaseArray::Iterator i = BaseArray::Begin(); i != BaseArray::End(); ++i )
-    {
-    *i = r;
-    }
-}
-
-template< typename T, unsigned int NVectorDimension >
-CovariantVector< T, NVectorDimension > &
-CovariantVector< T, NVectorDimension >
-::operator=(const ValueType r[NVectorDimension])
-{
-  BaseArray::operator=(r);
-  return *this;
-}
 
 template< typename T, unsigned int NVectorDimension >
 const typename CovariantVector< T, NVectorDimension >::Self &

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -36,24 +36,6 @@ FixedArray< TValue, VLength >
 }
 
 /**
- * Constructor assumes input points to array of correct size.
- * Values are copied individually instead of with a binary copy.  This
- * allows the ValueType's assignment operator to be executed.
- */
-template< typename TValue, unsigned int VLength >
-FixedArray< TValue, VLength >
-::FixedArray(const ValueType r[VLength])
-{
-  ConstIterator input = r;
-  Iterator      i = this->Begin();
-
-  while ( i != this->End() )
-    {
-    *i++ = *input++;
-    }
-}
-
-/**
  * Assignment operator assumes input points to array of correct size.
  * Values are copied individually instead of with a binary copy.  This
  * allows the ValueType's assignment operator to be executed.

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -178,8 +178,8 @@ public:
    * as SpacePrecisionType but may be set from float or double.
    * \sa GetOrigin() */
   itkSetMacro(Origin, PointType);
-  virtual void SetOrigin(const double origin[VImageDimension]);
-  virtual void SetOrigin(const float origin[VImageDimension]);
+  virtual void SetOrigin(const double (&origin)[VImageDimension]);
+  virtual void SetOrigin(const float (&origin)[VImageDimension]);
 
   /** Set the direction cosines of the image. The direction cosines
    * are vectors that point from one pixel to the next.
@@ -400,8 +400,8 @@ public:
    * transforms of the image.
    * \sa GetSpacing() */
   virtual void SetSpacing(const SpacingType & spacing);
-  virtual void SetSpacing(const double spacing[VImageDimension]);
-  virtual void SetSpacing(const float spacing[VImageDimension]);
+  virtual void SetSpacing(const double (&spacing)[VImageDimension]);
+  virtual void SetSpacing(const float (&spacing)[VImageDimension]);
 
   /** Get the index (discrete) of a voxel from a physical point.
    * Floating point index results are rounded to integers
@@ -732,14 +732,14 @@ protected:
   void Graft(const DataObject *data) override;
 
 private:
-  void InternalSetSpacing(const SpacingValueType spacing[VImageDimension])
+  void InternalSetSpacing(const SpacingValueType (&spacing)[VImageDimension])
     {
       SpacingType s(spacing);
       this->SetSpacing(s);
     }
 
   template <typename TSpacingValue>
-  void InternalSetSpacing(const TSpacingValue spacing[VImageDimension])
+  void InternalSetSpacing(const TSpacingValue (&spacing)[VImageDimension])
     {
       Vector<TSpacingValue,VImageDimension> sf(spacing);
       SpacingType                           s;

--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -120,7 +120,7 @@ ImageBase< VImageDimension >
 template< unsigned int VImageDimension >
 void
 ImageBase< VImageDimension >
-::SetSpacing(const double spacing[VImageDimension])
+::SetSpacing(const double (&spacing)[VImageDimension])
 {
   this->InternalSetSpacing(spacing);
 }
@@ -129,7 +129,7 @@ ImageBase< VImageDimension >
 template< unsigned int VImageDimension >
 void
 ImageBase< VImageDimension >
-::SetSpacing(const float spacing[VImageDimension])
+::SetSpacing(const float (&spacing)[VImageDimension])
 {
   this->InternalSetSpacing(spacing);
 }
@@ -138,7 +138,7 @@ ImageBase< VImageDimension >
 template< unsigned int VImageDimension >
 void
 ImageBase< VImageDimension >
-::SetOrigin(const double origin[VImageDimension])
+::SetOrigin(const double (&origin)[VImageDimension])
 {
   PointType p(origin);
 
@@ -149,7 +149,7 @@ ImageBase< VImageDimension >
 template< unsigned int VImageDimension >
 void
 ImageBase< VImageDimension >
-::SetOrigin(const float origin[VImageDimension])
+::SetOrigin(const float (&origin)[VImageDimension])
 {
   Point< float, VImageDimension > of(origin);
   PointType                       p;

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -85,20 +85,11 @@ public:
   Point & operator=(const Point &) = default;
   Point & operator=(Point &&) = default;
   ~Point() = default;
+  /* Inherit constructors from base class */
+  using Superclass::Superclass;
   /** Pass-through constructors for different type points. */
   template< typename TPointValueType >
   Point(const Point< TPointValueType, NPointDimension > & r):BaseArray(r) {}
-  /** Pass-through constructors for plain arrays. */
-  template< typename TPointValueType >
-  Point(const TPointValueType r[NPointDimension]):BaseArray(r) {}
-  Point(const ValueType r[NPointDimension]):BaseArray(r) {}
-  /** Pass-through constructors for single values */
-  template< typename TPointValueType >
-  Point(const TPointValueType & v):BaseArray(v) {}
-  Point(const ValueType & v):BaseArray(v) {}
-
-  /** Pass-through assignment operator for a plain array. */
-  Point & operator=(const ValueType r[NPointDimension]);
 
   /** Compare two points for equality. */
   bool

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -25,18 +25,6 @@
 namespace itk
 {
 /**
- * Assignment from a plain array
- */
-template< typename T, unsigned int TPointDimension >
-Point< T, TPointDimension > &
-Point< T, TPointDimension >
-::operator=(const ValueType r[TPointDimension])
-{
-  BaseArray::operator=(r);
-  return *this;
-}
-
-/**
  * In place increment by a vector
  */
 template< typename T, unsigned int TPointDimension >

--- a/Modules/Core/Common/include/itkSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkSpecialCoordinatesImage.h
@@ -251,11 +251,11 @@ public:
    * special-coordinates image.  Filters designed to produce a particular kind
    * of special-coordinates image should do this automatically. */
   void SetSpacing(const SpacingType &) override {}
-  void SetSpacing(const double[VImageDimension]) override {}
-  void SetSpacing(const float[VImageDimension]) override {}
+  void SetSpacing(const double(&)[VImageDimension]) override {}
+  void SetSpacing(const float(&)[VImageDimension]) override {}
   void SetOrigin(const PointType) override {}
-  void SetOrigin(const double[VImageDimension]) override {}
-  void SetOrigin(const float[VImageDimension]) override {}
+  void SetOrigin(const double(&)[VImageDimension]) override {}
+  void SetOrigin(const float(&)[VImageDimension]) override {}
 
   /* It is ILLEGAL in C++ to make a templated member function virtual! */
   /* Therefore, we must just let templates take care of everything.    */

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -103,22 +103,13 @@ public:
   Vector & operator=(Vector &&) = default;
   ~Vector() = default;
 
-#if !defined( ITK_LEGACY_FUTURE_REMOVE )
-  /** Constructor to initialize entire vector to one value.
-   * \warning Not intended to convert a scalar value into
-   * a Vector filled with that value.
-   * \deprecated */
-  Vector(const ValueType & r);
-#else
-  /** Constructor to initialize entire vector to one value,
-   * if explicitly invoked. */
-  explicit Vector(const ValueType & r);
-#endif
+  /* Inherit constructors from base class */
+  using Superclass::Superclass;
 
   /** Pass-through constructor for the Array base class. */
   template< typename TVectorValueType >
   Vector(const Vector< TVectorValueType, NVectorDimension > & r):BaseArray(r) {}
-  Vector(const ValueType r[Dimension]):BaseArray(r) {}
+  Vector(const ValueType (&r)[Dimension]):BaseArray(r) {}
 
   /** Pass-through assignment operator for the Array base class. */
   template< typename TVectorValueType >
@@ -128,7 +119,7 @@ public:
     return *this;
   }
 
-  Vector & operator=(const ValueType r[NVectorDimension]);
+  Vector & operator=(const ValueType (&r)[NVectorDimension]);
 
   /** Scalar operator*=.  Scales elements by a scalar. */
   template< typename Tt >

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -26,19 +26,9 @@
 namespace itk
 {
 template< typename T, unsigned int TVectorDimension >
-Vector< T, TVectorDimension >
-::Vector(const ValueType & r)
-{
-  for ( typename BaseArray::Iterator i = BaseArray::Begin(); i != BaseArray::End(); ++i )
-    {
-    *i = r;
-    }
-}
-
-template< typename T, unsigned int TVectorDimension >
 Vector< T, TVectorDimension > &
 Vector< T, TVectorDimension >
-::operator=(const ValueType r[TVectorDimension])
+::operator=(const ValueType (&r)[TVectorDimension])
 {
   BaseArray::operator=(r);
   return *this;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -68,7 +68,7 @@ public:
 
   QuadEdgeMeshPoint(const Superclass & r);
 
-  QuadEdgeMeshPoint(const ValueType r[VPointDimension]):Superclass(r)
+  QuadEdgeMeshPoint(const ValueType (&r)[VPointDimension]):Superclass(r)
   {
     this->Initialize();
   }

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -60,7 +60,7 @@ public:
   const VectorType & GetNormal(unsigned int index) const;
 
   /** Set Normal */
-  void SetNormal(VectorType & normal, unsigned int index);
+  void SetNormal(const VectorType & normal, unsigned int index);
 
   /** Copy one LineSpatialObjectPoint to another */
   Self & operator=(const LineSpatialObjectPoint & rhs);

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -72,7 +72,7 @@ LineSpatialObjectPoint< TPointDimension >
 template< unsigned int TPointDimension >
 void
 LineSpatialObjectPoint< TPointDimension >
-::SetNormal(VectorType & normal, unsigned int index)
+::SetNormal(const VectorType & normal, unsigned int index)
 {
   m_NormalArray[index] = normal;
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
@@ -74,23 +74,13 @@ MetaLineConverter< NDimensions >
     LinePointType pnt;
 
     using PointType = typename LinePointType::PointType;
-    PointType point;
     using NormalType = typename LinePointType::VectorType;
-
-    for ( unsigned int ii = 0; ii < ndims; ii++ )
-      {
-      point[ii] = ( *it2 )->m_X[ii];
-      }
-
+    const PointType point(( *it2 )->m_X);
     pnt.SetPosition(point);
 
     for ( unsigned int ii = 0; ii < ndims - 1; ii++ )
       {
-      NormalType normal;
-      for ( unsigned int jj = 0; jj < ndims; jj++ )
-        {
-        normal[jj] = ( *it2 )->m_V[ii][jj];
-        }
+      const NormalType normal(( *it2 )->m_V[ii]);
       pnt.SetNormal(normal, ii);
       }
 

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -218,14 +218,14 @@ public:
 
   /** Set the output image spacing. */
   itkSetMacro(OutputSpacing, SpacingType);
-  virtual void SetOutputSpacing(const double *values);
+  virtual void SetOutputSpacing(const double (&values)[ImageDimension]);
 
   /** Get the output image spacing. */
   itkGetConstReferenceMacro(OutputSpacing, SpacingType);
 
   /** Set the output image origin. */
   itkSetMacro(OutputOrigin, OriginPointType);
-  virtual void SetOutputOrigin(const double *values);
+  virtual void SetOutputOrigin(const double (&values)[ImageDimension]);
 
   /** Get the output image origin. */
   itkGetConstReferenceMacro(OutputOrigin, OriginPointType);

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -75,7 +75,7 @@ template< typename TInputImage,
           typename TTransformPrecisionType >
 void
 ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType >
-::SetOutputSpacing(const double *spacing)
+::SetOutputSpacing(const double (&spacing)[ImageDimension])
 {
   SpacingType s;
   for(unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
@@ -91,7 +91,7 @@ template< typename TInputImage,
           typename TTransformPrecisionType >
 void
 ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType >
-::SetOutputOrigin(const double *origin)
+::SetOutputOrigin(const double (&origin)[ImageDimension])
 {
   OriginPointType p(origin);
 

--- a/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
@@ -53,7 +53,7 @@ int itkGaborImageSourceTestHelper( char* outputFilename, bool calculcateImaginar
   gaborImage->SetSigma( sigma );
   TEST_SET_GET_VALUE( sigma, gaborImage->GetSigma() );
 
-  typename GaborSourceType::ArrayType mean = 0.1;
+  typename GaborSourceType::ArrayType mean = static_cast<GaborSourceType::ArrayType>(0.1);
   gaborImage->SetMean( mean );
   TEST_SET_GET_VALUE( mean, gaborImage->GetMean() );
 

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -934,21 +934,21 @@ int itkReadWriteSpatialObjectTest(int argc, char* argv[])
           {
           if(itk::Math::NotExactlyEquals((*pit).GetPosition()[d], value))
             {
-            std::cout<<" [FAILED]"<<std::endl;
+            std::cout<<" [FAILED]: Positition: " << (*pit).GetPosition() <<std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
             }
 
           if(itk::Math::NotExactlyEquals(((*pit).GetNormal(0))[d], d))
             {
-            std::cout<<" [FAILED]"<<std::endl;
+            std::cout<<" [FAILED]: Normal(0): " << (*pit).GetNormal(0) <<std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
             }
 
           if(itk::Math::NotExactlyEquals(((*pit).GetNormal(1))[d], 2*d))
             {
-            std::cout<<" [FAILED]"<<std::endl;
+            std::cout<<" [FAILED]: Normal(1): " << (*pit).GetNormal(1) <<std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
             }

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -267,7 +267,7 @@ int itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char *arg
   resample->SetOutputOrigin(  fixedImage->GetOrigin() );
   resample->SetOutputSpacing( fixedImage->GetSpacing() );
   resample->SetOutputDirection( fixedImage->GetDirection() );
-  resample->SetDefaultPixelValue( itk::NumericTraits<FixedImageType::PixelType::ValueType>::ZeroValue() );
+  resample->SetDefaultPixelValue( static_cast<ResampleFilterType::PixelType>(itk::NumericTraits<FixedImageType::PixelType::ValueType>::ZeroValue()) );
   resample->Update();
 
   //write out the displacement field


### PR DESCRIPTION
Niels suggested the change from ValueType[Dimension] (c-type ValueType*)
to `ValueType(&)[Dimension]`.
It is better now doubt, but it generates many breaking changes. That I
do think it could be worth to fix. The main one that is too big to
tackle right now is with all the interface of Cells.

This had to be inherited from VTK, but the interface in ITK could
enjoy a better interface than current raw pointers.
VTK does use c-arrays instead of pointers.
Compare VTK:
https://github.com/Kitware/VTK/blob/a7909e67d7df88dcf81984923296442c7ccaca5b/Common/DataModel/vtkCell.h#L197-L199
With ITK:
https://github.com/InsightSoftwareConsortium/ITK/blob/3a6158a416bd6f20882ac0dde27a0c1c50809991/Modules/Core/Common/include/itkCellInterface.h#L320-L326

ENH: Provide constructor from C-array to FixedArray

Also derived classes of FixedArray, inherit constructors from base.
`using Superclass::Superclass`
This allow to remove some repetition and homogenize the interface.

The only possible breaking change is marking as explicit two FixedArray
converting constructors:

```
explicit FixedArray(const ValueType & );

template< typename TFixedArrayValueType >
  explicit FixedArray(const FixedArray< TFixedArrayValueType, VLength > & r)
```

The template conversion is needed to avoid unexpected conversion in
derived classes. Also marking as explicit is in general a good practice.
Users might use static_cast instead of relying in the non-existant
implicit conversion.

ITK_LEGACY_FUTURE_REMOVE was used to switch between the explicit or
implicit constructor in itkVector. The switch is removed, that Vector behavior
is now handled from its base class (FixedArray).

COMP: Fix uninitialized FixedArray and const correctness

This is a false positive, the variables are not used uninitialized, but
we can solve it using the conversion constructor of FixedArray:

`FixedArray(Value r[VLenght])`

Also add missing const in SetNormal in LineSpatialObject

Fix warning:

```
Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx:
In member function ‘itk::MetaTubeConverter<NDimensions>::SpatialObjectPointer itk::MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType*) [with unsigned int NDimensions = 3]’:
Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx:172:3: warning: ‘point’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   m_X = newX;
   ^~~
Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx:
In member function ‘itk::MetaVesselTubeConverter<NDimensions>::SpatialObjectPointer itk::MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType*) [with unsigned int NDimensions = 3]’:
/home/user/Software/ITK/ITK-src/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx:172:3: warning: ‘point’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   m_X = newX;
```
