### PR TITLE
Remove outdated vxl version support

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -33,7 +33,8 @@ and/or warnings should be addressed.  Once dependent code builds and passes
 tests without legacy options, migration to v5 is complete.
 
 Support for for pre-20160229 `VXL_VERSION_DATE_FULL` system installed
-versions of VXL has been removed.
+versions of VXL has been removed.  VXL now supports more common Semantic Versioning
+conventions with the minimum supported version for ITKv5 being 2.0.2 (as of 2018-11-30).
 
 C++11
 -----

--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -21,10 +21,6 @@
 #include "itkMacro.h"
 
 #include "vxl_version.h"
-#if VXL_VERSION_DATE_FULL < 20110428
-#error "System installed VXL version is too old. Please make sure the version date is later than 2011-04-28."
-#endif
-
 #include "vnl/vnl_vector.h"
 
 namespace itk

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -39,12 +39,7 @@
 #include "itkFloatTypes.h"
 
 #include <vxl_version.h>
-#if VXL_VERSION_DATE_FULL < 20160229
-#include "vnl/vnl_matrix_fixed.txx" // Get the templates
-#else
 #include "vnl/vnl_matrix_fixed.hxx" // Get the templates
-#endif
-
 
 namespace itk
 {

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -38,9 +38,6 @@
  * supported.
  */
 #include <vxl_version.h>
-#if VXL_VERSION_DATE_FULL <= 20121114
-# error "VXL version must support vnl_math:: namespace versions of functions"
-#endif
 
 namespace itk
 {

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -22,11 +22,7 @@
 #include "itkCovariantVector.h"
 
 #include <vxl_version.h>
-#if VXL_VERSION_DATE_FULL < 20160229
-#include "vnl/vnl_matrix_fixed.txx" // Get the templates
-#else
 #include "vnl/vnl_matrix_fixed.hxx" // Get the templates
-#endif
 #include "vnl/vnl_transpose.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
 #include "vnl/vnl_matrix.h"

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -24,12 +24,7 @@
 #include <algorithm>
 
 #include "vxl_version.h"
-#if VXL_VERSION_DATE_FULL > 20040406
 #include "vnl/vnl_cross.h"
-#define itk_cross_3d vnl_cross_3d
-#else
-#define itk_cross_3d cross_3d
-#endif
 
 namespace itk
 {
@@ -421,7 +416,7 @@ SimplexMesh< TPixelType, VDimension, TMeshTraits >
   CovariantVectorType normal;
   normal.Fill(0.0);
   CovariantVectorType z;
-  z.SetVnlVector( itk_cross_3d( ( n2 - n1 ).GetVnlVector(), ( n3 - n1 ).GetVnlVector() ) );
+  z.SetVnlVector( vnl_cross_3d( ( n2 - n1 ).GetVnlVector(), ( n3 - n1 ).GetVnlVector() ) );
   z.Normalize();
   normal += z;
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
@@ -26,12 +26,7 @@
 #include "itkVectorContainer.h"
 
 #include "vxl_version.h"
-#if VXL_VERSION_DATE_FULL > 20040406
 #include "vnl/vnl_cross.h"
-#define itk_cross_3d vnl_cross_3d
-#else
-#define itk_cross_3d cross_3d
-#endif
 
 namespace itk
 {
@@ -183,7 +178,7 @@ public:
       mesh->GetPoint(p1, &v1);
       mesh->GetPoint(p2, &v2);
       mesh->GetPoint(p3, &v3);
-      return std::abs (itk_cross_3d( ( v2 - v1 ).GetVnlVector(), ( v3 - v1 ).GetVnlVector() ).two_norm() / 2.0);
+      return std::abs (vnl_cross_3d( ( v2 - v1 ).GetVnlVector(), ( v3 - v1 ).GetVnlVector() ).two_norm() / 2.0);
     }
 
     typename DoubleValueMapType::Pointer GetAreaMap()

--- a/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
+++ b/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
@@ -19,10 +19,7 @@
 #include "itkMath.h"
 
 #include "vxl_version.h"
-#if VXL_VERSION_DATE_FULL > 20040406
 #include "vnl/vnl_cross.h"
-#define cross_3d vnl_cross_3d
-#endif
 
 namespace itk
 {
@@ -75,12 +72,12 @@ SimplexMeshGeometry
   b = this->neighbors[2] - this->neighbors[0];
   c = this->neighbors[1] - this->neighbors[0];
 
-  cXb.SetVnlVector( cross_3d< double >( c.GetVnlVector(), b.GetVnlVector() ) );
+  cXb.SetVnlVector( vnl_cross_3d< double >( c.GetVnlVector(), b.GetVnlVector() ) );
 
   tmp.SetVnlVector( b.GetSquaredNorm()
-                    * cross_3d< double >( cXb.GetVnlVector(), c.GetVnlVector() )
+                    * vnl_cross_3d< double >( cXb.GetVnlVector(), c.GetVnlVector() )
                     + c.GetSquaredNorm()
-                    * cross_3d< double >( b.GetVnlVector(), cXb.GetVnlVector() ) );
+                    * vnl_cross_3d< double >( b.GetVnlVector(), cXb.GetVnlVector() ) );
 
   double cXbSquaredNorm = 2 * cXb.GetSquaredNorm();
 
@@ -94,8 +91,8 @@ SimplexMeshGeometry
   VectorType d, dXc, bXd, sphereTmp;
 
   d = pos - this->neighbors[0];
-  dXc.SetVnlVector( cross_3d< double >( d.GetVnlVector(), c.GetVnlVector() ) );
-  bXd.SetVnlVector( cross_3d< double >( b.GetVnlVector(), d.GetVnlVector() ) );
+  dXc.SetVnlVector( vnl_cross_3d< double >( d.GetVnlVector(), c.GetVnlVector() ) );
+  bXd.SetVnlVector( vnl_cross_3d< double >( b.GetVnlVector(), d.GetVnlVector() ) );
 
   sphereTmp.SetVnlVector( d.GetSquaredNorm() * cXb.GetVnlVector()
                           + b.GetSquaredNorm() * dXc.GetVnlVector()

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
@@ -20,11 +20,7 @@
 #include "itkMetaDataObject.h"
 
 #include <vxl_version.h>
-#if VXL_VERSION_DATE_FULL < 20160229
-#include "vnl/vnl_matrix_fixed.txx" // Get the templates
-#else
 #include "vnl/vnl_vector_fixed.hxx" // Get the templates
-#endif
 VNL_VECTOR_FIXED_INSTANTIATE(int,8);
 
 int itkPhilipsRECImageIOPrintTest( int argc, char * argv [] )

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
@@ -20,8 +20,7 @@
 #include "itkMetaDataObject.h"
 
 #include <vxl_version.h>
-#include "vnl/vnl_vector_fixed.hxx" // Get the templates
-VNL_VECTOR_FIXED_INSTANTIATE(int,8);
+#include "vnl/vnl_vector_fixed.h"
 
 int itkPhilipsRECImageIOPrintTest( int argc, char * argv [] )
 {

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
@@ -254,13 +254,8 @@ void LinearSystemWrapperVNL::MultiplyMatrixMatrix(unsigned int ResultMatrixIndex
   delete ( *m_Matrices )[ResultMatrixIndex];
   ( *m_Matrices )[ResultMatrixIndex] = new vnl_sparse_matrix<Float>( this->GetSystemOrder(), this->GetSystemOrder() );
 
-#if VXL_VERSION_DATE_FULL >= 20100109
   *( ( *m_Matrices )[ResultMatrixIndex] ) =
     *( ( *m_Matrices )[LeftMatrixIndex] ) * ( *( ( *m_Matrices )[RightMatrixIndex] ) );
-#else
-  ( ( *m_Matrices )[LeftMatrixIndex] )->mult( *( ( *m_Matrices )[RightMatrixIndex] ),
-                                          *( ( *m_Matrices )[ResultMatrixIndex] ) );
-#endif
 }
 
 void LinearSystemWrapperVNL::MultiplyMatrixVector(unsigned int ResultVectorIndex,

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -35,12 +35,7 @@
 #include <set>
 
 #include "vxl_version.h"
-#if VXL_VERSION_DATE_FULL > 20040406
 #include "vnl/vnl_cross.h"
-#define itk_cross_3d vnl_cross_3d
-#else
-#define itk_cross_3d cross_3d
-#endif
 
 namespace itk
 {
@@ -287,7 +282,7 @@ DeformableSimplexMesh3DFilter< TInputMesh, TOutputMesh >
     // compute normal
     normal.Fill(0.0);
 
-    z.SetVnlVector( itk_cross_3d( ( data->neighbors[1] - data->neighbors[0] ).GetVnlVector(),
+    z.SetVnlVector( vnl_cross_3d( ( data->neighbors[1] - data->neighbors[0] ).GetVnlVector(),
                                     ( data->neighbors[2] - data->neighbors[0] ).GetVnlVector() ) );
     z.Normalize();
     normal += z;
@@ -615,10 +610,10 @@ DeformableSimplexMesh3DFilter< TInputMesh, TOutputMesh >
   const PointType c = data->neighbors[2];
 
   VectorType n, na, nb, nc;
-  n.SetVnlVector( itk_cross_3d( ( b - a ).GetVnlVector(), ( c - a ).GetVnlVector() ) );
-  na.SetVnlVector( itk_cross_3d( ( c - b ).GetVnlVector(), ( p - b ).GetVnlVector() ) );
-  nb.SetVnlVector( itk_cross_3d( ( a - c ).GetVnlVector(), ( p - c ).GetVnlVector() ) );
-  nc.SetVnlVector( itk_cross_3d( ( b - a ).GetVnlVector(), ( p - a ).GetVnlVector() ) );
+  n.SetVnlVector( vnl_cross_3d( ( b - a ).GetVnlVector(), ( c - a ).GetVnlVector() ) );
+  na.SetVnlVector( vnl_cross_3d( ( c - b ).GetVnlVector(), ( p - b ).GetVnlVector() ) );
+  nb.SetVnlVector( vnl_cross_3d( ( a - c ).GetVnlVector(), ( p - c ).GetVnlVector() ) );
+  nc.SetVnlVector( vnl_cross_3d( ( b - a ).GetVnlVector(), ( p - a ).GetVnlVector() ) );
 
   PointType eps;
   eps[0] = dot_product( n.GetVnlVector(), na.GetVnlVector() ) / n.GetSquaredNorm();


### PR DESCRIPTION
Remove conditional code that supported older versions of VXL.

There is now a stricter requirement on the newer v2.02 version of VXL.