### PR TITLE
ENH: Add default-constructor and empty() to IndexRange

### DIFF
--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -295,6 +295,22 @@ public:
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
+  /** Default-constructor. Constructs an empty range.
+   * \note The other five "special member functions" (copy-constructor,
+   * copy-assignment operator, move-constructor, move-assignment operator,
+   * and destructor) are implicitly defaulted, following the C++ "Rule of Zero".
+   */
+  IndexRange() ITK_NOEXCEPT
+    :
+  m_MinIndex(),
+  m_MaxIndex()
+  {
+    // m_MinIndex and m_MaxIndex are "inclusive" boundaries of the index, so
+    // in order to construct an empty range, m_MaxIndex must take one step back.
+    m_MaxIndex.back() = -1;
+  }
+
+
   /** Constructs a range of indices for the specified grid size.
    */
   explicit IndexRange(const SizeType& gridSize)
@@ -393,6 +409,21 @@ public:
     }
     return result;
   }
+
+
+  /** Tells whether the range is empty. */
+  bool empty() const ITK_NOEXCEPT
+  {
+    for (unsigned i = 0; i < VDimension; ++i)
+    {
+      if (m_MaxIndex[i] == (m_MinIndex[i] - 1))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
 
 private:
 


### PR DESCRIPTION
Added default-constructor to `IndexRange`, allowing to easily create an empty
range. Added `IndexRange::empty()`, which returns true for a default-constructed
range, as well as for a range that was constructed for a zero-sized region.

Added unit tests for these two member functions.

Follow-up to:
 - SHA-1: e9d249e96525646c1e48151d79a3cc2a67a0af30 (8 December 2018)
 - SHA-1: f4b3b39fb038b4a4f531111121010c2e38783f4b (3 January 2019)