### PR TITLE
DOC: Suggest using 72 characters or less in commit hooks

### DIFF
--- a/Utilities/Hooks/prepare-commit-msg
+++ b/Utilities/Hooks/prepare-commit-msg
@@ -38,6 +38,13 @@ instructions='#\
 #   PERF:   - performance improvement\
 #   STYLE:  - no logic impact (indentation, comments)\
 #   WIP:    - Work In Progress not ready for merge\
+#
+# The first line of the commit message should preferably be 72 characters
+# or less; the maximum allowed is 78 characters.
+#
+# Follow the first line commit summary with an empty line, then a detailed
+# description in one or more paragraphs.
+#
 # To have an automatic link created between this patch set\
 # and the issue referenced at issues.itk.org, simply\
 # add #NNN somewhere in the commit message.


### PR DESCRIPTION
This ensures the entire summary fits into GitHub's renderings.

Also reference the 78 character max enforced by Git client and pull
request hooks.

Suggest the summary, space, detailed description formatting.

Following [discussion on Discourse](https://discourse.itk.org/t/new-convention-for-commit-messages-on-github/1427/10).