### PR TITLE
STYLE: Remove dynamic_cast from CastToSTLContainer(), add noexcept

### DIFF
--- a/Modules/Core/Common/include/itkMapContainer.h
+++ b/Modules/Core/Common/include/itkMapContainer.h
@@ -89,13 +89,15 @@ public:
   using STLContainerType = MapType;
 
   /** Cast the container to a STL container type */
-  STLContainerType & CastToSTLContainer()
-  { return dynamic_cast< STLContainerType & >( *this ); }
+  STLContainerType & CastToSTLContainer() ITK_NOEXCEPT
+  {
+    return *this;
+  }
 
   /** Cast the container to a const STL container type */
-  const STLContainerType & CastToSTLConstContainer() const
+  const STLContainerType & CastToSTLConstContainer() const ITK_NOEXCEPT
   {
-    return dynamic_cast< const STLContainerType & >( *this );
+    return *this;
   }
 
   using STLContainerType::begin;

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -102,15 +102,15 @@ public:
   class ConstIterator;
 
   /** Cast the container to a STL container type */
-  STLContainerType & CastToSTLContainer()
+  STLContainerType & CastToSTLContainer() ITK_NOEXCEPT
   {
-    return dynamic_cast< STLContainerType & >( *this );
+    return *this;
   }
 
   /** Cast the container to a const STL container type */
-  const STLContainerType & CastToSTLConstContainer() const
+  const STLContainerType & CastToSTLConstContainer() const ITK_NOEXCEPT
   {
-    return dynamic_cast< const STLContainerType & >( *this );
+    return *this;
   }
 
   using STLContainerType::begin;


### PR DESCRIPTION
Removed unnecessary dynamic_cast's from the implementations of
`CastToSTLContainer()` and `CastToSTLConstContainer()` member functions of
`itk::MapContainer` and `itk::VectorContainer`.

Without the dynamic_cast's, these member functions will certainly never throw
an exception anymore, so this commit also declares them 'noexcept'.