### PR TITLE
PERF: Replaced postfix ++ calls on ITK iterators by the prefix ++ calls

### DIFF
--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -182,7 +182,7 @@ ImageSource< TOutputImage >
   typename ImageBaseType::Pointer outputPtr;
 
   // Allocate the output memory
-  for ( OutputDataObjectIterator it(this); !it.IsAtEnd(); it++ )
+  for ( OutputDataObjectIterator it(this); !it.IsAtEnd(); ++it )
     {
     // Check whether the output is an image of the appropriate
     // dimension (use ProcessObject's version of the GetInput()

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -105,7 +105,7 @@ ImageToImageFilter< TInputImage, TOutputImage >
 {
   Superclass::GenerateInputRequestedRegion();
 
-  for( InputDataObjectIterator it( this ); !it.IsAtEnd(); it++ )
+  for( InputDataObjectIterator it( this ); !it.IsAtEnd(); ++it )
     {
     // Check whether the input is an image of the appropriate dimension
     using ImageBaseType = ImageBase< InputImageDimension >;

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
@@ -249,7 +249,7 @@ PointSetToImageFilter< TInputPointSet, TOutputImage >
       {
       OutputImage->SetPixel(index, m_InsideValue);
       }
-    pointItr++;
+    ++pointItr;
     }
 
   itkDebugMacro(<< "PointSetToImageFilter::Update() finished");

--- a/Modules/Core/Common/src/itkEquivalencyTable.cxx
+++ b/Modules/Core/Common/src/itkEquivalencyTable.cxx
@@ -88,7 +88,7 @@ void EquivalencyTable::Flatten()
   while ( it != this->End() )
     {
     ( *it ).second = this->RecursiveLookup( ( *it ).second );
-    it++;
+    ++it;
     }
 }
 

--- a/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
@@ -284,7 +284,7 @@ RegularSphereMeshSource< TOutputMesh >
         }
 
       // for all cells
-      cells++;
+      ++cells;
       }
 
     // Release input memory
@@ -293,7 +293,7 @@ RegularSphereMeshSource< TOutputMesh >
       {
       const CellInterfaceType *cellToBeDeleted = cells->Value();
       delete cellToBeDeleted;
-      cells++;
+      ++cells;
       }
 
     // set output

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -59,7 +59,7 @@ SimplexMesh< TPixelType, VDimension, TMeshTraits >
     {
     SimplexMeshGeometry *geometry = pointDataIterator->Value();
     delete geometry;
-    pointDataIterator++;
+    ++pointDataIterator;
     }
   // clear the map
   geometryMap->Initialize();

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -295,8 +295,8 @@ void SimplexMeshAdaptTopologyFilter< TInputMesh, TOutputMesh >
       this->ModifyNeighborCells(lineTwoFirstIdx, lineTwoSecondIdx, secondNewIndex);
 
       } // end if cell must be modified
-    areaIt++;
-    curvatureIt++;
+    ++areaIt;
+    ++curvatureIt;
     }
 }
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
@@ -83,7 +83,7 @@ void SimplexMeshToTriangleMeshFilter< TInputMesh, TOutputMesh >
       itkExceptionMacro(<< "Assertion failed for test of GetElementIfIndexExists()");
       }
 
-    pointsIt++;
+    ++pointsIt;
     }
 
   this->ProcessObject::SetNthOutput( 0,  meshSource->GetOutput() );

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -263,7 +263,7 @@ void SimplexMeshVolumeCalculator< TInputMesh >
       {
       CalculateTriangleVolume(p1, p2, p3);
       }
-    pointsIt++;
+    ++pointsIt;
     }
   this->Finalize();
 }

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -427,7 +427,7 @@ TriangleMeshToBinaryImageFilter< TInputMesh, TOutputImage >
     OutputImage->TransformPhysicalPointToContinuousIndex(p, ind);
     NewPoints->InsertElement(pointId++, ind);
 
-    points++;
+    ++points;
     }
   NewPointSet->SetPoints(NewPoints);
 
@@ -475,7 +475,7 @@ TriangleMeshToBinaryImageFilter< TInputMesh, TOutputImage >
       default:
         itkExceptionMacro(<< "Need Triangle or Polygon cells ONLY");
       }
-    cellIt++;
+    ++cellIt;
     }
 
   //create the equivalent of vtkStencilData from our zymatrix

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -184,7 +184,7 @@ void TriangleMeshToSimplexMeshFilter< TInputMesh, TOutputMesh >
     CreateEdgeForTrianglePair(idx, tp1, output);
     CreateEdgeForTrianglePair(idx, tp2, output);
 
-    points++;
+    ++points;
     }
 }
 
@@ -381,7 +381,7 @@ TriangleMeshToSimplexMeshFilter< TInputMesh, TOutputMesh >
         }
       featureId++;
       }
-    points++;
+    ++points;
     }
 }
 

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
@@ -136,7 +136,7 @@ VTKPolyDataWriter< TInputMesh >
       outputFile << std::endl;
 
       IdMap[pointIterator.Index()] = k++;
-      pointIterator++;
+      ++pointIterator;
       }
     }
 
@@ -171,7 +171,7 @@ VTKPolyDataWriter< TInputMesh >
         default:
           std::cerr << "Unhandled cell (volumic?)." << std::endl;
         }
-      cellIterator++;
+      ++cellIterator;
       }
 
     // VERTICES should go here
@@ -207,7 +207,7 @@ VTKPolyDataWriter< TInputMesh >
           default:
             break;
           }
-        cellIterator++;
+        ++cellIterator;
         }
       }
 
@@ -227,7 +227,7 @@ VTKPolyDataWriter< TInputMesh >
           {
           totalNumberOfPointsInPolygons += cellPointer->GetNumberOfPoints();
           }
-        cellIterator++;
+        ++cellIterator;
         }
       outputFile << "POLYGONS " << numberOfPolygons << " ";
       outputFile << totalNumberOfPointsInPolygons + numberOfPolygons; // FIXME: Is this right ?
@@ -258,7 +258,7 @@ VTKPolyDataWriter< TInputMesh >
           default:
             break;
           }
-        cellIterator++;
+        ++cellIterator;
         }
       }
     }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
@@ -188,7 +188,7 @@ void CopyMeshToMeshPointData(const TInputMesh *in, TOutputMesh *out)
     {
     typename OutputPointDataContainer::Element point( inIt.Value() );
     outputPointData->SetElement( inIt.Index(), point );
-    inIt++;
+    ++inIt;
     }
 
   out->SetPointData(outputPointData);

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -259,7 +259,7 @@ MetaMeshConverter< NDimensions, PixelType, TMeshTraits >
       }
     pnt->m_Id = ( *it_points )->Index();
     metamesh->GetPoints().push_back(pnt);
-    it_points++;
+    ++it_points;
     }
 
   // Add Cells
@@ -318,7 +318,7 @@ MetaMeshConverter< NDimensions, PixelType, TMeshTraits >
       default:
         metamesh->GetCells(MET_VERTEX_CELL).push_back(cell);
       }
-    it_cells++;
+    ++it_cells;
     }
 
   // Add cell links
@@ -342,7 +342,7 @@ MetaMeshConverter< NDimensions, PixelType, TMeshTraits >
         it++;
         }
       metamesh->GetCellLinks().push_back(link);
-      it_celllinks++;
+      ++it_celllinks;
       }
     }
 
@@ -360,7 +360,7 @@ MetaMeshConverter< NDimensions, PixelType, TMeshTraits >
       data->m_Id = ( *it_pd )->Index();
       data->m_Data = ( *it_pd )->Value();
       metamesh->GetPointData().push_back(data);
-      it_pd++;
+      ++it_pd;
       }
     }
 
@@ -380,7 +380,7 @@ MetaMeshConverter< NDimensions, PixelType, TMeshTraits >
       data->m_Id = ( *it_cd )->Index();
       data->m_Data = ( *it_cd )->Value();
       metamesh->GetCellData().push_back(data);
-      it_cd++;
+      ++it_cd;
       }
     }
   return metamesh;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
@@ -156,7 +156,7 @@ ScalarImageToCooccurrenceMatrixFilter< TImageType,
   // Next, find the minimum radius that encloses all the offsets.
   unsigned int minRadius = 0;
   typename OffsetVector::ConstIterator offsets;
-  for ( offsets = m_Offsets->Begin(); offsets != m_Offsets->End(); offsets++ )
+  for ( offsets = m_Offsets->Begin(); offsets != m_Offsets->End(); ++offsets )
     {
     for ( unsigned int i = 0; i < offsets.Value().GetOffsetDimension(); i++ )
       {
@@ -228,7 +228,7 @@ ScalarImageToCooccurrenceMatrixFilter< TImageType,
 
     typename OffsetVector::ConstIterator offsets;
     typename HistogramType::IndexType index;
-    for ( offsets = m_Offsets->Begin(); offsets != m_Offsets->End(); offsets++ )
+    for ( offsets = m_Offsets->Begin(); offsets != m_Offsets->End(); ++offsets )
       {
       bool            pixelInBounds;
       const PixelType pixelIntensity =
@@ -303,7 +303,7 @@ ScalarImageToCooccurrenceMatrixFilter< TImageType,
       }
 
     typename OffsetVector::ConstIterator offsets;
-    for ( offsets = this->GetOffsets()->Begin(); offsets != this->GetOffsets()->End(); offsets++ )
+    for ( offsets = this->GetOffsets()->Begin(); offsets != this->GetOffsets()->End(); ++offsets )
       {
       if ( maskNeighborIt.GetPixel( offsets.Value() ) != m_InsidePixelValue )
         {

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -136,7 +136,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>
   using InternalRunLengthFeatureName = typename RunLengthFeaturesFilterType::RunLengthFeatureName;
 
   for( offsetIt = this->m_Offsets->Begin(), offsetNum = 0;
-    offsetIt != this->m_Offsets->End(); offsetIt++, offsetNum++ )
+    offsetIt != this->m_Offsets->End(); ++offsetIt, offsetNum++ )
     {
     this->m_RunLengthMatrixGenerator->SetOffset( offsetIt.Value() );
     this->m_RunLengthMatrixGenerator->Update();
@@ -148,7 +148,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>
 
     typename FeatureNameVector::ConstIterator fnameIt;
     for( fnameIt = this->m_RequestedFeatures->Begin(), featureNum = 0;
-      fnameIt != this->m_RequestedFeatures->End(); fnameIt++, featureNum++ )
+      fnameIt != this->m_RequestedFeatures->End(); ++fnameIt, featureNum++ )
       {
       features[offsetNum][featureNum] = runLengthMatrixCalculator->GetFeature(
         ( InternalRunLengthFeatureName )fnameIt.Value() );
@@ -241,7 +241,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>
   this->m_FeatureStandardDeviations->clear();
   typename FeatureNameVector::ConstIterator fnameIt;
   for( fnameIt = this->m_RequestedFeatures->Begin();
-    fnameIt != this->m_RequestedFeatures->End(); fnameIt++ )
+    fnameIt != this->m_RequestedFeatures->End(); ++fnameIt )
     {
     this->m_FeatureMeans->push_back( runLengthMatrixCalculator->GetFeature(
       ( InternalRunLengthFeatureName )fnameIt.Value() ) );

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -175,7 +175,7 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>
 
   typename OffsetVector::ConstIterator offsets;
   for( offsets = this->GetOffsets()->Begin();
-    offsets != this->GetOffsets()->End(); offsets++ )
+    offsets != this->GetOffsets()->End(); ++offsets )
     {
 
     alreadyVisitedImage->FillBuffer( false );

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -120,14 +120,14 @@ ScalarImageToTextureFeaturesFilter< TImage, THistogramFrequencyContainer >::Full
   using InternalTextureFeatureName = typename TextureFeaturesFilterType::TextureFeatureName;
 
   for ( offsetIt = m_Offsets->Begin(), offsetNum = 0;
-        offsetIt != m_Offsets->End(); offsetIt++, offsetNum++ )
+        offsetIt != m_Offsets->End(); ++offsetIt, offsetNum++ )
     {
     this->m_GLCMGenerator->SetOffset( offsetIt.Value() );
     this->m_GLCMCalculator->Update();
 
     typename FeatureNameVector::ConstIterator fnameIt;
     for ( fnameIt = m_RequestedFeatures->Begin(), featureNum = 0;
-          fnameIt != m_RequestedFeatures->End(); fnameIt++, featureNum++ )
+          fnameIt != m_RequestedFeatures->End(); ++fnameIt, featureNum++ )
       {
       features[offsetNum][featureNum] = this->m_GLCMCalculator->GetFeature( (InternalTextureFeatureName)fnameIt.Value() );
       }
@@ -211,7 +211,7 @@ ScalarImageToTextureFeaturesFilter< TImage, THistogramFrequencyContainer >::Fast
   m_FeatureStandardDeviations->clear();
   typename FeatureNameVector::ConstIterator fnameIt;
   for ( fnameIt = m_RequestedFeatures->Begin();
-        fnameIt != m_RequestedFeatures->End(); fnameIt++ )
+        fnameIt != m_RequestedFeatures->End(); ++fnameIt )
     {
     m_FeatureMeans->push_back( this->m_GLCMCalculator->GetFeature( (InternalTextureFeatureName)fnameIt.Value() ) );
     m_FeatureStandardDeviations->push_back(0.0);

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -146,7 +146,7 @@ DeformableSimplexMesh3DFilter< TInputMesh, TOutputMesh >
     data = this->m_Data->GetElement(idx);
     delete data->neighborSet;
     data->neighborSet = nullptr;
-    pointItr++;
+    ++pointItr;
     }
 
   this->ComputeOutput();
@@ -224,7 +224,7 @@ DeformableSimplexMesh3DFilter< TInputMesh, TOutputMesh >
     delete neighborsList;
     data->neighborSet =  neighborSet;
 
-    pointItr++;
+    ++pointItr;
     }
 
 }
@@ -317,7 +317,7 @@ DeformableSimplexMesh3DFilter< TInputMesh, TOutputMesh >
 
     data->eps = ComputeBarycentricCoordinates(Foot, data);
     dataIt.Value() = data;
-    dataIt++;
+    ++dataIt;
     }
 }
 
@@ -353,7 +353,7 @@ DeformableSimplexMesh3DFilter< TInputMesh, TOutputMesh >
     data->pos += displacement;
     nonConstPoints->InsertElement(dataIt.Index(), data->pos);
 
-    dataIt++;
+    ++dataIt;
     }
 }
 
@@ -568,7 +568,7 @@ DeformableSimplexMesh3DFilter< TInputMesh, TOutputMesh >
     nonConstInputMesh->SetPointData(dataIt->Index(), H);
     dataIt.Value() = data;
     //      m_Data->InsertElement(dataIt->Index(),data);
-    dataIt++;
+    ++dataIt;
     }
 }
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -1015,7 +1015,7 @@ void Segmenter< TInputImage >
   typename SegmentTableType::edge_list_t::iterator list_ptr;
   for ( edge_table_entry_ptr = edgeHash.begin();
         edge_table_entry_ptr != edgeHash.end();
-        edge_table_entry_ptr++ )
+        ++edge_table_entry_ptr )
     {
     // Lookup the corresponding segment entry
     segment_ptr = segments->Lookup( ( *edge_table_entry_ptr ).first );
@@ -1033,8 +1033,8 @@ void Segmenter< TInputImage >
       {
       list_ptr->label = ( *edge_ptr ).first;
       list_ptr->height = ( *edge_ptr ).second;
-      edge_ptr++;
-      list_ptr++;
+      ++edge_ptr;
+      ++list_ptr;
       }
 
     // Clean up memory as we go


### PR DESCRIPTION
Replaced operator++ calls of the form 'it++' by '++it', on ITK iterators.

Following the classical C++ guideline, to prefer calling the prefix form,
rather than the postfix form of such operators:

  C++ Coding Standards: 101 Rules, Guidelines, and Best Practices
  "Prefer the canonical form of ++ and --. Prefer calling the prefix forms"
  Herb Sutter, Andrei Alexandrescu, 2004

This commit is likely to improve the performance (slightly) on many use cases.
