### PR TITLE
Bad cmake find itk wrap image dims

### DIFF
--- a/Modules/Core/SpatialObjects/test/CMakeLists.txt
+++ b/Modules/Core/SpatialObjects/test/CMakeLists.txt
@@ -107,7 +107,8 @@ itk_add_test(NAME itkNewMetaObjectTypeTest
       COMMAND ITKSpatialObjectsTestDriver itkNewMetaObjectTypeTest
       ${ITK_TEST_OUTPUT_DIR}/NewMetaObjectType.meta)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonSpatialObjectTest
     TEST_DRIVER_ARGS
     COMMAND SpatialObjectTest.py

--- a/Modules/Filtering/AnisotropicSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/AnisotropicSmoothing/test/CMakeLists.txt
@@ -23,7 +23,8 @@ itk_add_test(NAME itkGradientAnisotropicDiffusionImageFilterTest2
               ${ITK_TEST_OUTPUT_DIR}/GradientAnisotropicDiffusionImageFilterTest2.png
     itkGradientAnisotropicDiffusionImageFilterTest2 DATA{${ITK_DATA_ROOT}/Input/cake_easy.png} ${ITK_TEST_OUTPUT_DIR}/GradientAnisotropicDiffusionImageFilterTest2.png)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonCurvatureAnisotropicDiffusionImageFilterTest
     COMMAND CurvatureAnisotropicDiffusionImageFilterTest.py
       DATA{${ITK_DATA_ROOT}/Input/cthead1.png}

--- a/Modules/Filtering/AntiAlias/test/CMakeLists.txt
+++ b/Modules/Filtering/AntiAlias/test/CMakeLists.txt
@@ -13,7 +13,7 @@ itk_add_test(NAME itkAntiAliasBinaryImageFilterTest
   ${ITK_TEST_OUTPUT_DIR}/itkAntiAliasBinaryImageFilterTest.mha
   )
 
-list(FIND "${ITK_WRAP_IMAGE_DIMS}" 3 wrap_3_index)
+list(FIND ITK_WRAP_IMAGE_DIMS 3 wrap_3_index)
 if(ITK_WRAP_float AND wrap_3_index GREATER -1)
   itk_python_add_test(NAME PythonAntiAliasBinaryImageFilterTest
     TEST_DRIVER_ARGS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/CMakeLists.txt
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/CMakeLists.txt
@@ -135,7 +135,7 @@ itk_add_test(NAME itkBinaryThinningImageFilterTest
     itkBinaryThinningImageFilterTest DATA{${ITK_DATA_ROOT}/Input/Shapes.png} ${ITK_TEST_OUTPUT_DIR}/BinaryThinningImageFilterTest.png)
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
-list(FIND "${ITK_WRAP_IMAGE_DIMS}" 2 wrap_2_index)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
 if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonBinaryDilateImageFilterTest
     TEST_DRIVER_ARGS

--- a/Modules/Filtering/CurvatureFlow/test/CMakeLists.txt
+++ b/Modules/Filtering/CurvatureFlow/test/CMakeLists.txt
@@ -11,7 +11,8 @@ itk_add_test(NAME itkBinaryMinMaxCurvatureFlowImageFilterTest
 itk_add_test(NAME itkCurvatureFlowTesti
       COMMAND ITKCurvatureFlowTestDriver itkCurvatureFlowTest ${ITK_TEST_OUTPUT_DIR}/itkCurvatureFlowTest.vtk)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonCurvatureFlowImageFilterTest
     COMMAND CurvatureFlowImageFilterTest.py
       DATA{${ITK_DATA_ROOT}/Input/cthead1.png}

--- a/Modules/Filtering/FFT/test/CMakeLists.txt
+++ b/Modules/Filtering/FFT/test/CMakeLists.txt
@@ -274,8 +274,8 @@ list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
 if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonFFTImageFilterTest
     TEST_DRIVER_ARGS
-      --compare ${ITK_TEST_OUTPUT_DIR}/PythonFFTImageFilterRealTest.png DATA{Baseline/FFTImageFilterReal.png}
-      --compare ${ITK_TEST_OUTPUT_DIR}/PythonFFTImageFilterImaginaryTest.png DATA{Baseline/FFTImageFilterImaginary.png}
+      --compare ${ITK_TEST_OUTPUT_DIR}/PythonFFTImageFilterRealTest.png DATA{Baseline/PythonFFTImageFilterRealTest.png}
+      --compare ${ITK_TEST_OUTPUT_DIR}/PythonFFTImageFilterImaginaryTest.png DATA{Baseline/PythonFFTImageFilterImaginaryTest.png}
     COMMAND FFTImageFilterTest.py
       DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
       ${ITK_TEST_OUTPUT_DIR}/PythonFFTImageFilterRealTest.png

--- a/Modules/Filtering/FFT/test/CMakeLists.txt
+++ b/Modules/Filtering/FFT/test/CMakeLists.txt
@@ -270,7 +270,8 @@ add_executable(ITKFFTTestCircularDependency itkTestCircularDependency.cxx)
 target_link_libraries(ITKFFTTestCircularDependency ${ITKFFT-Test_LIBRARIES})
 itk_add_test(NAME itkFFTTestCircularDependency COMMAND ITKFFTTestCircularDependency)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonFFTImageFilterTest
     TEST_DRIVER_ARGS
       --compare ${ITK_TEST_OUTPUT_DIR}/PythonFFTImageFilterRealTest.png DATA{Baseline/FFTImageFilterReal.png}

--- a/Modules/Filtering/FastMarching/test/CMakeLists.txt
+++ b/Modules/Filtering/FastMarching/test/CMakeLists.txt
@@ -246,7 +246,8 @@ itk_add_test( NAME itkFastMarchingImageFilterTest_wm_multipleSeeds_NoHandlesTopo
 )
 set_property(TEST itkFastMarchingImageFilterTest_wm_multipleSeeds_NoHandlesTopo APPEND PROPERTY LABELS RUNS_LONG)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonFastMarchingLeftVentricleTest
     TEST_DRIVER_ARGS
       --compare ${ITK_TEST_OUTPUT_DIR}/FastMarchingLeftVentricleTest.png

--- a/Modules/Filtering/ImageFeature/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFeature/test/CMakeLists.txt
@@ -228,7 +228,8 @@ itk_python_add_test(NAME itkGradientVectorFlowImageFilterPythonTest
       ${ITK_TEST_OUTPUT_DIR}/itkGradientVectorFlowImageFilterPythonTestY.png
       50 50000.0 0.001)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonLaplacianImageFilterTest
     COMMAND LaplacianImageFilterTest.py
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}

--- a/Modules/Filtering/ImageFilterBase/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFilterBase/test/CMakeLists.txt
@@ -42,7 +42,7 @@ set(ITKImageFilterBaseGTests
 CreateGoogleTestDriver(ITKImageFilterBase "${ITKImageFilterBase-Test_LIBRARIES}" "${ITKImageFilterBaseGTests}")
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
-list(FIND "${ITK_WRAP_IMAGE_DIMS}" 2 wrap_2_index)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
 if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonCastImageFilterTest
     TEST_DRIVER_ARGS

--- a/Modules/Filtering/ImageGradient/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGradient/test/CMakeLists.txt
@@ -91,7 +91,8 @@ itk_add_test(NAME itkDifferenceOfGaussiansGradientTest
 
       COMMAND ITKImageGradientTestDriver itkDifferenceOfGaussiansGradientTest)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonGradientMagnitudeRecursiveGaussianImageFilterTest
     TEST_DRIVER_ARGS
       --compare ${ITK_TEST_OUTPUT_DIR}/GradientMagnitudeRecursiveGaussianImageFilterTest.png

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -299,7 +299,7 @@ set( ITKImageGridGTests
 CreateGoogleTestDriver(ITKImageGrid "${ITKImageGrid-Test_LIBRARIES}" "${ITKImageGridGTests}")
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
-list(FIND "${ITK_WRAP_IMAGE_DIMS}" 2 wrap_2_index)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
 if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonResampleImageFilterTest1
     TEST_DRIVER_ARGS

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -314,7 +314,7 @@ if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonResampleImageFilterTest2
     TEST_DRIVER_ARGS
       --compare ${ITK_TEST_OUTPUT_DIR}/PythonResampleImageFilterTest2.png
-                DATA{Baseline/ResampleImageFilterTest2.png}
+                DATA{Baseline/PythonResampleImageFilterTest2.png}
     COMMAND ResampleImageFilterTest.py
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/PythonResampleImageFilterTest2.png
@@ -324,7 +324,7 @@ if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonResampleImageFilterTest3
     TEST_DRIVER_ARGS
       --compare ${ITK_TEST_OUTPUT_DIR}/PythonResampleImageFilterTest3.png
-      DATA{Input/ResampleImageFilterTest3.png}
+      DATA{Baseline/PythonResampleImageFilterTest3.png}
     COMMAND ResampleImageFilterTest.py
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/PythonResampleImageFilterTest3.png
@@ -334,7 +334,7 @@ if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonResampleImageFilterTest4
     TEST_DRIVER_ARGS
       --compare ${ITK_TEST_OUTPUT_DIR}/PythonResampleImageFilterTest4.png
-                DATA{Baseline/ResampleImageFilterTest4.png}
+                DATA{Baseline/PythonResampleImageFilterTest4.png}
     COMMAND ResampleImageFilterTest.py
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/PythonResampleImageFilterTest4.png

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -357,7 +357,7 @@ endif()
 CreateGoogleTestDriver(ITKImageIntensity "${ITKImageIntensity-Test_LIBRARIES}" "${ITKImageIntensityGTests}")
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
-list(FIND "${ITK_WRAP_IMAGE_DIMS}" 2 wrap_2_index)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
 if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonSigmoidImageFilterTest
     TEST_DRIVER_ARGS

--- a/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
+++ b/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
@@ -522,7 +522,7 @@ itk_add_test(NAME itkRankImageFilterTest10
     itkRankImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/itkRankImageFilter10.png 10)
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
-list(FIND "${ITK_WRAP_IMAGE_DIMS}" 2 wrap_2_index)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
 if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonGrayscaleDilateImageFilterTest
     TEST_DRIVER_ARGS

--- a/Modules/Filtering/Smoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/Smoothing/test/CMakeLists.txt
@@ -70,7 +70,7 @@ itk_add_test(NAME itkRecursiveGaussianScaleSpaceTest1
               itkRecursiveGaussianScaleSpaceTest1)
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
-list(FIND "${ITK_WRAP_IMAGE_DIMS}" 2 wrap_2_index)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
 if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonMeanImageFilterTest
     TEST_DRIVER_ARGS

--- a/Modules/Filtering/Thresholding/test/CMakeLists.txt
+++ b/Modules/Filtering/Thresholding/test/CMakeLists.txt
@@ -350,7 +350,7 @@ itk_add_test(NAME itkKappaSigmaThresholdImageFilterTest02
     itkKappaSigmaThresholdImageFilterTest DATA{${ITK_DATA_ROOT}/Input/CellsFluorescence2.png} ${ITK_TEST_OUTPUT_DIR}/itkKappaSigmaThresholdImageFilterTest02.png 2 3.0)
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
-list(FIND "${ITK_WRAP_IMAGE_DIMS}" 2 wrap_2_index)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
 if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonBinaryThresholdImageFilterTest
     TEST_DRIVER_ARGS

--- a/Modules/IO/GDCM/test/CMakeLists.txt
+++ b/Modules/IO/GDCM/test/CMakeLists.txt
@@ -144,7 +144,8 @@ itk_add_test(NAME itkGDCMLoadImageNoSpacingTest
     1.0
   )
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonReadDicomAndReadTagTest
     COMMAND ReadDicomAndReadTagTest.py
       DATA{${ITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm}

--- a/Modules/Segmentation/LevelSets/test/CMakeLists.txt
+++ b/Modules/Segmentation/LevelSets/test/CMakeLists.txt
@@ -98,7 +98,8 @@ itk_add_test(NAME itkCurvesLevelSetImageFilterZeroSigmaTest
 
 itk_python_add_test(NAME PythonLazyLoadingImage COMMAND LazyLoadingImageTest.py)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
 # TODO: reenable the geodesic test once we get why the result is not the
 # same than with c++
 # keep just one to be sure it run, but don't compare the images

--- a/Modules/Segmentation/LevelSets/test/CMakeLists.txt
+++ b/Modules/Segmentation/LevelSets/test/CMakeLists.txt
@@ -108,7 +108,7 @@ if(ITK_WRAP_float AND wrap_2_index GREATER -1)
 #     --compare GeodesicActiveContourLeftVentricleTest.png
 #             DATA{${WrapITK_SOURCE_DIR}/images/GeodesicActiveContourLeftVentricleTest.png}
     COMMAND GeodesicActiveContourImageFilterTest.py
-      DATA{INput/BrainProtonDensitySlice.png}
+      DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/GeodesicActiveContourLeftVentricleTest.png
       81 114 5.0 1.0 -0.5 3.0 2.0
     )
@@ -116,7 +116,7 @@ if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonThresholdSegmentationLevelSetVentricleTest
     TEST_DRIVER_ARGS
     --compare ${ITK_TEST_OUTPUT_DIR}/PythonThresholdSegmentationLevelSetVentricleTest.png
-              DATA{Baseline/PythonThresholdSegmentationLevelSetVentricleTest.png}
+              DATA{PythonThresholdSegmentationLevelSetVentricleTest.png}
     COMMAND ThresholdSegmentationLevelSetImageFilterTest.py
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/PythonThresholdSegmentationLevelSetVentricleTest.png
@@ -126,7 +126,7 @@ if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonThresholdSegmentationLevelSetWhiteMatterTest
     TEST_DRIVER_ARGS
       --compare ${ITK_TEST_OUTPUT_DIR}/ThresholdSegmentationLevelSetWhiteMatterTest.png
-        DATA{Baseline/PythonThresholdSegmentationLevelSetWhiteMatterTest.png}
+        DATA{PythonThresholdSegmentationLevelSetWhiteMatterTest.png}
     COMMAND ThresholdSegmentationLevelSetImageFilterTest.py
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/ThresholdSegmentationLevelSetWhiteMatterTest.png

--- a/Modules/Segmentation/Watersheds/test/CMakeLists.txt
+++ b/Modules/Segmentation/Watersheds/test/CMakeLists.txt
@@ -159,7 +159,8 @@ itk_add_test(NAME itkMorphologicalWatershedImageFilterTestLevel50
               ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestLevel50.png
     itkMorphologicalWatershedImageFilterTest DATA{${ITK_DATA_ROOT}/Input/level.png} ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestLevel50.png 1 0 50)
 
-if(ITK_WRAP_float AND WRAP_2)
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_float AND wrap_2_index GREATER -1)
   itk_python_add_test(NAME PythonWatershedSegmentation1Test
     TEST_DRIVER_ARGS
       --compare ${ITK_TEST_OUTPUT_DIR}/PythonWatershedSegmentation1Test.png


### PR DESCRIPTION
This PR addresses problems introduced when moving Python tests from the global Wrapping/Generators/Python directory to their individual module directory.