### PR TITLE
PERF: N4BiasFieldCorrectionImageFilter implementation using ImageRange

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
@@ -137,6 +137,9 @@ public:
   using BiasFieldControlPointLatticeType = typename BSplineFilterType::PointDataImageType;
   using ArrayType = typename BSplineFilterType::ArrayType;
 
+  /** Ensures that this filter can compute the entire output at once.  */
+  void EnlargeOutputRequestedRegion(DataObject*) override;
+
   /**
    * The image expected for input for bias correction.
    */

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -24,6 +24,7 @@
 #include "itkBSplineControlPointImageFilter.h"
 #include "itkDivideImageFilter.h"
 #include "itkExpImageFilter.h"
+#include "itkImageRange.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionIteratorWithIndex.h"
@@ -66,16 +67,52 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   this->m_MaximumNumberOfIterations.Fill( 50 );
 }
 
+
+template<typename TInputImage, typename TMaskImage, typename TOutputImage>
+void
+N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
+::EnlargeOutputRequestedRegion(DataObject *output)
+{
+  Superclass::EnlargeOutputRequestedRegion(output);
+
+  if (output != nullptr)
+  {
+    output->SetRequestedRegionToLargestPossibleRegion();
+  }
+}
+
+
 template<typename TInputImage, typename TMaskImage, typename TOutputImage>
 void
 N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 ::GenerateData()
 {
+  using itk::Experimental::ImageRange;
+  using itk::Experimental::MakeImageRange;
+
   this->AllocateOutputs();
 
   const InputImageType * inputImage = this->GetInput();
   using RegionType = typename InputImageType::RegionType;
   const RegionType inputRegion = inputImage->GetBufferedRegion();
+
+  const typename InputImageType::SizeType inputImageSize = inputRegion.GetSize();
+
+  const MaskImageType *const maskImage = GetMaskImage();
+
+  if ((maskImage != nullptr) && (maskImage->GetBufferedRegion().GetSize() != inputImageSize))
+  {
+    itkExceptionMacro(
+      "If a mask image is specified, its size should be equal to the input image size");
+  }
+
+  const RealImageType *const confidenceImage = GetConfidenceImage();
+
+  if ((confidenceImage != nullptr) && (confidenceImage->GetBufferedRegion().GetSize() != inputImageSize))
+  {
+    itkExceptionMacro(
+      "If a confidence image is specified, its size should be equal to the input image size");
+  }
 
   // Calculate the log of the input image.
   RealImagePointer logInputImage = RealImageType::New();
@@ -85,25 +122,28 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 
   ImageAlgorithm::Copy( inputImage, logInputImage.GetPointer(), inputRegion, inputRegion);
 
-  const MaskImageType * maskImage = this->GetMaskImage();
-  const RealImageType * confidenceImage = this->GetConfidenceImage();
+  const auto maskImageRange = MakeImageRange(maskImage);
+  const auto confidenceImageRange = MakeImageRange(confidenceImage);
   const MaskPixelType maskLabel = this->GetMaskLabel();
   const bool useMaskLabel = this->GetUseMaskLabel();
 
-  ImageRegionIteratorWithIndex<RealImageType> It( logInputImage, inputRegion );
+  const ImageRange<RealImageType> logInputImageRange{ *logInputImage };
+  const std::size_t numberOfPixels = logInputImageRange.size();
 
-  for( It.GoToBegin(); !It.IsAtEnd(); ++It )
+  for( std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue )
     {
-    if( ( !maskImage
-          || ( useMaskLabel && maskImage->GetPixel( It.GetIndex() ) == maskLabel )
-          || ( !useMaskLabel &&  maskImage->GetPixel( It.GetIndex() ) != NumericTraits< MaskPixelType >::ZeroValue() )
+    if( ( maskImageRange.empty()
+          || ( useMaskLabel && maskImageRange[indexValue] == maskLabel )
+          || ( !useMaskLabel && maskImageRange[indexValue] != NumericTraits< MaskPixelType >::ZeroValue() )
           )
-        && ( !confidenceImage ||
-             confidenceImage->GetPixel( It.GetIndex() ) > 0.0 ) )
+        && ( confidenceImageRange.empty() ||
+             confidenceImageRange[indexValue] > 0.0 ) )
       {
-      if( It.Get() > NumericTraits<typename InputImageType::PixelType>::ZeroValue() )
+      auto&& logInputPixel = logInputImageRange[indexValue];
+
+      if(logInputPixel > NumericTraits<typename InputImageType::PixelType>::ZeroValue() )
         {
-        It.Set( std::log( static_cast< RealType >( It.Get() ) ) );
+        logInputPixel = std::log( static_cast< RealType >(logInputPixel) );
         }
       }
     }
@@ -230,8 +270,11 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::RealIma
 N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 ::SharpenImage( const RealImageType *unsharpenedImage ) const
 {
-  const MaskImageType * maskImage = this->GetMaskImage();
-  const RealImageType * confidenceImage = this->GetConfidenceImage();
+  using itk::Experimental::ImageRange;
+  using itk::Experimental::MakeImageRange;
+
+  const auto maskImageRange = MakeImageRange(this->GetMaskImage());
+  const auto confidenceImageRange = MakeImageRange(this->GetConfidenceImage());
   const MaskPixelType maskLabel = this->GetMaskLabel();
   const bool useMaskLabel = this->GetUseMaskLabel();
 
@@ -243,19 +286,19 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   RealType binMaximum = NumericTraits<RealType>::NonpositiveMin();
   RealType binMinimum = NumericTraits<RealType>::max();
 
-  ImageRegionConstIteratorWithIndex<RealImageType> ItU(
-    unsharpenedImage, unsharpenedImage->GetLargestPossibleRegion() );
+  const auto unsharpenedImageRange = MakeImageRange(unsharpenedImage);
+  const std::size_t numberOfPixels = unsharpenedImageRange.size();
 
-  for( ItU.GoToBegin(); !ItU.IsAtEnd(); ++ItU )
+  for( std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue )
     {
-    if( ( !maskImage ||
-          ( useMaskLabel && maskImage->GetPixel( ItU.GetIndex() ) == maskLabel )
-          || ( !useMaskLabel && maskImage->GetPixel( ItU.GetIndex() ) != NumericTraits< MaskPixelType >::ZeroValue() )
+    if( ( maskImageRange.empty()
+          || ( useMaskLabel && maskImageRange[indexValue] == maskLabel )
+          || ( !useMaskLabel && maskImageRange[indexValue] != NumericTraits< MaskPixelType >::ZeroValue() )
           )
-        && ( !confidenceImage ||
-             confidenceImage->GetPixel( ItU.GetIndex() ) > 0.0 ) )
+        && ( confidenceImageRange.empty() ||
+             confidenceImageRange[indexValue] > 0.0 ) )
       {
-      RealType pixel = ItU.Get();
+      RealType pixel = unsharpenedImageRange[indexValue];
       if( pixel > binMaximum )
         {
         binMaximum = pixel;
@@ -274,16 +317,16 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 
   vnl_vector<RealType> H( this->m_NumberOfHistogramBins, 0.0 );
 
-  for( ItU.GoToBegin(); !ItU.IsAtEnd(); ++ItU )
+  for( std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue )
     {
-    if( ( !maskImage ||
-          ( useMaskLabel && maskImage->GetPixel( ItU.GetIndex() ) == maskLabel )
-          || ( !useMaskLabel && maskImage->GetPixel( ItU.GetIndex() ) != NumericTraits< MaskPixelType >::ZeroValue() )
+    if( ( maskImageRange.empty()
+          || ( useMaskLabel && maskImageRange[indexValue] == maskLabel )
+          || ( !useMaskLabel && maskImageRange[indexValue] != NumericTraits< MaskPixelType >::ZeroValue() )
           )
-        && ( !confidenceImage ||
-             confidenceImage->GetPixel( ItU.GetIndex() ) > 0.0 ) )
+        && ( confidenceImageRange.empty() ||
+             confidenceImageRange[indexValue] > 0.0 ) )
       {
-      RealType pixel = ItU.Get();
+      RealType pixel = unsharpenedImageRange[indexValue];
 
       RealType cidx = ( static_cast<RealType>( pixel ) - binMinimum ) /
         histogramSlope;
@@ -440,19 +483,18 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   sharpenedImage->SetRegions( inputImage->GetLargestPossibleRegion() );
   sharpenedImage->Allocate( true ); // initialize buffer to zero
 
-  ImageRegionIterator<RealImageType> ItC(
-    sharpenedImage, sharpenedImage->GetLargestPossibleRegion() );
+  const ImageRange<RealImageType> sharpenedImageRange{ *sharpenedImage };
 
-  for( ItU.GoToBegin(), ItC.GoToBegin(); !ItU.IsAtEnd(); ++ItU, ++ItC )
+  for( std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue )
     {
-    if( ( !maskImage ||
-          ( useMaskLabel && maskImage->GetPixel( ItU.GetIndex() ) == maskLabel )
-          || ( !useMaskLabel && maskImage->GetPixel( ItU.GetIndex() ) != NumericTraits< MaskPixelType >::ZeroValue() )
+    if( ( maskImageRange.empty()
+          || ( useMaskLabel && maskImageRange[indexValue] == maskLabel )
+          || ( !useMaskLabel && maskImageRange[indexValue] != NumericTraits< MaskPixelType >::ZeroValue() )
           )
-        && ( !confidenceImage ||
-             confidenceImage->GetPixel( ItU.GetIndex() ) > 0.0 ) )
+        && ( confidenceImageRange.empty() ||
+             confidenceImageRange[indexValue] > 0.0 ) )
       {
-      RealType     cidx = ( ItU.Get() - binMinimum ) / histogramSlope;
+      RealType     cidx = ( unsharpenedImageRange[indexValue] - binMinimum ) / histogramSlope;
       unsigned int idx = itk::Math::floor( cidx );
 
       RealType correctedPixel = 0;
@@ -465,7 +507,7 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
         {
         correctedPixel = E[E.size() - 1];
         }
-      ItC.Set( correctedPixel );
+      sharpenedImageRange[indexValue] = correctedPixel;
       }
     }
 
@@ -478,6 +520,8 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::RealIma
 N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 ::UpdateBiasFieldEstimate( RealImageType* fieldEstimate )
 {
+  using itk::Experimental::MakeImageRange;
+
   // Temporarily set the direction cosine to identity since the B-spline
   // approximation algorithm works in parametric space and not physical
   // space.
@@ -506,8 +550,8 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
     BSplineFilterType::WeightsContainerType::New();
   weights->Initialize();
 
-  const MaskImageType * maskImage = this->GetMaskImage();
-  const RealImageType * confidenceImage = this->GetConfidenceImage();
+  const auto maskImageRange = MakeImageRange(this->GetMaskImage());
+  const auto confidenceImageRange = MakeImageRange(this->GetConfidenceImage());
   const MaskPixelType maskLabel = this->GetMaskLabel();
   const bool useMaskLabel = this->GetUseMaskLabel();
 
@@ -515,14 +559,14 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
     It( parametricFieldEstimate, parametricFieldEstimate->GetRequestedRegion() );
 
   unsigned int index = 0;
-  for ( It.GoToBegin(); !It.IsAtEnd(); ++It )
+  for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue, ++It)
     {
-    if( ( !maskImage ||
-          ( useMaskLabel && maskImage->GetPixel( It.GetIndex() ) == maskLabel )
-          || ( !useMaskLabel && maskImage->GetPixel( It.GetIndex() ) != NumericTraits< MaskPixelType >::ZeroValue() )
+    if( (maskImageRange.empty()
+          || ( useMaskLabel && maskImageRange[indexValue] == maskLabel )
+          || ( !useMaskLabel && maskImageRange[indexValue] != NumericTraits< MaskPixelType >::ZeroValue() )
           )
-        && ( !confidenceImage ||
-             confidenceImage->GetPixel( It.GetIndex() ) > 0.0 ) )
+        && ( confidenceImageRange.empty() ||
+             confidenceImageRange[indexValue] > 0.0 ) )
       {
       PointType point;
       parametricFieldEstimate->TransformIndexToPhysicalPoint( It.GetIndex(), point );
@@ -534,9 +578,9 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
       fieldPoints->SetPoint( index, point );
 
       RealType confidenceWeight = 1.0;
-      if( confidenceImage )
+      if( !confidenceImageRange.empty())
         {
-        confidenceWeight = confidenceImage->GetPixel( It.GetIndex() );
+        confidenceWeight = confidenceImageRange[indexValue];
         }
       weights->InsertElement( index, confidenceWeight );
       index++;
@@ -656,6 +700,7 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 ::CalculateConvergenceMeasurement( const RealImageType *fieldEstimate1,
                                    const RealImageType *fieldEstimate2 ) const
 {
+  using itk::Experimental::MakeImageRange;
   using SubtracterType =
       SubtractImageFilter<RealImageType, RealImageType, RealImageType>;
   typename SubtracterType::Pointer subtracter = SubtracterType::New();
@@ -669,25 +714,24 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   RealType sigma = 0.0;
   RealType N = 0.0;
 
-  const MaskImageType * maskImage = this->GetMaskImage();
-  const RealImageType * confidenceImage = this->GetConfidenceImage();
+  const auto maskImageRange = MakeImageRange(this->GetMaskImage());
+  const auto confidenceImageRange = MakeImageRange(this->GetConfidenceImage());
   const MaskPixelType maskLabel = this->GetMaskLabel();
   const bool useMaskLabel = this->GetUseMaskLabel();
 
-  ImageRegionConstIteratorWithIndex<RealImageType> It(
-    subtracter->GetOutput(),
-    subtracter->GetOutput()->GetLargestPossibleRegion() );
+  const auto subtracterImageRange = MakeImageRange(subtracter->GetOutput());
+  const std::size_t numberOfPixels = subtracterImageRange.size();
 
-  for( It.GoToBegin(); !It.IsAtEnd(); ++It )
+  for( std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue )
     {
-    if( ( !maskImage ||
-          ( useMaskLabel && maskImage->GetPixel( It.GetIndex() ) == maskLabel )
-          || ( !useMaskLabel && maskImage->GetPixel( It.GetIndex() ) != NumericTraits< MaskPixelType >::ZeroValue() )
+    if( ( maskImageRange.empty()
+          || ( useMaskLabel && maskImageRange[indexValue] == maskLabel )
+          || ( !useMaskLabel && maskImageRange[indexValue] != NumericTraits< MaskPixelType >::ZeroValue() )
           )
-        && ( !confidenceImage ||
-             confidenceImage->GetPixel( It.GetIndex() ) > 0.0 ) )
+        && ( confidenceImageRange.empty() ||
+             confidenceImageRange[indexValue] > 0.0 ) )
       {
-      RealType pixel = std::exp( It.Get() );
+      RealType pixel = std::exp( subtracterImageRange[indexValue] );
       N += 1.0;
 
       if( N > 1.0 )


### PR DESCRIPTION
Adapted N4BiasFieldCorrectionImageFilter to start using ImageRange internally.
This commit yields a significant performance improvement, especially because
it replaces the (rather expensive) itk::Image::GetPixel(index) calls by
more efficient ImageRange[indexValue] calls.

Added checks to GenerateData() that the image sizes of the mask image and
confidence image (if provided) are equal to the size of the input image.

Ensured that the entire output image is computed at once, by overriding
EnlargeOutputRequestedRegion(DataObject*), as suggested by Bradley (@blowekamp).

Using VS2015 (Release), ~10% reduction of the run-time duration was observed on
a 3-D MRI volume + mask (453x340x20 voxels), provided by Denis (@dpshamonin),
at LKEB, Leiden University Medical Center.