### PR TITLE
COMP: Mark DCMTKImageIO::CanWriteFile argument as unused

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -150,7 +150,7 @@ bool DCMTKImageIO::CanReadFile(const char *filename)
   return DCMTKFileReader::IsImageFile(filename);
 }
 
-bool DCMTKImageIO::CanWriteFile(const char *name)
+bool DCMTKImageIO::CanWriteFile(const char * itkNotUsed( name ))
 {
   // writing is currently not implemented
   return false;


### PR DESCRIPTION
To address:

  /ITK/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx:153:45: warning: unused
  parameter 'name' [-Wunused-parameter]
  bool DCMTKImageIO::CanWriteFile(const char *name)