### PR TITLE
BUG: Missing default argment override

### DIFF
--- a/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
@@ -319,7 +319,7 @@ public:
         return EXIT_SUCCESS;
         }
       std::string val;
-      if(this->GetElementOB(group,element,val) != EXIT_SUCCESS)
+      if(this->GetElementOB(group,element,val,throwException) != EXIT_SUCCESS)
         {
         DCMTKExceptionOrErrorReturn(<< "Cant find DecimalString element " << std::hex
                        << group << " " << std::hex


### PR DESCRIPTION
Missing default argument override.  When the thowException is
set to false, line 322 should act like lines 116 & 141 and
not throw an exception.