### PR TITLE
WIP: Fix MINC read/write to convert from/to RAS coordinate system

### DIFF
--- a/Modules/IO/MINC/include/itkMINCImageIO.h
+++ b/Modules/IO/MINC/include/itkMINCImageIO.h
@@ -91,6 +91,11 @@ public:
   void SetCompressionLevel(int level);
   int GetCompressionLevel() const;
 
+  /** Set the conversion between RAS and LPS coordinate systems.
+      Backwards compatibility feature for ezMINC tool */
+  itkSetMacro(ConvertCoordinatesToLPS, bool);
+  itkGetConstMacro(ConvertCoordinatesToLPS, bool);
+
   /*-------- This part of the interface deals with reading data. ------ */
 
   /** Determine the file type. Returns true if this ImageIO can read the
@@ -138,6 +143,8 @@ protected:
 private:
 
   MINCImageIOPImpl *m_MINCPImpl;
+
+  bool m_ConvertCoordinatesToLPS;
 
   MatrixType     m_DirectionCosines;
 

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -459,7 +459,6 @@ void MINCImageIO::ReadImageInformation()
 
   //MINC stores direction cosines in RAS, need to convert to LPS for ITK
   Matrix< double, 3,3 > RAS_tofrom_LPS;
-  RAS_tofrom_LPS.Fill(0.0);
   RAS_tofrom_LPS.SetIdentity();
   RAS_tofrom_LPS(0,0) = -1.0;
   RAS_tofrom_LPS(1,1) = -1.0;

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -252,7 +252,7 @@ MINCImageIO::MINCImageIO()
     }
 
   this->m_UseCompression = true;
-  this->m_ConvertCoordinatesToLPS = true;
+  this->m_ConvertCoordinatesToLPS = false;
   this->m_MINCPImpl->m_CompressionLevel = 4; // Range 0-9; 0 = no file compression, 9 =
                                 // maximum file compression
   this->m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;

--- a/Modules/IO/TransformMINC/include/itkMINCTransformIO.hxx
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformIO.hxx
@@ -103,11 +103,10 @@ MINCTransformIOTemplate<TParametersValueType>
 
       Matrix< double, 3,3 > RAS_affine_transform;
       Matrix< double, 3,3 > LPS_affine_transform;
-      RAS_affine_transform.Fill(0.0);
       RAS_affine_transform.SetIdentity();
+
       //MINC stores transforms in RAS, need to convert to LPS for ITK
       Matrix< double, 3,3 > RAS_tofrom_LPS;
-      RAS_tofrom_LPS.Fill(0.0);
       RAS_tofrom_LPS.SetIdentity();
       RAS_tofrom_LPS(0,0) = -1.0;
       RAS_tofrom_LPS(1,1) = -1.0;
@@ -289,7 +288,6 @@ MINCTransformIOTemplate<TParametersValueType>
       Matrix< double, 3,3 > RAS_tofrom_LPS;
       Matrix< double, 3,3 > RAS_affine_transform;
       Matrix< double, 3,3 > LPS_affine_transform;
-      RAS_tofrom_LPS.Fill(0.0);
       RAS_tofrom_LPS.SetIdentity();
       RAS_tofrom_LPS(0,0) = -1.0;
       RAS_tofrom_LPS(1,1) = -1.0;


### PR DESCRIPTION
Convert the coordinate system from RAS to LPS during MINC loading, and convert back on writing.

Also adds a setting to keep old configuration, so that MINC-based ITK tools (EZMinc) can maintain their original configuration and return sensible coordinate values in MINC-space.

Paging @vfonov 