### PR TITLE
PERF: Fast assign point data, weights BSplineScatteredData filter

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -261,18 +261,14 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>
   this->m_OutputPointData->Initialize();
   if( inputPointSet->GetNumberOfPoints() > 0 )
     {
-    typename PointDataContainerType::ConstIterator It =
-      inputPointSet->GetPointData()->Begin();
-    while( It != inputPointSet->GetPointData()->End() )
+    const auto& pointData = inputPointSet->GetPointData()->CastToSTLConstContainer();
+
+    if( !m_UsePointWeights )
       {
-      if( !this->m_UsePointWeights )
-        {
-        this->m_PointWeights->InsertElement( It.Index(), 1.0 );
-        }
-      this->m_InputPointData->InsertElement( It.Index(), It.Value() );
-      this->m_OutputPointData->InsertElement( It.Index(), It.Value() );
-      ++It;
+      m_PointWeights->CastToSTLContainer().assign(pointData.size(), 1);
       }
+    m_InputPointData->CastToSTLContainer() = pointData;
+    m_OutputPointData->CastToSTLContainer() = pointData;
     }
 
   this->m_CurrentLevel = 0;


### PR DESCRIPTION
`BSplineScatteredDataPointSetToImageFilter::GenerateData()` now does fast
assignments to the internal STL containers of `m_PointWeights`,
`m_InputPointData`, and `m_OutputPointData`, instead of calling the expensive
`itk::VectorContainer::InsertElement` member function.

Using VS2015 (Release), ~8% run-time duration reduction was observed on an
`Update()` of `BSplineScatteredDataPointSetToImageFilter`. For an `Update()`
of `N4BiasFieldCorrectionImageFilter` (which heavily uses
`BSplineScatteredDataPointSetToImageFilter`), ~7% run-time duration reduction
was observed (from 56 sec to 52 sec, on a 3-D MRI volume + mask (453x340x20),
provided by Denis (@dpshamonin), at LKEB, Leiden University Medical Center).