### PR TITLE
DOC: Fix the ITK Git cheat sheet file link.

### DIFF
--- a/Documentation/GitHelp.md
+++ b/Documentation/GitHelp.md
@@ -4,7 +4,7 @@ Git Help
 Additional information about [Git] may be obtained at these sites:
 
   * ITK Git cheat sheet
-    * [ITK Git PDF desk reference](./Documentation/GitCheatSheet.pdf)
+    * [ITK Git PDF desk reference](./GitCheatSheet.pdf)
   * General resources
     * [Git Homepage][Git]
     * [GitHub Try Git In Your Browser](https://try.github.io/)


### PR DESCRIPTION
Fix the `GitCheatSheet.pdf` file link.

The `Documentation` folder was mistakenly added to the path for the file
link in commit 094379c.