### PR TITLE
BUG: Add CircleCI configuration to ignore the dashboard branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:2.7
+    working_directory: ~/
+    branches:
+      ignore:
+        - gh-pages
+        - dashboard
+        - hooks
+    steps:
+      - checkout:
+          path : ~/ITK


### PR DESCRIPTION
CircleCI apparently requires this file to live on the `dashboard` branch
for the branch to be ignored.