### PR TITLE
 COMP: use HDF5 library names only to avoid abspaths w/ SYSTEM_HDF5

### DIFF
--- a/Modules/ThirdParty/HDF5/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
     ${HDF5_INCLUDE_DIR_CPP}
     )
   list(APPEND ITKHDF5_LIBRARIES
-    ${HDF5_LIBRARIES}
+    ${HDF5_CXX_LIBRARY_NAMES}
     )
   set(ITKHDF5_NO_SRC 1)
 else()


### PR DESCRIPTION
This change prevents the installed `ITKHDF5.cmake` config file from listing absolute paths when built with `ITK_USE_SYSTEM_HDF5`. Summary of how this happens, from [this comment](https://github.com/conda-forge/libitk-feedstock/issues/7#issuecomment-449040962):

In CMake's FindHDF5 routine, when building against a non-CMake HDF5 build (as in Anaconda):

1) FindHDF5 calls `h5cc -showconfig`
    - among many other things, this gives `Extra libraries: -lrt -lpthread -lz -ldl -lm`
2) [FindHDF5 matches anything in the output that has `-l<...>`](https://github.com/Kitware/CMake/blob/049d324e42451fb92d9504551f3885e221f05b8a/Modules/FindHDF5.cmake#L379-L381)
    - so it matches `-lrt`
3) runs `find_library` for every library identified by (2). This gives the FULL PATH to either the system library (or with changes the one in the host (BUILD_PREFIX) from conda CDT as in my note below).
4) puts the result of (3) in HDF5_LIBRARIES, which is [then included in the `ITKHDF5_LIBRARIES` variable](https://github.com/InsightSoftwareConsortium/ITK/blob/238363b90edebb6c76d444d6864f102796fcbe90/Modules/ThirdParty/HDF5/CMakeLists.txt#L44-L46), which ends up in `ITK_LIBRARIES`, as we see here.

---

This relates to the following issues:

- https://insightsoftwareconsortium.atlassian.net/browse/ITK-3545
- https://github.com/conda-forge/libitk-feedstock/issues/7
