### PR TITLE
DOC: Remove the convention that release branches start with "release"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,7 @@ For new development, start the topic from `upstream/master`:
    $ git checkout -b my-topic upstream/master
 ```
 
-For release branch fixes, start the topic from `upstream/release`, and by
-convention use a topic name starting in `release-`:
+For release branch fixes, start the topic from `upstream/release`:
 
 ```sh
    $ git checkout -b my-topic upstream/release


### PR DESCRIPTION
This was used as a way to indicated branches should be merged into the
`release` branch when using Gerrit and merging directly into the `release`
branch was not possible. Now that we can merge directly into the
`release` branch, it is no longer necessary.

Closes #180 