### PR TITLE
COMP: Do not use readNoPreambleDICOM with Emscripten

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -226,6 +226,7 @@ bool DCMTKImageIO::CanReadFile(const char *filename)
     itkDebugMacro(<< "No filename specified.");
     }
 
+#if !defined(__EMSCRIPTEN__)
     {
     std::ifstream file;
     try
@@ -243,6 +244,7 @@ bool DCMTKImageIO::CanReadFile(const char *filename)
        return false;
       }
     }
+#endif
   return DCMTKFileReader::IsImageFile(filename);
 }
 

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -242,7 +242,7 @@ bool GDCMImageIO::CanReadFile(const char *filename)
     }
 //Do not allow CanRead to return true for non-compliant DICOM files
 #define GDCMPARSER_IGNORE_MAGIC_NUMBER
-#if defined GDCMPARSER_IGNORE_MAGIC_NUMBER
+#if defined(GDCMPARSER_IGNORE_MAGIC_NUMBER) && !defined(__EMSCRIPTEN__)
   //
   // Try it anyways...
   //


### PR DESCRIPTION
This performance optimization returns false for DICOM files.