### PR TITLE
PERF: Add fast noexcept move semantics to Neighborhood and its Allocator

### DIFF
--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -113,8 +113,14 @@ public:
   /** Copy constructor. */
   Neighborhood(const Self & other);
 
+  /** Move-constructor. */
+  Neighborhood(Self &&) = default;
+
   /** Assignment operator. */
   Self & operator=(const Self & other);
+
+  /** Move-assignment. */
+  Self & operator=(Self&&) = default;
 
   /** Comparison operator. */
   bool

--- a/Modules/Core/Common/include/itkNeighborhoodAllocator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAllocator.h
@@ -81,8 +81,20 @@ public:
     std::copy(other.m_Data, other.m_Data + m_ElementCount, m_Data);
   }
 
+
+  /** Move-constructor. */
+  NeighborhoodAllocator(Self&& other) ITK_NOEXCEPT
+    :
+  m_ElementCount{ other.m_ElementCount },
+  m_Data{ other.m_Data }
+  {
+    other.m_ElementCount = 0;
+    other.m_Data = nullptr;
+  }
+
+
   /** Assignment operator. */
-  const Self & operator=(const Self & other)
+  Self & operator=(const Self & other)
   {
     if(this != &other)
       {
@@ -91,6 +103,22 @@ public:
     }
     return *this;
   }
+
+
+  /** Move-assignment. */
+  Self& operator=(Self&& other) ITK_NOEXCEPT
+  {
+    if (this != &other)
+    {
+      this->Deallocate();
+      m_ElementCount = other.m_ElementCount;
+      m_Data = other.m_Data;
+      other.m_ElementCount = 0;
+      other.m_Data = nullptr;
+    }
+    return *this;
+  }
+
 
   /** STL-style iterator support for the memory buffer. */
   iterator begin()


### PR DESCRIPTION
Added fast `noexcept` move-constructor and move-assignment operator to
`itk::NeighborhoodAllocator`. A performance improvement of 50 % was observed,
when move-assigning `itk::NeighborhoodAllocator` objects, on VS2017 Release.

Added explicitly-defaulted move-constructor and move-assignment operator to
`itk::Neighborhood`. Note that these two member functions are implicitly
noexcept, when template parameter TAllocator is `NeighborhoodAllocator<TPixel>`
(which is the default).

Also removed the unconventional `const` keyword from the return type of the
copy-assignment operator of `itk::NeighborhoodAllocator`.