### PR TITLE
PERF: Small improvements to equality operators of Image Region classes

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -178,18 +178,14 @@ public:
   bool
   operator==(const Self & region) const
   {
-    bool same = ( m_Index == region.m_Index );
-    same = same && ( m_Size == region.m_Size );
-    return same;
+    return (m_Index == region.m_Index) && (m_Size == region.m_Size);
   }
 
   /** Compare two regions. */
   bool
   operator!=(const Self & region) const
   {
-    bool same = ( m_Index == region.m_Index );
-    same = same && ( m_Size == region.m_Size );
-    return !same;
+    return !(*this == region);
   }
 
   /** Test if an index is inside */

--- a/Modules/Core/Common/src/itkImageIORegion.cxx
+++ b/Modules/Core/Common/src/itkImageIORegion.cxx
@@ -251,12 +251,9 @@ bool
 ImageIORegion
 ::operator==(const Self & region) const
 {
-  bool same;
-
-  same = ( m_Index == region.m_Index );
-  same = same && ( m_Size == region.m_Size );
-  same = same && ( m_ImageDimension == region.m_ImageDimension );
-  return same;
+  return (m_Index == region.m_Index) &&
+    (m_Size == region.m_Size) &&
+    (m_ImageDimension == region.m_ImageDimension);
 }
 
 /** Compare two regions. */
@@ -264,12 +261,7 @@ bool
 ImageIORegion
 ::operator!=(const Self & region) const
 {
-  bool same;
-
-  same = ( m_Index == region.m_Index );
-  same = same && ( m_Size == region.m_Size );
-  same = same && ( m_ImageDimension == region.m_ImageDimension );
-  return !same;
+  return !(*this == region);
 }
 
 void


### PR DESCRIPTION
Removed the local bool variable, 'same', from the operator= and operator!= of
both ImageRegion and ImageIORegion.

Ensured that short-circuit evaluation is applied. For example, when the two
regions have a different m_Index, there is no need to compare the other data
member(s) anymore.