### PR TITLE
COMP: added const qualifier for returning type DeformationFieldType * in itkMultiResolutionPDEDeformableRegistration.h

### DIFF
--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -185,7 +185,7 @@ public:
   /** Get output deformation field. */
   const DeformationFieldType * GetDeformationField(void)
   {
-    return itkDynamicCastInDebugMode<DeformationFieldType *> (this->GetDisplacementField());
+    return itkDynamicCastInDebugMode<const DeformationFieldType *> (this->GetDisplacementField());
   }
 #endif
 


### PR DESCRIPTION
Apparently this V3 compatibility snippets is missing const qualifier as
the return type of the method is defined as const DeformationFieldType *
GetDeformationField(void)
This patch solves this issue
https://insightsoftwareconsortium.atlassian.net/projects/ITK/issues/ITK-3653