### PR TITLE
WIP: Add noexcept to defaulted move-constructors and move-assignments

### DIFF
--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -68,9 +68,9 @@ public:
   /** Constructors */
   ContinuousIndex() = default;
   ContinuousIndex(const ContinuousIndex &) = default;
-  ContinuousIndex(ContinuousIndex &&) = default;
+  ContinuousIndex(ContinuousIndex &&) ITK_NOEXCEPT = default;
   ContinuousIndex & operator=(const ContinuousIndex &) = default;
-  ContinuousIndex & operator=(ContinuousIndex &&) = default;
+  ContinuousIndex & operator=(ContinuousIndex &&) ITK_NOEXCEPT = default;
   ~ContinuousIndex() = default;
 
   /** Pass-through constructor to the Point base class. */

--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -104,9 +104,9 @@ public:
   /** Default constructor. */
   CovariantVector() = default;
   CovariantVector(const CovariantVector&) = default;
-  CovariantVector(CovariantVector&&) = default;
+  CovariantVector(CovariantVector&&) ITK_NOEXCEPT = default;
   CovariantVector & operator=(const CovariantVector &) = default;
-  CovariantVector & operator=(CovariantVector &&) = default;
+  CovariantVector & operator=(CovariantVector &&) ITK_NOEXCEPT = default;
   ~CovariantVector() = default;
 
   /**

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -134,7 +134,7 @@ public:
   FixedArray() = default;
   FixedArray(const FixedArray &) = default;
   FixedArray & operator=(const FixedArray & ) = default;
-  FixedArray(FixedArray &&) = default;
+  FixedArray(FixedArray &&) ITK_NOEXCEPT = default;
   FixedArray & operator=(FixedArray && ) = default;
   ~FixedArray() = default;
 

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -81,9 +81,9 @@ public:
   /** Default constructor, assignments */
   Point() = default;
   Point(const Point &) = default;
-  Point(Point &&) = default;
+  Point(Point &&) ITK_NOEXCEPT = default;
   Point & operator=(const Point &) = default;
-  Point & operator=(Point &&) = default;
+  Point & operator=(Point &&) ITK_NOEXCEPT = default;
   ~Point() = default;
   /** Pass-through constructors for different type points. */
   template< typename TPointValueType >

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -80,8 +80,8 @@ public:
   RGBAPixel() { this->Fill(0); }
   RGBAPixel(const RGBAPixel &) = default;
   RGBAPixel & operator=(const RGBAPixel &) = default;
-  RGBAPixel( RGBAPixel &&) = default;
-  RGBAPixel & operator=(RGBAPixel &&) = default;
+  RGBAPixel( RGBAPixel &&) ITK_NOEXCEPT = default;
+  RGBAPixel & operator=(RGBAPixel &&) ITK_NOEXCEPT = default;
   ~RGBAPixel() = default;
 
   /** Pass-through constructor for the Array base class. */

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -78,9 +78,9 @@ public:
   /** Default constructors */
   RGBPixel() { this->Fill(0); }
   RGBPixel(const RGBPixel&) = default;
-  RGBPixel(RGBPixel&&) = default;
+  RGBPixel(RGBPixel&&) ITK_NOEXCEPT = default;
   RGBPixel & operator=(const RGBPixel &) = default;
-  RGBPixel & operator=(RGBPixel &&) = default;
+  RGBPixel & operator=(RGBPixel &&) ITK_NOEXCEPT = default;
   ~RGBPixel() = default;
 
   /** Constructor to fill Red=Blug=Green= r. */

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
@@ -107,9 +107,9 @@ public:
   /** Constructors */
   SymmetricSecondRankTensor() { this->Fill(0); }
   SymmetricSecondRankTensor(const SymmetricSecondRankTensor &) = default;
-  SymmetricSecondRankTensor(SymmetricSecondRankTensor &&) = default;
+  SymmetricSecondRankTensor(SymmetricSecondRankTensor &&) ITK_NOEXCEPT = default;
   SymmetricSecondRankTensor& operator=(const SymmetricSecondRankTensor &) = default;
-  SymmetricSecondRankTensor& operator=(SymmetricSecondRankTensor &&) = default;
+  SymmetricSecondRankTensor& operator=(SymmetricSecondRankTensor &&) ITK_NOEXCEPT = default;
   ~SymmetricSecondRankTensor() = default;
 
   SymmetricSecondRankTensor (const ComponentType & r) { this->Fill(r); }

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -98,9 +98,9 @@ public:
   /** Default constructors, assignments and destructor */
   Vector() = default;
   Vector(const Vector&) = default;
-  Vector(Vector&&) = default;
+  Vector(Vector&&) ITK_NOEXCEPT = default;
   Vector & operator=(const Vector &) = default;
-  Vector & operator=(Vector &&) = default;
+  Vector & operator=(Vector &&) ITK_NOEXCEPT = default;
   ~Vector() = default;
 
 #if !defined( ITK_LEGACY_FUTURE_REMOVE )

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
@@ -111,9 +111,9 @@ public:
 public:
   GeometricalQuadEdge();
   GeometricalQuadEdge(const GeometricalQuadEdge &) = default;
-  GeometricalQuadEdge(GeometricalQuadEdge &&) = default;
+  GeometricalQuadEdge(GeometricalQuadEdge &&) ITK_NOEXCEPT = default;
   GeometricalQuadEdge & operator=(const GeometricalQuadEdge &) = default;
-  GeometricalQuadEdge & operator=(GeometricalQuadEdge &&) = default;
+  GeometricalQuadEdge & operator=(GeometricalQuadEdge &&) ITK_NOEXCEPT = default;
   virtual ~GeometricalQuadEdge() override = default;
 
   /** Set methods. */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
@@ -249,9 +249,9 @@ public:
   /** Object creation methods. */
   QuadEdge();
   QuadEdge(const QuadEdge &) = default;
-  QuadEdge(QuadEdge &&) = default;
+  QuadEdge(QuadEdge &&) ITK_NOEXCEPT = default;
   QuadEdge & operator=(const QuadEdge &) = default;
-  QuadEdge & operator=(QuadEdge &&) = default;
+  QuadEdge & operator=(QuadEdge &&) ITK_NOEXCEPT = default;
   virtual ~QuadEdge();
 
   /** Sub-algebra Set methods. */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -61,9 +61,9 @@ public:
 public:
   QuadEdgeMeshPoint();
   QuadEdgeMeshPoint(const Self &) = default;
-  QuadEdgeMeshPoint(QuadEdgeMeshPoint &&) = default;
+  QuadEdgeMeshPoint(QuadEdgeMeshPoint &&) ITK_NOEXCEPT = default;
   QuadEdgeMeshPoint & operator=(const QuadEdgeMeshPoint &) = default;
-  QuadEdgeMeshPoint & operator=(QuadEdgeMeshPoint &&) = default;
+  QuadEdgeMeshPoint & operator=(QuadEdgeMeshPoint &&) ITK_NOEXCEPT = default;
   ~QuadEdgeMeshPoint() = default;
 
   QuadEdgeMeshPoint(const Superclass & r);


### PR DESCRIPTION
Add `noexcept` specifier to explicitly-defaulted move-constructors and
move-assignment operators.

Ensures that the compiler checks that these member functions are indeed
noexcept.