### PR TITLE
ENH: Added policy for constant NeighborhoodRange values outside image

### DIFF
--- a/Modules/Core/Common/include/itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h
@@ -1,0 +1,163 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+#ifndef itkConstantBoundaryImageNeighborhoodPixelAccessPolicy_h
+#define itkConstantBoundaryImageNeighborhoodPixelAccessPolicy_h
+
+#include "itkIndex.h"
+#include "itkOffset.h"
+#include "itkSize.h"
+
+namespace itk
+{
+namespace Experimental
+{
+
+/**
+ * \class ConstantBoundaryImageNeighborhoodPixelAccessPolicy
+ * ImageNeighborhoodPixelAccessPolicy class for ShapedImageNeighborhoodRange.
+ * Allows getting and setting the value of a pixel, located in a specified
+ * neighborhood location, at a specified offset. Uses a constant as value
+ * for pixels outside the image border.
+ *
+ * \see ShapedNeighborhoodIterator
+ * \see ConstantBoundaryCondition
+ * \ingroup ImageIterators
+ * \ingroup ITKCommon
+ */
+template <typename TImage>
+class ConstantBoundaryImageNeighborhoodPixelAccessPolicy final
+{
+private:
+  using NeighborhoodAccessorFunctorType = typename TImage::NeighborhoodAccessorFunctorType;
+  using PixelType = typename TImage::PixelType;
+  using InternalPixelType = typename TImage::InternalPixelType;
+
+  using ImageDimensionType = typename TImage::ImageDimensionType;
+  static constexpr ImageDimensionType ImageDimension = TImage::ImageDimension;
+
+  using IndexType = Index<ImageDimension>;
+  using OffsetType = Offset<ImageDimension>;
+  using ImageSizeType = Size<ImageDimension>;
+  using ImageSizeValueType = SizeValueType;
+
+  // Index value to the image buffer, indexing the current pixel. -1 is used to indicate out-of-bounds.
+  const IndexValueType m_PixelIndexValue;
+
+  // A reference to the accessor of the image.
+  const NeighborhoodAccessorFunctorType& m_NeighborhoodAccessor;
+
+  // The constant whose value is returned a pixel value outside the image is queried.
+  const PixelType m_Constant;
+
+
+  // Private helper function. Tells whether the pixel at 'pixelIndex' is inside the image.
+  static bool IsInside(
+    const IndexType& pixelIndex,
+    const ImageSizeType& imageSize) ITK_NOEXCEPT
+  {
+    bool result = true;
+
+    for (ImageDimensionType i = 0; i < ImageDimension; ++i)
+    {
+      const IndexValueType indexValue = pixelIndex[i];
+
+      // Note: Do not 'quickly' break or return out of the for-loop when the
+      // result is false! For performance reasons (loop unrolling, etc.) it
+      // appears preferable to complete the for-loop iteration in this case!
+      result = result &&
+        (indexValue >= 0) &&
+        (static_cast<ImageSizeValueType>(indexValue) < imageSize[i]);
+    }
+    return result;
+  }
+
+
+  // Private helper function. Calculates and returns the index value of the
+  // current pixel within the image buffer.
+  static IndexValueType CalculatePixelIndexValue(
+    const OffsetType& offsetTable,
+    const IndexType& pixelIndex) ITK_NOEXCEPT
+  {
+    IndexValueType result = 0;
+
+    for (ImageDimensionType i = 0; i < ImageDimension; ++i)
+    {
+      result += pixelIndex[i] * offsetTable[i];
+    }
+    return result;
+  }
+
+public:
+  /** This type is necessary to tell the ShapedImageNeighborhoodRange that the
+   * constructor accepts a pixel value as (optional) extra parameter. */
+  using PixelAccessParameterType = PixelType;
+
+  // Deleted member functions:
+  ConstantBoundaryImageNeighborhoodPixelAccessPolicy() = delete;
+  ConstantBoundaryImageNeighborhoodPixelAccessPolicy& operator=(const ConstantBoundaryImageNeighborhoodPixelAccessPolicy&) = delete;
+
+  // Explicitly-defaulted functions:
+  ~ConstantBoundaryImageNeighborhoodPixelAccessPolicy() = default;
+  ConstantBoundaryImageNeighborhoodPixelAccessPolicy(
+    const ConstantBoundaryImageNeighborhoodPixelAccessPolicy&) = default;
+
+  /** Constructor called directly by the pixel proxy of
+   * ShapedImageNeighborhoodRange. */
+  ConstantBoundaryImageNeighborhoodPixelAccessPolicy(
+    const ImageSizeType& imageSize,
+    const OffsetType& offsetTable,
+    const NeighborhoodAccessorFunctorType& neighborhoodAccessor,
+    const IndexType& pixelIndex,
+    const PixelType constant = {}) ITK_NOEXCEPT
+    :
+  m_PixelIndexValue
+  {
+    IsInside(pixelIndex, imageSize) ? CalculatePixelIndexValue(offsetTable, pixelIndex) : -1
+  },
+  m_NeighborhoodAccessor(neighborhoodAccessor),
+  m_Constant{constant}
+  {
+  }
+
+
+  /** Retrieves the pixel value from the image buffer, at the current
+   * index. When the index is out of bounds, it returns the constant
+   * value specified during construction. */
+  PixelType GetPixelValue(const InternalPixelType* const imageBufferPointer) const ITK_NOEXCEPT
+  {
+    return (m_PixelIndexValue < 0) ?
+      m_Constant :
+      m_NeighborhoodAccessor.Get(imageBufferPointer + m_PixelIndexValue);
+  }
+
+  /** Sets the value of the image buffer at the current index value to the
+   * specified value.  */
+  void SetPixelValue(InternalPixelType* const imageBufferPointer, const PixelType& pixelValue) const ITK_NOEXCEPT
+  {
+    if (m_PixelIndexValue >= 0)
+    {
+      m_NeighborhoodAccessor.Set(imageBufferPointer + m_PixelIndexValue, pixelValue);
+    }
+  }
+};
+
+} // namespace Experimental
+} // namespace itk
+
+#endif

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -627,6 +627,7 @@ set(ITKCommonGTests
       itkAggregateTypesTest.cxx
       itkBuildInformationTest.cxx
       itkConnectedImageNeighborhoodShapeGTest.cxx
+      itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
       itkImageNeighborhoodOffsetsGTest.cxx
       itkIndexRangeGTest.cxx
       itkShapedImageNeighborhoodRangeGTest.cxx

--- a/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
@@ -1,0 +1,164 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+ // First include the header file to be tested:
+#include "itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h"
+
+#include "itkShapedImageNeighborhoodRange.h"
+#include "itkConstantBoundaryCondition.h"
+#include "itkConstNeighborhoodIterator.h"
+#include "itkImage.h"
+#include "itkImageNeighborhoodOffsets.h"
+#include "itkVectorImage.h"
+
+#include <gtest/gtest.h>
+
+// Test template instantiations for various template arguments:
+template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 1>>;
+template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 2>>;
+template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 3>>;
+template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 4>>;
+template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const itk::Image<short>>;
+template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::VectorImage<short>>;
+template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const itk::VectorImage<short>>;
+
+namespace
+{
+  template<typename TImage>
+  typename TImage::Pointer CreateImage(const unsigned sizeX, const unsigned sizeY)
+  {
+    const auto image = TImage::New();
+    const typename TImage::SizeType imageSize = { { sizeX , sizeY } };
+    image->SetRegions(imageSize);
+    image->Allocate();
+    return image;
+  }
+
+
+  // Creates a test image, filled with a sequence of natural numbers, 1, 2, 3, ..., N.
+  template<typename TImage>
+  typename TImage::Pointer CreateImageFilledWithSequenceOfNaturalNumbers(const unsigned sizeX, const unsigned sizeY)
+  {
+    using PixelType = typename TImage::PixelType;
+    const auto image = CreateImage<TImage>(sizeX, sizeY);
+
+    const unsigned numberOfPixels = sizeX * sizeY;
+
+    PixelType* const bufferPointer = image->GetBufferPointer();
+
+    for (unsigned i = 0; i < numberOfPixels; ++i)
+    {
+      bufferPointer[i] = static_cast<typename TImage::PixelType>(i + 1);
+    }
+    return image;
+  }
+}
+
+
+// When no constant is specified (which is the default), an attempt to retrieve
+// a pixel outside the image boundaries should yield zero, for a scalar pixel type.
+TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsZeroOutsideImageByDefault)
+{
+  using PixelType = int;
+  using ImageType = itk::Image<PixelType>;
+  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType,
+    itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<ImageType> >;
+
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImage<ImageType>(sizeX, sizeY);
+  image->FillBuffer(42);
+
+  const ImageType::IndexType locationOutsideImage{ {-1, -1} };
+  const itk::Size<ImageType::ImageDimension> radius = { {} };
+  const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
+    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+  const RangeType range{ *image, locationOutsideImage, offsets };
+
+  for (const PixelType pixel : range)
+  {
+    EXPECT_EQ(pixel, 0);
+  }
+}
+
+
+// When the constant is added as extra argument of a neighborhood range, an attempt to retrieve
+// a pixel outside the image boundaries should yield this specific constant value.
+TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsSpecifiedConstantOutsideImage)
+{
+  using PixelType = int;
+  using ImageType = itk::Image<PixelType>;
+  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType,
+    itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<ImageType>>;
+
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImage<ImageType>(sizeX, sizeY);
+  image->FillBuffer(42);
+
+  const ImageType::IndexType locationOutsideImage{ {-1, -1} };
+  const itk::Size<ImageType::ImageDimension> radius = { {} };
+  const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
+    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+
+  for (PixelType constantValue = -1; constantValue <= 2; ++constantValue)
+  {
+    const RangeType range{ *image, locationOutsideImage, offsets, constantValue };
+
+    for (const PixelType pixel : range)
+    {
+      EXPECT_EQ(pixel, constantValue);
+    }
+  }
+}
+
+// With this policy, ShapedImageNeighborhoodRange should yield the same pixel
+// values as itk::ConstNeighborhoodIterator with itk::ConstantBoundaryCondition.
+TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsSameValuesAsConstantBoundaryCondition)
+{
+  using PixelType = int;
+  using ImageType = itk::Image<PixelType>;
+  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType,
+    itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const ImageType>>;
+
+  enum { sizeX = 3, sizeY = 4 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  const ImageType::IndexType location{ {} };
+  const itk::Size<ImageType::ImageDimension> radius = { { 1, 2 } };
+  const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
+    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+
+  for (PixelType constantValue = -1; constantValue <= 2; ++constantValue)
+  {
+    const RangeType range{ *image, location, offsets, constantValue };
+
+    itk::ConstantBoundaryCondition<ImageType> boundaryCondition;
+    boundaryCondition.SetConstant(constantValue);
+    itk::ConstNeighborhoodIterator<ImageType, itk::ConstantBoundaryCondition<ImageType>>
+      constNeighborhoodIterator(radius, image, image->GetRequestedRegion());
+    constNeighborhoodIterator.SetLocation(location);
+    constNeighborhoodIterator.SetBoundaryCondition(boundaryCondition);
+
+    itk::SizeValueType i = 0;
+
+    for (const PixelType pixel : range)
+    {
+      EXPECT_EQ(pixel, constNeighborhoodIterator.GetPixel(i));
+      ++i;
+    }
+  }
+}


### PR DESCRIPTION
Added ConstantBoundaryImageNeighborhoodPixelAccessPolicy - a policy to get a specified constant value from ShapedImageNeighborhoodRange when a pixel value outside the image is queried. Equivalent to itk::ConstantBoundaryCondition with itk::ConstNeighborhoodIterator.

Adapted ShapedImageNeighborhoodRange to allow the user to specify an optional pixel access parameter. This parameter allows specifying the constant value for this policy. A policy class that supports this pixel access parameter must have a nested PixelAccessParameterType type.