### PR TITLE
Fix Azure Pipelines commit checkout

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -12,6 +12,16 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 5
+    - bash: |
+        set -x
+        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+          git checkout $(System.PullRequest.SourceCommitId)
+        fi
+
+      displayName: Checkout pull request HEAD
     - bash: |
         set -x
 

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -12,6 +12,16 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 5
+    - bash: |
+        set -x
+        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+          git checkout $(System.PullRequest.SourceCommitId)
+        fi
+
+      displayName: Checkout pull request HEAD
     - bash: |
         set -x
 
@@ -33,6 +43,10 @@ jobs:
       workingDirectory: $(Agent.BuildDirectory)
     - script: |
         set -x
+
+        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+          git checkout $(System.PullRequest.SourceCommitId)
+        fi
 
         c++ --version
         cmake --version

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -12,6 +12,16 @@ jobs:
   pool:
     vmImage: 'macOS 10.13'
   steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 5
+    - bash: |
+        set -x
+        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+          git checkout $(System.PullRequest.SourceCommitId)
+        fi
+
+      displayName: Checkout pull request HEAD
     - bash: |
         set -x
 

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -12,6 +12,16 @@ jobs:
   pool:
     vmImage: 'macOS 10.13'
   steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 5
+    - bash: |
+        set -x
+        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+          git checkout $(System.PullRequest.SourceCommitId)
+        fi
+
+      displayName: Checkout pull request HEAD
     - bash: |
         set -x
 
@@ -41,5 +51,5 @@ jobs:
         export CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and Test
+      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -12,7 +12,14 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 5
     - script: |
+        if NOT "$(System.PullRequest.SourceCommitId)"=="" git checkout $(System.PullRequest.SourceCommitId)
+      displayName: Checkout pull request HEAD
+    - script: |
+
         pip3 install ninja
 
       displayName: Install dependencies

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -12,6 +12,12 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 5
+    - script: |
+        if NOT "$(System.PullRequest.SourceCommitId)"=="" git checkout $(System.PullRequest.SourceCommitId)
+      displayName: Checkout pull request HEAD
     - script: |
         pip3 install ninja numpy
 
@@ -39,5 +45,5 @@ jobs:
         set CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and Test
+      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)


### PR DESCRIPTION
By default, azure checks out refs/remotes/pull/<pullRequestId>/merge.
The merge changes the hash associated with the commit.