### PR TITLE
ENH: Employ the `rule of zero` for aggregate types

### DIFF
--- a/Modules/Core/Common/include/itkBuildInformation.h
+++ b/Modules/Core/Common/include/itkBuildInformation.h
@@ -44,6 +44,8 @@ namespace itk
 class ITKCommon_EXPORT BuildInformation final: public Object
 {
 public:
+  // Using the `rule of zero` to this aggregate type
+  // C++20 changes the definition of aggregate such that classes with any user-declared ctors are no longer aggregates.
   ITK_DISALLOW_COPY_AND_ASSIGN(BuildInformation);
 
   /** Standard class type aliases. */
@@ -64,10 +66,6 @@ private:
   class InformationValueType
   {
   public:
-    InformationValueType() = default;
-    InformationValueType( const InformationValueType & ) = default;
-    InformationValueType( InformationValueType && ) = default;
-
     const MapValueType            m_Value;
     const MapValueDescriptionType m_Description;
   };

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -65,6 +65,9 @@ template <unsigned int VDimension = 2>
 struct ITK_TEMPLATE_EXPORT Index final
 {
 public:
+  // Using the `rule of zero` to this aggregate type
+  // C++20 changes the definition of aggregate such that classes with any user-declared ctors are no longer aggregates.
+
   /** Standard class type aliases. */
   using Self = Index;
 
@@ -267,13 +270,6 @@ public:
    */
   static_assert( VDimension > 0, "Error: Only positive value sized VDimension allowed" );
   alignas(IndexValueType) IndexValueType m_InternalArray[VDimension];
-
-  // Explicitly require constructors
-  Index() = default;
-  Index( const Self & ) = default;
-  Index( Self && ) = default;
-  Self & operator=( const Self & ) = default;
-  Self & operator=( Self && ) = default;
 
   /** Copy values from a FixedArray by rounding each one of the components */
   template <typename TCoordRep>

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -66,6 +66,9 @@ template <unsigned int VDimension = 2>
 struct ITK_TEMPLATE_EXPORT Offset final
 {
 public:
+  // Using the `rule of zero` to this aggregate type
+  // C++20 changes the definition of aggregate such that classes with any user-declared ctors are no longer aggregates.
+
   /** Standard class type aliases. */
   using Self = Offset;
 
@@ -223,13 +226,6 @@ public:
    */
   static_assert( VDimension > 0, "Error: Only positive value sized VDimension allowed" );
   alignas(OffsetValueType) OffsetValueType m_InternalArray[VDimension];
-
-  // Explicitly require constructors
-  Offset() = default;
-  Offset( const Self & ) = default;
-  Offset( Self && ) = default;
-  Self & operator=( const Self & ) = default;
-  Self & operator=( Self && ) = default;
 
   /** Copy values from a FixedArray by rounding each one of the components */
   template <typename TCoordRep>

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -67,6 +67,9 @@ template <unsigned int VDimension = 2>
 struct ITK_TEMPLATE_EXPORT  Size final
 {
 public:
+  // Using the `rule of zero` to this aggregate type
+  // C++20 changes the definition of aggregate such that classes with any user-declared ctors are no longer aggregates.
+
   /** Standard class type aliases. */
   using Self = Size;
 
@@ -212,13 +215,6 @@ public:
    */
   static_assert( VDimension > 0, "Error: Only positive value sized VDimension allowed" );
   alignas(SizeValueType) SizeValueType m_InternalArray[VDimension];
-
-  // Explicitly require constructors
-  Size() = default;
-  Size( const Self & ) = default;
-  Size( Self && ) = default;
-  Self & operator=( const Self & ) = default;
-  Self & operator=( Self && ) = default;
 
   // ======================= Mirror the access pattern behavior of the std::array class
   /**


### PR DESCRIPTION
Using the `rule of zero` to this aggregate type
C++20 changes the definition of aggregate such that classes with any user-declared ctors are no longer aggregates.

Fixes: #319
