### PR TITLE
BUG: Fix move of histogram smart pointer

### DIFF
--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
@@ -133,7 +133,7 @@ protected:
   virtual void ThreadedComputeMinimumAndMaximum( const RegionType & inputRegionForThread );
 
 
-  virtual void ThreadedMergeHistogram( HistogramType *histogram );
+  virtual void ThreadedMergeHistogram( HistogramPointer &&histogram );
 
   std::mutex m_Mutex;
 

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
@@ -260,13 +260,13 @@ ImageToHistogramFilter< TImage >
     ++inputIt;
     }
 
-  this->ThreadedMergeHistogram( histogram );
+  this->ThreadedMergeHistogram( std::move(histogram) );
 }
 
 template< typename TImage >
 void
 ImageToHistogramFilter< TImage >
-::ThreadedMergeHistogram(HistogramType *histogram)
+::ThreadedMergeHistogram(HistogramPointer &&histogram)
 {
   while (true)
     {

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
@@ -111,7 +111,7 @@ MaskedImageToHistogramFilter< TImage, TMaskImage >
     }
 
 
-  this->ThreadedMergeHistogram( histogram );
+  this->ThreadedMergeHistogram( std::move(histogram) );
 }
 
 } // end of namespace Statistics


### PR DESCRIPTION
Fixes so the a ownership transfer of the histogram pointer can occur
via std::move in the ThreadedMergeHistogram method.
