### PR TITLE
ENH: Refactor BSplineTransform

### DIFF
--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -54,48 +54,44 @@ namespace itk
  * in the buffer; the N arrays are then concatentated together on form
  * a single array.
  *
- * For efficiency, this transform does not make a copy of the parameters.
- * It only keeps a pointer to the input parameters and assumes that the memory
- * is managed by the caller.
- *
  * The following illustrates the typical usage of this class:
- * \verbatim
- * using TransformType = BSplineTransform<double,2,3>;
- * TransformType::Pointer transform = TransformType::New();
- *
- * transform->SetTransformDomainOrigin( origin );
- * transform->SetTransformDomainPhysicalDimensions( physicalDimensions );
- * transform->SetTransformDomainDirection( direction );
- * transform->SetTransformDomainMeshSize( meshSize );
- *
- * // NB: the region must be set first before setting the parameters
- *
- * TransformType::ParametersType parameters( transform->GetNumberOfParameters() );
- *
- * // Fill the parameters with values
- *
- * transform->SetParameters( parameters )
- *
- * outputPoint = transform->TransformPoint( inputPoint );
- *
- * \endverbatim
+ * \code
+   using TransformType = BSplineTransform<double,2,3>;
+   TransformType::Pointer transform = TransformType::New();
+
+   transform->SetTransformDomainOrigin( origin );
+   transform->SetTransformDomainPhysicalDimensions( physicalDimensions );
+   transform->SetTransformDomainDirection( direction );
+   transform->SetTransformDomainMeshSize( meshSize );
+
+   // NB: The region must be set first before setting the parameters
+
+   TransformType::ParametersType parameters( transform->GetNumberOfParameters() );
+
+   // Fill the parameters with values
+
+   transform->SetParameters( parameters )
+
+   outputPoint = transform->TransformPoint( inputPoint );
+
+   \endcode
  *
  * An alternative way to set the B-spline coefficients is via array of
  * images. The fixed parameters of the transform are taken
  * directly from the first image. It is assumed that the subsequent images
  * are the same buffered region. The following illustrates the API:
- * \verbatim
+ * \code
+
+   TransformType::ImageConstPointer images[2];
+
+   // Fill the images up with values
+
+   transform->SetCoefficientImages( images );
+   outputPoint = transform->TransformPoint( inputPoint );
+
+   \endcode
  *
- * TransformType::ImageConstPointer images[2];
- *
- * // Fill the images up with values
- *
- * transform->SetCoefficientImages( images );
- * outputPoint = transform->TransformPoint( inputPoint );
- *
- * \endverbatim
- *
- * Warning: use either the SetParameters() or SetCoefficientImages()
+ * \warning Use either the SetParameters() or SetCoefficientImages()
  * API. Mixing the two modes may results in unexpected results.
  *
  * The class is templated coordinate representation type (float or double),

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -258,25 +258,25 @@ public:
   virtual void SetTransformDomainOrigin( const OriginType & );
 
   /** Function to retrieve the transform domain origin. */
-  itkGetConstMacro( TransformDomainOrigin, OriginType );
+  virtual OriginType GetTransformDomainOrigin( void ) const;
 
   /** Function to specify the transform domain physical dimensions. */
   virtual void SetTransformDomainPhysicalDimensions( const PhysicalDimensionsType & );
 
   /** Function to retrieve the transform domain physical dimensions. */
-  itkGetConstMacro( TransformDomainPhysicalDimensions, PhysicalDimensionsType );
+  virtual PhysicalDimensionsType GetTransformDomainPhysicalDimensions(void) const;
 
   /** Function to specify the transform domain direction. */
   virtual void SetTransformDomainDirection( const DirectionType & );
 
   /** Function to retrieve the transform domain direction. */
-  itkGetConstMacro( TransformDomainDirection, DirectionType );
+  virtual DirectionType GetTransformDomainDirection( void ) const;
 
   /** Function to specify the transform domain mesh size. */
   virtual void SetTransformDomainMeshSize( const MeshSizeType & );
 
   /** Function to retrieve the transform domain mesh size. */
-  itkGetConstMacro( TransformDomainMeshSize, MeshSizeType );
+  virtual MeshSizeType GetTransformDomainMeshSize( void ) const;
 
 protected:
   /** Print contents of an BSplineTransform. */
@@ -287,34 +287,25 @@ protected:
 
 private:
 
-  /** Construct control point grid size from transform domain information. */
-  void SetFixedParametersGridSizeFromTransformDomainInformation() const override;
-
-  /** Construct control point grid origin from transform domain information. */
-  void SetFixedParametersGridOriginFromTransformDomainInformation() const override;
-
-  /** Construct control point grid spacing from transform domain information. */
-  void SetFixedParametersGridSpacingFromTransformDomainInformation() const override;
-
-  /** Construct control point grid direction from transform domain information. */
-  void SetFixedParametersGridDirectionFromTransformDomainInformation() const override;
-
-  /** Set TransformDomain member variables from the coefficient images */
-  void SetTransformDomainInformationFromCoefficientImageInformation();
-
   /** Construct control point grid size from transform domain information in the fixed parameters. */
   void SetCoefficientImageInformationFromFixedParameters() override;
+
+  /** Methods have empty implementations */
+  virtual void SetFixedParametersGridSizeFromTransformDomainInformation() const override { };
+  virtual void SetFixedParametersGridOriginFromTransformDomainInformation() const override { };
+  virtual void SetFixedParametersGridSpacingFromTransformDomainInformation() const override { }
+  virtual void SetFixedParametersGridDirectionFromTransformDomainInformation() const override { };
 
   /** Check if a continuous index is inside the valid region. */
   bool InsideValidRegion( ContinuousIndexType & ) const override;
 
-private:
+  void SetFixedParametersFromCoefficientImageInformation();
 
-  OriginType             m_TransformDomainOrigin;
-  PhysicalDimensionsType m_TransformDomainPhysicalDimensions;
-  DirectionType          m_TransformDomainDirection;
+  void SetFixedParametersFromTransformDomainInformation( const OriginType &meshOrigin,
+                                                         const PhysicalDimensionsType & meshPhysical,
+                                                         const DirectionType &meshDirection,
+                                                         const MeshSizeType &meshSize);
 
-  MeshSizeType m_TransformDomainMeshSize;
 }; // class BSplineTransform
 }  // namespace itk
 

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -47,23 +47,30 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
   // dir[0][1],dir[1][1],dir[2][1],
   // dir[0][2],dir[1][2],dir[2][2]]
 
-  this->m_TransformDomainMeshSize.Fill( 0 );
-  this->m_TransformDomainOrigin.Fill( 0.0 );
-  this->m_TransformDomainPhysicalDimensions.Fill( 1.0 );
-  this->m_TransformDomainDirection.SetIdentity();
 
-  SizeType meshSize;
+  OriginType meshOrigin;
+  meshOrigin.Fill(0.0);
+  PhysicalDimensionsType meshPhysical;
+  meshPhysical.Fill(1.0);
+
+  DirectionType meshDirection;
+  meshDirection.SetIdentity();
+  MeshSizeType meshSize;
   meshSize.Fill( 1 );
 
-  this->SetTransformDomainMeshSize( meshSize );
+  this->m_FixedParameters.SetSize( NDimensions * ( NDimensions + 3 ) );
 
-  this->SetFixedParametersFromTransformDomainInformation();
+  this->SetFixedParametersFromTransformDomainInformation( meshOrigin, meshPhysical, meshDirection, meshSize );
+
+
   this->SetCoefficientImageInformationFromFixedParameters();
 }
+
 
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
 ::~BSplineTransform() = default;
+
 
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 std::string BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
@@ -78,6 +85,7 @@ std::string BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
   return  Superclass::GetTransformTypeAsString();
 }
 
+
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 typename BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::NumberOfParametersType
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
@@ -87,6 +95,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
   // of pixels in the grid region.
   return SpaceDimension * this->GetNumberOfParametersPerDimension();
 }
+
 
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 typename BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::NumberOfParametersType
@@ -104,49 +113,122 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
   return numberOfParametersPerDimension;
 }
 
+
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
 ::SetTransformDomainOrigin( const OriginType & origin )
 {
-  if( this->m_TransformDomainOrigin != origin )
+  if( this->GetTransformDomainOrigin() != origin )
     {
-    this->m_TransformDomainOrigin = origin;
-    this->SetFixedParametersFromTransformDomainInformation();
+    this->SetFixedParametersFromTransformDomainInformation(
+      origin,
+      this->GetTransformDomainPhysicalDimensions(),
+      this->GetTransformDomainDirection(),
+      this->GetTransformDomainMeshSize());
+
     this->SetCoefficientImageInformationFromFixedParameters();
 
     this->Modified();
     }
 }
+
+
+template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+auto
+BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
+::GetTransformDomainOrigin( void ) const -> OriginType
+{
+  OriginType origin;
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    const ScalarType spacing = this->m_FixedParameters[2 * NDimensions + i];
+    origin[i] = spacing * 0.5 * (SplineOrder - 1);
+    }
+
+  origin = this->GetTransformDomainDirection() * origin;
+
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    const ScalarType grid_origin = this->m_FixedParameters[NDimensions + i];
+    origin[i] += grid_origin;
+    }
+  return origin;
+}
+
 
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
 ::SetTransformDomainPhysicalDimensions( const PhysicalDimensionsType & dims )
 {
-  if( this->m_TransformDomainPhysicalDimensions != dims )
+  if( this->GetTransformDomainPhysicalDimensions() != dims )
     {
-    this->m_TransformDomainPhysicalDimensions = dims;
-    this->SetFixedParametersFromTransformDomainInformation();
+    this->SetFixedParametersFromTransformDomainInformation(
+      this->GetTransformDomainOrigin(),
+      dims,
+      this->GetTransformDomainDirection(),
+      this->GetTransformDomainMeshSize());
+
     this->SetCoefficientImageInformationFromFixedParameters();
 
     this->Modified();
     }
 }
 
+
+template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+auto
+BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
+::GetTransformDomainPhysicalDimensions(void) const -> PhysicalDimensionsType
+{
+  const MeshSizeType size = this->GetTransformDomainMeshSize();
+  PhysicalDimensionsType physicalDim;
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    ScalarType spacing = this->m_FixedParameters[2 * NDimensions + i];
+    physicalDim[i] = size[i] * spacing;
+    }
+  return physicalDim;
+}
+
+
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
 ::SetTransformDomainDirection( const DirectionType & direction )
 {
-  if( this->m_TransformDomainDirection != direction )
+  if( this->GetTransformDomainDirection() != direction )
     {
-    this->m_TransformDomainDirection = direction;
-    this->SetFixedParametersFromTransformDomainInformation();
+    this->SetFixedParametersFromTransformDomainInformation(
+      this->GetTransformDomainOrigin(),
+      this->GetTransformDomainPhysicalDimensions(),
+      direction,
+      this->GetTransformDomainMeshSize());
+
     this->SetCoefficientImageInformationFromFixedParameters();
 
     this->Modified();
     }
+}
+
+
+template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+auto
+BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
+::GetTransformDomainDirection( void ) const -> DirectionType
+{
+  DirectionType direction;
+
+  for( unsigned int di = 0; di < NDimensions; di++ )
+    {
+    for( unsigned int dj = 0; dj < NDimensions; dj++ )
+      {
+      const FixedParametersValueType v = this->m_FixedParameters[3 * NDimensions + ( di * NDimensions + dj )];
+      direction[di][dj] = static_cast<typename DirectionType::ValueType>(v);
+      }
+    }
+  return direction;
 }
 
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
@@ -154,51 +236,140 @@ void
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
 ::SetTransformDomainMeshSize( const MeshSizeType & meshSize )
 {
-  if( this->m_TransformDomainMeshSize != meshSize )
+  if( this->GetTransformDomainMeshSize() != meshSize )
     {
-    this->m_TransformDomainMeshSize = meshSize;
-    this->SetFixedParametersFromTransformDomainInformation();
-    this->SetCoefficientImageInformationFromFixedParameters();
+    this->SetFixedParametersFromTransformDomainInformation(
+      this->GetTransformDomainOrigin(),
+      this->GetTransformDomainPhysicalDimensions(),
+      this->GetTransformDomainDirection(),
+      meshSize);
 
-    // Check if we need to resize the default parameter buffer.
-    if( this->m_InternalParametersBuffer.GetSize() != this->GetNumberOfParameters() )
-      {
-      this->m_InternalParametersBuffer.SetSize( this->GetNumberOfParameters() );
-      // Fill with zeros for identity.
-      this->m_InternalParametersBuffer.Fill( 0 );
-      }
+    this->SetCoefficientImageInformationFromFixedParameters();
 
     this->Modified();
     }
 }
 
+
+template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+auto
+BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
+::GetTransformDomainMeshSize( void ) const -> MeshSizeType
+{
+  MeshSizeType meshSize;
+
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    using ValueType = typename MeshSizeType::SizeValueType;
+    meshSize[i] = static_cast<ValueType>(this->m_FixedParameters[i]) - SplineOrder;
+    }
+  return meshSize;
+}
+
+
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
-::SetTransformDomainInformationFromCoefficientImageInformation()
+::SetFixedParametersFromCoefficientImageInformation()
 {
+  // Fixed Parameters store the following information:
+  //  grid size
+  //  grid origin
+  //  grid spacing
+  //  grid direction
 
-  this->m_TransformDomainDirection = this->m_CoefficientImages[0]->GetDirection();
-
-  typename ImageType::PointType origin;
-  origin.Fill( 0.0 );
-  for( unsigned int i = 0; i < SpaceDimension; i++ )
+  // Set the grid size parameters
+  const SizeType & gridSize = this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetSize();
+  for( unsigned int i = 0; i < NDimensions; i++ )
     {
-    this->m_TransformDomainMeshSize[i] =
-      this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetSize()[i] - SplineOrder;
-
-    this->m_TransformDomainPhysicalDimensions[i] = static_cast<ScalarType>(
-      this->m_TransformDomainMeshSize[i] ) * this->m_CoefficientImages[0]->GetSpacing()[i];
-
-    origin[i] += ( this->m_CoefficientImages[0]->GetSpacing()[i] * 0.5 * ( SplineOrder - 1 ) );
+    this->m_FixedParameters[i] = static_cast<FixedParametersValueType>(gridSize[i] );
     }
-  origin = this->m_TransformDomainDirection * origin;
 
-  for( unsigned int j = 0; j < SpaceDimension; j++ )
+  const OriginType & origin = this->m_CoefficientImages[0]->GetOrigin();
+
+  for( unsigned int i = 0; i < NDimensions; i++ )
     {
-    this->m_TransformDomainOrigin[j] = this->m_CoefficientImages[0]->GetOrigin()[j] + origin[j];
+    this->m_FixedParameters[NDimensions + i] = static_cast<FixedParametersValueType>(
+      origin[i] );
+    }
+
+  // Set the spacing parameters
+  const SpacingType & spacing = this->m_CoefficientImages[0]->GetSpacing();
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    this->m_FixedParameters[2 * NDimensions + i] = static_cast<FixedParametersValueType>( spacing[i] );
+    }
+
+  // Set the direction parameters
+  const DirectionType & direction = this->m_CoefficientImages[0]->GetDirection();
+  for( unsigned int di = 0; di < NDimensions; di++ )
+    {
+    for( unsigned int dj = 0; dj < NDimensions; dj++ )
+      {
+      this->m_FixedParameters[3 * NDimensions + ( di * NDimensions + dj )] =
+        static_cast<FixedParametersValueType>( direction[di][dj] );
+      }
     }
 }
+
+
+template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+void
+BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
+::SetFixedParametersFromTransformDomainInformation( const OriginType &meshOrigin,
+                                                    const PhysicalDimensionsType & meshPhysical,
+                                                    const DirectionType &meshDirection,
+                                                    const MeshSizeType &meshSize)
+{
+
+  // Set the grid size parameters
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    this->m_FixedParameters[i] = static_cast<FixedParametersValueType>(
+      meshSize[i] + SplineOrder );
+    }
+
+
+  // Set the origin parameters
+  typedef typename ImageType::PointType PointType;
+  PointType origin;
+  origin.Fill( 0.0 );
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    ScalarType gridSpacing = meshPhysical[i] /
+      static_cast<ScalarType>( meshSize[i] );
+    origin[i] = -0.5 * gridSpacing * ( SplineOrder - 1 );
+    }
+
+  origin = meshDirection * origin;
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    this->m_FixedParameters[NDimensions + i] = static_cast<FixedParametersValueType>(
+      origin[i] + meshOrigin[i] );
+    }
+
+  // Set the spacing parameters
+  for( unsigned int i = 0; i < NDimensions; i++ )
+    {
+    ScalarType gridSpacing = meshPhysical[i]
+      / static_cast<ScalarType>( meshSize[i] );
+
+    this->m_FixedParameters[2 * NDimensions + i] =
+      static_cast<FixedParametersValueType>( gridSpacing );
+    }
+
+  // Set the direction parameters
+  for( unsigned int di = 0; di < NDimensions; di++ )
+    {
+    for( unsigned int dj = 0; dj < NDimensions; dj++ )
+      {
+      this->m_FixedParameters[3 * NDimensions + ( di * NDimensions + dj )] =
+        static_cast<FixedParametersValueType>( meshDirection[di][dj] );
+      }
+    }
+
+}
+
 
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
 void
@@ -247,7 +418,6 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
       }
     }
   this->m_CoefficientImages[0]->SetDirection( direction );
-  this->m_CoefficientImages[0]->Allocate(true); // initializes buffer to zero
 
   // Copy the information to the rest of the images
   for( unsigned int i = 1; i < SpaceDimension; i++ )
@@ -255,77 +425,20 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
     this->m_CoefficientImages[i]->CopyInformation( this->m_CoefficientImages[0] );
     this->m_CoefficientImages[i]->SetRegions(
       this->m_CoefficientImages[0]->GetLargestPossibleRegion() );
-    this->m_CoefficientImages[i]->Allocate(true); // initialize buffer to zero
     }
-}
 
-template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
-::SetFixedParametersGridSizeFromTransformDomainInformation() const
-{
-  // Set the grid size parameters
-  for( unsigned int i = 0; i < NDimensions; i++ )
+
+  // Check if we need to resize the default parameter buffer.
+  if( this->m_InternalParametersBuffer.GetSize() != this->GetNumberOfParameters() )
     {
-    this->m_FixedParameters[i] = static_cast<FixedParametersValueType>(
-      this->m_TransformDomainMeshSize[i] + SplineOrder );
-    }
-}
+    this->m_InternalParametersBuffer.SetSize( this->GetNumberOfParameters() );
+    // Fill with zeros for identity.
+    this->m_InternalParametersBuffer.Fill( 0 );
 
-template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
-::SetFixedParametersGridOriginFromTransformDomainInformation() const
-{
-  // Set the origin parameters
-  using PointType = typename ImageType::PointType;
-  PointType origin;
-  origin.Fill( 0.0 );
-  for( unsigned int i = 0; i < NDimensions; i++ )
-    {
-    ScalarType gridSpacing = this->m_TransformDomainPhysicalDimensions[i] /
-      static_cast<ScalarType>( this->m_TransformDomainMeshSize[i] );
-    origin[i] = -0.5 * gridSpacing * ( SplineOrder - 1 );
+    // Set the image's pixel container to this buffer
+    this->SetParameters( this->m_InternalParametersBuffer );
     }
 
-  origin = this->m_TransformDomainDirection * origin;
-  for( unsigned int i = 0; i < NDimensions; i++ )
-    {
-    this->m_FixedParameters[NDimensions + i] = static_cast<FixedParametersValueType>(
-      origin[i] + this->m_TransformDomainOrigin[i] );
-    }
-}
-
-template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
-::SetFixedParametersGridSpacingFromTransformDomainInformation() const
-{
-  // Set the spacing parameters
-  for( unsigned int i = 0; i < NDimensions; i++ )
-    {
-    ScalarType gridSpacing = this->m_TransformDomainPhysicalDimensions[i]
-      / static_cast<ScalarType>( this->m_TransformDomainMeshSize[i] );
-
-    this->m_FixedParameters[2 * NDimensions + i] =
-      static_cast<FixedParametersValueType>( gridSpacing );
-    }
-}
-
-template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
-::SetFixedParametersGridDirectionFromTransformDomainInformation() const
-{
-  // Set the direction parameters
-  for( unsigned int di = 0; di < NDimensions; di++ )
-    {
-    for( unsigned int dj = 0; dj < NDimensions; dj++ )
-      {
-      this->m_FixedParameters[3 * NDimensions + ( di * NDimensions + dj )] =
-        static_cast<FixedParametersValueType>( this->m_TransformDomainDirection[di][dj] );
-      }
-    }
 }
 
 template<typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
@@ -351,51 +464,8 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
                        << this->m_FixedParameters.Size() );
     }
 
-  SizeType gridSize;
-  for( unsigned int i = 0; i < NDimensions; i++ )
-    {
-    gridSize[i] = static_cast<SizeValueType>( this->m_FixedParameters[i] );
-    }
-  this->m_CoefficientImages[0]->SetRegions( gridSize );
 
-  // Set the origin parameters
-  OriginType origin;
-  for( unsigned int i = 0; i < NDimensions; i++ )
-    {
-    origin[i] = this->m_FixedParameters[NDimensions + i];
-    }
-  this->m_CoefficientImages[0]->SetOrigin( origin );
-
-  // Set the spacing parameters
-  SpacingType spacing;
-  for( unsigned int i = 0; i < NDimensions; i++ )
-    {
-    spacing[i] = this->m_FixedParameters[2 * NDimensions + i];
-    }
-  this->m_CoefficientImages[0]->SetSpacing( spacing );
-
-  // Set the direction parameters
-  DirectionType direction;
-  for( unsigned int di = 0; di < NDimensions; di++ )
-    {
-    for( unsigned int dj = 0; dj < NDimensions; dj++ )
-      {
-      direction[di][dj] =
-        this->m_FixedParameters[3 * NDimensions + ( di * NDimensions + dj )];
-      }
-    }
-  this->m_CoefficientImages[0]->SetDirection( direction );
-
-  // Copy the information to the rest of the images
-  for( unsigned int i = 1; i < SpaceDimension; i++ )
-    {
-    this->m_CoefficientImages[i]->CopyInformation( this->m_CoefficientImages[0] );
-    this->m_CoefficientImages[i]->SetRegions(
-      this->m_CoefficientImages[0]->GetLargestPossibleRegion() );
-    }
-
-
-  this->SetTransformDomainInformationFromCoefficientImageInformation();
+  this->SetCoefficientImageInformationFromFixedParameters();
 
 }
 
@@ -447,8 +517,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
     }
 
   // synchronize parameters
-  this->SetTransformDomainInformationFromCoefficientImageInformation();
-  this->SetFixedParametersFromTransformDomainInformation();
+  this->SetFixedParametersFromCoefficientImageInformation();
   this->SetParameters( this->m_InternalParametersBuffer );
 }
 
@@ -613,11 +682,12 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
   IndexType startIndex =
     this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetIndex();
 
+  const MeshSizeType meshSize = this->GetTransformDomainMeshSize();
   SizeType cumulativeGridSizes;
-  cumulativeGridSizes[0] = ( this->m_TransformDomainMeshSize[0] + SplineOrder );
+  cumulativeGridSizes[0] = ( meshSize[0] + SplineOrder );
   for( unsigned int d = 1; d < SpaceDimension; d++ )
     {
-    cumulativeGridSizes[d] = cumulativeGridSizes[d-1] * ( this->m_TransformDomainMeshSize[d] + SplineOrder );
+    cumulativeGridSizes[d] = cumulativeGridSizes[d-1] * ( meshSize[d] + SplineOrder );
     }
 
   SizeValueType numberOfParametersPerDimension = this->GetNumberOfParametersPerDimension();
@@ -650,11 +720,13 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
   this->Superclass::PrintSelf(os, indent);
 
   os << indent << "TransformDomainOrigin: "
-     << this->m_TransformDomainOrigin << std::endl;
+     << this->GetTransformDomainOrigin() << std::endl;
   os << indent << "TransformDomainPhysicalDimensions: "
-     << this->m_TransformDomainPhysicalDimensions << std::endl;
+     << this->GetTransformDomainPhysicalDimensions() << std::endl;
   os << indent << "TransformDomainDirection: "
-     << this->m_TransformDomainDirection << std::endl;
+     << this->GetTransformDomainDirection() << std::endl;
+  os << indent << "TransformDomainMeshSize: "
+     << this->GetTransformDomainMeshSize() << std::endl;
 
   os << indent << "GridSize: "
      << this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetSize()

--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -30,20 +30,21 @@ template<typename TParametersValueType,
          unsigned int VSplineOrder>
 void bspline_eq( const itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>  *bspline1,
                  const itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder> *bspline2,
-                 const std::string & description = "")
+                 const std::string & description = "",
+                 double tolerance = 1e-15)
 {
   using BSplineType = itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>;
   // Compare Transform Domain interface
 
   EXPECT_EQ( bspline1->GetNumberOfFixedParameters(), bspline2->GetNumberOfFixedParameters() ) << description;
-  EXPECT_EQ( bspline1->GetTransformDomainOrigin(), bspline2->GetTransformDomainOrigin() ) << description;
-  EXPECT_EQ( bspline1->GetTransformDomainDirection(), bspline2->GetTransformDomainDirection() ) << description;
+  EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainOrigin(), bspline2->GetTransformDomainOrigin(), tolerance  ) << description;
+  EXPECT_EQ( bspline1->GetTransformDomainDirection(), bspline2->GetTransformDomainDirection()) << description;
   EXPECT_EQ( bspline1->GetTransformDomainMeshSize(), bspline2->GetTransformDomainMeshSize() ) << description;
-  EXPECT_EQ( bspline1->GetTransformDomainPhysicalDimensions(), bspline2->GetTransformDomainPhysicalDimensions() ) << description;
+  EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainPhysicalDimensions(), bspline2->GetTransformDomainPhysicalDimensions(), tolerance  ) << description;
 
   // check transform parameters interface
-  EXPECT_EQ( bspline1->GetParameters(), bspline2->GetParameters() ) << description;
-  EXPECT_EQ( bspline1->GetFixedParameters(), bspline2->GetFixedParameters() ) << description;
+  EXPECT_VECTOR_NEAR( bspline1->GetParameters(), bspline2->GetParameters(), tolerance  ) << description;
+  EXPECT_VECTOR_NEAR( bspline1->GetFixedParameters(), bspline2->GetFixedParameters(), tolerance  ) << description;
 
   ASSERT_EQ( bspline1->GetCoefficientImages().Size(), NDimensions ) << description;
   ASSERT_EQ( bspline2->GetCoefficientImages().Size(), NDimensions ) << description;
@@ -56,9 +57,9 @@ void bspline_eq( const itk::BSplineTransform<TParametersValueType, NDimensions, 
     typename ImageType::Pointer coeffImage1 = bspline1->GetCoefficientImages()[i];
     typename ImageType::Pointer coeffImage2 = bspline2->GetCoefficientImages()[i];
 
-    EXPECT_EQ( coeffImage1->GetOrigin(), coeffImage2->GetOrigin() ) << description;
-    EXPECT_EQ( coeffImage1->GetDirection(), coeffImage2->GetDirection() ) << description;
-    EXPECT_EQ( coeffImage1->GetSpacing(), coeffImage2->GetSpacing() ) << description;
+    EXPECT_VECTOR_NEAR( coeffImage1->GetOrigin(), coeffImage2->GetOrigin(), tolerance ) << description;
+    EXPECT_EQ( coeffImage1->GetDirection(), coeffImage2->GetDirection()) << description;
+    EXPECT_VECTOR_NEAR( coeffImage1->GetSpacing(), coeffImage2->GetSpacing(), tolerance  ) << description;
     EXPECT_EQ( coeffImage1->GetLargestPossibleRegion(), coeffImage2->GetLargestPossibleRegion() ) << description;
     EXPECT_EQ( coeffImage1->GetBufferedRegion(), coeffImage2->GetBufferedRegion() ) << description;
 


### PR DESCRIPTION
Improve consistency and efficiency of BSplineTransform's
parameters. The set of TransformDomain IVAR have been remove, and the
accessors have been replaced which directly compute the value from the
fixed parameters. The TransformDomain set methods, now call a single
method which computes the fixed parameters from all the transform
domain parameters. The use for the fixed parameters for the
authoritative value of TransformDomain values follows from the fixed
parameters being the serialized values.

Additionally the extra allocation of the CoefficientImage buffers has
been removed, and replaced with the allocation of InternalParameters
and setting of their buffers.

