### PR TITLE
BUG: Remove static member function variable ( back port to 4.13 )

### DIFF
--- a/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
@@ -158,8 +158,7 @@ LBFGS2Optimizerv4::EvaluateCost( const LBFGS2Optimizerv4::PrecisionType *x,
                                  const LBFGS2Optimizerv4::PrecisionType
                                )
 {
-
-  static ParametersType xItk(n);
+  ParametersType xItk(n);
   std::memcpy(xItk.data_block(), x, n * sizeof(LBFGS2Optimizerv4::PrecisionType) );
 
   DerivativeType gItk(n);


### PR DESCRIPTION
The xItk array was not reinitialized to proper a proper size then
LBFGS2 was using multiple times or with transform adapters. This
caused a buffer over-run and segmentation fault.

