### PR TITLE
BUG: Synchronize BSpline MeshTransform parameters with fixed

### DIFF
--- a/Modules/Core/TestKernel/include/itkGTestTypedefsAndConstructors.h
+++ b/Modules/Core/TestKernel/include/itkGTestTypedefsAndConstructors.h
@@ -51,7 +51,7 @@ using IndexType = ImageBaseType::IndexType;
 using PointType = ImageBaseType::PointType;
 using DirectionType = ImageBaseType::DirectionType;
 using VectorType = ImageBaseType::SpacingType;
-
+using RegionType = ImageBaseType::RegionType;
 
 inline static PointType MakePoint(PointType::ValueType p1,
                            PointType::ValueType p2)
@@ -103,7 +103,7 @@ using IndexType = ImageBaseType::IndexType;
 using PointType = ImageBaseType::PointType;
 using DirectionType = ImageBaseType::DirectionType;
 using VectorType = ImageBaseType::SpacingType;
-
+using RegionType = ImageBaseType::RegionType;
 
 inline static PointType MakePoint(PointType::ValueType p1,
                                   PointType::ValueType p2,

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -299,7 +299,10 @@ private:
   /** Construct control point grid direction from transform domain information. */
   void SetFixedParametersGridDirectionFromTransformDomainInformation() const override;
 
-  /** Construct control point grid size from transform domain information. */
+  /** Set TransformDomain member variables from the coefficient images */
+  void SetTransformDomainInformationFromCoefficientImageInformation();
+
+  /** Construct control point grid size from transform domain information in the fixed parameters. */
   void SetCoefficientImageInformationFromFixedParameters() override;
 
   /** Check if a continuous index is inside the valid region. */

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -310,7 +310,6 @@ private:
   OriginType             m_TransformDomainOrigin;
   PhysicalDimensionsType m_TransformDomainPhysicalDimensions;
   DirectionType          m_TransformDomainDirection;
-  DirectionType          m_TransformDomainDirectionInverse;
 
   MeshSizeType m_TransformDomainMeshSize;
 }; // class BSplineTransform

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -365,6 +365,27 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
     this->m_CoefficientImages[i]->SetRegions(
       this->m_CoefficientImages[0]->GetLargestPossibleRegion() );
     }
+
+  // Update TransformDomain parameters.
+  this->m_TransformDomainDirection = this->m_CoefficientImages[0]->GetDirection();
+
+  typedef typename ImageType::PointType PointType;
+  PointType origin2;
+  origin2.Fill( 0.0 );
+  for( unsigned int i = 0; i < SpaceDimension; i++ )
+    {
+    this->m_TransformDomainMeshSize[i] =
+      this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetSize()[i] - SplineOrder;
+    this->m_TransformDomainPhysicalDimensions[i] = static_cast<ScalarType>(
+      this->m_TransformDomainMeshSize[i] ) * this->m_CoefficientImages[0]->GetSpacing()[i];
+    origin2[i] += ( this->m_CoefficientImages[0]->GetSpacing()[i] * 0.5 * ( SplineOrder - 1 ) );
+    }
+  origin2 = this->m_TransformDomainDirection * origin2;
+
+  for( unsigned int j = 0; j < SpaceDimension; j++ )
+    {
+    this->m_TransformDomainOrigin[j] = this->m_CoefficientImages[0]->GetOrigin()[j] + origin2[j];
+    }
 }
 
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
@@ -384,6 +405,8 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
     itkExceptionMacro( << "SetCoefficientImage() requires that an array of "
                        << "correctly sized images be supplied.");
     }
+
+  this->m_TransformDomainDirection = images[0]->GetDirection();
 
   using PointType = typename ImageType::PointType;
   PointType origin;

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -51,7 +51,6 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
   this->m_TransformDomainOrigin.Fill( 0.0 );
   this->m_TransformDomainPhysicalDimensions.Fill( 1.0 );
   this->m_TransformDomainDirection.SetIdentity();
-  this->m_TransformDomainDirectionInverse.SetIdentity();
 
   SizeType meshSize;
   meshSize.Fill( 1 );
@@ -143,7 +142,6 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
   if( this->m_TransformDomainDirection != direction )
     {
     this->m_TransformDomainDirection = direction;
-    this->m_TransformDomainDirectionInverse = direction.GetInverse();
     this->SetFixedParametersFromTransformDomainInformation();
     this->SetCoefficientImageInformationFromFixedParameters();
 

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -172,3 +172,9 @@ itk_add_test(NAME itkMultiTransformTest
       COMMAND ITKTransformTestDriver itkMultiTransformTest)
 itk_add_test(NAME itkTestTransformGetInverse
   COMMAND ITKTransformTestDriver itkTestTransformGetInverse)
+
+
+set(ITKTransformGTests
+  itkBSplineTransformGTest.cxx
+)
+CreateGoogleTestDriver(ITKTransform "${ITKTransform-Test_LIBRARIES}" "${ITKTransformGTests}")

--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -1,0 +1,177 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+#include "itkBSplineTransform.h"
+
+#include "itkImageRegionConstIterator.h"
+
+namespace {
+
+
+// Method which checks that two BSpline are exactly equal
+template<typename TParametersValueType,
+          unsigned int NDimensions,
+         unsigned int VSplineOrder>
+void bspline_eq( const itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>  *bspline1,
+                 const itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder> *bspline2,
+                 const std::string & description = "")
+{
+  using BSplineType = itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>;
+  // Compare Transform Domain interface
+
+  EXPECT_EQ( bspline1->GetNumberOfFixedParameters(), bspline2->GetNumberOfFixedParameters() ) << description;
+  EXPECT_EQ( bspline1->GetTransformDomainOrigin(), bspline2->GetTransformDomainOrigin() ) << description;
+  EXPECT_EQ( bspline1->GetTransformDomainDirection(), bspline2->GetTransformDomainDirection() ) << description;
+  EXPECT_EQ( bspline1->GetTransformDomainMeshSize(), bspline2->GetTransformDomainMeshSize() ) << description;
+  EXPECT_EQ( bspline1->GetTransformDomainPhysicalDimensions(), bspline2->GetTransformDomainPhysicalDimensions() ) << description;
+
+  // check transform parameters interface
+  EXPECT_EQ( bspline1->GetParameters(), bspline2->GetParameters() ) << description;
+  EXPECT_EQ( bspline1->GetFixedParameters(), bspline2->GetFixedParameters() ) << description;
+
+  ASSERT_EQ( bspline1->GetCoefficientImages().Size(), NDimensions ) << description;
+  ASSERT_EQ( bspline2->GetCoefficientImages().Size(), NDimensions ) << description;
+
+  for (unsigned int i = 0; i < NDimensions; ++i)
+    {
+    using ImageType = typename BSplineType::ImageType;
+    using ImageConstIterator = typename itk::ImageRegionConstIterator<ImageType>;
+
+    typename ImageType::Pointer coeffImage1 = bspline1->GetCoefficientImages()[i];
+    typename ImageType::Pointer coeffImage2 = bspline2->GetCoefficientImages()[i];
+
+    EXPECT_EQ( coeffImage1->GetOrigin(), coeffImage2->GetOrigin() ) << description;
+    EXPECT_EQ( coeffImage1->GetDirection(), coeffImage2->GetDirection() ) << description;
+    EXPECT_EQ( coeffImage1->GetSpacing(), coeffImage2->GetSpacing() ) << description;
+    EXPECT_EQ( coeffImage1->GetLargestPossibleRegion(), coeffImage2->GetLargestPossibleRegion() ) << description;
+    EXPECT_EQ( coeffImage1->GetBufferedRegion(), coeffImage2->GetBufferedRegion() ) << description;
+
+    ImageConstIterator iter1(coeffImage1, coeffImage1->GetBufferedRegion());
+    ImageConstIterator iter2(coeffImage2, coeffImage2->GetBufferedRegion());
+
+
+    while( !iter1.IsAtEnd() && iter2.IsAtEnd() )
+      {
+      EXPECT_EQ( iter1.Get(), iter2.Get() )  << description << " Expected value at: " << iter1.GetIndex();
+      ++iter1;
+      ++iter2;
+      }
+
+
+    }
+}
+
+}
+
+TEST(ITKBSplineTransform, Construction) {
+
+using BSplineType = itk::BSplineTransform<double, 3, 3>;
+
+BSplineType::Pointer bspline1 = BSplineType::New();
+BSplineType::Pointer bspline2 = BSplineType::New();
+
+bspline_eq(bspline1.GetPointer(), bspline1.GetPointer());
+bspline_eq(bspline2.GetPointer(), bspline2.GetPointer());
+bspline_eq(bspline1.GetPointer(), bspline2.GetPointer());
+bspline_eq(bspline2.GetPointer(), bspline1.GetPointer());
+}
+
+TEST(ITKBSplineTransform, Copying_Clone) {
+  // This test sets up an non-trivial bspline transform then,
+  // test various interface to set the parameters to the a new
+  // transform. It validates that the result it the same as the initial
+
+  using namespace itk::GTest::TypedefsAndConstructors::Dimension2;
+
+  using BSplineType = itk::BSplineTransform<double, 2, 3>;
+  using ImageType = typename BSplineType::ImageType;
+  using ImageIterator = typename itk::ImageRegionIterator<ImageType>;
+
+  typename BSplineType::CoefficientImageArray coeffImageArray;
+
+  ASSERT_EQ(coeffImageArray.Size(), 2);
+
+  SizeType imageSize = MakeSize(10, 10);
+  DirectionType imageDirection; // filled with zeros
+  imageDirection(0,1) = -1;
+  imageDirection(1,0) = 1;
+
+  VectorType imageSpacing = MakeVector( 1.1, 1.2 );
+
+  PointType imageOrigin = MakePoint( 0.9, 0.8 );
+
+  coeffImageArray[0] = ImageType::New();
+
+  unsigned short px_value = 3;
+
+  ImageType::Pointer coeffImage;
+  for ( unsigned int i = 0; i < Dimension; ++i )
+    {
+    coeffImageArray[i] = ImageType::New();
+    coeffImage = coeffImageArray[i];
+
+    coeffImage->SetRegions(RegionType(imageSize));
+
+    coeffImage->SetSpacing(imageSpacing);
+    coeffImage->SetOrigin(imageOrigin);
+    coeffImage->SetDirection(imageDirection);
+
+    coeffImage->Allocate();
+
+    ImageIterator iter(coeffImage, coeffImage->GetBufferedRegion());
+
+
+    while( !iter.IsAtEnd() )
+      {
+      iter.Set(px_value++);
+      ++iter;
+      }
+
+    }
+
+  BSplineType::Pointer bspline1 = BSplineType::New();
+  bspline1->SetCoefficientImages(coeffImageArray);
+
+  bspline_eq(bspline1.GetPointer(), bspline1.GetPointer(), "Check after initialization by coefficient images.");
+
+  EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainOrigin(), MakePoint(-0.3, 1.9), 1e-15 );
+  EXPECT_EQ( bspline1->GetTransformDomainDirection(), imageDirection );
+  EXPECT_EQ( bspline1->GetTransformDomainMeshSize(), MakeSize(7, 7) );
+  EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainPhysicalDimensions(), MakeVector( 7.7, 8.4 ), 1e-15 );
+
+  BSplineType::Pointer bspline2 = BSplineType::New();
+  bspline2->SetFixedParameters( bspline1->GetFixedParameters() );
+  bspline2->SetParameters( bspline1->GetParameters() );
+
+  bspline_eq(bspline1.GetPointer(), bspline2.GetPointer(), "Copying by parameters.");
+
+
+  bspline2 = BSplineType::New();
+  bspline2->SetTransformDomainOrigin( bspline1->GetTransformDomainOrigin() );
+  bspline2->SetTransformDomainPhysicalDimensions( bspline1->GetTransformDomainPhysicalDimensions() );
+  bspline2->SetTransformDomainDirection( bspline1->GetTransformDomainDirection() );
+  bspline2->SetTransformDomainMeshSize( bspline1->GetTransformDomainMeshSize() );
+  bspline2->SetParameters( bspline1->GetParameters() );
+
+  bspline_eq(bspline1.GetPointer(), bspline2.GetPointer(), "Set by transform domain then by parameters.");
+
+
+  bspline2 = bspline1->Clone();
+  bspline_eq(bspline1.GetPointer(), bspline2.GetPointer(), "Clone");
+}


### PR DESCRIPTION
When "SetFixedParameters" is called when reading a BSplineTransform, or a Clone ( SimpleITK copy-on-write), the TransformDomain* parameters are not updated.