### PR TITLE
WIP: Calling ~ObjectFactoryBasePrivateInitializer() twice results in …

### DIFF
--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -73,20 +73,26 @@ public:
   /** Delete the time stamp if it was created. */
   ~ObjectFactoryBasePrivateInitializer()
     {
-    ::itk::ObjectFactoryBase::UnRegisterAllFactories();
-    if ( m_ObjectFactoryBasePrivate->m_InternalFactories )
+    // If m_ObjectFactoryBasePrivate is null, then either we have already
+    // called the destructor once, and we would crash to run it a second time,
+    // or nothing has been initialized, and thier is no need to do anything.
+    if(m_ObjectFactoryBasePrivate)
       {
-      for ( std::list< itk::ObjectFactoryBase * >::iterator i =
-              m_ObjectFactoryBasePrivate->m_InternalFactories->begin();
-            i != m_ObjectFactoryBasePrivate->m_InternalFactories->end(); ++i )
+      ::itk::ObjectFactoryBase::UnRegisterAllFactories();
+      if ( m_ObjectFactoryBasePrivate->m_InternalFactories )
         {
-        (*i)->UnRegister();
+        for ( std::list< itk::ObjectFactoryBase * >::iterator i =
+                m_ObjectFactoryBasePrivate->m_InternalFactories->begin();
+              i != m_ObjectFactoryBasePrivate->m_InternalFactories->end(); ++i )
+          {
+          (*i)->UnRegister();
+          }
+        delete m_ObjectFactoryBasePrivate->m_InternalFactories;
+        m_ObjectFactoryBasePrivate->m_InternalFactories = ITK_NULLPTR;
         }
-      delete m_ObjectFactoryBasePrivate->m_InternalFactories;
-      m_ObjectFactoryBasePrivate->m_InternalFactories = ITK_NULLPTR;
+      delete m_ObjectFactoryBasePrivate;
+      m_ObjectFactoryBasePrivate = ITK_NULLPTR;
       }
-    delete m_ObjectFactoryBasePrivate;
-    m_ObjectFactoryBasePrivate = ITK_NULLPTR;
     }
 
   /** Create the GlobalTimeStamp if needed and return it. */

--- a/Modules/Core/Common/src/itkThreadPoolWin32_BACKUP_75909.cxx
+++ b/Modules/Core/Common/src/itkThreadPoolWin32_BACKUP_75909.cxx
@@ -1,0 +1,116 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkThreadPool.h"
+#include <utility>
+#include <process.h>
+
+namespace itk
+{
+
+//Returns the last Win32 error, in string format. Returns an empty string if there is no error.
+std::string GetLastErrorAsString()
+{
+  //Get the error message, if any.
+  DWORD errorMessageID = ::GetLastError();
+  if (errorMessageID == 0)
+    {
+    return std::string(); //No error message has been recorded
+    }
+
+  LPSTR messageBuffer = nullptr;
+  size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+      NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+  std::string message(messageBuffer, size);
+
+  //Free the buffer.
+  LocalFree(messageBuffer);
+
+  return message;
+}
+
+void
+ThreadPool
+::PlatformCreate(Semaphore &semaphore)
+{
+  semaphore = CreateSemaphore(nullptr, 0, 0x7ffffffel, nullptr);
+  if (semaphore == nullptr)
+    {
+    itkGenericExceptionMacro(<< "CreateSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformWait(Semaphore &semaphore)
+{
+  DWORD dwWaitResult = WaitForSingleObject(semaphore, INFINITE);
+  if (dwWaitResult != WAIT_OBJECT_0)
+    {
+    itkGenericExceptionMacro(<< "SemaphoreWait error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformSignal(Semaphore &semaphore)
+{
+  if (!ReleaseSemaphore(semaphore, 1, nullptr))
+    {
+    itkGenericExceptionMacro(<< "SignalSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformDelete(Semaphore &semaphore)
+{
+  if (!CloseHandle(semaphore))
+    {
+    itkGenericExceptionMacro(<< "DeleteSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+bool
+ThreadPool
+::PlatformClose(ThreadProcessIdType &threadId)
+{
+  return CloseHandle(threadId);
+}
+
+void
+ThreadPool
+::AddThread()
+{
+  ThreadProcessIdType threadHandle = reinterpret_cast<ThreadProcessIdType>(_beginthreadex(
+    nullptr,
+    0,
+    ThreadPool::ThreadExecute,
+    nullptr,
+    0,
+    nullptr));
+
+  if (threadHandle == nullptr)
+    {
+    itkDebugMacro(<< "ERROR adding thread to thread pool");
+    itkExceptionMacro(<< "Cannot create thread. " << GetLastErrorAsString());
+    }
+  m_Threads.push_back(threadHandle);
+}
+
+}

--- a/Modules/Core/Common/src/itkThreadPoolWin32_BASE_75909.cxx
+++ b/Modules/Core/Common/src/itkThreadPoolWin32_BASE_75909.cxx
@@ -1,0 +1,126 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkThreadPool.h"
+#include <utility>
+#include <process.h>
+
+namespace itk
+{
+ThreadIdType
+ThreadPool
+::GetGlobalDefaultNumberOfThreadsByPlatform()
+{
+  SYSTEM_INFO sysInfo;
+
+  GetSystemInfo(&sysInfo);
+  ThreadIdType num = sysInfo.dwNumberOfProcessors;
+  return num;
+}
+
+//Returns the last Win32 error, in string format. Returns an empty string if there is no error.
+std::string GetLastErrorAsString()
+{
+  //Get the error message, if any.
+  DWORD errorMessageID = ::GetLastError();
+  if (errorMessageID == 0)
+    {
+    return std::string(); //No error message has been recorded
+    }
+
+  LPSTR messageBuffer = nullptr;
+  size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+      NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+  std::string message(messageBuffer, size);
+
+  //Free the buffer.
+  LocalFree(messageBuffer);
+
+  return message;
+}
+
+void
+ThreadPool
+::PlatformCreate(Semaphore &semaphore)
+{
+  semaphore = CreateSemaphore(nullptr, 0, 0x7ffffffel, nullptr);
+  if (semaphore == nullptr)
+    {
+    itkGenericExceptionMacro(<< "CreateSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformWait(Semaphore &semaphore)
+{
+  DWORD dwWaitResult = WaitForSingleObject(semaphore, INFINITE);
+  if (dwWaitResult != WAIT_OBJECT_0)
+    {
+    itkGenericExceptionMacro(<< "SemaphoreWait error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformSignal(Semaphore &semaphore)
+{
+  if (!ReleaseSemaphore(semaphore, 1, nullptr))
+    {
+    itkGenericExceptionMacro(<< "SignalSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformDelete(Semaphore &semaphore)
+{
+  if (!CloseHandle(semaphore))
+    {
+    itkGenericExceptionMacro(<< "DeleteSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+bool
+ThreadPool
+::PlatformClose(ThreadProcessIdType &threadId)
+{
+  return CloseHandle(threadId);
+}
+
+void
+ThreadPool
+::AddThread()
+{
+  ThreadProcessIdType threadHandle = reinterpret_cast<ThreadProcessIdType>(_beginthreadex(
+    nullptr,
+    0,
+    ThreadPool::ThreadExecute,
+    nullptr,
+    0,
+    nullptr));
+
+  if (threadHandle == nullptr)
+    {
+    itkDebugMacro(<< "ERROR adding thread to thread pool");
+    itkExceptionMacro(<< "Cannot create thread. " << GetLastErrorAsString());
+    }
+  m_Threads.push_back(threadHandle);
+}
+
+}

--- a/Modules/Core/Common/src/itkThreadPoolWin32_REMOTE_75909.cxx
+++ b/Modules/Core/Common/src/itkThreadPoolWin32_REMOTE_75909.cxx
@@ -1,0 +1,116 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkThreadPool.h"
+#include <utility>
+#include <process.h>
+
+namespace itk
+{
+
+//Returns the last Win32 error, in string format. Returns an empty string if there is no error.
+std::string GetLastErrorAsString()
+{
+  //Get the error message, if any.
+  DWORD errorMessageID = ::GetLastError();
+  if (errorMessageID == 0)
+    {
+    return std::string(); //No error message has been recorded
+    }
+
+  LPSTR messageBuffer = nullptr;
+  size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+      NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+  std::string message(messageBuffer, size);
+
+  //Free the buffer.
+  LocalFree(messageBuffer);
+
+  return message;
+}
+
+void
+ThreadPool
+::PlatformCreate(Semaphore &semaphore)
+{
+  semaphore = CreateSemaphore(nullptr, 0, 0x7ffffffel, nullptr);
+  if (semaphore == nullptr)
+    {
+    itkGenericExceptionMacro(<< "CreateSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformWait(Semaphore &semaphore)
+{
+  DWORD dwWaitResult = WaitForSingleObject(semaphore, INFINITE);
+  if (dwWaitResult != WAIT_OBJECT_0)
+    {
+    itkGenericExceptionMacro(<< "SemaphoreWait error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformSignal(Semaphore &semaphore)
+{
+  if (!ReleaseSemaphore(semaphore, 1, nullptr))
+    {
+    itkGenericExceptionMacro(<< "SignalSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+void
+ThreadPool
+::PlatformDelete(Semaphore &semaphore)
+{
+  if (!CloseHandle(semaphore))
+    {
+    itkGenericExceptionMacro(<< "DeleteSemaphore error. " << GetLastErrorAsString());
+    }
+}
+
+bool
+ThreadPool
+::PlatformClose(ThreadProcessIdType &threadId)
+{
+  return CloseHandle(threadId);
+}
+
+void
+ThreadPool
+::AddThread()
+{
+  ThreadProcessIdType threadHandle = reinterpret_cast<ThreadProcessIdType>(_beginthreadex(
+    nullptr,
+    0,
+    ThreadPool::ThreadExecute,
+    nullptr,
+    0,
+    nullptr));
+
+  if (threadHandle == nullptr)
+    {
+    itkDebugMacro(<< "ERROR adding thread to thread pool");
+    itkExceptionMacro(<< "Cannot create thread. " << GetLastErrorAsString());
+    }
+  m_Threads.push_back(threadHandle);
+}
+
+}

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -569,3 +569,24 @@ itk_python_add_test(NAME itkMetaDataDictionaryPythonTest COMMAND itkMetaDataDict
 itk_python_add_test(NAME itkDirectoryPythonTest COMMAND itkDirectoryTest.py)
 itk_python_expression_add_test(NAME itkObjectPythonTest EXPRESSION "itkObject = itk.Object.New()")
 itk_python_add_test(NAME itkIndexOffsetPythonTest COMMAND itkIndexOffsetTest.py)
+
+if(NOT ITK_BUILD_SHARED_LIBS)
+  macro(BuildSharedTestLibrary _name _type)
+    add_library(SharedTestLibrary${_name} ${_type} SharedTestLibrary${_name}.cxx)
+    itk_module_target_label(SharedTestLibrary${_name})
+    target_link_libraries(SharedTestLibrary${_name} LINK_PUBLIC ${ITKCommon_LIBRARIES})
+    set_property(TARGET SharedTestLibrary${_name} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${ITK_TEST_OUTPUT_DIR})
+  endmacro()
+
+  # Linking static ITK libraries twice, into two different binaries for the same process, is not recommended or supported.
+  BuildSharedTestLibrary(A SHARED)
+  BuildSharedTestLibrary(B SHARED)
+  add_executable(itkObjectFactoryBasePrivateDestructor itkObjectFactoryBasePrivateDestructor.cxx )
+  itk_module_target_label(itkObjectFactoryBasePrivateDestructor)
+  target_link_libraries(itkObjectFactoryBasePrivateDestructor
+      LINK_PUBLIC
+      ${ITKCommon_LIBRARIES}
+      SharedTestLibraryA
+      SharedTestLibraryB)
+itk_add_test(NAME itkObjectFactoryBasePrivateDestructor COMMAND itkObjectFactoryBasePrivateDestructor)
+endif()

--- a/Modules/Core/Common/test/SharedTestLibraryA.cxx
+++ b/Modules/Core/Common/test/SharedTestLibraryA.cxx
@@ -1,0 +1,24 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "SharedTestLibraryA.h"
+
+void bar()
+{
+  typedef itk::Image<float,2> ImageType;
+  ImageType::Pointer image = ImageType::New();
+}

--- a/Modules/Core/Common/test/SharedTestLibraryA.h
+++ b/Modules/Core/Common/test/SharedTestLibraryA.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef SharedTestLibraryA_h
+#define SharedTestLibraryA_h
+
+#include <itkImage.h>
+
+void bar();
+
+#endif

--- a/Modules/Core/Common/test/SharedTestLibraryB.cxx
+++ b/Modules/Core/Common/test/SharedTestLibraryB.cxx
@@ -1,0 +1,24 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+ #include "SharedTestLibraryB.h"
+
+void foo()
+{
+  typedef itk::Image<float,2> ImageType;
+  ImageType::Pointer image = ImageType::New();
+}

--- a/Modules/Core/Common/test/SharedTestLibraryB.h
+++ b/Modules/Core/Common/test/SharedTestLibraryB.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef SharedTestLibraryB_h
+#define SharedTestLibraryB_h
+
+#include <itkImage.h>
+
+void foo();
+
+#endif

--- a/Modules/Core/Common/test/itkObjectFactoryBasePrivateDestructor.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryBasePrivateDestructor.cxx
@@ -1,0 +1,26 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "SharedTestLibraryA.h"
+#include "SharedTestLibraryB.h"
+
+int main()
+{
+  foo();
+  bar();
+  return 0;
+}


### PR DESCRIPTION
…crash

~ObjectFactoryBasePrivateInitializer() should in theory only be called
once, as it is one object that keeps track of one static variable.
In certain cases (i.e. if ITK is used as a static library multiple
times, such as in multiple shared objects themselves linked together,
this destructor could be called multiple times, resulting in a segfault.

Change-Id: I898f29f70337210f6b686802e11e7ef6f88458c0