### PR TITLE
WIP: PERF: add move semantics support for Array and Array2D

### DIFF
--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -66,6 +66,10 @@ public:
   /** Copy constructor.  Uses VNL copy construtor with correct
    *  setting for memory management.                          */
   Array(const Array&);
+  Array(Array&&);
+
+  Array(const VnlVectorType&);
+  Array(VnlVectorType&&);
 
   /** Constructor with size. Size can only be changed by assignment */
   explicit Array(SizeValueType dimension);
@@ -114,10 +118,12 @@ public:
     this->fill(v);
     }
 
-  /** Copy opertor */
+  /** Copy operator */
   const Self & operator=(const Self & rhs);
+  Self & operator=(Self && rhs);
 
   const Self & operator=(const VnlVectorType & rhs);
+  Self & operator=(VnlVectorType && rhs);
 
   /** Return the number of elements in the Array  */
   SizeValueType Size() const
@@ -175,10 +181,12 @@ public:
 #endif
 
   void Swap(Array &other)
-    {
+  {
+      itkAssertInDebugAndIgnoreInReleaseMacro(m_LetArrayManageMemory == other.m_LetArrayManageMemory);
+      if (m_LetArrayManageMemory != other.m_LetArrayManageMemory)
+        throw;
       using std::swap;
       this->VnlVectorType::swap(other);
-      swap(this->m_LetArrayManageMemory, other.m_LetArrayManageMemory);
     }
 
 private:

--- a/Modules/Core/Common/include/itkArray.hxx
+++ b/Modules/Core/Common/include/itkArray.hxx
@@ -42,6 +42,38 @@ Array<TValue>
 {
 }
 
+
+/** Move Copy constructor */
+template < typename TValue >
+Array<TValue>
+::Array( Self && rhs)
+  : Array()
+{
+  this->Swap(rhs);
+}
+
+
+/** conversion from vnl_vector */
+template < typename TValue >
+Array<TValue>
+::Array(const VnlVectorType & rhs)
+  : vnl_vector<TValue>(rhs),
+    // The vnl vector copy constructor creates new memory
+    // no matter the setting of let array manage memory of rhs
+    m_LetArrayManageMemory(true)
+{
+}
+
+
+/** Move  from vnl_vector  */
+template < typename TValue >
+Array<TValue>
+::Array(VnlVectorType && rhs)
+  : Array()
+{
+  this->VnlVectorType::swap(rhs);
+}
+
 /** Constructor with size */
 template< typename TValue >
 Array< TValue >
@@ -173,6 +205,7 @@ Array< TValue >
   return *this;
 }
 
+
 template< typename TValue >
 const typename Array< TValue >
 ::Self &
@@ -193,6 +226,33 @@ Array< TValue >
     }
   return *this;
 }
+
+
+template< typename TValue >
+typename Array< TValue >
+::Self &
+Array< TValue >
+::operator=(Self && rhs)
+{
+  if ( this != &rhs )
+    {
+    Self temp(std::move(rhs));
+    this->Swap(temp);
+    }
+  return *this;
+}
+
+template< typename TValue >
+typename Array< TValue >
+::Self &
+Array< TValue >
+::operator=( VnlVectorType && rhs)
+{
+  Self temp(rhs);
+  this->Swap(temp);
+  return *this;
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -54,11 +54,16 @@ public:
   Array2D();
   Array2D(unsigned int rows, unsigned int cols);
   Array2D(const Self & array);
+  Array2D(Self && array);
   Array2D(const VnlMatrixType & matrix);
+  Array2D(VnlMatrixType && matrix);
 
-  const Self & operator=(const Self & array);
+  const Self & operator=(const Self &array);
+  Self & operator=(Self &&array);
 
   const Self & operator=(const VnlMatrixType & matrix);
+  Self & operator=(VnlMatrixType && matrix);
+
 
   void Fill(TValue const & v) { this->fill(v); }
 
@@ -76,6 +81,11 @@ public:
 
   /** Destructively set the size to that given.  Will lose data.  */
   void SetSize(unsigned int m, unsigned int n);
+
+  void Swap(Array2D &other)  noexcept
+    {
+      this->VnlMatrixType::swap(other);
+    }
 
   /** This destructor is not virtual for performance reasons. However, this
    * means that subclasses cannot allocate memory. */
@@ -105,6 +115,14 @@ std::ostream & operator<<(std::ostream & os, const Array2D< TValue > & arr)
 
   return os;
 }
+
+
+template< typename TValue >
+inline void swap(Array2D<TValue> &a, Array2D<TValue> &b)
+{
+  a.Swap(b);
+}
+
 
 // declaration of specialization
 template<> ITKCommon_EXPORT std::ostream & operator<<(std::ostream & os, const Array2D< float > & arr);

--- a/Modules/Core/Common/include/itkArray2D.hxx
+++ b/Modules/Core/Common/include/itkArray2D.hxx
@@ -38,22 +38,57 @@ Array2D< TValue >
 /** Constructor from a vnl_matrix */
 template< typename TValue >
 Array2D< TValue >
-::Array2D(const VnlMatrixType & matrix):vnl_matrix< TValue >(matrix)
+::Array2D(const VnlMatrixType & matrix):
+  vnl_matrix< TValue >(matrix)
 {}
+
+
+/** Move Constructor from a vnl_matrix */
+template< typename TValue >
+Array2D< TValue >
+::Array2D( VnlMatrixType && matrix):
+  vnl_matrix< TValue >()
+{
+  matrix.swap(*this);
+}
 
 /** Copy Constructor  */
 template< typename TValue >
 Array2D< TValue >
-::Array2D(const Self & array):vnl_matrix< TValue >(array)
+::Array2D(const Self & array):
+  vnl_matrix< TValue >(array)
 {}
+
+
+/** Move Copy Constructor  */
+template< typename TValue >
+Array2D< TValue >
+::Array2D( Self && array):
+  Array2D< TValue >()
+{
+  this->Swap(array);
+}
+
 
 /** Assignment Operator from Array */
 template< typename TValue >
 const Array2D< TValue > &
 Array2D< TValue >
-::operator=(const Self & array)
+::operator=(const Self &array)
 {
   this->VnlMatrixType::operator=(array);
+  return *this;
+}
+
+
+/** Move Assignment Operator from Array */
+template< typename TValue >
+Array2D< TValue > &
+Array2D< TValue >
+::operator=(Self &&array)
+{
+  Self temp(array);
+  this->Swap(temp);
   return *this;
 }
 
@@ -64,6 +99,18 @@ Array2D< TValue >
 ::operator=(const VnlMatrixType & matrix)
 {
   this->VnlMatrixType::operator=(matrix);
+  return *this;
+}
+
+
+/** Move Assignment Operator from vnl_matrix */
+template< typename TValue >
+Array2D< TValue > &
+Array2D< TValue >
+::operator=(VnlMatrixType && matrix)
+{
+  Self temp(matrix);
+  this->Swap(temp);
   return *this;
 }
 

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
@@ -84,7 +84,9 @@ public:
 
     std::cout << "GetDerivative ( " << x << " , " << y << ") = ";
 
-    derivative = DerivativeType(SpaceDimension);
+    // DerivativeType tmp(SpaceDimension);
+    // derivative = std::move(tmp);
+    derivative.SetSize(SpaceDimension);
     derivative[0] = -(3*x + 2*y -2);
     derivative[1] = -(2*x + 6*y +8);
 


### PR DESCRIPTION
The Array and Array2D classes are heavily used in ITK registration for
the transform parameters and Jacobian derivative. Supporting move
semantics and eliminate unnecessary memory allocations and copies.

