### PR TITLE
COMP: ImageBufferRange iterator same as const_iterator, for const image

### DIFF
--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -539,9 +539,10 @@ private:
     }
 
     // Converts to a 'QualifiedIterator' object.
-    operator QualifiedIterator<false>() const ITK_NOEXCEPT
+    template <bool VIsConst>
+    operator QualifiedIterator<VIsConst>() const ITK_NOEXCEPT
     {
-      return QualifiedIterator<false>{m_OptionalAccessorFunctor, m_InternalPixelPointer};
+      return QualifiedIterator<VIsConst>{m_OptionalAccessorFunctor, m_InternalPixelPointer};
     }
 
     // Converts to a raw pixel pointer.
@@ -567,7 +568,7 @@ public:
   using const_iterator = typename std::conditional<UsingPointerAsIterator,
     const InternalPixelType*, QualifiedIterator<true>>::type;
   using iterator = typename std::conditional<UsingPointerAsIterator,
-    QualifiedInternalPixelType*, QualifiedIterator<false>>::type;
+    QualifiedInternalPixelType*, QualifiedIterator<IsImageTypeConst>>::type;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -35,6 +35,7 @@ template class itk::Experimental::ImageBufferRange<itk::Image<short, 3>>;
 template class itk::Experimental::ImageBufferRange<itk::Image<short, 4>>;
 template class itk::Experimental::ImageBufferRange<const itk::Image<short>>;
 template class itk::Experimental::ImageBufferRange<itk::VectorImage<short>>;
+template class itk::Experimental::ImageBufferRange<const itk::VectorImage<short, 4>>;
 
 using itk::Experimental::ImageBufferRange;
 using itk::Experimental::MakeImageBufferRange;
@@ -62,6 +63,27 @@ namespace
   static_assert(!DoesImageBufferRangeIteratorDereferenceOperatorReturnReference<const itk::VectorImage<int>>(),
     "ImageBufferRange::iterator::operator*() should not return a reference for a 'const' itk::VectorImage.");
 
+
+  // Tells whether or not ImageBufferRange<TImage>::iterator is the same type
+  // as ImageBufferRange<TImage>::const_iterator.
+  template <typename TImage>
+  constexpr bool IsIteratorTypeTheSameAsConstIteratorType()
+  {
+    using RangeType = ImageBufferRange<TImage>;
+
+    return std::is_same<
+      typename RangeType::iterator, typename RangeType::const_iterator>::value;
+  }
+
+
+  static_assert(
+    !IsIteratorTypeTheSameAsConstIteratorType<itk::Image<int>>() &&
+    !IsIteratorTypeTheSameAsConstIteratorType<itk::VectorImage<int>>(),
+    "For a non-const image, non-const iterator and const_iterator should be different types!");
+  static_assert(
+    IsIteratorTypeTheSameAsConstIteratorType<const itk::Image<int>>() &&
+    IsIteratorTypeTheSameAsConstIteratorType<const itk::VectorImage<int>>(),
+    "For a const image, non-const iterator and const_iterator should be the same type!");
 
   template<typename TImage>
   typename TImage::Pointer CreateImage(const unsigned sizeX, const unsigned sizeY)


### PR DESCRIPTION
When `TImage` is a `const` image type, it is not necessary to distinguish
between the non-const `iterator` type and the `const_iterator` type of
`ImageBufferRange<TImage>`.

This commit ensures that for a `const` image, `iterator` and `const_iterator`
are the same. They were the same already for a `const itk::Image`, but now they
are also the same for a `const itk::VectorImage`. Thereby this commit will reduce
"template code bloat" (reducing the number of template instantiations).

Also fixes `ImageBufferRange<const VectorImage>` errors reported by GCC ("could
not convert from 'IteratorInitializer'") and Clang ("no viable conversion...").