### PR TITLE
COMP: fixing compile errors on Ubuntu 16.04 with GCC 5.4.0

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_error.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_error.cxx
@@ -15,6 +15,8 @@
 
 #include <iostream>
 
+#include "vnl/vnl_error.h"
+
 //: Raise exception for invalid index.
 void vnl_error_vector_index (char const* fcn, int index)
 {

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_rotation_matrix.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_rotation_matrix.cxx
@@ -1,5 +1,6 @@
 // This is core/vnl/vnl_rotation_matrix.cxx
 #include <cmath>
+#include "vnl_rotation_matrix.h"
 
 bool vnl_rotation_matrix(double const x[3], double **R)
 {

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
@@ -13,7 +13,7 @@
 //   Oct.2010 - Peter Vanroose - mutators and setters now return *this
 // \endverbatim
 #include <iosfwd>
-# include <vnl/vnl_error.h>
+#include <vnl/vnl_error.h>
 
 #include <vcl_compiler.h>
 #ifdef _MSC_VER


### PR DESCRIPTION
Closes #192. Example error messages:

/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h:419: error: undefined reference to 'vnl_error_vector_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h:419: error: undefined reference to 'vnl_error_vector_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix.h:688: error: undefined reference to 'vnl_error_matrix_row_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix.h:690: error: undefined reference to 'vnl_error_matrix_col_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix.h:688: error: undefined reference to 'vnl_error_matrix_row_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix.h:690: error: undefined reference to 'vnl_error_matrix_col_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix_fixed.h:201: error: undefined reference to 'vnl_error_matrix_row_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix_fixed.h:203: error: undefined reference to 'vnl_error_matrix_col_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix_fixed.h:201: error: undefined reference to 'vnl_error_matrix_row_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix_fixed.h:203: error: undefined reference to 'vnl_error_matrix_col_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h:419: error: undefined reference to 'vnl_error_vector_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h:419: error: undefined reference to 'vnl_error_vector_index(char const*, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_matrix_exp.cxx:26: error: undefined reference to 'vnl_rotation_matrix(vnl_vector_fixed<double, 3u> const&)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_quaternion.cxx:132: error: undefined reference to 'vnl_rotation_matrix(vnl_vector_fixed<double, 3u> const&)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_quaternion.cxx:154: error: undefined reference to 'vnl_rotation_matrix(vnl_vector<double> const&)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_quaternion.cxx:155: error: undefined reference to 'vnl_rotation_matrix(vnl_vector<double> const&)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_quaternion.cxx:156: error: undefined reference to 'vnl_rotation_matrix(vnl_vector<double> const&)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h:484: error: undefined reference to 'vnl_error_vector_dimension(char const*, int, int)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_rotation_matrix.cxx:87: error: undefined reference to 'vnl_rotation_matrix(vnl_vector<double> const&)'
/home/dzenan/ITK-git/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h:484: error: undefined reference to 'vnl_error_vector_dimension(char const*, int, int)'


*This is a reminder of what a message in a pull request should minimally require. Please, **read the guidelines below**, and **delete** them so your pull request description only contains the intended message.*

See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as the PR message.

A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)

[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.

**Thanks for contributing to ITK!**
