### PR TITLE
ENH: Download ExternalData cache for CI builds

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - master
     - release*
+variables:
+  ExternalDataVersion: 5.0b01
 jobs:
 - job: Linux
   timeoutInMinutes: 0
@@ -10,14 +12,27 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-    - script: |
+    - bash: |
         set -x
-
-        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
         sudo pip3 install ninja
         sudo apt-get update
         sudo apt-get install -y python3-venv
+
+      displayName: Install dependencies
+    - bash: |
+        set -x
+
+        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+
+        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
+        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
+        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
+
+      displayName: Download dashboard script and testing data
+      workingDirectory: $(Agent.BuildDirectory)
+    - bash: |
+        set -x
 
         c++ --version
         cmake --version
@@ -27,5 +42,5 @@ jobs:
         export CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and Test
+      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - master
     - release*
+variables:
+  ExternalDataVersion: 5.0b01
 jobs:
 - job: Linux
   timeoutInMinutes: 0
@@ -10,14 +12,27 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-    - script: |
+    - bash: |
+        set -x
+
+        sudo pip3 install ninja
+        sudo apt-get update
+        sudo apt-get install -y python3-venv python3-numpy python-numpy
+
+      displayName: Install dependencies
+    - bash: |
         set -x
 
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
-        sudo pip3 install ninja
-        sudo apt-get update
-        sudo apt-get install -y python3-venv python-venv python3-numpy python-numpy
+        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
+        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
+        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
+
+      displayName: Download dashboard script and testing data
+      workingDirectory: $(Agent.BuildDirectory)
+    - script: |
+        set -x
 
         c++ --version
         cmake --version
@@ -28,5 +43,5 @@ jobs:
         export CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and Test
+      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - master
     - release*
+variables:
+  ExternalDataVersion: 5.0b01
 jobs:
 - job: macOS
   timeoutInMinutes: 0
@@ -10,12 +12,25 @@ jobs:
   pool:
     vmImage: 'macOS 10.13'
   steps:
-    - script: |
+    - bash: |
+        set -x
+
+        sudo pip3 install ninja
+
+      displayName: Install dependencies
+    - bash: |
         set -x
 
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
-        sudo pip3 install ninja
+        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
+        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
+        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
+
+      displayName: Download dashboard script and testing data
+      workingDirectory: $(Agent.BuildDirectory)
+    - script: |
+        set -x
 
         c++ --version
         cmake --version
@@ -24,5 +39,5 @@ jobs:
         export CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and Test
+      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - master
     - release*
+variables:
+  ExternalDataVersion: 5.0b01
 jobs:
 - job: macOS
   timeoutInMinutes: 0
@@ -10,12 +12,25 @@ jobs:
   pool:
     vmImage: 'macOS 10.13'
   steps:
-    - script: |
+    - bash: |
+        set -x
+
+        sudo pip3 install ninja numpy
+
+      displayName: Install dependencies
+    - bash: |
         set -x
 
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
-        sudo pip3 install ninja numpy
+        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
+        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
+        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
+
+      displayName: Download dashboard script and testing data
+      workingDirectory: $(Agent.BuildDirectory)
+    - bash: |
+        set -x
 
         c++ --version
         cmake --version

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - master
     - release*
+variables:
+  ExternalDataVersion: 5.0b01
 jobs:
 - job: Windows
   timeoutInMinutes: 0
@@ -11,10 +13,19 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
     - script: |
-        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
         pip3 install ninja
 
+      displayName: Install dependencies
+    - script: |
+        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+
+        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
+        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
+        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
+
+      displayName: Download dashboard script and testing data
+      workingDirectory: $(Agent.BuildDirectory)
+    - script: |
         cmake --version
 
         call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
@@ -26,5 +37,5 @@ jobs:
         set CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and Test
+      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - master
     - release*
+variables:
+  ExternalDataVersion: 5.0b01
 jobs:
 - job: Windows
   timeoutInMinutes: 0
@@ -11,10 +13,19 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
     - script: |
-        git clone -b dashboard --single-branch https://github.com/thewtex/ITK.git ITK-dashboard
-
         pip3 install ninja numpy
 
+      displayName: Install dependencies
+    - script: |
+        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+
+        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
+        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
+        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
+
+      displayName: Download dashboard script and testing data
+      workingDirectory: $(Agent.BuildDirectory)
+    - script: |
         cmake --version
 
         call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"


### PR DESCRIPTION
Avoid downloading files individually, which can be brittle.

Download the most recent archive from GitHub releases.
