### PR TITLE
STYLE: Use default member initialization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,3 +42,4 @@ zap.pl           crlf=input
 *                     hooks-max-size=100000
 Modules/ThirdParty/** hooks-max-size=300000
 Modules/ThirdParty/VNL/src/vxl/v3p/netlib/triangle.c hooks-max-size=670000
+Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx hooks-max-size=120000

--- a/Examples/DataRepresentation/Image/ImageAdaptor3.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor3.cxx
@@ -69,7 +69,7 @@ public:
   using InternalType = itk::CovariantVector<float,2>;
   using ExternalType = float;
 
-  VectorPixelAccessor() : m_Index(0) {}
+  VectorPixelAccessor()  {}
 
   VectorPixelAccessor & operator=( const VectorPixelAccessor & vpa ) = default;
   ExternalType Get( const InternalType & input ) const
@@ -82,7 +82,7 @@ public:
     }
 
 private:
-  unsigned int m_Index;
+  unsigned int m_Index{0};
 };
 // Software Guide : EndCodeSnippet
 }

--- a/Examples/DataRepresentation/Image/ImageAdaptor4.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor4.cxx
@@ -65,7 +65,7 @@ public:
   using InternalType = unsigned char;
   using ExternalType = unsigned char;
 
-  ThresholdingPixelAccessor() : m_Threshold(0) {};
+  ThresholdingPixelAccessor()  {};
 
   ExternalType Get( const InternalType & input ) const
     {
@@ -80,7 +80,7 @@ public:
     operator=( const ThresholdingPixelAccessor & vpa ) = default;
 
 private:
-  InternalType m_Threshold;
+  InternalType m_Threshold{0};
 };
 }
 

--- a/Examples/RegistrationITKv4/MultiResImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration1.cxx
@@ -281,7 +281,7 @@ public:
   itkNewMacro( Self );
 
 protected:
-  CommandIterationUpdate(): m_CumulativeIterationIndex(0) {};
+  CommandIterationUpdate() {};
 
 public:
   using OptimizerType = itk::RegularStepGradientDescentOptimizerv4<double>;
@@ -305,7 +305,7 @@ public:
   std::cout << m_CumulativeIterationIndex++ << std::endl;
   }
 private:
-  unsigned int m_CumulativeIterationIndex;
+  unsigned int m_CumulativeIterationIndex{0};
 };
 
 

--- a/Examples/RegistrationITKv4/MultiResImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration2.cxx
@@ -79,7 +79,7 @@ public:
   itkNewMacro( Self );
 
 protected:
-  CommandIterationUpdate(): m_CumulativeIterationIndex(0) {};
+  CommandIterationUpdate() {};
 
 public:
   using OptimizerType = itk::RegularStepGradientDescentOptimizer;
@@ -105,7 +105,7 @@ public:
     }
 
 private:
-  unsigned int m_CumulativeIterationIndex;
+  unsigned int m_CumulativeIterationIndex{0};
 };
 
 //  The following section of code implements a Command observer

--- a/Examples/RegistrationITKv4/MultiStageImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/MultiStageImageRegistration1.cxx
@@ -135,7 +135,7 @@ public:
   itkNewMacro( Self );
 
 protected:
-  CommandIterationUpdate(): m_CumulativeIterationIndex(0) {};
+  CommandIterationUpdate() {};
 
 public:
   using OptimizerType = itk::GradientDescentOptimizerv4Template<double>;
@@ -160,7 +160,7 @@ public:
     }
 
 private:
-  unsigned int m_CumulativeIterationIndex;
+  unsigned int m_CumulativeIterationIndex{0};
 };
 
 int main( int argc, char *argv[] )

--- a/Examples/RegistrationITKv4/MultiStageImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/MultiStageImageRegistration2.cxx
@@ -133,7 +133,7 @@ public:
   itkNewMacro( Self );
 
 protected:
-  CommandIterationUpdate(): m_CumulativeIterationIndex(0) {};
+  CommandIterationUpdate() {};
 
 public:
   using OptimizerType = itk::GradientDescentOptimizerv4Template<double>;
@@ -162,7 +162,7 @@ public:
     }
 
 private:
-  unsigned int m_CumulativeIterationIndex;
+  unsigned int m_CumulativeIterationIndex{0};
 };
 
 int main( int argc, char *argv[] )

--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -84,10 +84,7 @@ public:
 
   AnnulusOperator():
     NeighborhoodOperator< TPixel, TDimension, TAllocator >(),
-    m_InnerRadius(1.0),
-    m_Thickness( 1.0 ),
-    m_Normalize(false),
-    m_BrightCenter(false),
+
     m_InteriorValue(NumericTraits< PixelType >::ZeroValue()),
     m_AnnulusValue(NumericTraits< PixelType >::OneValue()),
     m_ExteriorValue(NumericTraits< PixelType >::ZeroValue()),
@@ -220,10 +217,10 @@ protected:
 
 private:
 
-  double      m_InnerRadius;
-  double      m_Thickness;
-  bool        m_Normalize;
-  bool        m_BrightCenter;
+  double      m_InnerRadius{1.0};
+  double      m_Thickness{ 1.0 };
+  bool        m_Normalize{false};
+  bool        m_BrightCenter{false};
   PixelType   m_InteriorValue;
   PixelType   m_AnnulusValue;
   PixelType   m_ExteriorValue;

--- a/Modules/Core/Common/include/itkAutoPointer.h
+++ b/Modules/Core/Common/include/itkAutoPointer.h
@@ -51,7 +51,7 @@ public:
   using Self = AutoPointer;
 
   /** Constructor.  */
-  AutoPointer ():m_Pointer(nullptr), m_IsOwner(false)
+  AutoPointer ():m_Pointer(nullptr)
   {}
 
   /** Copy constructor.  */
@@ -201,7 +201,7 @@ private:
 
   /** The pointer to the object referred to by this smart pointer. */
   ObjectType *m_Pointer;
-  bool        m_IsOwner;
+  bool        m_IsOwner{false};
 };
 
 template< typename T >

--- a/Modules/Core/Common/include/itkBarrier.h
+++ b/Modules/Core/Common/include/itkBarrier.h
@@ -76,9 +76,9 @@ private:
   Barrier();
   ~Barrier() override;
 
-  unsigned int            m_NumberArrived;
-  unsigned int            m_NumberExpected;
-  unsigned int            m_Generation; // Allows successive waits
+  unsigned int            m_NumberArrived{0};
+  unsigned int            m_NumberExpected{0};
+  unsigned int            m_Generation{0}; // Allows successive waits
   std::condition_variable m_ConditionVariable;
   std::mutex              m_Mutex;
 };

--- a/Modules/Core/Common/include/itkColorTable.h
+++ b/Modules/Core/Common/include/itkColorTable.h
@@ -118,7 +118,7 @@ private:
 
   void DeleteColors();
 
-  unsigned int m_NumberOfColors;
+  unsigned int m_NumberOfColors{ 0 };
 
   ColorNameVectorType         m_ColorName;
   ColorVectorType             m_Color;

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -29,8 +29,7 @@ namespace itk
 {
 template< typename TPixel >
 ColorTable< TPixel >
-::ColorTable() :
-  m_NumberOfColors( 0 )
+::ColorTable()
 {
 }
 

--- a/Modules/Core/Common/include/itkCommand.h
+++ b/Modules/Core/Common/include/itkCommand.h
@@ -395,10 +395,10 @@ protected:
   CStyleCommand();
   ~CStyleCommand() override;
 
-  void *                    m_ClientData;
-  FunctionPointer           m_Callback;
-  ConstFunctionPointer      m_ConstCallback;
-  DeleteDataFunctionPointer m_ClientDataDeleteCallback;
+  void *                    m_ClientData{ nullptr };
+  FunctionPointer           m_Callback{ nullptr };
+  ConstFunctionPointer      m_ConstCallback{ nullptr };
+  DeleteDataFunctionPointer m_ClientDataDeleteCallback{ nullptr };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkConditionalConstIterator.h
@@ -111,7 +111,7 @@ protected: //made protected so other iterators can access
   RegionType m_Region;
 
   /** Is the iterator at the end of its walk? */
-  bool m_IsAtEnd;
+  bool m_IsAtEnd{false};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkConditionalConstIterator.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 template< typename TImageType >
 ConditionalConstIterator< TImageType >
-::ConditionalConstIterator() : m_IsAtEnd(false)
+::ConditionalConstIterator()
 {}
 
 template< typename TImageType >

--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.h
@@ -124,10 +124,10 @@ protected:
 private:
   InputType     m_Origin;
   GradientType  m_OriginGradient;
-  double        m_DistanceMin;
-  double        m_DistanceMax;
-  double        m_Epsilon;
-  bool          m_Polarity;
+  double        m_DistanceMin{ 0.0 };
+  double        m_DistanceMax{ 0.0 };
+  double        m_Epsilon{ 0.0 };
+  bool          m_Polarity{ false };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
@@ -24,11 +24,8 @@ namespace itk
 {
 template< unsigned int VDimension, typename TInput >
 ConicShellInteriorExteriorSpatialFunction< VDimension, TInput >
-::ConicShellInteriorExteriorSpatialFunction() :
-  m_DistanceMin( 0.0 ),
-  m_DistanceMax( 0.0 ),
-  m_Epsilon( 0.0 ),
-  m_Polarity( false )
+::ConicShellInteriorExteriorSpatialFunction()
+
 {
   m_Origin.Fill(0.0);
   m_OriginGradient.Fill(0.0);

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -524,12 +524,12 @@ protected:
   mutable bool m_InBounds[Dimension];
 
   /** Denotes if iterator is entirely within bounds */
-  mutable bool m_IsInBounds;
+  mutable bool m_IsInBounds{false};
 
   /** Is the m_InBounds and m_IsInBounds variables up to date? Set to
    * false whenever the iterator is repositioned.  Set to true within
    * InBounds(). */
-  mutable bool m_IsInBoundsValid;
+  mutable bool m_IsInBoundsValid{false};
 
   /** Lower threshold of in-bounds loop counter values. */
   IndexType m_InnerBoundsLow;
@@ -541,7 +541,7 @@ protected:
   TBoundaryCondition m_InternalBoundaryCondition;
 
   /** Does the specified region need to worry about boundary conditions? */
-  bool m_NeedToUseBoundaryCondition;
+  bool m_NeedToUseBoundaryCondition{false};
 
   /** Functor type used to access neighborhoods of pixel pointers */
   NeighborhoodAccessorFunctorType m_NeighborhoodAccessorFunctor;

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -212,10 +212,8 @@ ConstNeighborhoodIterator< TImage, TBoundaryCondition >
 
 template< typename TImage, typename TBoundaryCondition >
 ConstNeighborhoodIterator< TImage, TBoundaryCondition >
-::ConstNeighborhoodIterator() :
-  m_IsInBounds(false),
-  m_IsInBoundsValid(false),
-  m_NeedToUseBoundaryCondition(false)
+::ConstNeighborhoodIterator()
+
 {
   IndexType zeroIndex; zeroIndex.Fill(0);
   SizeType zeroSize; zeroSize.Fill(0);

--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -84,7 +84,7 @@ protected:
   virtual void PrintSelf(std::ostream & os, Indent indent) const;
 
 private:
-  DataObject *m_DataObject;
+  DataObject *m_DataObject{nullptr};
 };
 
 /** \class InvalidRequestRegionError

--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
@@ -92,7 +92,7 @@ public:
   /** Get Vector lengths */
   VectorLengthType GetVectorLength() const { return m_VectorLength; }
 
-  DefaultVectorPixelAccessor() : m_VectorLength(0), m_OffsetMultiplier(0) {}
+  DefaultVectorPixelAccessor()  {}
 
   /** Constructor to initialize VectorLength at construction time */
   DefaultVectorPixelAccessor(VectorLengthType l)
@@ -104,8 +104,8 @@ public:
   ~DefaultVectorPixelAccessor() = default;
 
 private:
-  VectorLengthType m_VectorLength;
-  VectorLengthType m_OffsetMultiplier;
+  VectorLengthType m_VectorLength{0};
+  VectorLengthType m_OffsetMultiplier{0};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -77,7 +77,7 @@ public:
   using PixelRealType = typename Superclass::PixelRealType;
 
   /** Constructor. */
-  DerivativeOperator():m_Order(1) {}
+  DerivativeOperator() {}
 
   /** Copy constructor. */
   DerivativeOperator(const Self & other):
@@ -126,7 +126,7 @@ protected:
 
 private:
   /** Order of the derivative. */
-  unsigned int m_Order;
+  unsigned int m_Order{1};
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkDomainThreader.h
+++ b/Modules/Core/Common/include/itkDomainThreader.h
@@ -168,7 +168,7 @@ private:
    * the number allocated by the threader if the object does not split
    * well into that number.
    * This value is determined at the beginning of \c Execute(). */
-  ThreadIdType                             m_NumberOfWorkUnitsUsed;
+  ThreadIdType                             m_NumberOfWorkUnitsUsed{0};
   ThreadIdType                             m_NumberOfWorkUnits;
   typename DomainPartitionerType::Pointer  m_DomainPartitioner;
   DomainType                               m_CompleteDomain;

--- a/Modules/Core/Common/include/itkDomainThreader.hxx
+++ b/Modules/Core/Common/include/itkDomainThreader.hxx
@@ -26,8 +26,8 @@ namespace itk
 template< typename TDomainPartitioner, typename TAssociate >
 DomainThreader< TDomainPartitioner, TAssociate >
 ::DomainThreader()
-  : m_Associate(nullptr),
-    m_NumberOfWorkUnitsUsed(0)
+  : m_Associate(nullptr)
+
 {
   this->m_DomainPartitioner = DomainPartitionerType::New();
   this->m_MultiThreader = MultiThreaderBase::New();

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.h
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.h
@@ -105,11 +105,11 @@ protected:
 
 private:
   InputType                 m_Apex;
-  double                    m_AngleZ;
-  double                    m_ApertureAngleX;
-  double                    m_ApertureAngleY;
-  double                    m_TopPlane;
-  double                    m_BottomPlane;
+  double                    m_AngleZ{ 0.0f };
+  double                    m_ApertureAngleX{ 0.0f };
+  double                    m_ApertureAngleY{ 0.0f };
+  double                    m_TopPlane{ 0.0f };
+  double                    m_BottomPlane{ 0.0f };
   FrustumRotationPlaneType  m_RotationPlane;
 };
 } // end namespace itk

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
@@ -24,11 +24,7 @@ namespace itk
 {
 template< unsigned int VDimension, typename TInput >
 FrustumSpatialFunction< VDimension, TInput >::FrustumSpatialFunction() :
-  m_AngleZ( 0.0f ),
-  m_ApertureAngleX( 0.0f ),
-  m_ApertureAngleY( 0.0f ),
-  m_TopPlane( 0.0f ),
-  m_BottomPlane( 0.0f ),
+
   m_RotationPlane( RotateInXZPlane )
 {
   m_Apex.Fill( 0.0f );

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -185,25 +185,25 @@ private:
   }
 
   /** Normalize derivatives across scale space */
-  bool m_NormalizeAcrossScale;
+  bool m_NormalizeAcrossScale{true};
 
   /** Desired variance of the discrete Gaussian function. */
-  double m_Variance;
+  double m_Variance{1.0};
 
   /** Difference between the areas under the curves of the continuous and
    * discrete Gaussian functions. */
-  double m_MaximumError;
+  double m_MaximumError{0.005};
 
   /** Maximum kernel size allowed.  This value is used to truncate a kernel
    *  that has grown too large.  A warning is given when the specified maximum
    *  error causes the kernel to exceed this size. */
-  unsigned int m_MaximumKernelWidth;
+  unsigned int m_MaximumKernelWidth{30};
 
   /** Order of the derivative. */
-  unsigned int m_Order;
+  unsigned int m_Order{1};
 
   /** Spacing in the direction of this kernel. */
-  double m_Spacing;
+  double m_Spacing{1.0};
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -29,13 +29,8 @@ namespace itk
 
 template< typename TPixel, unsigned int VDimension, typename TAllocator >
 GaussianDerivativeOperator< TPixel, VDimension, TAllocator >
-::GaussianDerivativeOperator() :
-  m_NormalizeAcrossScale(true),
-  m_Variance(1.0),
-  m_MaximumError(0.005),
-  m_MaximumKernelWidth(30),
-  m_Order(1),
-  m_Spacing(1.0)
+::GaussianDerivativeOperator()
+
 {
 }
 

--- a/Modules/Core/Common/include/itkGaussianOperator.h
+++ b/Modules/Core/Common/include/itkGaussianOperator.h
@@ -75,7 +75,7 @@ public:
   itkTypeMacro(GaussianOperator, NeighborhoodOperator);
 
   /** Constructor. */
-  GaussianOperator():m_Variance(1), m_MaximumError(.01), m_MaximumKernelWidth(30) {}
+  GaussianOperator() {}
 
   /** Copy constructor */
   GaussianOperator(const Self & other):
@@ -177,16 +177,16 @@ protected:
 
 private:
   /** Desired variance of the discrete Gaussian function. */
-  double m_Variance;
+  double m_Variance{1};
 
   /** Difference between the areas under the curves of the continuous and
    * discrete Gaussian functions. */
-  double m_MaximumError;
+  double m_MaximumError{.01};
 
   /** Maximum kernel size allowed.  This value is used to truncate a kernel
    *  that has grown too large.  A warning is given when the specified maximum
    *  error causes the kernel to exceed this size. */
-  unsigned int m_MaximumKernelWidth;
+  unsigned int m_MaximumKernelWidth{30};
 
 };
 } // namespace itk

--- a/Modules/Core/Common/include/itkGaussianSpatialFunction.h
+++ b/Modules/Core/Common/include/itkGaussianSpatialFunction.h
@@ -98,9 +98,9 @@ private:
 
   ArrayType m_Mean;
 
-  double m_Scale;
+  double m_Scale{ 1.0 };
 
-  bool m_Normalized;
+  bool m_Normalized{ false };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
@@ -26,9 +26,8 @@ namespace itk
 {
 template< typename TOutput, unsigned int VImageDimension, typename TInput >
 GaussianSpatialFunction< TOutput, VImageDimension, TInput >
-::GaussianSpatialFunction() :
-  m_Scale( 1.0 ),
-  m_Normalized( false )
+::GaussianSpatialFunction()
+
 {
   m_Mean = ArrayType::Filled(10.0);
   m_Sigma = ArrayType::Filled(5.0);

--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
@@ -131,9 +131,8 @@ public:
 
   /** Default constructor. Needed since we provide a cast constructor. */
   ImageLinearConstIteratorWithIndex() :
-    ImageConstIteratorWithIndex< TImage >(),
-    m_Jump(0),
-    m_Direction(0)
+    ImageConstIteratorWithIndex< TImage >()
+
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a
@@ -218,8 +217,8 @@ public:
   }
 
 private:
-  OffsetValueType m_Jump;
-  unsigned int    m_Direction;
+  OffsetValueType m_Jump{0};
+  unsigned int    m_Direction{0};
 };
 
 //----------------------------------------------------------------------

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.h
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.h
@@ -169,8 +169,8 @@ private:
 
   void InternalAllocateOutputs( const TrueType& );
 
-  bool m_InPlace; // enable the possibility of in-place
-  bool m_RunningInPlace;
+  bool m_InPlace{true}; // enable the possibility of in-place
+  bool m_RunningInPlace{false};
 
 };
 } // end namespace itk

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
@@ -37,9 +37,8 @@ namespace itk
  */
 template< typename TInputImage, typename TOutputImage >
 InPlaceImageFilter< TInputImage, TOutputImage >
-::InPlaceImageFilter():
-  m_InPlace(true),
-  m_RunningInPlace(false)
+::InPlaceImageFilter()
+
 {}
 
 /**

--- a/Modules/Core/Common/include/itkLoggerOutput.h
+++ b/Modules/Core/Common/include/itkLoggerOutput.h
@@ -96,12 +96,12 @@ public:
   }
 
 protected:
-  LoggerOutput():m_Logger(nullptr) {}
+  LoggerOutput() {}
   ~LoggerOutput() override = default;
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  Logger *m_Logger;
+  Logger *m_Logger{nullptr};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkNeighborhoodAllocator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAllocator.h
@@ -53,7 +53,7 @@ public:
   using const_iterator = const TPixel *;
 
   /** Default constructor */
-  NeighborhoodAllocator():m_ElementCount(0), m_Data(nullptr)  {}
+  NeighborhoodAllocator(): m_Data(nullptr)  {}
 
   /** Default destructor */
   ~NeighborhoodAllocator()
@@ -124,7 +124,7 @@ public:
   }
 
 protected:
-  unsigned int m_ElementCount;
+  unsigned int m_ElementCount{0};
   TPixel *     m_Data;
 };
 

--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -202,7 +202,7 @@ protected:
 
 private:
   /** Enable/Disable debug messages. */
-  mutable bool m_Debug;
+  mutable bool m_Debug{false};
 
   /** Keep track of modification time. */
   mutable TimeStamp m_MTime;
@@ -212,7 +212,7 @@ private:
 
   /** Implementation class for Subject/Observer Pattern.
    * This is only allocated if used. */
-  SubjectImplementation *m_SubjectImplementation;
+  SubjectImplementation *m_SubjectImplementation{nullptr};
   /**
    * Implementation for holding Object MetaData
    * @see itk::MetaDataDictionary
@@ -220,7 +220,7 @@ private:
    * @see itk::MetaDataObject
    * This is only allocated if used.
    */
-  mutable MetaDataDictionary *m_MetaDataDictionary;
+  mutable MetaDataDictionary *m_MetaDataDictionary{nullptr};
 
   std::string m_ObjectName;
 };

--- a/Modules/Core/Common/include/itkObjectStore.h
+++ b/Modules/Core/Common/include/itkObjectStore.h
@@ -135,7 +135,7 @@ protected:
   SizeValueType GetGrowthSize();
 
   struct MemoryBlock {
-    MemoryBlock():Size(0), Begin(0) {}
+    MemoryBlock(): Begin(0) {}
 
     MemoryBlock(SizeValueType n):Size(n)
     { Begin = new ObjectType[n];  }
@@ -148,7 +148,7 @@ protected:
     }
 
     ObjectType *Begin;
-    SizeValueType Size;
+    SizeValueType Size{0};
   };
 
 private:

--- a/Modules/Core/Common/include/itkOctree.h
+++ b/Modules/Core/Common/include/itkOctree.h
@@ -163,11 +163,11 @@ private:
                                   unsigned y, unsigned z, unsigned xsize,
                                   unsigned ysize, unsigned zsize);
 
-  enum OctreePlaneType m_Plane; // The orientation of the plane for this octree
-  unsigned int         m_Width; // The width of the Octree
+  enum OctreePlaneType m_Plane{UNKNOWN_PLANE}; // The orientation of the plane for this octree
+  unsigned int         m_Width{0}; // The width of the Octree
                                 // ( This is always a power of 2, and large
                                 // enough to contain MAX(DIMS[1,2,3]))
-  unsigned int          m_Depth;         // < The depth of the Octree
+  unsigned int          m_Depth{0};         // < The depth of the Octree
   unsigned int          m_TrueDims[3];   // The true dimensions of the image
   OctreeNodeBranch      m_ColorTable[ColorTableSize];
   OctreeNode   m_Tree;

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 template< typename TPixel, unsigned int ColorTableSize, typename MappingFunctionType >
 Octree< TPixel, ColorTableSize,
-        MappingFunctionType >::Octree():m_Plane(UNKNOWN_PLANE), m_Width(0), m_Depth(0), m_Tree()
+        MappingFunctionType >::Octree(): m_Tree()
 {
   m_TrueDims[0] = 0;
   m_TrueDims[1] = 1;

--- a/Modules/Core/Common/include/itkRealTimeClock.h
+++ b/Modules/Core/Common/include/itkRealTimeClock.h
@@ -76,7 +76,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  FrequencyType m_Frequency;
+  FrequencyType m_Frequency{1};
   TimeStampType m_Difference;
   TimeStampType m_Origin;
 

--- a/Modules/Core/Common/include/itkSimpleFilterWatcher.h
+++ b/Modules/Core/Common/include/itkSimpleFilterWatcher.h
@@ -228,10 +228,10 @@ protected:
 
 private:
   TimeProbe                   m_TimeProbe;
-  int                         m_Steps;
-  int                         m_Iterations;
-  bool                        m_Quiet;
-  bool                        m_TestAbort;
+  int                         m_Steps{0};
+  int                         m_Iterations{0};
+  bool                        m_Quiet{false};
+  bool                        m_TestAbort{false};
   std::string                 m_Comment;
   itk::ProcessObject::Pointer m_Process;
 
@@ -242,11 +242,11 @@ private:
   CommandType::Pointer m_IterationFilterCommand;
   CommandType::Pointer m_AbortFilterCommand;
 
-  unsigned long m_StartTag;
-  unsigned long m_EndTag;
-  unsigned long m_ProgressTag;
-  unsigned long m_IterationTag;
-  unsigned long m_AbortTag;
+  unsigned long m_StartTag{0};
+  unsigned long m_EndTag{0};
+  unsigned long m_ProgressTag{0};
+  unsigned long m_IterationTag{0};
+  unsigned long m_AbortTag{0};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkSmapsFileParser.h
+++ b/Modules/Core/Common/include/itkSmapsFileParser.h
@@ -208,7 +208,7 @@ public:
                                                     VMMapData_10_2 & data);
 
 protected:
-  bool m_UsingSummary;
+  bool m_UsingSummary{false};
 };
 
 /** \class MapFileParser

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -158,9 +158,7 @@ public:
   EigenValueOrderType;
 
   SymmetricEigenAnalysis():
-  m_UseEigenLibrary(false),
-  m_Dimension(0),
-  m_Order(0),
+
   m_OrderEigenValues(OrderByValue) {}
 
   SymmetricEigenAnalysis(const unsigned int dimension):
@@ -281,9 +279,9 @@ public:
   }
   bool GetUseEigenLibrary() const { return m_UseEigenLibrary; }
 private:
-  bool                m_UseEigenLibrary;
-  unsigned int        m_Dimension;
-  unsigned int        m_Order;
+  bool                m_UseEigenLibrary{false};
+  unsigned int        m_Dimension{0};
+  unsigned int        m_Order{0};
   EigenValueOrderType m_OrderEigenValues;
 
   /** Reduces a real symmetric matrix to a symmetric tridiagonal matrix using

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.h
@@ -85,16 +85,16 @@ private:
   InputType m_Center;
 
   /** The unique axis length of the ellipsoid. */
-  double m_UniqueAxis;
+  double m_UniqueAxis{10};
 
   /** The symmetric axes lengths of the ellipsoid. */
-  double m_SymmetricAxes;
+  double m_SymmetricAxes{5};
 
   /** The orientation vector of the ellipsoid's unique axis. */
   Vector< double, VDimension > m_Orientation;
 
   /** The vector ratio. */
-  double m_VectorRatio;
+  double m_VectorRatio{0.0};
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -25,10 +25,7 @@ namespace itk
 {
 template< unsigned int VDimension, typename TInput >
 SymmetricEllipsoidInteriorExteriorSpatialFunction< VDimension, TInput >
-::SymmetricEllipsoidInteriorExteriorSpatialFunction() :
-  m_UniqueAxis(10),       // Length of unique axis
-  m_SymmetricAxes(5),     // Length of symmetric axes
-  m_VectorRatio(0.0)      // Vector ratio
+::SymmetricEllipsoidInteriorExteriorSpatialFunction()
 {
   m_Center.Fill(0.0);      // Origin of ellipsoid
   m_Orientation.Fill(1.0); // Orientation of unique axis

--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -149,7 +149,7 @@ private:
   std::vector< std::thread > m_Threads;
 
   /* Has destruction started? */
-  bool m_Stopping;
+  bool m_Stopping{ false };
 
   /** To lock on the internal variables */
   static ThreadPoolGlobals * m_ThreadPoolGlobals;

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.h
@@ -85,8 +85,8 @@ protected:
 
 private:
   InputType m_Origin;
-  double    m_MajorRadius;
-  double    m_MinorRadius;
+  double    m_MajorRadius{ 3.0 };
+  double    m_MinorRadius{ 1.0 };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
@@ -24,9 +24,8 @@ namespace itk
 {
 template< unsigned int VDimension, typename TInput >
 TorusInteriorExteriorSpatialFunction< VDimension, TInput >
-::TorusInteriorExteriorSpatialFunction() :
-  m_MajorRadius( 3.0 ),
-  m_MinorRadius( 1.0 )
+::TorusInteriorExteriorSpatialFunction()
+
 {
   m_Origin.Fill(0.0);
 }

--- a/Modules/Core/Common/include/itkTreeContainerBase.h
+++ b/Modules/Core/Common/include/itkTreeContainerBase.h
@@ -75,9 +75,9 @@ public:
 
 protected:
 
-  TreeContainerBase() : m_SubTree(false) {}
+  TreeContainerBase()  {}
   ~TreeContainerBase() override = default;
-  bool m_SubTree;
+  bool m_SubTree{false};
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -915,10 +915,10 @@ public:
   bool IsAProxy() const { return ! m_LetArrayManageMemory;}
 
 private:
-  bool              m_LetArrayManageMemory; // if true, the array is responsible
+  bool              m_LetArrayManageMemory{true}; // if true, the array is responsible
                                             // for memory of data
   TValue *          m_Data;                 // Array to hold data
-  ElementIdentifier m_NumElements;
+  ElementIdentifier m_NumElements{0};
 };
 
 /// \cond HIDE_META_PROGRAMMING

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -31,9 +31,9 @@ namespace itk
 /** Default constructor  */
 template< typename TValue >
 VariableLengthVector< TValue >
-::VariableLengthVector():m_LetArrayManageMemory(true),
-  m_Data(nullptr),
-  m_NumElements(0)
+::VariableLengthVector():
+  m_Data(nullptr)
+
 {}
 
 /** Constructor with size */

--- a/Modules/Core/Common/include/itkVectorImage.h
+++ b/Modules/Core/Common/include/itkVectorImage.h
@@ -346,7 +346,7 @@ protected:
   using Superclass::Graft;
 private:
   /** Length of the "vector pixel" */
-  VectorLengthType m_VectorLength;
+  VectorLengthType m_VectorLength{0};
 
   /** Memory for the current buffer. */
   PixelContainerPointer m_Buffer;

--- a/Modules/Core/Common/include/itkVectorImage.hxx
+++ b/Modules/Core/Common/include/itkVectorImage.hxx
@@ -37,8 +37,8 @@ namespace itk
  */
 template< typename TPixel, unsigned int VImageDimension >
 VectorImage< TPixel, VImageDimension >
-::VectorImage():
-  m_VectorLength(0)
+::VectorImage()
+
 {
   m_Buffer = PixelContainer::New();
 }

--- a/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
@@ -56,7 +56,7 @@ public:
   VectorImageNeighborhoodAccessorFunctor(VectorLengthType length):
     m_VectorLength(length), m_OffsetMultiplier(length - 1), m_Begin(nullptr) {}
   VectorImageNeighborhoodAccessorFunctor():
-    m_VectorLength(0), m_OffsetMultiplier(0), m_Begin(nullptr) {}
+     m_Begin(nullptr) {}
 
   /** Set the pointer index to the start of the buffer.
    * This must be set by the iterators to the starting location of the buffer.
@@ -126,8 +126,8 @@ public:
   }
 
 private:
-  VectorLengthType m_VectorLength;
-  VectorLengthType m_OffsetMultiplier; // m_OffsetMultiplier = m_VectorLength-1
+  VectorLengthType m_VectorLength{0};
+  VectorLengthType m_OffsetMultiplier{0}; // m_OffsetMultiplier = m_VectorLength-1
                                        // (precomputed for speedup).
   InternalPixelType *m_Begin;          // Begin of the buffer.
 };

--- a/Modules/Core/Common/src/itkBarrier.cxx
+++ b/Modules/Core/Common/src/itkBarrier.cxx
@@ -19,10 +19,7 @@
 
 namespace itk
 {
-Barrier::Barrier() :
-  m_NumberArrived(0),
-  m_NumberExpected(0),
-  m_Generation(0)
+Barrier::Barrier()
 {
 }
 

--- a/Modules/Core/Common/src/itkCommand.cxx
+++ b/Modules/Core/Common/src/itkCommand.cxx
@@ -23,11 +23,8 @@ namespace itk
 
   Command::~Command() = default;
 
-  CStyleCommand::CStyleCommand() :
-    m_ClientData( nullptr ),
-    m_Callback( nullptr ),
-    m_ConstCallback( nullptr ),
-    m_ClientDataDeleteCallback( nullptr )
+  CStyleCommand::CStyleCommand()
+
   {}
 
   CStyleCommand::~CStyleCommand()

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -34,7 +34,7 @@ bool DataObject:: m_GlobalReleaseDataFlag = false;
 
 DataObjectError
 ::DataObjectError() noexcept:
-  ExceptionObject(), m_DataObject(nullptr)
+  ExceptionObject()
 {}
 
 DataObjectError

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -49,15 +49,7 @@ namespace itk
   struct MultiThreaderBaseGlobals
   {
     // Initialize static members.
-    MultiThreaderBaseGlobals():GlobalDefaultThreaderTypeIsInitialized(false),
-#if defined(ITK_USE_TBB)
-    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderType::TBB),
-#else
-    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderType::Pool),
-#endif
-    m_GlobalMaximumNumberOfThreads(ITK_MAX_THREADS),
-    // Global default number of threads : 0 => Not initialized.
-    m_GlobalDefaultNumberOfThreads(0)
+    MultiThreaderBaseGlobals()
     {};
     // GlobalDefaultThreaderTypeIsInitialized is used only in this
     // file to ensure that the ITK_GLOBAL_DEFAULT_THREADER or
@@ -65,26 +57,33 @@ namespace itk
     // only used as a fall back option.  If the SetGlobalDefaultThreaderType
     // API is ever used by the developer, the developers choice is
     // respected over the environmental variable.
-    bool GlobalDefaultThreaderTypeIsInitialized;
+    bool GlobalDefaultThreaderTypeIsInitialized{false};
     std::mutex globalDefaultInitializerLock;
 
     // Global value to control weather the threadpool implementation should
     // be used. This defaults to the environmental variable
     // ITK_GLOBAL_DEFAULT_THREADER. If that is not present, then
     // ITK_USE_THREADPOOL is examined.
-    MultiThreaderBase::ThreaderType m_GlobalDefaultThreader;
+    MultiThreaderBase::ThreaderType m_GlobalDefaultThreader{
+#if defined(ITK_USE_TBB)
+    MultiThreaderBase::ThreaderType::TBB
+#else
+    MultiThreaderBase::ThreaderType::Pool
+#endif
+};
 
     // Global variable defining the maximum number of threads that can be used.
     //  The m_GlobalMaximumNumberOfThreads must always be less than or equal to
     //  ITK_MAX_THREADS and greater than zero. */
-    ThreadIdType m_GlobalMaximumNumberOfThreads;
+    ThreadIdType m_GlobalMaximumNumberOfThreads{ITK_MAX_THREADS};
 
     //  Global variable defining the default number of threads to set at
     //  construction time of a MultiThreaderBase instance.  The
     //  m_GlobalDefaultNumberOfThreads must always be less than or equal to the
     //  m_GlobalMaximumNumberOfThreads and larger or equal to 1 once it has been
     //  initialized in the constructor of the first MultiThreaderBase instantiation.
-    ThreadIdType m_GlobalDefaultNumberOfThreads;
+    // Global default number of threads : 0 => Not initialized.
+    ThreadIdType m_GlobalDefaultNumberOfThreads{0};
   };
 }//end of itk namespace
 

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -55,7 +55,7 @@ Observer::~Observer() { delete m_Event; }
 class ITKCommon_HIDDEN SubjectImplementation
 {
 public:
-  SubjectImplementation() : m_ListModified(false) { m_Count = 0; }
+  SubjectImplementation()  { m_Count = 0; }
   ~SubjectImplementation();
 
   unsigned long AddObserver(const EventObject & event, Command *cmd);
@@ -76,7 +76,7 @@ public:
 
   bool PrintObservers(std::ostream & os, Indent indent) const;
 
-  bool m_ListModified;
+  bool m_ListModified{false};
 
 protected:
 
@@ -593,9 +593,7 @@ Object
 Object
 ::Object():
   LightObject(),
-  m_Debug(false),
-  m_SubjectImplementation(nullptr),
-  m_MetaDataDictionary(nullptr),
+
   m_ObjectName()
 {
   this->Modified();

--- a/Modules/Core/Common/src/itkRealTimeClock.cxx
+++ b/Modules/Core/Common/src/itkRealTimeClock.cxx
@@ -29,7 +29,7 @@
 namespace itk
 {
 
-RealTimeClock::RealTimeClock():m_Frequency(1)
+RealTimeClock::RealTimeClock()
 {
 #if defined( WIN32 ) || defined( _WIN32 )
   LARGE_INTEGER frequency;

--- a/Modules/Core/Common/src/itkSimpleFilterWatcher.cxx
+++ b/Modules/Core/Common/src/itkSimpleFilterWatcher.cxx
@@ -49,21 +49,10 @@ SimpleFilterWatcher
 
 SimpleFilterWatcher
 ::SimpleFilterWatcher() :
-  m_Steps(0),
-  m_Iterations(0),
-#if defined( _COMPILER_VERSION ) && ( _COMPILER_VERSION == 730 )
-  m_Quiet(true),
-#else
-  m_Quiet(false),
-#endif
-  m_TestAbort(false),
+
   m_Comment("Not watching an object"),
-  m_Process(nullptr),
-  m_StartTag(0),
-  m_EndTag(0),
-  m_ProgressTag(0),
-  m_IterationTag(0),
-  m_AbortTag(0)
+  m_Process(nullptr)
+
 {
 }
 

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -416,8 +416,8 @@ SmapsData_2_6::GetStackUsage()
 /**              ---            VMMapData               ---              **/
 
 VMMapData_10_2
-::VMMapData_10_2():
-  m_UsingSummary(false)
+::VMMapData_10_2()
+
 {}
 
 VMMapData_10_2

--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -28,11 +28,11 @@ namespace itk
 {
   struct ThreadPoolGlobals
   {
-    ThreadPoolGlobals():m_DoNotWaitForThreads(false){};
+    ThreadPoolGlobals(){};
     // To lock on the internal variables.
     std::mutex          m_Mutex;
     ThreadPool::Pointer m_ThreadPoolInstance;
-    bool                m_DoNotWaitForThreads;
+    bool                m_DoNotWaitForThreads{false};
   };
 }//end of itk namespace
 
@@ -173,7 +173,7 @@ ThreadPool
 
 ThreadPool
 ::ThreadPool()
-  : m_Stopping( false )
+
 {
   m_ThreadPoolGlobals->m_ThreadPoolInstance = this; //threads need this
   m_ThreadPoolGlobals->m_ThreadPoolInstance->UnRegister(); // Remove extra reference

--- a/Modules/Core/Common/test/itkFactoryTestLib.cxx
+++ b/Modules/Core/Common/test/itkFactoryTestLib.cxx
@@ -54,7 +54,7 @@ public:
     }
   TestImportImageContainer()
      : m_TotalSize(0)
-     ,m_MemoryAllocatedByAllocator(false)
+
     {
     }
 
@@ -137,7 +137,7 @@ private:
   mutable TElementIdentifier m_TotalSize;
 
   mutable Allocator          m_Allocator;
-  mutable bool               m_MemoryAllocatedByAllocator;
+  mutable bool               m_MemoryAllocatedByAllocator{false};
 };
 
 class ImportImageContainerFactory : public itk::ObjectFactoryBase

--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -53,11 +53,11 @@ public:
     { return m_RegisterCount;}
 
 protected:
-  Derived1() : m_RegisterCount(0) {}
+  Derived1()  {}
 
   ~Derived1() override = default;
 
-  mutable unsigned int m_RegisterCount;
+  mutable unsigned int m_RegisterCount{0};
  };
 
 

--- a/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
@@ -170,7 +170,7 @@ public:
   VectorLengthType GetVectorLength() const { return Superclass::GetVectorLength(); }
 
   NthElementPixelAccessor( unsigned int length = 1)
-    :m_ElementNumber(0)
+
     {
     Superclass::SetVectorLength( length );
     }
@@ -194,7 +194,7 @@ protected:
   using Superclass = DefaultVectorPixelAccessor< TPixelType >;
 
 private:
-  VectorLengthType m_ElementNumber;
+  VectorLengthType m_ElementNumber{0};
 };
 
 }  // end namespace itk

--- a/Modules/Core/ImageAdaptors/include/itkVectorImageToImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkVectorImageToImageAdaptor.h
@@ -104,7 +104,7 @@ public:
   VectorLengthType GetVectorLength() const { return Superclass::GetVectorLength(); }
 
   VectorImageToImagePixelAccessor( unsigned int length = 1)
-    :m_ComponentIdx(0)
+
     {
     Superclass::SetVectorLength( length );
     }
@@ -113,7 +113,7 @@ protected:
   using Superclass = DefaultVectorPixelAccessor< TType >;
 
 private:
-  VectorLengthType m_ComponentIdx;
+  VectorLengthType m_ComponentIdx{0};
 };
 } // end namespace Accessor
 

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
@@ -184,17 +184,17 @@ private:
   typename TInputImage::SizeType m_DataLength;
 
   /** User specified spline order (3rd or cubic is the default). */
-  unsigned int m_SplineOrder;
+  unsigned int m_SplineOrder{ 0 };
 
   SplinePolesVectorType m_SplinePoles;
 
   int m_NumberOfPoles;
 
   /** Tolerance used for determining initial causal coefficient. Default is 1e-10.*/
-  double m_Tolerance;
+  double m_Tolerance{ 1e-10 };
 
   /** Direction for iterator incrementing. Default is 0. */
-  unsigned int m_IteratorDirection;
+  unsigned int m_IteratorDirection{ 0 };
 };
 } // namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -38,10 +38,8 @@ namespace itk
 
 template< typename TInputImage, typename TOutputImage >
 BSplineDecompositionImageFilter< TInputImage, TOutputImage >
-::BSplineDecompositionImageFilter() :
-  m_SplineOrder( 0 ),
-  m_Tolerance( 1e-10 ),   // Need some guidance on this one...what is reasonable?
-  m_IteratorDirection( 0 )
+::BSplineDecompositionImageFilter()
+
 {
   this->SetSplineOrder( 3 );
 

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.h
@@ -120,7 +120,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  unsigned int m_NeighborhoodRadius;
+  unsigned int m_NeighborhoodRadius{ 1 };
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
@@ -27,8 +27,8 @@ namespace itk
 
 template< typename TInputImage, typename TCoordRep >
 CovarianceImageFunction< TInputImage, TCoordRep >
-::CovarianceImageFunction() :
-  m_NeighborhoodRadius( 1 )
+::CovarianceImageFunction()
+
 {
 }
 

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
@@ -118,7 +118,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  unsigned int m_NeighborhoodRadius;
+  unsigned int m_NeighborhoodRadius{ 1 };
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -26,8 +26,8 @@ namespace itk
 
 template< typename TInputImage, typename TCoordRep >
 MeanImageFunction< TInputImage, TCoordRep >
-::MeanImageFunction() :
-  m_NeighborhoodRadius( 1 )
+::MeanImageFunction()
+
 {
 }
 

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
@@ -116,7 +116,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  unsigned int m_NeighborhoodRadius;
+  unsigned int m_NeighborhoodRadius{1};
 
 };
 } // end namespace itk

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
@@ -31,7 +31,7 @@ namespace itk
  */
 template< typename TInputImage, typename TCoordRep >
 MedianImageFunction< TInputImage, TCoordRep >
-::MedianImageFunction() : m_NeighborhoodRadius(1)
+::MedianImageFunction()
 {
 }
 

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.h
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.h
@@ -154,7 +154,7 @@ protected:
   void GenerateData() override;
 
 
-  bool       m_RegionOfInterestProvidedByUser;
+  bool       m_RegionOfInterestProvidedByUser{false};
   RegionType m_RegionOfInterest;
 
   void GenerateOutputInformation() override {}  // do nothing override
@@ -200,37 +200,37 @@ private:
   IdentifierType m_LastVoxel[14];
   IdentifierType m_CurrentVoxel[14];
 
-  IdentifierType **m_LastRow;
-  IdentifierType **m_LastFrame;
-  IdentifierType **m_CurrentRow;
-  IdentifierType **m_CurrentFrame;
+  IdentifierType **m_LastRow{nullptr};
+  IdentifierType **m_LastFrame{nullptr};
+  IdentifierType **m_CurrentRow{nullptr};
+  IdentifierType **m_CurrentFrame{nullptr};
 
-  unsigned short m_CurrentRowIndex;
-  unsigned short m_CurrentFrameIndex;
-  unsigned short m_LastRowNum;
-  unsigned short m_LastFrameNum;
-  unsigned short m_CurrentRowNum;
-  unsigned short m_CurrentFrameNum;
+  unsigned short m_CurrentRowIndex{0};
+  unsigned short m_CurrentFrameIndex{0};
+  unsigned short m_LastRowNum{0};
+  unsigned short m_LastFrameNum{0};
+  unsigned short m_CurrentRowNum{200};
+  unsigned short m_CurrentFrameNum{2000};
   unsigned char  m_AvailableNodes[14];
 
   double m_LocationOffset[14][3];
 
-  SizeValueType m_NumberOfNodes;
-  SizeValueType m_NumberOfCells;
+  SizeValueType m_NumberOfNodes{0};
+  SizeValueType m_NumberOfCells{0};
 
-  int m_NodeLimit;
-  int m_CellLimit;
-  int m_ImageWidth;
-  int m_ImageHeight;
-  int m_ImageDepth;
-  int m_ColFlag;
-  int m_RowFlag;
-  int m_FrameFlag;
-  int m_LastRowIndex;
-  int m_LastVoxelIndex;
-  int m_LastFrameIndex;
+  int m_NodeLimit{2000};
+  int m_CellLimit{4000};
+  int m_ImageWidth{0};
+  int m_ImageHeight{0};
+  int m_ImageDepth{0};
+  int m_ColFlag{0};
+  int m_RowFlag{0};
+  int m_FrameFlag{0};
+  int m_LastRowIndex{0};
+  int m_LastVoxelIndex{0};
+  int m_LastFrameIndex{0};
 
-  unsigned char  m_PointFound;
+  unsigned char  m_PointFound{0};
   InputPixelType m_ObjectValue;
 
   /** temporary variables used in CreateMesh to avoid thousands of

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -28,31 +28,7 @@ namespace itk
 template< typename TInputImage, typename TOutputMesh >
 BinaryMask3DMeshSource< TInputImage, TOutputMesh >
 ::BinaryMask3DMeshSource() :
-  m_RegionOfInterestProvidedByUser(false),
-  m_LastRow(nullptr),
-  m_LastFrame(nullptr),
-  m_CurrentRow(nullptr),
-  m_CurrentFrame(nullptr),
-  m_CurrentRowIndex(0),
-  m_CurrentFrameIndex(0),
-  m_LastRowNum(0),
-  m_LastFrameNum(0),
-  m_CurrentRowNum(200),
-  m_CurrentFrameNum(2000),
-  m_NumberOfNodes(0),
-  m_NumberOfCells(0),
-  m_NodeLimit(2000),
-  m_CellLimit(4000),
-  m_ImageWidth(0),
-  m_ImageHeight(0),
-  m_ImageDepth(0),
-  m_ColFlag(0),
-  m_RowFlag(0),
-  m_FrameFlag(0),
-  m_LastRowIndex(0),
-  m_LastVoxelIndex(0),
-  m_LastFrameIndex(0),
-  m_PointFound(0),
+
   m_ObjectValue(NumericTraits< InputPixelType >::OneValue()),
   m_OutputMesh(nullptr),
   m_InputImage(nullptr)

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.h
@@ -246,8 +246,8 @@ private:
   std::vector< OffsetValueType > m_Visited;
   SizeValueType                  m_NumberOfCellsInRegion;
   IdentifierType                 m_RegionNumber;
-  std::vector< IdentifierType > *m_Wave;
-  std::vector< IdentifierType > *m_Wave2;
+  std::vector< IdentifierType > *m_Wave{nullptr};
+  std::vector< IdentifierType > *m_Wave2{nullptr};
 }; // class declaration
 } // end namespace itk
 

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -44,9 +44,8 @@ ConnectedRegionsMeshFilter< TInputMesh, TOutputMesh >
 ::ConnectedRegionsMeshFilter() :
   m_ExtractionMode(Self::LargestRegion),
   m_NumberOfCellsInRegion(NumericTraits< SizeValueType >::ZeroValue()),
-  m_RegionNumber(NumericTraits< IdentifierType >::ZeroValue()),
-  m_Wave(nullptr),
-  m_Wave2(nullptr)
+  m_RegionNumber(NumericTraits< IdentifierType >::ZeroValue())
+
 {
   m_ClosestPoint.Fill(0);
 }

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
@@ -286,18 +286,18 @@ protected:
    * threshold controls the percentage of cells
    * to satify the selection criteria
    */
-  double m_Threshold;
+  double m_Threshold{0.5};
 
   /**
    * different criteria for cell refinement selection
    */
-  int m_SelectionMethod;
+  int m_SelectionMethod{0};
 
   /**
    * atttribute contains the number of cells
    * which were modified during the last Update()
    */
-  int m_ModifiedCount;
+  int m_ModifiedCount{0};
 
   /**
    * \brief member for accessing the filter result during

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -35,9 +35,7 @@ namespace itk
 template< typename TInputMesh, typename TOutputMesh >
 SimplexMeshAdaptTopologyFilter< TInputMesh, TOutputMesh >::SimplexMeshAdaptTopologyFilter() :
   m_IdOffset(0),
-  m_Threshold(0.5),
-  m_SelectionMethod(0),
-  m_ModifiedCount(0),
+
   m_Output(TOutputMesh::New())
 {
   this->ProcessObject::SetNumberOfRequiredOutputs(1);

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
@@ -199,24 +199,24 @@ private:
 
   InputMeshPointer m_SimplexMesh;
 
-  double m_Volume;
-  double m_VolumeX;
-  double m_VolumeY;
-  double m_VolumeZ;
-  double m_Area;
-  double m_Kx;
-  double m_Ky;
-  double m_Kz;
-  double m_Wxyz;
-  double m_Wxy;
-  double m_Wxz;
-  double m_Wyz;
+  double m_Volume{0.0};
+  double m_VolumeX{0.0};
+  double m_VolumeY{0.0};
+  double m_VolumeZ{0.0};
+  double m_Area{0.0};
+  double m_Kx{0.0};
+  double m_Ky{0.0};
+  double m_Kz{0.0};
+  double m_Wxyz{0.0};
+  double m_Wxy{0.0};
+  double m_Wxz{0.0};
+  double m_Wyz{0.0};
 
-  IndexValueType   m_Muncx;
-  IndexValueType   m_Muncy;
-  IndexValueType   m_Muncz;
+  IndexValueType   m_Muncx{0};
+  IndexValueType   m_Muncy{0};
+  IndexValueType   m_Muncz{0};
 
-  SizeValueType m_NumberOfTriangles;
+  SizeValueType m_NumberOfTriangles{0};
 };
 } //end of namespace
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -28,23 +28,8 @@ namespace itk
  */
 template< typename TInputMesh >
 SimplexMeshVolumeCalculator< TInputMesh >
-::SimplexMeshVolumeCalculator() :
-  m_Volume(0.0),
-  m_VolumeX(0.0),
-  m_VolumeY(0.0),
-  m_VolumeZ(0.0),
-  m_Area(0.0),
-  m_Kx(0.0),
-  m_Ky(0.0),
-  m_Kz(0.0),
-  m_Wxyz(0.0),
-  m_Wxy(0.0),
-  m_Wxz(0.0),
-  m_Wyz(0.0),
-  m_Muncx(0),
-  m_Muncy(0),
-  m_Muncz(0),
-  m_NumberOfTriangles(0)
+::SimplexMeshVolumeCalculator()
+
 {
 }
 

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
@@ -248,7 +248,7 @@ public:
 protected:
   OriginRefType      m_Origin;    // Geometrical information
   PrimalDataType     m_Data;      // User data associated to this edge.
-  bool               m_DataSet;   // Indicates if the data is set.
+  bool               m_DataSet{false};   // Indicates if the data is set.
   LineCellIdentifier m_LineCellIdent;
 };
 }

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
@@ -41,7 +41,7 @@ GeometricalQuadEdge< TVRef, TFRef, TPrimalData, TDualData, PrimalDual >
 ::GeometricalQuadEdge() :
   m_Origin(m_NoPoint),
   m_Data(),
-  m_DataSet(false),
+
   m_LineCellIdent(0)
 {
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
@@ -75,11 +75,11 @@ public:
 protected:
   /** Creator for specific metaObject, defined in subclass */
   virtual MetaObjectType *CreateMetaObject() = 0;
-  MetaConverterBase() : m_WriteImagesInSeparateFile(false)
+  MetaConverterBase()
     {}
 
 private:
-  bool m_WriteImagesInSeparateFile;
+  bool m_WriteImagesInSeparateFile{false};
 };
 
 }

--- a/Modules/Core/SpatialObjects/include/itkSceneSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSceneSpatialObject.h
@@ -123,7 +123,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Parent ID : default = -1 */
-  int m_ParentId;
+  int m_ParentId{0};
 };
 } // end of namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkSceneSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSceneSpatialObject.hxx
@@ -26,7 +26,7 @@ namespace itk
 /** Constructor */
 template< unsigned int TSpaceDimension >
 SceneSpatialObject< TSpaceDimension >
-::SceneSpatialObject() : m_ParentId(0)
+::SceneSpatialObject()
 {}
 
 /** Destructor */

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -115,7 +115,7 @@ protected:
   virtual void PrintSelf(std::ostream & os, Indent indent) const;
 
   /** A unique ID assigned to this SpatialObjectPoint */
-  int m_ID;
+  int m_ID{-1};
 
   /** Position of the point */
   PointType m_X;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -26,7 +26,7 @@ namespace itk
 template< unsigned int TPointDimension >
 SpatialObjectPoint< TPointDimension >
 ::SpatialObjectPoint()
-: m_ID(-1), m_X(0.0)
+:  m_X(0.0)
 {
   m_Color.SetRed(1.0); // red by default
   m_Color.SetGreen(0);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.h
@@ -98,8 +98,8 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  unsigned int m_ChildrenDepth;
-  unsigned int m_SamplingFactor;
+  unsigned int m_ChildrenDepth{ 0 };
+  unsigned int m_SamplingFactor{ 1 };
 };
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
@@ -25,9 +25,8 @@ namespace itk
 
 template< typename TInputSpatialObject, typename TOutputPointSet >
 SpatialObjectToPointSetFilter< TInputSpatialObject, TOutputPointSet >
-::SpatialObjectToPointSetFilter() :
-  m_ChildrenDepth( 0 ),
-  m_SamplingFactor( 1 )
+::SpatialObjectToPointSetFilter()
+
 {
   this->SetNumberOfRequiredInputs(1);
 }

--- a/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
@@ -23,7 +23,7 @@
 class MetaDummy : public MetaObject
 {
 public:
-  MetaDummy(unsigned int dims = 3) : m_Value(0.0)
+  MetaDummy(unsigned int dims = 3)
     {
       strcpy(m_ObjectTypeName,"Dummy");
       m_NDims = dims;
@@ -65,7 +65,7 @@ protected:
     }
 
 private:
-  float m_Value;
+  float m_Value{0.0};
 };
 
 namespace itk
@@ -98,7 +98,7 @@ public:
     }
 
 protected:
-  DummySpatialObject() : m_Value(0.0)
+  DummySpatialObject()
     {
       this->SetDimension(TDimension);
       this->SetTypeName ("DummySpatialObject");
@@ -110,7 +110,7 @@ protected:
   ~DummySpatialObject() override = default;
 
 private:
-  float m_Value;
+  float m_Value{0.0};
 };
 
 /** \class MetaConverterBase

--- a/Modules/Core/TestKernel/test/itkGoogleTestFixture.cxx
+++ b/Modules/Core/TestKernel/test/itkGoogleTestFixture.cxx
@@ -27,14 +27,14 @@ class GoogleTestFixture
   : public ::testing::Test
 {
 public:
-  GoogleTestFixture() : m_C(1) {}
+  GoogleTestFixture()  {}
   ~GoogleTestFixture() override = default;
 
 protected:
   void SetUp() override {}
   void TearDown() override {}
 
-  int m_C;
+  int m_C{1};
 };
 }
 

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
@@ -108,7 +108,7 @@ private:
   TransformPointer                m_Transform;
 
   MeshSizeType                    m_TransformDomainMeshSize;
-  bool                            m_SetTransformDomainMeshSizeViaInitializer;
+  bool                            m_SetTransformDomainMeshSizeViaInitializer{ false };
 
 }; //class BSplineTransformInitializer
 }  // namespace itk

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -30,8 +30,8 @@ namespace itk
 template<typename TTransform, typename TImage>
 BSplineTransformInitializer<TTransform, TImage>
 ::BSplineTransformInitializer() :
-  m_Transform( nullptr ),
-  m_SetTransformDomainMeshSizeViaInitializer( false )
+  m_Transform( nullptr )
+
 {
   this->m_TransformDomainMeshSize.Fill( 1 );
 }

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.h
@@ -105,7 +105,7 @@ private:
   DerivativeOperator< ScalarValueType, Self::ImageDimension > m_DerivativeOperator;
 
   /** Modified global average gradient magnitude term. */
-  double m_K;
+  double m_K{ 0.0 };
 
   static double m_MIN_NORM;
   SizeValueType m_Center;

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -28,8 +28,8 @@ double VectorCurvatureNDAnisotropicDiffusionFunction< TImage >
 
 template< typename TImage >
 VectorCurvatureNDAnisotropicDiffusionFunction< TImage >
-::VectorCurvatureNDAnisotropicDiffusionFunction():
-  m_K( 0.0 )
+::VectorCurvatureNDAnisotropicDiffusionFunction()
+
 {
   unsigned int i, j;
   RadiusType   r;

--- a/Modules/Filtering/BiasCorrection/include/itkCacheableScalarFunction.h
+++ b/Modules/Filtering/BiasCorrection/include/itkCacheableScalarFunction.h
@@ -115,22 +115,22 @@ protected:
 private:
   /** The number of samples will be precalcualted and saved in the
    * cache table. */
-  SizeValueType m_NumberOfSamples;
+  SizeValueType m_NumberOfSamples{0};
 
   /** Storage for the precalcualted function values. */
   MeasureArrayType m_CacheTable;
 
   /** The upper-bound of domain that is used for filling the cache table. */
-  double m_CacheUpperBound;
+  double m_CacheUpperBound{0.0};
 
   /** The lower-bound of domain that is used for filling the cache table. */
-  double m_CacheLowerBound;
+  double m_CacheLowerBound{0.0};
 
   /** Sampling interval for function evaluation. */
-  double m_TableInc;
+  double m_TableInc{0.0};
 
   /** Is the cache available?   */
-  bool m_CacheAvailable;
+  bool m_CacheAvailable{false};
 }; // end of class
 } // end of namespace itk
 #endif

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
@@ -559,23 +559,23 @@ private:
   int m_SlicingDirection;
 
   /** Bias Field character if true, multiplicative.  if false, additive. */
-  bool m_BiasFieldMultiplicative;
+  bool m_BiasFieldMultiplicative{ true };
 
   /** operation selection flags. */
   bool m_UsingInterSliceIntensityCorrection;
-  bool m_UsingSlabIdentification;
-  bool m_UsingBiasFieldCorrection;
-  bool m_GeneratingOutput;
+  bool m_UsingSlabIdentification{ false };
+  bool m_UsingBiasFieldCorrection{ true };
+  bool m_GeneratingOutput{ true };
 
-  unsigned int        m_SlabNumberOfSamples;
+  unsigned int        m_SlabNumberOfSamples{ 200 };
   InputImagePixelType m_SlabBackgroundMinimumThreshold;
-  double              m_SlabTolerance;
+  double              m_SlabTolerance{ 0.0 };
 
   /** The degree of the bias field estimate. */
-  int m_BiasFieldDegree;
+  int m_BiasFieldDegree{ 3 };
 
   /** The number of levels for the multires schedule. */
-  unsigned int m_NumberOfLevels;
+  unsigned int m_NumberOfLevels{ 0 };
 
   /** The multires schedule */
   ScheduleType m_Schedule;
@@ -588,15 +588,15 @@ private:
    * after optimization. */
   BiasFieldType::CoefficientArrayType m_EstimatedBiasFieldCoefficients;
 
-  int m_VolumeCorrectionMaximumIteration;
+  int m_VolumeCorrectionMaximumIteration{ 2000 };
 
-  int m_InterSliceCorrectionMaximumIteration;
+  int m_InterSliceCorrectionMaximumIteration{ 4000 };
 
   /** Storage for the optimizer's initial search radius. */
-  double m_OptimizerInitialRadius;
+  double m_OptimizerInitialRadius{ 1.01 };
 
   /** Storage for the optimizer's search radius grow factor. */
-  double m_OptimizerGrowthFactor;
+  double m_OptimizerGrowthFactor{ 1.05 };
 
   /** Storage for the optimizer's search radius shrink factor. */
   double m_OptimizerShrinkFactor;

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -210,19 +210,9 @@ MRIBiasFieldCorrectionFilter< TInputImage, TOutputImage, TMaskImage >
   m_InputMask( nullptr ),
   m_OutputMask( nullptr ),
   m_InternalInput( InternalImageType::New() ),
-  m_BiasFieldMultiplicative( true ),
-  m_UsingSlabIdentification( false ),
-  m_UsingBiasFieldCorrection( true ),
-  m_GeneratingOutput( true ),
-  m_SlabNumberOfSamples( 200 ),
+
   m_SlabBackgroundMinimumThreshold( NumericTraits< InputImagePixelType >::min() ),
-  m_SlabTolerance( 0.0 ),
-  m_BiasFieldDegree( 3 ),
-  m_NumberOfLevels( 0 ),
-  m_VolumeCorrectionMaximumIteration( 2000 ),
-  m_InterSliceCorrectionMaximumIteration( 4000 ),
-  m_OptimizerInitialRadius( 1.01 ),
-  m_OptimizerGrowthFactor( 1.05 ),
+
   m_OptimizerShrinkFactor( std::pow(m_OptimizerGrowthFactor, -0.25) )
 {
   m_NormalVariateGenerator->Initialize( time(nullptr) );

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
@@ -400,28 +400,28 @@ private:
   RealType CalculateConvergenceMeasurement( const RealImageType *, const RealImageType * ) const;
 
   MaskPixelType m_MaskLabel;
-  bool          m_UseMaskLabel;
+  bool          m_UseMaskLabel{ false };
 
   // Parameters for deconvolution with Wiener filter
 
-  unsigned int m_NumberOfHistogramBins;
-  RealType     m_WienerFilterNoise;
-  RealType     m_BiasFieldFullWidthAtHalfMaximum;
+  unsigned int m_NumberOfHistogramBins{ 200 };
+  RealType     m_WienerFilterNoise{ 0.01 };
+  RealType     m_BiasFieldFullWidthAtHalfMaximum{ 0.15 };
 
   // Convergence parameters
 
   VariableSizeArrayType m_MaximumNumberOfIterations;
-  unsigned int          m_ElapsedIterations;
-  RealType              m_ConvergenceThreshold;
+  unsigned int          m_ElapsedIterations{ 0 };
+  RealType              m_ConvergenceThreshold{ 0.001 };
   RealType              m_CurrentConvergenceMeasurement;
-  unsigned int          m_CurrentLevel;
+  unsigned int          m_CurrentLevel{ 0 };
 
   // B-spline fitting parameters
 
   typename
   BiasFieldControlPointLatticeType::Pointer m_LogBiasFieldControlPointLattice;
 
-  unsigned int m_SplineOrder;
+  unsigned int m_SplineOrder{ 3 };
   ArrayType    m_NumberOfControlPoints;
   ArrayType    m_NumberOfFittingLevels;
 

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -45,15 +45,9 @@ template <typename TInputImage, typename TMaskImage, typename TOutputImage>
 N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 ::N4BiasFieldCorrectionImageFilter() :
   m_MaskLabel( NumericTraits< MaskPixelType >::OneValue() ),
-  m_UseMaskLabel( false ),
-  m_NumberOfHistogramBins( 200 ),
-  m_WienerFilterNoise( 0.01 ),
-  m_BiasFieldFullWidthAtHalfMaximum( 0.15 ),
-  m_ElapsedIterations( 0 ),
-  m_ConvergenceThreshold( 0.001 ),
-  m_CurrentConvergenceMeasurement( NumericTraits<RealType>::ZeroValue() ),
-  m_CurrentLevel( 0 ),
-  m_SplineOrder( 3 )
+
+  m_CurrentConvergenceMeasurement( NumericTraits<RealType>::ZeroValue() )
+
 {
   // implicit:
   // #0 "Primary" required

--- a/Modules/Filtering/BiasCorrection/src/itkCacheableScalarFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCacheableScalarFunction.cxx
@@ -21,12 +21,9 @@ namespace itk
 {
 CacheableScalarFunction
 ::CacheableScalarFunction() :
-  m_NumberOfSamples(0),
-  m_CacheTable(0),
-  m_CacheUpperBound(0.0),
-  m_CacheLowerBound(0.0),
-  m_TableInc(0.0),
-  m_CacheAvailable(false)
+
+  m_CacheTable(0)
+
 {
 }
 

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -123,7 +123,7 @@ protected:
   void VerifyInputInformation() ITKv5_CONST override {};
 
 private:
-  bool m_Normalize;
+  bool m_Normalize{ false };
 
   DefaultBoundaryConditionType m_DefaultBoundaryCondition;
   BoundaryConditionPointerType m_BoundaryCondition;

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
@@ -25,7 +25,7 @@ namespace itk
 template< typename TInputImage, typename TKernelImage, typename TOutputImage >
 ConvolutionImageFilterBase< TInputImage, TKernelImage, TOutputImage >
 ::ConvolutionImageFilterBase() :
-  m_Normalize( false ),
+
   m_OutputRegionMode( Self::SAME )
 {
   this->AddRequiredInputName("KernelImage");

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -219,7 +219,7 @@ public:
 #endif
 
 protected:
-  MaskedFFTNormalizedCorrelationImageFilter():m_TotalForwardAndInverseFFTs(12)
+  MaskedFFTNormalizedCorrelationImageFilter()
   {
     // #0 "FixedImage" required
     Self::SetPrimaryInputName("FixedImage");
@@ -316,7 +316,7 @@ private:
   SizeValueType m_MaximumNumberOfOverlappingPixels;
 
   /** This is used for the progress reporter */
-  const unsigned int m_TotalForwardAndInverseFFTs;
+  const unsigned int m_TotalForwardAndInverseFFTs{12};
   /** The total accumulated progress */
   float m_AccumulatedProgress;
 };

--- a/Modules/Filtering/Deconvolution/include/itkParametricBlindLeastSquaresDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkParametricBlindLeastSquaresDeconvolutionImageFilter.h
@@ -150,7 +150,7 @@ private:
     class ITK_TEMPLATE_EXPORT ParametricBlindLeastSquaresDeconvolutionImageUpdate
   {
   public:
-    ParametricBlindLeastSquaresDeconvolutionImageUpdate() : m_Alpha(0.01) {}
+    ParametricBlindLeastSquaresDeconvolutionImageUpdate()  {}
     ~ParametricBlindLeastSquaresDeconvolutionImageUpdate() = default;
 
     bool operator!=(const ParametricBlindLeastSquaresDeconvolutionImageUpdate &) const
@@ -182,7 +182,7 @@ private:
     }
 
   private:
-    double m_Alpha;
+    double m_Alpha{0.01};
   };
 
   KernelSourcePointer             m_KernelSource;

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
@@ -323,29 +323,29 @@ protected:
 
 private:
   /** Parameters that define patch size and patch weights (mask). */
-  unsigned int     m_PatchRadius;
+  unsigned int     m_PatchRadius{ 4 };
   PatchWeightsType m_PatchWeights;
 
   /** Parameters that define the strategy for kernel-bandwidth estimation. */
-  bool         m_KernelBandwidthEstimation;
-  unsigned int m_KernelBandwidthUpdateFrequency;
+  bool         m_KernelBandwidthEstimation{ false };
+  unsigned int m_KernelBandwidthUpdateFrequency{ 3 };
 
   /** Parameters that define the total number of denoising iterations to perform
    *  and those completed so far. */
-  unsigned int m_NumberOfIterations;
-  unsigned int m_ElapsedIterations;
+  unsigned int m_NumberOfIterations{ 1 };
+  unsigned int m_ElapsedIterations{ 0 };
 
   /** Parameters defining the usage of a specific noise model, if desired. */
   NoiseModelType m_NoiseModel;
-  double         m_SmoothingWeight;
-  double         m_NoiseModelFidelityWeight;
+  double         m_SmoothingWeight{ 1.0 };
+  double         m_NoiseModelFidelityWeight{ 0.0 };
 
   /** Parameter indicating whether components should be treated as if they are in
       Euclidean space regardless of pixel type. */
-  bool               m_AlwaysTreatComponentsAsEuclidean;
+  bool               m_AlwaysTreatComponentsAsEuclidean{ false };
   ComponentSpaceType m_ComponentSpace;
 
-  bool m_ManualReinitialization;
+  bool m_ManualReinitialization{ false };
 
   FilterStateType m_State;
 };

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -28,17 +28,11 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>
 ::PatchBasedDenoisingBaseImageFilter() :
-  m_PatchRadius( 4 ),
-  m_KernelBandwidthEstimation( false ),
-  m_KernelBandwidthUpdateFrequency( 3 ),
-  m_NumberOfIterations( 1 ),
-  m_ElapsedIterations( 0 ),
+
   m_NoiseModel( NOMODEL ),
-  m_SmoothingWeight( 1.0 ),
-  m_NoiseModelFidelityWeight( 0.0 ),
-  m_AlwaysTreatComponentsAsEuclidean( false ),
+
   m_ComponentSpace( EUCLIDEAN ),
-  m_ManualReinitialization( false ),
+
   m_State( UNINITIALIZED )
 {
   m_InputImage  = nullptr;

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
@@ -499,32 +499,32 @@ private:
   /** The buffer that holds the updates for an iteration of the algorithm. */
   typename OutputImageType::Pointer m_UpdateBuffer;
 
-  unsigned int m_NumPixelComponents;
-  unsigned int m_NumIndependentComponents;
-  unsigned int m_TotalNumberPixels;
+  unsigned int m_NumPixelComponents{ 0 };
+  unsigned int m_NumIndependentComponents{ 0 };
+  unsigned int m_TotalNumberPixels{ 0 };
 
-  bool m_UseSmoothDiscPatchWeights;
+  bool m_UseSmoothDiscPatchWeights{ true };
 
-  bool m_UseFastTensorComputations;
+  bool m_UseFastTensorComputations{ true };
 
   RealArrayType  m_KernelBandwidthSigma;
-  bool           m_KernelBandwidthSigmaIsSet;
+  bool           m_KernelBandwidthSigmaIsSet{ false };
   RealArrayType  m_IntensityRescaleInvFactor;
   PixelType      m_ZeroPixel;
   PixelArrayType m_ImageMin;
   PixelArrayType m_ImageMax;
-  double         m_KernelBandwidthFractionPixelsForEstimation;
-  bool           m_ComputeConditionalDerivatives;
+  double         m_KernelBandwidthFractionPixelsForEstimation{ 0.20 };
+  bool           m_ComputeConditionalDerivatives{ false };
   double         m_MinSigma;
   double         m_MinProbability;
   unsigned int   m_SigmaUpdateDecimationFactor;
-  double         m_SigmaUpdateConvergenceTolerance;
+  double         m_SigmaUpdateConvergenceTolerance{ 0.01 };
   ShortArrayType m_SigmaConverged;
-  double         m_KernelBandwidthMultiplicationFactor;
+  double         m_KernelBandwidthMultiplicationFactor{ 1.0 };
 
   RealType m_NoiseSigma;
   RealType m_NoiseSigmaSquared;
-  bool     m_NoiseSigmaIsSet;
+  bool     m_NoiseSigmaIsSet{ false };
 
   BaseSamplerPointer                m_Sampler;
   typename ListAdaptorType::Pointer m_SearchSpaceList;

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -39,24 +39,16 @@ template <typename TInputImage, typename TOutputImage>
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>
 ::PatchBasedDenoisingImageFilter() :
   m_UpdateBuffer( OutputImageType::New() ),
-  m_NumPixelComponents( 0 ),       // not valid until Initialize()
-  m_NumIndependentComponents( 0 ), // not valid until Initialize()
-  m_TotalNumberPixels( 0 ),        // not valid until an image is provided
-  m_UseSmoothDiscPatchWeights( true ),
-  m_UseFastTensorComputations( true ),
-  m_KernelBandwidthSigmaIsSet( false ),
-  m_ZeroPixel(),                 // not valid until Initialize()
-  m_KernelBandwidthFractionPixelsForEstimation( 0.20 ),
-  m_ComputeConditionalDerivatives( false ),
+
+  m_ZeroPixel(),
   m_MinSigma( NumericTraits<RealValueType>::min() * 100 ), // to avoid divide by zero
   m_MinProbability( NumericTraits<RealValueType>::min() * 100 ), // to avoid divide by zero
   m_SigmaUpdateDecimationFactor( static_cast<unsigned int>
                                 ( Math::Round<double>( 1.0 / m_KernelBandwidthFractionPixelsForEstimation ) ) ),
-  m_SigmaUpdateConvergenceTolerance( 0.01 ),   // desired accuracy of Newton-Raphson sigma estimation
-  m_KernelBandwidthMultiplicationFactor( 1.0 ),
+
   m_NoiseSigma( 0.0 ),
   m_NoiseSigmaSquared( 0.0 ),
-  m_NoiseSigmaIsSet( false ),
+
   m_SearchSpaceList( ListAdaptorType::New() )
 {
   // By default, turn off automatic kernel bandwidth sigma estimation

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.h
@@ -169,7 +169,7 @@ private:
   ArrayType                               m_NumberOfControlPointsForTheConstantVelocityField;
   ArrayType                               m_NumberOfControlPointsForTheUpdateField;
 
-  SplineOrderType                         m_SplineOrder;
+  SplineOrderType                         m_SplineOrder{ 3 };
 };
 
 } // end namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -33,8 +33,8 @@ namespace itk
  */
 template<typename TParametersValueType, unsigned int NDimensions>
 BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>
-::BSplineExponentialDiffeomorphicTransform() :
-  m_SplineOrder( 3 )
+::BSplineExponentialDiffeomorphicTransform()
+
 {
   this->m_NumberOfControlPointsForTheConstantVelocityField.Fill( 4 );
   this->m_NumberOfControlPointsForTheUpdateField.Fill( 4 );

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
@@ -190,8 +190,8 @@ protected:
    DisplacementFieldPointer BSplineSmoothDisplacementField( const DisplacementFieldType *, const ArrayType & );
 
 private:
-  SplineOrderType             m_SplineOrder;
-  bool                        m_EnforceStationaryBoundary;
+  SplineOrderType             m_SplineOrder{ 3 };
+  bool                        m_EnforceStationaryBoundary{ true };
   ArrayType                   m_NumberOfControlPointsForTheUpdateField;
   ArrayType                   m_NumberOfControlPointsForTheTotalField;
 };

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -33,9 +33,8 @@ namespace itk
  */
 template<typename TParametersValueType, unsigned int NDimensions>
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>
-::BSplineSmoothingOnUpdateDisplacementFieldTransform() :
-  m_SplineOrder( 3 ),
-  m_EnforceStationaryBoundary( true )
+::BSplineSmoothingOnUpdateDisplacementFieldTransform()
+
 {
   this->m_NumberOfControlPointsForTheUpdateField.Fill( 4 );
   this->m_NumberOfControlPointsForTheTotalField.Fill( 0 );

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
@@ -198,14 +198,14 @@ protected:
 
   ConstantVelocityFieldPointer              m_ConstantVelocityField;
 
-  bool                                      m_CalculateNumberOfIntegrationStepsAutomatically;
+  bool                                      m_CalculateNumberOfIntegrationStepsAutomatically{ false };
 
   /** The interpolator. */
   ConstantVelocityFieldInterpolatorPointer  m_ConstantVelocityFieldInterpolator;
 
   /** Track when the VELOCITY field was last set/assigned, as
    * distinct from when it may have had its contents modified. */
-  ModifiedTimeType m_ConstantVelocityFieldSetTime;
+  ModifiedTimeType m_ConstantVelocityFieldSetTime{ 0 };
 
   ScalarType                                m_LowerTimeBound;
   ScalarType                                m_UpperTimeBound;

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -34,9 +34,8 @@ namespace itk
 template<typename TParametersValueType, unsigned int NDimensions>
 ConstantVelocityFieldTransform<TParametersValueType, NDimensions>
 ::ConstantVelocityFieldTransform() :
-  m_ConstantVelocityField( nullptr ),
-  m_CalculateNumberOfIntegrationStepsAutomatically( false ),
-  m_ConstantVelocityFieldSetTime( 0 )
+  m_ConstantVelocityField( nullptr )
+
 {
   this->m_FixedParameters.SetSize( ConstantVelocityFieldDimension * ( ConstantVelocityFieldDimension + 3 ) );
   this->m_FixedParameters.Fill( 0.0 );

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
@@ -265,22 +265,22 @@ protected:
   void GenerateData() override;
 
 private:
-  bool                                         m_EstimateInverse;
-  bool                                         m_EnforceStationaryBoundary;
-  unsigned int                                 m_SplineOrder;
+  bool                                         m_EstimateInverse{ false };
+  bool                                         m_EnforceStationaryBoundary{ true };
+  unsigned int                                 m_SplineOrder{ 3 };
   ArrayType                                    m_NumberOfControlPoints;
   ArrayType                                    m_NumberOfFittingLevels;
 
   typename WeightsContainerType::Pointer       m_PointWeights;
-  bool                                         m_UsePointWeights;
+  bool                                         m_UsePointWeights{ false };
 
   OriginType                                   m_BSplineDomainOrigin;
   SpacingType                                  m_BSplineDomainSpacing;
   SizeType                                     m_BSplineDomainSize;
   DirectionType                                m_BSplineDomainDirection;
 
-  bool                                         m_BSplineDomainIsDefined;
-  bool                                         m_UseInputFieldToDefineTheBSplineDomain;
+  bool                                         m_BSplineDomainIsDefined{ true };
+  bool                                         m_UseInputFieldToDefineTheBSplineDomain{ false };
 };
 
 } // end namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -32,13 +32,8 @@ namespace itk
  */
 template<typename TInputImage, typename TInputPointSet, typename TOutputImage>
 DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
-::DisplacementFieldToBSplineImageFilter() :
-  m_EstimateInverse( false ),
-  m_EnforceStationaryBoundary( true ),
-  m_SplineOrder( 3 ),
-  m_UsePointWeights( false ),
-  m_BSplineDomainIsDefined( true ),
-  m_UseInputFieldToDefineTheBSplineDomain( false )
+::DisplacementFieldToBSplineImageFilter()
+
 {
   this->SetNumberOfRequiredInputs( 0 );
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
@@ -441,7 +441,7 @@ protected:
 
   /** Track when the displacement field was last set/assigned, as
    * distinct from when it may have had its contents modified. */
-  ModifiedTimeType m_DisplacementFieldSetTime;
+  ModifiedTimeType m_DisplacementFieldSetTime{ 0 };
 
   /** Create an identity jacobian for use in
    * ComputeJacobianWithRespectToParameters. */

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -32,7 +32,7 @@ namespace itk
 template<typename TParametersValueType, unsigned int NDimensions>
 DisplacementFieldTransform<TParametersValueType, NDimensions>::DisplacementFieldTransform()
 : Superclass( 0 ),
-  m_DisplacementFieldSetTime( 0 ),
+
   m_CoordinateTolerance(ImageToImageFilterCommon::GetGlobalDefaultCoordinateTolerance()),
   m_DirectionTolerance(ImageToImageFilterCommon::GetGlobalDefaultDirectionTolerance())
 {

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
@@ -123,7 +123,7 @@ protected:
   /** Track when the temporary displacement field used during smoothing
    * was last modified/initialized. We only want to change it if the
    * main displacement field is also changed, i.e. assigned to a new object */
-  ModifiedTimeType                  m_GaussianSmoothingTempFieldModifiedTime;
+  ModifiedTimeType                  m_GaussianSmoothingTempFieldModifiedTime{0};
 
   /** Used in GaussianSmoothTimeVaryingVelocityField as variance for the
    * GaussianOperator

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
@@ -34,7 +34,7 @@ namespace itk
 template<typename TParametersValueType, unsigned int NDimensions>
 GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>
 ::GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform() :
-  m_GaussianSmoothingTempFieldModifiedTime(0),
+
   m_GaussianSpatialSmoothingVarianceForTheUpdateField(3.0),
   m_GaussianSpatialSmoothingVarianceForTheTotalField(0.5),
   m_GaussianTemporalSmoothingVarianceForTheUpdateField(0.25),

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
@@ -157,7 +157,7 @@ private:
   /** The interpolator. */
   typename InterpolatorType::Pointer m_Interpolator;
 
-  unsigned int m_MaximumNumberOfIterations;
+  unsigned int m_MaximumNumberOfIterations{20};
 
   RealType m_MaxErrorToleranceThreshold;
   RealType m_MeanErrorToleranceThreshold;
@@ -171,8 +171,8 @@ private:
   RealType    m_MeanErrorNorm;
   RealType    m_Epsilon;
   SpacingType m_DisplacementFieldSpacing;
-  bool        m_DoThreadedEstimateInverse;
-  bool        m_EnforceBoundaryCondition;
+  bool        m_DoThreadedEstimateInverse{false};
+  bool        m_EnforceBoundaryCondition{true};
   std::mutex  m_Mutex;
 
 };

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -36,7 +36,7 @@ template<typename TInputImage, typename TOutputImage>
 InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>
 ::InvertDisplacementFieldImageFilter() :
   m_Interpolator(DefaultInterpolatorType::New()),
-  m_MaximumNumberOfIterations(20),
+
   m_MaxErrorToleranceThreshold(0.1),
   m_MeanErrorToleranceThreshold(0.001),
 
@@ -44,9 +44,8 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>
   m_ScaledNormImage(RealImageType::New()),
   m_MaxErrorNorm(0.0),
   m_MeanErrorNorm(0.0),
-  m_Epsilon(0.0),
-  m_DoThreadedEstimateInverse(false),
-  m_EnforceBoundaryCondition(true)
+  m_Epsilon(0.0)
+
 {
   this->SetNumberOfRequiredInputs( 1 );
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
@@ -186,7 +186,7 @@ private:
   SpacingType          m_OutputSpacing;   // output image spacing
   OriginType           m_OutputOrigin;    // output image origin
   DirectionType        m_OutputDirection; // output image direction cosines
-  bool                 m_UseReferenceImage;
+  bool                 m_UseReferenceImage{ false };
 
 };
 } // end namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -30,8 +30,8 @@ namespace itk
 
 template< typename TOutputImage, typename TParametersValueType>
 TransformToDisplacementFieldFilter< TOutputImage, TParametersValueType>
-::TransformToDisplacementFieldFilter():
-  m_UseReferenceImage( false )
+::TransformToDisplacementFieldFilter()
+
 {
   this->m_OutputSpacing.Fill(1.0);
   this->m_OutputOrigin.Fill(0.0);

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
@@ -178,11 +178,11 @@ private:
   InputPixelType   m_BackgroundValue;
   InputSpacingType m_Spacing;
 
-  unsigned int m_CurrentDimension;
+  unsigned int m_CurrentDimension{0};
 
-  bool m_InsideIsPositive;
-  bool m_UseImageSpacing;
-  bool m_SquaredDistance;
+  bool m_InsideIsPositive{false};
+  bool m_UseImageSpacing{true};
+  bool m_SquaredDistance{false};
 
   const InputImageType *m_InputCache;
 };

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -36,10 +36,7 @@ SignedMaurerDistanceMapImageFilter< TInputImage, TOutputImage >
 ::SignedMaurerDistanceMapImageFilter():
   m_BackgroundValue( NumericTraits< InputPixelType >::ZeroValue() ),
   m_Spacing(0.0),
-  m_CurrentDimension(0),
-  m_InsideIsPositive(false),
-  m_UseImageSpacing(true),
-  m_SquaredDistance(false),
+
   m_InputCache(nullptr)
 {
   this->DynamicMultiThreadingOff();

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -142,14 +142,14 @@ public:
   class AxisNodeType:public NodeType
   {
 public:
-    AxisNodeType() : m_Axis(0) {}
+    AxisNodeType()  {}
     int GetAxis() const { return m_Axis; }
     void SetAxis(int axis) { m_Axis = axis; }
     const AxisNodeType & operator=(const NodeType & node)
     { this->NodeType::operator=(node); return *this; }
 
 private:
-    int m_Axis;
+    int m_Axis{0};
   };
 
   /** SpeedImage type alias support */

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.h
@@ -171,7 +171,7 @@ protected:
   OutputPointType     m_OutputOrigin;
   OutputSpacingType   m_OutputSpacing;
   OutputDirectionType m_OutputDirection;
-  bool                m_OverrideOutputInformation;
+  bool                m_OverrideOutputInformation{ false };
 
   /** Generate the output image meta information. */
   void GenerateOutputInformation() override;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -34,11 +34,11 @@ FastMarchingImageFilterBase< TInput, TOutput >:: InternalNodeStructure
 {
 public:
   InternalNodeStructure( ) :
-    m_Value( NumericTraits< OutputPixelType >::max() ), m_Axis( 0 ) {}
+    m_Value( NumericTraits< OutputPixelType >::max() ) {}
 
   NodeType        m_Node;
   OutputPixelType m_Value;
-  unsigned int    m_Axis;
+  unsigned int    m_Axis{ 0 };
 
   bool operator< ( const InternalNodeStructure& iRight ) const
     {
@@ -49,7 +49,7 @@ public:
 template< typename TInput, typename TOutput >
 FastMarchingImageFilterBase< TInput, TOutput >::
 FastMarchingImageFilterBase() :
-  m_OverrideOutputInformation( false ),
+
   m_LabelImage( LabelImageType::New() )
 {
   m_StartIndex.Fill(0);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.h
@@ -138,7 +138,7 @@ protected:
   OutputPixelType m_AliveValue;
   OutputPixelType m_TrialValue;
 
-  bool m_IsForbiddenImageBinaryMask;
+  bool m_IsForbiddenImageBinaryMask{ false };
 
   virtual void GenerateData();
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
@@ -32,8 +32,8 @@ FastMarchingImageToNodePairContainerAdaptor< TInput, TOutput, TImage >
   m_AliveImage( nullptr ), m_TrialImage( nullptr ), m_ForbiddenImage( nullptr ),
   m_AlivePoints( nullptr ), m_TrialPoints( nullptr ), m_ForbiddenPoints( nullptr ),
   m_AliveValue( NumericTraits< OutputPixelType >::ZeroValue() ),
-  m_TrialValue( NumericTraits< OutputPixelType >::ZeroValue() ),
-  m_IsForbiddenImageBinaryMask( false )
+  m_TrialValue( NumericTraits< OutputPixelType >::ZeroValue() )
+
 {}
 
 template< typename TInput, typename TOutput, typename TImage >

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
@@ -152,11 +152,10 @@ protected:
   FastMarchingReachedTargetNodesStoppingCriterion() :
     Superclass(),
     m_TargetCondition(AllTargets),
-    m_NumberOfTargetsToBeReached(0),
+
     m_TargetOffset(NumericTraits< OutputPixelType >::ZeroValue()),
-    m_StoppingValue(NumericTraits< OutputPixelType >::ZeroValue()),
-    m_Satisfied(false),
-    m_Initialized(false)
+    m_StoppingValue(NumericTraits< OutputPixelType >::ZeroValue())
+
   {
   }
 
@@ -166,11 +165,11 @@ protected:
   TargetConditionType     m_TargetCondition;
   std::vector< NodeType > m_TargetNodes;
   std::vector< NodeType > m_ReachedTargetNodes;
-  size_t                  m_NumberOfTargetsToBeReached;
+  size_t                  m_NumberOfTargetsToBeReached{0};
   OutputPixelType         m_TargetOffset;
   OutputPixelType         m_StoppingValue;
-  bool                    m_Satisfied;
-  bool                    m_Initialized;
+  bool                    m_Satisfied{false};
+  bool                    m_Initialized{false};
 
   void Reset() override
   {

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
@@ -127,8 +127,8 @@ private:
    * is used as the index value of the new dimension */
   using IndexValueType = unsigned int;
 
-  double m_Spacing;
-  double m_Origin;
+  double m_Spacing{ 1.0 };
+  double m_Origin{ 0.0 };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -26,9 +26,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 JoinSeriesImageFilter< TInputImage, TOutputImage >
-::JoinSeriesImageFilter() :
-  m_Spacing( 1.0 ),
-  m_Origin( 0.0 )
+::JoinSeriesImageFilter()
+
 {
   this->DynamicMultiThreadingOn();
 }

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -150,12 +150,12 @@ private:
     }
   };
 
-  double       m_Alpha;
-  double       m_Beta;
-  double       m_Gamma;
-  unsigned int m_ObjectDimension;
-  bool         m_BrightObject;
-  bool         m_ScaleObjectnessMeasure;
+  double       m_Alpha{0.5};
+  double       m_Beta{0.5};
+  double       m_Gamma{5.0};
+  unsigned int m_ObjectDimension{1};
+  bool         m_BrightObject{true};
+  bool         m_ScaleObjectnessMeasure{true};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -32,13 +32,8 @@ namespace itk
 
 template< typename TInputImage, typename TOutputImage >
 HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
-::HessianToObjectnessMeasureImageFilter() :
-  m_Alpha(0.5),
-  m_Beta(0.5),
-  m_Gamma(5.0),
-  m_ObjectDimension(1),
-  m_BrightObject(true),
-  m_ScaleObjectnessMeasure(true)
+::HessianToObjectnessMeasureImageFilter()
+
 {
   this->DynamicMultiThreadingOn();
 }

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -206,20 +206,20 @@ protected:
 
 private:
 
-  double                m_SweepAngle;
-  double                m_MinimumRadius;
-  double                m_MaximumRadius;
-  double                m_Threshold;
+  double                m_SweepAngle{ 0.0 };
+  double                m_MinimumRadius{ 0.0 };
+  double                m_MaximumRadius{ 10.0 };
+  double                m_Threshold{ 0.0 };
   double                m_GradientNormThreshold;
-  double                m_SigmaGradient;
+  double                m_SigmaGradient{ 1.0 };
 
   RadiusImagePointer    m_RadiusImage;
   CirclesListType       m_CirclesList;
-  CirclesListSizeType   m_NumberOfCircles;
-  double                m_DiscRadiusRatio;
-  double                m_Variance;
+  CirclesListSizeType   m_NumberOfCircles{ 1 };
+  double                m_DiscRadiusRatio{ 1 };
+  double                m_Variance{ 10 };
   bool                  m_UseImageSpacing;
-  ModifiedTimeType      m_OldModifiedTime;
+  ModifiedTimeType      m_OldModifiedTime{ 0 };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -30,17 +30,11 @@ namespace itk
 template< typename TInputPixelType, typename TOutputPixelType, typename TRadiusPixelType >
 HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPixelType >
 ::HoughTransform2DCirclesImageFilter() :
-  m_SweepAngle( 0.0 ),
-  m_MinimumRadius( 0.0 ),
-  m_MaximumRadius( 10.0 ),
-  m_Threshold( 0.0 ),
+
   m_GradientNormThreshold{ 1.0 },
-  m_SigmaGradient( 1.0 ),
-  m_NumberOfCircles( 1 ),
-  m_DiscRadiusRatio( 1 ),
-  m_Variance( 10 ),
-  m_UseImageSpacing{ true },
-  m_OldModifiedTime( 0 )
+
+  m_UseImageSpacing{ true }
+
 {
   this->SetNumberOfRequiredInputs( 1 );
 }

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
@@ -183,15 +183,15 @@ protected:
 
 private:
 
-  double             m_AngleResolution;
-  double             m_Threshold;
+  double             m_AngleResolution{ 500 };
+  double             m_Threshold{ 0 };
 
   OutputImagePointer m_SimplifyAccumulator;
   LinesListType      m_LinesList;
-  LinesListSizeType  m_NumberOfLines;
-  double             m_DiscRadius;
-  double             m_Variance;
-  ModifiedTimeType   m_OldModifiedTime;
+  LinesListSizeType  m_NumberOfLines{ 1 };
+  double             m_DiscRadius{ 10 };
+  double             m_Variance{ 5 };
+  ModifiedTimeType   m_OldModifiedTime{ 0 };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -31,13 +31,9 @@ namespace itk
 template< typename TInputPixelType, typename TOutputPixelType >
 HoughTransform2DLinesImageFilter< TInputPixelType, TOutputPixelType >
 ::HoughTransform2DLinesImageFilter() :
-  m_AngleResolution( 500 ),
-  m_Threshold( 0 ),
-  m_LinesList(),
-  m_NumberOfLines( 1 ),
-  m_DiscRadius( 10 ),
-  m_Variance( 5 ),
-  m_OldModifiedTime( 0 )
+
+  m_LinesList()
+
 {
 }
 

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
@@ -174,13 +174,13 @@ private:
   private:
     FunctorRealType m_Amount;
     FunctorRealType m_Threshold;
-    bool m_Clamp;
+    bool m_Clamp{false};
 
   public:
     UnsharpMaskingFunctor()
       : m_Amount(0.5),
-      m_Threshold(0.0),
-      m_Clamp(false)
+      m_Threshold(0.0)
+
     {
     }
 

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
@@ -149,8 +149,8 @@ public:
 #endif
 
 protected:
-  MaskNeighborhoodOperatorImageFilter():m_DefaultValue(NumericTraits< OutputPixelType >::ZeroValue()),
-    m_UseDefaultValue(true) {}
+  MaskNeighborhoodOperatorImageFilter():m_DefaultValue(NumericTraits< OutputPixelType >::ZeroValue())
+    {}
   ~MaskNeighborhoodOperatorImageFilter() override = default;
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -177,7 +177,7 @@ protected:
 
 private:
   OutputPixelType m_DefaultValue;
-  bool            m_UseDefaultValue;
+  bool            m_UseDefaultValue{true};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
@@ -226,7 +226,7 @@ protected:
 private:
   /** Direction in which the filter is to be applied
    * this should be in the range [0,ImageDimension-1]. */
-  unsigned int m_Direction;
+  unsigned int m_Direction{ 0 };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
@@ -47,8 +47,8 @@ RecursiveSeparableImageFilter< TInputImage, TOutputImage >
   m_BM1( 0.0 ),
   m_BM2( 0.0 ),
   m_BM3( 0.0 ),
-  m_BM4( 0.0 ),
-  m_Direction( 0 )
+  m_BM4( 0.0 )
+
 {
   this->SetNumberOfRequiredOutputs(1);
   this->SetNumberOfRequiredInputs(1);

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
@@ -190,12 +190,12 @@ private:
   FrequencyValueType m_LowFrequencyThreshold;
   FrequencyValueType m_HighFrequencyThreshold;
 
-  bool m_PassBand;
-  bool m_PassLowFrequencyThreshold;
-  bool m_PassHighFrequencyThreshold;
-  bool m_RadialBand;
-  bool m_PassNegativeLowFrequencyThreshold;
-  bool m_PassNegativeHighFrequencyThreshold;
+  bool m_PassBand{true};
+  bool m_PassLowFrequencyThreshold{true};
+  bool m_PassHighFrequencyThreshold{true};
+  bool m_RadialBand{true};
+  bool m_PassNegativeLowFrequencyThreshold{true};
+  bool m_PassNegativeHighFrequencyThreshold{true};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
@@ -31,13 +31,8 @@ template< typename TImageType, typename TFrequencyIterator >
 FrequencyBandImageFilter< TImageType, TFrequencyIterator >
 ::FrequencyBandImageFilter()
   : m_LowFrequencyThreshold(0),
-  m_HighFrequencyThreshold(0.5), // Nyquist in hertz
-  m_PassBand(true),
-  m_PassLowFrequencyThreshold(true),
-  m_PassHighFrequencyThreshold(true),
-  m_RadialBand(true),
-  m_PassNegativeLowFrequencyThreshold(true),
-  m_PassNegativeHighFrequencyThreshold(true)
+  m_HighFrequencyThreshold(0.5)
+
 {
   this->InPlaceOff();
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -140,8 +140,8 @@ public:
   using FrequencyValueType = typename ImageType::SpacingValueType;
   /** Default constructor. Needed since we provide a cast constructor. */
   FrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex() :
-    ImageRegionConstIteratorWithIndex< TImage >(),
-    m_ActualXDimensionIsOdd(false)
+    ImageRegionConstIteratorWithIndex< TImage >()
+
   {
     this->Init();
   }
@@ -324,7 +324,7 @@ private:
   IndexType     m_MaxIndex;
   FrequencyType m_FrequencyOrigin;
   FrequencyType m_FrequencySpacing;
-  bool          m_ActualXDimensionIsOdd;
+  bool          m_ActualXDimensionIsOdd{false};
 };
 } // end namespace itk
 #endif

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
@@ -194,7 +194,7 @@ protected:
 private:
   std::function< void( const ImageRegionType& ) > m_DynamicThreadedGenerateDataFunction;
 
-  bool m_ActualXDimensionIsOdd;
+  bool m_ActualXDimensionIsOdd{false};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.hxx
@@ -28,7 +28,7 @@ namespace itk
 template< typename TImageType, typename TFrequencyIterator >
 UnaryFrequencyDomainFilter< TImageType, TFrequencyIterator >
 ::UnaryFrequencyDomainFilter()
-  : m_ActualXDimensionIsOdd(false)
+
 {
   this->InPlaceOff();
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.h
@@ -245,8 +245,8 @@ private:
   OriginType                                   m_Origin;
   DirectionType                                m_Direction;
 
-  bool                                         m_DoMultilevel;
-  unsigned int                                 m_MaximumNumberOfLevels;
+  bool                                         m_DoMultilevel{ false };
+  unsigned int                                 m_MaximumNumberOfLevels{ 1 };
   ArrayType                                    m_NumberOfControlPoints;
   ArrayType                                    m_CloseDimension;
   ArrayType                                    m_SplineOrder;
@@ -260,7 +260,7 @@ private:
   typename KernelOrder2Type::Pointer           m_KernelOrder2;
   typename KernelOrder3Type::Pointer           m_KernelOrder3;
 
-  RealType                                     m_BSplineEpsilon;
+  RealType                                     m_BSplineEpsilon{ 1e-3 };
 
   inline typename RealImageType::IndexType
   NumberToIndex( unsigned int number, typename RealImageType::SizeType size )

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -34,10 +34,9 @@ namespace itk
 template<typename TInputImage, typename TOutputImage>
 BSplineControlPointImageFilter<TInputImage, TOutputImage>
 ::BSplineControlPointImageFilter() :
-  m_DoMultilevel( false ),
-  m_MaximumNumberOfLevels( 1 ),
-  m_NumberOfLevels( 1 ),
-  m_BSplineEpsilon( 1e-3 )
+
+  m_NumberOfLevels( 1 )
+
 {
   this->m_Size.Fill( 0 );
   this->m_Spacing.Fill( 1.0 );

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
@@ -328,11 +328,11 @@ private:
    * the local control point neighborhoods. */
   IndexType NumberToIndex( const unsigned int, const SizeType );
 
-  bool                                         m_DoMultilevel;
-  bool                                         m_GenerateOutputImage;
-  bool                                         m_UsePointWeights;
-  unsigned int                                 m_MaximumNumberOfLevels;
-  unsigned int                                 m_CurrentLevel;
+  bool                                         m_DoMultilevel{ false };
+  bool                                         m_GenerateOutputImage{ true };
+  bool                                         m_UsePointWeights{ false };
+  unsigned int                                 m_MaximumNumberOfLevels{ 1 };
+  unsigned int                                 m_CurrentLevel{ 0 };
   ArrayType                                    m_NumberOfControlPoints;
   ArrayType                                    m_CurrentNumberOfControlPoints;
   ArrayType                                    m_CloseDimension;
@@ -359,8 +359,8 @@ private:
   std::vector<RealImagePointer>                m_OmegaLatticePerThread;
   std::vector<PointDataImagePointer>           m_DeltaLatticePerThread;
 
-  RealType                                     m_BSplineEpsilon;
-  bool                                         m_IsFittingComplete;
+  RealType                                     m_BSplineEpsilon{ 1e-3 };
+  bool                                         m_IsFittingComplete{ false };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -35,14 +35,8 @@ namespace itk
 
 template<typename TInputPointSet, typename TOutputImage>
 BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>
-::BSplineScatteredDataPointSetToImageFilter() :
-  m_DoMultilevel( false ),
-  m_GenerateOutputImage( true ),
-  m_UsePointWeights( false ),
-  m_MaximumNumberOfLevels( 1 ),
-  m_CurrentLevel( 0 ),
-  m_BSplineEpsilon( 1e-3 ),
-  m_IsFittingComplete( false )
+::BSplineScatteredDataPointSetToImageFilter()
+
 {
   this->m_SplineOrder.Fill( 3 );
   this->DynamicMultiThreadingOff();

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.h
@@ -134,7 +134,7 @@ protected:
 
 private:
   FlipAxesArrayType m_FlipAxes;
-  bool              m_FlipAboutOrigin;
+  bool              m_FlipAboutOrigin{ true };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
@@ -27,8 +27,8 @@ namespace itk
 
 template< typename TImage >
 FlipImageFilter< TImage >
-::FlipImageFilter() :
-  m_FlipAboutOrigin( true )
+::FlipImageFilter()
+
 {
   m_FlipAxes.Fill(false);
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
@@ -295,9 +295,9 @@ protected:
 private:
   std::string GetMajorAxisFromPatientRelativeDirectionCosine(double x, double y, double z);
 
-  CoordinateOrientationCode m_GivenCoordinateOrientation;
-  CoordinateOrientationCode m_DesiredCoordinateOrientation;
-  bool                      m_UseImageDirection;
+  CoordinateOrientationCode m_GivenCoordinateOrientation{SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP};
+  CoordinateOrientationCode m_DesiredCoordinateOrientation{SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP};
+  bool                      m_UseImageDirection{false};
 
   PermuteOrderArrayType m_PermuteOrder;
   FlipAxesArrayType     m_FlipAxes;

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
@@ -30,9 +30,7 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 OrientImageFilter< TInputImage, TOutputImage >
 ::OrientImageFilter():
-  m_GivenCoordinateOrientation  (SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP),
-  m_DesiredCoordinateOrientation(SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP),
-  m_UseImageDirection (false),
+
   m_FlipAxes(false)
 {
   // Map between axis string labels and SpatialOrientation

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -354,7 +354,7 @@ private:
   OriginPointType m_OutputOrigin;         // output image origin
   DirectionType   m_OutputDirection;      // output image direction cosines
   IndexType       m_OutputStartIndex;     // output image start index
-  bool            m_UseReferenceImage;
+  bool            m_UseReferenceImage{ false };
 
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -40,8 +40,8 @@ ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTra
 ::ResampleImageFilter() :
   m_Extrapolator( nullptr ),
   m_OutputSpacing( 1.0 ),
-  m_OutputOrigin( 0.0 ),
-  m_UseReferenceImage( false )
+  m_OutputOrigin( 0.0 )
+
 {
 
   m_Size.Fill( 0 );

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
@@ -94,9 +94,9 @@ public:
   class TileInfo
   {
 public:
-    int                   m_ImageNumber;
+    int                   m_ImageNumber{-1};
     OutputImageRegionType m_Region;
-    TileInfo():m_ImageNumber(-1) {}
+    TileInfo() {}
   };
 
   using TileImageType = Image< TileInfo, Self::OutputImageDimension >;

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
@@ -193,9 +193,9 @@ protected:
                           const THistogramMeasurement maxValue);
 
 private:
-  SizeValueType m_NumberOfHistogramLevels;
-  SizeValueType m_NumberOfMatchPoints;
-  bool          m_ThresholdAtMeanIntensity;
+  SizeValueType m_NumberOfHistogramLevels{256};
+  SizeValueType m_NumberOfMatchPoints{1};
+  bool          m_ThresholdAtMeanIntensity{true};
 
   InputPixelType  m_SourceIntensityThreshold;
   InputPixelType  m_ReferenceIntensityThreshold;
@@ -220,8 +220,8 @@ private:
 
   using GradientArrayType = vnl_vector< double >;
   GradientArrayType m_Gradients;
-  double            m_LowerGradient;
-  double            m_UpperGradient;
+  double            m_LowerGradient{0.0};
+  double            m_UpperGradient{0.0};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -29,9 +29,7 @@ namespace itk
 template< typename TInputImage, typename TOutputImage, typename THistogramMeasurement >
 HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
 ::HistogramMatchingImageFilter() :
-  m_NumberOfHistogramLevels(256),
-  m_NumberOfMatchPoints(1),
-  m_ThresholdAtMeanIntensity(true),
+
   m_SourceIntensityThreshold(NumericTraits<InputPixelType>::ZeroValue()),
   m_ReferenceIntensityThreshold(NumericTraits<InputPixelType>::ZeroValue()),
   m_OutputIntensityThreshold(NumericTraits<OutputPixelType>::ZeroValue()),
@@ -46,9 +44,8 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
   m_OutputMeanValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
   m_SourceHistogram(HistogramType::New()),
   m_ReferenceHistogram(HistogramType::New()),
-  m_OutputHistogram(HistogramType::New()),
-  m_LowerGradient(0.0),
-  m_UpperGradient(0.0)
+  m_OutputHistogram(HistogramType::New())
+
 {
   this->SetNumberOfRequiredInputs(2);
 

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.h
@@ -136,7 +136,7 @@ private:
 
   ProjPlanePointType m_FocalPoint;
 
-  double m_FocalDistance;
+  double m_FocalDistance{ 0.0 };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -40,8 +40,8 @@ PolylineMaskImageFilter< TInputImage, TPolyline, TVector, TOutputImage >
   m_ViewVector( 1 ),
   m_UpVector( 1 ),
   m_CameraCenterPoint( 0 ),
-  m_FocalPoint( 0.0 ),
-  m_FocalDistance( 0.0 )
+  m_FocalPoint( 0.0 )
+
 {
   this->SetNumberOfRequiredInputs( 2 );
 

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.h
@@ -109,8 +109,8 @@ protected:
 
 
 private:
-  double m_Mean;
-  double m_StandardDeviation;
+  double m_Mean{ 0.0 };
+  double m_StandardDeviation{ 1.0 };
 
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -28,9 +28,8 @@ namespace itk
 
 template <class TInputImage, class TOutputImage>
 AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
-::AdditiveGaussianNoiseImageFilter() :
-  m_Mean( 0.0 ),
-  m_StandardDeviation( 1.0 )
+::AdditiveGaussianNoiseImageFilter()
+
 {
   this->DynamicMultiThreadingOn();
 }

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.h
@@ -77,7 +77,7 @@ protected:
   static OutputImagePixelType ClampCast(const double &value);
 
 private:
-  uint32_t m_Seed;
+  uint32_t m_Seed{0};
 
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -27,7 +27,7 @@ namespace itk
 template <class TInputImage, class TOutputImage>
 NoiseBaseImageFilter<TInputImage, TOutputImage>
 ::NoiseBaseImageFilter()
-  : m_Seed(0)
+
 {
   Self::SetSeed();
 

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.h
@@ -128,7 +128,7 @@ protected:
   void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
 private:
-  double               m_Probability;
+  double               m_Probability{ 0.01 };
   OutputImagePixelType m_SaltValue;
   OutputImagePixelType m_PepperValue;
 

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -29,7 +29,7 @@ namespace itk
 template <class TInputImage, class TOutputImage>
 SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>
 ::SaltAndPepperNoiseImageFilter() :
-  m_Probability( 0.01 ),
+
   m_SaltValue( NumericTraits<OutputImagePixelType>::max() ),
   m_PepperValue( NumericTraits<OutputImagePixelType>::NonpositiveMin() )
 {

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.h
@@ -146,7 +146,7 @@ protected:
 
 
 private:
-  double m_Scale;
+  double m_Scale{ 1.0 };
 
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -29,8 +29,8 @@ namespace itk
 
 template <class TInputImage, class TOutputImage>
 ShotNoiseImageFilter<TInputImage, TOutputImage>
-::ShotNoiseImageFilter() :
-  m_Scale( 1.0 )
+::ShotNoiseImageFilter()
+
 {
   this->DynamicMultiThreadingOn();
 }

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.h
@@ -104,7 +104,7 @@ protected:
   void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
 private:
-  double m_StandardDeviation;
+  double m_StandardDeviation{ 1.0 };
 
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -29,8 +29,8 @@ namespace itk
 
 template <class TInputImage, class TOutputImage>
 SpeckleNoiseImageFilter<TInputImage, TOutputImage>
-::SpeckleNoiseImageFilter() :
-  m_StandardDeviation( 1.0 )
+::SpeckleNoiseImageFilter()
+
 {
   this->DynamicMultiThreadingOn();
 }

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.h
@@ -105,12 +105,12 @@ protected:
   void GenerateData() override;
 
 private:
-  bool m_CalculateImaginaryPart;
+  bool m_CalculateImaginaryPart{ false };
 
-  double m_Frequency;
+  double m_Frequency{ 0.4 };
 
   /** Evaluate using a stretched gabor filter (ensure zero dc response) */
-  double m_PhaseOffset;
+  double m_PhaseOffset{ 0.0 };
 
   ArrayType m_Sigma;
 

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
@@ -29,10 +29,8 @@ namespace itk
 
 template< typename TOutputImage >
 GaborImageSource< TOutputImage >
-::GaborImageSource() :
-  m_CalculateImaginaryPart( false ),
-  m_Frequency( 0.4 ),
-  m_PhaseOffset( 0.0 )
+::GaborImageSource()
+
 {
   // Gabor parameters, defined so that the Gaussian
   // is centered in the default image

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.h
@@ -138,9 +138,9 @@ private:
 
   ArrayType m_Mean;
 
-  double m_Scale;
+  double m_Scale{ 255.0 };
 
-  bool m_Normalized;
+  bool m_Normalized{ false };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -29,9 +29,8 @@ namespace itk
 
 template< typename TOutputImage >
 GaussianImageSource< TOutputImage >
-::GaussianImageSource() :
-  m_Scale( 255.0 ),
-  m_Normalized( false )
+::GaussianImageSource()
+
 {
   // Gaussian parameters, defined so that the Gaussian
   // is centered in the default image

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
@@ -136,7 +136,7 @@ private:
   PointType     m_Origin;
   DirectionType m_Direction;
   IndexType     m_StartIndex;
-  bool          m_UseReferenceImage;
+  bool          m_UseReferenceImage{ false };
 
 };
 

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
@@ -27,8 +27,8 @@ template< typename TOutputImage >
 GenerateImageSource< TOutputImage >
 ::GenerateImageSource()
   : m_Spacing( 1.0 ),
-    m_Origin( 0.0 ),
-    m_UseReferenceImage( false )
+    m_Origin( 0.0 )
+
 {
   this->m_Size.Fill( 64 ); // arbitrary default size
   this->m_Direction.SetIdentity();

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.h
@@ -144,7 +144,7 @@ private:
 
   BoolArrayType m_WhichDimensions;
 
-  RealType m_Scale;
+  RealType m_Scale{ 255.0 };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
@@ -28,8 +28,8 @@ namespace itk
 {
 template< typename TOutputImage >
 GridImageSource< TOutputImage >
-::GridImageSource() :
-  m_Scale( 255.0 )
+::GridImageSource()
+
 {
   this->m_Sigma.Fill(0.5);
   this->m_GridSpacing.Fill(4.0);

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
@@ -44,7 +44,7 @@ public:
   using RealType = float;
 
   AdaptiveEqualizationHistogram()
-    : m_BoundaryCount(0)
+
     {
     }
 
@@ -128,7 +128,7 @@ private:
 
 
   MapType       m_Map;
-  size_t        m_BoundaryCount;
+  size_t        m_BoundaryCount{0};
 
 };
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -198,10 +198,10 @@ private:
 
   ImageSizeType m_InputImageSize;
 
-  unsigned int m_NumberOfPixels;
+  unsigned int m_NumberOfPixels{0};
 
   // The number of input images for PCA
-  unsigned int m_NumberOfTrainingImages;
+  unsigned int m_NumberOfTrainingImages{0};
 
   // The number of output Principal Components
   unsigned int m_NumberOfPrincipalComponentsRequired;

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 ImagePCAShapeModelEstimator< TInputImage, TOutputImage >
-::ImagePCAShapeModelEstimator():m_NumberOfPixels(0), m_NumberOfTrainingImages(0)
+::ImagePCAShapeModelEstimator()
 {
   m_EigenVectors.set_size(0, 0);
   m_EigenValues.set_size(0);

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
@@ -181,7 +181,7 @@ private:
   CompensatedSummation<RealType> m_ThreadSum;
   CompensatedSummation<RealType> m_SumOfSquares;
 
-  SizeValueType m_Count;
+  SizeValueType m_Count{1};
   PixelType     m_ThreadMin;
   PixelType     m_ThreadMax;
 

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
@@ -30,7 +30,7 @@ StatisticsImageFilter< TInputImage >
 ::StatisticsImageFilter()
   :m_ThreadSum(1),
    m_SumOfSquares(1),
-   m_Count(1),
+
    m_ThreadMin(1),
    m_ThreadMax(1)
 {

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.h
@@ -130,7 +130,7 @@ private:
 
   InputImagePixelType m_BackgroundValue;
 
-  bool                m_FullyConnected;
+  bool                m_FullyConnected{ false };
 
 }; // end of class
 

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
@@ -30,8 +30,8 @@ template <typename TInputImage>
 BinaryGrindPeakImageFilter<TInputImage>
 ::BinaryGrindPeakImageFilter() :
   m_ForegroundValue( NumericTraits<InputImagePixelType>::max() ),
-  m_BackgroundValue( NumericTraits<InputImagePixelType>::ZeroValue() ),
-  m_FullyConnected ( false )
+  m_BackgroundValue( NumericTraits<InputImagePixelType>::ZeroValue() )
+
 {
 }
 

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.h
@@ -171,11 +171,11 @@ protected:
   void GenerateData() override;
 
 private:
-  bool                 m_FullyConnected;
+  bool                 m_FullyConnected{false};
   OutputImagePixelType m_BackgroundValue;
   OutputImagePixelType m_ForegroundValue;
-  SizeValueType        m_NumberOfObjects;
-  bool                 m_ReverseOrdering;
+  SizeValueType        m_NumberOfObjects{0};
+  bool                 m_ReverseOrdering{false};
   AttributeType        m_Attribute;
 }; // end of class
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
@@ -26,11 +26,10 @@ namespace itk
 template< typename TInputImage >
 BinaryShapeKeepNObjectsImageFilter< TInputImage >
 ::BinaryShapeKeepNObjectsImageFilter() :
-  m_FullyConnected(false),
+
   m_BackgroundValue(NumericTraits< OutputImagePixelType >::NonpositiveMin()),
   m_ForegroundValue(NumericTraits< OutputImagePixelType >::max()),
-  m_NumberOfObjects(0),
-  m_ReverseOrdering(false),
+
   m_Attribute(LabelObjectType::NUMBER_OF_PIXELS)
 {
 }

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.h
@@ -198,11 +198,11 @@ protected:
   void GenerateData() override;
 
 private:
-  bool                 m_FullyConnected;
+  bool                 m_FullyConnected{false};
   OutputImagePixelType m_BackgroundValue;
   OutputImagePixelType m_ForegroundValue;
-  SizeValueType        m_NumberOfObjects;
-  bool                 m_ReverseOrdering;
+  SizeValueType        m_NumberOfObjects{0};
+  bool                 m_ReverseOrdering{false};
   AttributeType        m_Attribute;
 }; // end of class
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
@@ -26,11 +26,10 @@ namespace itk
 template< typename TInputImage, typename TFeatureImage >
 BinaryStatisticsKeepNObjectsImageFilter< TInputImage, TFeatureImage >
 ::BinaryStatisticsKeepNObjectsImageFilter() :
-  m_FullyConnected(false),
+
   m_BackgroundValue(NumericTraits< OutputImagePixelType >::NonpositiveMin()),
   m_ForegroundValue(NumericTraits< OutputImagePixelType >::max()),
-  m_NumberOfObjects(0),
-  m_ReverseOrdering(false),
+
   m_Attribute(LabelObjectType::MEAN)
 {
   this->SetNumberOfRequiredInputs(2);

--- a/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.h
@@ -172,7 +172,7 @@ protected:
   }
 
 private:
-  bool m_InPlace;
+  bool m_InPlace{true};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
@@ -47,7 +47,7 @@ namespace itk
  */
 template< typename TInputImage >
 InPlaceLabelMapFilter< TInputImage >
-::InPlaceLabelMapFilter():m_InPlace(true)
+::InPlaceLabelMapFilter()
 {}
 
 /**

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.h
@@ -130,8 +130,8 @@ protected:
 
 private:
   typename InputImageType::Iterator m_LabelObjectIterator;
-  float                             m_InverseNumberOfLabelObjects;
-  SizeValueType                     m_NumberOfLabelObjectsProcessed;
+  float                             m_InverseNumberOfLabelObjects{ 1.0f };
+  SizeValueType                     m_NumberOfLabelObjectsProcessed{ 1 };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
@@ -34,9 +34,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 LabelMapFilter< TInputImage, TOutputImage >
-::LabelMapFilter():
-  m_InverseNumberOfLabelObjects( 1.0f ),
-  m_NumberOfLabelObjectsProcessed( 1 )
+::LabelMapFilter()
+
 {
   this->DynamicMultiThreadingOn();
 }

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.h
@@ -176,8 +176,8 @@ protected:
 private:
   InputImagePixelType       m_Label;
   OutputImagePixelType      m_BackgroundValue;
-  bool                      m_Negated;
-  bool                      m_Crop;
+  bool                      m_Negated{ false };
+  bool                      m_Crop{ false };
   SizeType                  m_CropBorder;
 
   TimeStamp                 m_CropTimeStamp;

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -31,9 +31,8 @@ template <typename TInputImage, typename TOutputImage>
 LabelMapMaskImageFilter<TInputImage, TOutputImage>
 ::LabelMapMaskImageFilter() :
   m_Label( NumericTraits< InputImagePixelType >::OneValue() ),
-  m_BackgroundValue( NumericTraits< OutputImagePixelType >::ZeroValue() ),
-  m_Negated( false ),
-  m_Crop( false )
+  m_BackgroundValue( NumericTraits< OutputImagePixelType >::ZeroValue() )
+
 {
   this->SetNumberOfRequiredInputs(2);
   m_CropBorder.Fill( 0 );

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
@@ -157,7 +157,7 @@ private:
   OutputPixelType m_InsideValue;
   OutputPixelType m_OutsideValue;
 
-  unsigned long m_NumberOfIterationsUsed;
+  unsigned long m_NumberOfIterationsUsed{1};
 
   bool m_FullyConnected;
 };

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
@@ -27,8 +27,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 DoubleThresholdImageFilter< TInputImage, TOutputImage >
-::DoubleThresholdImageFilter():
-  m_NumberOfIterationsUsed(1)
+::DoubleThresholdImageFilter()
+
 {
   m_Threshold1 = NumericTraits< InputPixelType >::NonpositiveMin();
   m_Threshold2 = NumericTraits< InputPixelType >::NonpositiveMin();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.h
@@ -121,7 +121,7 @@ protected:
   void GenerateData() override;
 
 private:
-  unsigned long       m_NumberOfIterationsUsed;
+  unsigned long       m_NumberOfIterationsUsed{1};
   InputImageIndexType m_Seed;
 
   bool m_FullyConnected;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -28,8 +28,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 GrayscaleConnectedClosingImageFilter< TInputImage, TOutputImage >
-::GrayscaleConnectedClosingImageFilter():
-  m_NumberOfIterationsUsed(1)
+::GrayscaleConnectedClosingImageFilter()
+
 {
   m_Seed.Fill(NumericTraits< typename InputImageIndexType::OffsetValueType >::ZeroValue());
   m_FullyConnected = false;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.h
@@ -122,7 +122,7 @@ protected:
   void GenerateData() override;
 
 private:
-  unsigned long       m_NumberOfIterationsUsed;
+  unsigned long       m_NumberOfIterationsUsed{1};
   InputImageIndexType m_Seed;
 
   bool m_FullyConnected;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -28,8 +28,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 GrayscaleConnectedOpeningImageFilter< TInputImage, TOutputImage >
-::GrayscaleConnectedOpeningImageFilter():
-  m_NumberOfIterationsUsed(1)
+::GrayscaleConnectedOpeningImageFilter()
+
 {
   m_Seed.Fill(NumericTraits< typename InputImageIndexType::OffsetValueType >::ZeroValue());
   m_FullyConnected = false;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.h
@@ -123,7 +123,7 @@ protected:
   void GenerateData() override;
 
 private:
-  unsigned long m_NumberOfIterationsUsed;
+  unsigned long m_NumberOfIterationsUsed{1};
 
   bool m_FullyConnected;
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
@@ -29,8 +29,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 GrayscaleFillholeImageFilter< TInputImage, TOutputImage >
-::GrayscaleFillholeImageFilter():
-  m_NumberOfIterationsUsed(1)
+::GrayscaleFillholeImageFilter()
+
 {
   m_FullyConnected = false;
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.h
@@ -137,7 +137,7 @@ protected:
   void GenerateData() override;
 
 private:
-  unsigned long m_NumberOfIterationsUsed;
+  unsigned long m_NumberOfIterationsUsed{1};
 
   bool m_FullyConnected;
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
@@ -39,8 +39,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 GrayscaleGrindPeakImageFilter< TInputImage, TOutputImage >
-::GrayscaleGrindPeakImageFilter():
-  m_NumberOfIterationsUsed(1)
+::GrayscaleGrindPeakImageFilter()
+
 {
   m_FullyConnected = false;
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
@@ -153,7 +153,7 @@ private:
   // and the name of the filter
   int m_Algorithm;
 
-  bool m_SafeBorder;
+  bool m_SafeBorder{true};
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.hxx
@@ -37,8 +37,8 @@ GrayscaleMorphologicalOpeningImageFilter< TInputImage, TOutputImage, TKernel >
   m_VanHerkGilWermanDilateFilter(VanHerkGilWermanDilateFilterType::New()),
   m_VanHerkGilWermanErodeFilter(VanHerkGilWermanErodeFilterType::New()),
   m_AnchorFilter(AnchorFilterType::New()),
-  m_Algorithm(HISTO),
-  m_SafeBorder(true)
+  m_Algorithm(HISTO)
+
 {
 }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
@@ -124,8 +124,8 @@ protected:
 
 private:
   InputImagePixelType m_Height;
-  unsigned long       m_NumberOfIterationsUsed;
-  bool                m_FullyConnected;
+  unsigned long       m_NumberOfIterationsUsed{ 1 };
+  bool                m_FullyConnected{ false };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
@@ -28,9 +28,8 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 HConcaveImageFilter< TInputImage, TOutputImage >
 ::HConcaveImageFilter() :
-  m_Height( 2 ),
-  m_NumberOfIterationsUsed( 1 ),
-  m_FullyConnected( false )
+  m_Height( 2 )
+
 {
 }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
@@ -124,8 +124,8 @@ protected:
 
 private:
   InputImagePixelType m_Height;
-  unsigned long       m_NumberOfIterationsUsed;
-  bool                m_FullyConnected;
+  unsigned long       m_NumberOfIterationsUsed{ 1 };
+  bool                m_FullyConnected{ false };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
@@ -28,9 +28,8 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 HConvexImageFilter< TInputImage, TOutputImage >
 ::HConvexImageFilter() :
-  m_Height( 2 ),
-  m_NumberOfIterationsUsed( 1 ),
-  m_FullyConnected( false )
+  m_Height( 2 )
+
 {
 }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
@@ -135,8 +135,8 @@ protected:
 
 private:
   InputImagePixelType m_Height;
-  unsigned long       m_NumberOfIterationsUsed;
-  bool                m_FullyConnected;
+  unsigned long       m_NumberOfIterationsUsed{ 1 };
+  bool                m_FullyConnected{ false };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
@@ -30,9 +30,8 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 HMaximaImageFilter< TInputImage, TOutputImage >
 ::HMaximaImageFilter() :
-  m_Height( 2 ),
-  m_NumberOfIterationsUsed( 1 ),
-  m_FullyConnected( false )
+  m_Height( 2 )
+
 {
 }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
@@ -134,8 +134,8 @@ protected:
 
 private:
   InputImagePixelType m_Height;
-  unsigned long       m_NumberOfIterationsUsed;
-  bool                m_FullyConnected;
+  unsigned long       m_NumberOfIterationsUsed{ 1 };
+  bool                m_FullyConnected{ false };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
@@ -30,9 +30,8 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 HMinimaImageFilter< TInputImage, TOutputImage >
 ::HMinimaImageFilter() :
-  m_Height( 2 ),
-  m_NumberOfIterationsUsed( 1 ),
-  m_FullyConnected( false )
+  m_Height( 2 )
+
 {
 }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
@@ -144,8 +144,8 @@ protected:
   void GenerateData() override;
 
 private:
-  bool                 m_FullyConnected;
-  bool                 m_FlatIsMaxima;
+  bool                 m_FullyConnected{ false };
+  bool                 m_FlatIsMaxima{ true };
   OutputImagePixelType m_ForegroundValue;
   OutputImagePixelType m_BackgroundValue;
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
@@ -31,8 +31,7 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 RegionalMaximaImageFilter< TInputImage, TOutputImage >
 ::RegionalMaximaImageFilter():
-  m_FullyConnected( false ),
-  m_FlatIsMaxima( true ),
+
   m_ForegroundValue( NumericTraits< OutputImagePixelType >::max() ),
   m_BackgroundValue( NumericTraits< OutputImagePixelType >::NonpositiveMin() )
 {

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
@@ -143,8 +143,8 @@ protected:
   void GenerateData() override;
 
 private:
-  bool                 m_FullyConnected;
-  bool                 m_FlatIsMinima;
+  bool                 m_FullyConnected{ false };
+  bool                 m_FlatIsMinima{ true };
   OutputImagePixelType m_ForegroundValue;
   OutputImagePixelType m_BackgroundValue;
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
@@ -32,8 +32,7 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 RegionalMinimaImageFilter< TInputImage, TOutputImage >
 ::RegionalMinimaImageFilter():
-  m_FullyConnected( false ),
-  m_FlatIsMinima( true ),
+
   m_ForegroundValue( NumericTraits< OutputImagePixelType >::max() ),
   m_BackgroundValue( NumericTraits< OutputImagePixelType >::NonpositiveMin() )
 {

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
@@ -159,8 +159,8 @@ protected:
 private:
   typename TInputImage::PixelType m_MarkerValue;
 
-  bool m_FullyConnected;
-  bool m_Flat;
+  bool m_FullyConnected{ false };
+  bool m_Flat{ false };
 
   using OutIndexType = typename OutputImageType::IndexType;
   using InIndexType = typename InputImageType::IndexType;

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -33,11 +33,8 @@ template< typename TInputImage, typename TOutputImage, typename TFunction1,
 ValuedRegionalExtremaImageFilter< TInputImage, TOutputImage, TFunction1,
                                   TFunction2 >
 ::ValuedRegionalExtremaImageFilter():
-  m_MarkerValue( 0 ),
-  m_FullyConnected( false ),
-  // not really useful, just to always have the same value before
-  //the filter has run
-  m_Flat( false )
+  m_MarkerValue( 0 )
+
 {
 }
 

--- a/Modules/Filtering/Path/include/itkHilbertPath.h
+++ b/Modules/Filtering/Path/include/itkHilbertPath.h
@@ -178,7 +178,7 @@ private:
 
   PathIndexType GetBitRange( const PathIndexType, const PathIndexType, const PathIndexType, const PathIndexType );
 
-  HilbertOrderType             m_HilbertOrder;
+  HilbertOrderType             m_HilbertOrder{ 1 };
   HilbertPathType              m_HilbertPath;
 };
 } // end namespace itk

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -26,8 +26,8 @@ namespace itk
 /** Constructor */
 template<typename TIndexValue, unsigned int VDimension>
 HilbertPath<TIndexValue, VDimension>
-::HilbertPath() :
-  m_HilbertOrder( 1 )
+::HilbertPath()
+
 {
 }
 

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
@@ -76,7 +76,7 @@ protected:
   void GenerateData() override;
 
 private:
-  bool m_MaximallyConnected;
+  bool m_MaximallyConnected{ false };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.hxx
@@ -25,8 +25,8 @@ namespace itk
 
 template< typename TInputPath, typename TOutputChainCodePath >
 PathToChainCodePathFilter< TInputPath, TOutputChainCodePath >
-::PathToChainCodePathFilter() :
-  m_MaximallyConnected( false )
+::PathToChainCodePathFilter()
+
 {
   this->SetNumberOfRequiredInputs(1);
 }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
@@ -90,8 +90,8 @@ protected:
   EdgeDecimationQuadEdgeMeshFilter();
   ~EdgeDecimationQuadEdgeMeshFilter() override;
 
-  bool m_Relocate;
-  bool m_CheckOrientation;
+  bool m_Relocate{true};
+  bool m_CheckOrientation{false};
 
   PriorityQueuePointer m_PriorityQueue;
   QueueMapType         m_QueueMapper;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
@@ -26,8 +26,7 @@ template< typename TInput, typename TOutput, typename TCriterion >
 EdgeDecimationQuadEdgeMeshFilter< TInput, TOutput,TCriterion >::
 EdgeDecimationQuadEdgeMeshFilter() :
   Superclass(),
-  m_Relocate(true),
-  m_CheckOrientation(false),
+
   m_Element(nullptr)
 
 {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
@@ -212,7 +212,7 @@ protected:
 
   CoefficientsComputationType* m_CoefficientsMethod;
 
-  unsigned int              m_Order;
+  unsigned int              m_Order{1};
   AreaType                  m_AreaComputationType;
 
   void PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -25,7 +25,7 @@ namespace itk
 template< typename TInputMesh, typename TOutputMesh, typename TSolverTraits >
 LaplacianDeformationQuadEdgeMeshFilter< TInputMesh, TOutputMesh, TSolverTraits >
 ::LaplacianDeformationQuadEdgeMeshFilter():
-  m_CoefficientsMethod( nullptr ), m_Order(1), m_AreaComputationType( NONE )
+  m_CoefficientsMethod( nullptr ),  m_AreaComputationType( NONE )
 {}
 
 template< typename TInputMesh, typename TOutputMesh, typename TSolverTraits >

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
@@ -167,7 +167,7 @@ private:
   FirstGaussianFilterPointer    m_FirstSmoothingFilter;
   CastingFilterPointer          m_CastingFilter;
 
-  bool m_NormalizeAcrossScale;
+  bool m_NormalizeAcrossScale{ false };
 
   SigmaArrayType m_Sigma;
 };

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
@@ -27,8 +27,8 @@ namespace itk
 
 template< typename TInputImage, typename TOutputImage >
 SmoothingRecursiveGaussianImageFilter< TInputImage, TOutputImage >
-::SmoothingRecursiveGaussianImageFilter() :
-  m_NormalizeAcrossScale( false )
+::SmoothingRecursiveGaussianImageFilter()
+
 {
   // NB: The first filter is the last dimension because it does not
   // always run in-place. As this dimension provides the least amount

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -202,9 +202,9 @@ private:
   InputPixelType      m_Threshold;
   MaskPixelType       m_MaskValue;
   CalculatorPointer   m_Calculator;
-  unsigned            m_NumberOfHistogramBins;
+  unsigned            m_NumberOfHistogramBins{ 256 };
   bool                m_AutoMinimumMaximum;
-  bool                m_MaskOutput;
+  bool                m_MaskOutput{ true };
 };
 
 } // end namespace itk

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
@@ -34,9 +34,8 @@ HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
   m_InsideValue( NumericTraits<OutputPixelType>::max() ),
   m_OutsideValue( NumericTraits<OutputPixelType>::ZeroValue() ),
   m_Threshold( NumericTraits<InputPixelType>::ZeroValue() ),
-  m_MaskValue ( NumericTraits<MaskPixelType>::max() ),
-  m_NumberOfHistogramBins( 256 ),
-  m_MaskOutput( true )
+  m_MaskValue ( NumericTraits<MaskPixelType>::max() )
+
 {
   this->SetNumberOfRequiredOutputs(1);
 

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.h
@@ -115,10 +115,10 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool           m_Valid;             // Have moments been computed yet?
+  bool           m_Valid{ false };             // Have moments been computed yet?
   MaskPixelType  m_MaskValue;
-  double         m_SigmaFactor;
-  unsigned int   m_NumberOfIterations;
+  double         m_SigmaFactor{ 2 };
+  unsigned int   m_NumberOfIterations{ 2 };
   InputPixelType m_Output;
 
   InputImageConstPointer m_Image;

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
@@ -27,10 +27,9 @@ namespace itk
 template< typename TInputImage, typename TMaskImage >
 KappaSigmaThresholdImageCalculator< TInputImage, TMaskImage >
 ::KappaSigmaThresholdImageCalculator() :
-  m_Valid( false ),
+
   m_MaskValue( NumericTraits<MaskPixelType>::max() ),
-  m_SigmaFactor( 2 ),
-  m_NumberOfIterations( 2 ),
+
   m_Output( NumericTraits<InputPixelType>::ZeroValue() )
 {
 }

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.h
@@ -165,8 +165,8 @@ protected:
 
 private:
   MaskPixelType   m_MaskValue;
-  double          m_SigmaFactor;
-  unsigned int    m_NumberOfIterations;
+  double          m_SigmaFactor{ 2 };
+  unsigned int    m_NumberOfIterations{ 2 };
   InputPixelType  m_Threshold;
   OutputPixelType m_InsideValue;
   OutputPixelType m_OutsideValue;

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
@@ -28,8 +28,7 @@ template< typename TInputImage, typename TMaskImage, typename TOutputImage >
 KappaSigmaThresholdImageFilter< TInputImage, TMaskImage, TOutputImage >
 ::KappaSigmaThresholdImageFilter() :
   m_MaskValue( NumericTraits<MaskPixelType>::max() ),
-  m_SigmaFactor( 2 ),
-  m_NumberOfIterations( 2 ),
+
   m_Threshold( NumericTraits<InputPixelType>::ZeroValue() ),
   m_InsideValue( NumericTraits<OutputPixelType>::max() ),
   m_OutsideValue( NumericTraits<OutputPixelType>::ZeroValue() )

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
@@ -112,10 +112,10 @@ protected:
 
 private:
 
-  SizeValueType m_NumberOfThresholds;
+  SizeValueType m_NumberOfThresholds{ 1 };
   OutputType    m_Output;
-  bool          m_ValleyEmphasis;
-  bool          m_ReturnBinMidpoint;
+  bool          m_ValleyEmphasis{ false };
+  bool          m_ReturnBinMidpoint{ false };
 };
 } // end of namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -25,10 +25,8 @@ namespace itk
 {
 template< typename TInputHistogram >
 OtsuMultipleThresholdsCalculator< TInputHistogram >
-::OtsuMultipleThresholdsCalculator() :
-  m_NumberOfThresholds( 1 ),
-  m_ValleyEmphasis( false ),
-  m_ReturnBinMidpoint( false )
+::OtsuMultipleThresholdsCalculator()
+
 {
   m_Output.resize(m_NumberOfThresholds);
   std::fill(m_Output.begin(), m_Output.end(), NumericTraits< MeasurementType >::ZeroValue());

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
@@ -145,12 +145,12 @@ protected:
   void GenerateData() override;
 
 private:
-  SizeValueType       m_NumberOfHistogramBins;
-  SizeValueType       m_NumberOfThresholds;
+  SizeValueType       m_NumberOfHistogramBins{ 128 };
+  SizeValueType       m_NumberOfThresholds{ 1 };
   OutputPixelType     m_LabelOffset;
   ThresholdVectorType m_Thresholds;
-  bool                m_ValleyEmphasis;
-  bool                m_ReturnBinMidpoint;
+  bool                m_ValleyEmphasis{ false };
+  bool                m_ReturnBinMidpoint{ false };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
@@ -27,11 +27,9 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 OtsuMultipleThresholdsImageFilter< TInputImage, TOutputImage >
 ::OtsuMultipleThresholdsImageFilter() :
-  m_NumberOfHistogramBins( 128 ),
-  m_NumberOfThresholds( 1 ),
-  m_LabelOffset( NumericTraits< OutputPixelType >::ZeroValue() ),
-  m_ValleyEmphasis( false ),
-  m_ReturnBinMidpoint( false )
+
+  m_LabelOffset( NumericTraits< OutputPixelType >::ZeroValue() )
+
 {
   m_Thresholds.clear();
 }

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.h
@@ -75,8 +75,8 @@ public:
   }
 
 protected:
-  OtsuThresholdCalculator() :
-    m_ReturnBinMidpoint( false )
+  OtsuThresholdCalculator()
+
   {
     m_OtsuMultipleThresholdsCalculator = OtsuMultipleThresholdsCalculator<THistogram>::New();
   }
@@ -87,7 +87,7 @@ protected:
 private:
   typename OtsuMultipleThresholdsCalculator<THistogram>::Pointer m_OtsuMultipleThresholdsCalculator;
 
-  bool m_ReturnBinMidpoint;
+  bool m_ReturnBinMidpoint{ false };
 };
 
 } // end namespace itk

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -108,8 +108,8 @@ public:
   itkBooleanMacro(ReturnBinMidpoint);
 
 protected:
-  OtsuThresholdImageFilter() :
-      m_ReturnBinMidpoint( false )
+  OtsuThresholdImageFilter()
+
   {
     this->SetCalculator( CalculatorType::New() );
   }
@@ -121,7 +121,7 @@ protected:
     calc->SetReturnBinMidpoint(m_ReturnBinMidpoint);
     this->Superclass::GenerateData();
   }
-  bool m_ReturnBinMidpoint;
+  bool m_ReturnBinMidpoint{ false };
 };
 
 } // end namespace itk

--- a/Modules/IO/BMP/include/itkBMPImageIO.h
+++ b/Modules/IO/BMP/include/itkBMPImageIO.h
@@ -104,13 +104,13 @@ private:
 
   std::ifstream               m_Ifstream;
   std::ofstream               m_Ofstream;
-  long                        m_BitMapOffset;
-  bool                        m_FileLowerLeft;
-  short                       m_Depth;
-  unsigned short              m_NumberOfColors;
-  unsigned int                m_ColorPaletteSize;
-  long                        m_BMPCompression;
-  unsigned long               m_BMPDataSize;
+  long                        m_BitMapOffset{ 0 };
+  bool                        m_FileLowerLeft{ false };
+  short                       m_Depth{ 8 };
+  unsigned short              m_NumberOfColors{ 0 };
+  unsigned int                m_ColorPaletteSize{ 0 };
+  long                        m_BMPCompression{ 0 };
+  unsigned long               m_BMPDataSize{ 0 };
   PaletteType                 m_ColorPalette;
 };
 } // end namespace itk

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -24,13 +24,7 @@ namespace itk
 {
 /** Constructor */
 BMPImageIO::BMPImageIO() :
-  m_BitMapOffset( 0 ),
-  m_FileLowerLeft( false ),
-  m_Depth( 8 ),
-  m_NumberOfColors( 0 ),
-  m_ColorPaletteSize( 0 ),
-  m_BMPCompression( 0 ),
-  m_BMPDataSize( 0 ),
+
   m_ColorPalette( 0 ) // palette has no element by default
 {
   this->SetNumberOfDimensions( 2 );

--- a/Modules/IO/Bruker/include/itkBruker2dseqImageIO.h
+++ b/Modules/IO/Bruker/include/itkBruker2dseqImageIO.h
@@ -130,7 +130,7 @@ protected:
 private:
   void SwapBytesIfNecessary(void *buffer, SizeValueType numberOfPixels);
 
-  ImageIOBase::IOComponentType  m_OnDiskComponentType;
+  ImageIOBase::IOComponentType  m_OnDiskComponentType{ UCHAR };
   ImageIOBase::ByteOrder        m_MachineByteOrder;
 };
 

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -321,8 +321,8 @@ void ReadJCAMPDX(const std::string &filename, MetaDataDictionary &dict)
 }
 }
 
-Bruker2dseqImageIO::Bruker2dseqImageIO() :
-  m_OnDiskComponentType( UCHAR )
+Bruker2dseqImageIO::Bruker2dseqImageIO()
+
 {
   // By default, only have 3 dimensions
   this->SetNumberOfDimensions(3);

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -61,12 +61,12 @@ namespace itk
 class InternalHeader
 {
 public:
-  InternalHeader():m_Header(nullptr) {}
+  InternalHeader() {}
   ~InternalHeader()
   {
     delete m_Header;
   }
-  gdcm::File *m_Header;
+  gdcm::File *m_Header{nullptr};
 };
 
 GDCMImageIO::GDCMImageIO()

--- a/Modules/IO/HDF5/include/itkHDF5ImageIO.h
+++ b/Modules/IO/HDF5/include/itkHDF5ImageIO.h
@@ -193,9 +193,9 @@ private:
   void CloseH5File();
   void CloseDataSet();
 
-  H5::H5File  *m_H5File;
-  H5::DataSet *m_VoxelDataSet;
-  bool         m_ImageInformationWritten;
+  H5::H5File  *m_H5File{nullptr};
+  H5::DataSet *m_VoxelDataSet{nullptr};
+  bool         m_ImageInformationWritten{false};
 };
 } // end namespace itk
 

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -27,9 +27,8 @@
 namespace itk
 {
 
-HDF5ImageIO::HDF5ImageIO() : m_H5File(nullptr),
-                             m_VoxelDataSet(nullptr),
-                             m_ImageInformationWritten(false)
+HDF5ImageIO::HDF5ImageIO()
+
 {
 
   const char *extensions[] =

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -560,16 +560,16 @@ protected:
   virtual bool HasSupportedWriteExtension( const char * fileName, bool ignoreCase = true );
 
   /** Used internally to keep track of the type of the pixel. */
-  IOPixelType m_PixelType;
+  IOPixelType m_PixelType{SCALAR};
 
   /** Used internally to keep track of the type of the component. It is set
    * when ComputeStrides() is invoked. */
-  IOComponentType m_ComponentType;
+  IOComponentType m_ComponentType{UNKNOWNCOMPONENTTYPE};
 
   /** Big or Little Endian, and the type of the file. (May be ignored.) */
-  ByteOrder m_ByteOrder;
+  ByteOrder m_ByteOrder{OrderNotApplicable};
 
-  FileType m_FileType;
+  FileType m_FileType{TypeNotApplicable};
 
   /** Does the ImageIOBase object have enough info to be of use? */
   bool m_Initialized;
@@ -582,7 +582,7 @@ protected:
   unsigned int m_NumberOfComponents;
 
   /** The number of independent dimensions in the image. */
-  unsigned int m_NumberOfDimensions;
+  unsigned int m_NumberOfDimensions{0};
 
   /** Should we compress the data? */
   bool m_UseCompression;

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.h
@@ -164,12 +164,8 @@ public:
 
 protected:
   ImageSeriesReader() :
-    m_ImageIO(nullptr),
-    m_ReverseOrder(false),
-    m_ForceOrthogonalDirection(true),
-    m_NumberOfDimensionsInImage(0),
-    m_UseStreaming(true),
-    m_MetaDataDictionaryArrayUpdate(true)
+    m_ImageIO(nullptr)
+
       {}
   ~ImageSeriesReader() override;
   void PrintSelf(std::ostream & os, Indent indent) const override;
@@ -181,10 +177,10 @@ protected:
   ImageIOBase::Pointer m_ImageIO;
 
   /** Select the traversal order. */
-  bool m_ReverseOrder;
+  bool m_ReverseOrder{false};
 
   /** Do we want to force orthogonal direction cosines? */
-  bool m_ForceOrthogonalDirection;
+  bool m_ForceOrthogonalDirection{true};
 
   /** A list of filenames to be processed. */
   FileNamesContainer m_FileNames;
@@ -194,13 +190,13 @@ protected:
    *  index for the output image. That is for reading a series of 2D
    *  images into  a 3D image, the moving dimension index is 2.
    */
-  unsigned int m_NumberOfDimensionsInImage;
+  unsigned int m_NumberOfDimensionsInImage{0};
 
   /** Array of MetaDataDictionaries. This allows to hold information from the
    * ImageIO objects after reading every sub image in the series */
   DictionaryArrayType m_MetaDataDictionaryArray;
 
-  bool m_UseStreaming;
+  bool m_UseStreaming{true};
 
 private:
   using ReaderType = ImageFileReader< TOutputImage >;
@@ -211,7 +207,7 @@ private:
   TimeStamp m_MetaDataDictionaryArrayMTime;
 
   /** Indicated if the MMDA should be updated */
-  bool m_MetaDataDictionaryArrayUpdate;
+  bool m_MetaDataDictionaryArrayUpdate{true};
 };
 } //namespace ITK
 

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
@@ -214,7 +214,7 @@ protected:
   ImageIOBase::Pointer m_ImageIO;
 
   //track whether the ImageIO is user specified
-  bool m_UserSpecifiedImageIO;
+  bool m_UserSpecifiedImageIO{false};
 
 private:
   /** A list of filenames to be processed. */
@@ -226,13 +226,13 @@ private:
    * to use additional SeriesFileNames such as the DICOM filenames generators.
    * */
   std::string   m_SeriesFormat;
-  SizeValueType m_StartIndex;
-  SizeValueType m_IncrementIndex;
+  SizeValueType m_StartIndex{1};
+  SizeValueType m_IncrementIndex{1};
 
   bool m_UseCompression;
 
   /** Array of MetaDataDictionary used for passing information to each slice */
-  DictionaryArrayRawPointer m_MetaDataDictionaryArray;
+  DictionaryArrayRawPointer m_MetaDataDictionaryArray{nullptr};
 
   // These two methods provide now a common implementation for the
   // GenerateNumericFileNamesAndWrite() and avoid the duplication of code that

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -39,9 +39,8 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 ImageSeriesWriter< TInputImage, TOutputImage >
 ::ImageSeriesWriter():
-  m_ImageIO(nullptr), m_UserSpecifiedImageIO(false),
-  m_SeriesFormat("%d"),
-  m_StartIndex(1), m_IncrementIndex(1), m_MetaDataDictionaryArray(nullptr)
+  m_ImageIO(nullptr),
+  m_SeriesFormat("%d")
 {
   m_UseCompression = false;
 }

--- a/Modules/IO/ImageBase/include/itkNumericSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkNumericSeriesFileNames.h
@@ -101,9 +101,9 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  SizeValueType m_StartIndex;
-  SizeValueType m_EndIndex;
-  SizeValueType m_IncrementIndex;
+  SizeValueType m_StartIndex{1};
+  SizeValueType m_EndIndex{1};
+  SizeValueType m_IncrementIndex{1};
 
   /** A string for formatting the names of files in the series. */
   std::string m_SeriesFormat;

--- a/Modules/IO/ImageBase/include/itkRegularExpressionSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkRegularExpressionSeriesFileNames.h
@@ -112,8 +112,7 @@ public:
 protected:
   RegularExpressionSeriesFileNames():
     m_Directory("."),
-    m_SubMatch(1),
-    m_NumericSort(false),
+
     m_RegularExpression(".*\\.([0-9]+)")
   {}
   ~RegularExpressionSeriesFileNames() override = default;
@@ -121,8 +120,8 @@ protected:
 
 private:
   std::string  m_Directory;
-  unsigned int m_SubMatch;
-  bool         m_NumericSort;
+  unsigned int m_SubMatch{1};
+  bool         m_NumericSort{false};
   std::string  m_RegularExpression;
 
   std::vector< std::string > m_FileNames;

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -25,12 +25,8 @@
 
 namespace itk
 {
-ImageIOBase::ImageIOBase():
-  m_PixelType(SCALAR),
-  m_ComponentType(UNKNOWNCOMPONENTTYPE),
-  m_ByteOrder(OrderNotApplicable),
-  m_FileType(TypeNotApplicable),
-  m_NumberOfDimensions(0)
+ImageIOBase::ImageIOBase()
+
 {
   Reset(false);
 }

--- a/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
@@ -25,7 +25,7 @@ namespace itk
 {
 NumericSeriesFileNames
 ::NumericSeriesFileNames():
-  m_StartIndex(1), m_EndIndex(1), m_IncrementIndex(1), m_SeriesFormat("%d")
+   m_SeriesFormat("%d")
 {}
 
 #if defined(_MSC_VER)

--- a/Modules/IO/MRC/include/itkMRCHeaderObject.h
+++ b/Modules/IO/MRC/include/itkMRCHeaderObject.h
@@ -273,10 +273,10 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  SizeValueType m_ExtendedHeaderSize;
-  void *        m_ExtendedHeader;
+  SizeValueType m_ExtendedHeaderSize{0};
+  void *        m_ExtendedHeader{nullptr};
 
-  FeiExtendedHeader *m_ExtendedFeiHeader;
+  FeiExtendedHeader *m_ExtendedFeiHeader{nullptr};
 
   bool m_BigEndianHeader;
 };

--- a/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
+++ b/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
@@ -193,9 +193,8 @@ bool MRCHeaderObject::IsOriginalHeaderBigEndian() const
 }
 
 MRCHeaderObject::MRCHeaderObject()
-  : m_ExtendedHeaderSize(0),
-    m_ExtendedHeader(nullptr),
-    m_ExtendedFeiHeader(nullptr)
+
+
 {
   memset( &this->m_Header, 0, sizeof( Header ) );
   this->m_BigEndianHeader = ByteSwapper< void * >::SystemIsBE();

--- a/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
+++ b/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
@@ -144,7 +144,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  StreamOffsetType m_FilePosition;
+  StreamOffsetType m_FilePosition{0};
   SizeValueType    m_PartId;
   SizeValueType    m_FirstCellId;
   SizeValueType    m_LastCellId;

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -24,7 +24,7 @@ namespace itk
 {
 BYUMeshIO
 ::BYUMeshIO() :
-  m_FilePosition(0),
+
   m_PartId(NumericTraits< SizeValueType >::max()),
   m_FirstCellId(NumericTraits< SizeValueType >::OneValue()),
   m_LastCellId(NumericTraits< SizeValueType >::max())

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -709,32 +709,32 @@ protected:
 
 protected:
   /** Big or Little Endian, and the type of the file. (May be ignored.) */
-  ByteOrder m_ByteOrder;
-  FileType  m_FileType;
+  ByteOrder m_ByteOrder{OrderNotApplicable};
+  FileType  m_FileType{ASCII};
 
   /** Filename to read */
   std::string m_FileName;
 
   /** Should we compress the data? */
-  bool m_UseCompression;
+  bool m_UseCompression{false};
 
   /** Used internally to keep track of the type of the component. */
-  IOComponentType m_PointComponentType;
-  IOComponentType m_CellComponentType;
-  IOComponentType m_PointPixelComponentType;
-  IOComponentType m_CellPixelComponentType;
+  IOComponentType m_PointComponentType{UNKNOWNCOMPONENTTYPE};
+  IOComponentType m_CellComponentType{UNKNOWNCOMPONENTTYPE};
+  IOComponentType m_PointPixelComponentType{UNKNOWNCOMPONENTTYPE};
+  IOComponentType m_CellPixelComponentType{UNKNOWNCOMPONENTTYPE};
 
   /** Used internally to keep track of the type of the pixel. */
-  IOPixelType m_PointPixelType;
-  IOPixelType m_CellPixelType;
+  IOPixelType m_PointPixelType{SCALAR};
+  IOPixelType m_CellPixelType{SCALAR};
 
   /** Stores the number of components per pixel. This will be 1 for
     * grayscale images, 3 for RGBPixel images, and 4 for RGBPixelA images. */
-  unsigned int m_NumberOfPointPixelComponents;
-  unsigned int m_NumberOfCellPixelComponents;
+  unsigned int m_NumberOfPointPixelComponents{0};
+  unsigned int m_NumberOfCellPixelComponents{0};
 
   /** The number of independent dimensions in the point. */
-  SizeValueType m_PointDimension;
+  SizeValueType m_PointDimension{0};
 
   /** The number of points and cells */
   SizeValueType m_NumberOfPoints;
@@ -747,10 +747,10 @@ protected:
 
   /** Flags indicate whether read or write points, cells, point data and cell
     data */
-  bool m_UpdatePoints;
-  bool m_UpdateCells;
-  bool m_UpdatePointData;
-  bool m_UpdateCellData;
+  bool m_UpdatePoints{false};
+  bool m_UpdateCells{false};
+  bool m_UpdatePointData{false};
+  bool m_UpdateCellData{false};
 
 private:
   ArrayOfExtensionsType m_SupportedReadExtensions;

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -22,27 +22,13 @@ namespace itk
 {
 MeshIOBase
 ::MeshIOBase():
-  m_ByteOrder(OrderNotApplicable),
-  m_FileType(ASCII),
-  m_UseCompression(false),
-  m_PointComponentType(UNKNOWNCOMPONENTTYPE),
-  m_CellComponentType(UNKNOWNCOMPONENTTYPE),
-  m_PointPixelComponentType(UNKNOWNCOMPONENTTYPE),
-  m_CellPixelComponentType(UNKNOWNCOMPONENTTYPE),
-  m_PointPixelType(SCALAR),
-  m_CellPixelType(SCALAR),
-  m_NumberOfPointPixelComponents(0),
-  m_NumberOfCellPixelComponents(0),
-  m_PointDimension(0),
+
   m_NumberOfPoints(itk::NumericTraits< SizeValueType >::ZeroValue()),
   m_NumberOfCells(itk::NumericTraits< SizeValueType >::ZeroValue()),
   m_NumberOfPointPixels(itk::NumericTraits< SizeValueType >::ZeroValue()),
   m_NumberOfCellPixels(itk::NumericTraits< SizeValueType >::ZeroValue()),
-  m_CellBufferSize(itk::NumericTraits< SizeValueType >::ZeroValue()),
-  m_UpdatePoints(false),
-  m_UpdateCells(false),
-  m_UpdatePointData(false),
-  m_UpdateCellData(false)
+  m_CellBufferSize(itk::NumericTraits< SizeValueType >::ZeroValue())
+
 {}
 
 const MeshIOBase::ArrayOfExtensionsType &

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIO.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIO.h
@@ -177,8 +177,8 @@ protected:
   void CloseFile();
 
 private:
-  StreamOffsetType m_FilePosition;
-  itk::uint32_t    m_FileTypeIdentifier;
+  StreamOffsetType m_FilePosition{0};
+  itk::uint32_t    m_FileTypeIdentifier{0};
   std::ifstream    m_InputFile;
 };
 } // end namespace itk

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -23,9 +23,8 @@
 namespace itk
 {
 FreeSurferBinaryMeshIO
-::FreeSurferBinaryMeshIO() :
-  m_FilePosition(0),
-  m_FileTypeIdentifier(0)
+::FreeSurferBinaryMeshIO()
+
 {
   this->AddSupportedWriteExtension(".fsb");
   this->AddSupportedWriteExtension(".fcv");

--- a/Modules/IO/Meta/include/itkMetaArrayReader.h
+++ b/Modules/IO/Meta/include/itkMetaArrayReader.h
@@ -252,7 +252,7 @@ private:
 
   std::string m_FileName;
 
-  void *m_Buffer;
+  void *m_Buffer{ nullptr };
 };
 } // namespace itk
 

--- a/Modules/IO/Meta/include/itkMetaArrayWriter.h
+++ b/Modules/IO/Meta/include/itkMetaArrayWriter.h
@@ -160,16 +160,16 @@ protected:
 
 private:
 
-  bool          m_Binary;
+  bool          m_Binary{ false };
 
-  unsigned int  m_Precision;
+  unsigned int  m_Precision{ 6 };
 
   std::string   m_FileName;
   std::string   m_DataFileName;
 
   MetaArray     m_MetaArray;
 
-  const void   *m_Buffer;
+  const void   *m_Buffer{ nullptr };
 };
 } // namespace itk
 

--- a/Modules/IO/Meta/src/itkMetaArrayReader.cxx
+++ b/Modules/IO/Meta/src/itkMetaArrayReader.cxx
@@ -22,8 +22,8 @@ namespace itk
 
 MetaArrayReader
 ::MetaArrayReader() :
-  m_FileName( "" ),
-  m_Buffer( nullptr )
+  m_FileName( "" )
+
 {
 }
 

--- a/Modules/IO/Meta/src/itkMetaArrayWriter.cxx
+++ b/Modules/IO/Meta/src/itkMetaArrayWriter.cxx
@@ -21,11 +21,10 @@ namespace itk
 {
 MetaArrayWriter
 ::MetaArrayWriter() :
-  m_Binary( false ),
-  m_Precision( 6 ),
+
   m_FileName( "" ),
-  m_DataFileName( "" ),
-  m_Buffer( nullptr )
+  m_DataFileName( "" )
+
 {
 }
 

--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -166,12 +166,12 @@ private:
 
   NiftiImageProxy& m_NiftiImage;
 
-  double m_RescaleSlope;
-  double m_RescaleIntercept;
+  double m_RescaleSlope{1.0};
+  double m_RescaleIntercept{0.0};
 
-  IOComponentType m_OnDiskComponentType;
+  IOComponentType m_OnDiskComponentType{UNKNOWNCOMPONENTTYPE};
 
-  bool m_LegacyAnalyze75Mode;
+  bool m_LegacyAnalyze75Mode{true};
 
 };
 } // end namespace itk

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -412,11 +412,8 @@ public:
 
 NiftiImageIO::NiftiImageIO() :
   m_NiftiImageHolder(new NiftiImageProxy(nullptr)),
-  m_NiftiImage(*m_NiftiImageHolder.get()),
-  m_RescaleSlope(1.0),
-  m_RescaleIntercept(0.0),
-  m_OnDiskComponentType(UNKNOWNCOMPONENTTYPE),
-  m_LegacyAnalyze75Mode(true)
+  m_NiftiImage(*m_NiftiImageHolder.get())
+
 {
   this->SetNumberOfDimensions(3);
   nifti_set_debug_level(0); // suppress error messages

--- a/Modules/IO/PNG/include/itkPNGImageIO.h
+++ b/Modules/IO/PNG/include/itkPNGImageIO.h
@@ -99,7 +99,7 @@ protected:
 
   /** Determines the level of compression for written files.
    *  Range 0-9; 0 = none, 9 = maximum , default = 4 */
-  int m_CompressionLevel;
+  int m_CompressionLevel{ 4 };
 
   PaletteType m_ColorPalette;
 };

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -279,7 +279,7 @@ void PNGImageIO::Read(void *buffer)
 }
 
 PNGImageIO::PNGImageIO() :
-  m_CompressionLevel( 4 ),
+
   m_ColorPalette( 0 )// palette has no elements by default
 {
   this->SetNumberOfDimensions( 2 );

--- a/Modules/IO/TIFF/include/itkTIFFImageIO.h
+++ b/Modules/IO/TIFF/include/itkTIFFImageIO.h
@@ -176,8 +176,8 @@ protected:
 
   void ReadTIFFTags();
 
-  int m_Compression;
-  int m_JPEGQuality;
+  int m_Compression{ TIFFImageIO::PackBits };
+  int m_JPEGQuality{ 75 };
 
   PaletteType m_ColorPalette;
 
@@ -221,8 +221,8 @@ private:
   unsigned short *m_ColorRed;
   unsigned short *m_ColorGreen;
   unsigned short *m_ColorBlue;
-  int             m_TotalColors;
-  unsigned int    m_ImageFormat;
+  int             m_TotalColors{ -1 };
+  unsigned int    m_ImageFormat{ TIFFImageIO::NOFORMAT };
 };
 } // end namespace itk
 

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -208,11 +208,9 @@ void TIFFImageIO::Read(void *buffer)
 }
 
 TIFFImageIO::TIFFImageIO() :
-  m_Compression( TIFFImageIO::PackBits ),
-  m_JPEGQuality( 75 ),
-  m_ColorPalette( 0 ), // palette has no element by default
-  m_TotalColors( -1 ),
-  m_ImageFormat( TIFFImageIO::NOFORMAT )
+
+  m_ColorPalette( 0 )
+
 {
   this->SetNumberOfDimensions( 2 );
 

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -141,9 +141,9 @@ protected:
   std::string            m_FileName;
   TransformListType      m_ReadTransformList;
   ConstTransformListType m_WriteTransformList;
-  bool                   m_AppendMode;
+  bool                   m_AppendMode{false};
   /** Should we compress the data? */
-  bool                   m_UseCompression;
+  bool                   m_UseCompression{false};
 
   /* The following struct returns the string name of computation type */
   /* default implementation */

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.hxx
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.hxx
@@ -30,8 +30,7 @@ namespace itk
 template<typename TParametersValueType>
 TransformIOBaseTemplate<TParametersValueType>
 ::TransformIOBaseTemplate()
- : m_AppendMode(false)
- , m_UseCompression(false)
+
 {
 }
 

--- a/Modules/IO/XML/include/itkDOMNode.h
+++ b/Modules/IO/XML/include/itkDOMNode.h
@@ -211,7 +211,7 @@ protected:
 
 private:
   /** The parent node that this node was placed into. */
-  DOMNode* m_Parent;
+  DOMNode* m_Parent{ nullptr };
 
   /** The XML tag of this node. */
   std::string m_Name;

--- a/Modules/IO/XML/include/itkDOMNodeXMLReader.h
+++ b/Modules/IO/XML/include/itkDOMNodeXMLReader.h
@@ -150,7 +150,7 @@ private:
   OutputPointer m_DOMNodeXML;
 
   /** Variable to keep the current context during XML parsing. */
-  OutputType* m_Context;
+  OutputType* m_Context{nullptr};
 };
 
 } // namespace itk

--- a/Modules/IO/XML/src/itkDOMNode.cxx
+++ b/Modules/IO/XML/src/itkDOMNode.cxx
@@ -23,7 +23,7 @@
 namespace itk
 {
 
-DOMNode::DOMNode() : m_Parent( nullptr )
+DOMNode::DOMNode()
 {
 }
 

--- a/Modules/IO/XML/src/itkDOMNodeXMLReader.cxx
+++ b/Modules/IO/XML/src/itkDOMNodeXMLReader.cxx
@@ -52,7 +52,7 @@ static void itkXMLParserCharacterDataHandler( void* parser, const char* data, in
   static_cast<DOMNodeXMLReader*>(parser)->CharacterDataHandler( data, length );
 }
 
-DOMNodeXMLReader::DOMNodeXMLReader() : m_Context(nullptr)
+DOMNodeXMLReader::DOMNodeXMLReader()
 {
 }
 

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
@@ -37,9 +37,9 @@ class ITK_TEMPLATE_EXPORT BandNode
 public:
   TDataType   m_Data;
   TIndexType  m_Index;
-  signed char m_NodeState;
+  signed char m_NodeState{0};
   BandNode() :
-    m_Data(NumericTraits<TDataType>::ZeroValue()), m_NodeState(0)
+    m_Data(NumericTraits<TDataType>::ZeroValue())
   {}
 };
 
@@ -164,10 +164,10 @@ public:
   float GetInnerRadius() const { return m_InnerRadius; }
 
 protected:
-  NarrowBand() : m_TotalRadius( 0.0 ), m_InnerRadius( 0.0 ) {}
+  NarrowBand()  {}
 
-  float m_TotalRadius;
-  float m_InnerRadius;
+  float m_TotalRadius{ 0.0 };
+  float m_InnerRadius{ 0.0 };
 
 private:
   NodeContainerType m_NodeContainer;

--- a/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
@@ -133,16 +133,16 @@ protected:
   // made protected so subclass can access
   DerivativeType m_Gradient;
 
-  bool m_Maximize;
+  bool m_Maximize{false};
 
-  double m_LearningRate;
+  double m_LearningRate{1.0};
 
 private:
-  bool               m_Stop;
-  double             m_Value;
-  StopConditionType  m_StopCondition;
-  SizeValueType      m_NumberOfIterations;
-  SizeValueType      m_CurrentIteration;
+  bool               m_Stop{false};
+  double             m_Value{0.0};
+  StopConditionType  m_StopCondition{MaximumNumberOfIterations};
+  SizeValueType      m_NumberOfIterations{100};
+  SizeValueType      m_CurrentIteration{0};
   std::ostringstream m_StopConditionDescription;
 };
 } // end namespace itk

--- a/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
@@ -192,17 +192,17 @@ private:
   // counts, etc.
   friend class LBFGSBOptimizerHelper;
 
-  bool         m_Trace;
-  bool         m_OptimizerInitialized;
-  double       m_CostFunctionConvergenceFactor;
-  double       m_ProjectedGradientTolerance;
-  unsigned int m_MaximumNumberOfIterations;
-  unsigned int m_MaximumNumberOfEvaluations;
-  unsigned int m_MaximumNumberOfCorrections;
-  unsigned int m_CurrentIteration;
-  double       m_InfinityNormOfProjectedGradient;
+  bool         m_Trace{false};
+  bool         m_OptimizerInitialized{false};
+  double       m_CostFunctionConvergenceFactor{1e+7};
+  double       m_ProjectedGradientTolerance{1e-5};
+  unsigned int m_MaximumNumberOfIterations{500};
+  unsigned int m_MaximumNumberOfEvaluations{500};
+  unsigned int m_MaximumNumberOfCorrections{5};
+  unsigned int m_CurrentIteration{0};
+  double       m_InfinityNormOfProjectedGradient{0.0};
 
-  InternalOptimizerType * m_VnlOptimizer;
+  InternalOptimizerType * m_VnlOptimizer{nullptr};
   BoundValueType          m_LowerBound;
   BoundValueType          m_UpperBound;
   BoundSelectionType      m_BoundSelection;

--- a/Modules/Numerics/Optimizers/include/itkOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOptimizer.h
@@ -94,7 +94,7 @@ protected:
   /** Set the current position. */
   virtual void SetCurrentPosition(const ParametersType & param);
 
-  bool m_ScalesInitialized;
+  bool m_ScalesInitialized{ false };
 
   // Keep m_CurrentPosition as a protected var so that subclasses can
   // have fast access.  This is important when optimizing high-dimensional

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
@@ -228,10 +228,10 @@ protected:
   double                                       m_PercentageParticlesConverged;
   CostFunctionType::MeasureType                m_FunctionConvergenceTolerance;
   std::vector<ParticleData>                    m_Particles;
-  CostFunctionType::MeasureType                m_FunctionBestValue;
+  CostFunctionType::MeasureType                m_FunctionBestValue{0};
   std::vector<MeasureType>                     m_FunctionBestValueMemory;
   ParametersType                               m_ParametersBestValue;
-  NumberOfIterationsType                       m_IterationIndex;
+  NumberOfIterationsType                       m_IterationIndex{0};
   RandomVariateGeneratorType::IntegerType      m_Seed;
   bool                                         m_UseSeed;
 };

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
@@ -134,7 +134,7 @@ protected:
   DerivativeType m_Gradient;
   DerivativeType m_PreviousGradient;
 
-  bool               m_Stop;
+  bool               m_Stop{false};
   bool               m_Maximize;
   MeasureType        m_Value;
   double             m_GradientMagnitudeTolerance;

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -213,7 +213,7 @@ protected:
 
   DerivativeType m_Delta;
 
-  bool m_Stop;
+  bool m_Stop{false};
 
   StopConditionType m_StopCondition;
 

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -26,14 +26,8 @@ namespace itk
  * Constructor
  */
 GradientDescentOptimizer
-::GradientDescentOptimizer() :
-  m_Maximize(false),
-  m_LearningRate(1.0),
-  m_Stop(false),
-  m_Value(0.0),
-  m_StopCondition(MaximumNumberOfIterations),
-  m_NumberOfIterations(100),
-  m_CurrentIteration(0)
+::GradientDescentOptimizer()
+
 {
   itkDebugMacro("Constructor");
 

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -52,17 +52,8 @@ private:
  * Constructor
  */
 LBFGSBOptimizer
-::LBFGSBOptimizer():
-  m_Trace(false),
-  m_OptimizerInitialized(false),
-  m_CostFunctionConvergenceFactor(1e+7),
-  m_ProjectedGradientTolerance(1e-5),
-  m_MaximumNumberOfIterations(500),
-  m_MaximumNumberOfEvaluations(500),
-  m_MaximumNumberOfCorrections(5),
-  m_CurrentIteration(0),
-  m_InfinityNormOfProjectedGradient(0.0),
-  m_VnlOptimizer(nullptr)
+::LBFGSBOptimizer()
+
 {
   m_LowerBound       = InternalBoundValueType(0);
   m_UpperBound       = InternalBoundValueType(0);

--- a/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
@@ -27,8 +27,8 @@ namespace itk
  */
 
 Optimizer
-::Optimizer() :
-  m_ScalesInitialized( false )
+::Optimizer()
+
 {
 }
 

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -23,9 +23,8 @@ namespace itk
 
 
 ParticleSwarmOptimizerBase
-::ParticleSwarmOptimizerBase():
-  m_FunctionBestValue(0),
-  m_IterationIndex(0)
+::ParticleSwarmOptimizerBase()
+
 {
   this->m_PrintSwarm = false;
   this->m_InitializeNormalDistribution = false;

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -26,8 +26,8 @@ namespace itk
  * Constructor
  */
 RegularStepGradientDescentBaseOptimizer
-::RegularStepGradientDescentBaseOptimizer():
-  m_Stop(false)
+::RegularStepGradientDescentBaseOptimizer()
+
 {
   itkDebugMacro("Constructor");
 

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -25,8 +25,8 @@ namespace itk
  * ************************* Constructor ************************
  */
 SPSAOptimizer
-::SPSAOptimizer():
-  m_Stop(false)
+::SPSAOptimizer()
+
 {
   itkDebugMacro("Constructor");
 

--- a/Modules/Numerics/Optimizers/test/itkLBFGSBOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSBOptimizerTest.cxx
@@ -149,15 +149,14 @@ public:
     }
 
 protected:
-  EventChecker(): m_HadStartEvent( false ),
-    m_HadIterationEvent( false ),
-    m_HadEndEvent( false )
+  EventChecker()
+
   {}
 
 private:
-  bool m_HadStartEvent;
-  bool m_HadIterationEvent;
-  bool m_HadEndEvent;
+  bool m_HadStartEvent{ false };
+  bool m_HadIterationEvent{ false };
+  bool m_HadEndEvent{ false };
 };
 
 

--- a/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
@@ -138,7 +138,7 @@ protected:
   /**
    * Constructor
    */
-  CommandIterationUpdatev4() : m_PrintParameters( false ) {};
+  CommandIterationUpdatev4()  {};
 
 private:
 
@@ -147,7 +147,7 @@ private:
    */
   WeakPointer<OptimizerType>   m_Optimizer;
 
-  bool m_PrintParameters;
+  bool m_PrintParameters{ false };
 };
 
 } // end namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.h
@@ -153,8 +153,8 @@ protected:
   ParametersType  m_InitialPosition;
   MeasureType     m_CurrentValue;
   StepsType       m_NumberOfSteps;
-  bool            m_Stop;
-  double          m_StepLength;
+  bool            m_Stop{false};
+  double          m_StepLength{1.0};
   ParametersType  m_CurrentIndex;
   MeasureType     m_MaximumMetricValue;
   MeasureType     m_MinimumMetricValue;

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -28,8 +28,7 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>
 ::ExhaustiveOptimizerv4() :
   m_CurrentValue(0),
   m_NumberOfSteps(0),
-  m_Stop(false),
-  m_StepLength(1.0),
+
   m_CurrentIndex(0),
   m_MaximumMetricValue(0.0),
   m_MinimumMetricValue(0.0),

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
@@ -209,7 +209,7 @@ protected:
   typename DomainThreader<ThreadedIndexedContainerPartitioner, Self>::Pointer m_ModifyGradientByLearningRateThreader;
 
   /* Common variables for optimization control and reporting */
-  bool                          m_Stop;
+  bool                          m_Stop{false};
   StopConditionType             m_StopCondition;
   StopConditionDescriptionType  m_StopConditionDescription;
 

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -28,8 +28,8 @@ namespace itk
 //-------------------------------------------------------------------
 template<typename TInternalComputationValueType>
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>
-::GradientDescentOptimizerBasev4Template():
-  m_Stop(false)
+::GradientDescentOptimizerBasev4Template()
+
 {
   /** Threader for apply scales to gradient */
   typename GradientDescentOptimizerBasev4ModifyGradientByScalesThreaderTemplate<TInternalComputationValueType>::Pointer modifyGradientByScalesThreader =

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
@@ -225,7 +225,7 @@ protected:
   MeasureType                   m_CurrentBestValue;
   ParametersType                m_BestParameters;
 
-  bool                          m_ReturnBestParametersAndValue;
+  bool                          m_ReturnBestParametersAndValue{ false };
 
   /** Store the previous gradient value at each iteration,
    * so we can detect the changes in gradient direction.

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -29,8 +29,8 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>
   m_LearningRate( NumericTraits<TInternalComputationValueType>::OneValue() ),
   m_MinimumConvergenceValue( 1e-8 ),
   m_ConvergenceValue( NumericTraits<TInternalComputationValueType>::max() ),
-  m_CurrentBestValue( NumericTraits<MeasureType>::max() ),
-  m_ReturnBestParametersAndValue( false )
+  m_CurrentBestValue( NumericTraits<MeasureType>::max() )
+
 {
   this->m_PreviousGradient.Fill( NumericTraits<TInternalComputationValueType>::ZeroValue() );
 }

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
@@ -171,7 +171,7 @@ protected:
   friend class LBFGSBOptimizerHelperv4;
 
 private:
-  unsigned int m_MaximumNumberOfCorrections;
+  unsigned int m_MaximumNumberOfCorrections{5};
 
   ParametersType          m_InitialPosition;
   BoundValueType          m_LowerBound;

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
@@ -140,18 +140,18 @@ protected:
 
   using CostFunctionAdaptorType = Superclass::CostFunctionAdaptorType;
 
-  bool                         m_OptimizerInitialized;
+  bool                         m_OptimizerInitialized{false};
 
   using InternalOptimizerAutoPointer = std::unique_ptr<InternalOptimizerType>;
   InternalOptimizerAutoPointer  m_VnlOptimizer;
 
   mutable std::ostringstream    m_StopConditionDescription;
 
-  bool         m_Trace;
-  unsigned int m_MaximumNumberOfFunctionEvaluations;
-  double       m_GradientConvergenceTolerance;
-  double       m_InfinityNormOfProjectedGradient;
-  double       m_CostFunctionConvergenceFactor;
+  bool         m_Trace{false};
+  unsigned int m_MaximumNumberOfFunctionEvaluations{2000};
+  double       m_GradientConvergenceTolerance{1e-5};
+  double       m_InfinityNormOfProjectedGradient{0.0};
+  double       m_CostFunctionConvergenceFactor{1e+7};
 
   // give the helper access to member variables, to update iteration
   // counts, etc.

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
@@ -72,13 +72,8 @@ LBFGSOptimizerBaseHelperv4<TInternalVnlOptimizerType>
 
 template<typename TInternalVnlOptimizerType>
 LBFGSOptimizerBasev4<TInternalVnlOptimizerType>
-::LBFGSOptimizerBasev4():
-  m_OptimizerInitialized(false),
-  m_Trace(false),
-  m_MaximumNumberOfFunctionEvaluations(2000),
-  m_GradientConvergenceTolerance(1e-5),
-  m_InfinityNormOfProjectedGradient(0.0),
-  m_CostFunctionConvergenceFactor(1e+7)
+::LBFGSOptimizerBasev4()
+
 {
   Superclass::SetNumberOfIterations(500);
 }

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerv4.h
@@ -143,9 +143,9 @@ protected:
   using InternalOptimizerType = vnl_lbfgs;
 
 private:
-  bool         m_Verbose;
-  double       m_LineSearchAccuracy;
-  double       m_DefaultStepLength;
+  bool         m_Verbose{false};
+  double       m_LineSearchAccuracy{0.9};
+  double       m_DefaultStepLength{1.0};
 };
 } // end namespace itk
 #endif

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
@@ -129,7 +129,7 @@ public:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /* Common variables for optimization control and reporting */
-  bool                          m_Stop;
+  bool                          m_Stop{false};
   StopConditionType             m_StopCondition;
   StopConditionDescriptionType  m_StopConditionDescription;
   OptimizersListType            m_OptimizersList;

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -26,8 +26,8 @@ namespace itk
 //-------------------------------------------------------------------
 template<typename TInternalComputationValueType>
 MultiGradientOptimizerv4Template<TInternalComputationValueType>
-::MultiGradientOptimizerv4Template():
-  m_Stop(false)
+::MultiGradientOptimizerv4Template()
+
 {
   this->m_NumberOfIterations = static_cast<SizeValueType>(0);
   this->m_StopCondition      = Superclass::MAXIMUM_NUMBER_OF_ITERATIONS;

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
@@ -141,7 +141,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /* Common variables for optimization control and reporting */
-  bool                          m_Stop;
+  bool                          m_Stop{false};
   StopConditionType             m_StopCondition;
   StopConditionDescriptionType  m_StopConditionDescription;
   ParametersListType            m_ParametersList;

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -26,8 +26,8 @@ namespace itk
 //-------------------------------------------------------------------
 template<typename TInternalComputationValueType>
 MultiStartOptimizerv4Template<TInternalComputationValueType>
-::MultiStartOptimizerv4Template():
-  m_Stop(false)
+::MultiStartOptimizerv4Template()
+
 {
   this->m_NumberOfIterations = static_cast<SizeValueType>(0);
   this->m_StopCondition      = MAXIMUM_NUMBER_OF_ITERATIONS;

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
@@ -338,7 +338,7 @@ protected:
   /** Store the number of points used during most recent value and derivative
    * calculation.
    * \sa VerifyNumberOfValidPoints() */
-  mutable SizeValueType                   m_NumberOfValidPoints;
+  mutable SizeValueType                   m_NumberOfValidPoints{0};
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -32,8 +32,8 @@ namespace itk
 template<unsigned int TFixedDimension, unsigned int TMovingDimension, typename TVirtualImage,
  typename TParametersValueType>
 ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParametersValueType>
-::ObjectToObjectMetric():
-  m_NumberOfValidPoints(0)
+::ObjectToObjectMetric()
+
 {
   /* Both transforms default to an identity transform */
   using MovingIdentityTransformType = IdentityTransform<TParametersValueType, Self::MovingDimension  >;

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.h
@@ -202,26 +202,26 @@ protected:
   itkSetMacro(Stop, bool);
 
 private:
-  unsigned int m_SpaceDimension;
+  unsigned int m_SpaceDimension{0};
 
   /** Current iteration */
-  unsigned int m_CurrentLineIteration;
+  unsigned int m_CurrentLineIteration{0};
 
   /** Maximum iteration limit. */
-  unsigned int m_MaximumIteration;
-  unsigned int m_MaximumLineIteration;
+  unsigned int m_MaximumIteration{100};
+  unsigned int m_MaximumLineIteration{100};
 
-  bool   m_CatchGetValueException;
-  double m_MetricWorstPossibleValue;
+  bool   m_CatchGetValueException{false};
+  double m_MetricWorstPossibleValue{0};
 
   /** The minimal size of search */
-  double m_StepLength;
-  double m_StepTolerance;
+  double m_StepLength{0};
+  double m_StepTolerance{0};
 
   ParametersType       m_LineOrigin;
   vnl_vector< double > m_LineDirection;
 
-  double m_ValueTolerance;
+  double m_ValueTolerance{0};
 
   /** Internal storage for the value type / used as a cache  */
   MeasureType m_CurrentCost;
@@ -230,7 +230,7 @@ private:
    * when users call StartOptimization, this value will be set false.
    * By calling StopOptimization, this flag will be set true, and
    * optimization will stop at the next iteration. */
-  bool m_Stop;
+  bool m_Stop{false};
 
   ParametersType m_CurrentPosition;
 

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -25,17 +25,9 @@ namespace itk
 template<typename TInternalComputationValueType>
 PowellOptimizerv4<TInternalComputationValueType>
 ::PowellOptimizerv4():
-  m_SpaceDimension(0),
-  m_CurrentLineIteration(0),
-  m_MaximumIteration(100),
-  m_MaximumLineIteration(100),
-  m_CatchGetValueException(false),
-  m_MetricWorstPossibleValue(0),
-  m_StepLength(0),
-  m_StepTolerance(0),
-  m_ValueTolerance(0),
-  m_CurrentCost(0),
-  m_Stop(false)
+
+  m_CurrentCost(0)
+
 {
   m_StopConditionDescription << this->GetNameOfClass() << ": ";
 }

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
@@ -123,7 +123,7 @@ public:
 protected:
 
   /** The maximum tolerable number of iteration without any progress */
-  SizeValueType m_MaximumIterationsWithoutProgress;
+  SizeValueType m_MaximumIterationsWithoutProgress{30};
 
   /** The information about the current step */
   ParametersType m_CurrentPosition;
@@ -136,7 +136,7 @@ protected:
   /** The best value so far and relevant information */
   MeasureType    m_BestValue;
   ParametersType m_BestPosition;
-  SizeValueType  m_BestIteration;
+  SizeValueType  m_BestIteration{0};
 
   /** The Quasi-Newton step */
   DerivativeType m_NewtonStep;

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -27,11 +27,11 @@ namespace itk
 template<typename TInternalComputationValueType>
 QuasiNewtonOptimizerv4Template<TInternalComputationValueType>
 ::QuasiNewtonOptimizerv4Template():
-  m_MaximumIterationsWithoutProgress(30),
+
   m_PreviousValue(0.0),
   m_BestValue(0.0),
-  m_BestPosition(0),
-  m_BestIteration(0)
+  m_BestPosition(0)
+
 {
   this->m_LearningRate = NumericTraits<TInternalComputationValueType>::OneValue();
 

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -61,7 +61,7 @@ LBFGSBOptimizerHelperv4
 
 LBFGSBOptimizerv4
   ::LBFGSBOptimizerv4():
-  m_MaximumNumberOfCorrections(5),
+
   m_InitialPosition(0),
   m_LowerBound(0),
   m_UpperBound(0),

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
@@ -22,10 +22,8 @@
 namespace itk
 {
 LBFGSOptimizerv4
-  ::LBFGSOptimizerv4():
-  m_Verbose(false),
-  m_LineSearchAccuracy(0.9),
-  m_DefaultStepLength(1.0)
+  ::LBFGSOptimizerv4()
+
 {
 }
 

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
@@ -192,15 +192,14 @@ public:
     }
 
 protected:
-  EventChecker(): m_HadStartEvent( false ),
-    m_HadIterationEvent( false ),
-    m_HadEndEvent( false )
+  EventChecker()
+
   {}
 
 private:
-  bool m_HadStartEvent;
-  bool m_HadIterationEvent;
-  bool m_HadEndEvent;
+  bool m_HadStartEvent{ false };
+  bool m_HadIterationEvent{ false };
+  bool m_HadEndEvent{ false };
 };
 
 

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -61,8 +61,8 @@ public:
   using DerivativeType = Superclass::DerivativeType;
   using MeasureType = Superclass::MeasureType;
 
-  MultiGradientOptimizerv4TestMetric() :
-    m_Parameters(nullptr)
+  MultiGradientOptimizerv4TestMetric()
+
   {}
 
   void Initialize() throw ( itk::ExceptionObject ) override {}
@@ -142,7 +142,7 @@ public:
 
 private:
 
-  ParametersPointer m_Parameters;
+  ParametersPointer m_Parameters{nullptr};
 };
 
 /** A second test metric with slightly different optimum */
@@ -166,8 +166,8 @@ public:
   using DerivativeType = Superclass::DerivativeType;
   using MeasureType = Superclass::MeasureType;
 
-  MultiGradientOptimizerv4TestMetric2() :
-    m_Parameters(nullptr)
+  MultiGradientOptimizerv4TestMetric2()
+
   {}
 
   void Initialize() throw ( itk::ExceptionObject ) override {}
@@ -247,7 +247,7 @@ public:
 
 private:
 
-  ParametersPointer m_Parameters;
+  ParametersPointer m_Parameters{nullptr};
 };
 
 ///////////////////////////////////////////////////////////

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
@@ -180,8 +180,8 @@ private:
   /** Target data sample pointer*/
   const TSample *m_Sample;
 
-  int m_MaxIteration;
-  int m_CurrentIteration;
+  int m_MaxIteration{100};
+  int m_CurrentIteration{0};
 
   TERMINATION_CODE     m_TerminationCode;
   ComponentVectorType  m_ComponentVector;

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
@@ -30,8 +30,7 @@ template< typename TSample >
 ExpectationMaximizationMixtureModelEstimator< TSample >
 ::ExpectationMaximizationMixtureModelEstimator() :
   m_Sample(nullptr),
-  m_MaxIteration(100),
-  m_CurrentIteration(0),
+
   m_TerminationCode(NOT_CONVERGED),
   m_MembershipFunctionsObject           (MembershipFunctionVectorObjectType::New()),
   m_MembershipFunctionsWeightArrayObject(MembershipFunctionsWeightsArrayObjectType::New())

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -473,7 +473,7 @@ private:
   using OffsetTableType = std::vector< InstanceIdentifier >;
   OffsetTableType           m_OffsetTable;
   FrequencyContainerPointer m_FrequencyContainer;
-  unsigned int              m_NumberOfInstances;
+  unsigned int              m_NumberOfInstances{0};
 
   // This method is provided here just to avoid a "hidden" warning
   // related to the virtual method available in DataObject.
@@ -488,7 +488,7 @@ private:
   mutable MeasurementVectorType m_TempMeasurementVector;
   mutable IndexType             m_TempIndex;
 
-  bool m_ClipBinsAtEnds;
+  bool m_ClipBinsAtEnds{true};
 };
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -31,9 +31,8 @@ Histogram< TMeasurement, TFrequencyContainer >
 ::Histogram() :
   m_Size(0),
   m_OffsetTable(OffsetTableType(Superclass::GetMeasurementVectorSize() + 1)),
-  m_FrequencyContainer(FrequencyContainerType::New()),
-  m_NumberOfInstances(0),
-  m_ClipBinsAtEnds(true)
+  m_FrequencyContainer(FrequencyContainerType::New())
+
 {
   for ( unsigned int i = 0; i < this->GetMeasurementVectorSize() + 1; i++ )
     {

--- a/Modules/Numerics/Statistics/include/itkHistogramToEntropyImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToEntropyImageFilter.h
@@ -62,8 +62,8 @@ public:
   // Returns pixels of float..
   using OutputPixelType = TOutput;
 
-  HistogramEntropyFunction():
-    m_TotalFrequency(1) {}
+  HistogramEntropyFunction()
+    {}
 
   ~HistogramEntropyFunction() = default;
 
@@ -94,7 +94,7 @@ public:
   }
 
 private:
-  SizeValueType m_TotalFrequency;
+  SizeValueType m_TotalFrequency{1};
 };
 }
 

--- a/Modules/Numerics/Statistics/include/itkHistogramToIntensityImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToIntensityImageFilter.h
@@ -46,8 +46,8 @@ public:
   //Intensity function returns pixels of SizeValueType.
   using OutputPixelType = TOutput;
 
-  HistogramIntensityFunction():
-    m_TotalFrequency(1) {}
+  HistogramIntensityFunction()
+    {}
 
   ~HistogramIntensityFunction() = default;
 
@@ -67,7 +67,7 @@ public:
   }
 
 private:
-  SizeValueType m_TotalFrequency;
+  SizeValueType m_TotalFrequency{1};
 };
 }
 

--- a/Modules/Numerics/Statistics/include/itkHistogramToLogProbabilityImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToLogProbabilityImageFilter.h
@@ -57,8 +57,8 @@ public:
   // Returns pixels of float..
   using OutputPixelType = TOutput;
 
-  HistogramLogProbabilityFunction():
-    m_TotalFrequency(1) {}
+  HistogramLogProbabilityFunction()
+    {}
 
   ~HistogramLogProbabilityFunction() = default;
 
@@ -89,7 +89,7 @@ public:
   }
 
 private:
-  SizeValueType m_TotalFrequency;
+  SizeValueType m_TotalFrequency{1};
 };
 }
 

--- a/Modules/Numerics/Statistics/include/itkHistogramToProbabilityImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToProbabilityImageFilter.h
@@ -57,8 +57,8 @@ public:
   // Returns pixels of float..
   using OutputPixelType = TOutput;
 
-  HistogramProbabilityFunction():
-    m_TotalFrequency(1) {}
+  HistogramProbabilityFunction()
+    {}
 
   ~HistogramProbabilityFunction() = default;
 
@@ -79,7 +79,7 @@ public:
   }
 
 private:
-  SizeValueType m_TotalFrequency;
+  SizeValueType m_TotalFrequency{1};
 };
 }
 

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
@@ -309,7 +309,7 @@ private:
   mutable IndexType                  m_NeighborIndexInternal;
   NeighborhoodRadiusType             m_Radius;
   RegionType                         m_Region;
-  bool                               m_UseImageRegion;
+  bool                               m_UseImageRegion{true};
   OffsetTableType                    m_OffsetTable;
 
 }; // end of class ImageToNeighborhoodSampleAdaptor

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -27,8 +27,8 @@ namespace Statistics {
 ImageToNeighborhoodSampleAdaptor< TImage, TBoundaryCondition>
   ::ImageToNeighborhoodSampleAdaptor() :
     m_Image(nullptr),
-    m_InstanceIdentifierInternal(0),
-    m_UseImageRegion(true)
+    m_InstanceIdentifierInternal(0)
+
 {
   m_Radius.Fill(0);
   m_NeighborIndexInternal.Fill(0);

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
@@ -172,7 +172,7 @@ protected:
   class CandidateVector
   {
 public:
-    CandidateVector() : m_MeasurementVectorSize(0) {}
+    CandidateVector()  {}
 
     struct Candidate {
       CentroidType Centroid;
@@ -249,7 +249,7 @@ private:
     std::vector< Candidate > m_Candidates;
 
     /** Length of each measurement vector */
-    MeasurementVectorSizeType m_MeasurementVectorSize;
+    MeasurementVectorSizeType m_MeasurementVectorSize{0};
   };  // end of class
 
   /** gets the sum of squared difference between the previous position
@@ -294,14 +294,14 @@ private:
 
 private:
   /** current number of iteration */
-  int m_CurrentIteration;
+  int m_CurrentIteration{0};
   /** maximum number of iteration. termination criterion */
-  int m_MaximumIteration;
+  int m_MaximumIteration{100};
   /** sum of squared centroid position changes at the current iteration */
-  double m_CentroidPositionChanges;
+  double m_CentroidPositionChanges{0.0};
   /** threshold for the sum of squared centroid position changes.
    * termination criterion */
-  double m_CentroidPositionChangesThreshold;
+  double m_CentroidPositionChangesThreshold{0.0};
   /** pointer to the k-d tree */
   typename TKdTree::Pointer m_KdTree;
   /** pointer to the euclidean distance function */
@@ -314,10 +314,10 @@ private:
 
   ParameterType m_TempVertex;
 
-  bool                                  m_UseClusterLabels;
-  bool                                  m_GenerateClusterLabels;
+  bool                                  m_UseClusterLabels{false};
+  bool                                  m_GenerateClusterLabels{false};
   ClusterLabelsType                     m_ClusterLabels;
-  MeasurementVectorSizeType             m_MeasurementVectorSize;
+  MeasurementVectorSizeType             m_MeasurementVectorSize{0};
   MembershipFunctionVectorObjectPointer m_MembershipFunctionsObject;
 };  // end of class
 } // end of namespace Statistics

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -28,15 +28,10 @@ namespace Statistics
 template< typename TKdTree >
 KdTreeBasedKmeansEstimator< TKdTree >
 ::KdTreeBasedKmeansEstimator() :
-  m_CurrentIteration(0),
-  m_MaximumIteration(100),
-  m_CentroidPositionChanges(0.0),
-  m_CentroidPositionChangesThreshold(0.0),
+
   m_KdTree(nullptr),
   m_DistanceMetric(EuclideanDistanceMetric< ParameterType >::New()),
-  m_UseClusterLabels(false),
-  m_GenerateClusterLabels(false),
-  m_MeasurementVectorSize(0),
+
   m_MembershipFunctionsObject(MembershipFunctionVectorObjectType::New())
 {
   m_TempVertex.Fill(0.0);

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
@@ -122,8 +122,8 @@ private:
   // when covariace matirx is set.  This speed up the GetProbability()
   CovarianceMatrixType m_InverseCovariance;
 
-  double m_Epsilon;
-  double m_DoubleMax;
+  double m_Epsilon{1e-100};
+  double m_DoubleMax{1e+20};
 
   void CalculateInverseCovariance();
 };

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
@@ -26,9 +26,8 @@ namespace Statistics
 {
 template< typename TVector >
 MahalanobisDistanceMetric< TVector >
-::MahalanobisDistanceMetric():
-  m_Epsilon(1e-100),
-  m_DoubleMax(1e+20)
+::MahalanobisDistanceMetric()
+
 {
   MeasurementVectorSizeType size;
 

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
@@ -119,7 +119,7 @@ protected:
 
 private:
   DistanceMapPointer m_DistanceMap;
-  bool               m_ComputeSquaredDistance;
+  bool               m_ComputeSquaredDistance{ false };
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
@@ -26,8 +26,8 @@ namespace itk
 
 template< typename TFixedPointSet, typename TMovingPointSet, typename TDistanceMap >
 EuclideanDistancePointMetric< TFixedPointSet, TMovingPointSet, TDistanceMap >
-::EuclideanDistancePointMetric() :
-  m_ComputeSquaredDistance( false )
+::EuclideanDistancePointMetric()
+
 {
 
 }

--- a/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.h
@@ -75,8 +75,8 @@ protected:
 private:
   ScalarType          m_GaussianSmoothingVarianceForTheConstantVelocityField;
   ScalarType          m_GaussianSmoothingVarianceForTheUpdateField;
-  ModifiedTimeType    m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime;
-  ModifiedTimeType    m_GaussianSmoothingVarianceForTheUpdateFieldSetTime;
+  ModifiedTimeType    m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime{ 0 };
+  ModifiedTimeType    m_GaussianSmoothingVarianceForTheUpdateFieldSetTime{ 0 };
 
 }; //class GaussianExponentialDiffeomorphicTransformParametersAdaptor
 }  // namespace itk

--- a/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
@@ -28,9 +28,8 @@ template<typename TTransform>
 GaussianExponentialDiffeomorphicTransformParametersAdaptor<TTransform>
 ::GaussianExponentialDiffeomorphicTransformParametersAdaptor() :
   m_GaussianSmoothingVarianceForTheConstantVelocityField( 0.5 ),
-  m_GaussianSmoothingVarianceForTheUpdateField( 1.75 ),
-  m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime( 0 ),
-  m_GaussianSmoothingVarianceForTheUpdateFieldSetTime( 0 )
+  m_GaussianSmoothingVarianceForTheUpdateField( 1.75 )
+
 {
 }
 

--- a/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.h
@@ -76,8 +76,8 @@ private:
   ScalarType          m_GaussianSmoothingVarianceForTheUpdateField;
   ScalarType          m_GaussianSmoothingVarianceForTheTotalField;
 
-  ModifiedTimeType    m_GaussianSmoothingVarianceForTheUpdateFieldSetTime;
-  ModifiedTimeType    m_GaussianSmoothingVarianceForTheTotalFieldSetTime;
+  ModifiedTimeType    m_GaussianSmoothingVarianceForTheUpdateFieldSetTime{ 0 };
+  ModifiedTimeType    m_GaussianSmoothingVarianceForTheTotalFieldSetTime{ 0 };
 
 }; //class GaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor
 }  // namespace itk

--- a/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -28,9 +28,8 @@ template<typename TTransform>
 GaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>
 ::GaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor() :
   m_GaussianSmoothingVarianceForTheUpdateField( 1.75 ),
-  m_GaussianSmoothingVarianceForTheTotalField( 0.5 ),
-  m_GaussianSmoothingVarianceForTheUpdateFieldSetTime( 0 ),
-  m_GaussianSmoothingVarianceForTheTotalFieldSetTime( 0 )
+  m_GaussianSmoothingVarianceForTheTotalField( 0.5 )
+
 {
 }
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -339,10 +339,10 @@ public:
     unsigned int        valueIndex;
   };
 
-  bool                     m_UseFixedImageIndexes;
+  bool                     m_UseFixedImageIndexes{false};
   FixedImageIndexContainer m_FixedImageIndexes;
 
-  bool                m_UseFixedImageSamplesIntensityThreshold;
+  bool                m_UseFixedImageSamplesIntensityThreshold{false};
   FixedImagePixelType m_FixedImageSamplesIntensityThreshold;
 
   /** FixedImageSamplePoint type alias support */
@@ -360,13 +360,13 @@ public:
   /** Container to store a set of points and fixed image values. */
   FixedImageSampleContainer m_FixedImageSamples;
 
-  SizeValueType          m_NumberOfParameters;
+  SizeValueType          m_NumberOfParameters{0};
 
-  SizeValueType m_NumberOfFixedImageSamples;
+  SizeValueType m_NumberOfFixedImageSamples{50000};
   //m_NumberOfPixelsCounted must be mutable because the const
   //thread consolidation functions merge each work unit's values
   //onto this accumulator variable.
-  mutable SizeValueType m_NumberOfPixelsCounted;
+  mutable SizeValueType m_NumberOfPixelsCounted{0};
 
   FixedImageConstPointer  m_FixedImage;
   MovingImageConstPointer m_MovingImage;
@@ -379,18 +379,18 @@ public:
 
   InterpolatorPointer m_Interpolator;
 
-  bool                 m_ComputeGradient;
+  bool                 m_ComputeGradient{true};
   GradientImagePointer m_GradientImage;
 
   FixedImageMaskConstPointer  m_FixedImageMask;
   MovingImageMaskConstPointer m_MovingImageMask;
 
-  ThreadIdType m_NumberOfWorkUnits;
+  ThreadIdType m_NumberOfWorkUnits{1};
 
-  bool m_UseAllPixels;
-  bool m_UseSequentialSampling;
+  bool m_UseAllPixels{false};
+  bool m_UseSequentialSampling{false};
 
-  bool m_ReseedIterator;
+  bool m_ReseedIterator{false};
 
   mutable int m_RandomSeed;
 
@@ -401,11 +401,11 @@ public:
     * of a mapped point.  */
 
   /** Boolean to indicate if the transform is BSpline deformable. */
-  bool m_TransformIsBSpline;
+  bool m_TransformIsBSpline{false};
 
   /** The number of BSpline transform weights is the number of
     * of parameter in the support region (per dimension ). */
-  SizeValueType m_NumBSplineWeights;
+  SizeValueType m_NumBSplineWeights{0};
 
   static constexpr unsigned int DeformationSplineOrder = 3;
 
@@ -448,7 +448,7 @@ public:
 
   // Variables needed for optionally caching values when using a BSpline
   // transform.
-  bool                                   m_UseCachingOfBSplineWeights;
+  bool                                   m_UseCachingOfBSplineWeights{true};
   mutable BSplineTransformWeightsType    m_BSplineTransformWeights;
   mutable BSplineTransformIndexArrayType m_BSplineTransformIndices;
 
@@ -473,7 +473,7 @@ public:
                                              ThreadIdType threadId) const;
 
   /** Boolean to indicate if the interpolator BSpline. */
-  bool m_InterpolatorIsBSpline;
+  bool m_InterpolatorIsBSpline{false};
   /** Pointer to BSplineInterpolator. */
   typename BSplineInterpolatorType::Pointer m_BSplineInterpolator;
 
@@ -495,9 +495,9 @@ public:
 
   MultiThreaderType::Pointer m_Threader;
   MultiThreaderParameterType m_ThreaderParameter;
-  mutable unsigned int *     m_ThreaderNumberOfMovingImageSamples;
-  bool                       m_WithinThreadPreProcess;
-  bool                       m_WithinThreadPostProcess;
+  mutable unsigned int *     m_ThreaderNumberOfMovingImageSamples{nullptr};
+  bool                       m_WithinThreadPreProcess{false};
+  bool                       m_WithinThreadPostProcess{false};
 
   void                           GetValueMultiThreadedPreProcessInitiate() const;
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -30,64 +30,31 @@ namespace itk
 template< typename TFixedImage, typename TMovingImage >
 ImageToImageMetric< TFixedImage, TMovingImage >
 ::ImageToImageMetric():
-  m_UseFixedImageIndexes(false),
   m_FixedImageIndexes(0),
-
-  m_UseFixedImageSamplesIntensityThreshold(false),
   m_FixedImageSamplesIntensityThreshold(0),
-
   m_FixedImageSamples(0),
-  m_NumberOfParameters(0),
-
-  m_NumberOfFixedImageSamples(50000),
-
-  m_NumberOfPixelsCounted(0),
-
   m_FixedImage(nullptr), // has to be provided by the user.
   m_MovingImage(nullptr), // has to be provided by the user.
-
   m_Transform(nullptr), // has to be provided by the user.
   m_ThreaderTransform(nullptr), // constructed at initialization.
-
-  m_Interpolator(nullptr), // has to be provided by the user.
-
-  m_ComputeGradient(true), // metric computes gradient by default
+  m_Interpolator(nullptr),  // metric computes gradient by default
   m_GradientImage(nullptr),   // computed at initialization
-
   m_FixedImageMask(nullptr),
   m_MovingImageMask(nullptr),
-
-  m_NumberOfWorkUnits(1),
-
-  m_UseAllPixels(false),
-  m_UseSequentialSampling(false),
-  m_ReseedIterator(false),
   m_RandomSeed(Statistics::MersenneTwisterRandomVariateGenerator::GetNextSeed()),
-
-  m_TransformIsBSpline(false),
-  m_NumBSplineWeights(0),
-
   m_BSplineTransform(nullptr),
   m_BSplineTransformWeightsArray(),
   m_BSplineTransformIndicesArray(),
   m_BSplinePreTransformPointsArray(0),
   m_WithinBSplineSupportRegionArray(0),
   m_BSplineParametersOffset(),
-
-  m_UseCachingOfBSplineWeights(true),
   m_BSplineTransformWeights(),
   m_BSplineTransformIndices(),
   m_ThreaderBSplineTransformWeights(nullptr),
   m_ThreaderBSplineTransformIndices(nullptr),
-
-  m_InterpolatorIsBSpline(false),
   m_BSplineInterpolator(nullptr),
   m_DerivativeCalculator(nullptr),
-
-  m_Threader(MultiThreaderType::New()),
-  m_ThreaderNumberOfMovingImageSamples(nullptr),
-  m_WithinThreadPreProcess(false),
-  m_WithinThreadPostProcess(false)
+  m_Threader(MultiThreaderType::New())
 {
   this->m_ThreaderParameter.metric = this;
   this->m_NumberOfWorkUnits = this->m_Threader->GetNumberOfWorkUnits();

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
@@ -170,7 +170,7 @@ protected:
 
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
-  MeasureType              m_MatchMeasure;
+  MeasureType              m_MatchMeasure{0};
   DerivativeType           m_MatchMeasureDerivatives;
   mutable TransformPointer m_Transform;
   InterpolatorPointer      m_Interpolator;

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
@@ -25,8 +25,8 @@ namespace itk
 /** Constructor */
 template< typename TFixedImage, typename TMovingSpatialObject >
 ImageToSpatialObjectMetric< TFixedImage, TMovingSpatialObject >
-::ImageToSpatialObjectMetric():
-  m_MatchMeasure(0)
+::ImageToSpatialObjectMetric()
+
 {
   m_FixedImage          = nullptr; // has to be provided by the user.
   m_MovingSpatialObject = nullptr; // has to be provided by the user.

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.h
@@ -127,7 +127,7 @@ protected:
 
 private:
   RealType m_ForegroundValue;
-  bool     m_Complement;
+  bool     m_Complement{ false };
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -28,8 +28,8 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage>
 KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>
 ::KappaStatisticImageToImageMetric() :
-  m_ForegroundValue( 255 ),
-  m_Complement( false )
+  m_ForegroundValue( 255 )
+
 {
   this->SetComputeGradient(true);
 }

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
@@ -202,7 +202,7 @@ private:
   LandmarkPointContainer m_MovingLandmarks;
   /** weights for affine landmarks */
   LandmarkWeightType     m_LandmarkWeight;
-  unsigned int           m_BSplineNumberOfControlPoints;
+  unsigned int           m_BSplineNumberOfControlPoints{4};
 
 }; //class LandmarkBasedTransformInitializer
 }  // namespace itk

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -34,8 +34,8 @@ LandmarkBasedTransformInitializer< TTransform, TFixedImage, TMovingImage >
   m_Transform(nullptr),
   m_FixedLandmarks(0),
   m_MovingLandmarks(0),
-  m_LandmarkWeight(0),
-  m_BSplineNumberOfControlPoints(4)
+  m_LandmarkWeight(0)
+
 {}
 
 /** default transform initializer, if transform type isn't

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -291,15 +291,15 @@ private:
                                                                movingImageGradientValue) const override;
 
   /** Variables to define the marginal and joint histograms. */
-  SizeValueType m_NumberOfHistogramBins;
-  PDFValueType  m_MovingImageNormalizedMin;
-  PDFValueType  m_FixedImageNormalizedMin;
-  PDFValueType  m_FixedImageTrueMin;
-  PDFValueType  m_FixedImageTrueMax;
-  PDFValueType  m_MovingImageTrueMin;
-  PDFValueType  m_MovingImageTrueMax;
-  PDFValueType  m_FixedImageBinSize;
-  PDFValueType  m_MovingImageBinSize;
+  SizeValueType m_NumberOfHistogramBins{50};
+  PDFValueType  m_MovingImageNormalizedMin{0.0};
+  PDFValueType  m_FixedImageNormalizedMin{0.0};
+  PDFValueType  m_FixedImageTrueMin{0.0};
+  PDFValueType  m_FixedImageTrueMax{0.0};
+  PDFValueType  m_MovingImageTrueMin{0.0};
+  PDFValueType  m_MovingImageTrueMax{0.0};
+  PDFValueType  m_FixedImageBinSize{0.0};
+  PDFValueType  m_MovingImageBinSize{0.0};
 
   /** Cubic BSpline kernel for computing Parzen histograms. */
   typename CubicBSplineFunctionType::Pointer           m_CubicBSplineKernel;
@@ -347,8 +347,8 @@ private:
   mutable AlignedMMIMetricPerThreadStruct * m_MMIMetricPerThreadVariables;
 #endif
 
-  bool         m_UseExplicitPDFDerivatives;
-  mutable bool m_ImplicitDerivativesSecondPass;
+  bool         m_UseExplicitPDFDerivatives{true};
+  mutable bool m_ImplicitDerivativesSecondPass{false};
 };
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -35,15 +35,7 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage>
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>
 ::MattesMutualInformationImageToImageMetric() :
-  m_NumberOfHistogramBins(50),
-  m_MovingImageNormalizedMin(0.0),
-  m_FixedImageNormalizedMin(0.0),
-  m_FixedImageTrueMin(0.0),
-  m_FixedImageTrueMax(0.0),
-  m_MovingImageTrueMin(0.0),
-  m_MovingImageTrueMax(0.0),
-  m_FixedImageBinSize(0.0),
-  m_MovingImageBinSize(0.0),
+
 
   m_CubicBSplineKernel(nullptr),
   m_CubicBSplineDerivativeKernel(nullptr),
@@ -53,10 +45,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>
   // Initialize memory
   m_MovingImageMarginalPDF(0),
 
-  m_MMIMetricPerThreadVariables(nullptr),
+  m_MMIMetricPerThreadVariables(nullptr)
 
-  m_UseExplicitPDFDerivatives(true),
-  m_ImplicitDerivativesSecondPass(false)
 {
   this->SetComputeGradient(false); // don't use the default gradient for now
   this->m_WithinThreadPreProcess = true;

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
@@ -193,13 +193,13 @@ private:
   class SpatialSample
   {
 public:
-    SpatialSample():FixedImageValue(0.0), MovingImageValue(0.0)
+    SpatialSample()
     { FixedImagePointValue.Fill(0.0); }
     ~SpatialSample()= default;
 
     FixedImagePointType FixedImagePointValue;
-    double              FixedImageValue;
-    double              MovingImageValue;
+    double              FixedImageValue{0.0};
+    double              MovingImageValue{0.0};
   };
 
   /** SpatialSampleContainer type alias support */

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
@@ -124,7 +124,7 @@ private:
   CoordRepType                               m_PointSetSigma;
   MeasureType                                m_PreFactor;
   MeasureType                                m_Denominator;
-  unsigned int                               m_EvaluationKNeighborhood;
+  unsigned int                               m_EvaluationKNeighborhood{ 50 };
 
 };
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
@@ -29,8 +29,8 @@ ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
 ::ExpectationBasedPointSetToPointSetMetricv4() :
   m_PointSetSigma( 1.0 ),
   m_PreFactor( 0.0 ),
-  m_Denominator( 0.0 ),
-  m_EvaluationKNeighborhood( 50 )
+  m_Denominator( 0.0 )
+
 {
 }
 

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
@@ -228,7 +228,7 @@ private:
   DensityFunctionPointer                   m_MovingDensityFunction;
   DensityFunctionPointer                   m_FixedDensityFunction;
 
-  bool                                     m_UseAnisotropicCovariances;
+  bool                                     m_UseAnisotropicCovariances{ false };
 
   RealType                                 m_PointSetSigma;
   RealType                                 m_KernelSigma;

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -27,7 +27,7 @@ namespace itk {
 template<typename TPointSet, class TInternalComputationValueType>
 JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputationValueType>
 ::JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4() :
-  m_UseAnisotropicCovariances( false ),
+
   m_PointSetSigma( static_cast<RealType>( 1.0 ) ),
   m_KernelSigma( static_cast<RealType>( 10.0 ) ),
   m_CovarianceKNeighborhood( static_cast<unsigned int>( 5 ) ),

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.h
@@ -186,7 +186,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Count of the number of valid histogram points. */
-  SizeValueType   m_JointHistogramTotalCount;
+  SizeValueType   m_JointHistogramTotalCount{0};
 
 private:
   /** The fixed image marginal PDF */

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -28,8 +28,8 @@ namespace itk
 
 template <typename TFixedImage, typename TMovingImage, typename TVirtualImage, typename TInternalComputationValueType, typename TMetricTraits>
 JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,TMovingImage,TVirtualImage,TInternalComputationValueType, TMetricTraits>
-::JointHistogramMutualInformationImageToImageMetricv4():
-  m_JointHistogramTotalCount(0)
+::JointHistogramMutualInformationImageToImageMetricv4()
+
 {
   // Initialize histogram properties
   this->m_NumberOfHistogramBins = 20;

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -186,14 +186,14 @@ protected:
 private:
   typename PointsLocatorType::Pointer           m_PointsLocator;
 
-  unsigned int                                  m_CovarianceKNeighborhood;
-  unsigned int                                  m_EvaluationKNeighborhood;
+  unsigned int                                  m_CovarianceKNeighborhood{ 5 };
+  unsigned int                                  m_EvaluationKNeighborhood{ 50 };
   RealType                                      m_RegularizationSigma;
   RealType                                      m_KernelSigma;
 
   GaussianContainerType                         m_Gaussians;
-  bool                                          m_Normalize;
-  bool                                          m_UseAnisotropicCovariances;
+  bool                                          m_Normalize{ true };
+  bool                                          m_UseAnisotropicCovariances{ true };
 };
 
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -29,12 +29,10 @@ template <typename TPointSet, typename TOutput, typename TCoordRep>
 ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>
 ::ManifoldParzenWindowsPointSetFunction() :
   m_PointsLocator( nullptr ),
-  m_CovarianceKNeighborhood( 5 ),
-  m_EvaluationKNeighborhood( 50 ),
+
   m_RegularizationSigma( 1.0 ),
-  m_KernelSigma( 1.0 ),
-  m_Normalize( true ),
-  m_UseAnisotropicCovariances( true )
+  m_KernelSigma( 1.0 )
+
 {
 }
 

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
@@ -225,7 +225,7 @@ protected:
   OffsetValueType ComputeSingleFixedImageParzenWindowIndex( const FixedImagePixelType & value ) const;
 
   /** Variables to define the marginal and joint histograms. */
-  SizeValueType m_NumberOfHistogramBins;
+  SizeValueType m_NumberOfHistogramBins{50};
   PDFValueType  m_MovingImageNormalizedMin;
   PDFValueType  m_FixedImageNormalizedMin;
   PDFValueType  m_FixedImageTrueMin;
@@ -281,7 +281,7 @@ public:
     void DoubleBufferSize();
 
     DerivativeBufferManager() :
-      m_CurrentFillSize(0),
+
       m_MemoryBlock(0)
     {
     }
@@ -321,7 +321,7 @@ public:
 
 private:
     // How many AccumlatorElements used
-    size_t                       m_CurrentFillSize;
+    size_t                       m_CurrentFillSize{0};
     // Continguous chunk of memory for efficiency
     std::vector<PDFValueType>    m_MemoryBlock;
     // The (number of lines in the buffer) * (cells per line)

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -28,7 +28,7 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage, typename TVirtualImage, typename TInternalComputationValueType, typename TMetricTraits>
 MattesMutualInformationImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputationValueType, TMetricTraits>
 ::MattesMutualInformationImageToImageMetricv4() :
-  m_NumberOfHistogramBins(50),
+
   m_MovingImageNormalizedMin(0.0),
   m_FixedImageNormalizedMin(0.0),
   m_FixedImageTrueMin(0.0),

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
@@ -115,8 +115,8 @@ public:
 
 protected:
   JointPDFStatus() :
-    m_MIMetric( nullptr ),
-    m_Count( 0 )
+    m_MIMetric( nullptr )
+
     {
     this->m_Writer = WriterType::New();
     }
@@ -124,7 +124,7 @@ protected:
 private:
   const MIMetricType * m_MIMetric;
 
-  unsigned int m_Count;
+  unsigned int m_Count{ 0 };
   std::string  m_OutputFileNameBase;
 
   using WriterType = typename itk::ImageFileWriter< typename MIMetricType::JointPDFType >;

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
@@ -204,7 +204,7 @@ private:
   FieldExponentiatorPointer m_Exponentiator;
   VectorWarperPointer       m_Warper;
   AdderPointer              m_Adder;
-  bool                      m_UseFirstOrderExp;
+  bool                      m_UseFirstOrderExp{false};
 };
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
@@ -28,8 +28,8 @@ namespace itk
  */
 template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 DiffeomorphicDemonsRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
-::DiffeomorphicDemonsRegistrationFilter():
-  m_UseFirstOrderExp(false)
+::DiffeomorphicDemonsRegistrationFilter()
+
 {
   typename DemonsRegistrationFunctionType::Pointer drfp;
   drfp = DemonsRegistrationFunctionType::New();

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
@@ -230,7 +230,7 @@ protected:
   OutputTransformPointer                                          m_FixedToMiddleTransform;
 
   RealType                                                        m_ConvergenceThreshold;
-  unsigned int                                                    m_ConvergenceWindowSize;
+  unsigned int                                                    m_ConvergenceWindowSize{ 10 };
 
   NumberOfIterationsArrayType                                     m_NumberOfIterationsPerLevel;
   bool                                                            m_DownsampleImagesForMetricDerivatives;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -40,7 +40,7 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
 ::SyNImageRegistrationMethod() :
   m_LearningRate( 0.25 ),
   m_ConvergenceThreshold( 1.0e-6 ),
-  m_ConvergenceWindowSize( 10 ),
+
   m_GaussianSmoothingVarianceForTheUpdateField( 3.0 ),
   m_GaussianSmoothingVarianceForTheTotalField( 0.5 )
 {

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
@@ -227,11 +227,11 @@ private:
   RealType                                            m_LearningRate;
 
   RealType                                            m_ConvergenceThreshold;
-  unsigned int                                        m_ConvergenceWindowSize;
+  unsigned int                                        m_ConvergenceWindowSize{ 10 };
 
   NumberOfIterationsArrayType                         m_NumberOfIterationsPerLevel;
 
-  SizeValueType                                       m_NumberOfTimePointSamples;
+  SizeValueType                                       m_NumberOfTimePointSamples{ 4 };
 
   WeightsElementType                                  m_BoundaryWeight;
 };

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -43,8 +43,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage, TMovingImage
 ::TimeVaryingBSplineVelocityFieldImageRegistrationMethod() :
   m_LearningRate( 0.25 ),
   m_ConvergenceThreshold( 1.0e-7 ),
-  m_ConvergenceWindowSize( 10 ),
-  m_NumberOfTimePointSamples( 4 ),
+
   m_BoundaryWeight( 1e10 )
 {
   this->m_NumberOfIterationsPerLevel.SetSize( 3 );

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.h
@@ -173,7 +173,7 @@ private:
   RealType                                                        m_LearningRate;
 
   RealType                                                        m_ConvergenceThreshold;
-  unsigned int                                                    m_ConvergenceWindowSize;
+  unsigned int                                                    m_ConvergenceWindowSize{ 10 };
 
   NumberOfIterationsArrayType                                     m_NumberOfIterationsPerLevel;
 };

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -40,8 +40,8 @@ template<typename TFixedImage, typename TMovingImage, typename TOutputTransform,
 TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage, TMovingImage, TOutputTransform, TVirtualImage, TPointSet>
 ::TimeVaryingVelocityFieldImageRegistrationMethodv4() :
   m_LearningRate( 0.25 ),
-  m_ConvergenceThreshold( 1.0e-7 ),
-  m_ConvergenceWindowSize( 10 )
+  m_ConvergenceThreshold( 1.0e-7 )
+
 {
   this->m_NumberOfIterationsPerLevel.SetSize( 3 );
   this->m_NumberOfIterationsPerLevel[0] = 20;

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.h
@@ -230,13 +230,13 @@ protected:
 private:
 
 
-  bool m_UserProvidedPriors;
+  bool m_UserProvidedPriors{ false };
 
-  bool m_UserProvidedSmoothingFilter;
+  bool m_UserProvidedSmoothingFilter{ false };
 
   SmoothingFilterPointer m_SmoothingFilter;
 
-  unsigned int m_NumberOfSmoothingIterations;
+  unsigned int m_NumberOfSmoothingIterations{ 0 };
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -39,10 +39,9 @@ template< typename TInputVectorImage, typename TLabelsType,
 BayesianClassifierImageFilter< TInputVectorImage, TLabelsType,
                                TPosteriorsPrecisionType, TPriorsPrecisionType >
 ::BayesianClassifierImageFilter() :
-  m_UserProvidedPriors( false ),
-  m_UserProvidedSmoothingFilter( false ),
-  m_SmoothingFilter( nullptr ),
-  m_NumberOfSmoothingIterations( 0 )
+
+  m_SmoothingFilter( nullptr )
+
 {
   this->SetNumberOfRequiredOutputs( 2 );
   PosteriorsImagePointer p =

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.h
@@ -176,8 +176,8 @@ protected:
   void GenerateData() override;
 
 private:
-  bool         m_UserSuppliesMembershipFunctions;
-  unsigned int m_NumberOfClasses;
+  bool         m_UserSuppliesMembershipFunctions{false};
+  unsigned int m_NumberOfClasses{0};
 
   typename MembershipFunctionContainerType::Pointer m_MembershipFunctionContainer;
 };

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -37,9 +37,8 @@ namespace itk
 {
 template< typename TInputImage, typename TProbabilityPrecisionType >
 BayesianClassifierInitializationImageFilter< TInputImage, TProbabilityPrecisionType >
-::BayesianClassifierInitializationImageFilter():
-  m_UserSuppliesMembershipFunctions(false),
-  m_NumberOfClasses(0)
+::BayesianClassifierInitializationImageFilter()
+
 {
   m_MembershipFunctionContainer = nullptr;
 }

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
@@ -142,7 +142,7 @@ private:
 
   MatrixType  m_NumberOfSamples;
   MatrixType  m_Means;
-  MatrixType *m_Covariance;
+  MatrixType *m_Covariance{nullptr};
 
   TrainingImagePointer m_TrainingImage;
 

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
@@ -28,8 +28,8 @@ template< typename TInputImage,
           typename TMembershipFunction,
           typename TTrainingImage >
 ImageGaussianModelEstimator< TInputImage, TMembershipFunction, TTrainingImage >
-::ImageGaussianModelEstimator(void):
-  m_Covariance(nullptr)
+::ImageGaussianModelEstimator(void)
+
 {}
 
 template< typename TInputImage,

--- a/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.h
@@ -138,7 +138,7 @@ protected:
 
 private:
 
-  unsigned int m_NumberOfModels;
+  unsigned int m_NumberOfModels{0};
 
   /** Container to hold the membership functions */
   MembershipFunctionPointerVector m_MembershipFunctions;

--- a/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.hxx
@@ -26,8 +26,8 @@ namespace itk
 template< typename TInputImage,
           typename TMembershipFunction >
 ImageModelEstimatorBase< TInputImage, TMembershipFunction >
-::ImageModelEstimatorBase(void):
-  m_NumberOfModels(0)
+::ImageModelEstimatorBase(void)
+
 {}
 
 template< typename TInputImage,

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
@@ -174,11 +174,11 @@ private:
 
   ParametersType m_FinalMeans;
 
-  bool m_UseNonContiguousLabels;
+  bool m_UseNonContiguousLabels{ false };
 
   ImageRegionType m_ImageRegion;
 
-  bool m_ImageRegionDefined;
+  bool m_ImageRegionDefined{ false };
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
@@ -29,9 +29,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 ScalarImageKmeansImageFilter< TInputImage, TOutputImage >
-::ScalarImageKmeansImageFilter() :
-  m_UseNonContiguousLabels( false ),
-  m_ImageRegionDefined( false )
+::ScalarImageKmeansImageFilter()
+
 {
 }
 

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
@@ -248,10 +248,8 @@ public:
 
 protected:
 
-  RelabelComponentImageFilter():
-    m_NumberOfObjects(0), m_NumberOfObjectsToPrint(10),
-    m_OriginalNumberOfObjects(0), m_MinimumObjectSize(0),
-    m_SortByObjectSize(true)
+  RelabelComponentImageFilter()
+
   { this->InPlaceOff(); }
   ~RelabelComponentImageFilter() override = default;
 
@@ -304,11 +302,11 @@ protected:
 
 private:
 
-  LabelType      m_NumberOfObjects;
-  LabelType      m_NumberOfObjectsToPrint;
-  LabelType      m_OriginalNumberOfObjects;
-  ObjectSizeType m_MinimumObjectSize;
-  bool           m_SortByObjectSize;
+  LabelType      m_NumberOfObjects{0};
+  LabelType      m_NumberOfObjectsToPrint{10};
+  LabelType      m_OriginalNumberOfObjects{0};
+  ObjectSizeType m_MinimumObjectSize{0};
+  bool           m_SortByObjectSize{true};
 
   ObjectSizeInPixelsContainerType         m_SizeOfObjectsInPixels;
   ObjectSizeInPhysicalUnitsContainerType  m_SizeOfObjectsInPhysicalUnits;

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
@@ -356,22 +356,22 @@ private:
   using KLMSegmentationRegionPtr = typename KLMSegmentationRegion::Pointer;
   using KLMSegmentationBorderPtr = typename KLMSegmentationBorder::Pointer;
 
-  double       m_MaximumLambda;
-  unsigned int m_NumberOfRegions;
+  double       m_MaximumLambda{1000};
+  unsigned int m_NumberOfRegions{0};
 
   /** Local variables. */
 
-  double       m_InternalLambda;
-  unsigned int m_InitialNumberOfRegions;
-  double       m_TotalBorderLength;
+  double       m_InternalLambda{0};
+  unsigned int m_InitialNumberOfRegions{0};
+  double       m_TotalBorderLength{0.0};
 
   std::vector< KLMSegmentationRegionPtr >      m_RegionsPointer;
   std::vector< KLMSegmentationBorderPtr >      m_BordersPointer;
   std::vector< KLMSegmentationBorderArrayPtr > m_BordersDynamicPointer;
-  KLMSegmentationBorderArrayPtr *              m_BorderCandidate;
+  KLMSegmentationBorderArrayPtr *              m_BorderCandidate{nullptr};
 
   MeanRegionIntensityType m_InitialRegionMean;
-  double                  m_InitialRegionArea;
+  double                  m_InitialRegionArea{0};
 }; // class KLMRegionGrowImageFilter
 } // namespace itk
 

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -23,14 +23,8 @@ namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
 KLMRegionGrowImageFilter< TInputImage, TOutputImage >
-::KLMRegionGrowImageFilter(void):
-  m_MaximumLambda(1000),
-  m_NumberOfRegions(0),
-  m_InternalLambda(0),
-  m_InitialNumberOfRegions(0),
-  m_TotalBorderLength(0.0),
-  m_BorderCandidate(nullptr),
-  m_InitialRegionArea(0)
+::KLMRegionGrowImageFilter(void)
+
 {
   m_InitialRegionMean.set_size(InputImageVectorDimension);
   m_InitialRegionMean.fill(0);

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkSegmentationBorder.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkSegmentationBorder.h
@@ -76,7 +76,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  double m_BorderLength;
+  double m_BorderLength{0};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkSegmentationRegion.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkSegmentationRegion.h
@@ -84,8 +84,8 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  RegionLabelType m_RegionLabel;
-  double          m_RegionArea;
+  RegionLabelType m_RegionLabel{0};
+  double          m_RegionArea{0};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationBorder.cxx
@@ -20,8 +20,8 @@
 namespace itk
 {
 SegmentationBorder
-::SegmentationBorder(void):
-  m_BorderLength(0)
+::SegmentationBorder(void)
+
 {}
 
 SegmentationBorder

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationRegion.cxx
@@ -20,9 +20,8 @@
 namespace itk
 {
 SegmentationRegion
-::SegmentationRegion(void):
-  m_RegionLabel(0),
-  m_RegionArea(0)
+::SegmentationRegion(void)
+
 {}
 
 SegmentationRegion

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
@@ -180,8 +180,8 @@ protected:
 
 private:
   OutputPixelType m_LabelForUndecidedPixels;
-  bool            m_HasLabelForUndecidedPixels;
-  size_t          m_TotalLabelCount;
+  bool            m_HasLabelForUndecidedPixels{ false };
+  size_t          m_TotalLabelCount{ 0 };
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -30,9 +30,8 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 LabelVotingImageFilter< TInputImage, TOutputImage >
 ::LabelVotingImageFilter() :
-  m_LabelForUndecidedPixels( 0 ),
-  m_HasLabelForUndecidedPixels( false ),
-  m_TotalLabelCount( 0 )
+  m_LabelForUndecidedPixels( 0 )
+
 {
 }
 

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
@@ -269,13 +269,9 @@ public:
 
 protected:
   MultiLabelSTAPLEImageFilter() :
-    m_TotalLabelCount(0),
+
     m_LabelForUndecidedPixels(NumericTraits<OutputPixelType>::ZeroValue()),
-    m_HasLabelForUndecidedPixels(false),
-    m_HasPriorProbabilities(false),
-    m_HasMaximumNumberOfIterations(false),
-    m_MaximumNumberOfIterations(0),
-    m_ElapsedNumberOfIterations(0u),
+
     m_TerminationUpdateThreshold(1e-5)
   {
   }
@@ -295,12 +291,12 @@ protected:
   void EnlargeOutputRequestedRegion( DataObject * ) override;
 
 private:
-  size_t m_TotalLabelCount;
+  size_t m_TotalLabelCount{0};
 
   OutputPixelType    m_LabelForUndecidedPixels;
-  bool               m_HasLabelForUndecidedPixels;
+  bool               m_HasLabelForUndecidedPixels{false};
 
-  bool                   m_HasPriorProbabilities;
+  bool                   m_HasPriorProbabilities{false};
   PriorProbabilitiesType m_PriorProbabilities;
 
   void InitializePriorProbabilities();
@@ -311,9 +307,9 @@ private:
   void AllocateConfusionMatrixArray();
   void InitializeConfusionMatrixArrayFromVoting();
 
-  bool         m_HasMaximumNumberOfIterations;
-  unsigned int m_MaximumNumberOfIterations;
-  unsigned int m_ElapsedNumberOfIterations;
+  bool         m_HasMaximumNumberOfIterations{false};
+  unsigned int m_MaximumNumberOfIterations{0};
+  unsigned int m_ElapsedNumberOfIterations{0u};
 
   TWeights m_TerminationUpdateThreshold;
 };

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.h
@@ -114,9 +114,8 @@ public:
   void Initialize(const RadiusType & r) override;
 
 protected:
-  CurvesLevelSetFunction() :
-    m_Center(0),
-    m_DerivativeSigma(1.0)
+  CurvesLevelSetFunction()
+
   {
     //Curvature term is the minimal curvature.
     this->UseMinimalCurvatureOn();
@@ -139,12 +138,12 @@ private:
   std::slice x_slice[ImageDimension];
 
   /** The offset of the center pixel in the neighborhood. */
-  OffsetValueType m_Center;
+  OffsetValueType m_Center{0};
 
   /** Stride length along the y-dimension. */
   OffsetValueType m_xStride[ImageDimension];
 
-  double m_DerivativeSigma;
+  double m_DerivativeSigma{1.0};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.h
@@ -293,8 +293,7 @@ public:
 
 protected:
   LevelSetFunction() :
-    m_Center(0),
-    m_UseMinimalCurvature(false),
+
     m_EpsilonMagnitude(static_cast< ScalarValueType >( 1.0e-5 )),
     m_AdvectionWeight(NumericTraits< ScalarValueType >::ZeroValue()),
     m_PropagationWeight(NumericTraits< ScalarValueType >::ZeroValue()),
@@ -314,12 +313,12 @@ protected:
   std::slice x_slice[Self::ImageDimension];
 
   /** The offset of the center pixel in the neighborhood. */
-  OffsetValueType m_Center;
+  OffsetValueType m_Center{0};
 
   /** Stride length along the y-dimension. */
   OffsetValueType m_xStride[Self::ImageDimension];
 
-  bool m_UseMinimalCurvature;
+  bool m_UseMinimalCurvature{false};
 
   /** This method's only purpose is to initialize the zero vector
    * constant. */

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.h
@@ -156,15 +156,15 @@ private:
 
   void      GenerateDataNarrowBand();
 
-  double m_LevelSetValue;
+  double m_LevelSetValue{0.0};
 
   NodeContainerPointer m_InsidePoints;
   NodeContainerPointer m_OutsidePoints;
 
   LevelSetConstPointer m_InputLevelSet;
 
-  bool                 m_NarrowBanding;
-  double               m_NarrowBandwidth;
+  bool                 m_NarrowBanding{false};
+  double               m_NarrowBandwidth{12.0};
   NodeContainerPointer m_InputNarrowBand;
 
   typename LevelSetImageType::RegionType m_ImageRegion;
@@ -172,7 +172,7 @@ private:
 
   std::vector< NodeType > m_NodesUsed;
 
-  bool m_LastPointIsInside;
+  bool m_LastPointIsInside{false};
 };
 } // namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -33,15 +33,14 @@ namespace itk
 template< typename TLevelSet >
 LevelSetNeighborhoodExtractor< TLevelSet >
 ::LevelSetNeighborhoodExtractor() :
-  m_LevelSetValue(0.0),
+
   m_InsidePoints(nullptr),
   m_OutsidePoints(nullptr),
   m_InputLevelSet(nullptr),
-  m_NarrowBanding(false),
-  m_NarrowBandwidth(12.0),
+
   m_InputNarrowBand(nullptr),
-  m_LargeValue(NumericTraits< PixelType >::max()),
-  m_LastPointIsInside(false)
+  m_LargeValue(NumericTraits< PixelType >::max())
+
 {
   m_NodesUsed.resize(SetDimension);
 }

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -352,7 +352,7 @@ protected:
 
   /** The constant gradient to maintain between isosurfaces in the
       spare-field of the level-set image.  This value defaults to 1.0 */
-  double m_ConstantGradientValue;
+  double m_ConstantGradientValue{1.0};
 
   /** Multiplicative identity of the ValueType. */
   static ValueType m_ValueOne;
@@ -684,31 +684,31 @@ protected:
   //  void WriteActivePointsToFile ();
 
   /** The number of threads to use. */
-  ThreadIdType m_NumOfThreads;
+  ThreadIdType m_NumOfThreads{0};
 
   /** The dimension along which to distribute the load. */
-  unsigned int m_SplitAxis;
+  unsigned int m_SplitAxis{0};
 
   /** The length of the dimension along which to distribute the load. */
-  unsigned int m_ZSize;
+  unsigned int m_ZSize{0};
 
   /** A boolean variable stating if the boundaries had been changed during
    *  CheckLoadBalance() */
-  bool m_BoundaryChanged;
+  bool m_BoundaryChanged{false};
 
   /** The boundaries defining thread regions */
-  unsigned int *m_Boundary;
+  unsigned int *m_Boundary{nullptr};
 
   /** Histogram of number of pixels in each Z plane for the entire 3D volume */
-  int *m_GlobalZHistogram;
+  int *m_GlobalZHistogram{nullptr};
 
   /** The mapping from a z-value to the thread in whose region the z-value lies
     */
-  unsigned int *m_MapZToThreadNumber;
+  unsigned int *m_MapZToThreadNumber{nullptr};
 
   /** Cumulative frequency of number of pixels in each Z plane for the entire 3D
    *  volume  */
-  int *m_ZCumulativeFrequency;
+  int *m_ZCumulativeFrequency{nullptr};
 
   /** A global barrier used for synchronization between all threads. */
   typename Barrier::Pointer m_Barrier;
@@ -767,19 +767,19 @@ protected:
 
   /** Used to check if there are too few pixels remaining. If yes, then we can
    *  stop iterating. */
-  bool m_Stop;
+  bool m_Stop{false};
 
   /** This flag tells the solver whether or not to interpolate for the actual
       surface location when calculating change at each active layer node.  By
       default this is turned on. Subclasses which do not sample propagation
       (speed), advection, or curvature terms should turn this flag off. */
-  bool m_InterpolateSurfaceLocation;
+  bool m_InterpolateSurfaceLocation{true};
 
 private:
 
   /** This flag is true when methods need to check boundary conditions and
    *  false when methods do not need to check for boundary conditions. */
-  bool m_BoundsCheckingActive;
+  bool m_BoundsCheckingActive{false};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -131,21 +131,12 @@ ParallelSparseFieldLevelSetImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 ParallelSparseFieldLevelSetImageFilter< TInputImage, TOutputImage >
 ::ParallelSparseFieldLevelSetImageFilter() :
-  m_ConstantGradientValue(1.0),
+
   m_NumberOfLayers(ImageDimension),
   m_IsoSurfaceValue(m_ValueZero),
-  m_NumOfThreads(0),
-  m_SplitAxis(0),
-  m_ZSize(0),
-  m_BoundaryChanged(false),
-  m_Boundary(nullptr),
-  m_GlobalZHistogram(nullptr),
-  m_MapZToThreadNumber(nullptr),
-  m_ZCumulativeFrequency(nullptr),
-  m_Data(nullptr),
-  m_Stop(false),
-  m_InterpolateSurfaceLocation(true),
-  m_BoundsCheckingActive(false)
+
+  m_Data(nullptr)
+
 {
   this->SetRMSChange( static_cast< double >( m_ValueOne ) );
   this->DynamicMultiThreadingOff();

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
@@ -422,7 +422,7 @@ protected:
 
   /** The constant gradient to maintain between isosurfaces in the
       sparse-field of the level-set image.  This value defaults to 1.0 */
-  double m_ConstantGradientValue;
+  double m_ConstantGradientValue{1.0};
 
   /** Multiplicative identity of the ValueType. */
   static ValueType m_ValueOne;
@@ -465,7 +465,7 @@ protected:
    * consist of m_NumberOfLayers layers on both sides of a single active layer.
    * This active layer is the interface of interest, i.e. the zero
    * level set. */
-  unsigned int m_NumberOfLayers;
+  unsigned int m_NumberOfLayers{2};
 
   /** An image of status values used internally by the algorithm. */
   typename StatusImageType::Pointer m_StatusImage;
@@ -489,7 +489,7 @@ protected:
       surface location when calculating change at each active layer node.  By
       default this is turned on. Subclasses which do not sample propagation
       (speed), advection, or curvature terms should turn this flag off. */
-  bool m_InterpolateSurfaceLocation;
+  bool m_InterpolateSurfaceLocation{true};
 
   const InputImageType *m_InputImage;
   OutputImageType      *m_OutputImage;
@@ -497,7 +497,7 @@ protected:
 private:
   /** This flag is true when methods need to check boundary conditions and
       false when methods do not need to check for boundary conditions. */
-  bool m_BoundsCheckingActive;
+  bool m_BoundsCheckingActive{false};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -130,13 +130,12 @@ SparseFieldLevelSetImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 SparseFieldLevelSetImageFilter< TInputImage, TOutputImage >
 ::SparseFieldLevelSetImageFilter() :
-  m_ConstantGradientValue(1.0),
-  m_NumberOfLayers(2),
+
   m_IsoSurfaceValue(m_ValueZero),
-  m_InterpolateSurfaceLocation(true),
+
   m_InputImage(nullptr),
-  m_OutputImage(nullptr),
-  m_BoundsCheckingActive(false)
+  m_OutputImage(nullptr)
+
 {
   m_LayerNodeStore = LayerNodeStorageType::New();
   m_LayerNodeStore->SetGrowthStrategyToExponential();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.h
@@ -227,11 +227,11 @@ protected:
   // RequestedRegion are used to define the currently requested
   // region. The LargestPossibleRegion is always requested region = 0
   // and number of regions = 1;
-  RegionType m_MaximumNumberOfRegions;
-  RegionType m_NumberOfRegions;
-  RegionType m_RequestedNumberOfRegions;
-  RegionType m_BufferedRegion;
-  RegionType m_RequestedRegion;
+  RegionType m_MaximumNumberOfRegions{0};
+  RegionType m_NumberOfRegions{0};
+  RegionType m_RequestedNumberOfRegions{0};
+  RegionType m_BufferedRegion{0};
+  RegionType m_RequestedRegion{0};
 };
 }
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
@@ -29,12 +29,8 @@ namespace itk
 
 template< typename TInput, unsigned int VDimension, typename TOutput, typename TDomain >
 LevelSetBase< TInput, VDimension, TOutput, TDomain >
-::LevelSetBase() :
-  m_MaximumNumberOfRegions(0),
-  m_NumberOfRegions(0),
-  m_RequestedNumberOfRegions(0),
-  m_BufferedRegion(0),
-  m_RequestedRegion(0)
+::LevelSetBase()
+
 {}
 
 // ----------------------------------------------------------------------------

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.h
@@ -87,7 +87,7 @@ protected:
 
 private:
   KdTreePointer     m_KdTree;
-  NeighborsIdType   m_NumberOfNeighbors;
+  NeighborsIdType   m_NumberOfNeighbors{ 10 };
 };
 
 } //end namespace itk

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.hxx
@@ -25,7 +25,7 @@ namespace itk
 template< typename TImage >
 LevelSetDomainPartitionImageWithKdTree< TImage >
 ::LevelSetDomainPartitionImageWithKdTree() :
-  m_KdTree(nullptr), m_NumberOfNeighbors( 10 )
+  m_KdTree(nullptr)
 {
 }
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.h
@@ -125,7 +125,7 @@ protected:
 
   using NeighborhoodIteratorType = ShapedNeighborhoodIterator< LabelImageType >;
 
-  bool m_IsUsingUnPhasedPropagation;
+  bool m_IsUsingUnPhasedPropagation{ true };
 
   /** Compute the updates for all points in the 0 layer and store in UpdateContainer */
   void FillUpdateContainer();

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
@@ -31,8 +31,8 @@ template< unsigned int VDimension, typename TEquationContainer >
 UpdateMalcolmSparseLevelSet< VDimension, TEquationContainer >
 ::UpdateMalcolmSparseLevelSet() :
   m_CurrentLevelSetId( NumericTraits< IdentifierType >::ZeroValue() ),
-  m_RMSChangeAccumulator( NumericTraits< LevelSetOutputRealType >::ZeroValue() ),
-  m_IsUsingUnPhasedPropagation( true )
+  m_RMSChangeAccumulator( NumericTraits< LevelSetOutputRealType >::ZeroValue() )
+
 {
   this->m_Offset.Fill( 0 );
   this->m_OutputLevelSet = LevelSetType::New();

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
@@ -359,18 +359,18 @@ private:
   LabelledImageNeighborhoodRadiusType    m_LabelledImageNeighborhoodRadius;
   LabelStatusImageNeighborhoodRadiusType m_LabelStatusImageNeighborhoodRadius;
 
-  unsigned int m_NumberOfClasses;
-  unsigned int m_MaximumNumberOfIterations;
+  unsigned int m_NumberOfClasses{0};
+  unsigned int m_MaximumNumberOfIterations{50};
   unsigned int m_KernelSize;
 
-  int               m_ErrorCounter;
-  int               m_NeighborhoodSize;
-  int               m_TotalNumberOfValidPixelsInOutputImage;
-  int               m_TotalNumberOfPixelsInInputImage;
-  double            m_ErrorTolerance;
-  double            m_SmoothingFactor;
-  double *          m_ClassProbability;         //Class liklihood
-  unsigned int      m_NumberOfIterations;
+  int               m_ErrorCounter{0};
+  int               m_NeighborhoodSize{27};
+  int               m_TotalNumberOfValidPixelsInOutputImage{1};
+  int               m_TotalNumberOfPixelsInInputImage{1};
+  double            m_ErrorTolerance{0.2};
+  double            m_SmoothingFactor{1};
+  double *          m_ClassProbability{nullptr};         //Class liklihood
+  unsigned int      m_NumberOfIterations{0};
   StopConditionType m_StopCondition;
 
   LabelStatusImagePointer m_LabelStatusImage;

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -24,16 +24,7 @@ namespace itk
 template< typename TInputImage, typename TClassifiedImage >
 MRFImageFilter< TInputImage, TClassifiedImage >
 ::MRFImageFilter():
-  m_NumberOfClasses(0),
-  m_MaximumNumberOfIterations(50),
-  m_ErrorCounter(0),
-  m_NeighborhoodSize(27),
-  m_TotalNumberOfValidPixelsInOutputImage(1),
-  m_TotalNumberOfPixelsInInputImage(1),
-  m_ErrorTolerance(0.2),
-  m_SmoothingFactor(1),
-  m_ClassProbability(nullptr),
-  m_NumberOfIterations(0),
+
   m_StopCondition(MaximumNumberOfIterations),
   m_ClassifierPtr(nullptr)
 {

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
@@ -215,51 +215,51 @@ private:
   TrainingImageType      m_TrainingImage;             /** image to train the
                                                         filter. */
   LabelledImageType      m_LabelledImage;             /** output */
-  unsigned int           m_NumberOfClasses;           /** the number of class
+  unsigned int           m_NumberOfClasses{0};           /** the number of class
                                                         need to be classified.
                                                         */
-  unsigned int           m_MaximumNumberOfIterations; /** number of the
+  unsigned int           m_MaximumNumberOfIterations{10}; /** number of the
                                                         iteration. */
 
   typename ClassifierType::Pointer m_ClassifierPtr;
 
-  unsigned int m_BoundaryGradient; /** the threshold for the existence of a
+  unsigned int m_BoundaryGradient{7}; /** the threshold for the existence of a
                                      boundary. */
-  double       m_BoundaryWeight;   /** weight for H_1 */
-  double       m_GibbsPriorWeight; /** weight for H_2 */
-  int          m_StartRadius;      /** define the start region of the object. */
-  int          m_RecursiveNumber;  /** number of SA iterations. */
-  LabelType *  m_LabelStatus;      /** array for the state of each pixel. */
+  double       m_BoundaryWeight{1};   /** weight for H_1 */
+  double       m_GibbsPriorWeight{1}; /** weight for H_2 */
+  int          m_StartRadius{10};      /** define the start region of the object. */
+  int          m_RecursiveNumber{0};  /** number of SA iterations. */
+  LabelType *  m_LabelStatus{nullptr};      /** array for the state of each pixel. */
 
   InputImagePointer m_MediumImage;    /** the medium image to store intermedium
                                         result */
 
-  unsigned int m_Temp;            /** for SA algo. */
+  unsigned int m_Temp{0};            /** for SA algo. */
   IndexType    m_StartPoint;      /** the seed of object */
 
-  unsigned int   m_ImageWidth;    /** image size. */
-  unsigned int   m_ImageHeight;
-  unsigned int   m_ImageDepth;
-  unsigned int   m_ClusterSize;  /** region size smaller than the threshold will
+  unsigned int   m_ImageWidth{0};    /** image size. */
+  unsigned int   m_ImageHeight{0};
+  unsigned int   m_ImageDepth{0};
+  unsigned int   m_ClusterSize{10};  /** region size smaller than the threshold will
                                    be erased. */
-  LabelType      m_ObjectLabel;  /** the label for object region. */
-  unsigned int   m_VecDim;       /** the channel number in the image. */
+  LabelType      m_ObjectLabel{1};  /** the label for object region. */
+  unsigned int   m_VecDim{0};       /** the channel number in the image. */
   InputPixelType m_LowPoint;     /** the point give lowest value of H-1 in
                                    neighbor. */
 
-  unsigned short *m_Region;      /** for region erase. */
-  unsigned short *m_RegionCount; /** for region erase. */
+  unsigned short *m_Region{nullptr};      /** for region erase. */
+  unsigned short *m_RegionCount{nullptr}; /** for region erase. */
 
   /** weights for different clique configuration. */
-  double m_CliqueWeight_1;  /** weight for cliques that v/h smooth boundayr */
-  double m_CliqueWeight_2;  /** weight for clique that has an intermadiate
+  double m_CliqueWeight_1{0.0};  /** weight for cliques that v/h smooth boundayr */
+  double m_CliqueWeight_2{0.0};  /** weight for clique that has an intermadiate
                               smooth boundary */
-  double m_CliqueWeight_3;  /** weight for clique that has a diagonal smooth
+  double m_CliqueWeight_3{0.0};  /** weight for clique that has a diagonal smooth
                               boundary */
-  double m_CliqueWeight_4;  /** weight for clique consists only object pixels */
-  double m_CliqueWeight_5;  /** weight for clique consists only background
+  double m_CliqueWeight_4{0.0};  /** weight for clique consists only object pixels */
+  double m_CliqueWeight_5{0.0};  /** weight for clique consists only background
                               pixels */
-  double m_CliqueWeight_6;  /** weight for clique other than these */
+  double m_CliqueWeight_6{0.0};  /** weight for clique other than these */
 
   /** calculate H_2. */
   void  GibbsTotalEnergy(int i);
@@ -280,7 +280,7 @@ private:
   void  GreyScalarBoundary(LabelledImageIndexType Index3D); /** calculate H_1.
                                                               */
 
-  double m_ObjectThreshold;
+  double m_ObjectThreshold{5.0};
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -35,33 +35,13 @@ RGBGibbsPriorFilter< TInputImage, TClassifiedImage >
   m_InputImage(nullptr),
   m_TrainingImage(nullptr),
   m_LabelledImage(nullptr),
-  m_NumberOfClasses(0),
-  m_MaximumNumberOfIterations(10),
+
   m_ClassifierPtr(nullptr),
-  m_BoundaryGradient(7),
-  m_BoundaryWeight(1),
-  m_GibbsPriorWeight(1),
-  m_StartRadius(10),
-  m_RecursiveNumber(0),
-  m_LabelStatus(nullptr),
+
   m_MediumImage(nullptr),
-  m_Temp(0),
-  m_ImageWidth(0),
-  m_ImageHeight(0),
-  m_ImageDepth(0),
-  m_ClusterSize(10),
-  m_ObjectLabel(1),
-  m_VecDim(0),
-  m_LowPoint(),
-  m_Region(nullptr),
-  m_RegionCount(nullptr),
-  m_CliqueWeight_1(0.0),
-  m_CliqueWeight_2(0.0),
-  m_CliqueWeight_3(0.0),
-  m_CliqueWeight_4(0.0),
-  m_CliqueWeight_5(0.0),
-  m_CliqueWeight_6(0.0),
-  m_ObjectThreshold(5.0)
+
+  m_LowPoint()
+
 {
   m_StartPoint.Fill(0);
 }

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
@@ -192,7 +192,7 @@ private:
 
   SuperGridSizeType m_SuperGridSize;
   unsigned int      m_MaximumNumberOfIterations;
-  double            m_SpatialProximityWeight;
+  double            m_SpatialProximityWeight{ 10.0 };
 
   FixedArray<double,ImageDimension> m_DistanceScales;
   std::vector<ClusterComponentType> m_Clusters;
@@ -219,9 +219,9 @@ private:
   typename DistanceImageType::Pointer m_DistanceImage;
   typename MarkerImageType::Pointer   m_MarkerImage;
 
-  bool m_EnforceConnectivity;
+  bool m_EnforceConnectivity{true};
 
-  bool m_InitializationPerturbation;
+  bool m_InitializationPerturbation{true};
 
   double               m_AverageResidual;
   std::mutex m_Mutex;

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -46,9 +46,7 @@ template<typename TInputImage, typename TOutputImage, typename TDistancePixel>
 SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>
 ::SLICImageFilter()
   : m_MaximumNumberOfIterations( (ImageDimension > 2) ? 5 : 10),
-    m_SpatialProximityWeight( 10.0 ),
-    m_EnforceConnectivity(true),
-    m_InitializationPerturbation(true),
+
     m_AverageResidual(NumericTraits<double>::max())
 {
   this->DynamicMultiThreadingOff();

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -115,7 +115,7 @@ protected:
   void GenerateData() override;
 
 private:
-  unsigned int m_NumberOfSeeds;
+  unsigned int m_NumberOfSeeds{ 0 };
   PointType    m_VorBoundary;
   OutputType   m_OutputVD;
   SeedsType    m_Seeds;
@@ -158,16 +158,13 @@ private:
   class FortuneEdge
   {
   public:
-    float        m_A, m_B, m_C;    // explicit line function: Ax + By = C;
+    float        m_A{0.0}, m_B{0.0}, m_C{0.0};    // explicit line function: Ax + By = C;
     FortuneSite *m_Ep[2];
     FortuneSite *m_Reg[2];
-    int          m_Edgenbr;
+    int          m_Edgenbr{0};
 
-    FortuneEdge() :
-      m_A(0.0),
-      m_B(0.0),
-      m_C(0.0),
-      m_Edgenbr(0)
+    FortuneEdge()
+
     {
       m_Ep[0] = m_Ep[1] = m_Reg[0] = m_Reg[1] = nullptr;
     }
@@ -181,18 +178,18 @@ private:
     FortuneHalfEdge *m_Left;
     FortuneHalfEdge *m_Right;
     FortuneEdge *    m_Edge;
-    bool             m_RorL;
+    bool             m_RorL{false};
     FortuneSite *    m_Vert;
-    double           m_Ystar;
+    double           m_Ystar{0.0};
     FortuneHalfEdge *m_Next;
 
     FortuneHalfEdge() :
       m_Left(nullptr),
       m_Right(nullptr),
       m_Edge(nullptr),
-      m_RorL(false),
+
       m_Vert(nullptr),
-      m_Ystar(0.0),
+
       m_Next(nullptr)
     {}
 
@@ -209,23 +206,23 @@ private:
     ~FortuneHalfEdge() = default;
   };
 
-  double m_Pxmin;
-  double m_Pxmax;
-  double m_Pymin;
-  double m_Pymax;
-  double m_Deltax;
-  double m_Deltay;
-  double m_SqrtNSites;
+  double m_Pxmin{ 0.0 };
+  double m_Pxmax{ 0.0 };
+  double m_Pymin{ 0.0 };
+  double m_Pymax{ 0.0 };
+  double m_Deltax{ 0.0 };
+  double m_Deltay{ 0.0 };
+  double m_SqrtNSites{ 0.0 };
 
-  unsigned int                   m_PQcount;
-  int                            m_PQmin;
-  unsigned int                   m_PQhashsize;
-  unsigned int                   m_Nedges;
-  unsigned int                   m_Nvert;
+  unsigned int                   m_PQcount{ 0 };
+  int                            m_PQmin{ 0 };
+  unsigned int                   m_PQhashsize{ 0 };
+  unsigned int                   m_Nedges{ 0 };
+  unsigned int                   m_Nvert{ 0 };
   FortuneSite *                  m_BottomSite;
   std::vector< FortuneHalfEdge > m_PQHash;
 
-  unsigned int                     m_ELhashsize;
+  unsigned int                     m_ELhashsize{ 0 };
   FortuneHalfEdge                  m_ELleftend;
   FortuneHalfEdge                  m_ELrightend;
   std::vector< FortuneHalfEdge * > m_ELHash;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -31,22 +31,10 @@ constexpr double DIFF_TOLERENCE = 0.001;
 
 template< typename TCoordRepType >
 VoronoiDiagram2DGenerator< TCoordRepType >::VoronoiDiagram2DGenerator() :
-  m_NumberOfSeeds( 0 ),
-  m_OutputVD( Self::GetOutput() ), // Note: this line is suspicious
-  m_Pxmin( 0.0 ),
-  m_Pxmax( 0.0 ),
-  m_Pymin( 0.0 ),
-  m_Pymax( 0.0 ),
-  m_Deltax( 0.0 ),
-  m_Deltay( 0.0 ),
-  m_SqrtNSites( 0.0 ),
-  m_PQcount( 0 ),
-  m_PQmin( 0 ),
-  m_PQhashsize( 0 ),
-  m_Nedges( 0 ),
-  m_Nvert( 0 ),
-  m_BottomSite( nullptr ),
-  m_ELhashsize( 0 )
+
+  m_OutputVD( Self::GetOutput() ),
+  m_BottomSite( nullptr )
+
 {
   m_VorBoundary.Fill( 0.0 );
 }

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.h
@@ -105,7 +105,7 @@ protected:
   bool TestHomogeneity(IndexList & Plist) override;
 
   // Threshold for homogeneity criterion
-  double m_SigmaThreshold;
+  double m_SigmaThreshold{10};
 };
 } //end namespace
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
@@ -26,8 +26,8 @@ namespace itk
 /* constructor: seting the default value of the parameters */
 template< typename TInputImage, typename TOutputImage >
 VoronoiPartitioningImageFilter< TInputImage, TOutputImage >
-::VoronoiPartitioningImageFilter():
-  m_SigmaThreshold(10)
+::VoronoiPartitioningImageFilter()
+
 {}
 
 /* destructor */

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.h
@@ -128,12 +128,12 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  double m_Mean;
-  double m_STD;
-  double m_MeanTolerance;
-  double m_STDTolerance;
-  double m_MeanPercentError;
-  double m_STDPercentError;
+  double m_Mean{ 0.0 };
+  double m_STD{ 0.0 };
+  double m_MeanTolerance{ 0.0 };
+  double m_STDTolerance{ 0.0 };
+  double m_MeanPercentError{ 0.10 };
+  double m_STDPercentError{ 1.5 };
 
   bool TestHomogeneity(IndexList & Plist) override;
 };

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -26,13 +26,8 @@ namespace itk
 
 template< typename TInputImage, typename TOutputImage, typename TBinaryPriorImage >
 VoronoiSegmentationImageFilter< TInputImage, TOutputImage, TBinaryPriorImage >
-::VoronoiSegmentationImageFilter() :
-  m_Mean( 0.0 ),
-  m_STD( 0.0 ),
-  m_MeanTolerance( 0.0 ),
-  m_STDTolerance( 0.0 ),
-  m_MeanPercentError( 0.10 ),
-  m_STDPercentError( 1.5 )
+::VoronoiSegmentationImageFilter()
+
 {
 }
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
@@ -220,21 +220,21 @@ protected:
   void GenerateData() override; //general pipeline function.
 
   SizeType      m_Size;
-  int           m_NumberOfSeeds;
-  SizeValueType m_MinRegion;
-  int           m_Steps;
-  int           m_LastStepSeeds;
-  int           m_NumberOfSeedsToAdded;
-  int           m_NumberOfBoundary;
+  int           m_NumberOfSeeds{200};
+  SizeValueType m_MinRegion{20};
+  int           m_Steps{0};
+  int           m_LastStepSeeds{0};
+  int           m_NumberOfSeedsToAdded{0};
+  int           m_NumberOfBoundary{0};
 
   std::vector< SizeValueType >           m_NumberOfPixels;
   std::vector< unsigned char >           m_Label;
 
-  double m_MeanDeviation;
-  bool   m_UseBackgroundInAPrior;
-  bool   m_OutputBoundary; //if =1 then output the boundaries, if = 0 then
+  double m_MeanDeviation{0.8};
+  bool   m_UseBackgroundInAPrior{false};
+  bool   m_OutputBoundary{false}; //if =1 then output the boundaries, if = 0 then
                            // output the object.
-  bool m_InteractiveSegmentation;
+  bool m_InteractiveSegmentation{false};
 
   typename VoronoiDiagram::Pointer m_WorkingVD;
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -30,16 +30,7 @@ namespace itk
 template< typename TInputImage, typename TOutputImage, typename TBinaryPriorImage >
 VoronoiSegmentationImageFilterBase< TInputImage, TOutputImage, TBinaryPriorImage >
 ::VoronoiSegmentationImageFilterBase() :
-  m_NumberOfSeeds(200),
-  m_MinRegion(20),
-  m_Steps(0),
-  m_LastStepSeeds(0),
-  m_NumberOfSeedsToAdded(0),
-  m_NumberOfBoundary(0),
-  m_MeanDeviation(0.8),
-  m_UseBackgroundInAPrior(false),
-  m_OutputBoundary(false),
-  m_InteractiveSegmentation(false),
+
   m_WorkingVD(VoronoiDiagram::New()),
   m_VDGenerator(VoronoiDiagramGenerator::New())
 {

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.h
@@ -177,9 +177,9 @@ protected:
   void GenerateData() override;
 
 private:
-  bool m_FullyConnected;
+  bool m_FullyConnected{ false };
 
-  bool m_MarkWatershedLine;
+  bool m_MarkWatershedLine{ true };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
@@ -35,9 +35,8 @@ namespace itk
 
 template< typename TInputImage, typename TLabelImage >
 MorphologicalWatershedFromMarkersImageFilter< TInputImage, TLabelImage >
-::MorphologicalWatershedFromMarkersImageFilter():
-  m_FullyConnected( false ),
-  m_MarkWatershedLine( true )
+::MorphologicalWatershedFromMarkersImageFilter()
+
 
 {
   this->SetNumberOfRequiredInputs(2);

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
@@ -125,9 +125,9 @@ protected:
   void GenerateData() override;
 
 private:
-  bool m_FullyConnected;
+  bool m_FullyConnected{ false };
 
-  bool m_MarkWatershedLine;
+  bool m_MarkWatershedLine{ true };
 
   InputImagePixelType m_Level;
 }; // end of class

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
@@ -31,8 +31,7 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 MorphologicalWatershedImageFilter< TInputImage, TOutputImage >
 ::MorphologicalWatershedImageFilter():
-  m_FullyConnected( false ),
-  m_MarkWatershedLine( true ),
+
   m_Level( NumericTraits< InputImagePixelType >::ZeroValue() )
 {
 }

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
@@ -119,7 +119,7 @@ public:
   DataObjectPointer MakeOutput(DataObjectPointerArraySizeType idx) override;
 
 protected:
-  BoundaryResolver():m_Face(0)
+  BoundaryResolver()
   {
     EquivalencyTable::Pointer eq =
       static_cast< EquivalencyTable * >( this->MakeOutput(0).GetPointer() );
@@ -133,7 +133,7 @@ protected:
   void operator=(const Self &) {}
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
-  unsigned short m_Face;
+  unsigned short m_Face{0};
   void GenerateOutputRequestedRegion(DataObject *output) override;
 };
 } // end namespace watershed

--- a/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
@@ -265,13 +265,13 @@ private:
   /** A Percentage of the maximum depth (max - min pixel value) in the input
    *  image.  This percentage will be used to threshold the minimum values in
    *  the image. */
-  double m_Threshold;
+  double m_Threshold{0.0};
 
   /** The percentage of the maximum saliency value among adjacencies in the
    *  segments of the initial segmentation to which "flooding" of the image
    *  should occur.  A tree of segment merges is calculated up to this
    *  level. */
-  double m_Level;
+  double m_Level{0.0};
 
   /** The component parts of the segmentation algorithm.  These objects
    * must save state between calls to GenerateData() so that the

--- a/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.hxx
@@ -78,7 +78,7 @@ CLANG_PRAGMA_POP    \
 
 template< typename TInputImage >
 WatershedImageFilter< TInputImage >
-::WatershedImageFilter():m_Threshold(0.0), m_Level(0.0)
+::WatershedImageFilter()
 {
   // Set up the mini-pipeline for the first execution.
   m_Segmenter    = watershed::Segmenter< InputImageType >::New();

--- a/Modules/Segmentation/Watersheds/include/itkWatershedMiniPipelineProgressCommand.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedMiniPipelineProgressCommand.h
@@ -64,15 +64,15 @@ public:
   itkGetConstMacro(NumberOfFilters, unsigned int);
 
 protected:
-  WatershedMiniPipelineProgressCommand():m_Count(0.0), m_Filter(nullptr),
-    m_NumberOfFilters(1) {}
+  WatershedMiniPipelineProgressCommand()
+    {}
   ~WatershedMiniPipelineProgressCommand() override = default;
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  double         m_Count;
-  ProcessObject *m_Filter;
-  unsigned int   m_NumberOfFilters;
+  double         m_Count{0.0};
+  ProcessObject *m_Filter{nullptr};
+  unsigned int   m_NumberOfFilters{1};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.h
@@ -146,7 +146,7 @@ protected:
   void operator=(const Self &) {}
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
-  double m_FloodLevel;
+  double m_FloodLevel{0.0};
   void GenerateOutputRequestedRegion(DataObject *output) override;
 
   void GenerateInputRequestedRegion() override;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -26,7 +26,7 @@ namespace itk
 namespace watershed
 {
 template< typename TScalar, unsigned int TImageDimension >
-Relabeler< TScalar, TImageDimension >::Relabeler():m_FloodLevel(0.0)
+Relabeler< TScalar, TImageDimension >::Relabeler()
 {
   typename ImageType::Pointer img =
     static_cast< ImageType * >( this->MakeOutput(0).GetPointer() );

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
@@ -215,9 +215,9 @@ protected:
   void GenerateInputRequestedRegion() override;
 
 private:
-  bool   m_Merge;
-  double m_FloodLevel;
-  bool   m_ConsumeInput;
+  bool   m_Merge{false};
+  double m_FloodLevel{0.0};
+  bool   m_ConsumeInput{false};
 
   using HashMapType = itksys::hash_map< IdentifierType, bool,
                             itksys::hash< IdentifierType > >;
@@ -228,7 +228,7 @@ private:
    *  calculated.  m_FloodLevel can be manipulated anywhere below this
    *  level without re-executing the filter, preventing unnecessary
    *  updates. */
-  double m_HighestCalculatedFloodLevel;
+  double m_HighestCalculatedFloodLevel{0.0};
 };
 } // end namespace watershed
 } // end namespace itk

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -28,8 +28,7 @@ namespace watershed
 {
 template< typename TScalar >
 SegmentTreeGenerator< TScalar >
-::SegmentTreeGenerator():m_Merge(false), m_FloodLevel(0.0),
-  m_ConsumeInput(false), m_HighestCalculatedFloodLevel(0.0)
+::SegmentTreeGenerator()
 {
   typename SegmentTreeType::Pointer st =
     static_cast< SegmentTreeType * >( this->MakeOutput(0).GetPointer() );

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.h
@@ -239,8 +239,8 @@ protected:
     InputPixelType bounds_min;
     //    InputPixelType  bounds_max; // <-- may not be necc.
     InputPixelType value;
-    bool is_on_boundary;
-    flat_region_t():is_on_boundary(false) {}
+    bool is_on_boundary{false};
+    flat_region_t() {}
   };
 
   /** Table for storing flat region information.  */

--- a/Modules/Video/Core/include/itkRingBuffer.h
+++ b/Modules/Video/Core/include/itkRingBuffer.h
@@ -104,7 +104,7 @@ protected:
   /**-PROTECTED MEMBERS------------------------------------------------------*/
 
   /** Pointer to the current active buffer */
-  SizeValueType               m_HeadIndex;
+  SizeValueType               m_HeadIndex{0};
 
   /** Vector of pointers to elements */
   std::vector<ElementPointer> m_PointerVector;

--- a/Modules/Video/Core/include/itkRingBuffer.hxx
+++ b/Modules/Video/Core/include/itkRingBuffer.hxx
@@ -32,7 +32,7 @@ namespace itk
 template< typename TElement >
 RingBuffer< TElement >
 ::RingBuffer()
-  : m_HeadIndex(0),
+  :
     m_PointerVector()
 {
   // Default to 3 buffers

--- a/Modules/Video/Core/include/itkTemporalDataObject.h
+++ b/Modules/Video/Core/include/itkTemporalDataObject.h
@@ -113,7 +113,7 @@ protected:
   TemporalRegionType m_RequestedTemporalRegion;
   TemporalRegionType m_BufferedTemporalRegion;
 
-  TemporalUnitType m_TemporalUnit;
+  TemporalUnitType m_TemporalUnit{Frame};
 };  // end class TemporalDataObject
 
 } // end namespace itk

--- a/Modules/Video/Core/include/itkTemporalProcessObject.h
+++ b/Modules/Video/Core/include/itkTemporalProcessObject.h
@@ -218,20 +218,20 @@ protected:
 
   /** Members to indicate the number of input frames and output frames required
    * to perform a single pass through the processing. */
-  SizeValueType  m_UnitInputNumberOfFrames;
-  SizeValueType  m_UnitOutputNumberOfFrames;
+  SizeValueType  m_UnitInputNumberOfFrames{1};
+  SizeValueType  m_UnitOutputNumberOfFrames{1};
 
   /** Number of frames to move in order to produce each set of output frames.
    * There is no public API for this member, but subclasses can set it
    * internally (or provide access to it) if they wish. */
-  OffsetValueType  m_FrameSkipPerOutput;
+  OffsetValueType  m_FrameSkipPerOutput{1};
 
   /** Member to indicate the location of the "current frame" in the minimum set
    * of input frames. For example, if the unit number of input frames is 6 and
    * m_InputStencilCurrentFrameIndex = 4, this indicates that for output frame
    * n, frames n-4 through n+1 are required, whereas if
    * m_InputStencilCurrentFrameIndex = 0, frames n through n+5 are required. */
-  SizeValueType  m_InputStencilCurrentFrameIndex;
+  SizeValueType  m_InputStencilCurrentFrameIndex{0};
 };  // end class TemporalProcessObject
 
 } // end namespace itk

--- a/Modules/Video/Core/include/itkTemporalRegion.h
+++ b/Modules/Video/Core/include/itkTemporalRegion.h
@@ -95,8 +95,8 @@ protected:
   /** Time boundaries */
   RealTimeStamp    m_RealStart;
   RealTimeInterval m_RealDuration;
-  FrameOffsetType  m_FrameStart;
-  FrameOffsetType  m_FrameDuration;
+  FrameOffsetType  m_FrameStart{0};
+  FrameOffsetType  m_FrameDuration{0};
 
 };  // end class TemporalRegion
 

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -35,8 +35,8 @@ namespace itk
 TemporalDataObject::TemporalDataObject()
   : m_LargestPossibleTemporalRegion(),
     m_RequestedTemporalRegion(),
-    m_BufferedTemporalRegion(),
-    m_TemporalUnit(Frame)
+    m_BufferedTemporalRegion()
+
 {
   m_DataObjectBuffer = BufferType::New();
 }

--- a/Modules/Video/Core/src/itkTemporalProcessObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalProcessObject.cxx
@@ -29,10 +29,8 @@ namespace itk
 // Constructor
 //
 TemporalProcessObject::TemporalProcessObject()
-  : m_UnitInputNumberOfFrames(1),
-    m_UnitOutputNumberOfFrames(1),
-    m_FrameSkipPerOutput(1),
-    m_InputStencilCurrentFrameIndex(0)
+
+
 {}
 
 //

--- a/Modules/Video/Core/src/itkTemporalRegion.cxx
+++ b/Modules/Video/Core/src/itkTemporalRegion.cxx
@@ -26,9 +26,8 @@ namespace itk
 TemporalRegion
 ::TemporalRegion()
   : m_RealStart(),
-    m_RealDuration(0,0),
-    m_FrameStart(0),
-    m_FrameDuration(0)
+    m_RealDuration(0,0)
+
 {
 }
 

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -414,7 +414,7 @@ protected:
 
   /** Constructor */
   DummyTemporalProcessObject()
-    : m_IdNumber(0)
+
   {
     DummyTemporalDataObject::Pointer po = DummyTemporalDataObject::New();
 
@@ -424,7 +424,7 @@ protected:
 private:
 
   /** ID number used for debugging */
-  SizeValueType m_IdNumber;
+  SizeValueType m_IdNumber{0};
 
 };
 

--- a/Modules/Video/IO/include/itkVideoFileWriter.h
+++ b/Modules/Video/IO/include/itkVideoFileWriter.h
@@ -134,10 +134,10 @@ private:
   TemporalRegion     m_OutputTemporalRegion;
 
   /** Parameters for writing. */
-  TemporalRatioType            m_FramesPerSecond;
+  TemporalRatioType            m_FramesPerSecond{24};
   std::string                  m_FourCC;
   std::vector<SizeValueType>   m_Dimensions;
-  SizeValueType                m_NumberOfComponents;
+  SizeValueType                m_NumberOfComponents{0};
   ImageIOBase::IOComponentType m_ComponentType;
 };
 

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -33,9 +33,9 @@ VideoFileWriter< TInputVideoStream >
 ::VideoFileWriter() :
   m_FileName(""),
   m_VideoIO(nullptr),
-  m_FramesPerSecond(24),
-  m_FourCC("MP42"),
-  m_NumberOfComponents(0)
+
+  m_FourCC("MP42")
+
 {
   // TemporalProcessObject inherited members
   this->TemporalProcessObject::m_UnitInputNumberOfFrames = 1;

--- a/Modules/Video/IO/include/itkVideoIOBase.h
+++ b/Modules/Video/IO/include/itkVideoIOBase.h
@@ -120,16 +120,16 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member Variables */
-  ReadType           m_ReadType;
-  TemporalRatioType  m_FramesPerSecond;
+  ReadType           m_ReadType{ReadFromFile};
+  TemporalRatioType  m_FramesPerSecond{0.0};
   FrameOffsetType    m_FrameTotal;
   FrameOffsetType    m_CurrentFrame;
   FrameOffsetType    m_IFrameInterval;
   FrameOffsetType    m_LastIFrame;
-  TemporalRatioType  m_Ratio;
-  TemporalOffsetType m_PositionInMSec;
-  bool               m_WriterOpen;
-  bool               m_ReaderOpen;
+  TemporalRatioType  m_Ratio{0.0};
+  TemporalOffsetType m_PositionInMSec{0.0};
+  bool               m_WriterOpen{false};
+  bool               m_ReaderOpen{false};
 };
 
 } // end namespace itk

--- a/Modules/Video/IO/src/itkVideoIOBase.cxx
+++ b/Modules/Video/IO/src/itkVideoIOBase.cxx
@@ -25,16 +25,12 @@ namespace itk
 {
 
 VideoIOBase::VideoIOBase() :
-  m_ReadType(ReadFromFile),
-  m_FramesPerSecond(0.0),
+
   m_FrameTotal(NumericTraits<SizeValueType>::ZeroValue()),
   m_CurrentFrame(NumericTraits<SizeValueType>::ZeroValue()),
   m_IFrameInterval(NumericTraits<SizeValueType>::ZeroValue()),
-  m_LastIFrame(NumericTraits<SizeValueType>::ZeroValue()),
-  m_Ratio(0.0),
-  m_PositionInMSec(0.0),
-  m_WriterOpen(false),
-  m_ReaderOpen(false)
+  m_LastIFrame(NumericTraits<SizeValueType>::ZeroValue())
+
 {
 }
 

--- a/Utilities/ITKv5Preparation/modernize-use-default-member-init.sh
+++ b/Utilities/ITKv5Preparation/modernize-use-default-member-init.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+# \author Hans J. Johnson
+#
+# This script assists with using clang-tidy.
+#
+# STEP 0;
+# I recommend downloading or building the latest
+# version of llvm with clang and the clang-tidy
+# tools in a private repo. NOTE:  Apple does
+# not currently distribute these.
+#
+# STEP 1:
+# Build your source tree with cmake and use
+# export PATH=${MYCLANG_FROM_STEP0}:$PATH
+# export CXX=${MYCLANG_FROM_STEP0}
+# export CC=${MYCLANG_FROM_STEP0}
+# cd ${MYBLD}
+# cmake -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON ${MYSRC}
+# to generate the compile_commands.json
+# comple options database files.
+#
+# STEP 2:
+# Run clang-tidy with the
+
+SRCDIR=$1
+BLDDIR=$2
+
+this_script_name=$(basename $0)
+CMTMSG=$(mktemp -q /tmp/${this_script_name}.XXXXXX)
+FILES_TO_CHECK=$(mktemp -q /tmp/${this_script_name}_files.XXXXXX)
+
+cat > ${CMTMSG} << EOF
+STYLE: Use default member initialization
+
+Converts a default constructor’s member initializers into the new
+default member initializers in C++11. Other member initializers that match the
+default member initializer are removed. This can reduce repeated code or allow
+use of ‘= default’.
+
+SRCDIR=${SRCDIR} #My local SRC
+BLDDIR=${BLDDIR} #My local BLD
+
+cd ${BLDDIR}
+run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-default-member-init  -header-filter=.* -fix
+
+EOF
+
+export CC=/Users/johnsonhj/local/ccache/bin/clang_ccache
+export CXX=/Users/johnsonhj/local/ccache/bin/clang++11_ccache
+export PATH=~/local/llvm/llvm_trunk-build/bin:$PATH
+cd ${BLDDIR}
+/Users/johnsonhj/Dashboard/src/scripts/run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-default-member-init  -header-filter=.* -fix
+
+cd ${SRCDIR}
+git add -A && git commit --file ${CMTMSG}


### PR DESCRIPTION
Converts a default constructor’s member initializers into the new
default member initializers in C++11. Other member initializers that match the
default member initializer are removed. This can reduce repeated code or allow
use of ‘= default’.

VIM FIXUP:  :%s/\({[^}][^}]*}\)\(\1\)*/\1/g

SRCDIR=/Users/johnsonhj/Dashboard/src/ITK #My local SRC
BLDDIR=/Users/johnsonhj/Dashboard/src/ITK-clang/ #My local BLD

cd /Users/johnsonhj/Dashboard/src/ITK-clang/
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-default-member-init  -header-filter=.* -fix