### PR TITLE
BUG: Fix Azure Pipelines master checkout on Windows

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -16,7 +16,7 @@ jobs:
       clean: true
       fetchDepth: 5
     - script: |
-        if NOT "$(System.PullRequest.SourceCommitId)"=="" git checkout $(System.PullRequest.SourceCommitId)
+        if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
       displayName: Checkout pull request HEAD
     - script: |
 

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -16,7 +16,7 @@ jobs:
       clean: true
       fetchDepth: 5
     - script: |
-        if NOT "$(System.PullRequest.SourceCommitId)"=="" git checkout $(System.PullRequest.SourceCommitId)
+        if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
       displayName: Checkout pull request HEAD
     - script: |
         pip3 install ninja numpy


### PR DESCRIPTION
The expression results in the literal "$(System.PullRequest.SourceCommitId)"
outside of pull requests.