### PR TITLE
WIP: Add itkLoad method to IO plugin modules

### DIFF
--- a/CMake/itkLoad.cxx.in
+++ b/CMake/itkLoad.cxx.in
@@ -1,0 +1,38 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *===========================================================
+*/
+
+#include "itk@_factory_class@Factory.h"
+
+/**
+ * Routine that is called when the shared library is loaded by
+ * itk::ObjectFactoryBase::LoadDynamicFactories().
+ *
+ * itkLoad() is C (not C++) function.
+ */
+extern "C"
+{
+
+  @itk-module@_EXPORT
+  itk::ObjectFactoryBase*
+  itkLoad()
+  {
+    static itk::@_factory_class@Factory::Pointer f = itk::@_factory_class@Factory::New();
+    return f.GetPointer();
+  }
+}


### PR DESCRIPTION
ITK has the capability to search in a directory for shared libraries
which contain an exported "itkLoad" method. This method returns a
factory, which is registered. Thus enabling the expansion of the
supported IOs at run-time rather than compile time.

Use cases include making remote or external modules, IO plugins so
that they could be utilized by binaries unaware to the option during
initial compilation.