### PR TITLE
COMP: Float narrowing conversion in BSpline classes

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
@@ -405,14 +405,14 @@ private:
   // Parameters for deconvolution with Wiener filter
 
   unsigned int m_NumberOfHistogramBins{ 200 };
-  RealType     m_WienerFilterNoise{ 0.01 };
-  RealType     m_BiasFieldFullWidthAtHalfMaximum{ 0.15 };
+  RealType     m_WienerFilterNoise{ static_cast< RealType >( 0.01 ) };
+  RealType     m_BiasFieldFullWidthAtHalfMaximum{ static_cast< RealType >( 0.15 ) };
 
   // Convergence parameters
 
   VariableSizeArrayType m_MaximumNumberOfIterations;
   unsigned int          m_ElapsedIterations{ 0 };
-  RealType              m_ConvergenceThreshold{ 0.001 };
+  RealType              m_ConvergenceThreshold{ static_cast< RealType >( 0.001 ) };
   RealType              m_CurrentConvergenceMeasurement;
   unsigned int          m_CurrentLevel{ 0 };
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.h
@@ -260,7 +260,7 @@ private:
   typename KernelOrder2Type::Pointer           m_KernelOrder2;
   typename KernelOrder3Type::Pointer           m_KernelOrder3;
 
-  RealType                                     m_BSplineEpsilon{ 1e-3 };
+  RealType                                     m_BSplineEpsilon{ static_cast< RealType >( 1e-3 ) };
 
   inline typename RealImageType::IndexType
   NumberToIndex( unsigned int number, typename RealImageType::SizeType size )

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
@@ -359,7 +359,7 @@ private:
   std::vector<RealImagePointer>                m_OmegaLatticePerThread;
   std::vector<PointDataImagePointer>           m_DeltaLatticePerThread;
 
-  RealType                                     m_BSplineEpsilon{ 1e-3 };
+  RealType                                     m_BSplineEpsilon{ static_cast< RealType >( 1e-3 ) };
   bool                                         m_IsFittingComplete{ false };
 };
 } // end namespace itk


### PR DESCRIPTION
…lter

To address build error uncovered by Windows Python wrapping:

```
c:\itk\modules\filtering\biascorrection\include\itkN4BiasFieldCorrectionImageFilter.h(415): error C2397: conversion from 'double' to 'itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::RealType' requires a narrowing conversion
c:\itk\modules\filtering\imagegrid\include\itkBSplineScatteredDataPointSetToImageFilter.h(362): error C2397: conversion from 'double' to 'itk::BSplineScatteredDataPointSetToImageFilter<itk::PointSet<itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType,2,itk::DefaultStaticMeshTraits<TPixelType,2,2,float,float,TPixelType>>,itk::Image<itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType,2>>::RealType' requires a narrowing conversion
        with
        [
            TPixelType=itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType
        ]
c:\itk\modules\filtering\imagegrid\include\itkBSplineScatteredDataPointSetToImageFilter.hxx(40): note: while compiling class template member function 'itk::BSplineScatteredDataPointSetToImageFilter<itk::PointSet<itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType,2,itk::DefaultStaticMeshTraits<TPixelType,2,2,float,float,TPixelType>>,itk::Image<itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType,2>>::BSplineScatteredDataPointSetToImageFilter(void)'
        with
        [
            TPixelType=itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType
        ]
c:\itk\modules\filtering\imagegrid\include\itkBSplineScatteredDataPointSetToImageFilter.h(142): note: see reference to function template instantiation 'itk::BSplineScatteredDataPointSetToImageFilter<itk::PointSet<itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType,2,itk::DefaultStaticMeshTraits<TPixelType,2,2,float,float,TPixelType>>,itk::Image<itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType,2>>::BSplineScatteredDataPointSetToImageFilter(void)' being compiled
        with
        [
            TPixelType=itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType
        ]
c:\itk\modules\filtering\biascorrection\include\itkN4BiasFieldCorrectionImageFilter.h(137): note: see reference to class template instantiation 'itk::BSplineScatteredDataPointSetToImageFilter<itk::PointSet<itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType,2,itk::DefaultStaticMeshTraits<TPixelType,2,2,float,float,TPixelType>>,itk::Image<itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType,2>>' being compiled
        with
        [
            TPixelType=itk::N4BiasFieldCorrectionImageFilter<ImageType,MaskImageType,ImageType>::ScalarType
        ]
```