### PR TITLE
PERF: Remove SystemInformation data from ResourceProbe, fix issue #350

### DIFF
--- a/Modules/Core/Common/include/itkResourceProbe.h
+++ b/Modules/Core/Common/include/itkResourceProbe.h
@@ -151,8 +151,8 @@ protected:
   void PrintJSONvar(std::ostream & os, const char* varName, T varValue,
       unsigned indent = 4, bool comma = true);
 
-  /** Get System information */
-  virtual void GetSystemInformation();
+  /** Obsolete member function from ITK 4.8 - 4.13. Does not do anything anymore. */
+  itkLegacyMacro(virtual void GetSystemInformation());
 
 private:
 
@@ -172,23 +172,6 @@ private:
   std::string                m_NameOfProbe;
   std::string                m_TypeString;
   std::string                m_UnitString;
-
-  std::string                m_SystemName;
-  std::string                m_ProcessorName;
-  int                        m_ProcessorCacheSize;
-  float                      m_ProcessorClockFrequency;
-  unsigned int               m_NumberOfPhysicalCPU;
-  unsigned int               m_NumberOfLogicalCPU;
-  std::string                m_OSName;
-  std::string                m_OSRelease;
-  std::string                m_OSVersion;
-  std::string                m_OSPlatform;
-  bool                       m_Is64Bits;
-  std::string                m_ITKVersion;
-  size_t                     m_TotalVirtualMemory;
-  size_t                     m_AvailableVirtualMemory;
-  size_t                     m_TotalPhysicalMemory;
-  size_t                     m_AvailablePhysicalMemory;
 
   static constexpr unsigned int  tabwidth  = 15;
 };


### PR DESCRIPTION
ITK 4.9 added system info to `itk::ResourceProbe` (the base class of
`itk::TimeProbe` and `itk::MemoryProbe`), by calling `GetSystemInformation()`
in its constructor. This function call appeared very time consuming.
Using Visual Studio 2017 (Release configuration), it was observed that a single
`GetSystemInformation()` function call took more than 0.1 second.

This commit removes the `this->GetSystemInformation()` function call from
ResourceProbe, deprecates the member function, removes the related data
members, and only retrieves the system info when and where it is actually being
used: in `PrintSystemInformation` and `PrintJSONSystemInformation`.

Fixes issue #350, "Major performance issue TimeProbe, ResourceProbe
constructor", which was based on the analysis of an `elastix` example
case by Theo van Walsum (@tvanwalsum).