### PR TITLE
ENH: Made ShapedImageNeighborhoodRange assignable and tested copy + move

### DIFF
--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -573,7 +573,10 @@ public:
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 
-  /** Constructs an empty range
+  /** Explicitly-defaulted default-constructor. Constructs an empty range.
+   * \note The other five "special member functions" (copy-constructor,
+   * copy-assignment operator, move-constructor, move-assignment operator,
+   * and destructor) are defaulted implicitly, following the C++ "Rule of Zero".
    */
   ImageBufferRange() = default;
 
@@ -666,10 +669,6 @@ public:
 
     return this->begin()[static_cast<std::ptrdiff_t>(n)];
   }
-
-
-  /** Explicitly-defaulted destructor. */
-  ~ImageBufferRange() = default;
 };
 
 /** Creates a range to iterate over the pixels of the specified image.

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -619,9 +619,9 @@ private:
   const OffsetType* m_ShapeOffsets{ nullptr };
 
   // The number of neighborhood pixels.
-  const std::size_t m_NumberOfNeighborhoodPixels{ 0 };
+  std::size_t m_NumberOfNeighborhoodPixels{ 0 };
 
-  const OptionalPixelAccessParameterType m_OptionalPixelAccessParameter{};
+  OptionalPixelAccessParameterType m_OptionalPixelAccessParameter{};
 
 public:
   using const_iterator = QualifiedIterator<true>;
@@ -629,7 +629,11 @@ public:
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-  /** Default-constructor. Constructs an empty range. */
+  /** Explicitly-defaulted default-constructor. Constructs an empty range.
+   * \note The other five "special member functions" (copy-constructor,
+   * copy-assignment operator, move-constructor, move-assignment operator,
+   * and destructor) are defaulted implicitly, following the C++ "Rule of Zero".
+   */
   ShapedImageNeighborhoodRange() = default;
 
   /** Specifies a range for the neighborhood of a pixel at the specified
@@ -797,10 +801,6 @@ public:
     m_RelativeLocation = location;
     SubtractIndex(m_RelativeLocation, m_BufferedRegionData.m_Index);
   }
-
-
-  /** Explicitly-defaulted destructor. */
-  ~ShapedImageNeighborhoodRange() = default;
 };
 
 

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -21,6 +21,7 @@
 
 #include "itkImage.h"
 #include "itkMacro.h" // For itkNotUsed.
+#include "itkRangeGTestUtilities.h"
 #include "itkVectorImage.h"
 
 #include <gtest/gtest.h>
@@ -39,6 +40,7 @@ template class itk::Experimental::ImageBufferRange<const itk::VectorImage<short,
 
 using itk::Experimental::ImageBufferRange;
 using itk::Experimental::MakeImageBufferRange;
+using itk::Experimental::RangeGTestUtilities;
 
 
 namespace
@@ -133,6 +135,19 @@ namespace
   }
 
 
+  template<typename TImage>
+  typename TImage::Pointer CreateSmallImage()
+  {
+    const auto image = TImage::New();
+    typename TImage::SizeType imageSize;
+    imageSize.Fill(0);
+    image->SetRegions(imageSize);
+    SetVectorLengthIfImageIsVectorImage(*image, 1);
+    image->Allocate(true);
+    return image;
+  }
+
+
   template <typename TRange>
   void ExpectBeginIsEndWhenRangeIsDefaultConstructed()
   {
@@ -198,6 +213,46 @@ namespace
 
     EXPECT_EQ(actualRange.begin(), expectedRange.begin());
     EXPECT_EQ(actualRange.end(), expectedRange.end());
+  }
+
+
+  template <typename TImage>
+  void ExpectCopyConstructedRangeHasSameIteratorsAsOriginal()
+  {
+    const auto image = CreateSmallImage<TImage>();
+    const ImageBufferRange<TImage> originalRange{ *image };
+
+    RangeGTestUtilities::ExpectCopyConstructedRangeHasSameIteratorsAsOriginal(originalRange);
+  }
+
+
+  template <typename TImage>
+  void ExpectCopyAssignedRangeHasSameIteratorsAsOriginal()
+  {
+    const auto image = CreateSmallImage<TImage>();
+    const ImageBufferRange<TImage> originalRange{ *image };
+
+    RangeGTestUtilities::ExpectCopyAssignedRangeHasSameIteratorsAsOriginal(originalRange);
+  }
+
+
+  template <typename TImage>
+  void ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove()
+  {
+    const auto image = CreateSmallImage<TImage>();
+
+    RangeGTestUtilities::ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove(
+      ImageBufferRange<TImage>{ *image });
+  }
+
+
+  template <typename TImage>
+  void ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove()
+  {
+    const auto image = CreateSmallImage<TImage>();
+
+    RangeGTestUtilities::ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove(
+      ImageBufferRange<TImage>{ *image });
   }
 
 }  // namespace
@@ -799,4 +854,36 @@ TEST(ImageBufferRange, MakeImageBufferRangeReturnsCorrectRangeForNonEmptyImage)
 {
   ExpectMakeImageBufferRangeReturnsCorrectRangeForNonEmptyImage<itk::Image<int>>();
   ExpectMakeImageBufferRangeReturnsCorrectRangeForNonEmptyImage<itk::VectorImage<int>>();
+}
+
+
+// Tests that a copy-constructed range has the same iterators (begin and end) as the original.
+TEST(ImageBufferRange, CopyConstructedRangeHasSameIterators)
+{
+  ExpectCopyConstructedRangeHasSameIteratorsAsOriginal<itk::Image<int>>();
+  ExpectCopyConstructedRangeHasSameIteratorsAsOriginal<itk::VectorImage<int>>();
+}
+
+
+// Tests that a copy-assigned range has the same iterators (begin and end) as the original.
+TEST(ImageBufferRange, CopyAssignedRangeHasSameIterators)
+{
+  ExpectCopyAssignedRangeHasSameIteratorsAsOriginal<itk::Image<int>>();
+  ExpectCopyAssignedRangeHasSameIteratorsAsOriginal<itk::VectorImage<int>>();
+}
+
+
+// Tests that a move-constructed range has the same iterators as the original, before the move.
+TEST(ImageBufferRange, MoveConstructedRangeHasSameIterators)
+{
+  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::Image<int>>();
+  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::VectorImage<int>>();
+}
+
+
+// Tests that a move-assigned range has the same iterators as the original, before the move.
+TEST(ImageBufferRange, MoveAssignedRangeHasSameIterators)
+{
+  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::Image<int>>();
+  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::VectorImage<int>>();
 }

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -1,0 +1,92 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkRangeGTestUtilities_h
+#define itkRangeGTestUtilities_h
+
+#include <gtest/gtest.h>  // For EXPECT_EQ.
+
+#include <utility>  // For move.
+#include <iterator>  // For begin and end.
+
+namespace itk
+{
+namespace Experimental
+{
+// Utilities for GoogleTest unit tests of iterator ranges.
+// Note: This class is only for internal (testing) purposes.
+// It is not part of the public API of ITK.
+class RangeGTestUtilities
+{
+public:
+
+  template <typename TRange>
+  static void ExpectCopyConstructedRangeHasSameIteratorsAsOriginal(const TRange& originalRange)
+  {
+    const TRange copyConstructedRange(originalRange);
+
+    ExpectRangesHaveEqualBeginAndEnd(copyConstructedRange, originalRange);
+  }
+
+
+  template <typename TRange>
+  static void ExpectCopyAssignedRangeHasSameIteratorsAsOriginal(const TRange& originalRange)
+  {
+    TRange copyAssignedRange;
+    copyAssignedRange = originalRange;
+
+    ExpectRangesHaveEqualBeginAndEnd(copyAssignedRange, originalRange);
+  }
+
+
+  template <typename TRange>
+  static void ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove(TRange&& originalRange)
+  {
+    const TRange originalRangeBeforeMove = originalRange;
+    TRange moveConstructedRange(std::move(originalRange));
+
+    ExpectRangesHaveEqualBeginAndEnd(moveConstructedRange, originalRangeBeforeMove);
+  }
+
+
+  template <typename TRange>
+  static void ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove(TRange&& originalRange)
+  {
+    const TRange originalRangeBeforeMove = originalRange;
+
+    TRange moveAssignedRange;
+    moveAssignedRange = std::move(originalRange);
+
+    ExpectRangesHaveEqualBeginAndEnd(moveAssignedRange, originalRangeBeforeMove);
+  }
+
+private:
+
+  template <typename TRange>
+  static void ExpectRangesHaveEqualBeginAndEnd(const TRange& range1, const TRange& range2)
+  {
+    EXPECT_EQ(std::begin(range1), std::begin(range2));
+    EXPECT_EQ(std::end(range1), std::end(range2));
+  }
+
+};
+
+}  // end namespace Experimental
+}  // end namespace itk
+
+#endif

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -24,6 +24,7 @@
 #include "itkConstNeighborhoodIterator.h"
 #include "itkImage.h"
 #include "itkImageNeighborhoodOffsets.h"
+#include "itkRangeGTestUtilities.h"
 #include "itkVectorImage.h"
 
 #include <gtest/gtest.h>
@@ -42,6 +43,7 @@ template class itk::Experimental::ShapedImageNeighborhoodRange<itk::VectorImage<
 template class itk::Experimental::ShapedImageNeighborhoodRange<const itk::VectorImage<short>>;
 
 using itk::Experimental::ShapedImageNeighborhoodRange;
+using itk::Experimental::RangeGTestUtilities;
 
 namespace
 {
@@ -90,6 +92,19 @@ namespace
     const unsigned itkNotUsed(vectorLength))
   {
     // Do not set the VectorLength. The specified image is not a VectorImage.
+  }
+
+
+  template<typename TImage>
+  typename TImage::Pointer CreateSmallImage()
+  {
+    const auto image = TImage::New();
+    typename TImage::SizeType imageSize;
+    imageSize.Fill(0);
+    image->SetRegions(imageSize);
+    SetVectorLengthIfImageIsVectorImage(*image, 1);
+    image->Allocate(true);
+    return image;
   }
 
 
@@ -162,6 +177,62 @@ namespace
     const typename TImage::IndexType location{ {} };
 
     EXPECT_FALSE((ShapedImageNeighborhoodRange<TImage>{ *image, location, shapeOffsets }.empty()));
+  }
+
+
+  template <typename TImage>
+  void ExpectCopyConstructedRangeHasSameIteratorsAsOriginal()
+  {
+    const auto image = CreateSmallImage<TImage>();
+    const itk::Size<TImage::ImageDimension> radius{ {1} };
+    const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
+      itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    const typename TImage::IndexType location{ {} };
+    const ShapedImageNeighborhoodRange<TImage> originalRange{ *image, location, shapeOffsets };
+
+    RangeGTestUtilities::ExpectCopyConstructedRangeHasSameIteratorsAsOriginal(originalRange);
+  }
+
+
+  template <typename TImage>
+  void ExpectCopyAssignedRangeHasSameIteratorsAsOriginal()
+  {
+    const auto image = CreateSmallImage<TImage>();
+    const itk::Size<TImage::ImageDimension> radius{ {1} };
+    const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
+      itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    const typename TImage::IndexType location{ {} };
+    const ShapedImageNeighborhoodRange<TImage> originalRange{ *image, location, shapeOffsets };
+
+    RangeGTestUtilities::ExpectCopyAssignedRangeHasSameIteratorsAsOriginal(originalRange);
+  }
+
+
+  template <typename TImage>
+  void ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove()
+  {
+    const auto image = CreateSmallImage<TImage>();
+    const itk::Size<TImage::ImageDimension> radius{ {1} };
+    const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
+      itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    const typename TImage::IndexType location{ {} };
+
+    RangeGTestUtilities::ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove(
+      ShapedImageNeighborhoodRange<TImage>{ *image, location, shapeOffsets });
+  }
+
+
+  template <typename TImage>
+  void ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove()
+  {
+    const auto image = CreateSmallImage<TImage>();
+    const itk::Size<TImage::ImageDimension> radius{ {1} };
+    const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
+      itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    const typename TImage::IndexType location{ {} };
+
+    RangeGTestUtilities::ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove(
+      ShapedImageNeighborhoodRange<TImage>{ *image, location, shapeOffsets });
   }
 
 }  // namespace
@@ -944,4 +1015,36 @@ TEST(ShapedImageNeighborhoodRange, IsNotEmptyWhenImageAndShapeOffsetContainerAre
 {
   ExpectRangeIsNotEmptyForNonEmptyImageAndShapeOffsetContainer<itk::Image<int>>();
   ExpectRangeIsNotEmptyForNonEmptyImageAndShapeOffsetContainer<itk::VectorImage<int>>();
+}
+
+
+// Tests that a copy-constructed range has the same iterators (begin and end) as the original.
+TEST(ShapedImageNeighborhoodRange, CopyConstructedRangeHasSameIterators)
+{
+  ExpectCopyConstructedRangeHasSameIteratorsAsOriginal<itk::Image<int>>();
+  ExpectCopyConstructedRangeHasSameIteratorsAsOriginal<itk::VectorImage<int>>();
+}
+
+
+// Tests that a copy-assigned range has the same iterators (begin and end) as the original.
+TEST(ShapedImageNeighborhoodRange, CopyAssignedRangeHasSameIterators)
+{
+  ExpectCopyAssignedRangeHasSameIteratorsAsOriginal<itk::Image<int>>();
+  ExpectCopyAssignedRangeHasSameIteratorsAsOriginal<itk::VectorImage<int>>();
+}
+
+
+// Tests that a move-constructed range has the same iterators as the original, before the move.
+TEST(ShapedImageNeighborhoodRange, MoveConstructedRangeHasSameIterators)
+{
+  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::Image<int>>();
+  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::VectorImage<int>>();
+}
+
+
+// Tests that a move-assigned range has the same iterators as the original, before the move.
+TEST(ShapedImageNeighborhoodRange, MoveAssignedRangeHasSameIterators)
+{
+  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::Image<int>>();
+  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::VectorImage<int>>();
 }


### PR DESCRIPTION
Allowed assigning one `ShapedImageNeighborhoodRange` object to another, by
declaring all of the range data members non-const.

Followed the C++ "Rule of Zero" for both `ShapedImageNeighborhoodRange`
and `ImageBufferRange`.

Tested copy and move semantics of both range template classes, introducing a
class of test utilities, `RangeGTestUtilities`, to implement these unit tests.

Triggered by a comment by @dzenanz, 3 January 2019, at pull request #362