### PR TITLE
ENH: Add script to priviledge C++11 type alias over typedef.

### DIFF
--- a/Utilities/ITKv5Preparation/prefer-type-alias-over-typedef.sh
+++ b/Utilities/ITKv5Preparation/prefer-type-alias-over-typedef.sh
@@ -1,0 +1,37 @@
+cat > ./typdef_vim_script.vim << EOF
+:%s/typedef  *\(.*<\_s*.*[>,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+
+:%s/\*\(.*\) typedef\(s*\)\(.*\)\*/*\1 type alias\3*/ge
+:%s/\*\*\(.*\) typedef\(s*\)\(.*\)/**\1 type alias\3/ge
+:%s/\/\/\(.*\)typedefs/\/\/\1type alias/ge
+
+:%s/typedef  *\(.*<\_s*.*,\_s*.*,\_s*[^>]*>\)  *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/\/\/\(.*\)typedefs/\/\/\1type alias/ge
+:%s/typedef  *\(.*<\_s*.*[>,]\_s.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/\*\(.*\) typedef\(s*\)\(.*\)\*/*\1 type alias\3*/ge
+:%s/\*\*\(.*\) typedef\(s*\)\(.*\)/**\1 type alias\3/ge
+:%s/typedef  *\(.*[><,]*\_s*.*[><,]\_s.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[>,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[>,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+
+:%s/typedef  *\(.*\) * \([a-zA-Z0-9]*\);/using \2 = \1;/g
+:%s/typedef  *\(.*<\_s*.*,\n[^>]*>\)  *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*,.*>\{-}>\)  *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/\(  *\)typedef  *\(.*<.*>\)\_s\(  *\)\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/\1using \4 =\r\1    \2;/ge
+:%s/typedef support\(\.*\)/type alias support/ge
+
+:%s/  *;/;/ge
+:w
+:q
+EOF
+
+for ff in $(git grep -l "typedef" |fgrep -v ThirdParty |head -n 1500); do
+   vim -S ./typdef_vim_script.vim $ff;
+done
+
+rm ./typdef_vim_script.vim


### PR DESCRIPTION
Add script to priviledge C++11 type alias over `typedef`.

This was motivated by this topic:
http://review.source.kitware.com/#/c/23103/

And the change has been applied across many of the ITK remote modules
besides the ITK source itself.

However, the piece of code in the mentioned commit never made into a
script, and even if its use should me marginal because most related code
has been changed, it may be worthwhile to add it here so that it is
accessible if it has to be used again.
