### PR TITLE
COMP: Remove Doxygen \ref, \copydetails commands

### DIFF
--- a/Modules/Core/Common/include/itkFloatingPointExceptions.h
+++ b/Modules/Core/Common/include/itkFloatingPointExceptions.h
@@ -49,8 +49,6 @@ public:
 
   /** Disable floating point exceptions.
    *
-   * \copydetails Enable
-   *
    * \sa Enable, SetEnabled, GetEnabled
    */
   static void Disable();
@@ -59,8 +57,6 @@ public:
   static bool GetEnabled();
 
   /** Set the state to specified value.
-   *
-   * \copydetails Enable
    *
    * \sa Enable, Disable, GetEnabled
    */

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
@@ -43,9 +43,9 @@ namespace itk
  *
  * The output generated from a ForwardFFTImageFilter is in the
  * dual space or frequency domain.
- * Refer to \ref FrequencyFFTLayoutImageRegionConstIteratorWithIndex
+ * Refer to FrequencyFFTLayoutImageRegionConstIteratorWithIndex
  * for a description of the layout of frequencies generated after a forward FFT.
- * Also see \ref ITKImageFrequency for a set of filters requiring input images in the frequency domain.
+ * Also see ITKImageFrequency for a set of filters requiring input images in the frequency domain.
  *
  * \ingroup FourierTransform
  *

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
@@ -37,20 +37,20 @@ namespace itk
  * frequency layout of the input image.
  *
  * Images in the dual space can be acquired experimentally, from scattering experiments or other techniques.
- * In that case use \ref FrequencyImageRegionIteratorWithIndex because
+ * In that case use FrequencyImageRegionIteratorWithIndex because
  * the layout of dual space images is the same as spatial domain images.
  *
  * Frequency-domain images can be computed from any spatial-domain applying a Fourier Transform.
- * If \ref ForwardFFTImageFilter was used, template this filter with
- * the \ref FrequencyFFTLayoutImageRegionIteratorWithIndex.
- * Please note that \ref FrequencyFFTLayoutImageRegionIteratorWithIndex requires a full FFT,
+ * If ForwardFFTImageFilter was used, template this filter with
+ * the FrequencyFFTLayoutImageRegionIteratorWithIndex.
+ * Please note that FrequencyFFTLayoutImageRegionIteratorWithIndex requires a full FFT,
  * and is not compatible with the Hermitian optimization.
  *
  * To use this filter with Hermitian (halved-frequency) FFTs, use
- * \ref FrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex or its const version.
+ * FrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex or its const version.
  *
- * If the output of the FFT is shifted, for example after applying \ref FFTShiftImageFilter,
- * use \ref FrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.
+ * If the output of the FFT is shifted, for example after applying FFTShiftImageFilter,
+ * use FrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.
  *
  * \sa UnaryGeneratorImageFilter
  *


### PR DESCRIPTION
Doxygen will implicitly pick up these references. Adding them explicitly
causes warnings in the Python wrapping, when their definition is not
available. Remove them also makes it a little easier to read the
comment.

To address:

```
/home/matt/src/ITK2/Modules/Core/Common/include/itkFloatingPointExceptions.h:50: warning: @copydetails or @copydoc target 'Enable' not found
/home/matt/src/ITK2/Modules/Core/Common/include/itkFloatingPointExceptions.h:61: warning: @copydetails or @copydoc target 'Enable' not found
[5864/6441] Building CXX object Wrapping/Modules/ITKColormap/CMakeFiles/ITKColormapPython.dir/itkScalarToRGBColormapImageFilterPython.cpp.o
/home/matt/src/ITK2/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h:44: warning: unable to resolve reference to `FrequencyFFTLayoutImageRegionConstIteratorWithIndex' for \ref command
/home/matt/src/ITK2/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h:46: warning: unable to resolve reference to `ITKImageFrequency' for \ref command
/home/matt/src/ITK2/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h:38: warning: unable to resolve reference to `FrequencyImageRegionIteratorWithIndex' for \ref command
/home/matt/src/ITK2/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h:42: warning: unable to resolve reference to `ForwardFFTImageFilter' for \ref command
/home/matt/src/ITK2/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h:43: warning: unable to resolve reference to `FrequencyFFTLayoutImageRegionIteratorWithIndex' for \ref command
/home/matt/src/ITK2/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h:44: warning: unable to resolve reference to `FrequencyFFTLayoutImageRegionIteratorWithIndex' for \ref command
/home/matt/src/ITK2/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h:48: warning: unable to resolve reference to `FrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex' for \ref command
/home/matt/src/ITK2/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h:50: warning: unable to resolve reference to `FrequencyShiftedFFTLayoutImageRegionIteratorWithIndex' for \ref command
```
