### PR TITLE
ENH: Update IOSTL to 2019-01-16 master

### DIFF
--- a/Modules/Remote/IOSTL.remote.cmake
+++ b/Modules/Remote/IOSTL.remote.cmake
@@ -3,5 +3,5 @@ itk_fetch_module(IOSTL
   "This module contains classes for reading and writing QuadEdgeMeshes using
   the STL (STereoLithography)file format. https://hdl.handle.net/10380/3452"
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSTLMeshIO.git
-  GIT_TAG f4723954fdfe294f84f69907e964b50e48b60218
+  GIT_TAG e681a38aba1d89561eec89584d80f62dd2affa23
   )


### PR DESCRIPTION
 Jon Haitz Legarreta Gorroño (3):
       ENH: Improve the `README` file.
       ENH: Add CI.
       DOC: Re-use `README.rst` info in `itk-module.cmake`.

 Matt McCormick (1):
       ENH: Enable mesh module factory registration
