### PR TITLE
PERF: DCMTK & GDCM CanRead fails very slowly for non-DICOM files.

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -137,6 +137,85 @@ DCMTKImageIO::~DCMTKImageIO()
   DcmRLEDecoderRegistration::cleanup();
 }
 
+/**
+* Helper function to test for some dicom like formatting.
+* @param file A stream to test if the file is dicom like
+* @return true if the structure of the file is dicom like
+*/
+static bool
+readNoPreambleDicom( std::ifstream & file )  // NOTE: This file is duplicated in itkGDCMImageIO.cxx
+{
+  // Adapted from https://stackoverflow.com/questions/2381983/c-how-to-read-parts-of-a-file-dicom
+  /* This heuristic tries to determine if the file follows the basic structure of a dicom file organization.
+   * Any file that begins with the a byte sequence
+   * where groupNo matches below will be then read several SOP Instance sections.
+   */
+
+  unsigned short groupNo = 0xFFFF;
+  unsigned short tagElementNo = 0xFFFF;
+  do {
+    file.read(reinterpret_cast<char *>(&groupNo),sizeof(unsigned short));
+    ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&groupNo);
+    file.read(reinterpret_cast<char *>(&tagElementNo),sizeof(unsigned short));
+    ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&tagElementNo);
+
+    if(groupNo != 0x0002 && groupNo != 0x0008) // Only groupNo 2 & 8 are supported without preambles
+    {
+      return false;
+    }
+
+    char vrcode[3] = { '\0', '\0', '\0' };
+    file.read(vrcode, 2);
+
+    long length=std::numeric_limits<long>::max();
+    const std::string vr{vrcode};
+    if ( vr == "AE" || vr == "AS" || vr == "AT"
+         || vr == "CS" || vr == "DA" || vr == "DS"
+         || vr == "DT" || vr == "FL" || vr == "FD"
+         || vr == "IS" || vr == "LO" || vr == "PN"
+         || vr == "SH" || vr == "SL" || vr == "SS"
+         || vr == "ST" || vr == "TM" || vr == "UI"
+         || vr == "UL" || vr == "US"
+        )
+    {
+      unsigned short uslength=0;
+      file.read(reinterpret_cast<char *>(&uslength),sizeof(unsigned short));
+      ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&uslength);
+      length = uslength;
+    }
+    else {
+      //Read the reserved byte
+      unsigned short uslength=0;
+      file.read(reinterpret_cast<char *>(&uslength),sizeof(unsigned short));
+      ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&uslength);
+
+      unsigned int uilength=0;
+      file.read(reinterpret_cast<char *>(&uilength),sizeof(unsigned int));
+      ByteSwapper<unsigned int>::SwapFromSystemToLittleEndian(&uilength);
+
+      length = uilength;
+    }
+    if(length <= 0 )
+    {
+      return false;
+    }
+    file.ignore(length);
+    if(file.eof())
+    {
+      return false;
+    }
+  } while (groupNo == 2);
+
+#if defined( NDEBUG )
+  std::ostringstream itkmsg;
+ itkmsg << "No DICOM magic number found, but the file appears to be DICOM without a preamble.\n"
+        << "Proceeding without caution.";
+    ::itk::OutputWindowDisplayDebugText( itkmsg.str().c_str() );
+#endif
+  return true;
+}
+
+
 bool DCMTKImageIO::CanReadFile(const char *filename)
 {
   // First check the filename extension
@@ -147,6 +226,23 @@ bool DCMTKImageIO::CanReadFile(const char *filename)
     itkDebugMacro(<< "No filename specified.");
     }
 
+    {
+    std::ifstream file;
+    try
+      {
+      this->OpenFileForReading( file, filename );
+      }
+    catch( ExceptionObject & )
+      {
+      return false;
+      }
+    const bool hasdicomsig = readNoPreambleDicom(file);
+    file.close();
+    if ( ! hasdicomsig )
+      {
+       return false;
+      }
+    }
   return DCMTKFileReader::IsImageFile(filename);
 }
 

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -56,8 +56,9 @@
 #include <fstream>
 #include <sstream>
 
-namespace itk
-{
+namespace itk {
+
+
 class InternalHeader
 {
 public:
@@ -119,7 +120,85 @@ GDCMImageIO::~GDCMImageIO()
   delete this->m_DICOMHeader;
 }
 
-// This method will only test if the header looks like a
+/**
+ * Helper function to test for some dicom like formatting.
+ * @param file A stream to test if the file is dicom like
+ * @return true if the structure of the file is dicom like
+ */
+static bool
+readNoPreambleDicom( std::ifstream & file )  // NOTE: This file is duplicated in itkDCMTKImageIO.cxx
+{
+  // Adapted from https://stackoverflow.com/questions/2381983/c-how-to-read-parts-of-a-file-dicom
+  /* This heuristic tries to determine if the file follows the basic structure of a dicom file organization.
+   * Any file that begins with the a byte sequence
+   * where groupNo matches below will be then read several SOP Instance sections.
+   */
+
+  unsigned short groupNo = 0xFFFF;
+  unsigned short tagElementNo = 0xFFFF;
+  do {
+    file.read(reinterpret_cast<char *>(&groupNo),sizeof(unsigned short));
+    ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&groupNo);
+    file.read(reinterpret_cast<char *>(&tagElementNo),sizeof(unsigned short));
+    ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&tagElementNo);
+
+    if(groupNo != 0x0002 && groupNo != 0x0008) // Only groupNo 2 & 8 are supported without preambles
+    {
+      return false;
+    }
+
+    char vrcode[3] = { '\0', '\0', '\0' };
+    file.read(vrcode, 2);
+
+    long length=std::numeric_limits<long>::max();
+    const std::string vr{vrcode};
+    if ( vr == "AE" || vr == "AS" || vr == "AT"
+         || vr == "CS" || vr == "DA" || vr == "DS"
+         || vr == "DT" || vr == "FL" || vr == "FD"
+         || vr == "IS" || vr == "LO" || vr == "PN"
+         || vr == "SH" || vr == "SL" || vr == "SS"
+         || vr == "ST" || vr == "TM" || vr == "UI"
+         || vr == "UL" || vr == "US"
+        )
+    {
+      unsigned short uslength=0;
+      file.read(reinterpret_cast<char *>(&uslength),sizeof(unsigned short));
+      ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&uslength);
+      length = uslength;
+    }
+    else {
+      //Read the reserved byte
+      unsigned short uslength=0;
+      file.read(reinterpret_cast<char *>(&uslength),sizeof(unsigned short));
+      ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&uslength);
+
+      unsigned int uilength=0;
+      file.read(reinterpret_cast<char *>(&uilength),sizeof(unsigned int));
+      ByteSwapper<unsigned int>::SwapFromSystemToLittleEndian(&uilength);
+
+      length = uilength;
+    }
+    if(length <= 0 )
+    {
+      return false;
+    }
+    file.ignore(length);
+    if(file.eof())
+    {
+      return false;
+    }
+  } while (groupNo == 2);
+
+#if defined( NDEBUG )
+   std::ostringstream itkmsg;
+   itkmsg << "No DICOM magic number found, but the file appears to be DICOM without a preamble.\n"
+          << "Proceeding without caution.";
+      ::itk::OutputWindowDisplayDebugText( itkmsg.str().c_str() );
+#endif
+  return true;
+}
+
+  // This method will only test if the header looks like a
 // GDCM image file.
 bool GDCMImageIO::CanReadFile(const char *filename)
 {
@@ -155,23 +234,24 @@ bool GDCMImageIO::CanReadFile(const char *filename)
       return false;
       }
     buf[4] = '\0';
-    std::string sig(buf);
+    const std::string sig{buf};
     if(sig == "DICM")
       {
       dicomsig = true;
       }
     }
+//Do not allow CanRead to return true for non-compliant DICOM files
+#define GDCMPARSER_IGNORE_MAGIC_NUMBER
+#if defined GDCMPARSER_IGNORE_MAGIC_NUMBER
+  //
+  // Try it anyways...
+  //
   if(!dicomsig)
     {
     file.seekg(0,std::ios_base::beg);
-    unsigned short groupNo;
-    file.read(reinterpret_cast<char *>(&groupNo),sizeof(unsigned short));
-    ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&groupNo);
-    if(groupNo == 0x0002 || groupNo == 0x0008)
-      {
-      dicomsig = true;
-      }
+    dicomsig = readNoPreambleDicom( file );
     }
+#endif // GDCMPARSER_IGNORE_MAGIC_NUMBER
   if(dicomsig)
     {
     // Check to see if its a valid dicom file gdcm is able to parse:

--- a/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
@@ -41,9 +41,16 @@ int itkGDCMImageIONoCrashTest(int ac, char* av[])
   using ImageIOType = itk::GDCMImageIO;
   ImageIOType::Pointer gdcmImageIO = ImageIOType::New();
 
+  const std::string inputFile{ av[1] };
+
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( av[1] );
+  reader->SetFileName( inputFile );
   reader->SetImageIO( gdcmImageIO );
+  if ( ! gdcmImageIO->CanReadFile( inputFile.c_str() ) )
+    {
+    std::cerr << "exception in file reader " << inputFile << " not supported by itk::GDCMImageIO." << std::endl;
+    return EXIT_FAILURE;
+    }
 
   try
     {


### PR DESCRIPTION
Some images take an extremely long time to load because of GDCMImageIO::CanReadFile
takes several minutes to fail.  This is due to GDCM's default behavior of trying
to read non-compliant Dicom files that do not have the required DICM header.

This resolves #388.

NOTE:  This does break backward compatibility for default reading of degenerate Dicom files through the factory mechanism.  One can still read degenerate files by explicitly requesting the GDCM io modules.