### PR TITLE
BUG: ShapedImageNeighborhoodRange should not try to avoid rvalue offsets

### DIFF
--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -544,6 +544,9 @@ public:
   /** Specifies a range for the neighborhood of a pixel at the specified
    * location. The shape of the neighborhood is specified by a pointer to a
    * contiguous sequence of offsets, relative to the location index.
+   * \note The caller (the client code) should ensure that both the specified
+   * image and the specified shape offsets remain alive while the range (or one
+   * of its iterators) is being used.
    */
   ShapedImageNeighborhoodRange(
     ImageType& image,
@@ -575,12 +578,15 @@ public:
    * offsets, relative to the location index. This container of offsets must be
    * a contiguous container, for example std::vector<OffsetType> or
    * std::array<OffsetType>.
+   * \note The caller (the client code) should ensure that both the specified
+   * image and the specified shape offsets remain alive while the range (or one
+   * of its iterators) is being used.
    */
   template <typename TContainerOfOffsets>
   ShapedImageNeighborhoodRange(
     ImageType& image,
     const IndexType& location,
-    TContainerOfOffsets&& shapeOffsets)
+    const TContainerOfOffsets& shapeOffsets)
     :
   ShapedImageNeighborhoodRange{
     image,
@@ -588,8 +594,6 @@ public:
     shapeOffsets.data(),
     shapeOffsets.size()}
   {
-    static_assert(!std::is_rvalue_reference<decltype(shapeOffsets)>::value,
-      "The container of offsets should not be a temporary (rvalue) object!");
   }
 
   /** Returns an iterator to the first neighborhood pixel. */

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -727,3 +727,20 @@ TEST(ShapedImageNeighborhoodRange, ProvidesReverseIterators)
   EXPECT_EQ(reversedStdVector1, reversedStdVector2);
   EXPECT_EQ(reversedStdVector1, reversedStdVector3);
 }
+
+
+TEST(ShapedImageNeighborhoodRange, ConstructorSupportsRValueShapeOffsets)
+{
+  using ImageType = itk::Image<unsigned char>;
+  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType>;
+  using OffsetType = ImageType::OffsetType;
+
+  const auto image = CreateImage<ImageType>(1, 2);
+  const ImageType::IndexType location{ { 1, 1 } };
+
+  // Note that the expression 'std::vector<OffsetType>{1}' is an rvalue.
+  // The code is carefully written so that this rvalue remains alive while
+  // the range 'RangeType{...}' is being used.
+  ASSERT_EQ(
+    (RangeType{ *image, location, std::vector<OffsetType>{1} }).size(), 1);
+}


### PR DESCRIPTION
One of the ShapedImageNeighborhoodRange constructors had a static_assert, trying to prevent users from accidentally passing a temporary 'rvalue' as container of shape offsets. Unfortunately, this did not completely ensure that the offsets would be kept alive, as long as the range would be used. While it would prevent a valid use case.

Instead of that static_assert, a note is added to the documentation, to make users aware that the shape offsets (and the image!) should remain alive while using the range.