### PR TITLE
ENH: Follow remote repositories name changes.

### DIFF
--- a/Modules/Remote/LabelErodeDilate.remote.cmake
+++ b/Modules/Remote/LabelErodeDilate.remote.cmake
@@ -7,6 +7,6 @@ itk_fetch_module(LabelErodeDilate
   http://www.insight-journal.org/browse/publication/228
   https://hdl.handle.net/10380/3399"
   #UPSTREAM_GIT_REPOSITORY
-  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/LabelErodeDilate.git
-  GIT_TAG 009e0456007885550d23057fbe16fc33e511198b
+  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKLabelErodeDilate.git
+  GIT_TAG 648541fc0ba6c3d06fc7facb2251574b11a0aa40
   )

--- a/Modules/Remote/MeshNoise.remote.cmake
+++ b/Modules/Remote/MeshNoise.remote.cmake
@@ -1,10 +1,10 @@
 # Contact: Davis Marc Vigneault <davis.vigneault@gmail.com>
-itk_fetch_module(DVMeshNoise
+itk_fetch_module(MeshNoise
   "Perturb itk::Mesh and itk::QuadEdgeMesh coordinates with Gaussian noise.
   Please see the following Insight Journal article for an introduction to this module:
   Vigneault, DM.  Perturbing Mesh Vertices with Additive Gaussian Noise.
   http://hdl.handle.net/10380/3567
   "
-  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/DVMeshNoise
-  GIT_TAG 80d7815221173b20fcea75aabd973afb72c1e294
+  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMeshNoise.git
+  GIT_TAG 14dc50513fd5324b1cd75ccb4752572aab9ea617
   )

--- a/Modules/Remote/SmoothingRecursiveYvvGaussianFilter.remote.cmake
+++ b/Modules/Remote/SmoothingRecursiveYvvGaussianFilter.remote.cmake
@@ -2,6 +2,6 @@
 itk_fetch_module(SmoothingRecursiveYvvGaussianFilter
   "GPU and CPU Young & Van Vliet Recursive Gaussian Smoothing Filter: https://hdl.handle.net/10380/3425"
   #UPSTREAM_REPO GIT_REPOSITORY ${git_protocol}://github.com/Inria-Asclepios/SmoothingRecursiveYvvGaussianFilter
-  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/SmoothingRecursiveYvvGaussianFilter.git
-  GIT_TAG 978da8a4a4c1d3739462f5607937119423a72825
+  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter.git
+  GIT_TAG 2b14aa9167d104cce5672b0c9bcbd2b72a4d741a
   )


### PR DESCRIPTION
Follow remote repositories name changes: change the names of the
modules/repositories URLs following recent changes to the following
remotes:
- `LabelErodeDilate` to `ITKLabelErodeDilate`
- `DVMeshNoise` to `ITKMeshNoise`
- `SmoothingRecursiveYvvGaussianFilter` to
  `ITKSmoothingRecursiveYvvGaussianFilter`

Update the git tags accordingly.
