### PR TITLE
PERF: Enable MINC internal compression by default

### DIFF
--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -251,7 +251,7 @@ MINCImageIO::MINCImageIO()
     this->AddSupportedWriteExtension(ext);
     }
 
-  this->m_UseCompression = false;
+  this->m_UseCompression = true;
   this->m_MINCPImpl->m_CompressionLevel = 4; // Range 0-9; 0 = no file compression, 9 =
                                 // maximum file compression
   this->m_MINCPImpl->m_Volume_type = MI_TYPE_FLOAT;


### PR DESCRIPTION
MINC has built-in ZLIB compression as part of the underlying HDF5 file format. This is transparent and universally supported. It has pretty nice file size savings particularly in zero-background images due to the compression combined in HDF5 internal chunking. ITK already transparently handles reading these internally compressed files.

Some quick tests show a 30-50% size saving depending upon amount of background voxels.
