### PR TITLE
DOC: documentation change for ConnectedComponentImageFilter

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
@@ -32,8 +32,11 @@ namespace itk
  * Each distinct object is assigned a unique label. The filter experiments
  * with some improvements to the existing implementation, and is based on
  * run length encoding along raster lines.
- * The final object labels start with 1 and are consecutive. Objects
- * that are reached earlier by a raster order scan have a lower
+ * If the output background value is set to zero (the default), the final 
+ * object labels start with 1 and are consecutive. If the output background 
+ * is set to a non-zero value (by calling the SetBackgroundValue() routine of the filter), 
+ * the final labels start at 0, and remain consecutive except for skipping the background 
+ * value as needed. Objects that are reached earlier by a raster order scan have a lower
  * label. This is different to the behaviour of the original connected
  * component image filter which did not produce consecutive labels or
  * impose any particular ordering.


### PR DESCRIPTION
DOC: documentation change

For better documentation of how the output labels are assigned when the output background value is set to a non-zero value, as discussed here:
https://discourse.itk.org/t/connectedcomponentimagefilter-doc/1368/2



See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as the PR message.

A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)

[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.

Thanks for contributing to ITK!