### PR TITLE
ENH: Add PhaseSymmetry remote module

### DIFF
--- a/Modules/Remote/PhaseSymmetry.remote.cmake
+++ b/Modules/Remote/PhaseSymmetry.remote.cmake
@@ -1,0 +1,15 @@
+# Contact: Matt McCormick <matt.mccormick@kitware.com>
+itk_fetch_module(PhaseSymmetry
+"Provides multi-scale steerable filters for computing phase symmetry.
+
+For more information, see the Insight Journal article:
+
+Hatt C.
+Multi-scale Steerable Phase-Symmetry Filters for ITK
+The Insight Journal. July-December. 2011.
+http://hdl.handle.net/10380/3330
+http://www.insight-journal.org/browse/publication/846
+"
+  GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKPhaseSymmetry.git
+  GIT_TAG 5aa98577bb973c00f0493eb5244f368f97b7d776
+  )


### PR DESCRIPTION
This is a module for the `Insight Toolkit (ITK) <http://itk.org>`_ that
provides multi-scale steerable filters for computing phase symmetry
(PS).

Multi-scale steerable phase-symmetry filters are applied in the image Fourier
transform domain, and have been shown to be a useful pre-processing measure
for performing image registration and segmentation.

For more information, see the `Insight Journal article
<http://hdl.handle.net/10380/3330>`_::

  Hatt C.
  Multi-scale Steerable Phase-Symmetry Filters for ITK
  The Insight Journal. July-December. 2011.
  http://hdl.handle.net/10380/3330
  http://www.insight-journal.org/browse/publication/846


Thanks to @jhlegarreta , who helped get the CI set up for this module and who started the wrapping configuration! :green_apple: 