### PR TITLE
STYLE: C++ "Rule of Zero" for iterator classes of Range types

### DIFF
--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -321,6 +321,11 @@ private:
      * the guarantee added to the C++14 Standard: "value-initialized iterators
      * may be compared and shall compare equal to other value-initialized
      * iterators of the same type."
+     * \note `QualifiedIterator<VIsConst>` follows the C++ "Rule of Zero" when
+     * VIsConst is true: The other five "special member functions" of the class
+     * are then implicitly defaulted. When VIsConst is false, its
+     * copy-constructor is provided explicitly, but it still behaves the same as
+     * a default implementation.
      */
     QualifiedIterator() = default;
 
@@ -485,10 +490,6 @@ private:
 
     /** Explicitly-defaulted assignment operator. */
     QualifiedIterator& operator=(const QualifiedIterator&) ITK_NOEXCEPT = default;
-
-
-    /** Explicitly-defaulted destructor. */
-    ~QualifiedIterator() = default;
   };
 
   static constexpr bool IsImageTypeConst = std::is_const<TImage>::value;

--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -95,7 +95,10 @@ public:
     using iterator_category = std::bidirectional_iterator_tag;
 
     /** Default-constructor, as required for any C++11 Forward Iterator.
-      */
+     * \note The other five "special member functions" (copy-constructor,
+     * copy-assignment operator, move-constructor, move-assignment operator,
+     * and destructor) are defaulted implicitly, following the C++ "Rule of Zero".
+     */
     const_iterator() = default;
 
 

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -385,6 +385,11 @@ private:
      * the guarantee added to the C++14 Standard: "value-initialized iterators
      * may be compared and shall compare equal to other value-initialized
      * iterators of the same type."
+     * \note `QualifiedIterator<VIsConst>` follows the C++ "Rule of Zero" when
+     * VIsConst is true: The other five "special member functions" of the class
+     * are then implicitly defaulted. When VIsConst is false, its
+     * copy-constructor is provided explicitly, but it still behaves the same as
+     * a default implementation.
      */
     QualifiedIterator() = default;
 
@@ -561,10 +566,6 @@ private:
 
     /** Explicitly-defaulted assignment operator. */
     QualifiedIterator& operator=(const QualifiedIterator&) ITK_NOEXCEPT = default;
-
-
-    /** Explicitly-defaulted destructor. */
-    ~QualifiedIterator() = default;
   };
 
   static constexpr bool IsImageTypeConst = std::is_const<TImage>::value;


### PR DESCRIPTION
Documented using the C++ "Rule of Zero" for the iterator classes of
`ImageBufferRange`, `ShapedImageNeighborhoodRange`, and `IndexRange`.

Removed explicitly-defaulted destructors from the iterator classes of
`ImageBufferRange` and `ShapedImageNeighborhoodRange`.