### PR TITLE
COMP: Use the right constructors for fixed eigen3 matrix

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -807,7 +807,7 @@ private:
     using ValueType = typename std::remove_cv<ValueTypeCV>::type;
     using EigenLibMatrixType = Eigen::Matrix< ValueType, VDimension, VDimension, Eigen::RowMajor>;
     using EigenConstMatrixMap = Eigen::Map<const EigenLibMatrixType>;
-    EigenConstMatrixMap inputMatrix(pointerToData, VDimension, VDimension);
+    EigenConstMatrixMap inputMatrix(pointerToData);
     using EigenSolverType = Eigen::SelfAdjointEigenSolver<EigenLibMatrixType>;
     EigenSolverType solver(inputMatrix); // Computes EigenValues and EigenVectors
     const auto & eigenValues = solver.eigenvalues();
@@ -861,7 +861,7 @@ private:
   {
   using ValueType = decltype(GetMatrixValueType(true));
   using EigenLibMatrixType = Eigen::Matrix< ValueType, VDimension, VDimension, Eigen::RowMajor>;
-  EigenLibMatrixType inputMatrix( VDimension, VDimension);
+  EigenLibMatrixType inputMatrix;
   for (unsigned int row = 0; row < VDimension; ++row)
     {
     for (unsigned int col = 0; col < VDimension; ++col)
@@ -923,7 +923,7 @@ private:
     {
     using ValueType = decltype(GetMatrixValueType(true));
     using EigenLibMatrixType = Eigen::Matrix< ValueType, VDimension, VDimension, Eigen::RowMajor>;
-    EigenLibMatrixType inputMatrix(VDimension, VDimension);
+    EigenLibMatrixType inputMatrix;
     for (unsigned int row = 0; row < VDimension; ++row)
       {
       for (unsigned int col = 0; col < VDimension; ++col)
@@ -969,7 +969,7 @@ private:
     using ValueType = typename std::remove_cv<ValueTypeCV>::type;
     using EigenLibMatrixType = Eigen::Matrix< ValueType, VDimension, VDimension, Eigen::RowMajor>;
     using EigenConstMatrixMap = Eigen::Map<const EigenLibMatrixType>;
-    EigenConstMatrixMap inputMatrix(pointerToData, VDimension, VDimension);
+    EigenConstMatrixMap inputMatrix(pointerToData);
     using EigenSolverType = Eigen::SelfAdjointEigenSolver<EigenLibMatrixType>;
     EigenSolverType solver(inputMatrix, Eigen::EigenvaluesOnly);
     auto eigenValues = solver.eigenvalues();

--- a/Modules/ThirdParty/Eigen3/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/CMakeLists.txt
@@ -8,10 +8,9 @@ option(ITK_USE_SYSTEM_EIGEN "Use an outside build of Eigen3." ${ITK_USE_SYSTEM_L
 mark_as_advanced(ITK_USE_SYSTEM_EIGEN)
 
 if(ITK_USE_SYSTEM_EIGEN)
+  find_package(Eigen3 ${_Eigen3_min_version} REQUIRED CONFIG)
   set(Eigen3_DIR_INSTALL ${Eigen3_DIR})
   set(Eigen3_DIR_BUILD ${Eigen3_DIR})
-  set(Eigen3_DIR ${Eigen3_DIR_BUILD})
-  find_package(Eigen3 ${_Eigen3_min_version} REQUIRED CONFIG)
 else()
   set(Eigen3_DIR_INSTALL "${CMAKE_INSTALL_PREFIX}/${ITK_INSTALL_LIBRARY_DIR}/cmake/ITK-${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}/Modules")
   set(Eigen3_DIR_BUILD "${CMAKE_CURRENT_BINARY_DIR}/src/itkeigen")


### PR DESCRIPTION
COMP: Reorder variables associated find_package in Eigen3

The new order always populates `Eigen3_DIR_BUILD|INSTALL` correctly.