### PR TITLE
STYLE: Move test utils default-constructed ranges to RangeGTestUtilities

### DIFF
--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -148,30 +148,6 @@ namespace
   }
 
 
-  template <typename TRange>
-  void ExpectBeginIsEndWhenRangeIsDefaultConstructed()
-  {
-    TRange defaultConstructedRange;
-    EXPECT_EQ(defaultConstructedRange.begin(), defaultConstructedRange.end());
-  }
-
-
-  template <typename TRange>
-  void ExpectZeroSizeWhenRangeIsDefaultConstructed()
-  {
-    TRange defaultConstructedRange;
-    EXPECT_EQ(defaultConstructedRange.size(), 0);
-  }
-
-
-  template <typename TRange>
-  void ExpectRangeIsEmptyWhenDefaultConstructed()
-  {
-    TRange defaultConstructedRange;
-    EXPECT_TRUE(defaultConstructedRange.empty());
-  }
-
-
   template <typename TImage>
   void ExpectRangeIsNotEmptyForNonEmptyImage()
   {
@@ -811,24 +787,30 @@ TEST(ImageBufferRange, ProvidesReverseIterators)
 // Tests that begin() == end() for a default-constructed range.
 TEST(ImageBufferRange, BeginIsEndWhenDefaultConstructed)
 {
-  ExpectBeginIsEndWhenRangeIsDefaultConstructed<ImageBufferRange<itk::Image<int>>>();
-  ExpectBeginIsEndWhenRangeIsDefaultConstructed<ImageBufferRange<itk::VectorImage<int>>>();
+  RangeGTestUtilities::ExpectBeginIsEndWhenRangeIsDefaultConstructed<
+    ImageBufferRange<itk::Image<int>>>();
+  RangeGTestUtilities::ExpectBeginIsEndWhenRangeIsDefaultConstructed<
+    ImageBufferRange<itk::VectorImage<int>>>();
 }
 
 
 // Tests that size() returns 0 for a default-constructed range.
 TEST(ImageBufferRange, SizeIsZeroWhenDefaultConstructed)
 {
-  ExpectZeroSizeWhenRangeIsDefaultConstructed<ImageBufferRange<itk::Image<int>>>();
-  ExpectZeroSizeWhenRangeIsDefaultConstructed<ImageBufferRange<itk::VectorImage<int>>>();
+  RangeGTestUtilities::ExpectZeroSizeWhenRangeIsDefaultConstructed<
+    ImageBufferRange<itk::Image<int>>>();
+  RangeGTestUtilities::ExpectZeroSizeWhenRangeIsDefaultConstructed<
+    ImageBufferRange<itk::VectorImage<int>>>();
 }
 
 
 // Tests empty() for a default-constructed range.
 TEST(ImageBufferRange, IsEmptyWhenDefaultConstructed)
 {
-  ExpectRangeIsEmptyWhenDefaultConstructed<ImageBufferRange<itk::Image<int>>>();
-  ExpectRangeIsEmptyWhenDefaultConstructed<ImageBufferRange<itk::VectorImage<int>>>();
+  RangeGTestUtilities::ExpectRangeIsEmptyWhenDefaultConstructed<
+    ImageBufferRange<itk::Image<int>>>();
+  RangeGTestUtilities::ExpectRangeIsEmptyWhenDefaultConstructed<
+    ImageBufferRange<itk::VectorImage<int>>>();
 }
 
 

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -34,6 +34,29 @@ namespace Experimental
 class RangeGTestUtilities
 {
 public:
+  template <typename TRange>
+  static void ExpectBeginIsEndWhenRangeIsDefaultConstructed()
+  {
+    TRange defaultConstructedRange;
+    EXPECT_EQ(std::begin(defaultConstructedRange), std::end(defaultConstructedRange));
+  }
+
+
+  template <typename TRange>
+  static void ExpectZeroSizeWhenRangeIsDefaultConstructed()
+  {
+    TRange defaultConstructedRange;
+    EXPECT_EQ(defaultConstructedRange.size(), 0);
+  }
+
+
+  template <typename TRange>
+  static void ExpectRangeIsEmptyWhenDefaultConstructed()
+  {
+    TRange defaultConstructedRange;
+    EXPECT_TRUE(defaultConstructedRange.empty());
+  }
+
 
   template <typename TRange>
   static void ExpectCopyConstructedRangeHasSameIteratorsAsOriginal(const TRange& originalRange)

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -108,29 +108,6 @@ namespace
   }
 
 
-  template <typename TRange>
-  void ExpectBeginIsEndWhenRangeIsDefaultConstructed()
-  {
-    TRange defaultConstructedRange;
-    EXPECT_EQ(defaultConstructedRange.begin(), defaultConstructedRange.end());
-  }
-
-
-  template <typename TRange>
-  void ExpectZeroSizeWhenRangeIsDefaultConstructed()
-  {
-    TRange defaultConstructedRange;
-    EXPECT_EQ(defaultConstructedRange.size(), 0);
-  }
-
-
-  template <typename TRange>
-  void ExpectRangeIsEmptyWhenDefaultConstructed()
-  {
-    TRange defaultConstructedRange;
-    EXPECT_TRUE(defaultConstructedRange.empty());
-  }
-
   template <typename TImage>
   void ExpectRangeIsEmptyForAnEmptyContainerOfShapeOffsets()
   {
@@ -980,24 +957,30 @@ TEST(ShapedImageNeighborhoodRange, SupportsArbitraryBufferedRegionIndex)
 // Tests that begin() == end() for a default-constructed range.
 TEST(ShapedImageNeighborhoodRange, BeginIsEndWhenDefaultConstructed)
 {
-  ExpectBeginIsEndWhenRangeIsDefaultConstructed<ShapedImageNeighborhoodRange<itk::Image<int>>>();
-  ExpectBeginIsEndWhenRangeIsDefaultConstructed<ShapedImageNeighborhoodRange<itk::VectorImage<int>>>();
+  RangeGTestUtilities::ExpectBeginIsEndWhenRangeIsDefaultConstructed<
+    ShapedImageNeighborhoodRange<itk::Image<int>>>();
+  RangeGTestUtilities::ExpectBeginIsEndWhenRangeIsDefaultConstructed<
+    ShapedImageNeighborhoodRange<itk::VectorImage<int>>>();
 }
 
 
 // Tests that size() returns 0 for a default-constructed range.
 TEST(ShapedImageNeighborhoodRange, SizeIsZeroWhenDefaultConstructed)
 {
-  ExpectZeroSizeWhenRangeIsDefaultConstructed<ShapedImageNeighborhoodRange<itk::Image<int>>>();
-  ExpectZeroSizeWhenRangeIsDefaultConstructed<ShapedImageNeighborhoodRange<itk::VectorImage<int>>>();
+  RangeGTestUtilities::ExpectZeroSizeWhenRangeIsDefaultConstructed<
+    ShapedImageNeighborhoodRange<itk::Image<int>>>();
+  RangeGTestUtilities::ExpectZeroSizeWhenRangeIsDefaultConstructed<
+    ShapedImageNeighborhoodRange<itk::VectorImage<int>>>();
 }
 
 
 // Tests empty() for a default-constructed range.
 TEST(ShapedImageNeighborhoodRange, IsEmptyWhenDefaultConstructed)
 {
-  ExpectRangeIsEmptyWhenDefaultConstructed<ShapedImageNeighborhoodRange<itk::Image<int>>>();
-  ExpectRangeIsEmptyWhenDefaultConstructed<ShapedImageNeighborhoodRange<itk::VectorImage<int>>>();
+  RangeGTestUtilities::ExpectRangeIsEmptyWhenDefaultConstructed<
+    ShapedImageNeighborhoodRange<itk::Image<int>>>();
+  RangeGTestUtilities::ExpectRangeIsEmptyWhenDefaultConstructed<
+    ShapedImageNeighborhoodRange<itk::VectorImage<int>>>();
 }
 
 


### PR DESCRIPTION
Moved utility functions that test the expected behavior of default-constructed
ranges from itkShapedImageNeighborhoodRangeGTest.cxx and
itkImageBufferRangeGTest.cxx to itkRangeGTestUtilities.h, to reduce the amount
of duplicate code in GTest cxx files.