### PR TITLE
PERF: N4BiasFieldCorrectionImageFilter adds points + weights ~20% faster 

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
@@ -389,7 +389,7 @@ private:
    * the estimate and adds the resulting control point values to the total
    * bias field estimate.
    */
-  RealImagePointer UpdateBiasFieldEstimate( RealImageType * );
+  RealImagePointer UpdateBiasFieldEstimate( RealImageType *, std::size_t );
 
   /**
    * Reconstruct bias field given the control point lattice.


### PR DESCRIPTION
N4BiasFieldCorrectionImageFilter::UpdateBiasFieldEstimate now adds the points
and weights for the internally used BSplineFilter in a much faster way than
before, by:
 * Reserving the memory needed to store the data beforehand.
 * Directly doing `push_back` on the STL containers from the internally used
itk::PointSet and itk::VectorContainer.

Using VS2015 (Release), approximately 20% reduction of the run-time duration was
observed (from 70 down to 56 seconds) on a 3-D MRI volume + mask (453x340x20),
provided by Denis (@dpshamonin), at LKEB, Leiden University Medical Center.