### PR TITLE
COMP: Remove itk::ThreadPool::GetGlobalDefaultNumberOfThreadsByPlatform

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -258,19 +258,21 @@ AfterThreadedGenerateData()
 }
 ```
 
-`Get/SetGlobalMaximumNumberOfThreads()` and `GlobalDefaultNumberOfThreads()`
-now reside in `itk::MultiThreaderBase`. With a warning, they are still
-available in `itk::PlatformMultiThreader`. In image filters and other
-descendents of `itk::ProcessObject`, method `SetNumberOfThreads`
-has been renamed into `SetNumberOfWorkUnits`. For `itk::MultiThreaderBase`
-and descendents, `SetNumberOfThreads` has been split into
-`SetMaximumNumberOfThreads` and `SetNumberOfWorkUnits`.
-Load balancing is possible when `NumberOfWorkUnits` is greater
-than the number of threads. The common case of
-`innerFilter->SetNumberOfThreads(1);` should be replaced by
-`innerFilter->SetNumberOfWorkUnits(1);`. Generally, in most places
-where threads were being manipulated before, work units should be
-accessed or changed now.
+`Get/SetGlobalMaximumNumberOfThreads()`, and `GlobalDefaultNumberOfThreads()`
+now reside in `itk::MultiThreaderBase`.  With a warning, they are still
+available in `itk::PlatformMultiThreader`.
+`GetGlobalDefaultNumberOfThreadsByPlatform()` has also been moved from
+`itk::ThreadPool` to `itk::MultiThreaderBase`.  In image filters and other
+descendents of `itk::ProcessObject`, method `SetNumberOfThreads` has been
+renamed into `SetNumberOfWorkUnits`.  For `itk::MultiThreaderBase` and
+descendents, `SetNumberOfThreads` has been split into
+`SetMaximumNumberOfThreads` and `SetNumberOfWorkUnits`.  Load balancing is
+possible when `NumberOfWorkUnits` is greater than the number of threads. The
+common case of `innerFilter->SetNumberOfThreads(1);` should be replaced by
+`innerFilter->SetNumberOfWorkUnits(1);`. Generally, in most places where
+threads were being manipulated before, work units should be accessed or
+changed now.
+
 
 To transition to the new threading model, it is usually enough to rename
 `ThreadedGenerateData` into `DynamicThreadedGenerateData`, remove the

--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -106,9 +106,6 @@ public:
   /** The approximate number of idle threads. */
   int GetNumberOfCurrentlyIdleThreads() const;
 
-  /** Platform specific number of threads. Deprecated! */
-  itkLegacyMacro( static ThreadIdType GetGlobalDefaultNumberOfThreadsByPlatform() );
-
   /** Set/Get wait for threads.
   This function should be used carefully, probably only during static
   initialization phase to disable waiting for threads when ITK is built as a


### PR DESCRIPTION
This does not have an implementation after migration to
itk::MultiThreaderBase. This causes errors on Windows and with the
Python wrapping.

Remove and make a note in the Migration Guide.