### PR TITLE
BUG: ResourceProbe::Reset() should set m_MaximumValue to lowest value

### DIFF
--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -60,7 +60,7 @@ ResourceProbe< ValueType, MeanType >
   this->m_TotalValue        = NumericTraits< ValueType >::ZeroValue();
   this->m_StartValue        = NumericTraits< ValueType >::ZeroValue();
   this->m_MinimumValue      = NumericTraits< ValueType >::max();
-  this->m_MaximumValue      = NumericTraits< ValueType >::min();
+  this->m_MaximumValue      = NumericTraits< ValueType >::NonpositiveMin();
   this->m_StandardDeviation = NumericTraits< ValueType >::ZeroValue();
 
   this->m_NumberOfStarts    = NumericTraits< CountType >::ZeroValue();


### PR DESCRIPTION
Before this commit, `ResourceProbe<ValueType, MeanType>::Reset()` did assign
`DBL_MIN` (~2.2e-308) to `m_MaximumValue`, when `ValueType` = `double` (for
example, for `itk::TimeProbe`). This gave incorrect results, when all values
retrieved by `GetInstantValue()` were less than `DBL_MIN`.

This commit fixes this bug by assigning the lowest value, `NonpositiveMin()`
(instead of `min()`) to `m_MaximumValue`, within `ResourceProbe::Reset()`.