### PR TITLE
ENH: adding wrapping for UnaryFrequencyDomainFilter

### DIFF
--- a/Modules/Filtering/ImageFrequency/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFrequency/test/CMakeLists.txt
@@ -18,6 +18,9 @@ itk_add_test(NAME itkFrequencyBandImageFilterEvenTest
 itk_add_test(NAME itkFrequencyBandImageFilterOddTest
   COMMAND ITKImageFrequencyTestDriver itkFrequencyBandImageFilterTest "Odd")
 
+itk_python_expression_add_test(NAME itkUnaryFrequencyDomainFilterPythonTest
+  EXPRESSION "instance = itk.UnaryFrequencyDomainFilter.New()")
+
 itk_python_expression_add_test(NAME itkFrequencyBandImageFilterPythonTest
   EXPRESSION "instance = itk.FrequencyBandImageFilter.New()")
 

--- a/Modules/Filtering/ImageFrequency/wrapping/itkUnaryFrequencyDomainFilter.wrap
+++ b/Modules/Filtering/ImageFrequency/wrapping/itkUnaryFrequencyDomainFilter.wrap
@@ -1,0 +1,7 @@
+itk_wrap_class("itk::UnaryFrequencyDomainFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_COMPLEX_REAL})
+      itk_wrap_template("${ITKM_I${t}${d}}" "${ITKT_I${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
Closes #190. I could not quite properly test this today. Build succeeds on my Linux box, but the Python instantiation test fails due to runtime error in ITKCommon. And on Windows, complete build is also taking super-long.