### PR TITLE
BUG: Avoid premature GaussianDerivative kernel computation HoughCircles

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -107,9 +107,11 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
 
   using DoGFunctionType = GaussianDerivativeImageFunction< InputImageType >;
   const auto DoGFunction = DoGFunctionType::New();
-  DoGFunction->SetInputImage(inputImage);
   DoGFunction->SetSigma(m_SigmaGradient);
   DoGFunction->SetUseImageSpacing(m_UseImageSpacing);
+  // Set input image _after_ setting the other GaussianDerivative properties,
+  // to avoid multiple kernel recomputation within GaussianDerivativeImageFunction.
+  DoGFunction->SetInputImage(inputImage);
 
   m_RadiusImage = RadiusImageType::New();
 


### PR DESCRIPTION
GaussianDerivativeImageFunction only computes its kernel once its input image is valid (not null). To avoid unnecessary kernel recomputation triggered by imageFunction.SetSigma and/or imageFunction.SetUseImageSpacing, just call imageFunction.SetInputImage after the other settings, in HoughTransform2DCirclesImageFilter::GenerateData().