### PR TITLE
ENH: Support for tuples passed as arguments through itkTemplate New()…

### DIFF
--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -368,4 +368,8 @@ if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
       ${ITK_TEST_OUTPUT_DIR}/PythonSigmoidImageFilterTest.png
       10 240 10 170
     )
+    itk_python_add_test(NAME PythonIntensityWindowingImageFilterTest
+      COMMAND itkIntensityWindowingImageFilterTest.py
+      DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+      )
 endif()

--- a/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.py
+++ b/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.py
@@ -1,0 +1,34 @@
+#==========================================================================
+#
+#   Copyright Insight Software Consortium
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+from __future__ import print_function
+
+import itk
+from sys import argv, stderr, exit
+itk.auto_progress(2)
+
+
+if(len(argv) < 2):
+    print((
+        "Missing Parameters \n Usage: IntensityWindowingImageFilter.py inputImageFile"), file=stderr)
+    exit(1)
+
+image = itk.imread(argv[1], itk.F)
+# Verifies that ITK supports getting tuples for filter parameters. Not testing the filter
+# results.
+intensity_filter = itk.IntensityWindowingImageFilter.New(image, WindowLevel=[255, 127])

--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -612,8 +612,19 @@ def set_inputs(new_itk_object, args=[], kargs={}):
             if attribName.islower():
                 attribName = _snake_to_camel(attribName)
             attrib = getattr(new_itk_object, 'Set' + attribName)
-            attrib(output(value))
 
+           # Do not use try-except mechanism as this leads to
+            # segfaults. Instead limit the number of types that are
+            # tested. The list of tested type could maybe be replaced by
+            # a test that would check for iterables.
+            if type(value) in [list, tuple]:
+                try:
+                    output_value = [output(x) for x in value]
+                    attrib(*output_value)
+                except:
+                    attrib(output(value))
+            else:
+                attrib(output(value))
 
 class templated_class:
 


### PR DESCRIPTION
… function

To set options for an ITK filter in Python, one can directly pass a value
inside the New() function call. However, this was only working if the
corresponding C++ function was expecting only one argument. This commit
allows a user to pass multiple arguments at once as a list.