### PR TITLE
Replace centered transforms with non-centered versions

### DIFF
--- a/Examples/RegistrationITKv4/ImageRegistration12.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration12.cxx
@@ -30,7 +30,7 @@
 #include "itkMeanSquaresImageToImageMetricv4.h"
 #include "itkRegularStepGradientDescentOptimizerv4.h"
 
-#include "itkCenteredRigid2DTransform.h"
+#include "itkEuler2DTransform.h"
 #include "itkCenteredTransformInitializer.h"
 
 #include "itkImageFileReader.h"
@@ -109,7 +109,7 @@ int main( int argc, char *argv[] )
   using FixedImageType = itk::Image< PixelType, Dimension >;
   using MovingImageType = itk::Image< PixelType, Dimension >;
 
-  using TransformType = itk::CenteredRigid2DTransform< double >;
+  using TransformType = itk::Euler2DTransform< double >;
 
   using OptimizerType = itk::RegularStepGradientDescentOptimizerv4<double>;
   using MetricType = itk::MeanSquaresImageToImageMetricv4<
@@ -166,8 +166,6 @@ int main( int argc, char *argv[] )
   optimizerScales[0] = 1.0;
   optimizerScales[1] = translationScale;
   optimizerScales[2] = translationScale;
-  optimizerScales[3] = translationScale;
-  optimizerScales[4] = translationScale;
 
   optimizer->SetScales( optimizerScales );
 
@@ -315,10 +313,11 @@ int main( int argc, char *argv[] )
                                       transform->GetParameters();
 
   const double finalAngle           = finalParameters[0];
-  const double finalRotationCenterX = finalParameters[1];
-  const double finalRotationCenterY = finalParameters[2];
-  const double finalTranslationX    = finalParameters[3];
-  const double finalTranslationY    = finalParameters[4];
+  const double finalTranslationX    = finalParameters[1];
+  const double finalTranslationY    = finalParameters[2];
+
+  const double rotationCenterX = registration->GetOutput()->Get()->GetFixedParameters()[0];
+  const double rotationCenterY = registration->GetOutput()->Get()->GetFixedParameters()[1];
 
   const unsigned int numberOfIterations = optimizer->GetCurrentIteration();
   const double bestValue = optimizer->GetValue();
@@ -330,12 +329,12 @@ int main( int argc, char *argv[] )
   std::cout << "Result = " << std::endl;
   std::cout << " Angle (radians) " << finalAngle  << std::endl;
   std::cout << " Angle (degrees) " << finalAngleInDegrees  << std::endl;
-  std::cout << " Center X      = " << finalRotationCenterX  << std::endl;
-  std::cout << " Center Y      = " << finalRotationCenterY  << std::endl;
-  std::cout << " Translation X = " << finalTranslationX  << std::endl;
-  std::cout << " Translation Y = " << finalTranslationY  << std::endl;
-  std::cout << " Iterations    = " << numberOfIterations << std::endl;
-  std::cout << " Metric value  = " << bestValue          << std::endl;
+  std::cout << " Translation X  = " << finalTranslationX  << std::endl;
+  std::cout << " Translation Y  = " << finalTranslationY  << std::endl;
+  std::cout << " Fixed Center X = " << rotationCenterX  << std::endl;
+  std::cout << " Fixed Center Y = " << rotationCenterY  << std::endl;
+  std::cout << " Iterations     = " << numberOfIterations << std::endl;
+  std::cout << " Metric value   = " << bestValue          << std::endl;
 
   //  Software Guide : BeginLatex
   //
@@ -352,17 +351,15 @@ int main( int argc, char *argv[] )
   //  $Y$. Both images have unit-spacing and are shown in Figure
   //  \ref{fig:FixedMovingImageRegistration5}.
   //
-  //  The registration converges after $23$ iterations and produces the
+  //  The registration converges after $20$ iterations and produces the
   //  following results:
   //
   //  \begin{verbatim}
   //
-  //  Angle (radians) 0.174407
-  //  Angle (degrees) 9.99281
-  //  Center X      = 111.172
-  //  Center Y      = 131.563
-  //  Translation X = 12.4584
-  //  Translation Y = 16.0726
+  //  Angle (radians) 0.174712
+  //  Angle (degrees) 10.0103
+  //  Translation X = 12.4521
+  //  Translation Y = 16.0765
   //
   //  \end{verbatim}
   //

--- a/Examples/RegistrationITKv4/ImageRegistration14.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration14.cxx
@@ -27,7 +27,7 @@
 // Software Guide : BeginCodeSnippet
 #include "itkImageRegistrationMethod.h"
 
-#include "itkCenteredRigid2DTransform.h"
+#include "itkEuler2DTransform.h"
 #include "itkCenteredTransformInitializer.h"
 
 #include "itkNormalizedMutualInformationHistogramImageToImageMetric.h"
@@ -111,7 +111,7 @@ int main( int argc, char *argv[] )
   using FixedImageType = itk::Image< PixelType, Dimension >;
   using MovingImageType = itk::Image< PixelType, Dimension >;
 
-  using TransformType = itk::CenteredRigid2DTransform< double >;
+  using TransformType = itk::Euler2DTransform< double >;
 
   using OptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
   using InterpolatorType = itk::LinearInterpolateImageFunction<
@@ -223,10 +223,8 @@ int main( int argc, char *argv[] )
   FixedImageType::SpacingType spacing = fixedImage->GetSpacing();
 
   optimizerScales[0] = 1.0 / 0.1;  // make angle move slowly
-  optimizerScales[1] = 10000.0;    // prevent the center from moving
-  optimizerScales[2] = 10000.0;    // prevent the center from moving
-  optimizerScales[3] = 1.0 / ( 0.1 * size[0] * spacing[0] );
-  optimizerScales[4] = 1.0 / ( 0.1 * size[1] * spacing[1] );
+  optimizerScales[1] = 1.0 / ( 0.1 * size[0] * spacing[0] );
+  optimizerScales[2] = 1.0 / ( 0.1 * size[1] * spacing[1] );
   std::cout << "optimizerScales = " << optimizerScales << std::endl;
   optimizer->SetScales( optimizerScales );
 
@@ -273,10 +271,12 @@ int main( int argc, char *argv[] )
   using ParametersType = RegistrationType::ParametersType;
   ParametersType finalParameters = registration->GetLastTransformParameters();
   const double finalAngle           = finalParameters[0];
-  const double finalRotationCenterX = finalParameters[1];
-  const double finalRotationCenterY = finalParameters[2];
-  const double finalTranslationX    = finalParameters[3];
-  const double finalTranslationY    = finalParameters[4];
+  const double finalTranslationX    = finalParameters[1];
+  const double finalTranslationY    = finalParameters[2];
+
+  const double rotationCenterX = registration->GetOutput()->Get()->GetFixedParameters()[0];
+  const double rotationCenterY = registration->GetOutput()->Get()->GetFixedParameters()[1];
+
 
   const unsigned int numberOfIterations = optimizer->GetCurrentIteration();
   const double bestValue = optimizer->GetValue();
@@ -286,12 +286,12 @@ int main( int argc, char *argv[] )
   std::cout << " Result = " << std::endl;
   std::cout << " Angle (radians) " << finalAngle  << std::endl;
   std::cout << " Angle (degrees) " << finalAngleInDegrees  << std::endl;
-  std::cout << " Center X      = " << finalRotationCenterX  << std::endl;
-  std::cout << " Center Y      = " << finalRotationCenterY  << std::endl;
-  std::cout << " Translation X = " << finalTranslationX  << std::endl;
-  std::cout << " Translation Y = " << finalTranslationY  << std::endl;
-  std::cout << " Iterations    = " << numberOfIterations << std::endl;
-  std::cout << " Metric value  = " << bestValue          << std::endl;
+  std::cout << " Translation X  = " << finalTranslationX  << std::endl;
+  std::cout << " Translation Y  = " << finalTranslationY  << std::endl;
+  std::cout << " Fixed Center X = " << rotationCenterX  << std::endl;
+  std::cout << " Fixed Center Y = " << rotationCenterY  << std::endl;
+  std::cout << " Iterations     = " << numberOfIterations << std::endl;
+  std::cout << " Metric value   = " << bestValue          << std::endl;
 
   using ResampleFilterType = itk::ResampleImageFilter<
             MovingImageType, FixedImageType >;

--- a/Examples/RegistrationITKv4/ImageRegistration5.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration5.cxx
@@ -37,14 +37,14 @@
 
 // Software Guide : BeginLatex
 //
-// This example illustrates the use of the \doxygen{CenteredRigid2DTransform}
+// This example illustrates the use of the \doxygen{Euler2DTransform}
 // for performing rigid registration in $2D$. The example code is for the
 // most part identical to that presented in Section
 // \ref{sec:IntroductionImageRegistration}.  The main difference is the use
-// of the CenteredRigid2DTransform here instead of the
+// of the Euler2DTransform here instead of the
 // \doxygen{TranslationTransform}.
 //
-// \index{itk::CenteredRigid2DTransform}
+// \index{itk::Euler2DTransform}
 //
 // Software Guide : EndLatex
 
@@ -58,12 +58,12 @@
 //  In addition to the headers included in previous examples, the
 //  following header must also be included.
 //
-//  \index{itk::CenteredRigid2DTransform!header}
+//  \index{itk::Euler2DTransform!header}
 //
 //  Software Guide : EndLatex
 
 // Software Guide : BeginCodeSnippet
-#include "itkCenteredRigid2DTransform.h"
+#include "itkEuler2DTransform.h"
 // Software Guide : EndCodeSnippet
 
 
@@ -138,12 +138,12 @@ int main( int argc, char *argv[] )
   //  template parameter for this class is the representation type of the
   //  space coordinates.
   //
-  //  \index{itk::CenteredRigid2DTransform!Instantiation}
+  //  \index{itk::Euler2DTransform!Instantiation}
   //
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  using TransformType = itk::CenteredRigid2DTransform< double >;
+  using TransformType = itk::Euler2DTransform< double >;
   // Software Guide : EndCodeSnippet
 
 
@@ -230,8 +230,8 @@ int main( int argc, char *argv[] )
   //  This transform will be initialized, and its initial parameters will be
   //  used when the registration process starts.
   //
-  //  \index{itk::CenteredRigid2DTransform!New()}
-  //  \index{itk::CenteredRigid2DTransform!Pointer}
+  //  \index{itk::Euler2DTransform!New()}
+  //  \index{itk::Euler2DTransform!Pointer}
   //
   //  Software Guide : EndLatex
 
@@ -365,8 +365,7 @@ int main( int argc, char *argv[] )
   //  Keep in mind that the scale of units in rotation and translation is
   //  quite different. For example, here we know that the first element of the
   //  parameters array corresponds to the angle that is measured in radians, while
-  //  the other parameters correspond to the translations and the center point
-  //  coordinates that are measured in millimeters,
+  //  the other parameters correspond to the translations that are measured in millimeters,
   //  so a naive application of gradient descent optimizer will not produce a smooth
   //  change of parameters, because a similar change of $\delta$
   //  to each parameter will produce a different magnitude of impact on the transform.
@@ -375,11 +374,11 @@ int main( int argc, char *argv[] )
   //  by the optimizers.
   //
   //  In this example we use small factors in the scales associated with
-  //  translations and the coordinates of the rotation center.
-  //  However, for the transforms with larger parameters sets, it is not intuitive for a user to
-  //  set the scales. Fortunately, a framework for automated estimation of
-  //  parameter scales is provided by ITKv4 that will be discussed later in the example of
-  //  section \ref{sec:MultiStageRegistration}.
+  //  translations. However, for the transforms with larger parameters
+  //  sets, it is not intuitive for a user to  set the
+  //  scales. Fortunately, a framework for automated estimation of
+  //  parameter scales is provided by ITKv4 that will be discussed
+  //  later in the example of section \ref{sec:MultiStageRegistration}.
   //
   //  Software Guide : EndLatex
 
@@ -392,8 +391,6 @@ int main( int argc, char *argv[] )
   optimizerScales[0] = 1.0;
   optimizerScales[1] = translationScale;
   optimizerScales[2] = translationScale;
-  optimizerScales[3] = translationScale;
-  optimizerScales[4] = translationScale;
 
   optimizer->SetScales( optimizerScales );
   // Software Guide : EndCodeSnippet
@@ -470,10 +467,11 @@ int main( int argc, char *argv[] )
                             registration->GetOutput()->Get()->GetParameters();
 
   const double finalAngle           = finalParameters[0];
-  const double finalRotationCenterX = finalParameters[1];
-  const double finalRotationCenterY = finalParameters[2];
-  const double finalTranslationX    = finalParameters[3];
-  const double finalTranslationY    = finalParameters[4];
+  const double finalTranslationX    = finalParameters[1];
+  const double finalTranslationY    = finalParameters[2];
+
+  const double rotationCenterX = registration->GetOutput()->Get()->GetCenter()[0];
+  const double rotationCenterY = registration->GetOutput()->Get()->GetCenter()[1];
 
   const unsigned int numberOfIterations = optimizer->GetCurrentIteration();
 
@@ -485,14 +483,14 @@ int main( int argc, char *argv[] )
   const double finalAngleInDegrees = finalAngle * 180.0 / itk::Math::pi;
 
   std::cout << "Result = " << std::endl;
-  std::cout << " Angle (radians)   = " << finalAngle  << std::endl;
-  std::cout << " Angle (degrees)   = " << finalAngleInDegrees  << std::endl;
-  std::cout << " Center X      = " << finalRotationCenterX  << std::endl;
-  std::cout << " Center Y      = " << finalRotationCenterY  << std::endl;
-  std::cout << " Translation X = " << finalTranslationX  << std::endl;
-  std::cout << " Translation Y = " << finalTranslationY  << std::endl;
-  std::cout << " Iterations    = " << numberOfIterations << std::endl;
-  std::cout << " Metric value  = " << bestValue          << std::endl;
+  std::cout << " Angle (radians) = " << finalAngle  << std::endl;
+  std::cout << " Angle (degrees) = " << finalAngleInDegrees  << std::endl;
+  std::cout << " Translation X   = " << finalTranslationX  << std::endl;
+  std::cout << " Translation Y   = " << finalTranslationY  << std::endl;
+  std::cout << " Fixed Center X  = " << rotationCenterX  << std::endl;
+  std::cout << " Fixed Center Y  = " << rotationCenterY  << std::endl;
+  std::cout << " Iterations      = " << numberOfIterations << std::endl;
+  std::cout << " Metric value    = " << bestValue          << std::endl;
 
 
   //  Software Guide : BeginLatex
@@ -508,21 +506,20 @@ int main( int argc, char *argv[] )
   //  The second image is the result of intentionally rotating the first image
   //  by $10$ degrees around the geometrical center of the image. Both images
   //  have unit-spacing and are shown in Figure
-  //  \ref{fig:FixedMovingImageRegistration5}. The registration takes $20$
+  //  \ref{fig:FixedMovingImageRegistration5}. The registration takes $17$
   //  iterations and produces the results:
   //
   //  \begin{center}
   //  \begin{verbatim}
-  //  [0.17762, 110.489, 128.487, 0.00925022, 0.00140223]
+  //  [0.177612, 0.00681015, 0.00396471]
   //  \end{verbatim}
   //  \end{center}
   //
   //  These results are interpreted as
   //
   //  \begin{itemize}
-  //  \item Angle         =                  $0.17762$     radians
-  //  \item Center        = $( 110.489    , 128.487      )$ millimeters
-  //  \item Translation   = $(   0.00925022,   0.00140223 )$ millimeters
+  //  \item Angle         =                  $0.177612$     radians
+  //  \item Translation   = $( 0.00681015, 0.00396471 )$ millimeters
   //  \end{itemize}
   //
   //  As expected, these values match the misalignment intentionally introduced
@@ -547,7 +544,7 @@ int main( int argc, char *argv[] )
   // \includegraphics[width=0.32\textwidth]{ImageRegistration5DifferenceAfter}
   // \itkcaption[Rigid2D Registration output images]{Resampled moving image
   // (left). Differences between the fixed and moving images, before (center)
-  // and after (right) registration using the CenteredRigid2D transform.}
+  // and after (right) registration using the Euler2D transform.}
   // \label{fig:ImageRegistration5Outputs}
   // \end{figure}
   //
@@ -564,7 +561,7 @@ int main( int argc, char *argv[] )
   // \includegraphics[height=0.32\textwidth]{ImageRegistration5TraceAngle1}
   // \includegraphics[height=0.32\textwidth]{ImageRegistration5TraceTranslations1}
   // \itkcaption[Rigid2D Registration output plots]{Metric values, rotation
-  // angle and translations during registration with the CenteredRigid2D
+  // angle and translations during registration with the Euler2D
   // transform.}
   // \label{fig:ImageRegistration5Plots}
   // \end{figure}
@@ -700,21 +697,20 @@ int main( int argc, char *argv[] )
   //
   //  \code{optimizer->SetMaximumStepLength( 1.3 );}
   //
-  //  The registration now takes $35$ iterations and produces the following
+  //  The registration now takes $37$ iterations and produces the following
   //  results:
   //
   //  \begin{center}
   //  \begin{verbatim}
-  //  [0.174552, 110.041, 128.917, 12.9339, 15.9149]
+  //  [0.174582, 13.0002, 16.0007]
   //  \end{verbatim}
   //  \end{center}
   //
   //  These parameters are interpreted as
   //
   //  \begin{itemize}
-  //  \item Angle         =                     $0.17452$   radians
-  //  \item Center        = $( 110.041     , 128.917      )$ millimeters
-  //  \item Translation   = $(  12.9339     ,  15.9149     )$ millimeters
+  //  \item Angle         =                     $0.174582$   radians
+  //  \item Translation   = $( 13.0002,  16.0007 )$ millimeters
   //  \end{itemize}
   //
   //  These values approximately match the initial misalignment intentionally
@@ -754,7 +750,7 @@ int main( int argc, char *argv[] )
   // \includegraphics[height=0.32\textwidth]{ImageRegistration5TraceAngle2}
   // \includegraphics[height=0.32\textwidth]{ImageRegistration5TraceTranslations2}
   // \itkcaption[Rigid2D Registration output plots]{Metric values, rotation
-  // angle and translations during the registration using the CenteredRigid2D
+  // angle and translations during the registration using the Euler2D
   // transform on an image with rotation and translation mis-registration.}
   // \label{fig:ImageRegistration5Plots2}
   // \end{figure}

--- a/Examples/RegistrationITKv4/ImageRegistration7.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration7.cxx
@@ -27,12 +27,12 @@
 
 // Software Guide : BeginLatex
 //
-// This example illustrates the use of the \doxygen{CenteredSimilarity2DTransform}
+// This example illustrates the use of the \doxygen{Simularity2DTransform}
 // class for performing registration in $2D$. The example code is for
 // the most part identical to the code presented in Section
 // \ref{sec:InitializingRegistrationWithMoments}.  The main difference is the
-// use of \doxygen{CenteredSimilarity2DTransform} here rather than the
-// \doxygen{CenteredRigid2DTransform} class.
+// use of \doxygen{Simularity2DTransform} here rather than the
+// \doxygen{Euler2DTransform} class.
 //
 // A similarity transform can be seen as a composition of rotations,
 // translations and uniform $\left(\text{isotropic}\right)$ scaling. It
@@ -49,7 +49,7 @@
 // specific center. This center is used both for rotation and scaling.
 //
 //
-// \index{itk::CenteredSimilarity2DTransform}
+// \index{itk::Simularity2DTransform}
 //
 // Software Guide : EndLatex
 
@@ -66,12 +66,12 @@
 //  In addition to the headers included in previous examples, here the
 //  following header must be included.
 //
-//  \index{itk::CenteredSimilarity2DTransform!header}
+//  \index{itk::Simularity2DTransform!header}
 //
 //  Software Guide : EndLatex
 
 // Software Guide : BeginCodeSnippet
-#include "itkCenteredSimilarity2DTransform.h"
+#include "itkSimilarity2DTransform.h"
 // Software Guide : EndCodeSnippet
 
 
@@ -150,12 +150,12 @@ int main( int argc, char *argv[] )
   //  template parameter of this class is the representation type of the
   //  space coordinates.
   //
-  //  \index{itk::CenteredSimilarity2DTransform!Instantiation}
+  //  \index{itk::Simularity2DTransform!Instantiation}
   //
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  using TransformType = itk::CenteredSimilarity2DTransform< double >;
+  using TransformType = itk::Similarity2DTransform< double >;
   // Software Guide : EndCodeSnippet
 
 
@@ -179,7 +179,7 @@ int main( int argc, char *argv[] )
   //  As before, the transform object is constructed and initialized before it
   //  is passed to the registration filter.
   //
-  //  \index{itk::CenteredSimilarity2DTransform!Pointer}
+  //  \index{itk::Simularity2DTransform!Pointer}
   //
   //  Software Guide : EndLatex
 
@@ -206,7 +206,8 @@ int main( int argc, char *argv[] )
   //
   //  In this example, we again use the helper class
   //  \doxygen{CenteredTransformInitializer} to compute a reasonable
-  //  value for the initial center of rotation and the translation.
+  //  value for the initial center of rotation and scaling along with
+  //  an initial translation.
   //
   //  Software Guide : EndLatex
 
@@ -235,8 +236,8 @@ int main( int argc, char *argv[] )
   //
   //  The remaining parameters of the transform are initialized below.
   //
-  //  \index{itk::CenteredSimilarity2DTransform!SetScale()}
-  //  \index{itk::CenteredSimilarity2DTransform!SetAngle()}
+  //  \index{itk::Simularity2DTransform!SetScale()}
+  //  \index{itk::Simularity2DTransform!SetAngle()}
   //
   //  Software Guide : EndLatex
 
@@ -282,10 +283,9 @@ int main( int argc, char *argv[] )
   //  translation are quite different, we take advantage of the scaling
   //  functionality provided by the optimizers. We know that the first element
   //  of the parameters array corresponds to the scale factor, the second
-  //  corresponds to the angle, third and fourth are the center of rotation and
-  //  fifth and sixth are the remaining translation. We use henceforth small
-  //  factors in the scales associated with translations and the rotation
-  //  center.
+  //  corresponds to the angle, third and fourth are the remaining
+  //  translation. We use henceforth small factors in the scales
+  //  associated with translations.
   //
   //  Software Guide : EndLatex
 
@@ -298,8 +298,6 @@ int main( int argc, char *argv[] )
   optimizerScales[1] =  1.0;
   optimizerScales[2] =  translationScale;
   optimizerScales[3] =  translationScale;
-  optimizerScales[4] =  translationScale;
-  optimizerScales[5] =  translationScale;
 
   optimizer->SetScales( optimizerScales );
   // Software Guide : EndCodeSnippet
@@ -372,10 +370,11 @@ int main( int argc, char *argv[] )
 
   const double finalScale           = finalParameters[0];
   const double finalAngle           = finalParameters[1];
-  const double finalRotationCenterX = finalParameters[2];
-  const double finalRotationCenterY = finalParameters[3];
-  const double finalTranslationX    = finalParameters[4];
-  const double finalTranslationY    = finalParameters[5];
+  const double finalTranslationX    = finalParameters[2];
+  const double finalTranslationY    = finalParameters[3];
+
+  const double rotationCenterX = registration->GetOutput()->Get()->GetFixedParameters()[0];
+  const double rotationCenterY = registration->GetOutput()->Get()->GetFixedParameters()[1];
 
   const unsigned int numberOfIterations = optimizer->GetCurrentIteration();
 
@@ -388,15 +387,15 @@ int main( int argc, char *argv[] )
 
   std::cout << std::endl;
   std::cout << "Result = " << std::endl;
-  std::cout << " Scale         = " << finalScale  << std::endl;
-  std::cout << " Angle (radians) " << finalAngle  << std::endl;
-  std::cout << " Angle (degrees) " << finalAngleInDegrees  << std::endl;
-  std::cout << " Center X      = " << finalRotationCenterX  << std::endl;
-  std::cout << " Center Y      = " << finalRotationCenterY  << std::endl;
-  std::cout << " Translation X = " << finalTranslationX  << std::endl;
-  std::cout << " Translation Y = " << finalTranslationY  << std::endl;
-  std::cout << " Iterations    = " << numberOfIterations << std::endl;
-  std::cout << " Metric value  = " << bestValue          << std::endl;
+  std::cout << " Scale           = " << finalScale  << std::endl;
+  std::cout << " Angle (radians) = " << finalAngle  << std::endl;
+  std::cout << " Angle (degrees) =  " << finalAngleInDegrees  << std::endl;
+  std::cout << " Translation X   = " << finalTranslationX  << std::endl;
+  std::cout << " Translation Y   = " << finalTranslationY  << std::endl;
+  std::cout << " Fixed Center X  = " << rotationCenterX  << std::endl;
+  std::cout << " Fixed Center Y  = " << rotationCenterY  << std::endl;
+  std::cout << " Iterations      = " << numberOfIterations << std::endl;
+  std::cout << " Metric value    = " << bestValue          << std::endl;
 
 
   //  Software Guide : BeginLatex
@@ -412,22 +411,21 @@ int main( int argc, char *argv[] )
   //  The second image is the result of intentionally rotating the first image
   //  by $10$ degrees, scaling by $1/1.2$ and then translating by $(-13,-17)$.
   //  Both images have unit-spacing and are shown in Figure
-  //  \ref{fig:FixedMovingImageRegistration7}. The registration takes $60$
+  //  \ref{fig:FixedMovingImageRegistration7}. The registration takes $53$
   //  iterations and produces:
   //
   //  \begin{center}
   //  \begin{verbatim}
-  //  [0.833193, -0.174514, 111.025, 131.92, -12.7267, -12.757]
+  //  [0.833237, -0.174511, -12.8065, -12.7244 ]
   //  \end{verbatim}
   //  \end{center}
   //
   //  That are interpreted as
   //
   //  \begin{itemize}
-  //  \item Scale factor  =                     $0.833193$
-  //  \item Angle         =                     $-0.174514$   radians
-  //  \item Center        = $( 111.025     , 131.92     )$ millimeters
-  //  \item Translation   = $( -12.7267    , -12.757    )$ millimeters
+  //  \item Scale factor  =                     $0.833237$
+  //  \item Angle         =                     $-0.174511$   radians
+  //  \item Translation   = $( -12.8065, -12.7244 )$ millimeters
   //  \end{itemize}
   //
   //
@@ -439,7 +437,7 @@ int main( int argc, char *argv[] )
   // \includegraphics[width=0.44\textwidth]{BrainProtonDensitySliceBorder20}
   // \includegraphics[width=0.44\textwidth]{BrainProtonDensitySliceR10X13Y17S12}
   // \itkcaption[Fixed and Moving image registered with
-  // CenteredSimilarity2DTransform]{Fixed and Moving image provided as input to the
+  // Simularity2DTransform]{Fixed and Moving image provided as input to the
   // registration method using the Similarity2D transform.}
   // \label{fig:FixedMovingImageRegistration7}
   // \end{figure}
@@ -450,7 +448,7 @@ int main( int argc, char *argv[] )
   // \includegraphics[width=0.32\textwidth]{ImageRegistration7Output}
   // \includegraphics[width=0.32\textwidth]{ImageRegistration7DifferenceBefore}
   // \includegraphics[width=0.32\textwidth]{ImageRegistration7DifferenceAfter}
-  // \itkcaption[Output of the CenteredSimilarity2DTransform registration]{Resampled
+  // \itkcaption[Output of the Simularity2DTransform registration]{Resampled
   // moving image (left). Differences between fixed and
   // moving images, before (center) and after (right) registration with the
   // Similarity2D transform.}
@@ -467,7 +465,7 @@ int main( int argc, char *argv[] )
   // \includegraphics[height=0.32\textwidth]{ImageRegistration7TraceAngle}
   // \includegraphics[height=0.32\textwidth]{ImageRegistration7TraceScale}
   // \includegraphics[height=0.32\textwidth]{ImageRegistration7TraceTranslations}
-  // \itkcaption[CenteredSimilarity2DTransform registration plots]{Plots of the Metric,
+  // \itkcaption[Simularity2DTransform registration plots]{Plots of the Metric,
   // rotation angle, scale factor, and translations during
   // the registration using
   // Similarity2D transform.}

--- a/Examples/RegistrationITKv4/ImageRegistration9.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration9.cxx
@@ -31,7 +31,7 @@
 // for performing registration in $2D$. The example code is, for the most part,
 // identical to that in \ref{sec:InitializingRegistrationWithMoments}.
 // The main difference is the use of the AffineTransform here instead of the
-// \doxygen{CenteredRigid2DTransform}. We will focus on the most
+// \doxygen{Euler2DTransform}. We will focus on the most
 // relevant changes in the current code and skip the basic elements already
 // explained in previous examples.
 //


### PR DESCRIPTION
The centered transforms are not recommended to be used because the
transforms are over parameterized, or having dependent
parameters. This makes the optimization more "difficult" and less
efficient.

In the ITKv4 examples, their usage is replaced with the regular
transforms.
