### PR TITLE
BUG: Remove invalid ShapeDetectionLevelSetFilter arguments

### DIFF
--- a/Examples/Segmentation/ShapeDetectionLevelSetFilter.cxx
+++ b/Examples/Segmentation/ShapeDetectionLevelSetFilter.cxx
@@ -34,9 +34,6 @@
 //  Software Guide : BeginCommandLineArgs
 //    INPUTS:  {BrainProtonDensitySlice.png}
 //    OUTPUTS: {ShapeDetectionLevelSetFilterOutput8.png}
-//    OUTPUTS: {ShapeDetectionLevelSetFilterOutput1.png}
-//    OUTPUTS: {ShapeDetectionLevelSetFilterOutput2.png}
-//    OUTPUTS: {ShapeDetectionLevelSetFilterOutput3.png}
 //    ARGUMENTS:    40 90 5 0.5  -0.3  2.0   .05 1
 //  Software Guide : EndCommandLineArgs
 


### PR DESCRIPTION
These are used when building the ITK Software Guide.
