### PR TITLE
Small improvements for default pixel accessors

### DIFF
--- a/Modules/Core/Common/include/itkDefaultPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultPixelAccessor.h
@@ -56,7 +56,7 @@ class ITK_TEMPLATE_EXPORT DefaultPixelAccessor
 public:
 
   DefaultPixelAccessor() = default;
-  virtual ~DefaultPixelAccessor() = default;
+  ~DefaultPixelAccessor() = default;
 
   /** External type alias. It defines the external aspect
    * that this class will exhibit. */

--- a/Modules/Core/Common/include/itkDefaultPixelAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkDefaultPixelAccessorFunctor.h
@@ -77,7 +77,7 @@ public:
    * The type PixelAccessorType is obtained from the ImageType over which the iterators
    * are templated.
    * */
-  inline void SetPixelAccessor(PixelAccessorType & accessor)
+  inline void SetPixelAccessor(const PixelAccessorType & accessor)
   {
     m_PixelAccessor = accessor;
   }

--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
@@ -101,7 +101,7 @@ public:
     m_OffsetMultiplier = l - 1;
   }
 
-  virtual ~DefaultVectorPixelAccessor() = default;
+  ~DefaultVectorPixelAccessor() = default;
 
 private:
   VectorLengthType m_VectorLength;

--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessorFunctor.h
@@ -83,7 +83,7 @@ public:
    * The type PixelAccessorType is obtained from the ImageType over which the iterators
    * are templated.
    * */
-  inline void SetPixelAccessor(PixelAccessorType & accessor)
+  inline void SetPixelAccessor(const PixelAccessorType & accessor)
   {
     m_PixelAccessor = accessor;
   }


### PR DESCRIPTION
Two small improvements for default pixel accessors:

-  PERF: Removed 'virtual' from Default Pixel Accessor destructors 
-  STYLE: AccessorFunctor::SetPixelAccessor parameter reference to const 