### PR TITLE
ENH: compile VNL in parallel on Visual Studio

### DIFF
--- a/Modules/ThirdParty/VNL/src/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/CMakeLists.txt
@@ -20,6 +20,9 @@ set(BUILD_EXAMPLES ${BUILD_EXAMPLES} CACHE BOOL "Build the examples from the ITK
 
 foreach(lib itkvcl itkv3p_netlib itktestlib itkvnl itkvnl_algo itknetlib)
   itk_module_target(${lib} NO_INSTALL)
+  if (MSVC)
+    target_compile_definitions(${lib} PRIVATE "/MP") # enable object level parallel compilation
+  endif()
 endforeach()
 
 foreach(exe


### PR DESCRIPTION
As ITKCommon depends on VNL, it is one of the libraries which are built
before main ITK code gets into compile phase. If VNL is modified,
the incremental build becomes sequential during compilation of VNL.
This enables object-level parallelism in VNL libraries.

