### PR TITLE
WIP: member of dll interface class was declared with dll interface

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_numeric_traits.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_numeric_traits.h
@@ -47,13 +47,13 @@ class VNL_EXPORT vnl_numeric_traits
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr vnl_numeric_traits_not_a_valid_type zero;
+  static constexpr vnl_numeric_traits_not_a_valid_type zero;
 
   //: Multiplicative identity
-  static VNL_EXPORT constexpr vnl_numeric_traits_not_a_valid_type one;
+  static constexpr vnl_numeric_traits_not_a_valid_type one;
 
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr vnl_numeric_traits_not_a_valid_type maxval;
+  static constexpr vnl_numeric_traits_not_a_valid_type maxval;
 
   //: Return value of abs()
   typedef vnl_numeric_traits_not_a_valid_type abs_t;
@@ -72,11 +72,11 @@ class VNL_EXPORT vnl_numeric_traits<bool>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr bool zero = false;
+  static constexpr bool zero = false;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr bool one = true;
+  static constexpr bool one = true;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr bool maxval = true;
+  static constexpr bool maxval = true;
   //: Return value of abs()
   typedef unsigned int abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -94,19 +94,19 @@ class VNL_EXPORT vnl_numeric_traits<char>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr char zero = 0;
+  static constexpr char zero = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr char one = 1;
+  static constexpr char one = 1;
   //: Maximum value which this type can assume.
   //  It is 127 (and not 255) since "char" is not guaranteed to be unsigned.
 #ifdef _MSC_VER
 #ifdef _CHAR_UNSIGNED
-  static VNL_EXPORT constexpr char maxval = 255;
+  static constexpr char maxval = 255;
 #else
-  static VNL_EXPORT constexpr char maxval = 127;
+  static constexpr char maxval = 127;
 #endif
 #else
-  static VNL_EXPORT constexpr char maxval = (char(255)<char(0)?char(127):char(255));
+  static constexpr char maxval = (char(255)<char(0)?char(127):char(255));
 #endif
   //: Return value of abs()
   typedef unsigned char abs_t;
@@ -124,11 +124,11 @@ class VNL_EXPORT vnl_numeric_traits<unsigned char>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr unsigned char zero = 0;
+  static constexpr unsigned char zero = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr unsigned char one = 1;
+  static constexpr unsigned char one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr unsigned char maxval = 255;
+  static constexpr unsigned char maxval = 255;
   //: Return value of abs()
   typedef unsigned char abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -145,11 +145,11 @@ class VNL_EXPORT vnl_numeric_traits<signed char>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr signed char zero = 0;
+  static constexpr signed char zero = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr signed char one = 1;
+  static constexpr signed char one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr signed char maxval = 127;
+  static constexpr signed char maxval = 127;
   //: Return value of abs()
   typedef unsigned char abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -166,11 +166,11 @@ class VNL_EXPORT vnl_numeric_traits<short>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr short zero  = 0;
+  static constexpr short zero  = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr short one = 1;
+  static constexpr short one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr short maxval = 0x7fff; // = 0x7fff;
+  static constexpr short maxval = 0x7fff; // = 0x7fff;
   //: Return value of abs()
   typedef unsigned short abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -187,11 +187,11 @@ class VNL_EXPORT vnl_numeric_traits<unsigned short>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr unsigned short zero  = 0;
+  static constexpr unsigned short zero  = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr unsigned short one = 1;
+  static constexpr unsigned short one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr unsigned short maxval = 0xffff; // = 0xffff;
+  static constexpr unsigned short maxval = 0xffff; // = 0xffff;
   //: Return value of abs()
   typedef unsigned short abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -208,11 +208,11 @@ class VNL_EXPORT vnl_numeric_traits<int>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr int zero  = 0;
+  static constexpr int zero  = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr int one = 1;
+  static constexpr int one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr int maxval = 0x7fffffff; // = 0x7fffffff;
+  static constexpr int maxval = 0x7fffffff; // = 0x7fffffff;
   //: Return value of abs()
   typedef unsigned int abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -229,11 +229,11 @@ class VNL_EXPORT vnl_numeric_traits<unsigned int>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr unsigned int zero  = 0;
+  static constexpr unsigned int zero  = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr unsigned int one = 1;
+  static constexpr unsigned int one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr unsigned int maxval = 0xffffffff; // = 0xffffffff;
+  static constexpr unsigned int maxval = 0xffffffff; // = 0xffffffff;
   //: Return value of abs()
   typedef unsigned int abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -250,11 +250,11 @@ class VNL_EXPORT vnl_numeric_traits<long>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr long zero  = 0;
+  static constexpr long zero  = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr long one = 1;
+  static constexpr long one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr long maxval = sizeof(long)==8?(vxl_uint_64)(-1)/2:0x7fffffffL; // = 0x7fffffffL or 0x7fffffffffffffffL;
+  static constexpr long maxval = sizeof(long)==8?(vxl_uint_64)(-1)/2:0x7fffffffL; // = 0x7fffffffL or 0x7fffffffffffffffL;
   //: Return value of abs()
   typedef unsigned long abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -271,11 +271,11 @@ class VNL_EXPORT vnl_numeric_traits<unsigned long>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr unsigned long zero  = 0;
+  static constexpr unsigned long zero  = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr unsigned long one = 1;
+  static constexpr unsigned long one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr unsigned long maxval =  sizeof(unsigned long)==8?((vxl_uint_64)(-1)):0xffffffffL ;
+  static constexpr unsigned long maxval =  sizeof(unsigned long)==8?((vxl_uint_64)(-1)):0xffffffffL ;
   // = 0xffffffffL or 0xffffffffffffffffL;
   //: Return value of abs()
   typedef unsigned long abs_t;
@@ -295,11 +295,11 @@ class VNL_EXPORT vnl_numeric_traits<long long>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr long long zero  = 0;
+  static constexpr long long zero  = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr long long one = 1;
+  static constexpr long long one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr long long maxval =  sizeof(long long)==8?((vxl_uint_64)(-1))/2:0x7fffffffL ;
+  static constexpr long long maxval =  sizeof(long long)==8?((vxl_uint_64)(-1))/2:0x7fffffffL ;
   //: Return value of abs()
   typedef unsigned long long abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -316,11 +316,11 @@ class VNL_EXPORT vnl_numeric_traits<unsigned long long>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr unsigned long long zero  = 0;
+  static constexpr unsigned long long zero  = 0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr unsigned long long one = 1;
+  static constexpr unsigned long long one = 1;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr unsigned long long maxval = sizeof(unsigned long long)==8?(vxl_uint_64)(-1):0xffffffffL;
+  static constexpr unsigned long long maxval = sizeof(unsigned long long)==8?(vxl_uint_64)(-1):0xffffffffL;
   //: Return value of abs()
   typedef unsigned long long abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -338,11 +338,11 @@ class VNL_EXPORT vnl_numeric_traits<float>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr float zero = 0.0F;
+  static constexpr float zero = 0.0F;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr float one = 1.0F;
+  static constexpr float one = 1.0F;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr float maxval = 3.40282346638528860e+38F;
+  static constexpr float maxval = 3.40282346638528860e+38F;
   //: Return value of abs()
   typedef float abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -359,11 +359,11 @@ class VNL_EXPORT vnl_numeric_traits<double>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr double zero = 0.0;
+  static constexpr double zero = 0.0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr double one = 1.0;
+  static constexpr double one = 1.0;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr double maxval = 1.7976931348623157E+308;
+  static constexpr double maxval = 1.7976931348623157E+308;
   //: Return value of abs()
   typedef double abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -380,11 +380,11 @@ class VNL_EXPORT vnl_numeric_traits<long double>
 {
  public:
   //: Additive identity
-  static VNL_EXPORT constexpr long double zero = 0.0;
+  static constexpr long double zero = 0.0;
   //: Multiplicative identity
-  static VNL_EXPORT constexpr long double one = 1.0;
+  static constexpr long double one = 1.0;
   //: Maximum value which this type can assume
-  static VNL_EXPORT constexpr long double maxval = 1.7976931348623157E+308;
+  static constexpr long double maxval = 1.7976931348623157E+308;
   //: Return value of abs()
   typedef long double abs_t;
   //: Name of a type twice as long as this one for accumulators and products.
@@ -401,11 +401,11 @@ class VNL_EXPORT vnl_numeric_traits< std::complex<float> >
 {
  public:
   //: Additive identity
-  static VNL_EXPORT const std::complex<float> zero;
+  static const std::complex<float> zero;
   //: Multiplicative identity
-  static VNL_EXPORT const std::complex<float> one;
+  static const std::complex<float> one;
   // Maximum value which this type can assume; makes no sense for this type
-  //static VNL_EXPORT const std::complex<float> maxval;
+  //static const std::complex<float> maxval;
 
   //: Return value of abs()
   typedef float abs_t;
@@ -423,11 +423,11 @@ class VNL_EXPORT vnl_numeric_traits< std::complex<double> >
 {
  public:
   //: Additive identity
-  static VNL_EXPORT const std::complex<double> zero;
+  static const std::complex<double> zero;
   //: Multiplicative identity
-  static VNL_EXPORT const std::complex<double> one;
+  static const std::complex<double> one;
   // Maximum value which this type can assume; makes no sense for this type
-  //static VNL_EXPORT const std::complex<double> maxval;
+  //static const std::complex<double> maxval;
 
   //: Return value of abs()
   typedef double abs_t;
@@ -445,11 +445,11 @@ class VNL_EXPORT vnl_numeric_traits< std::complex<long double> >
 {
  public:
   //: Additive identity
-  static VNL_EXPORT const std::complex<long double> zero;
+  static const std::complex<long double> zero;
   //: Multiplicative identity
-  static VNL_EXPORT const std::complex<long double> one;
+  static const std::complex<long double> one;
   // Maximum value which this type can assume; makes no sense for this type
-  //static VNL_EXPORT const std::complex<long double> maxval;
+  //static const std::complex<long double> maxval;
 
   //: Return value of abs()
   typedef long double abs_t;


### PR DESCRIPTION
Affected members: 'zero', 'one' and 'maxval'. Example error message:

C:\Jenkins\workspace\ITKWinVS14Ninja\ITK-src\Modules\ThirdParty\VNL\src\vxl\core\vnl/vnl_numeric_traits.h(75): error C2487: 'zero': member of dll interface class may not be declared with dll interface