### PR TITLE
ENH: Add setup-girder-api-key Git Setup script

### DIFF
--- a/Documentation/UploadBinaryData.md
+++ b/Documentation/UploadBinaryData.md
@@ -76,25 +76,27 @@ references in the [ITK collection] and other redundant storage locations.
 
 ### Upload via the shell script
 
-The script will authenticate to [data.kitware.com], upload the file to your
-user account's *Public* folder, and create a `*.sha512` [CMake] `ExternalData`
-content link file. After the content link has been created, you will need to
-add the `*.sha512` file to your commit.
+The [UploadBinaryData.sh] script will authenticate to [data.kitware.com],
+upload the file to your user account's *Public* folder, and create a
+`*.sha512` [CMake] `ExternalData` content link file. After the content link
+has been created, you will need to add the `*.sha512` file to your commit.
 
-To use the script:
+When `./Utilities/SetupForDevelopment.sh` is executed, as described in
+[CONTRIBUTING.md], authentication to Girder is configured in Git. If the Git
+`girder.api-key` config or `GIRDER_API_KEY` environmental variable is not set,
+a prompt will appear for your username and password. The API key can be
+created in the data.kitware.com user account web browser interface.
 
-  1. Sign up for an account at [data.kitware.com].
-  2. Place the binary file at the desired location in the Git repository.
-  3. Run this script, and pass in the binary file(s) as arguments to script.
-  4. In the corresponding `test/CMakeLists.txt` file, use the
-     `itk_add_test macro` and reference the file path with \`DATA\` and braces,
-     e.g.: DATA{<Relative/Path/To/Source/Tree/File>}.
-  5. Re-build ITK, and the testing data will be downloaded into the build tree.
+To upload new binary testing data:
 
-
-If a `GIRDER_API_KEY` environmental variable is not set, a prompt will appear
-for your username and password. The API key can be created from the
-[data.kitware.com] user account web browser interace.
+  1. Place the binary file at the desired location in the Git repository.
+  2. Run the `git data-upload` alias, and pass in the binary file(s) as arguments. E.g.
+     `cd ITK; git data-upload ./Modules/Core/Common/test/Input/cthead1.png`.
+  3. In the corresponding `test/CMakeLists.txt` file, use the
+     `itk_add_test` macro and reference the relative file path with `DATA` and braces.
+     E.g.: `DATA{Input/cthead1.png}`.
+  4. Re-build ITK, the `ITKData` target specifically, and the testing data will be
+     downloaded into the build tree. The path in the build tree is used in test execution.
 
 
 ### Upload via the web interface

--- a/Utilities/GitSetup/setup-girder-api-key
+++ b/Utilities/GitSetup/setup-girder-api-key
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#=============================================================================
+# Copyright 2018 Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+# Run this script to set up the Girder API keys. This is used by the
+# Utilities/UploadBinaryData.sh script to perform authenticated uploads of
+# binary testing data.
+
+die() {
+	echo 1>&2 "$@" ; exit 1
+}
+
+json_field() {
+  local key=$1
+  local json=$2
+  echo $json | awk 'BEGIN { FS="\""; RS="," }; { if ($2 == "'$key'") {print $4} }'
+}
+
+
+# Make sure we are inside the repository.
+cd "${BASH_SOURCE%/*}" &&
+
+protocol=$(git config -f config --get girder.protocol || echo "https") &&
+host=$(git config -f config --get girder.host || echo "data.kitware.com") &&
+site=$(git config -f config --get girder.site || echo "$protocol://$host")
+
+api_key=$(git config --get girder.api-key || echo '')
+
+# Tell user about current configuration.
+if test -n "$api_key"; then
+	echo 'The Girder API key is currently set to "'"${api_key:0:5}"'..."' &&
+	read -ep 'Reconfigure Girder API key? [y/N]: ' ans &&
+	if [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
+		setup=1
+	else
+		setup=''
+	fi
+else
+	echo 'A Girder API key is not configured to upload testing data.
+' &&
+	read -ep 'Configure Git to contribute testing data to '"$host"'? [Y/n]: ' ans &&
+	if [ "$ans" == "n" ] || [ "$ans" == "N" ]; then
+		exit 0
+	else
+		setup=1
+	fi
+fi &&
+
+setup_instructions='Once registered, login to Girder at
+
+  '"$site/#?dialog=login"'
+
+Then visit
+
+  <username> (upper right) > My account > API keys > Create new key
+
+To create a new API key.
+'
+
+# Perform setup if necessary.
+if test -n "$setup"; then
+	echo 'Register for an account at
+
+  '"$site/#?dialog=register"'
+
+'"$setup_instructions" &&
+	read -ep "Girder API key?: " gak &&
+	git config girder.api-key "$gak" &&
+        api_key=$(git config --get girder.api-key) &&
+	echo 'The Girder API key is now configured to
+
+  '"${api_key:0:5}..."'
+'
+fi &&
+
+# Optionally test GitHub access.
+if test -n "$api_key"; then
+  read -ep 'Test access to Girder via API key? [y/N]: ' ans &&
+  if [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
+    echo -n 'Testing Girder access via API key...'
+    token=""
+    token_response=$(curl -s -X POST --header 'Content-Length: 0' --header 'Content-Type: application/json' --header 'Accept: application/json' "https://data.kitware.com/api/v1/api_key/token?key=${api_key}&duration=1" || die "Could not retrieve token from API key.")
+    token=$(json_field "token" "${token_response}")
+    if test -z "$token"; then
+      echo 'failed.' &&
+      die 'Could not access Girder via your API key.'
+    else
+      echo 'passed.'
+    fi
+  fi
+fi

--- a/Utilities/SetupForDevelopment.sh
+++ b/Utilities/SetupForDevelopment.sh
@@ -27,6 +27,8 @@ Utilities/GitSetup/setup-git-aliases && echo &&
  echo 'Failed to setup origin.  Run this again to retry.') && echo &&
 (Utilities/GitSetup/setup-github ||
  echo 'Failed to setup GitHub.  Run this again to retry.') && echo &&
+(Utilities/GitSetup/setup-girder-api-key ||
+ echo 'Failed to setup the Girder API key.  Run this again to retry.') && echo &&
 Utilities/GitSetup/tips &&
 Utilities/GitSetup/github-tips
 
@@ -101,5 +103,5 @@ echo -e "Git version $git_version is OK.\n"
 
 
 # Record the version of this setup so Hooks/pre-commit can check it.
-SetupForDevelopment_VERSION=5
+SetupForDevelopment_VERSION=6
 git config hooks.SetupForDevelopment ${SetupForDevelopment_VERSION}

--- a/Utilities/UploadBinaryData.sh
+++ b/Utilities/UploadBinaryData.sh
@@ -39,10 +39,9 @@ To use the script:
 5. Re-build ITK, and the testing data will be downloaded into the build tree.
 
 
-If a GIRDER_API_KEY environmental variable is not set, a prompt will appear
-for your username and password. The API key can be created in the
-data.kitware.com user account web browser interface.
-
+If the Git `girder.api-key` config or `GIRDER_API_KEY` environmental variable
+is not set, a prompt will appear for your username and password. The API key
+can be created in the data.kitware.com user account web browser interface.
 
 The script will authenticate to data.kitware.com, upload the file to your
 user account's Public folder, and create a *.sha512 CMake ExternalData
@@ -102,7 +101,12 @@ fi
 
 # Authenticate
 token=""
-if test -n "${GIRDER_API_KEY}"; then
+git_config_api_key=$(git config --get girder.api-key || echo '')
+if test -n "${git_config_api_key}"; then
+  token_response=$(curl -s -X POST --header 'Content-Length: 0' --header 'Content-Type: application/json' --header 'Accept: application/json' "https://data.kitware.com/api/v1/api_key/token?key=${git_config_api_key}&duration=1" || die "Could not retrieve token from API key.")
+  token=$(json_field "token" "${token_response}")
+fi
+if test -z "${token}" -a -n "${GIRDER_API_KEY}"; then
   token_response=$(curl -s -X POST --header 'Content-Length: 0' --header 'Content-Type: application/json' --header 'Accept: application/json' "https://data.kitware.com/api/v1/api_key/token?key=${GIRDER_API_KEY}&duration=1" || die "Could not retrieve token from API key.")
   token=$(json_field "token" "${token_response}")
 fi


### PR DESCRIPTION
This script is a re-usable Git Setup script for use with the Kitware Git
Setup infrastructure designed by Brad King and with the
ITK/Utilities/UploadBinaryData.sh. During
./Utilities/SetupForDevelopment.sh it help the user set up a Girder API
key in the repository's Git configuration. This API key is used to
automate authenticated uploads when uploading testing data with the
UploadBinaryData.sh script via the `git data-upload` alias.

Closes #93 