### PR TITLE
DOC: issue #273: SyNImageRegistrationMethod default member initializers

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
@@ -175,14 +175,12 @@ public:
 
   /**
    * Get/Set the Gaussian smoothing variance for the update field.
-   * Default = 1.75.
    */
   itkSetMacro( GaussianSmoothingVarianceForTheUpdateField, RealType );
   itkGetConstReferenceMacro( GaussianSmoothingVarianceForTheUpdateField, RealType );
 
   /**
    * Get/Set the Gaussian smoothing variance for the total field.
-   * Default = 0.5.
    */
   itkSetMacro( GaussianSmoothingVarianceForTheTotalField, RealType );
   itkGetConstReferenceMacro( GaussianSmoothingVarianceForTheTotalField, RealType );
@@ -224,21 +222,21 @@ protected:
   virtual DisplacementFieldPointer GaussianSmoothDisplacementField( const DisplacementFieldType *, const RealType );
   virtual DisplacementFieldPointer InvertDisplacementField( const DisplacementFieldType *, const DisplacementFieldType * = nullptr );
 
-  RealType                                                        m_LearningRate;
+  RealType                                                        m_LearningRate{ 0.25 };
 
-  OutputTransformPointer                                          m_MovingToMiddleTransform;
-  OutputTransformPointer                                          m_FixedToMiddleTransform;
+  OutputTransformPointer                                          m_MovingToMiddleTransform{ nullptr };
+  OutputTransformPointer                                          m_FixedToMiddleTransform{ nullptr };
 
-  RealType                                                        m_ConvergenceThreshold;
+  RealType                                                        m_ConvergenceThreshold{ static_cast<RealType>(1.0e-6) };
   unsigned int                                                    m_ConvergenceWindowSize{ 10 };
 
   NumberOfIterationsArrayType                                     m_NumberOfIterationsPerLevel;
-  bool                                                            m_DownsampleImagesForMetricDerivatives;
-  bool                                                            m_AverageMidPointGradients;
+  bool                                                            m_DownsampleImagesForMetricDerivatives{ true };
+  bool                                                            m_AverageMidPointGradients{ false };
 
 private:
-  RealType                                                        m_GaussianSmoothingVarianceForTheUpdateField;
-  RealType                                                        m_GaussianSmoothingVarianceForTheTotalField;
+  RealType                                                        m_GaussianSmoothingVarianceForTheUpdateField{ 3.0 };
+  RealType                                                        m_GaussianSmoothingVarianceForTheTotalField{ 0.5 };
 };
 } // end namespace itk
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -37,21 +37,14 @@ namespace itk
  */
 template<typename TFixedImage, typename TMovingImage, typename TOutputTransform, typename TVirtualImage, typename TPointSet>
 SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtualImage, TPointSet>
-::SyNImageRegistrationMethod() :
-  m_LearningRate( 0.25 ),
-  m_ConvergenceThreshold( 1.0e-6 ),
-
-  m_GaussianSmoothingVarianceForTheUpdateField( 3.0 ),
-  m_GaussianSmoothingVarianceForTheTotalField( 0.5 )
+::SyNImageRegistrationMethod()
 {
   this->m_NumberOfIterationsPerLevel.SetSize( 3 );
   this->m_NumberOfIterationsPerLevel[0] = 20;
   this->m_NumberOfIterationsPerLevel[1] = 30;
   this->m_NumberOfIterationsPerLevel[2] = 40;
-  this->m_DownsampleImagesForMetricDerivatives = true;
-  this->m_AverageMidPointGradients = false;
-  this->m_FixedToMiddleTransform = nullptr;
-  this->m_MovingToMiddleTransform = nullptr;
+
+  // Note: the other data members are initialized by C++11 default member initializers.
 }
 
 template<typename TFixedImage, typename TMovingImage, typename TOutputTransform, typename TVirtualImage, typename TPointSet>


### PR DESCRIPTION
Initialized data members of SyNImageRegistrationMethod by C++11 default member
initializers, within the class definition, instead of within the implementation
of its default constructor. (C++11 non-static data member initialization,
"NSDMI".) This has the great advantage that its default values are included
with the class documentation, as generated by Doxygen.

Fixed issue #273: "Mismatch documentation and code SyNImageRegistrationMethod
GaussianSmoothingVarianceForTheUpdateField default value"