### PR TITLE
ENH: Added HoughTransform2DCirclesImageFilter::UseImageSpacing

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -167,6 +167,12 @@ public:
   itkSetMacro(SweepAngle, double);
   itkGetConstMacro(SweepAngle, double);
 
+  /** Specifies whether to use the spacing of the input image internally, when
+  * doing Gaussian Derivative calculation and Gaussian image filtering. */
+  itkSetMacro(UseImageSpacing, bool);
+  itkGetConstMacro(UseImageSpacing, bool);
+
+
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro( IntConvertibleToOutputCheck,
@@ -212,6 +218,7 @@ private:
   CirclesListSizeType   m_NumberOfCircles;
   double                m_DiscRadiusRatio;
   double                m_Variance;
+  bool                  m_UseImageSpacing;
   ModifiedTimeType      m_OldModifiedTime;
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -39,6 +39,7 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
   m_NumberOfCircles( 1 ),
   m_DiscRadiusRatio( 1 ),
   m_Variance( 10 ),
+  m_UseImageSpacing{ true },
   m_OldModifiedTime( 0 )
 {
   this->SetNumberOfRequiredInputs( 1 );
@@ -108,6 +109,7 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
   const auto DoGFunction = DoGFunctionType::New();
   DoGFunction->SetInputImage(inputImage);
   DoGFunction->SetSigma(m_SigmaGradient);
+  DoGFunction->SetUseImageSpacing(m_UseImageSpacing);
 
   m_RadiusImage = RadiusImageType::New();
 
@@ -229,6 +231,8 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
 
     gaussianFilter->SetInput(outputImage); // The output is the accumulator image
     gaussianFilter->SetVariance(m_Variance);
+    gaussianFilter->SetUseImageSpacing(m_UseImageSpacing);
+
     gaussianFilter->Update();
     const InternalImageType::Pointer postProcessImage = gaussianFilter->GetOutput();
 
@@ -315,6 +319,7 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
   os << indent << "Disc Radius Ratio: " << m_DiscRadiusRatio << std::endl;
   os << indent << "Accumulator blur variance: " << m_Variance << std::endl;
   os << indent << "Sweep angle : " << m_SweepAngle << std::endl;
+  os << indent << "UseImageSpacing: " << m_UseImageSpacing << std::endl;
 
   itkPrintSelfObjectMacro( RadiusImage );
 

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -404,6 +404,10 @@ int itkHoughTransform2DCirclesImageTest( int, char* [] )
   houghFilter->SetNumberOfCircles( numberOfCircles );
   TEST_SET_GET_VALUE( numberOfCircles, houghFilter->GetNumberOfCircles() );
 
+  bool useImageSpacing = false;
+  houghFilter->SetUseImageSpacing( useImageSpacing );
+  TEST_SET_GET_VALUE( useImageSpacing, houghFilter->GetUseImageSpacing() );
+
   houghFilter->SetInput( caster->GetOutput() );
 
   TRY_EXPECT_EXCEPTION( houghFilter->GetCircles() );


### PR DESCRIPTION
Added UseImageSpacing property to allow switching off the
corresponding property from both the image function
(GaussianDerivativeImageFunction) and the smoothing filter
(DiscreteGaussianImageFilter) that are internally used by
HoughTransform2DCirclesImageFilter.

HoughTransform2DCirclesImageFilter::UseImageSpacing is initialized by
'true', in order to preserve the original behavior, by default.