### PR TITLE
COMP: Fix "unreachable code" MakeOutput RegistrationMethods

### DIFF
--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -303,15 +303,11 @@ DataObject::Pointer
 ImageRegistrationMethod< TFixedImage, TMovingImage >
 ::MakeOutput(DataObjectPointerArraySizeType output)
 {
-  switch ( output )
-    {
-    case 0:
-      return TransformOutputType::New().GetPointer();
-      break;
-    default:
-      itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs");
-      return nullptr;
-    }
+  if (output > 0)
+  {
+    itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs.");
+  }
+  return TransformOutputType::New().GetPointer();
 }
 
 template< typename TFixedImage, typename TMovingImage >

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
@@ -165,15 +165,11 @@ DataObject::Pointer
 ImageToSpatialObjectRegistrationMethod< TFixedImage, TMovingSpatialObject >
 ::MakeOutput(DataObjectPointerArraySizeType output)
 {
-  switch ( output )
-    {
-    case 0:
-      return TransformOutputType::New().GetPointer();
-      break;
-    default:
-      itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs");
-      return nullptr;
-    }
+  if (output > 0)
+  {
+    itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs.");
+  }
+  return TransformOutputType::New().GetPointer();
 }
 
 template< typename TFixedImage, typename TMovingSpatialObject >

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -465,15 +465,11 @@ DataObject::Pointer
 MultiResolutionImageRegistrationMethod< TFixedImage, TMovingImage >
 ::MakeOutput(DataObjectPointerArraySizeType output)
 {
-  switch ( output )
-    {
-    case 0:
-      return TransformOutputType::New().GetPointer();
-      break;
-    default:
-      itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs");
-      return nullptr;
-    }
+  if (output > 0)
+  {
+    itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs.");
+  }
+  return TransformOutputType::New().GetPointer();
 }
 } // end namespace itk
 

--- a/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
@@ -164,15 +164,11 @@ DataObject::Pointer
 PointSetToImageRegistrationMethod< TFixedPointSet, TMovingImage >
 ::MakeOutput(DataObjectPointerArraySizeType output)
 {
-  switch ( output )
-    {
-    case 0:
-      return TransformOutputType::New().GetPointer();
-      break;
-    default:
-      itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs");
-      return nullptr;
-    }
+  if (output > 0)
+  {
+    itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs.");
+  }
+  return TransformOutputType::New().GetPointer();
 }
 
 template< typename TFixedPointSet, typename TMovingImage >

--- a/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
@@ -158,15 +158,11 @@ DataObject::Pointer
 PointSetToPointSetRegistrationMethod< TFixedPointSet, TMovingPointSet >
 ::MakeOutput(DataObjectPointerArraySizeType output)
 {
-  switch ( output )
-    {
-    case 0:
-      return TransformOutputType::New().GetPointer();
-      break;
-    default:
-      itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs");
-      return nullptr;
-    }
+  if (output > 0)
+  {
+    itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs.");
+  }
+  return TransformOutputType::New().GetPointer();
 }
 
 template< typename TFixedPointSet, typename TMovingPointSet >

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1224,20 +1224,15 @@ DataObject::Pointer
 ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, TPointSet>
 ::MakeOutput( DataObjectPointerArraySizeType output )
 {
-  switch ( output )
-    {
-    case 0:
-      {
-      OutputTransformPointer ptr;
-      Self::MakeOutputTransform(ptr);
-      DecoratedOutputTransformPointer transformDecorator =  DecoratedOutputTransformType::New();
-      transformDecorator->Set( ptr );
-      return transformDecorator.GetPointer();
-      }
-    default:
-      itkExceptionMacro( "MakeOutput request for an output number larger than the expected number of outputs." );
-      return nullptr;
-    }
+  if (output > 0)
+  {
+    itkExceptionMacro("MakeOutput request for an output number larger than the expected number of outputs.");
+  }
+  OutputTransformPointer ptr;
+  Self::MakeOutputTransform(ptr);
+  DecoratedOutputTransformPointer transformDecorator =  DecoratedOutputTransformType::New();
+  transformDecorator->Set( ptr );
+  return transformDecorator.GetPointer();
 }
 
 template<typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>


### PR DESCRIPTION
The MakeOutput(output) member functions of six RegistrationMethod classes did
return, after throwing an exception. It appears that MakeOutput(output)
functions already did so in 2011 (for example, SimpleImageRegistrationMethod
SHA-1: 2e548c6b0f20007779ec4f74a1a13d9dbe6b7ec2). Unfortunately, these return
statements triggered Visual C++ warnings (at Warning Level 4):

    itk\modules\core\common\include\itksmartpointer.h(70): warning C4702: unreachable code

This commit refactors these MakeOutput(output) member functions, avoiding the
compiler warning and simplifying the code.