### PR TITLE
BUG: Fixed MoveAssignedRangeHasSameIterators GTest of two range types

### DIFF
--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -884,6 +884,6 @@ TEST(ImageBufferRange, MoveConstructedRangeHasSameIterators)
 // Tests that a move-assigned range has the same iterators as the original, before the move.
 TEST(ImageBufferRange, MoveAssignedRangeHasSameIterators)
 {
-  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::Image<int>>();
-  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::VectorImage<int>>();
+  ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove<itk::Image<int>>();
+  ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove<itk::VectorImage<int>>();
 }

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -1045,6 +1045,6 @@ TEST(ShapedImageNeighborhoodRange, MoveConstructedRangeHasSameIterators)
 // Tests that a move-assigned range has the same iterators as the original, before the move.
 TEST(ShapedImageNeighborhoodRange, MoveAssignedRangeHasSameIterators)
 {
-  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::Image<int>>();
-  ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove<itk::VectorImage<int>>();
+  ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove<itk::Image<int>>();
+  ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove<itk::VectorImage<int>>();
 }


### PR DESCRIPTION
Fixed MoveAssignedRangeHasSameIterators tests from `itkImageBufferRangeGTest`
and `itkShapedImageNeighborhoodRangeGTest`, which both tested move-construction,
instead of move-assignment!

Bug found through Mac10.13-AppleClang warning: unused function template
'ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove' [-Wunused-template]