### PR TITLE
ITKv5_CONST macro for VerifyPreconditions and VerifyInputInformation

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -252,6 +252,8 @@ namespace itk
   #define ITK_HAS_CPP11_ALIGNAS error "Replace ITK_HAS_CPP11_ALIGNAS with ITK_COMPILER_CXX_ALIGNAS"
 #endif
 
+// A macro for methods which are const in ITKv5, but not in ITKv4
+#define ITKv5_CONST
 
 #if ITK_COMPILER_CXX_CONSTEXPR
   #define ITK_CONSTEXPR_FUNC constexpr


### PR DESCRIPTION
ITKv5_CONST was introduced on 2018-11-12 by commit
5141d32e39a277318ca0efbbec2e3f68980d3193.
We now define the same macro in ITK 4.13,
so the user applications can build easily
against either version 4 or 5 of the toolkit.
