### PR TITLE
STYLE: Small improvements ImageBase constructor, SetRequestedRegion, '\'

### DIFF
--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -42,8 +42,9 @@ namespace itk
 template< unsigned int VImageDimension >
 ImageBase< VImageDimension >
 ::ImageBase()
+:
+m_OffsetTable{}
 {
-  memset(m_OffsetTable, 0, sizeof(m_OffsetTable));
   m_Spacing.Fill(1.0);
   m_Origin.Fill(0.0);
   m_Direction.SetIdentity();
@@ -474,10 +475,7 @@ void
 ImageBase< VImageDimension >
 ::SetRequestedRegion(const RegionType & region)
 {
-  if ( m_RequestedRegion != region )
-    {
-    m_RequestedRegion = region;
-    }
+  m_RequestedRegion = region;
 }
 
 
@@ -547,7 +545,7 @@ ImageBase< VImageDimension >
 
   os << indent << "Spacing: " << this->GetSpacing() << std::endl;
 
-  os << indent << "Origin: " << this->GetOrigin() << std::endl; \
+  os << indent << "Origin: " << this->GetOrigin() << std::endl;
 
   os << indent << "Direction: " << std::endl << this->GetDirection() << std::endl;
 


### PR DESCRIPTION
Initialized ImageBase::m_OffsetTable (a 'C array' of integers) by curly braces,
`{}`, in constructor member-initializer-list, instead of calling `memset`.

Removed check if m_RequestedRegion != region before ImageRegion assignment, as
this assignment is already very fast and `noexcept`. Note that this apparently
unnecessary 'if' was there already in 2001 (in Code/Common/itkImageBase.txx),
SHA-1: 73e22b2cb3fa156192f819c3d11706f86b6c9845

Removed dangling backslash, `\`, from PrintSelf, introduced in 2005 (in
Code/Common/itkImageBase.txx), SHA-1: 7510eae6effdf82a9b0307983dec0942d316f32b