### PR TITLE
BUG: python itk.Image returned by GetImageFromArray manages its own buffer

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -139,15 +139,14 @@
         *numpy.reshape*.
         """
 
-        # perform deep copy of the array buffer
-        array_copy = numpy.array(ndarr)
+        # Create a temporary image view of the array
+        imageView = itkPyBuffer@PyBufferTypes@.GetImageViewFromArray(ndarr, is_vector)
 
-        image = itkPyBuffer@PyBufferTypes@.GetImageViewFromArray(array_copy, is_vector)
-
-        # attaches the copy of the array to the image to avoid releasing memory
-        # when leaving current scope.
-        image._ndarr = array_copy
-        return image
+        # Duplicate the image to let it manage its own memory buffer
+        duplicator = itkImageDuplicator@PyBufferTypes@.New()
+        duplicator.SetInputImage(imageView)
+        duplicator.Update()
+        return duplicator.GetOutput()
 
     GetImageFromArray = staticmethod(GetImageFromArray)
 

--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
@@ -31,4 +31,6 @@ def _get_numpy_pixelid(itk_Image_type):
         return _np_itk[itk_Image_type]
     except KeyError as e:
         raise e
+
+from itkImageDuplicatorPython import *
 %}

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -201,6 +201,14 @@ try:
     assert arr.shape[0] == 2
     assert arr.shape[1] == 3
     assert arr[1,1] == 5
+    arr = arr.copy()
+    image = itk.GetImageFromArray(arr)
+    image2 = type(image).New()
+    image2.Graft(image)
+    del image # Delete image but pixel data should be kept in img2
+    image = itk.GetImageFromArray(arr+1) # Fill former memory if wrongly released
+    assert np.array_equal(arr, itk.GetArrayViewFromImage(image2))
+    image2.SetPixel([0]*image2.GetImageDimension(), 3) # For mem check in dynamic analysis
     # VNL Vectors
     v1 = itk.vnl_vector.D(2)
     v1.fill(1)


### PR DESCRIPTION
The memory buffer could be lost after grafting the returned image to
another because the _ndarr member was not backed up by Graft. The added
test reproduces the problem that the patch fixes.