### PR TITLE
PERF: Added C++11 final, noexcept, default, initializers to ImageRegion

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -66,7 +66,7 @@ class ITK_TEMPLATE_EXPORT ImageBase;
  * \endwiki
  */
 template< unsigned int VImageDimension >
-class ITK_TEMPLATE_EXPORT ImageRegion:public Region
+class ITK_TEMPLATE_EXPORT ImageRegion final: public Region
 {
 public:
   /** Standard class type aliases. */
@@ -107,32 +107,42 @@ public:
   { return Superclass::ITK_STRUCTURED_REGION; }
 
   /** Constructor. ImageRegion is a lightweight object that is not reference
-   * counted, so the constructor is public. */
-  ImageRegion();
+   * counted, so the constructor is public. Its two data members are filled
+   * with zeros (using C++11 default member initializers). */
+  ImageRegion() ITK_NOEXCEPT = default;
 
   /** Destructor. ImageRegion is a lightweight object that is not reference
    * counted, so the destructor is public. */
-  ~ImageRegion() override;
+  ~ImageRegion() override = default;
 
   /** Copy constructor. ImageRegion is a lightweight object that is not
    * reference counted, so the copy constructor is public. */
-  ImageRegion(const Self & region):Region(region), m_Index(region.m_Index), m_Size(region.m_Size) {}
+  ImageRegion(const Self & region) ITK_NOEXCEPT = default;
 
   /** Constructor that takes an index and size. ImageRegion is a lightweight
    * object that is not reference counted, so this constructor is public. */
-  ImageRegion(const IndexType & index, const SizeType & size)
-  { m_Index = index; m_Size = size; }
+  ImageRegion(const IndexType & index, const SizeType & size) ITK_NOEXCEPT
+    :
+  // Note: Use parentheses instead of curly braces to initialize data members,
+  // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."
+  m_Index(index),
+  m_Size(size)
+  {
+  }
 
   /** Constructor that takes a size and assumes an index of zeros. ImageRegion
    * is lightweight object that is not reference counted so this constructor
    * is public. */
-  ImageRegion(const SizeType & size)
-  { m_Size = size; m_Index.Fill(0); }
+  ImageRegion(const SizeType & size) ITK_NOEXCEPT
+    :
+  m_Size(size)
+  {
+    // Note: m_Index is initialized by its C++11 default member initializer.
+  }
 
   /** operator=. ImageRegion is a lightweight object that is not reference
    * counted, so operator= is public. */
-  void operator=(const Self & region)
-    { m_Index = region.m_Index;m_Size = region.m_Size; }
+  Self& operator=(const Self & region) ITK_NOEXCEPT = default;
 
   /** Set the index defining the corner of the region. */
   void SetIndex(const IndexType & index)
@@ -176,14 +186,14 @@ public:
 
   /** Compare two regions. */
   bool
-  operator==(const Self & region) const
+  operator==(const Self & region) const ITK_NOEXCEPT
   {
     return (m_Index == region.m_Index) && (m_Size == region.m_Size);
   }
 
   /** Compare two regions. */
   bool
-  operator!=(const Self & region) const
+  operator!=(const Self & region) const ITK_NOEXCEPT
   {
     return !(*this == region);
   }
@@ -306,8 +316,8 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  IndexType m_Index;
-  SizeType  m_Size;
+  IndexType m_Index = {{0}};
+  SizeType  m_Size = {{0}};
 
   /** Friends of ImageRegion */
   friend class ImageBase< VImageDimension >;

--- a/Modules/Core/Common/include/itkImageRegion.hxx
+++ b/Modules/Core/Common/include/itkImageRegion.hxx
@@ -32,24 +32,6 @@
 
 namespace itk
 {
-/**
- * Instantiate object.
- */
-template< unsigned int VImageDimension >
-ImageRegion< VImageDimension >
-::ImageRegion()
-{
-  m_Index.Fill(0);
-  m_Size.Fill(0);
-}
-
-/**
- * Destructor for the ImageRegion class.
- */
-template< unsigned int VImageDimension >
-ImageRegion< VImageDimension >
-::~ImageRegion() = default;
-
 template< unsigned int VImageDimension >
 typename ImageRegion< VImageDimension >::IndexType
 ImageRegion< VImageDimension >


### PR DESCRIPTION
itk::ImageRegion now uses C++11 features more extensively:

 - Added 'final' specifier to its class definition.
 - Declared all constructors and operators 'noexcept'
 - Defaulted default-constructor, copy-constructor, destructor and assignment.
 - Added default member initializers ('= {{0}}') to its data members.

Also replaced assignment of data members in constructors by old-style (C++98)
data member initialization.

These changes aim to improve performance, readability, and maintainability.