### PR TITLE
BUG: python itk.Image returned by GetImageFromArray now manages its own buffer

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -139,15 +139,14 @@
         *numpy.reshape*.
         """
 
-        # perform deep copy of the array buffer
-        array_copy = numpy.array(ndarr)
+        # Create a temporary image view of the array
+        imageView = itkPyBuffer@PyBufferTypes@.GetImageViewFromArray(ndarr, is_vector)
 
-        image = itkPyBuffer@PyBufferTypes@.GetImageViewFromArray(array_copy, is_vector)
-
-        # attaches the copy of the array to the image to avoid releasing memory
-        # when leaving current scope.
-        image._ndarr = array_copy
-        return image
+        # Duplicate the image to let it manage its own memory buffer
+        duplicator = itkImageDuplicator@PyBufferTypes@.New()
+        duplicator.SetInputImage(imageView)
+        duplicator.Update()
+        return duplicator.GetOutput()
 
     GetImageFromArray = staticmethod(GetImageFromArray)
 

--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
@@ -31,4 +31,6 @@ def _get_numpy_pixelid(itk_Image_type):
         return _np_itk[itk_Image_type]
     except KeyError as e:
         raise e
+
+from itkImageDuplicatorPython import *
 %}

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -201,6 +201,14 @@ try:
     assert arr.shape[0] == 2
     assert arr.shape[1] == 3
     assert arr[1,1] == 5
+    arr = arr.copy()
+    image = itk.GetImageFromArray(arr)
+    image2 = type(image).New()
+    image2.Graft(image)
+    del image # Delete image but pixel data should be kept in img2
+    image = itk.GetImageFromArray(arr+1) # Fill former memory if wrongly released
+    assert np.array_equal(arr, itk.GetArrayViewFromImage(image2))
+    image2.SetPixel([0]*image2.GetImageDimension(), 3) # For mem check in dynamic analysis
     # VNL Vectors
     v1 = itk.vnl_vector.D(2)
     v1.fill(1)


### PR DESCRIPTION
The memory buffer could be lost after grafting the returned image to another because the _ndarr member was not backed up by Graft.

@thewtex @fbudin69500 This PR follows the [discusion on discourse](https://discourse.itk.org/t/pythons-numpy-bridge-getimagefromarray-freed-buffer-pointer-after-graft/1506). The implementation choice has been to keep using python's GetImageViewFromArray instead of a new C++ function or a boolean parameter to avoid duplicating the code of this function in python's GetImageFromArray. I believe that the proposed fix is more clean than having a parameter in both the C++ and the python function because this additional parameter would be seen by the user after wrapping. I would have prefered to use the itk.Image.Clone() function than using the ImageDuplicator but, if I'm not wrong, this function is not implemented (there is no InternalClone implementation in itk::Image).