### PR TITLE
COMP: Fixed ImageRange warning, passing object to variadic constructor

### DIFF
--- a/Modules/Core/Common/include/itkImageRange.h
+++ b/Modules/Core/Common/include/itkImageRange.h
@@ -174,7 +174,7 @@ private:
     PixelProxy(const PixelProxy&) ITK_NOEXCEPT = default;
 
     // Constructor, called directly by operator*() of the iterator class.
-    PixelProxy(
+    explicit PixelProxy(
       InternalPixelType& internalPixel,
       const AccessorFunctorType& accessorFunctor) ITK_NOEXCEPT
       :
@@ -260,12 +260,21 @@ private:
     public:
       QualifiedPixelType& m_Pixel;
 
-      explicit PixelReferenceWrapper(QualifiedPixelType& pixel, ...) ITK_NOEXCEPT
+      // Wraps the pixel reference that is specified by the first argument.
+      // Note: the second parameter is unused, but it is there just to support
+      // the use case of iterator::operator*(), which uses either
+      // PixelReferenceWrapper or PixelProxy, interchangeable, in a generic way.
+      // (PixelProxy has an explicit constructor for which the second parameter
+      // is its essential AccessorFunctor parameter!)
+      explicit PixelReferenceWrapper(
+        QualifiedPixelType& pixel,
+        EmptyAccessorFunctor) ITK_NOEXCEPT
         :
       m_Pixel(pixel)
       {
       }
 
+      // Converts implicitly to a reference to the pixel.
       operator QualifiedPixelType&() const ITK_NOEXCEPT
       {
         return m_Pixel;


### PR DESCRIPTION
Fixed Mac10.13-AppleClang-dbg-x86_64-static warning from https://open.cdash.org/viewBuildError.php?type=1&buildid=5660763 that said:

    [CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkImageRange.h:334:53: warning: passing object of class type 'const itk::Experimental::ImageRange<itk::Image<short, 1> >::OptionalAccessorFunctorType' (aka 'const itk::Experimental::ImageRange<itk::Image<short, 1> >::EmptyAccessorFunctor') through variadic constructor [-Wclass-varargs]

The warning wasn't very severe, because the "object of class type" that was passed to this specific variadic constructor was unused anyway.

This commit fixes the warning by replacing the variadic constructor of PixelReferenceWrapper by a non-variadic one. It also adds comments to PixelReferenceWrapper, and improves the coding style by declaring the corresponding PixelProxy constructor 'explicit'.