### PR TITLE
ITKv5_CONST macro for VerifyPreconditions() and VerifyInputInformation()

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -267,7 +267,9 @@ This change should be relevant only in tests.
 With ITK 5.0, `itk::ProcessObject::VerifyPreconditions()`  and
 `itk::ProcessObject::VerifyInputInformation` are now declared `const`,
 so if you have overridden these virtual member function, make sure that you
-also add `const`. 
+also add `const`. If your application needs to compile with both ITKv4 and ITKv5,
+you should use macro `ITKv5_CONST` instead of `const` keyword.
+This macro is present in ITKv4 since [TODO commit link].
 
 Update scripts
 --------------

--- a/Modules/Core/Common/include/itkImageToImageFilter.h
+++ b/Modules/Core/Common/include/itkImageToImageFilter.h
@@ -232,7 +232,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
 
   /** What is the input requested region that is required to produce
    * the output requested region? The base assumption for image

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -165,7 +165,7 @@ ImageToImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 ImageToImageFilter< TInputImage, TOutputImage >
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
 
   using ImageBaseType = const ImageBase< InputImageDimension >;

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1336,6 +1336,14 @@ class kernel                                \
 #define ITK_ITERATOR_FINAL
 #endif
 
+#if defined( ITKV4_COMPATIBILITY )
+// A macro for methods which are const in ITKv5, but not in ITKv4
+#define ITKv5_CONST
+#else
+// A macro for methods which are const in ITKv5, but not in ITKv4
+#define ITKv5_CONST const
+#endif
+
 #include "itkExceptionObject.h"
 
 /** itkDynamicCastInDebugMode

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -674,7 +674,7 @@ protected:
    * NumberOfRequiredInputs are set and not null.
    *
    */
-  virtual void VerifyPreconditions() const;
+  virtual void VerifyPreconditions() ITKv5_CONST;
 
   /** \brief Verifies that the inputs meta-data is consistent and valid
    * for continued execution of the pipeline, throws an exception if
@@ -686,7 +686,7 @@ protected:
    * check if all the inputs are in the same coordinate frame.
    *
    */
-  virtual void VerifyInputInformation() const;
+  virtual void VerifyInputInformation() ITKv5_CONST;
 
   /** What is the input requested region that is required to produce the
    * output requested region? By default, the largest possible region is

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1400,7 +1400,7 @@ ProcessObject
 
 void
 ProcessObject
-::VerifyPreconditions() const
+::VerifyPreconditions() ITKv5_CONST
 {
   /**
    * Make sure that all the required named inputs are there and non null
@@ -1446,7 +1446,7 @@ ProcessObject
 
 void
 ProcessObject
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
 }
 

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
@@ -129,7 +129,7 @@ protected:
 
   void AfterThreadedGenerateData() override;
 
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
 
   OutputPixelType m_DifferenceThreshold;
 

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -276,7 +276,7 @@ ComparisonImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 ComparisonImageFilter< TInputImage, TOutputImage >
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
   if(m_VerifyInputInformation)
     {

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -120,7 +120,7 @@ protected:
 
   /** Default superclass implementation ensures that input images
    * occupy same physical space. This is not needed for this filter. */
-  void VerifyInputInformation() const override {};
+  void VerifyInputInformation() ITKv5_CONST override {};
 
 private:
   bool m_Normalize;

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -242,7 +242,7 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Overlap the VerifyInputInformation method */
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
 
   /** Standard pipeline method.*/
   void GenerateData() override;

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -579,7 +579,7 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
 template< typename TInputImage, typename TOutputImage, typename TMaskImage >
 void
 MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
  {
   // Call the superclass' implementation of this method.
   Superclass::VerifyInputInformation();

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -285,7 +285,7 @@ protected:
 
   void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
-  void VerifyPreconditions() const override;
+  void VerifyPreconditions() ITKv5_CONST override;
 
   /** enum to indicate if the gradient image is specified as a single multi-
    * component image or as several separate images */

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -649,7 +649,7 @@ void DiffusionTensor3DReconstructionImageFilter< TReferenceImagePixelType,
                                                  TGradientImagePixelType,
                                                  TTensorPixelType,
                                                  TMaskImageType >
-::VerifyPreconditions() const
+::VerifyPreconditions() ITKv5_CONST
 {
   Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
@@ -103,7 +103,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
 
   /** Overrides GenerateOutputInformation() in order to produce
    * an image which has a different information than the first input.

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -36,7 +36,7 @@ JoinSeriesImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 JoinSeriesImageFilter< TInputImage, TOutputImage >
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
 
   Superclass::VerifyInputInformation();

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -133,7 +133,7 @@ protected:
   ~HessianToObjectnessMeasureImageFilter() override = default;
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
-  void VerifyPreconditions() const override;
+  void VerifyPreconditions() ITKv5_CONST override;
 
   void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -46,7 +46,7 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
-::VerifyPreconditions() const
+::VerifyPreconditions() ITKv5_CONST
 {
   Superclass::VerifyPreconditions();
   if ( m_ObjectDimension >= ImageDimension )

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -107,7 +107,7 @@ public:
   itkNewMacro(Self);
 
   /** Verifies the preconditions of this filter. */
-  void VerifyPreconditions() const override;
+  void VerifyPreconditions() ITKv5_CONST override;
 
   /** Method for evaluating the implicit function over the image. */
   void GenerateData() override;

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -81,7 +81,7 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
 template< typename TInputPixelType, typename TOutputPixelType, typename TRadiusPixelType >
 void
 HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPixelType >
-::VerifyPreconditions() const
+::VerifyPreconditions() ITKv5_CONST
 {
   Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
@@ -156,7 +156,7 @@ protected:
   * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
   void GenerateInputRequestedRegion() override;
 
-  void VerifyPreconditions() const override;
+  void VerifyPreconditions() ITKv5_CONST override;
   void GenerateData() override;
 
   void PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.hxx
@@ -60,7 +60,7 @@ UnsharpMaskImageFilter< TInputImage, TOutputImage, TInternalPrecision >
 template< typename TInputImage, typename TOutputImage, typename TInternalPrecision >
 void
 UnsharpMaskImageFilter< TInputImage, TOutputImage, TInternalPrecision >
-::VerifyPreconditions() const
+::VerifyPreconditions() ITKv5_CONST
 {
   Superclass::VerifyPreconditions();
   if (m_Threshold < 0.0)

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
@@ -179,7 +179,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /* Checks the logic of FrequencyThresholds. */
-  void VerifyPreconditions() const override;
+  void VerifyPreconditions() ITKv5_CONST override;
 
   /* This is the box functor, which implements the filter's behavior. */
   void BandPass( FrequencyIteratorType& frequency );

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
@@ -123,7 +123,7 @@ FrequencyBandImageFilter< TImageType, TFrequencyIterator >
 template< typename TImageType, typename TFrequencyIterator >
 void
 FrequencyBandImageFilter< TImageType, TFrequencyIterator >
-::VerifyPreconditions() const
+::VerifyPreconditions() ITKv5_CONST
 {
   this->Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.h
@@ -228,7 +228,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override {}
+  void VerifyInputInformation() ITKv5_CONST override {}
 
 private:
   InputImagePointer m_ReferenceImage;

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
@@ -172,7 +172,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override {}
+  void VerifyInputInformation() ITKv5_CONST override {}
 
 private:
 

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
@@ -133,7 +133,7 @@ public:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override {}
+  void VerifyInputInformation() ITKv5_CONST override {}
 
 protected:
   PasteImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -303,7 +303,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override { }
+  void VerifyInputInformation() ITKv5_CONST override { }
 
   /** ResampleImageFilter can be implemented as a multithreaded filter.
    * Therefore, this implementation provides a DynamicThreadedGenerateData()

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.h
@@ -161,7 +161,7 @@ protected:
   SliceBySliceImageFilter();
   ~SliceBySliceImageFilter() override = default;
 
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
 
   void GenerateData() override;
 

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
@@ -41,7 +41,7 @@ template< typename TInputImage, typename TOutputImage, typename TInputFilter, ty
 void
 SliceBySliceImageFilter< TInputImage, TOutputImage, TInputFilter, TOutputFilter, TInternalInputImageType,
                          TInternalOutputImageType >
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
 
   Superclass::VerifyInputInformation();

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.h
@@ -148,7 +148,7 @@ protected:
   void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
 
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
 
 private:
   IndexType m_Start;

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -318,7 +318,7 @@ SliceImageFilter< TInputImage, TOutputImage >
 template< class TInputImage, class TOutputImage >
 void
 SliceImageFilter< TInputImage, TOutputImage >
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
 
   Superclass::VerifyInputInformation();

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
@@ -146,7 +146,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
 
 private:
   typename TileImageType::Pointer m_TileImage;

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -368,7 +368,7 @@ TileImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 TileImageFilter< TInputImage, TOutputImage >
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
 
   // Do not call superclass's VerifyInputInformation method.

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -249,7 +249,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
 
   /** This function should be in an interpolator but none of the ITK
    * interpolators at this point handle edge conditions properly

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -113,7 +113,7 @@ WarpImageFilter< TInputImage, TOutputImage, TDisplacementField >
 template< typename TInputImage, typename TOutputImage, typename TDisplacementField >
 void
 WarpImageFilter< TInputImage, TOutputImage, TDisplacementField >
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
   if (ImageDimension != GetDisplacementField()->GetNumberOfComponentsPerPixel())
     {

--- a/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
@@ -100,7 +100,7 @@ protected:
 
   ~DivideImageFilter() override = default;
 
-  void VerifyPreconditions() const override
+  void VerifyPreconditions() ITKv5_CONST override
   {
     Superclass::VerifyPreconditions();
 

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
@@ -179,7 +179,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override {}
+  void VerifyInputInformation() ITKv5_CONST override {}
 
   /** Compute min, max and mean of an image. */
   void ComputeMinMaxMean(const InputImageType *image,

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
@@ -168,7 +168,7 @@ protected:
 
   /* See superclass for doxygen. This method adds the additional check
    * that sigma is greater than zero. */
-  void VerifyPreconditions() const override;
+  void VerifyPreconditions() ITKv5_CONST override;
 
 private:
   /** Compute the N coefficients in the recursive filter. */

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -335,7 +335,7 @@ RecursiveGaussianImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 RecursiveGaussianImageFilter< TInputImage, TOutputImage >
-::VerifyPreconditions() const
+::VerifyPreconditions() ITKv5_CONST
 {
   this->Superclass::VerifyPreconditions();
 

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
@@ -139,7 +139,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override {}
+  void VerifyInputInformation() ITKv5_CONST override {}
 
 private:
   bool m_UseMovingImageGradient;

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -250,7 +250,7 @@ protected:
    *
    * \sa ProcessObject::VerifyInputInformation
    */
-  void VerifyInputInformation() const override {}
+  void VerifyInputInformation() ITKv5_CONST override {}
 
 private:
   RegistrationPointer       m_RegistrationFilter;

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
@@ -165,7 +165,7 @@ protected:
 
   /* See superclass for doxygen. This methods additionally checks that
    * the number of means is not 0. */
-  void VerifyPreconditions() const override;
+  void VerifyPreconditions() ITKv5_CONST override;
 
 private:
   using MeansContainer = std::vector< RealPixelType >;

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
@@ -46,7 +46,7 @@ void ScalarImageKmeansImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 ScalarImageKmeansImageFilter< TInputImage, TOutputImage >
-::VerifyPreconditions() const
+::VerifyPreconditions() ITKv5_CONST
 {
   this->Superclass::VerifyPreconditions();
 

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.h
@@ -138,7 +138,7 @@ protected:
   // Override since the filter produces the entire dataset
   void EnlargeOutputRequestedRegion(DataObject *output) override;
 
-  void VerifyInputInformation() const override;
+  void VerifyInputInformation() ITKv5_CONST override;
   void GenerateData() override;
 };
 } // end namespace itk

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
@@ -67,7 +67,7 @@ IsolatedWatershedImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 IsolatedWatershedImageFilter< TInputImage, TOutputImage >
-::VerifyInputInformation() const
+::VerifyInputInformation() ITKv5_CONST
 {
   Superclass::VerifyInputInformation();
 


### PR DESCRIPTION
ITKv5_CONST enables backwards compatible behavior when ITKV4_COMPATIBILITY
is turned ON for methods which have acquired `const` qualifier in ITKv5.
Breaking changes were originally introduced by commits
3e6b6f5bd6772316aa0fa6b89f31b42bef562112 (on 2018-10-18) and
16eae15c1bb6cc1bae9fba3e09a3102bdc02e955 (on 2018-10-23).