### PR TITLE
WIP:  This is work that has partiallly addressed elsewhere BUG: Fix dynamic_cast failure in shared libraries

### DIFF
--- a/CMake/ITKModuleTest.cmake
+++ b/CMake/ITKModuleTest.cmake
@@ -60,6 +60,11 @@ EM_ASM(
     FUNCTION  ProcessArgumentsAndRegisterRequiredFactories
     )
   add_executable(${KIT}TestDriver ${KIT}TestDriver.cxx ${Tests} ${ADDITIONAL_SRC})
+
+  set_target_properties(${KIT}TestDriver PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  set_target_properties(${KIT}TestDriver PROPERTIES C_VISIBILITY_PRESET hidden)
+  set_target_properties(${KIT}TestDriver PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
+
   target_link_libraries(${KIT}TestDriver LINK_PUBLIC ${KIT_LIBS} ${ITKTestKernel_LIBRARIES})
   itk_module_target_label(${KIT}TestDriver)
 endmacro()
@@ -114,6 +119,11 @@ EM_ASM(
     FUNCTION  ProcessArgumentsAndRegisterBuiltInFactories
     )
   add_executable(${KIT}TestDriver ${KIT}TestDriver.cxx ${Tests} ${ADDITIONAL_SRC})
+
+  set_target_properties(${KIT}TestDriver PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  set_target_properties(${KIT}TestDriver PROPERTIES C_VISIBILITY_PRESET hidden)
+  set_target_properties(${KIT}TestDriver PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
+
   target_link_libraries(${KIT}TestDriver LINK_PUBLIC ${KIT_LIBS} ${ITKTestKernel_LIBRARIES})
   itk_module_target_label(${KIT}TestDriver)
 endmacro()

--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -300,4 +300,22 @@ private:
 #include "itkImage.hxx"
 #endif
 
+namespace itk
+{
+/** Explicit instantiations */
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_PUSH()
+#endif
+ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
+
+extern template class ITKCommon_EXPORT Image< float, 2u >; // required by python wrappings
+extern template class ITKCommon_EXPORT Image< unsigned char, 2u >; // required by python wrappings
+
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_POP()
+#else
+  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
+#endif
+}
+
 #endif

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -759,4 +759,30 @@ private:
 #include "itkImageBase.hxx"
 #endif
 
+namespace itk
+{
+/** Explicit instantiations */
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_PUSH()
+#endif
+ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
+
+extern template class ITKCommon_EXPORT ImageBase< 1u >;
+extern template class ITKCommon_EXPORT ImageBase< 2u >;
+extern template class ITKCommon_EXPORT ImageBase< 3u >;
+extern template class ITKCommon_EXPORT ImageBase< 4u >;
+extern template class ITKCommon_EXPORT ImageBase< 5u >;
+extern template class ITKCommon_EXPORT ImageBase< 6u >;
+extern template class ITKCommon_EXPORT ImageBase< 7u >;
+extern template class ITKCommon_EXPORT ImageBase< 8u >;
+extern template class ITKCommon_EXPORT ImageBase< 9u >;
+extern template class ITKCommon_EXPORT ImageBase< 10u >;
+
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_POP()
+#else
+  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
+#endif
+}
+
 #endif

--- a/Modules/Core/Common/include/itkImportImageContainer.h
+++ b/Modules/Core/Common/include/itkImportImageContainer.h
@@ -42,7 +42,7 @@ namespace itk
  */
 
 template< typename TElementIdentifier, typename TElement >
-class ITK_TEMPLATE_EXPORT ImportImageContainer:public Object
+class ITKCommon_EXPORT ImportImageContainer:public Object
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(ImportImageContainer);

--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -59,6 +59,8 @@ set(ITKCommon_SRCS
   itkProgressAccumulator.cxx
   itkNumericTraits.cxx
   itkHexahedronCellTopology.cxx
+  itkImageBase.cxx
+  itkImage.cxx
   itkIndent.cxx
   itkEventObject.cxx
   itkFileOutputWindow.cxx

--- a/Modules/Core/Common/src/itkImage.cxx
+++ b/Modules/Core/Common/src/itkImage.cxx
@@ -1,0 +1,36 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImage.h"
+
+namespace itk
+{
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_PUSH()
+#endif
+ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
+
+template class ITKCommon_EXPORT Image< float, 2u >;
+template class ITKCommon_EXPORT Image< unsigned char, 2u >;
+
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_POP()
+#else
+  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
+#endif
+}  // end namespace itk

--- a/Modules/Core/Common/src/itkImageBase.cxx
+++ b/Modules/Core/Common/src/itkImageBase.cxx
@@ -1,0 +1,44 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImageBase.h"
+
+namespace itk
+{
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_PUSH()
+#endif
+ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
+
+template class ITKCommon_EXPORT ImageBase< 1u >;
+template class ITKCommon_EXPORT ImageBase< 2u >;
+template class ITKCommon_EXPORT ImageBase< 3u >;
+template class ITKCommon_EXPORT ImageBase< 4u >;
+template class ITKCommon_EXPORT ImageBase< 5u >;
+template class ITKCommon_EXPORT ImageBase< 6u >;
+template class ITKCommon_EXPORT ImageBase< 7u >;
+template class ITKCommon_EXPORT ImageBase< 8u >;
+template class ITKCommon_EXPORT ImageBase< 9u >;
+template class ITKCommon_EXPORT ImageBase< 10u >;
+
+#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
+  ITK_GCC_PRAGMA_DIAG_POP()
+#else
+  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
+#endif
+}  // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -34,7 +34,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT ArrowSpatialObject:
+class ITKSpatialObjects_EXPORT ArrowSpatialObject:
   public SpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
@@ -43,7 +43,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT BlobSpatialObject:
+class ITKSpatialObjects_EXPORT BlobSpatialObject:
   public PointBasedSpatialObject<  TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup ITKSpatialObjects
  */
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT BoxSpatialObject:
+class ITKSpatialObjects_EXPORT BoxSpatialObject:
   public SpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -36,7 +36,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT ContourSpatialObject:
+class ITKSpatialObjects_EXPORT ContourSpatialObject:
   public PointBasedSpatialObject<  TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup ITKSpatialObjects
  */
 template< unsigned int TPointDimension = 3 >
-class ITK_TEMPLATE_EXPORT ContourSpatialObjectPoint:
+class ITKSpatialObjects_EXPORT ContourSpatialObjectPoint:
   public SpatialObjectPoint< TPointDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkCylinderSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkCylinderSpatialObject.h
@@ -29,7 +29,7 @@ namespace itk
  * \brief This class describe a cylinder in 3D only.
  * \ingroup ITKSpatialObjects
  */
-class CylinderSpatialObject:
+class ITKSpatialObjects_EXPORT CylinderSpatialObject:
   public SpatialObject< 3 >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.h
@@ -39,7 +39,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT DTITubeSpatialObject:
+class ITKSpatialObjects_EXPORT DTITubeSpatialObject:
   public TubeSpatialObject< TDimension,
                             DTITubeSpatialObjectPoint< TDimension >  >
 {

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup ITKSpatialObjects
  */
 template< unsigned int TPointDimension = 3 >
-class ITK_TEMPLATE_EXPORT DTITubeSpatialObjectPoint:
+class ITKSpatialObjects_EXPORT DTITubeSpatialObjectPoint:
   public TubeSpatialObjectPoint< TPointDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -35,7 +35,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT EllipseSpatialObject:
+class ITKSpatialObjects_EXPORT EllipseSpatialObject:
   public SpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -40,7 +40,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT GaussianSpatialObject:
+class ITKSpatialObjects_EXPORT GaussianSpatialObject:
   public SpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.h
@@ -36,7 +36,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT GroupSpatialObject:
+class ITKSpatialObjects_EXPORT GroupSpatialObject:
   public SpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -35,7 +35,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT ImageMaskSpatialObject:
+class ITKSpatialObjects_EXPORT ImageMaskSpatialObject:
   public ImageSpatialObject< TDimension, unsigned char >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -37,7 +37,7 @@ namespace itk
 template< unsigned int TDimension = 3,
           typename TPixelType = unsigned char
           >
-class ITK_TEMPLATE_EXPORT ImageSpatialObject:
+class ITKSpatialObjects_EXPORT ImageSpatialObject:
   public SpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
@@ -35,7 +35,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT LandmarkSpatialObject:
+class ITKSpatialObjects_EXPORT LandmarkSpatialObject:
   public PointBasedSpatialObject<  TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
@@ -40,7 +40,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT LineSpatialObject:
+class ITKSpatialObjects_EXPORT LineSpatialObject:
   public PointBasedSpatialObject<  TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -39,7 +39,7 @@ namespace itk
  */
 
 template< unsigned int TPointDimension = 3 >
-class ITK_TEMPLATE_EXPORT LineSpatialObjectPoint:
+class ITKSpatialObjects_EXPORT LineSpatialObjectPoint:
   public SpatialObjectPoint< TPointDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -34,7 +34,7 @@ namespace itk
  */
 
 template< typename TMesh = Mesh< int > >
-class ITK_TEMPLATE_EXPORT MeshSpatialObject:
+class ITKSpatialObjects_EXPORT MeshSpatialObject:
   public SpatialObject< TMesh::PointDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkMetaEvent.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaEvent.h
@@ -21,6 +21,8 @@
 #include "itkMacro.h"
 #include "metaEvent.h"
 
+#include "ITKSpatialObjectsExport.h"
+
 namespace itk
 {
 /** \class MetaEvent
@@ -32,9 +34,9 @@ namespace itk
  * \ingroup ITKSpatialObjects
  */
 #if (METAIO_USE_NAMESPACE)
-class MetaEvent : public METAIO_NAMESPACE::MetaEvent
+class ITKSpatialObjects_EXPORT MetaEvent : public METAIO_NAMESPACE::MetaEvent
 #else
-class MetaEvent : public ::MetaEvent
+class ITKSpatialObjects_EXPORT MetaEvent : public ::MetaEvent
 #endif
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkPlaneSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPlaneSpatialObject.h
@@ -34,7 +34,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3  >
-class ITK_TEMPLATE_EXPORT PlaneSpatialObject:
+class ITKSpatialObjects_EXPORT PlaneSpatialObject:
   public SpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -34,7 +34,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT PointBasedSpatialObject:
+class ITKSpatialObjects_EXPORT PointBasedSpatialObject:
   public SpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkPolygonGroupSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPolygonGroupSpatialObject.h
@@ -47,7 +47,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT PolygonGroupSpatialObject:
+class ITKSpatialObjects_EXPORT PolygonGroupSpatialObject:
   public GroupSpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
@@ -27,7 +27,7 @@ namespace itk
  * \ingroup ITKSpatialObjects
  */
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT PolygonSpatialObject:
+class ITKSpatialObjects_EXPORT PolygonSpatialObject:
   public BlobSpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkSceneSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSceneSpatialObject.h
@@ -35,7 +35,7 @@ namespace itk
  */
 
 template< unsigned int TSpaceDimension = 3 >
-class ITK_TEMPLATE_EXPORT SceneSpatialObject:
+class ITKSpatialObjects_EXPORT SceneSpatialObject:
   public Object
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -30,6 +30,8 @@
 #include "itkImageRegion.h"
 #include "itkSpatialObjectTreeNode.h"
 
+#include "ITKSpatialObjectsExport.h"
+
 namespace itk
 {
 /**
@@ -57,7 +59,7 @@ template< unsigned int VDimension >
 class ITK_FORWARD_EXPORT SpatialObjectTreeNode;
 
 template< unsigned int VDimension = 3 >
-class ITK_TEMPLATE_EXPORT SpatialObject:
+class ITKSpatialObjects_EXPORT SpatialObject:
   public DataObject
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectFactoryBase.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectFactoryBase.h
@@ -30,6 +30,7 @@
 
 #include "itkObjectFactoryBase.h"
 #include "itkSpatialObjectExport.h"
+#include "ITKSpatialObjectsExport.h"
 
 namespace itk
 {
@@ -38,7 +39,7 @@ namespace itk
  * \ingroup ITKSpatialObjects
  */
 
-class SpatialObjectFactoryBase:public ObjectFactoryBase
+class ITKSpatialObjects_EXPORT SpatialObjectFactoryBase:public ObjectFactoryBase
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SpatialObjectFactoryBase);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -22,6 +22,8 @@
 #include "vnl/vnl_vector_fixed.h"
 #include "itkRGBAPixel.h"
 
+#include "ITKSpatialObjectsExport.h"
+
 namespace itk
 {
 /** \class SpatialObjectPoint
@@ -34,7 +36,7 @@ namespace itk
  */
 
 template< unsigned int TPointDimension = 3 >
-class ITK_TEMPLATE_EXPORT SpatialObjectPoint
+class ITKSpatialObjects_EXPORT SpatialObjectPoint
 {
 public:
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectTreeNode.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectTreeNode.h
@@ -21,6 +21,8 @@
 #include "itkTreeNode.h"
 #include "itkSpatialObject.h"
 
+#include "ITKSpatialObjectsExport.h"
+
 namespace itk
 {
 
@@ -33,7 +35,7 @@ class ITK_FORWARD_EXPORT SpatialObject;
  * \ingroup ITKSpatialObjects
  */
 template< unsigned int TDimension >
-class ITK_TEMPLATE_EXPORT SpatialObjectTreeNode:public TreeNode< SpatialObject< TDimension > * >
+class ITKSpatialObjects_EXPORT SpatialObjectTreeNode:public TreeNode< SpatialObject< TDimension > * >
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SpatialObjectTreeNode);

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -36,7 +36,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT SurfaceSpatialObject:
+class ITKSpatialObjects_EXPORT SurfaceSpatialObject:
   public PointBasedSpatialObject<  TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
@@ -35,7 +35,7 @@ namespace itk
  */
 
 template< unsigned int TPointDimension = 3 >
-class ITK_TEMPLATE_EXPORT SurfaceSpatialObjectPoint:
+class ITKSpatialObjects_EXPORT SurfaceSpatialObjectPoint:
   public SpatialObjectPoint< TPointDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -40,7 +40,7 @@ namespace itk
 
 template< unsigned int TDimension = 3,
           typename TTubePointType = TubeSpatialObjectPoint< TDimension > >
-class ITK_TEMPLATE_EXPORT TubeSpatialObject:
+class ITKSpatialObjects_EXPORT TubeSpatialObject:
   public PointBasedSpatialObject< TDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
@@ -35,7 +35,7 @@ namespace itk
  */
 
 template< unsigned int TPointDimension = 3 >
-class ITK_TEMPLATE_EXPORT TubeSpatialObjectPoint:
+class ITKSpatialObjects_EXPORT TubeSpatialObjectPoint:
   public SpatialObjectPoint< TPointDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/include/itkVesselTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkVesselTubeSpatialObject.h
@@ -39,7 +39,7 @@ namespace itk
  */
 
 template< unsigned int TDimension = 3 >
-class ITK_TEMPLATE_EXPORT VesselTubeSpatialObject:
+class ITKSpatialObjects_EXPORT VesselTubeSpatialObject:
   public TubeSpatialObject< TDimension,
                             VesselTubeSpatialObjectPoint< TDimension >  >
 {

--- a/Modules/Core/SpatialObjects/include/itkVesselTubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkVesselTubeSpatialObjectPoint.h
@@ -34,7 +34,7 @@ namespace itk
  */
 
 template< unsigned int TPointDimension = 3 >
-class ITK_TEMPLATE_EXPORT VesselTubeSpatialObjectPoint:
+class ITKSpatialObjects_EXPORT VesselTubeSpatialObjectPoint:
   public TubeSpatialObjectPoint< TPointDimension >
 {
 public:

--- a/Modules/Core/SpatialObjects/itk-module.cmake
+++ b/Modules/Core/SpatialObjects/itk-module.cmake
@@ -6,6 +6,7 @@ approximations of shape by combining them into hierarchical structures similar
 to scene graphs.")
 
 itk_module(ITKSpatialObjects
+  ENABLE_SHARED
   DEPENDS
     ITKTransform
   PRIVATE_DEPENDS

--- a/Modules/Core/Transform/include/itkAffineTransform.h
+++ b/Modules/Core/Transform/include/itkAffineTransform.h
@@ -99,7 +99,7 @@ template<
   typename TParametersValueType = double,
   unsigned int NDimensions = 3 >
 // Number of dimensions in the input space
-class ITK_TEMPLATE_EXPORT AffineTransform:
+class ITKTransform_EXPORT AffineTransform:
   public MatrixOffsetTransformBase< TParametersValueType, NDimensions, NDimensions>
 {
 public:


### PR DESCRIPTION
1. Explicitly instantiate commonly used itk::ImageBase and itk::Image templates
to prevent separate compilation units from generating their own typeinfos
which can cause dynamic_cast to fail.

2. Add export statements to SpatialObjects so that typeinfos generated for
those templates are visible to the linker and can be coalesced at link time.
If every compilation unit uses its own private typeinfo this
can cause dynamic_cast to fail.

3. Use hidden visibility when compiling tests so that symbol visibility is
consistent in every compilation unit that goes into the executable.
If the same template is instantiated in two compilation units with different
visibility settings this can cause dynamic_cast to fail.