### PR TITLE
BUG: Fixed ShapedImageNeighborhoodRange copying pixel access parameter

### DIFF
--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -396,6 +396,7 @@ private:
       m_ImageSize(arg.m_ImageSize),
       m_OffsetTable(arg.m_OffsetTable),
       m_NeighborhoodAccessor(arg.m_NeighborhoodAccessor),
+      m_OptionalPixelAccessParameter(arg.m_OptionalPixelAccessParameter),
       m_Location(arg.m_Location),
       m_CurrentOffset{arg.m_CurrentOffset}
     {

--- a/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
@@ -113,13 +113,24 @@ TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsSpecifiedConstant
   const itk::Size<ImageType::ImageDimension> radius = { {} };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
     itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+  const auto numberOfExpectedNeighbors = offsets.size();
 
   for (PixelType constantValue = -1; constantValue <= 2; ++constantValue)
   {
     const RangeType range{ *image, locationOutsideImage, offsets, constantValue };
 
+    // Test by using a range-based for-loop:
     for (const PixelType pixel : range)
     {
+      EXPECT_EQ(pixel, constantValue);
+    }
+
+    ASSERT_EQ(range.size(), numberOfExpectedNeighbors);
+
+    // Test by using RangeType::operator[]:
+    for (std::size_t i = 0; i < numberOfExpectedNeighbors; ++i)
+    {
+      const PixelType pixel = range[i];
       EXPECT_EQ(pixel, constantValue);
     }
   }


### PR DESCRIPTION
One of the constructors of the ShapedImageNeighborhoodRange iterator types did not copy the pixel access parameter. This bug might cause serious problems (undefined behavior) when using ConstantBoundaryImageNeighborhoodPixelAccessPolicy.

The bug was introduced with 0be5876ee010c46ea17521dc12ed2eaa825ddad9 (merged onto the ITK master branch on November 20, 2018).

This commit fixes this constructor and extends the GTest ConstantBoundaryImageNeighborhoodPixelAccessPolicy.YieldsSpecifiedConstantOutsideImage to test this particular issue as well. The issue occurred when using ShapedImageNeighborhoodRange::operator[].
