### PR TITLE
ENH: Adding IOOpenSlide ImageIO remote module to ITK

### DIFF
--- a/Modules/Remote/IOOpenSlide.remote.cmake
+++ b/Modules/Remote/IOOpenSlide.remote.cmake
@@ -1,0 +1,5 @@
+itk_fetch_module(IOOpenSlide
+  "ITK ImageIO for OpenSlide library supported file formats. These are generally TIFF-based microscopy formats."
+  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKIOOpenSlide.git
+  GIT_TAG 1432b1008282b612574522a5025f0df673f00f19
+  )


### PR DESCRIPTION
This module provides an ImageIO for the OpenSlide library supported file
formats. These are generally TIFF-based microscopy formats.

Change-Id: I13979c16e7cd8b40c6c3ae28d884191c9ef52c40
