### PR TITLE
COMP: Fixed IndexRange warnings -Wshadow -Wmissing-field-initializers

### DIFF
--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -294,12 +294,12 @@ public:
 
   /** Constructs a range of indices for the specified grid size.
    */
-  explicit IndexRange(const SizeType& size)
+  explicit IndexRange(const SizeType& gridSize)
     :
     // Note: Use parentheses instead of curly braces to initialize data members,
     // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."
     m_MinIndex(),
-    m_MaxIndex(CalculateMaxIndex({}, size))
+    m_MaxIndex(CalculateMaxIndex({}, gridSize))
   {
   }
 

--- a/Modules/Core/Common/test/itkIndexRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexRangeGTest.cxx
@@ -140,7 +140,7 @@ TEST(IndexRange, IteratorsCanBePassedToStdForEach)
 
   std::for_each(range.begin(), range.end(), [](const IndexType index)
   {
-    EXPECT_TRUE(index >= IndexType{});
+    EXPECT_TRUE(index >= IndexType());
   });
 }
 
@@ -155,7 +155,7 @@ TEST(IndexRange, CanBeUsedAsExpressionOfRangeBasedForLoop)
 
   for (auto&& index : range)
   {
-    EXPECT_TRUE(index >= IndexType{});
+    EXPECT_TRUE(index >= IndexType());
   }
 }
 


### PR DESCRIPTION
Fixed two types of warnings from Linux-x86_64-gcc4.8-m32:

itkIndexRange.h:298:5: warning: declaration of 'size' shadows a member of 'this' [-Wshadow]

itkIndexRangeGTest.cxx: warning: missing initializer for member 'itk::Index<2u>::m_InternalArray' [-Wmissing-field-initializers]

Reported by Hans J Johnson @hjmjohnson 