### PR TITLE
BUG: Remove ExternalData MD5 content link generation

### DIFF
--- a/CMake/ITKExternalData.cmake
+++ b/CMake/ITKExternalData.cmake
@@ -45,10 +45,6 @@ if(NOT ITK_FORBID_DOWNLOADS)
     )
 endif()
 
-# Tell ExternalData commands to transform raw files to content links.
-# TODO: Condition this feature on presence of our pre-commit hook.
-set(ExternalData_LINK_CONTENT MD5)
-
 # Emscripten currently has difficulty reading symlinks.
 if(EMSCRIPTEN)
   set(ExternalData_NO_SYMLINKS 1)


### PR DESCRIPTION
We now use ITK/Utilities/UploadBinaryData.sh to generate SHA512 content
links and upload binary data. Prevent the CMake ExternalData module from
consuming binary data files.