### PR TITLE
COMP: Add missing mutex include to itkImageToHistogramFilter.h

### DIFF
--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
@@ -18,6 +18,8 @@
 #ifndef itkImageToHistogramFilter_h
 #define itkImageToHistogramFilter_h
 
+#include <mutex>
+
 #include "itkHistogram.h"
 #include "itkImageTransformer.h"
 #include "itkSimpleDataObjectDecorator.h"


### PR DESCRIPTION
To address:

2018-11-07T00:56:29.5022052Z D:/a/1/s/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h:138:8: error: no type named 'mutex' in namespace 'std'
2018-11-07T00:56:29.5188235Z   std::mutex m_Mutex;%