### PR TITLE
4.13.1 BUG: don't quote argument to URL_HASH for FFTW

### DIFF
--- a/CMake/itkExternal_FFTW.cmake
+++ b/CMake/itkExternal_FFTW.cmake
@@ -90,7 +90,7 @@ else()
       ExternalProject_add(fftwf
         PREFIX fftwf
         URL "${_fftw_url}"
-        URL_HASH SHA512="${_fftw_url_hash}"
+        URL_HASH SHA512=${_fftw_url_hash}
         DOWNLOAD_NAME "fftw-${_fftw_target_version}.tar.gz"
         CONFIGURE_COMMAND
           env
@@ -118,7 +118,7 @@ else()
       ExternalProject_add(fftwd
         PREFIX fftwd
         URL "${_fftw_url}"
-        URL_HASH SHA512="${_fftw_url_hash}"
+        URL_HASH SHA512=${_fftw_url_hash}
         DOWNLOAD_NAME "fftw-${_fftw_target_version}.tar.gz"
         CONFIGURE_COMMAND
           env


### PR DESCRIPTION
The hash method was switched from URL_MD5 to URL_HASH in:

https://github.com/InsightSoftwareConsortium/ITK/commit/716fe079a6fad64f63f1166c7cb1565acef982ee#diff-3410c0d07b017317e4e05d74e9ad6941

Unfortunately, doing so with quoting breaks the the build due to a subtle difference in how URL_MD5 and URL_HASH are interpreted:

```
ATTENTION: You have enabled the use of FFTW. This library is distributed under a GPL license. By enabling this option, the ITK libraries binary that is built will be covered by a GPL license and so will any executable that is linked against these libraries.
CMake Error at /_build_env/share/cmake-3.13/Modules/ExternalProject.cmake:2430 (message):
  URL_HASH is set to

    SHA512="1ee2c7bec3657f6846e63c6dfa71410563830d2b951966bf0123bd8f4f2f5d6b50f13b76d9a7b0eae70e44856f829ca6ceb3d080bb01649d1572c9f3f68e8eb1"

  but must be ALGO=value where ALGO is

    MD5|SHA1|SHA224|SHA256|SHA384|SHA512|SHA3_224|SHA3_256|SHA3_384|SHA3_512

  and value is a hex string.
Call Stack (most recent call first):
  /_build_env/share/cmake-3.13/Modules/ExternalProject.cmake:3105 (_ep_add_download_command)
  CMake/itkExternal_FFTW.cmake:90 (ExternalProject_add)
  CMakeLists.txt:321 (include)
```

See the following CMake MR for more information:

https://gitlab.kitware.com/cmake/cmake/merge_requests/2718
