### PR TITLE
ENH: On Azure DevOps only show test output on failure

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -24,7 +24,8 @@ jobs:
 
         export BUILD_EXAMPLES=OFF
         export CTEST_BUILD_CONFIGURATION=MinSizeRel
+        export CTEST_OUTPUT_ON_FAILURE=1
 
-        ctest -S ITK-dashboard/azure_dashboard.cmake -VV -j 4
+        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
       displayName: Build and Test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -25,7 +25,8 @@ jobs:
         export BUILD_EXAMPLES=OFF
         export CTEST_BUILD_CONFIGURATION=MinSizeRel
         export ITK_WRAP_PYTHON=ON
+        export CTEST_OUTPUT_ON_FAILURE=1
 
-        ctest -S ITK-dashboard/azure_dashboard.cmake -VV -j 4
+        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
       displayName: Build and Test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -21,7 +21,8 @@ jobs:
         cmake --version
 
         export BUILD_SHARED_LIBS=ON
+        export CTEST_OUTPUT_ON_FAILURE=1
 
-        ctest -S ITK-dashboard/azure_dashboard.cmake -VV -j 4
+        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
       displayName: Build and Test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -23,7 +23,8 @@ jobs:
         export BUILD_EXAMPLES=OFF
         export CTEST_BUILD_CONFIGURATION=Release
         export ITK_WRAP_PYTHON=ON
+        export CTEST_OUTPUT_ON_FAILURE=1
 
-        ctest -S ITK-dashboard/azure_dashboard.cmake -VV -j 4
+        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
       displayName: Build and Test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -23,7 +23,8 @@ jobs:
         set CTEST_BUILD_CONFIGURATION=MinSizeRel
         set CC=cl.exe
         set CXX=cl.exe
+        set CTEST_OUTPUT_ON_FAILURE=1
 
-        ctest -S ITK-dashboard/azure_dashboard.cmake -VV -j 4
+        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
       displayName: Build and Test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -25,7 +25,8 @@ jobs:
         set ITK_BUILD_DEFAULT_MODULES=OFF
         set CC=cl.exe
         set CXX=cl.exe
+        set CTEST_OUTPUT_ON_FAILURE=1
 
-        ctest -S ITK-dashboard/azure_dashboard.cmake -VV -j 4
+        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
       displayName: Build and Test
       workingDirectory: $(Agent.BuildDirectory)


### PR DESCRIPTION
To reduce the size of the logs, reduce the verbosity of ctest and only
show test out when the test fails.
