### PR TITLE
COMP: fix compiler warning in itkIndexRange.h

### DIFF
--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -299,7 +299,7 @@ public:
     // Note: Use parentheses instead of curly braces to initialize data members,
     // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."
     m_MinIndex(),
-    m_MaxIndex(CalculateMaxIndex({}, gridSize))
+    m_MaxIndex(CalculateMaxIndex(typename iterator::MinIndexType(), gridSize))
   {
   }
 


### PR DESCRIPTION
/scratch/dashboards/Linux-x86_64-gcc4.8-valgrindModules/Core/Common/include/itkIndexRange.h:302:46: warning: missing initializer for member 'itk::Index<1u>::m_InternalArray' [-Wmissing-field-initializers]
