### PR TITLE
ENH: Added ImageRange: a range of iterators to the pixels of an image

### DIFF
--- a/Modules/Core/Common/include/itkImageRange.h
+++ b/Modules/Core/Common/include/itkImageRange.h
@@ -1,0 +1,620 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+#ifndef itkImageRange_h
+#define itkImageRange_h
+
+#include <cassert>
+#include <cstddef> // For ptrdiff_t.
+#include <iterator> // For random_access_iterator_tag.
+#include <limits>
+#include <type_traits> // For conditional, is_same, and is_const.
+
+#include "itkDefaultPixelAccessor.h"
+#include "itkDefaultPixelAccessorFunctor.h"
+#include "itkDefaultVectorPixelAccessor.h"
+#include "itkDefaultVectorPixelAccessorFunctor.h"
+#include "itkImageRegion.h"
+
+namespace itk
+{
+namespace Experimental
+{
+
+/**
+ * \class ImageRange
+ * Modern C++11 range to iterate over the pixels of an image.
+ * Designed to conform to Standard C++ Iterator requirements,
+ * so that it can be used in range-based for loop, and passed to
+ * Standard C++ algorithms.
+ *
+ * The following example adds 42 to each pixel, using a range-based for loop:
+   \code
+   ImageRange<ImageType> range{ *image };
+
+   for (auto&& pixel : range)
+   {
+     pixel = pixel + 42;
+   }
+   \endcode
+ *
+ * The following example prints the values of the pixels:
+   \code
+   for (const auto pixel : range)
+   {
+     std::cout << pixel << std::endl;
+   }
+   \endcode
+ *
+ * \author Niels Dekker, LKEB, Leiden University Medical Center
+ *
+ * \see ImageIterator
+ * \see ImageConstIterator
+ * \see IndexRange
+ * \see ShapedImageNeighborhoodRange
+ * \ingroup ImageIterators
+ * \ingroup ITKCommon
+ */
+template<typename TImage>
+class ImageRange final
+{
+private:
+  using ImageType = TImage;
+  using PixelType = typename TImage::PixelType;
+  using InternalPixelType = typename TImage::InternalPixelType;
+  using AccessorFunctorType = typename TImage::AccessorFunctorType;
+
+  // Tells whether or not this range supports direct pixel access. If it does,
+  // iterator::operator*() returns a reference to the internally stored pixel,
+  // otherwise iterator::operator*() returns a proxy, which internally uses the
+  // AccessorFunctor of the image to access the pixel indirectly.
+  constexpr static bool SupportsDirectPixelAccess =
+    std::is_same<PixelType, InternalPixelType>::value &&
+    std::is_same<typename TImage::AccessorType, DefaultPixelAccessor<PixelType>>::value &&
+    std::is_same<AccessorFunctorType, DefaultPixelAccessorFunctor<typename std::remove_const<TImage>::type>>::value;
+
+  struct EmptyAccessorFunctor {};
+
+  using OptionalAccessorFunctorType = typename std::conditional<SupportsDirectPixelAccess,
+    EmptyAccessorFunctor, AccessorFunctorType>::type;
+
+  // PixelProxy: internal class that aims to act like a reference to a pixel:
+  // It acts either like 'PixelType &' or like 'const PixelType &', depending
+  // on its boolean template argument, VIsConst.
+  // The proxy retrieves the pixel value using the AccessorFunctor from the image.
+  // Note: the extra TDummy argument aims to fix AppleClang 6.0.0.6000056 error
+  // "explicit specialization of 'PixelProxy'"and GCC 5.4.0 error "explicit
+  // specialization in non-namespace scope".
+  template <bool VIsConst, typename TDummy = void> class PixelProxy {};
+
+  // PixelProxy specialization for const pixel types:
+  // acts like 'const PixelType &'
+  template <typename TDummy>
+  class PixelProxy<true, TDummy> final
+  {
+  private:
+    // Reference to the internal representation of the pixel, located in the image buffer.
+    const InternalPixelType& m_InternalPixel;
+
+    // The accessor functor of the image.
+    const AccessorFunctorType m_AccessorFunctor;
+
+  public:
+    // Deleted member functions:
+    PixelProxy() = delete;
+    PixelProxy& operator=(const PixelProxy&) = delete;
+
+    // Explicitly-defaulted member functions:
+    PixelProxy(const PixelProxy&) ITK_NOEXCEPT = default;
+    ~PixelProxy() = default;
+
+    // Constructor, called directly by operator*() of the iterator class.
+    PixelProxy(
+      const InternalPixelType& internalPixel,
+      const AccessorFunctorType& accessorFunctor) ITK_NOEXCEPT
+      :
+    m_InternalPixel{ internalPixel },
+    m_AccessorFunctor(accessorFunctor)
+    {
+    }
+
+    // Allows implicit conversion from non-const to const proxy.
+    PixelProxy(const PixelProxy<false>& pixelProxy) ITK_NOEXCEPT
+      :
+    m_InternalPixel{ pixelProxy.m_InternalPixel },
+    m_AccessorFunctor{ pixelProxy.m_AccessorFunctor }
+    {
+    }
+
+    // Conversion operator.
+    operator PixelType() const ITK_NOEXCEPT
+    {
+      return m_AccessorFunctor.Get(m_InternalPixel);
+    }
+  };
+
+
+  // PixelProxy specialization for non-const pixel types:
+  // acts like 'PixelType &'.
+  template <typename TDummy>
+  class PixelProxy<false, TDummy> final
+  {
+  private:
+    // The const proxy is a friend, to ease implementing conversion from
+    // a non-const proxy to a const proxy.
+    friend class PixelProxy<true>;
+
+    // Reference to the internal representation of the pixel, located in the image buffer.
+    InternalPixelType& m_InternalPixel;
+
+    // The accessor functor of the image.
+    const AccessorFunctorType m_AccessorFunctor;
+
+  public:
+    // Deleted member functions:
+    PixelProxy() = delete;
+
+    // Explicitly-defaulted member functions:
+    ~PixelProxy() = default;
+    PixelProxy(const PixelProxy&) ITK_NOEXCEPT = default;
+
+    // Constructor, called directly by operator*() of the iterator class.
+    PixelProxy(
+      InternalPixelType& internalPixel,
+      const AccessorFunctorType& accessorFunctor) ITK_NOEXCEPT
+      :
+    m_InternalPixel{ internalPixel },
+    m_AccessorFunctor(accessorFunctor)
+    {
+    }
+
+    // Conversion operator.
+    operator PixelType() const ITK_NOEXCEPT
+    {
+      return m_AccessorFunctor.Get(m_InternalPixel);
+    }
+
+    // Operator to assign a pixel value to the proxy.
+    PixelProxy& operator=(const PixelType& pixelValue) ITK_NOEXCEPT
+    {
+      m_AccessorFunctor.Set(m_InternalPixel, pixelValue);
+      return *this;
+    }
+
+    // Copy-assignment operator.
+    PixelProxy& operator=(const PixelProxy& pixelProxy) ITK_NOEXCEPT
+    {
+      // Note that this assignment operator only copies the pixel value.
+      // That is the normal behavior when a reference is assigned to another.
+      const PixelType pixelValue = pixelProxy;
+      *this = pixelValue;
+      return *this;
+    }
+
+
+    friend void swap(PixelProxy lhs, PixelProxy rhs) ITK_NOEXCEPT
+    {
+      const auto lhsPixelValue = lhs.m_AccessorFunctor.Get(lhs.m_InternalPixel);
+      const auto rhsPixelValue = rhs.m_AccessorFunctor.Get(rhs.m_InternalPixel);
+
+      // Swap only the pixel values, not the image buffer pointers!
+      lhs.m_AccessorFunctor.Set(lhs.m_InternalPixel, rhsPixelValue);
+      rhs.m_AccessorFunctor.Set(rhs.m_InternalPixel, lhsPixelValue);
+    }
+  };
+
+
+  /**
+   * \class QualifiedIterator
+   * Iterator class that is either 'const' or non-const qualified.
+   * A non-const qualified instantiation of this template allows the pixel that
+   * it points to, to be modified. A const qualified instantiation does not.
+   *
+   * \note The definition of this class is private. Please use its type alias
+   * ImageRange::iterator, or ImageRange::const_iterator!
+   * \see ImageRange
+   * \ingroup ImageIterators
+   * \ingroup ITKCommon
+   */
+  template <bool VIsConst>
+  class QualifiedIterator final
+  {
+  private:
+    // Const and non-const iterators are friends, in order to implement the
+    // constructor that allow conversion from non-const to const iterator.
+    friend class QualifiedIterator<!VIsConst>;
+
+    // ImageRange is a friend, as it should be the only one that can
+    // directly use the private constructor of the iterator.
+    friend class ImageRange;
+
+    // Image type class that is either 'const' or non-const qualified, depending on QualifiedIterator and TImage.
+    using QualifiedImageType = typename std::conditional<VIsConst, const ImageType, ImageType>::type;
+
+    static constexpr bool IsImageTypeConst = std::is_const<QualifiedImageType>::value;
+
+    using QualifiedInternalPixelType = typename std::conditional<IsImageTypeConst, const InternalPixelType, InternalPixelType>::type;
+
+    // Pixel type class that is either 'const' or non-const qualified, depending on QualifiedImageType.
+    using QualifiedPixelType = typename std::conditional<IsImageTypeConst, const PixelType, PixelType>::type;
+
+
+    // Wraps a reference to a pixel.
+    class PixelReferenceWrapper final
+    {
+    public:
+      QualifiedPixelType& m_Pixel;
+
+      explicit PixelReferenceWrapper(QualifiedPixelType& pixel, ...) ITK_NOEXCEPT
+        :
+      m_Pixel(pixel)
+      {
+      }
+
+      operator QualifiedPixelType&() const ITK_NOEXCEPT
+      {
+        return m_Pixel;
+      }
+    };
+
+
+    // QualifiedIterator data members (strictly private):
+
+    // The accessor functor of the image.
+    OptionalAccessorFunctorType m_OptionalAccessorFunctor;
+
+    // Pointer to the current pixel.
+    QualifiedInternalPixelType* m_InternalPixelPointer = nullptr;
+
+    // Private constructor, used to create the begin and the end iterator of a range.
+    // Only used by its friend class ImageRange.
+    QualifiedIterator(
+      const OptionalAccessorFunctorType& accessorFunctor,
+      QualifiedInternalPixelType* const internalPixelPointer) ITK_NOEXCEPT
+      :
+    // Note: Use parentheses instead of curly braces to initialize data members,
+    // to avoid AppleClang 6.0.0.6000056 compilation error, "no viable conversion..."
+    m_OptionalAccessorFunctor(accessorFunctor),
+    m_InternalPixelPointer{ internalPixelPointer }
+    {
+    }
+
+  public:
+    // Types conforming the iterator requirements of the C++ standard library:
+    using difference_type = std::ptrdiff_t;
+    using value_type = PixelType;
+    using reference = typename std::conditional< SupportsDirectPixelAccess,
+      QualifiedPixelType&, PixelProxy<IsImageTypeConst>>::type;
+    using pointer = QualifiedPixelType*;
+    using iterator_category = std::random_access_iterator_tag;
+
+
+    /** Default-constructor, as required for any C++11 Forward Iterator. Offers
+     * the guarantee added to the C++14 Standard: "value-initialized iterators
+     * may be compared and shall compare equal to other value-initialized
+     * iterators of the same type."
+     */
+    QualifiedIterator() = default;
+
+    /** Constructor that allows implicit conversion from non-const to const
+     * iterator. Also serves as copy-constructor of a non-const iterator.  */
+    QualifiedIterator(const QualifiedIterator<false>& arg) ITK_NOEXCEPT
+      :
+      // Note: Use parentheses instead of curly braces to initialize data members,
+      // to avoid AppleClang 6.0.0.6000056 compilation error, "no viable conversion..."
+      m_OptionalAccessorFunctor(arg.m_OptionalAccessorFunctor),
+      m_InternalPixelPointer{ arg.m_InternalPixelPointer }
+    {
+    }
+
+
+    /**  Returns a reference to the current pixel. */
+    reference operator*() const ITK_NOEXCEPT
+    {
+      assert(m_InternalPixelPointer != nullptr);
+
+      using PixelWrapper = typename std::conditional<SupportsDirectPixelAccess,
+        PixelReferenceWrapper, reference>::type;
+
+      return PixelWrapper{ *m_InternalPixelPointer, m_OptionalAccessorFunctor };
+    }
+
+
+    /** Prefix increment ('++it'). */
+    QualifiedIterator& operator++() ITK_NOEXCEPT
+    {
+      assert(m_InternalPixelPointer != nullptr);
+      ++m_InternalPixelPointer;
+      return *this;
+    }
+
+
+    /** Postfix increment ('it++').
+     * \note Usually prefix increment ('++it') is preferable. */
+    QualifiedIterator operator++(int) ITK_NOEXCEPT
+    {
+      auto result = *this;
+      ++(*this);
+      return result;
+    }
+
+
+    /** Prefix decrement ('--it'). */
+    QualifiedIterator& operator--() ITK_NOEXCEPT
+    {
+      assert(m_InternalPixelPointer != nullptr);
+      --m_InternalPixelPointer;
+      return *this;
+    }
+
+
+    /** Postfix increment ('it--').
+     * \note  Usually prefix increment ('--it') is preferable. */
+    QualifiedIterator operator--(int) ITK_NOEXCEPT
+    {
+      auto result = *this;
+      --(*this);
+      return result;
+    }
+
+
+    /** Returns (it1 == it2) for iterators it1 and it2. Note that these iterators
+     * should be from the same range. This operator does not support comparing iterators
+     * from different ranges. */
+    friend bool operator==(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      return lhs.m_InternalPixelPointer == rhs.m_InternalPixelPointer;
+    }
+
+
+    /** Returns (it1 != it2) for iterators it1 and it2. */
+    friend bool operator!=(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      // Implemented just like the corresponding std::rel_ops operator.
+      return !(lhs == rhs);
+    }
+
+
+    /** Returns (it1 < it2) for iterators it1 and it2. */
+    friend bool operator<(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      return lhs.m_InternalPixelPointer < rhs.m_InternalPixelPointer;
+    }
+
+
+    /** Returns (it1 > it2) for iterators it1 and it2. */
+    friend bool operator>(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      // Implemented just like the corresponding std::rel_ops operator.
+      return rhs < lhs;
+    }
+
+
+    /** Returns (it1 <= it2) for iterators it1 and it2. */
+    friend bool operator<=(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      // Implemented just like the corresponding std::rel_ops operator.
+      return !(rhs < lhs);
+    }
+
+
+    /** Returns (it1 >= it2) for iterators it1 and it2. */
+    friend bool operator>=(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      // Implemented just like the corresponding std::rel_ops operator.
+      return !(lhs < rhs);
+    }
+
+
+    /** Does (it += d) for iterator 'it' and integer value 'n'. */
+    friend QualifiedIterator& operator+=(QualifiedIterator& it, const difference_type n) ITK_NOEXCEPT
+    {
+      it.m_InternalPixelPointer += n;
+      return it;
+    }
+
+    /** Does (it -= d) for iterator 'it' and integer value 'n'. */
+    friend QualifiedIterator& operator-=(QualifiedIterator& it, const difference_type n) ITK_NOEXCEPT
+    {
+      it += (-n);
+      return it;
+    }
+
+    /** Returns (it1 - it2) for iterators it1 and it2. */
+    friend difference_type operator-(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      return lhs.m_InternalPixelPointer - rhs.m_InternalPixelPointer;
+    }
+
+
+    /** Returns (it + n) for iterator 'it' and integer value 'n'. */
+    friend QualifiedIterator operator+(QualifiedIterator it, const difference_type n) ITK_NOEXCEPT
+    {
+      return it += n;
+    }
+
+
+    /** Returns (n + it) for iterator 'it' and integer value 'n'. */
+    friend QualifiedIterator operator+(const difference_type n, QualifiedIterator it) ITK_NOEXCEPT
+    {
+      return it += n;
+    }
+
+
+    /** Returns (it - n) for iterator 'it' and integer value 'n'. */
+    friend QualifiedIterator operator-(QualifiedIterator it, const difference_type n) ITK_NOEXCEPT
+    {
+      return it += (-n);
+    }
+
+
+    /** Returns it[n] for iterator 'it' and integer value 'n'. */
+    reference operator[](const difference_type n) const ITK_NOEXCEPT
+    {
+      return *(*this + n);
+    }
+
+
+    /** Explicitly-defaulted assignment operator. */
+    QualifiedIterator& operator=(const QualifiedIterator&) ITK_NOEXCEPT = default;
+
+
+    /** Explicitly-defaulted destructor. */
+    ~QualifiedIterator() = default;
+  };
+
+  static constexpr bool IsImageTypeConst = std::is_const<TImage>::value;
+
+  using QualifiedInternalPixelType = typename std::conditional<IsImageTypeConst, const InternalPixelType, InternalPixelType>::type;
+
+  class AccessorFunctorInitializer final
+  {
+  private:
+    ImageType& m_Image;
+  public:
+    explicit AccessorFunctorInitializer(ImageType& image) ITK_NOEXCEPT
+      :
+      m_Image(image)
+    {
+    }
+
+    operator EmptyAccessorFunctor() const ITK_NOEXCEPT
+    {
+      return {};
+    }
+
+    operator AccessorFunctorType() const ITK_NOEXCEPT
+    {
+      AccessorFunctorType result = {};
+      result.SetPixelAccessor(m_Image.GetPixelAccessor());
+      result.SetBegin(m_Image.ImageType::GetBufferPointer());
+      return result;
+    }
+  };
+
+  // ImageRange data members (strictly private):
+
+  // The accessor functor of the image.
+  OptionalAccessorFunctorType m_OptionalAccessorFunctor;
+
+  // Pointer to the buffer of the image. Should not be null.
+  QualifiedInternalPixelType* m_ImageBufferPointer;
+
+  // Image size.
+  SizeValueType m_NumberOfPixels;
+
+public:
+  using const_iterator = QualifiedIterator<true>;
+  using iterator = QualifiedIterator<false>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  /** Specifies a range of the pixels of an image.
+   */
+  explicit ImageRange(ImageType& image)
+    :
+  // Note: Use parentheses instead of curly braces to initialize data members,
+  // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."
+  m_OptionalAccessorFunctor(AccessorFunctorInitializer{ image }),
+  m_ImageBufferPointer{ image.ImageType::GetBufferPointer() },
+  m_NumberOfPixels{ image.ImageType::GetBufferedRegion().GetNumberOfPixels() }
+  {
+  }
+
+
+  /** Returns an iterator to the first pixel. */
+  iterator begin() const ITK_NOEXCEPT
+  {
+    assert(m_ImageBufferPointer != nullptr);
+    return iterator{ m_OptionalAccessorFunctor, m_ImageBufferPointer };
+  }
+
+  /** Returns an 'end iterator' for this range. */
+  iterator end() const ITK_NOEXCEPT
+  {
+    assert(m_ImageBufferPointer != nullptr);
+    return iterator{ m_OptionalAccessorFunctor, m_ImageBufferPointer + m_NumberOfPixels, };
+  }
+
+  /** Returns a const iterator to the first pixel.
+   * Provides only read-only access to the pixel data. */
+  const_iterator cbegin() const ITK_NOEXCEPT
+  {
+    return this->begin();
+  }
+
+  /** Returns a const 'end iterator' for this range. */
+  const_iterator cend() const ITK_NOEXCEPT
+  {
+    return this->end();
+  }
+
+  /** Returns a reverse 'begin iterator' for this range. */
+  reverse_iterator rbegin() const ITK_NOEXCEPT
+  {
+    return reverse_iterator(this->end());
+  }
+
+  /** Returns a reverse 'end iterator' for this range. */
+  reverse_iterator rend() const ITK_NOEXCEPT
+  {
+    return reverse_iterator(this->begin());
+  }
+
+  /** Returns a const reverse 'begin iterator' for this range. */
+  const_reverse_iterator crbegin() const ITK_NOEXCEPT
+  {
+    return this->rbegin();
+  }
+
+  /** Returns a const reverse 'end iterator' for this range. */
+  const_reverse_iterator crend() const ITK_NOEXCEPT
+  {
+    return this->rend();
+  }
+
+
+  /** Returns the size of the range, that is the number of pixels. */
+  std::size_t size() const ITK_NOEXCEPT
+  {
+    return m_NumberOfPixels;
+  }
+
+
+  /** Subscript operator. Allows random access, to the nth pixel.
+  * \note The return type QualifiedIterator<false>::reference is equivalent to
+  * iterator::reference.
+  */
+  typename QualifiedIterator<false>::reference operator[](const std::size_t n) const ITK_NOEXCEPT
+  {
+    assert(n < this->size());
+    assert(n <= static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max()));
+
+    return this->begin()[static_cast<std::ptrdiff_t>(n)];
+  }
+
+
+  /** Explicitly-defaulted destructor. */
+  ~ImageRange() = default;
+};
+
+
+} // namespace Experimental
+} // namespace itk
+
+#endif

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -629,6 +629,7 @@ set(ITKCommonGTests
       itkConnectedImageNeighborhoodShapeGTest.cxx
       itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
       itkImageNeighborhoodOffsetsGTest.cxx
+      itkImageRangeGTest.cxx
       itkIndexRangeGTest.cxx
       itkShapedImageNeighborhoodRangeGTest.cxx
       itkSmartPointerGTest.cxx

--- a/Modules/Core/Common/test/itkImageRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRangeGTest.cxx
@@ -1,0 +1,645 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+ // First include the header file to be tested:
+#include "itkImageRange.h"
+
+#include "itkImage.h"
+#include "itkVectorImage.h"
+
+#include <gtest/gtest.h>
+#include <algorithm>  // For std::reverse_copy, std::equal, etc.
+#include <numeric>  // For std::inner_product
+#include <type_traits>  // For std::is_reference.
+
+// Test template instantiations for various ImageDimension values, and const Image:
+template class itk::Experimental::ImageRange<itk::Image<short, 1>>;
+template class itk::Experimental::ImageRange<itk::Image<short, 2>>;
+template class itk::Experimental::ImageRange<itk::Image<short, 3>>;
+template class itk::Experimental::ImageRange<itk::Image<short, 4>>;
+template class itk::Experimental::ImageRange<const itk::Image<short>>;
+template class itk::Experimental::ImageRange<itk::VectorImage<short>>;
+
+using itk::Experimental::ImageRange;
+
+
+namespace
+{
+  // Tells whether or not ImageRange<TImage>::iterator::operator*() returns a reference.
+  // (If it does not return a reference, it actually returns a proxy to the pixel.)
+  template <typename TImage>
+  constexpr bool DoesImageRangeIteratorDereferenceOperatorReturnReference()
+  {
+    using IteratorType = typename ImageRange<TImage>::iterator;
+
+    return std::is_reference<decltype(*std::declval<IteratorType>())>::value;
+  }
+
+
+  static_assert(DoesImageRangeIteratorDereferenceOperatorReturnReference<itk::Image<int>>(),
+    "ImageRange::iterator::operator*() should return a reference for an itk::Image.");
+  static_assert(DoesImageRangeIteratorDereferenceOperatorReturnReference<const itk::Image<int>>(),
+    "ImageRange::iterator::operator*() should return a reference for a 'const' itk::Image.");
+  static_assert(!DoesImageRangeIteratorDereferenceOperatorReturnReference<itk::VectorImage<int>>(),
+    "ImageRange::iterator::operator*() should not return a reference for an itk::VectorImage.");
+  static_assert(!DoesImageRangeIteratorDereferenceOperatorReturnReference<const itk::VectorImage<int>>(),
+    "ImageRange::iterator::operator*() should not return a reference for a 'const' itk::VectorImage.");
+
+
+  template<typename TImage>
+  typename TImage::Pointer CreateImage(const unsigned sizeX, const unsigned sizeY)
+  {
+    const auto image = TImage::New();
+    const typename TImage::SizeType imageSize = { { sizeX , sizeY } };
+    image->SetRegions(imageSize);
+    image->Allocate();
+    return image;
+  }
+
+
+  // Creates a test image, filled with a sequence of natural numbers, 1, 2, 3, ..., N.
+  template<typename TImage>
+  typename TImage::Pointer CreateImageFilledWithSequenceOfNaturalNumbers(const unsigned sizeX, const unsigned sizeY)
+  {
+    using PixelType = typename TImage::PixelType;
+    const auto image = CreateImage<TImage>(sizeX, sizeY);
+
+    const unsigned numberOfPixels = sizeX * sizeY;
+
+    PixelType* const bufferPointer = image->GetBufferPointer();
+
+    for (unsigned i = 0; i < numberOfPixels; ++i)
+    {
+      bufferPointer[i] =  static_cast<typename TImage::PixelType>(i + 1);
+    }
+    return image;
+  }
+
+}  // namespace
+
+
+// Tests that a begin iterator compares equal to another begin iterator of the
+// same range. Also does this test for end iterators.
+TEST(ImageRange, EquivalentBeginOrEndIteratorsCompareEqual)
+{
+  using ImageType = itk::Image<int>;
+
+  const auto image = CreateImage<ImageType>(2, 3);
+
+  ImageRange<ImageType> range{ *image };
+
+  const ImageRange<ImageType>::iterator begin = range.begin();
+  const ImageRange<ImageType>::iterator end = range.end();
+  const ImageRange<ImageType>::const_iterator cbegin = range.cbegin();
+  const ImageRange<ImageType>::const_iterator cend = range.cend();
+
+  // An iterator object compares equal to itself:
+  EXPECT_EQ(begin, begin);
+  EXPECT_EQ(end, end);
+  EXPECT_EQ(cbegin, cbegin);
+  EXPECT_EQ(cend, cend);
+
+  // Multiple calls of the same function yield equivalent objects:
+  EXPECT_EQ(range.begin(), range.begin());
+  EXPECT_EQ(range.end(), range.end());
+  EXPECT_EQ(range.cbegin(), range.cbegin());
+  EXPECT_EQ(range.cend(), range.cend());
+
+  // Corresponding const_iterator and non-const iterator compare equal:
+  EXPECT_EQ(begin, cbegin);
+  EXPECT_EQ(end, cend);
+  EXPECT_EQ(cbegin, begin);
+  EXPECT_EQ(cend, end);
+}
+
+
+TEST(ImageRange, BeginAndEndDoNotCompareEqual)
+{
+  using ImageType = itk::Image<int>;
+
+  const auto image = CreateImage<ImageType>(2, 3);
+
+  ImageRange<ImageType> range{ *image };
+
+  EXPECT_FALSE(range.begin() == range.end());
+  EXPECT_NE(range.begin(), range.end());
+}
+
+
+// Tests that an iterator converts (implicitly) to a const_iterator.
+TEST(ImageRange, IteratorConvertsToConstIterator)
+{
+  using ImageType = itk::Image<int>;
+
+  const auto image = CreateImage<ImageType>(2, 3);
+
+  ImageRange<ImageType> range{ *image };
+
+  const ImageRange<ImageType>::iterator begin = range.begin();
+  const ImageRange<ImageType>::const_iterator const_begin_from_begin = begin;
+  EXPECT_EQ(const_begin_from_begin, begin);
+
+  const ImageRange<ImageType>::const_iterator const_begin_from_range_begin = range.begin();
+  EXPECT_EQ(const_begin_from_range_begin, range.begin());
+}
+
+
+// Tests that the iterators of an ImageRange can be used as first and
+// second argument of an std::vector constructor.
+TEST(ImageRange, IteratorsCanBePassedToStdVectorConstructor)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  ImageRange<ImageType> range{ *image };
+
+  // Easily store all pixels of the ImageRange in an std::vector:
+  const std::vector<PixelType> stdVector(range.begin(), range.end());
+  EXPECT_EQ(stdVector, std::vector<PixelType>(range.cbegin(), range.cend()));
+  EXPECT_TRUE(std::equal(stdVector.begin(), stdVector.end(), range.cbegin()));
+}
+
+
+// Tests that the iterators can be used as first and
+// second argument of std::reverse (which requires bidirectional iterators).
+TEST(ImageRange, IteratorsCanBePassedToStdReverseCopy)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  ImageRange<ImageType> range{ *image };
+
+  const unsigned numberOfPixels = sizeX * sizeY;
+
+  const std::vector<PixelType> stdVector(range.begin(), range.end());
+  std::vector<PixelType> reversedStdVector1(numberOfPixels);
+  std::vector<PixelType> reversedStdVector2(numberOfPixels);
+  std::vector<PixelType> reversedStdVector3(numberOfPixels);
+
+  // Checks bidirectionality of the ImageRange iterators!
+  std::reverse_copy(stdVector.cbegin(), stdVector.cend(), reversedStdVector1.begin());
+  std::reverse_copy(range.begin(), range.end(), reversedStdVector2.begin());
+  std::reverse_copy(range.cbegin(), range.cend(), reversedStdVector3.begin());
+
+  // Sanity check
+  EXPECT_NE(reversedStdVector1, stdVector);
+  EXPECT_NE(reversedStdVector2, stdVector);
+  EXPECT_NE(reversedStdVector3, stdVector);
+
+  // The real tests:
+  EXPECT_EQ(reversedStdVector1, reversedStdVector2);
+  EXPECT_EQ(reversedStdVector1, reversedStdVector3);
+}
+
+
+// Tests that the iterators can be used as first and
+// second argument of std::inner_product.
+TEST(ImageRange, IteratorsCanBePassedToStdInnerProduct)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  enum { sizeX = 2, sizeY = 2 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  ImageRange<ImageType> range{ *image };
+
+  const double innerProduct = std::inner_product(range.begin(), range.end(), range.begin(), 0.0);
+
+  EXPECT_EQ(innerProduct, 30);
+}
+
+
+// Tests that the iterators can be used as first and
+// second argument of std::for_each.
+TEST(ImageRange, IteratorsCanBePassedToStdForEach)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  ImageRange<ImageType> range{ *image };
+
+  std::for_each(range.begin(), range.end(), [](const PixelType pixel)
+  {
+    EXPECT_TRUE(pixel > 0);
+  });
+}
+
+
+// Tests that an ImageRange can be used as the "range expression" of a
+// C++11 range-based for loop.
+TEST(ImageRange, CanBeUsedAsExpressionOfRangeBasedForLoop)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  using RangeType = ImageRange<ImageType>;
+
+  enum { sizeX = 2, sizeY = 3 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  RangeType range{ *image };
+
+  for (const PixelType pixel : range)
+  {
+    EXPECT_NE(pixel, 42);
+  }
+
+  for (auto&& pixel : range)
+  {
+    pixel = 42;
+  }
+
+  for (const PixelType pixel : range)
+  {
+    EXPECT_EQ(pixel, 42);
+  }
+}
+
+
+// Tests that the distance between two iterators, it1 and it2, can be obtained by
+// subtraction (it2 - it1).
+TEST(ImageRange, DistanceBetweenIteratorsCanBeObtainedBySubtraction)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImage<ImageType>(sizeX, sizeY);
+
+  ImageRange<ImageType> range{ *image };
+
+  ImageRange<ImageType>::iterator it1 = range.begin();
+
+  const std::size_t numberOfPixels = range.size();
+
+  for (std::size_t i1 = 0; i1 < numberOfPixels; ++i1, ++it1)
+  {
+    ImageRange<ImageType>::iterator it2 = it1;
+
+    for (std::size_t i2 = 0; i2 < numberOfPixels; ++i2, ++it2)
+    {
+      EXPECT_EQ(it2 - it1, std::distance(it1, it2));
+    }
+  }
+}
+
+
+// Tests that iterator::reference and const_iterator::reference act like a real
+// (built-in) C++ reference to the pixel type.
+TEST(ImageRange, IteratorReferenceActsLikeARealReference)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+  using RangeType = ImageRange<ImageType>;
+
+  RangeType range{ *image };
+  RangeType::iterator it = range.begin();
+
+  RangeType::iterator::reference reference1 = *it;
+  RangeType::iterator::reference reference2 = *(++it);
+  RangeType::const_iterator::reference reference3 = *(++it);
+  EXPECT_EQ(reference1, 1);
+  EXPECT_EQ(reference2, 2);
+  EXPECT_EQ(reference3, 3);
+
+  RangeType::const_iterator::reference reference4 = reference1;
+  RangeType::const_iterator::reference reference5 = reference2;
+  RangeType::const_iterator::reference reference6 = reference3;
+  EXPECT_EQ(reference4, 1);
+  EXPECT_EQ(reference5, 2);
+  EXPECT_EQ(reference6, 3);
+
+  PixelType pixelValue1 = reference1;
+  EXPECT_EQ(pixelValue1, reference1);
+
+  reference1 = 42;
+  EXPECT_EQ(reference1, 42);
+
+  pixelValue1 = reference1;
+  EXPECT_EQ(pixelValue1, 42);
+
+  reference2 = reference1;
+  EXPECT_EQ(reference1, 42);
+  EXPECT_EQ(reference2, 42);
+
+  reference2 = 0;
+  EXPECT_EQ(reference1, 42);
+  EXPECT_EQ(reference2, 0);
+}
+
+
+// Tests that ImageRange<VectorImage<T>> is supported well.
+TEST(ImageRange, SupportsVectorImage)
+{
+  using ImageType = itk::VectorImage<unsigned char>;
+  using PixelType = ImageType::PixelType;
+  enum { vectorLength = 2, sizeX = 2, sizeY = 2, sizeZ = 2 };
+  const auto image = ImageType::New();
+  const typename ImageType::SizeType imageSize = { { sizeX , sizeY, sizeZ } };
+  image->SetRegions(imageSize);
+  image->SetVectorLength(vectorLength);
+  image->Allocate(true);
+  PixelType fillPixelValue(vectorLength);
+  fillPixelValue.Fill(42);
+  image->FillBuffer(fillPixelValue);
+
+  using RangeType = ImageRange<ImageType>;
+  RangeType range{ *image };
+
+  for (PixelType pixelValue : range)
+  {
+    EXPECT_EQ(pixelValue, fillPixelValue);
+  }
+
+  PixelType otherPixelValue(vectorLength);
+  otherPixelValue.Fill(1);
+  image->SetPixel({ {} }, otherPixelValue);
+
+  RangeType::const_iterator it = range.begin();
+  const PixelType firstPixelValueFromRange = *it;
+  EXPECT_EQ(firstPixelValueFromRange, otherPixelValue);
+  ++it;
+  const PixelType secondPixelValueFromRange = *it;
+  EXPECT_EQ(secondPixelValueFromRange, fillPixelValue);
+}
+
+
+TEST(ImageRange, IteratorsCanBePassedToStdSort)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  enum { sizeX = 3, sizeY = 3 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  ImageRange<ImageType> range{ *image };
+
+  // Initial order: (1, 2, 3, ..., 9).
+  const std::vector<PixelType> initiallyOrderedPixels(range.cbegin(), range.cend());
+  const std::vector<PixelType> reverseOrderedPixels(initiallyOrderedPixels.rbegin(), initiallyOrderedPixels.rend());
+
+  // Sanity checks before doing the "real" tests:
+  EXPECT_EQ(std::vector<PixelType>(range.cbegin(), range.cend()), initiallyOrderedPixels);
+  EXPECT_NE(std::vector<PixelType>(range.cbegin(), range.cend()), reverseOrderedPixels);
+
+  // Test std::sort with predicate (lambda expression), to revert the order:
+  std::sort(range.begin(), range.end(), [](PixelType lhs, PixelType rhs) { return rhs < lhs; });
+  EXPECT_EQ(std::vector<PixelType>(range.cbegin(), range.cend()), reverseOrderedPixels);
+
+  // Test std::sort without predicate, to go back to the initial order (1, 2, 3, ..., 9):
+  std::sort(range.begin(), range.end());
+  EXPECT_EQ(std::vector<PixelType>(range.cbegin(), range.cend()), initiallyOrderedPixels);
+}
+
+
+TEST(ImageRange, IteratorsCanBePassedToStdNthElement)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  enum { sizeX = 3, sizeY = 3 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  ImageRange<ImageType> range{ *image };
+
+  std::reverse(range.begin(), range.end());
+
+  std::vector<PixelType> pixels(range.cbegin(), range.cend());
+
+  // The 'n' to be used with 'nth_element':
+  const size_t n = pixels.size() / 2;
+
+  std::nth_element(pixels.begin(), pixels.begin() + n, pixels.end());
+
+  // Sanity check, before the "real" test:
+  EXPECT_NE(std::vector<PixelType>(range.cbegin(), range.cend()), pixels);
+
+  // nth_element on the range should rearrange the pixels in the same way as
+  // it did on the std::vector of pixels.
+  std::nth_element(range.begin(), range.begin() + n, range.end());
+  EXPECT_EQ(std::vector<PixelType>(range.cbegin(), range.cend()), pixels);
+}
+
+
+TEST(ImageRange, IteratorIsDefaultConstructible)
+{
+  using RangeType = ImageRange<itk::Image<int>>;
+
+  RangeType::iterator defaultConstructedIterator;
+
+  // Test that a default-constructed iterator behaves according to C++ proposal
+  // N3644, "Null Forward Iterators" by Alan Talbot, which is accepted with
+  // C++14: "value-initialized iterators may be compared and shall compare
+  // equal to other value-initialized iterators of the same type."
+  // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3644.pdf
+
+  EXPECT_TRUE(defaultConstructedIterator == defaultConstructedIterator);
+  EXPECT_FALSE(defaultConstructedIterator != defaultConstructedIterator);
+  EXPECT_EQ(defaultConstructedIterator, RangeType::iterator{});
+}
+
+
+TEST(ImageRange, IteratorsSupportRandomAccess)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  using RangeType = ImageRange<ImageType>;
+  enum { sizeX = 3, sizeY = 3 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  RangeType range{ *image };
+
+  // Testing expressions from Table 111 "Random access iterator requirements
+  // (in addition to bidirectional iterator)", C++11 Standard, section 24.2.7
+  // "Random access iterator" [random.access.iterators].
+
+  // Note: The 1-letter identifiers (X, a, b, n, r) and the operational semantics
+  // are directly from the C++11 Standard.
+  using X = RangeType::iterator;
+  X a = range.begin();
+  X b = range.end();
+
+  const X initialIterator = range.begin();
+  X mutableIterator = initialIterator;
+  X& r = mutableIterator;
+
+  using difference_type = X::difference_type;
+  using reference = X::reference;
+
+  {
+    // Expression to be tested: 'r += n'
+    difference_type n = 3;
+
+    static_assert(std::is_same<decltype(r += n), X&>::value, "Return type tested");
+
+    r = initialIterator;
+    const auto expectedResult = [&r, n]
+    {
+      // Operational semantics, as specified by the C++11 Standard:
+      difference_type m = n;
+      if (m >= 0) while (m--) ++r;
+      else while (m++) --r;
+      return r;
+    }();
+    r = initialIterator;
+    const auto actualResult = r += n;
+    EXPECT_EQ(actualResult, expectedResult);
+  }
+  {
+    // Expressions to be tested: 'a + n' and 'n + a'
+    difference_type n = 3;
+
+    static_assert(std::is_same<decltype(a + n), X>::value, "Return type tested");
+    static_assert(std::is_same<decltype(n + a), X>::value, "Return type tested");
+
+    const auto expectedResult = [a, n]
+    {
+      // Operational semantics, as specified by the C++11 Standard:
+      X tmp = a;
+      return tmp += n;
+    }();
+
+    EXPECT_EQ(a + n, expectedResult);
+    EXPECT_TRUE(a + n == n + a);
+  }
+  {
+    // Expression to be tested: 'r -= n'
+    difference_type n = 3;
+
+    static_assert(std::is_same<decltype(r -= n), X&>::value, "Return type tested");
+
+    r = initialIterator;
+    const auto expectedResult = [&r, n]
+    {
+      // Operational semantics, as specified by the C++11 Standard:
+      return r += -n;
+    }();
+    r = initialIterator;
+    const auto actualResult = r -= n;
+    EXPECT_EQ(actualResult, expectedResult);
+  }
+  {
+    // Expression to be tested: 'a - n'
+    difference_type n = -3;
+
+    static_assert(std::is_same<decltype(a - n), X>::value, "Return type tested");
+
+    const auto expectedResult = [a, n]
+    {
+      // Operational semantics, as specified by the C++11 Standard:
+      X tmp = a;
+      return tmp -= n;
+    }();
+
+    EXPECT_EQ(a - n, expectedResult);
+  }
+  {
+    // Expression to be tested: 'b - a'
+    static_assert(std::is_same<decltype(b - a), difference_type>::value, "Return type tested");
+
+    difference_type n = b - a;
+    EXPECT_TRUE(a + n == b);
+    EXPECT_TRUE(b == a + (b - a));
+  }
+  {
+    // Expression to be tested: 'a[n]'
+    difference_type n = 3;
+    static_assert(std::is_convertible<decltype(a[n]), reference>::value, "Return type tested");
+    EXPECT_EQ(a[n], *(a + n));
+  }
+  {
+    // Expressions to be tested: 'a < b', 'a > b', 'a >= b', and 'a <= b':
+    static_assert(std::is_convertible<decltype(a < b), bool>::value, "Return type tested");
+    static_assert(std::is_convertible<decltype(a > b), bool>::value, "Return type tested");
+    static_assert(std::is_convertible<decltype(a >= b), bool>::value, "Return type tested");
+    static_assert(std::is_convertible<decltype(a <= b), bool>::value, "Return type tested");
+    EXPECT_EQ(a < b, b - a > 0);
+    EXPECT_EQ(a > b, b < a);
+    EXPECT_EQ(a >= b, !(a < b));
+    EXPECT_EQ(a <= b, !(b < a));
+  }
+}
+
+
+TEST(ImageRange, SupportsSubscript)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  using RangeType = ImageRange<ImageType>;
+
+  enum { sizeX = 3, sizeY = 3 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  RangeType range{ *image };
+
+  const std::size_t numberOfNeighbors = range.size();
+
+  RangeType::iterator it = range.begin();
+
+  for (std::size_t i = 0; i < numberOfNeighbors; ++i)
+  {
+    RangeType::iterator::reference neighbor = range[i];
+    EXPECT_EQ(neighbor, *it);
+    ++it;
+  }
+}
+
+
+TEST(ImageRange, ProvidesReverseIterators)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  using RangeType = ImageRange<ImageType>;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+
+  RangeType range{ *image };
+
+  const unsigned numberOfPixels = sizeX * sizeY;
+
+  const std::vector<PixelType> stdVector(range.begin(), range.end());
+  std::vector<PixelType> reversedStdVector1(numberOfPixels);
+  std::vector<PixelType> reversedStdVector2(numberOfPixels);
+  std::vector<PixelType> reversedStdVector3(numberOfPixels);
+
+  std::reverse_copy(stdVector.cbegin(), stdVector.cend(), reversedStdVector1.begin());
+
+  const RangeType::const_reverse_iterator crbegin = range.crbegin();
+  const RangeType::const_reverse_iterator crend = range.crend();
+  const RangeType::reverse_iterator rbegin = range.rbegin();
+  const RangeType::reverse_iterator rend = range.rend();
+
+  EXPECT_EQ(crbegin, rbegin);
+  EXPECT_EQ(crend, rend);
+
+  std::copy(crbegin, crend, reversedStdVector2.begin());
+  std::copy(rbegin, rend, reversedStdVector3.begin());
+
+  // Sanity check
+  EXPECT_NE(reversedStdVector1, stdVector);
+  EXPECT_NE(reversedStdVector2, stdVector);
+  EXPECT_NE(reversedStdVector3, stdVector);
+
+  // The real tests:
+  EXPECT_EQ(reversedStdVector1, reversedStdVector2);
+  EXPECT_EQ(reversedStdVector1, reversedStdVector3);
+}


### PR DESCRIPTION
Added Experimental::ImageRange<TImage>: a modern C++ range of iterators to the pixels of an image. Supports any ITK image type (both itk::Image and itk::VectorImage). For "regular" image types (itk::Image), iterator::operator*() returns a reference to the current pixel. For other image types (like itk::VectorImage), iterator::operator*() returns a proxy, that behaves like a reference to the pixel.

Supports iterating over an image by a C++11 range-based for-loop, for example:

    ImageRange<ImageType> imageRange{ *image };

    for (auto&& pixel : imageRange)
    {
      pixel = pixel + 42;
    }

Also supports random access to any pixel of the image:

    std::size_t indexValue = std::rand() % imageRange.size();
    auto&& pixel = imageRange[indexValue];

Its iterators can be passed to an algorithm from the Standard C++ Library, for example:

	// Fills the image with pixel values 1, 2, 3, ..., n.
    std::iota(imageRange.begin(), imageRange.end(), 1);