### PR TITLE
ENH: Eigen3: Add ITK option for enabling EIGEN_MPL2_ONLY

### DIFF
--- a/Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt
@@ -686,8 +686,15 @@ else ()
   add_library (eigen INTERFACE)
   add_library (Eigen3::Eigen ALIAS eigen)
 
-  set(EIGEN_DEFINITIONS "EIGEN_MPL2_ONLY")
-  target_compile_definitions (eigen INTERFACE ${EIGEN_DEFINITIONS})
+  if(NOT DEFINED ITK_USE_EIGEN_MPL2_ONLY)
+    option(ITK_USE_EIGEN_MPL2_ONLY "Set compile definition EIGEN_MPL2_ONLY. It might leak to when third parties use Eigen and ITK. Use only internally." OFF)
+    mark_as_advanced(ITK_USE_EIGEN_MPL2_ONLY)
+  endif()
+
+  if(ITK_USE_EIGEN_MPL2_ONLY)
+    set(EIGEN_DEFINITIONS "EIGEN_MPL2_ONLY")
+    target_compile_definitions (eigen INTERFACE ${EIGEN_DEFINITIONS})
+  endif()
   # BUILD: go one directory before to localize the headers:
   #   #include <itkeigen/Eigen/x>
   #   #include "itk_eigen.h"


### PR DESCRIPTION
The current approach of always enable the compile definition
EIGEN_MPL2_ONLY when including `itk_eigen.h` can generate
problems with third parties that use Eigen3 and ITK.

See https://github.com/DGtal-team/DGtal/issues/1370

Here we add an (advanced) option to ITK to enable this definition.
This could be turned ON only in ITK CI, to check that, internally, only
MPL2 Eigen3 header is included. But saving imposing this definition
to any other third party.

Minimal Example showing current failure:

```bash
mkdir DGtal; cd DGtal
git clone https://github.com/DGtal-team/DGtal src
mkdir build; cd build
cmake -DWITH_ITK:BOOL=ON -DWITH_EIGEN:BOOL=ON -DITK_DIR:PATH=/path/ITK-build ../src
make examplePropagation
```
Fix: https://github.com/DGtal-team/DGtal/issues/1370