### PR TITLE
COMP: ShapedImageNeighborhoodRangeGTest array initialization

### DIFF
--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -145,7 +145,7 @@ namespace
 
     using OffsetType = typename TImage::OffsetType;
 
-    const std::array<OffsetType, 0> emptyArrayOfOffsets{};
+    const std::array<OffsetType, 0> emptyArrayOfOffsets{ {} };
     const std::vector<OffsetType> emptyVectorOfOffsets{};
 
     EXPECT_TRUE((


### PR DESCRIPTION
To address:

 [CTest: warning matched] /scratch/dashboards/Linux-x86_64-gcc4.8Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx:148:57: warning: missing initializer for member 'std::array<itk::Offset<2u>, 0ul>::_M_elems' [-Wmissing-field-initializers]
     const std::array<OffsetType, 0> emptyArrayOfOffsets{};