### PR TITLE
BUG: Prevent square root of negative number

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -167,7 +167,11 @@ LabelStatisticsImageFilter< TInputImage, TLabelImage >
       }
 
     // sigma
-    labelStats.m_Sigma = std::sqrt( labelStats.m_Variance );
+    labelStats.m_Sigma = 0.0;
+    if ( labelStats.m_Variance >= 0.0 )
+      {
+      labelStats.m_Sigma = std::sqrt( labelStats.m_Variance );
+      }
     }
 
     {


### PR DESCRIPTION
Assume variance is 0 when intermediate variance value is less than
zero due to numeric inaccuracies.

