### PR TITLE
BUG: background label could be the same as one of the object labels

### DIFF
--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -214,7 +214,12 @@ protected:
       const auto label = static_cast< size_t >( m_UnionFind[i] );
       if ( label == i )
         {
-        m_Consecutive[label] = ++consecutiveLabel;
+        if ( consecutiveLabel == backgroundValue )
+          {
+          ++consecutiveLabel;
+          }
+        m_Consecutive[label] = consecutiveLabel;
+        ++consecutiveLabel;
         ++count;
         }
       }

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
@@ -32,8 +32,11 @@ namespace itk
  * Each distinct object is assigned a unique label. The filter experiments
  * with some improvements to the existing implementation, and is based on
  * run length encoding along raster lines.
- * The final object labels start with 1 and are consecutive. Objects
- * that are reached earlier by a raster order scan have a lower
+ * If the output background value is set to zero (the default), the final
+ * object labels start with 1 and are consecutive. If the output background
+ * is set to a non-zero value (by calling the SetBackgroundValue() routine of the filter),
+ * the final labels start at 0, and remain consecutive except for skipping the background
+ * value as needed. Objects that are reached earlier by a raster order scan have a lower
  * label. This is different to the behaviour of the original connected
  * component image filter which did not produce consecutive labels or
  * impose any particular ordering.

--- a/Modules/Segmentation/ConnectedComponents/test/CMakeLists.txt
+++ b/Modules/Segmentation/ConnectedComponents/test/CMakeLists.txt
@@ -49,7 +49,7 @@ itk_add_test(NAME itkConnectedComponentImageFilterTest3
     itkConnectedComponentImageFilterTest DATA{${ITK_DATA_ROOT}/Input/Shapes.png} ${ITK_TEST_OUTPUT_DIR}/ConnectedComponentImageFilterTest3.png 128 255 1)
 itk_add_test(NAME itkConnectedComponentImageFilterBackgroundTest1
       COMMAND ITKConnectedComponentsTestDriver
-    itkConnectedComponentImageFilterBackgroundTest 3)
+    itkConnectedComponentImageFilterBackgroundTest 1)
 itk_add_test(NAME itkConnectedComponentImageFilterBackgroundTest2
       COMMAND ITKConnectedComponentsTestDriver
     itkConnectedComponentImageFilterBackgroundTest -1)


### PR DESCRIPTION
Restoring the test which tests that.
Documentation update authored by @fijoy.
