### PR TITLE
COMP: Addressed unused parameter warning in ImageRegion default

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -117,7 +117,7 @@ public:
 
   /** Copy constructor. ImageRegion is a lightweight object that is not
    * reference counted, so the copy constructor is public. */
-  ImageRegion(const Self & region) ITK_NOEXCEPT = default;
+  ImageRegion(const Self & ) ITK_NOEXCEPT = default;
 
   /** Constructor that takes an index and size. ImageRegion is a lightweight
    * object that is not reference counted, so this constructor is public. */
@@ -142,7 +142,7 @@ public:
 
   /** operator=. ImageRegion is a lightweight object that is not reference
    * counted, so operator= is public. */
-  Self& operator=(const Self & region) ITK_NOEXCEPT = default;
+  Self& operator=(const Self & ) ITK_NOEXCEPT = default;
 
   /** Set the index defining the corner of the region. */
   void SetIndex(const IndexType & index)


### PR DESCRIPTION
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36) reports warning unused
arguments with default-ed members.


