### PR TITLE
STYLE: Explicitly defaulted default-constructors Vector Accessor classes

### DIFF
--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
@@ -92,7 +92,7 @@ public:
   /** Get Vector lengths */
   VectorLengthType GetVectorLength() const { return m_VectorLength; }
 
-  DefaultVectorPixelAccessor()  {}
+  DefaultVectorPixelAccessor() = default;
 
   /** Constructor to initialize VectorLength at construction time */
   DefaultVectorPixelAccessor(VectorLengthType l)

--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessorFunctor.h
@@ -77,7 +77,7 @@ public:
   }
 
 
-  DefaultVectorPixelAccessorFunctor () : m_Begin(nullptr) {}
+  DefaultVectorPixelAccessorFunctor() = default;
 
   /** Set the PixelAccessor. This is set at construction time by the image iterators.
    * The type PixelAccessorType is obtained from the ImageType over which the iterators
@@ -106,7 +106,7 @@ public:
 
 private:
   PixelAccessorType  m_PixelAccessor;    // The pixel accessor
-  InternalPixelType *m_Begin;            // Begin of the buffer
+  InternalPixelType *m_Begin{nullptr};   // Begin of the buffer
 };
 }
 

--- a/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
@@ -54,9 +54,8 @@ public:
   using ImageBoundaryConditionType = ImageBoundaryCondition<ImageType, TOutput>;
 
   VectorImageNeighborhoodAccessorFunctor(VectorLengthType length):
-    m_VectorLength(length), m_OffsetMultiplier(length - 1), m_Begin(nullptr) {}
-  VectorImageNeighborhoodAccessorFunctor():
-     m_Begin(nullptr) {}
+    m_VectorLength(length), m_OffsetMultiplier(length - 1) {}
+  VectorImageNeighborhoodAccessorFunctor() = default;
 
   /** Set the pointer index to the start of the buffer.
    * This must be set by the iterators to the starting location of the buffer.
@@ -129,7 +128,7 @@ private:
   VectorLengthType m_VectorLength{0};
   VectorLengthType m_OffsetMultiplier{0}; // m_OffsetMultiplier = m_VectorLength-1
                                        // (precomputed for speedup).
-  InternalPixelType *m_Begin;          // Begin of the buffer.
+  InternalPixelType *m_Begin{nullptr}; // Begin of the buffer.
 };
 } // end namespace itk
 #endif


### PR DESCRIPTION
Defaulted (`= default`) the default-constructors of Vector Accessor classes,
`DefaultVectorPixelAccessor`, `DefaultVectorPixelAccessorFunctor`, and
`VectorImageNeighborhoodAccessorFunctor`.

Initialized the `m_Begin` data member of both `Functor` classes by a C++11
in-class default member initializer, `{nullptr}`.

Note: this commit ensures that these default-constructors will usually get a
non-throwing exception specification (implicitly). For example,
`noexcept(itk::DefaultVectorPixelAccessor<int>{})` was `false` before this
commit, and will be `true` after this commit.