### PR TITLE
PERF: readability container size empty

### DIFF
--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.cxx
@@ -278,7 +278,7 @@ bool ParticleSwarmOptimizerSAXReader::ContextIs( const char* test ) const
     {
     s += "/" + std::string(currentTag);
     }
-  if ( s.size() == 0 )
+  if ( s.empty() )
     {
     s = "/";
     }

--- a/Modules/Core/Common/include/itkPolygonCell.hxx
+++ b/Modules/Core/Common/include/itkPolygonCell.hxx
@@ -168,7 +168,7 @@ void
 PolygonCell< TCellInterface >
 ::BuildEdges()
 {
-  if ( m_PointIds.size() > 0 )
+  if ( !m_PointIds.empty() )
     {
     m_Edges.resize( m_PointIds.size() );
     const auto numberOfPoints = static_cast< unsigned int >( m_PointIds.size() );
@@ -291,7 +291,7 @@ typename PolygonCell< TCellInterface >::PointIdIterator
 PolygonCell< TCellInterface >
 ::PointIdsBegin()
 {
-  if ( m_PointIds.size() > 0 )
+  if ( !m_PointIds.empty() )
     {
     return &*( m_PointIds.begin() );
     }
@@ -311,7 +311,7 @@ typename PolygonCell< TCellInterface >::PointIdConstIterator
 PolygonCell< TCellInterface >
 ::PointIdsBegin() const
 {
-  if ( m_PointIds.size() > 0 )
+  if ( !m_PointIds.empty() )
     {
     return &*( m_PointIds.begin() );
     }
@@ -330,7 +330,7 @@ typename PolygonCell< TCellInterface >::PointIdIterator
 PolygonCell< TCellInterface >
 ::PointIdsEnd()
 {
-  if ( m_PointIds.size() > 0 )
+  if ( !m_PointIds.empty() )
     {
     return &m_PointIds[m_PointIds.size() - 1] + 1;
     }
@@ -350,7 +350,7 @@ typename PolygonCell< TCellInterface >::PointIdConstIterator
 PolygonCell< TCellInterface >
 ::PointIdsEnd() const
 {
-  if ( m_PointIds.size() > 0 )
+  if ( !m_PointIds.empty() )
     {
     return &m_PointIds[m_PointIds.size() - 1] + 1;
     }

--- a/Modules/Core/Common/include/itkTreeNode.hxx
+++ b/Modules/Core/Common/include/itkTreeNode.hxx
@@ -125,7 +125,7 @@ bool
 TreeNode< TValue >
 ::HasChildren() const
 {
-  return ( m_Children.size() > 0 ) ? true : false;
+  return ( !m_Children.empty() ) ? true : false;
 }
 
 /** Return the number of children */

--- a/Modules/Core/Common/src/itkFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkFileOutputWindow.cxx
@@ -56,7 +56,7 @@ FileOutputWindow
 {
   if ( !m_Stream )
     {
-    if ( m_FileName == "" )
+    if ( m_FileName.empty() )
       {
       m_FileName = "itkMessageLog.txt";
       }

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -424,7 +424,7 @@ ThreadIdType MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
       std::string item;
       while( std::getline(numberOfThreadsEnvListStream, item, ':') )
         {
-        if( item.size() > 0 ) // Do not add empty items.
+        if( !item.empty() ) // Do not add empty items.
           {
           ITK_NUMBER_OF_THREADS_ENV_LIST.push_back(item);
           }

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -356,7 +356,7 @@ ObjectFactoryBase
     {
     return;
     }
-  if ( LoadPath.size() == 0 )
+  if ( LoadPath.empty() )
     {
     return;
     }

--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -215,7 +215,7 @@ ThreadPool
 ThreadPool
 ::~ThreadPool()
 {
-  bool waitForThreads = m_Threads.size() > 0;
+  bool waitForThreads = !m_Threads.empty();
 #if defined(_WIN32) && defined(ITKCommon_EXPORTS)
   //This destructor is called during DllMain's DLL_PROCESS_DETACH.
   //Because ITKCommon-4.X.dll is usually being detached due to process termination,

--- a/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
@@ -44,7 +44,7 @@ XMLFileOutputWindow
 {
   if ( !m_Stream )
     {
-    if ( m_FileName == "" )
+    if ( m_FileName.empty() )
       {
       m_FileName = "itkMessageLog.xml";
       }

--- a/Modules/Core/Common/test/itkColorTableTest.cxx
+++ b/Modules/Core/Common/test/itkColorTableTest.cxx
@@ -101,7 +101,7 @@ int ColorTableTestSpecialConditionChecker(
     }
 
   std::string name = colors->GetColorName( numberOfColors );
-  if( name != "" )
+  if( !name.empty() )
     {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in itk::ColorTable::GetColorName" << std::endl;

--- a/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
@@ -40,7 +40,7 @@ bool ImageBoundaryFaceCalculatorTest(TImage * image, typename TImage::RegionType
       }
     }
 
-  if( !faceList.size() )
+  if( faceList.empty() )
     return true;
 
   image->FillBuffer(0);

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -310,7 +310,7 @@ ConnectedRegionsMeshFilter< TInputMesh, TOutputMesh >
   CellsContainerConstIterator    cell;
   CellDataContainerConstIterator cellData;
   bool                           CellDataPresent = (   nullptr != inCellData
-                                                    && 0 != inCellData->size() );
+                                                    && !inCellData->empty() );
   InputMeshCellPointer           cellCopy; // need an autopointer to duplicate
                                            // a cell
 
@@ -443,7 +443,7 @@ ConnectedRegionsMeshFilter< TInputMesh, TOutputMesh >
   std::vector< IdentifierType > *         tmpWave;
   typename std::set< InputMeshCellIdentifier >::iterator citer;
 
-  while ( m_Wave->size() > 0 )
+  while ( !m_Wave->empty() )
     {
     for ( i = m_Wave->begin(); i != m_Wave->end(); ++i )
       {

--- a/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
@@ -51,7 +51,7 @@ VTKPolyDataReader< TOutputMesh >
   outputMesh->SetCellsAllocationMethod(
     OutputMeshType::CellsAllocatedDynamicallyCellByCell);
 
-  if ( m_FileName == "" )
+  if ( m_FileName.empty() )
     {
     itkExceptionMacro(<< "No input FileName");
     }

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
@@ -79,7 +79,7 @@ void
 VTKPolyDataWriter< TInputMesh >
 ::GenerateData()
 {
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No FileName");
     return;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -472,7 +472,7 @@ QuadEdgeMesh< TPixel, VDimension, TTraits >
 {
 
   // sanity check
-  if( m_FreePointIndexes.size() == 0 )
+  if( m_FreePointIndexes.empty() )
     {
     return;
     }
@@ -499,7 +499,7 @@ QuadEdgeMesh< TPixel, VDimension, TTraits >
   QEType* EdgeRingIter;
 
   // for all the free indexes and while there is any gap
-  while( ( m_FreePointIndexes.size() != 0 )
+  while( ( !m_FreePointIndexes.empty() )
     && ( last.Index() >= this->GetNumberOfPoints() ) )
     {
 
@@ -622,7 +622,7 @@ QuadEdgeMesh< TPixel, VDimension, TTraits >
 {
   CellIdentifier cid;
 
-  if ( m_FreeCellIndexes.size() == 0 )
+  if ( m_FreeCellIndexes.empty() )
     {
     cid = this->GetNumberOfCells();
 
@@ -757,7 +757,7 @@ QuadEdgeMesh< TPixel, VDimension, TTraits >
 {
   CellIdentifier eid = 0;
 
-  if ( this->GetEdgeCells()->size() > 0 )
+  if ( !this->GetEdgeCells()->empty() )
     {
     CellsContainerConstIterator last = this->GetEdgeCells()->End();
     --last;
@@ -1110,7 +1110,7 @@ typename QuadEdgeMesh< TPixel, VDimension, TTraits >::QEPrimal *
 QuadEdgeMesh< TPixel, VDimension, TTraits >
 ::GetEdge() const
 {
-  if ( this->GetEdgeCells()->size() == 0 )
+  if ( this->GetEdgeCells()->empty() )
     {
     return ( (QEPrimal *)nullptr );
     }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
@@ -173,7 +173,7 @@ public:
   {
     // NOTE ALEX: should update the array on the fly to make it faster
     MakePointIds();
-    if ( m_PointIds.size() == 0 )
+    if ( m_PointIds.empty() )
       {
       return ( static_cast< PointIdIterator >( nullptr ) );
       }
@@ -186,7 +186,7 @@ public:
   PointIdIterator PointIdsEnd() override
   {
     // NOTE ALEX: should update the array on the fly to make it faster
-    if ( m_PointIds.size() == 0 )
+    if ( m_PointIds.empty() )
       {
       return ( static_cast< PointIdIterator >( nullptr ) );
       }
@@ -200,7 +200,7 @@ public:
   {
     // NOTE ALEX: should update the array on the fly to make it faster
     MakePointIds();
-    if ( m_PointIds.size() == 0 )
+    if ( m_PointIds.empty() )
       {
       return ( static_cast< PointIdIterator >( nullptr ) );
       }
@@ -213,7 +213,7 @@ public:
   PointIdConstIterator PointIdsEnd() const override
   {
     // NOTE ALEX: should update the array on the fly to make it faster
-    if ( m_PointIds.size() == 0 )
+    if ( m_PointIds.empty() )
       {
       return ( static_cast< PointIdIterator >( nullptr ) );
       }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.hxx
@@ -66,7 +66,7 @@ QuadEdgeMeshScalarDataVTKPolyDataWriter< TMesh >
       outputFile << "CELL_DATA " << this->m_Input->GetNumberOfFaces() << std::endl;
       outputFile << "SCALARS ";
 
-      if ( m_CellDataName != "" )
+      if ( !m_CellDataName.empty() )
         {
         outputFile << m_CellDataName << " " << m_CellDataName << std::endl;
         }
@@ -119,7 +119,7 @@ QuadEdgeMeshScalarDataVTKPolyDataWriter< TMesh >
     outputFile << "POINT_DATA " << this->m_Input->GetNumberOfPoints() << std::endl;
     outputFile << "SCALARS ";
 
-    if ( m_PointDataName != "" )
+    if ( !m_PointDataName.empty() )
       {
       outputFile << m_PointDataName << " " << m_PointDataName << std::endl;
       }

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -111,7 +111,7 @@ DTITubeSpatialObjectPoint< TPointDimension >
 {
   std::string charname = this->TranslateEnumToChar(name);
 
-  if ( charname.size() > 0 )
+  if ( !charname.empty() )
     {
     this->SetField(charname.c_str(), value);
     }
@@ -130,7 +130,7 @@ DTITubeSpatialObjectPoint< TPointDimension >
 {
   std::string charname = this->TranslateEnumToChar(name);
 
-  if ( charname.size() > 0 )
+  if ( !charname.empty() )
     {
     FieldType field(itksys::SystemTools::LowerCase(charname).c_str(), value);
     m_Fields.push_back(field);
@@ -169,7 +169,7 @@ DTITubeSpatialObjectPoint< TPointDimension >
 ::GetField(FieldEnumType name) const
 {
   std::string charname = this->TranslateEnumToChar(name);
-  if ( charname.size() > 0 )
+  if ( !charname.empty() )
     {
     return this->GetField( itksys::SystemTools::LowerCase(charname).c_str() );
     }

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -167,7 +167,7 @@ MetaImageConverter< NDimensions, PixelType, TSpatialObjectType >
   if ( this->GetWriteImagesInSeparateFile())
     {
     std::string filename = imageSO->GetProperty()->GetName();
-    if ( filename.size() == 0 )
+    if ( filename.empty() )
       {
       std::cout << "Error: you should set the image name when using"
                 << " WriteImagesInSeparateFile." << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkSceneSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSceneSpatialObjectTest.cxx
@@ -75,7 +75,7 @@ int itkSceneSpatialObjectTest(int, char* [])
   std::cout << "[PASSED]" << std::endl;
 
   std::cout << "Testing BoundingBoxChildrenName: ";
-  if(object->GetBoundingBoxChildrenName() != "")
+  if(!object->GetBoundingBoxChildrenName().empty())
   {
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -117,7 +117,7 @@ int itkSpatialObjectDuplicatorTest(int, char* [])
     found = true;
     unsigned int value=0;
 
-    if(dtiTube_copy->GetPoints().size() == 0)
+    if(dtiTube_copy->GetPoints().empty())
       {
       std::cout<<" [FAILED] : Size of the point list is zero" <<std::endl;
       return EXIT_FAILURE;

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -101,7 +101,7 @@ PipelineMonitorImageFilter<TImageType>
     itkWarningMacro(<<"input: " << input->GetLargestPossibleRegion() << "updated: " << m_UpdatedOutputLargestPossibleRegion );
     return false;
     }
-  if(m_UpdatedBufferedRegions.size() && !m_UpdatedOutputLargestPossibleRegion.IsInside(m_UpdatedBufferedRegions.back()))
+  if(!m_UpdatedBufferedRegions.empty() && !m_UpdatedOutputLargestPossibleRegion.IsInside(m_UpdatedBufferedRegions.back()))
     {
     itkWarningMacro(<<"The input filter's BufferedRegion is not contained by LargestPossibleRegion");
     return false;

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -58,7 +58,7 @@ bool BMPImageIO::CanReadFile(const char *filename)
   // First check the filename
   std::string fname = filename;
 
-  if ( fname == "" )
+  if ( fname.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     }
@@ -152,7 +152,7 @@ bool BMPImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     }
@@ -971,7 +971,7 @@ void BMPImageIO::PrintSelf(std::ostream & os, Indent indent) const
     {
     os << "Read as Scalar Image plus palette" << "\n";
     }
-  if( m_ColorPalette.size() > 0  )
+  if( !m_ColorPalette.empty()  )
     {
     os << indent << "ColorPalette:" << std::endl;
     for( unsigned int i = 0; i < m_ColorPalette.size(); ++i )

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -132,7 +132,7 @@ bool BioRadImageIO::CanReadFile(const char *filename)
   std::ifstream file;
   std::string   fname(filename);
 
-  if ( fname == "" )
+  if ( fname.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;
@@ -389,7 +389,7 @@ bool BioRadImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;

--- a/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
+++ b/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
@@ -104,7 +104,7 @@ CSVNumericObjectFileWriter<TValue,NRows,NColumns>
 ::PrepareForWriting()
 {
   // throw an exception if no filename is provided
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro( << "A filename for writing was not specified!" );
     }

--- a/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
+++ b/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
@@ -57,7 +57,7 @@ void
 CSVFileReaderBase
 ::PrepareForParsing()
 {
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro( << "There is no file name provided!"
                        << "Please provide a filename." );

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -720,7 +720,7 @@ bool GDCMImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if (  filename == "" )
+  if (  filename.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;
@@ -1008,7 +1008,7 @@ void GDCMImageIO::Write(const void *buffer)
   ExposeMetaData< std::string >(dict, "0028|1052", rescaleintercept);
   std::string rescaleslope;
   ExposeMetaData< std::string >(dict, "0028|1053", rescaleslope);
-  if ( rescaleintercept != "" && rescaleslope != "" )
+  if ( !rescaleintercept.empty() && !rescaleslope.empty() )
     {
     std::stringstream sstr1;
     sstr1 << rescaleintercept;
@@ -1024,7 +1024,7 @@ void GDCMImageIO::Write(const void *buffer)
       }
     // header->InsertValEntry( "US", 0x0028, 0x1054 ); // Rescale Type
     }
-  else if ( rescaleintercept != "" || rescaleslope != "" ) // xor
+  else if ( !rescaleintercept.empty() || !rescaleslope.empty() ) // xor
     {
     itkExceptionMacro("Both RescaleSlope & RescaleIntercept need to be present");
     }
@@ -1093,7 +1093,7 @@ void GDCMImageIO::Write(const void *buffer)
   gdcm::PixelFormat outpixeltype = gdcm::PixelFormat::UNKNOWN;
   if ( pixeltype == gdcm::PixelFormat::FLOAT32 || pixeltype == gdcm::PixelFormat::FLOAT64 )
     {
-    if ( bitsAllocated != "" && bitsStored != "" && highBit != "" && pixelRep != "" )
+    if ( !bitsAllocated.empty() && !bitsStored.empty() && !highBit.empty() && !pixelRep.empty() )
       {
       outpixeltype.SetBitsAllocated( static_cast<unsigned short int>(std::stoi( bitsAllocated.c_str() ) ));
       outpixeltype.SetBitsStored( static_cast<unsigned short int>(std::stoi( bitsStored.c_str() )) );

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -52,7 +52,7 @@ void GDCMSeriesFileNames::SetInputDirectory(const char *name)
 
 void GDCMSeriesFileNames::SetInputDirectory(std::string const & name)
 {
-  if ( name == "" )
+  if ( name.empty() )
     {
     itkWarningMacro(<< "You need to specify a directory where "
                        "the DICOM files are located");
@@ -84,7 +84,7 @@ const GDCMSeriesFileNames::SeriesUIDContainerType & GDCMSeriesFileNames::GetSeri
   gdcm::FileList *flist = m_SerieHelper->GetFirstSingleSerieUIDFileSet();
   while ( flist )
     {
-    if ( flist->size() ) //make sure we have at leat one serie
+    if ( !flist->empty() ) //make sure we have at leat one serie
       {
       gdcm::File *file = ( *flist )[0]; //for example take the first one
 
@@ -96,7 +96,7 @@ const GDCMSeriesFileNames::SeriesUIDContainerType & GDCMSeriesFileNames::GetSeri
       }
     flist = m_SerieHelper->GetNextSingleSerieUIDFileSet();
     }
-  if ( !m_SeriesUIDs.size() )
+  if ( m_SeriesUIDs.empty() )
     {
     itkWarningMacro(<< "No Series were found");
     }
@@ -114,12 +114,12 @@ const GDCMSeriesFileNames::FileNamesContainerType & GDCMSeriesFileNames::GetFile
       << "No Series can be found, make sure your restrictions are not too strong");
     return m_InputFileNames;
     }
-  if ( serie != "" ) // user did not specify any sub selection based on UID
+  if ( !serie.empty() ) // user did not specify any sub selection based on UID
     {
     bool found = false;
     while ( flist && !found )
       {
-      if ( flist->size() ) //make sure we have at leat one serie
+      if ( !flist->empty() ) //make sure we have at leat one serie
         {
         gdcm::File *file = ( *flist )[0]; //for example take the first one
         std::string id = m_SerieHelper->
@@ -142,7 +142,7 @@ const GDCMSeriesFileNames::FileNamesContainerType & GDCMSeriesFileNames::GetFile
   m_SerieHelper->OrderFileList(flist);
 
   gdcm::FileList::iterator it;
-  if ( flist->size() )
+  if ( !flist->empty() )
     {
     ProgressReporter progress(this, 0,
       static_cast<itk::SizeValueType>(flist->size()), 10);
@@ -209,7 +209,7 @@ const GDCMSeriesFileNames::FileNamesContainerType & GDCMSeriesFileNames::GetOutp
     m_OutputDirectory += '/';
     }
 
-  if ( m_InputFileNames.size() )
+  if ( !m_InputFileNames.empty() )
     {
     bool hasExtension = false;
     for ( std::vector< std::string >::const_iterator it = m_InputFileNames.begin();

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -180,7 +180,7 @@ bool GiplImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     }
@@ -1107,7 +1107,7 @@ bool GiplImageIO::CheckExtension(const char *filename)
 {
   std::string fname = filename;
 
-  if ( fname == "" )
+  if ( fname.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -168,7 +168,7 @@ void IPLCommonImageIO::ReadImageInformation()
   itk::EncapsulateMetaData< std::string >( thisDic, ITK_PatientID, std::string(m_ImageHeader->patientId) );
   itk::EncapsulateMetaData< std::string >( thisDic, ITK_ExperimentDate, std::string(m_ImageHeader->date) );
 
-  if ( _imagePath == "" )
+  if ( _imagePath.empty() )
     {
     RAISE_EXCEPTION();
     }

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -81,7 +81,7 @@ ImageFileReader< TOutputImage, ConvertPixelTraits >
 
   // Check to see if we can read the file given the name or prefix
   //
-  if ( this->GetFileName() == "" )
+  if ( this->GetFileName().empty() )
     {
     throw ImageFileReaderException(__FILE__, __LINE__, "FileName must be specified", ITK_LOCATION);
     }
@@ -111,7 +111,7 @@ ImageFileReader< TOutputImage, ConvertPixelTraits >
     std::ostringstream msg;
     msg << " Could not create IO object for reading file "
         << this->GetFileName().c_str() << std::endl;
-    if ( m_ExceptionMessage.size() )
+    if ( !m_ExceptionMessage.empty() )
       {
       msg << m_ExceptionMessage;
       }
@@ -119,7 +119,7 @@ ImageFileReader< TOutputImage, ConvertPixelTraits >
       {
       std::list< LightObject::Pointer > allobjects =
         ObjectFactoryBase::CreateAllInstance("itkImageIOBase");
-      if (allobjects.size() > 0)
+      if (!allobjects.empty())
         {
         msg << "  Tried to create one of the following:" << std::endl;
         for (auto & allobject : allobjects)

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -117,7 +117,7 @@ ImageFileWriter< TInputImage >
 
   // Make sure that we can write the file given the name
   //
-  if ( m_FileName == "" )
+  if ( m_FileName.empty() )
     {
     itkExceptionMacro(<< "No filename was specified");
     }
@@ -151,7 +151,7 @@ ImageFileWriter< TInputImage >
       ObjectFactoryBase::CreateAllInstance("itkImageIOBase");
     msg << " Could not create IO object for writing file "
         << m_FileName.c_str() << std::endl;
-    if (allobjects.size() > 0)
+    if (!allobjects.empty())
       {
       msg << "  Tried to create one of the following:" << std::endl;
       for (auto & allobject : allobjects)

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -35,7 +35,7 @@ ImageSeriesReader< TOutputImage >
 ::~ImageSeriesReader()
 {
   // Clear the eventual previous content of the MetaDictionary array
-  if ( m_MetaDataDictionaryArray.size() )
+  if ( !m_MetaDataDictionaryArray.empty() )
     {
     for ( unsigned int i = 0; i < m_MetaDataDictionaryArray.size(); i++ )
       {
@@ -104,7 +104,7 @@ void ImageSeriesReader< TOutputImage >
   std::string key("ITK_ImageOrigin");
 
   // Clear the previous content of the MetaDictionary array
-  if ( m_MetaDataDictionaryArray.size() )
+  if ( !m_MetaDataDictionaryArray.empty() )
     {
     for ( unsigned int i = 0; i < m_MetaDataDictionaryArray.size(); i++ )
       {

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -126,7 +126,7 @@ ArchetypeSeriesFileNames
   // If there is no "/" in the name, the directory is not specified.
   // In that case, use the default ".".  This is necessary for the
   // RegularExpressionSeriesFileNames.
-  if ( fileNamePath == "" )
+  if ( fileNamePath.empty() )
     {
     fileNamePath = ".";
     pathPrefix = "./";
@@ -215,7 +215,7 @@ ArchetypeSeriesFileNames
 
   // If the group list is empty, create a single group containing the
   // archetype.
-  if ( m_Groupings.size() == 0 && itksys::SystemTools::FileExists( unixArchetype.c_str() ) )
+  if ( m_Groupings.empty() && itksys::SystemTools::FileExists( unixArchetype.c_str() ) )
     {
     std::vector< std::string > tlist;
 

--- a/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
@@ -49,7 +49,7 @@ RegularExpressionSeriesFileNames
 ::GetFileNames()
 {
   // Validate the ivars
-  if ( m_Directory == "" )
+  if ( m_Directory.empty() )
     {
     itkExceptionMacro (<< "No directory defined!");
     }

--- a/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
@@ -296,7 +296,7 @@ StreamingImageIOBase::GetActualNumberOfSplitsForWriting(unsigned int numberOfReq
     //
     // todo check for byte order
 
-    if ( errorMessage.size() )
+    if ( !errorMessage.empty() )
       {
       // 0) Can't read file
       }
@@ -338,7 +338,7 @@ StreamingImageIOBase::GetActualNumberOfSplitsForWriting(unsigned int numberOfReq
         }
       }
 
-    if ( errorMessage.size() )
+    if ( !errorMessage.empty() )
       {
       itkExceptionMacro("Unable to paste because pasting file exists and is different. " << errorMessage);
       }

--- a/Modules/IO/ImageBase/test/itkIOCommonTest.cxx
+++ b/Modules/IO/ImageBase/test/itkIOCommonTest.cxx
@@ -87,7 +87,7 @@ bool CheckFileNameParsing(const std::string & fileName,
   bool nameMatches;
   if ( strlen(nameOnly) == 0 )
     {
-    nameMatches = correctNameOnly.size() == 0;
+    nameMatches = correctNameOnly.empty();
     }
   else
     {
@@ -98,7 +98,7 @@ bool CheckFileNameParsing(const std::string & fileName,
   bool extensionMatches;
   if ( strlen(extension) == 0 )
     {
-    extensionMatches = correctExtension.size() == 0;
+    extensionMatches = correctExtension.empty();
     }
   else
     {
@@ -109,7 +109,7 @@ bool CheckFileNameParsing(const std::string & fileName,
   bool pathMatches;
   if ( strlen(path) == 0 )
     {
-    pathMatches = correctPath.size() == 0;
+    pathMatches = correctPath.empty();
     }
   else
     {

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -92,7 +92,7 @@ bool JPEGImageIO::CanReadFile(const char *file)
   // First check the extension
   std::string filename = file;
 
-  if (  filename == "" )
+  if (  filename.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;
@@ -374,7 +374,7 @@ bool JPEGImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     return false;
     }

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -111,7 +111,7 @@ bool LSMImageIO::CanReadFile(const char *filename)
 {
   std::string   fname(filename);
 
-  if ( fname == "" )
+  if ( fname.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;
@@ -196,7 +196,7 @@ bool LSMImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     return false;
     }

--- a/Modules/IO/Mesh/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/Mesh/src/itkOFFMeshIO.cxx
@@ -337,7 +337,7 @@ OFFMeshIO
 ::WriteMeshInformation()
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -398,7 +398,7 @@ OFFMeshIO
 ::WritePoints(void *buffer)
 {
   // check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -604,7 +604,7 @@ OFFMeshIO
 ::WriteCells(void *buffer)
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -293,7 +293,7 @@ BYUMeshIO
 ::WriteMeshInformation()
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -324,7 +324,7 @@ BYUMeshIO
 ::WritePoints(void *buffer)
 {
   // check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -432,7 +432,7 @@ BYUMeshIO
 ::WriteCells(void *buffer)
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -481,7 +481,7 @@ void
 MeshFileReader< TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits >
 ::GenerateOutputInformation()
 {
-  if ( m_FileName == "" )
+  if ( m_FileName.empty() )
     {
     throw MeshFileReaderException(__FILE__, __LINE__, "FileName must be specified", ITK_LOCATION);
     }
@@ -505,7 +505,7 @@ MeshFileReader< TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits >
     {
     std::ostringstream msg;
     msg << " Could not create IO object for file " << m_FileName.c_str() << std::endl;
-    if ( m_ExceptionMessage.size() )
+    if ( !m_ExceptionMessage.empty() )
       {
       msg << m_ExceptionMessage;
       }

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -89,7 +89,7 @@ MeshFileWriter< TInputMesh >
     }
 
   // Make sure that we can write the file given the name
-  if ( m_FileName == "" )
+  if ( m_FileName.empty() )
     {
     throw MeshFileWriterException(__FILE__, __LINE__, "FileName must be specified", ITK_LOCATION);
     }

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -210,7 +210,7 @@ FreeSurferAsciiMeshIO
 ::WriteMeshInformation()
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -238,7 +238,7 @@ FreeSurferAsciiMeshIO
 ::WritePoints(void *buffer)
 {
   // check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -347,7 +347,7 @@ FreeSurferAsciiMeshIO
 ::WriteCells(void *buffer)
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -289,7 +289,7 @@ FreeSurferBinaryMeshIO
 ::WriteMeshInformation()
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -344,7 +344,7 @@ FreeSurferBinaryMeshIO
 ::WritePoints(void *buffer)
 {
   // check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -452,7 +452,7 @@ FreeSurferBinaryMeshIO
 ::WriteCells(void *buffer)
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -548,7 +548,7 @@ FreeSurferBinaryMeshIO
 ::WritePointData(void *buffer)
 {
   // check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -356,7 +356,7 @@ OBJMeshIO
 ::WriteMeshInformation()
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -386,7 +386,7 @@ OBJMeshIO::
 WritePoints(void *buffer)
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -496,7 +496,7 @@ OBJMeshIO
 ::WriteCells(void *buffer)
 {
   // check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -599,7 +599,7 @@ OBJMeshIO
     }
 
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -1044,7 +1044,7 @@ VTKPolyDataMeshIO
 ::WriteMeshInformation()
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -1159,7 +1159,7 @@ VTKPolyDataMeshIO
 ::WritePoints(void *buffer)
 {
   // Check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -1293,7 +1293,7 @@ void
 VTKPolyDataMeshIO
 ::WriteCells(void *buffer)
 {
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -1348,7 +1348,7 @@ VTKPolyDataMeshIO
 ::WritePointData(void *buffer)
 {
   // check file name
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }
@@ -1402,7 +1402,7 @@ void
 VTKPolyDataMeshIO
 ::WriteCellData(void *buffer)
 {
-  if ( this->m_FileName == "" )
+  if ( this->m_FileName.empty() )
     {
     itkExceptionMacro("No Input FileName");
     }

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -73,7 +73,7 @@ bool MetaImageIO::CanReadFile(const char *filename)
   // First check the extension
   std::string fname = filename;
 
-  if (  fname == "" )
+  if (  fname.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;
@@ -504,7 +504,7 @@ bool MetaImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if (  filename == "" )
+  if (  filename.empty() )
     {
     return false;
     }
@@ -647,7 +647,7 @@ MetaImageIO
 
     value = strs.str();
 
-    if (value == "" )
+    if (value.empty() )
       {
       // if the value is an empty string then the resulting entry in
       // the header will not be able to be read the the metaIO
@@ -1214,7 +1214,7 @@ MetaImageIO::GetActualNumberOfSplitsForWriting(unsigned int numberOfRequestedSpl
     // 5)direction cosines
     //
 
-    if ( errorMessage.size() )
+    if ( !errorMessage.empty() )
       {
       // 0) Can't read file
       }
@@ -1261,7 +1261,7 @@ MetaImageIO::GetActualNumberOfSplitsForWriting(unsigned int numberOfRequestedSpl
         }
       }
 
-    if ( errorMessage.size() )
+    if ( !errorMessage.empty() )
       {
       itkExceptionMacro("Unable to paste because pasting file exists and is different. " << errorMessage);
       }

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -832,7 +832,7 @@ bool NrrdImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if (  filename == "" )
+  if (  filename.empty() )
     {
     return false;
     }

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -80,7 +80,7 @@ bool PNGImageIO::CanReadFile(const char *file)
   // First check the filename
   std::string filename = file;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;
@@ -313,7 +313,7 @@ void PNGImageIO::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 
   os << indent << "CompressionLevel: " << m_CompressionLevel << std::endl;
-  if( m_ColorPalette.size() > 0  )
+  if( !m_ColorPalette.empty()  )
     {
     os << indent << "ColorPalette:" << std::endl;
     for( unsigned int i = 0; i < m_ColorPalette.size(); ++i )
@@ -501,7 +501,7 @@ bool PNGImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     return false;
     }

--- a/Modules/IO/RAW/include/itkRawImageIO.hxx
+++ b/Modules/IO/RAW/include/itkRawImageIO.hxx
@@ -64,7 +64,7 @@ SizeValueType RawImageIO< TPixel, VImageDimension >::GetHeaderSize()
 {
   std::ifstream file;
 
-  if ( m_FileName == "" )
+  if ( m_FileName.empty() )
     {
     itkExceptionMacro(<< "A FileName must be specified.");
     }
@@ -179,7 +179,7 @@ bool RawImageIO< TPixel, VImageDimension >
 {
   std::string filename(fname);
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     return false;
     }

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -63,7 +63,7 @@ bool StimulateImageIO::CanReadFile(const char *filename)
   char          buffer[256];
   std::string   fname(filename);
 
-  if ( fname == "" )
+  if ( fname.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;
@@ -113,7 +113,7 @@ void StimulateImageIO::Read(void *buffer)
   //read data file
   std::ifstream file_data;
 
-  if ( m_DataFileName == "" )
+  if ( m_DataFileName.empty() )
     {
     //if no data filename was specified try to guess one:
     //based on filename.spr , options are:
@@ -409,7 +409,7 @@ void StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
       //otherwise prepend the path of the .spr file.
       std::string datafilenamePath =
         ::itksys::SystemTools::GetFilenamePath (datafilename);
-      if ( datafilenamePath == "" )
+      if ( datafilenamePath.empty() )
         {
         std::string fileNamePath = ::itksys::SystemTools::GetFilenamePath ( m_FileName.c_str() );
         m_DataFileName = fileNamePath + "/" + datafilename;
@@ -459,7 +459,7 @@ bool StimulateImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -31,7 +31,7 @@ bool TIFFImageIO::CanReadFile(const char *file)
   // First check the filename
   std::string filename = file;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     itkDebugMacro(<< "No filename specified.");
     return false;
@@ -252,7 +252,7 @@ void TIFFImageIO::PrintSelf(std::ostream & os, Indent indent) const
 
   os << indent << "Compression: " << m_Compression << std::endl;
   os << indent << "JPEGQuality: " << m_JPEGQuality << std::endl;
-  if( m_ColorPalette.size() > 0  )
+  if( !m_ColorPalette.empty()  )
     {
     os << indent << "Image RGB palette:" << "\n";
     for (size_t i=0; i< m_ColorPalette.size(); ++i)
@@ -493,7 +493,7 @@ bool TIFFImageIO::CanWriteFile(const char *name)
 {
   std::string filename = name;
 
-  if ( filename == "" )
+  if ( filename.empty() )
     {
     return false;
     }

--- a/Modules/IO/TransformBase/include/itkTransformFileReader.hxx
+++ b/Modules/IO/TransformBase/include/itkTransformFileReader.hxx
@@ -86,7 +86,7 @@ template<typename TParametersValueType>
 void TransformFileReaderTemplate<TParametersValueType>
 ::Update()
 {
-  if ( m_FileName == "" )
+  if ( m_FileName.empty() )
     {
     itkExceptionMacro ("No file name given");
     }
@@ -107,7 +107,7 @@ void TransformFileReaderTemplate<TParametersValueType>
 
       std::list< LightObject::Pointer > allobjects =  ObjectFactoryBase::CreateAllInstance("itkTransformIOBaseTemplate");
 
-      if (allobjects.size() > 0)
+      if (!allobjects.empty())
         {
         msg << "  Tried to create one of the following:" << std::endl;
         for (auto & allobject : allobjects)

--- a/Modules/IO/TransformBase/include/itkTransformFileWriter.hxx
+++ b/Modules/IO/TransformBase/include/itkTransformFileWriter.hxx
@@ -114,7 +114,7 @@ void TransformFileWriterTemplate<TParametersValueType>
   const std::string transformName = transform->GetNameOfClass();
   if( transformName.find("CompositeTransform") != std::string::npos )
     {
-    if(this->m_TransformList.size() > 0)
+    if(!this->m_TransformList.empty())
       {
       itkExceptionMacro("Can only write a transform of type CompositeTransform "
                         "as the first transform in the file.");
@@ -128,7 +128,7 @@ template<typename TParametersValueType>
 void TransformFileWriterTemplate<TParametersValueType>
 ::Update()
 {
-  if ( m_FileName == "" )
+  if ( m_FileName.empty() )
     {
     itkExceptionMacro ("No file name given");
     }
@@ -145,7 +145,7 @@ void TransformFileWriterTemplate<TParametersValueType>
 
       std::list< LightObject::Pointer > allobjects =  ObjectFactoryBase::CreateAllInstance("itkTransformIOBaseTemplate");
 
-      if (allobjects.size() > 0)
+      if (!allobjects.empty())
         {
         msg << "  Tried to create one of the following:" << std::endl;
         for (auto & allobject : allobjects)

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.hxx
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.hxx
@@ -109,7 +109,7 @@ Superclass::PrintSelf(os, indent);
 os << indent << "FileName: " << m_FileName << std::endl;
 os << indent << "AppendMode: "
 << ( m_AppendMode ? "true" : "false" ) << std::endl;
-if ( m_ReadTransformList.size() > 0 )
+if ( !m_ReadTransformList.empty() )
   {
   os << indent << "ReadTransformList: " << std::endl;
   auto it = m_ReadTransformList.begin();
@@ -119,7 +119,7 @@ if ( m_ReadTransformList.size() > 0 )
     ++it;
     }
   }
-if ( m_WriteTransformList.size() > 0 )
+if ( !m_WriteTransformList.empty() )
   {
   os << indent << "WriteTransformList: " << std::endl;
 

--- a/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIO.hxx
+++ b/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIO.hxx
@@ -295,7 +295,7 @@ inline void print_vector(std::ofstream& s, vnl_vector<TParametersValueType> cons
     {
     s << convert(v[i]) << ' ';
     }
-  if (v.size() > 0)
+  if (!v.empty())
     {
     s << convert(v[v.size()-1]);
     }

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -60,7 +60,7 @@ int VTKImageIO::GetNextLine(std::ifstream& ifs, std::string& line, bool lowerCas
     }
 
   // Check an empty line with the size of a read line from *.vtk file
-  if(line.size() < 1)
+  if(line.empty())
     {
     return GetNextLine(ifs, line, lowerCase, ++count);
     }

--- a/Modules/IO/XML/include/itkFileTools.h
+++ b/Modules/IO/XML/include/itkFileTools.h
@@ -62,7 +62,7 @@ FileTools::CreateDirectory( const std::string &dir )
     }
 
   // do nothing if it already exists
-  if ( "" == dir || "." == dir || itksys::SystemTools::FileIsDirectory(dir.c_str()) )
+  if ( dir.empty() || "." == dir || itksys::SystemTools::FileIsDirectory(dir.c_str()) )
     {
     return;
     }

--- a/Modules/IO/XML/src/itkDOMNode.cxx
+++ b/Modules/IO/XML/src/itkDOMNode.cxx
@@ -224,7 +224,7 @@ DOMNode::RemoveAllChildren()
 void
 DOMNode::AddChild( DOMNode* node, IdentifierType i )
 {
-  if ( this->m_Children.size() == 0 )
+  if ( this->m_Children.empty() )
     {
     this->AddChildAtEnd( node );
     return;
@@ -494,7 +494,7 @@ DOMNode::Find( const std::string& path )
   DOMNode* node = nullptr;
 
   // /<rpath>
-  if ( s == "" )
+  if ( s.empty() )
     {
     node = this->GetRoot();
     }
@@ -592,7 +592,7 @@ DOMNode::Find( const std::string& path )
       }
     }
 
-  if ( rpath == "" || node == nullptr )
+  if ( rpath.empty() || node == nullptr )
     {
     return node;
     }

--- a/Modules/IO/XML/src/itkDOMNodeXMLReader.cxx
+++ b/Modules/IO/XML/src/itkDOMNodeXMLReader.cxx
@@ -179,7 +179,7 @@ DOMNodeXMLReader::CharacterDataHandler( const char* text, int len )
   std::string s( text, len );
 
   StringTools::Trim( s );
-  if ( s.size() == 0 )
+  if ( s.empty() )
     {
     return;
     }

--- a/Modules/IO/XML/src/itkDOMNodeXMLWriter.cxx
+++ b/Modules/IO/XML/src/itkDOMNodeXMLWriter.cxx
@@ -53,7 +53,7 @@ DOMNodeXMLWriter::Update( std::ostream& os, std::string indent )
 
   // write the "id" attribute if it is present
   std::string id = input->GetID();
-  if ( id != "" )
+  if ( !id.empty() )
     {
     os << " id=\"" << id << "\"";
     }
@@ -71,7 +71,7 @@ DOMNodeXMLWriter::Update( std::ostream& os, std::string indent )
   using ConstChildrenListType = InputType::ConstChildrenListType;
   ConstChildrenListType children;
   input->GetAllChildren( children );
-  if ( children.size() )
+  if ( !children.empty() )
     {
     // write the closing bracket for the start tag
     os << ">" << std::endl;

--- a/Modules/IO/XML/src/itkStringTools.cxx
+++ b/Modules/IO/XML/src/itkStringTools.cxx
@@ -124,7 +124,7 @@ void
 StringTools::Split( const std::string& s, std::vector<std::string>& result, const std::string& delims )
 {
   std::string str = s;
-  while ( str.size() )
+  while ( !str.empty() )
     {
     std::string::size_type pos = str.find_first_of( delims );
     if ( pos != std::string::npos )

--- a/Modules/IO/XML/test/itkDOMTest6.cxx
+++ b/Modules/IO/XML/test/itkDOMTest6.cxx
@@ -346,7 +346,7 @@ void testStringToolsForStringOperations()
       throw "testStringToolsForStringOperations: failed [not] trimming both sides";
     }
   s = "    ";
-  if ( itk::StringTools::Trim(s) != "" )
+  if ( !itk::StringTools::Trim(s).empty() )
     {
       throw "testStringToolsForStringOperations: failed trimming entire string";
     }

--- a/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
@@ -232,7 +232,7 @@ LevenbergMarquardtOptimizer
     {
     GetOptimizer()->diagnose_outcome(outcome);
     }
-  reason << this->GetNameOfClass() << ": " << ( ( outcome.str().size() > 0 ) ? outcome.str().c_str() : "" );
+  reason << this->GetNameOfClass() << ": " << ( ( !outcome.str().empty() ) ? outcome.str().c_str() : "" );
   return reason.str();
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -363,7 +363,7 @@ RegistrationParameterScalesEstimator< TMetric >
     }
 
   // Sanity check
-  if( this->m_SamplePoints.size() == 0 )
+  if( this->m_SamplePoints.empty() )
     {
     itkExceptionMacro("No sample points were created.");
     }

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -236,11 +236,11 @@ public:
   static MeasurementVectorLength Assert(const FixedArray< TValue1, VLength > &,
                                         const std::vector< TValue2 > & b, const char *errMsg = "Length Mismatch")
   {
-    if ( b.size() == 0 )
+    if ( b.empty() )
       {
       return VLength;
       }
-    if ( b.size() != 0 )
+    if ( !b.empty() )
       {
       if ( b.size() != VLength )
         {
@@ -359,7 +359,7 @@ public:
   static MeasurementVectorLength Assert(const std::vector< TValue > & a,
                                         const MeasurementVectorLength l, const char *errMsg = "Length Mismatch")
   {
-    if ( ( ( l != 0 ) && ( a.size() != l ) ) || ( a.size() == 0 ) )
+    if ( ( ( l != 0 ) && ( a.size() != l ) ) || ( a.empty() ) )
       {
       itkGenericExceptionMacro(<< errMsg);
       }

--- a/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
@@ -27,7 +27,7 @@ MaximumDecisionRule
 {
   ClassIdentifierType maxIndex = 0;
 
-  if (discriminantScores.size() > 0)
+  if (!discriminantScores.empty())
     {
     MembershipValueType  max = discriminantScores[0];
     ClassIdentifierType i;

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -46,7 +46,7 @@ MaximumRatioDecisionRule
       os << ", ";
       }
     }
-  if (m_PriorProbabilities.size() > 0 && m_PriorProbabilities.size() < N)
+  if (!m_PriorProbabilities.empty() && m_PriorProbabilities.size() < N)
     {
     os << ", ...";
     }

--- a/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
@@ -27,7 +27,7 @@ MinimumDecisionRule
 {
   ClassIdentifierType minIndex = 0;
 
-  if (discriminantScores.size() > 0)
+  if (!discriminantScores.empty())
     {
     MembershipValueType  min = discriminantScores[0];
     ClassIdentifierType i;

--- a/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
@@ -124,7 +124,7 @@ int itkGaussianRandomSpatialNeighborSubsamplerTest(int argc, char* argv[] )
     inImage->SetPixel(index, 255);
     }
 
-  if (outFile != "")
+  if (!outFile.empty())
     {
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName( outFile );

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -117,7 +117,7 @@ int itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char* argv[] )
     inImage->SetPixel(index, 255);
     }
 
-  if (outFile != "")
+  if (!outFile.empty())
     {
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName( outFile );

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -298,7 +298,7 @@ ImageToImageMetric< TFixedImage, TMovingImage >
   //are mutually exclusive, so they should not both be checked.
   if ( this->m_UseFixedImageIndexes  == true )
     {
-    if( this->m_FixedImageIndexes.size() == 0 )
+    if( this->m_FixedImageIndexes.empty() )
       {
       itkExceptionMacro(<< "FixedImageIndexes list is empty");
       }

--- a/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
@@ -227,7 +227,7 @@ LabeledPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComp
       }
     }
 
-  if( uncommonLabelSet.size() > 0 )
+  if( !uncommonLabelSet.empty() )
     {
     itkWarningMacro( "The label sets are not bijective." );
     }

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
@@ -172,7 +172,7 @@ public:
    */
   const typename JointPDFType::Pointer GetJointPDF () const
     {
-    if( this->m_ThreaderJointPDF.size() == 0 )
+    if( this->m_ThreaderJointPDF.empty() )
       {
       return typename JointPDFType::Pointer(nullptr);
       }

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
@@ -72,7 +72,7 @@ ClassifierBase< TDataContainer >
     return;
     }
 
-  if ( m_MembershipFunctions.size() == 0 )
+  if ( m_MembershipFunctions.empty() )
     {
     itkExceptionMacro("No membership function");
     return;

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
@@ -49,7 +49,7 @@ ScalarImageKmeansImageFilter< TInputImage, TOutputImage >
 {
   this->Superclass::VerifyPreconditions();
 
-  if ( this->m_InitialMeans.size() == 0 )
+  if ( this->m_InitialMeans.empty() )
     {
     itkExceptionMacro("Atleast One InialMean is required.");
     }

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
@@ -53,15 +53,15 @@ int itkScalarImageKmeansImageFilter3DTest (int argc, char *argv[])
     }
 
   bool violated=false;
-  if (inputVolume.size() == 0)
+  if (inputVolume.empty())
     {
     violated = true; std::cout << "  --inputVolume Required! "  << std::endl;
     }
-  if (input3DSkullStripVolume.size() == 0)
+  if (input3DSkullStripVolume.empty())
     {
     violated = true; std::cout << "  --input3DSkullStripVolume Required! "  << std::endl;
     }
-  if (outputLabelMapVolume.size() == 0)
+  if (outputLabelMapVolume.empty())
     {
     violated = true; std::cout << "  --outputLabelMapVolume Required! "  << std::endl;
     }

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -180,7 +180,7 @@ HardConnectedComponentImageFilter< TInputImage, TOutputImage >
     }
 
   ot.GoToBegin();
-  if ( m_Seeds.size() == 0 )
+  if ( m_Seeds.empty() )
     {
     for (; !ot.IsAtEnd(); ++ot )
       {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.hxx
@@ -165,7 +165,7 @@ bool
 LevelSetContainerBase< TIdentifier, TLevelSet >
 ::HasDomainMap() const
 {
-  if( !this->m_DomainMapFilter.IsNull() && this->m_DomainMapFilter->GetDomainMap().size() > 0 )
+  if( !this->m_DomainMapFilter.IsNull() && !this->m_DomainMapFilter->GetDomainMap().empty() )
     {
     return true;
     }

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -341,7 +341,7 @@ void
 MRFImageFilter< TInputImage, TClassifiedImage >
 ::SetMRFNeighborhoodWeight(std::vector< double > betaMatrix)
 {
-  if ( betaMatrix.size() == 0 )
+  if ( betaMatrix.empty() )
     {
     //Call a the function to set the default neighborhood
     this->SetDefaultMRFNeighborhoodWeight();

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
@@ -67,7 +67,7 @@ void
 ConnectedThresholdImageFilter< TInputImage, TOutputImage >
 ::ClearSeeds()
 {
-  if ( m_Seeds.size() > 0 )
+  if ( !m_Seeds.empty() )
     {
     this->m_Seeds.clear();
     this->Modified();

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -130,7 +130,7 @@ void
 IsolatedConnectedImageFilter< TInputImage, TOutputImage >
 ::ClearSeeds1()
 {
-  if ( this->m_Seeds1.size() > 0 )
+  if ( !this->m_Seeds1.empty() )
     {
     this->m_Seeds1.clear();
     this->Modified();
@@ -165,7 +165,7 @@ void
 IsolatedConnectedImageFilter< TInputImage, TOutputImage >
 ::ClearSeeds2()
 {
-  if ( this->m_Seeds2.size() > 0 )
+  if ( !this->m_Seeds2.empty() )
     {
     this->m_Seeds2.clear();
     this->Modified();

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
@@ -43,7 +43,7 @@ void
 NeighborhoodConnectedImageFilter< TInputImage, TOutputImage >
 ::ClearSeeds()
 {
-  if ( this->m_Seeds.size() > 0 )
+  if ( !this->m_Seeds.empty() )
     {
     this->m_Seeds.clear();
     this->Modified();

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -88,7 +88,7 @@ void
 VectorConfidenceConnectedImageFilter< TInputImage, TOutputImage >
 ::ClearSeeds()
 {
-  if ( this->m_Seeds.size() > 0 )
+  if ( !this->m_Seeds.empty() )
     {
     this->m_Seeds.clear();
     this->Modified();

--- a/Modules/Segmentation/RegionGrowing/test/itkConnectedThresholdImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConnectedThresholdImageFilterTest.cxx
@@ -77,7 +77,7 @@ int itkConnectedThresholdImageFilterTest( int argc, char* argv[] )
 
   connectedThresholdFilter->ClearSeeds();
   seedContainer = connectedThresholdFilter->GetSeeds();
-  if( seedContainer.size() != 0 )
+  if( !seedContainer.empty() )
     {
     std::cerr << "Test FAILED !" << std::endl;
     std::cerr << "Seed container not empty after clearing filter seed container !" << std::endl;

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -187,7 +187,7 @@ TobogganImageFilter< TInputImage, TOutputImage >
         itkDebugMacro (<< "\tFinished slide at: " << CurrentPositionIndex
                        << " Value: " << MinimumNeighborValue
                        << " Class: " << MinimumNeighborClass);
-        while ( OpenList.size() )
+        while ( !OpenList.empty() )
           {
           // Pop the last one off
           IndexType SeedIndex = OpenList.back();

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -96,7 +96,7 @@ VideoFileWriter< TInputVideoStream >
     }
 
   // Make sure FileName is specified
-  if (m_FileName == "")
+  if (m_FileName.empty())
     {
     itkExceptionMacro("No FileName set for writer");
     }

--- a/Modules/Video/IO/src/itkFileListVideoIO.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIO.cxx
@@ -405,7 +405,7 @@ void FileListVideoIO::OpenWriter()
     }
 
   // Make sure FileNames have been specified
-  if (m_FileNames.size() == 0)
+  if (m_FileNames.empty())
     {
     itkExceptionMacro("Cannot open reader without file names set");
     }

--- a/Utilities/ITKv5Preparation/readability-container-size-empty.sh
+++ b/Utilities/ITKv5Preparation/readability-container-size-empty.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -e
+# \author Hans J. Johnson
+#
+# This script assists with using clang-tidy.
+#
+# STEP 0;
+# I recommend downloading or building the latest
+# version of llvm with clang and the clang-tidy
+# tools in a private repo. NOTE:  Apple does
+# not currently distribute these.
+#
+# STEP 1:
+# Build your source tree with cmake and use
+# export PATH=${MYCLANG_FROM_STEP0}:$PATH
+# export CXX=${MYCLANG_FROM_STEP0}
+# export CC=${MYCLANG_FROM_STEP0}
+# cd ${MYBLD}
+# cmake -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON ${MYSRC}
+# to generate the compile_commands.json
+# comple options database files.
+#
+# STEP 2:
+# Run clang-tidy with the
+
+SRCDIR=$1
+BLDDIR=$2
+
+this_script_name=$(basename $0)
+CMTMSG=$(mktemp -q /tmp/${this_script_name}.XXXXXX)
+FILES_TO_CHECK=$(mktemp -q /tmp/${this_script_name}_files.XXXXXX)
+
+cat > ${CMTMSG} << EOF
+PERF: readability container size empty
+
+The emptiness of a container should be checked using the empty() method
+instead of the size() method. It is not guaranteed that size() is a
+constant-time function, and it is generally more efficient and also
+shows clearer intent to use empty(). Furthermore some containers may
+implement the empty() method but not implement the size() method. Using
+empty() whenever possible makes it easier to switch to another container
+in the future.
+
+SRCDIR=${SRCDIR} #My local SRC
+BLDDIR=${BLDDIR} #My local BLD
+
+cd ${BLDDIR}
+run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,readability-container-size-empty  -header-filter=.* -fix
+
+EOF
+
+export CC=/Users/johnsonhj/local/ccache/bin/clang_ccache
+export CXX=/Users/johnsonhj/local/ccache/bin/clang++11_ccache
+export PATH=~/local/llvm/llvm_trunk-build/bin:$PATH
+cd ${BLDDIR}
+/Users/johnsonhj/Dashboard/src/scripts/run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,readability-container-size-empty  -header-filter=.* -fix
+
+cd ${SRCDIR}
+git add -A && git commit --file ${CMTMSG}


### PR DESCRIPTION
The emptiness of a container should be checked using the empty() method
instead of the size() method. It is not guaranteed that size() is a
constant-time function, and it is generally more efficient and also
shows clearer intent to use empty(). Furthermore some containers may
implement the empty() method but not implement the size() method. Using
empty() whenever possible makes it easier to switch to another container
in the future.

SRCDIR=/Users/johnsonhj/Dashboard/src/ITK #My local SRC
BLDDIR=/Users/johnsonhj/Dashboard/src/ITK-clang #My local BLD

cd /Users/johnsonhj/Dashboard/src/ITK-clang
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,readability-container-size-empty  -header-filter=.* -fix