### PR TITLE
BUG: Address valgrind leaks for classes which use ScanlineFilterCommon

### DIFF
--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -431,7 +431,7 @@ protected:
       }
   }
 
-  typename EnclosingFilter::Pointer m_EnclosingFilter;
+  WeakPointer<EnclosingFilter> m_EnclosingFilter;
 
   struct WorkUnitData
   {


### PR DESCRIPTION
The ScanlineFilterCommon class is used with multiple inheritance. This
class held a shared pointer to the other parent which could never be
released to the derived classes holding a reference to
themselves. Change the self pointer to a WeakPointer to avoid circular
dependencies.

