### PR TITLE
BUG: Calling ~ObjectFactoryBasePrivateInitializer() twice results in …

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -630,3 +630,23 @@ set(ITKCommonGTests
       itkMetaDataDictionaryGTest.cxx
 )
 CreateGoogleTestDriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
+if(NOT ITK_BUILD_SHARED_LIBS)
+  macro(BuildSharedTestLibrary _name _type)
+    add_library(SharedTestLibrary${_name} ${_type} SharedTestLibrary${_name}.cxx)
+    itk_module_target_label(SharedTestLibrary${_name})
+    target_link_libraries(SharedTestLibrary${_name} LINK_PUBLIC ${ITKCommon_LIBRARIES})
+    set_property(TARGET SharedTestLibrary${_name} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${ITK_TEST_OUTPUT_DIR})
+  endmacro()
+
+  # Linking static ITK libraries twice, into two different binaries for the same process, is not recommended or supported.
+  BuildSharedTestLibrary(A SHARED)
+  BuildSharedTestLibrary(B SHARED)
+  add_executable(itkObjectFactoryBasePrivateDestructor itkObjectFactoryBasePrivateDestructor.cxx )
+  itk_module_target_label(itkObjectFactoryBasePrivateDestructor)
+  target_link_libraries(itkObjectFactoryBasePrivateDestructor
+      LINK_PUBLIC
+      ${ITKCommon_LIBRARIES}
+      SharedTestLibraryA
+      SharedTestLibraryB)
+itk_add_test(NAME itkObjectFactoryBasePrivateDestructor COMMAND itkObjectFactoryBasePrivateDestructor)
+endif()

--- a/Modules/Core/Common/test/SharedTestLibraryA.cxx
+++ b/Modules/Core/Common/test/SharedTestLibraryA.cxx
@@ -1,0 +1,24 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "SharedTestLibraryA.h"
+
+void bar()
+{
+  typedef itk::Image<float,2> ImageType;
+  ImageType::Pointer image = ImageType::New();
+}

--- a/Modules/Core/Common/test/SharedTestLibraryA.h
+++ b/Modules/Core/Common/test/SharedTestLibraryA.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef SharedTestLibraryA_h
+#define SharedTestLibraryA_h
+
+#include <itkImage.h>
+
+void bar();
+
+#endif

--- a/Modules/Core/Common/test/SharedTestLibraryB.cxx
+++ b/Modules/Core/Common/test/SharedTestLibraryB.cxx
@@ -1,0 +1,24 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+ #include "SharedTestLibraryB.h"
+
+void foo()
+{
+  typedef itk::Image<float,2> ImageType;
+  ImageType::Pointer image = ImageType::New();
+}

--- a/Modules/Core/Common/test/SharedTestLibraryB.h
+++ b/Modules/Core/Common/test/SharedTestLibraryB.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef SharedTestLibraryB_h
+#define SharedTestLibraryB_h
+
+#include <itkImage.h>
+
+void foo();
+
+#endif

--- a/Modules/Core/Common/test/itkObjectFactoryBasePrivateDestructor.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryBasePrivateDestructor.cxx
@@ -1,0 +1,26 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "SharedTestLibraryA.h"
+#include "SharedTestLibraryB.h"
+
+int main()
+{
+  foo();
+  bar();
+  return 0;
+}


### PR DESCRIPTION
…crash

~ObjectFactoryBasePrivateInitializer() should in theory only be called
once, as it is one object that keeps track of one static variable.
In certain cases (i.e. if ITK is used as a static library multiple
times, such as in multiple shared objects themselves linked together,
this destructor could be called multiple times, resulting in a segfault.