### PR TITLE
BUG: Default MeshIOBase PointDimension is 3

### DIFF
--- a/Modules/IO/MeshBase/include/itkMeshFileTestHelper.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileTestHelper.h
@@ -271,6 +271,13 @@ test(char *INfilename, char *OUTfilename, bool IsBinary)
     std::cerr << err << std::endl;
     return EXIT_FAILURE;
     }
+  reader->GetMeshIO()->Print( std::cout );
+
+  if( TMesh::PointDimension != reader->GetMeshIO()->GetPointDimension() )
+    {
+    std::cerr << "Unexpected PointDimension" << std::endl;
+    return EXIT_FAILURE;
+    }
 
   MeshFileWriterPointer writer = MeshFileWriterType::New();
   if( itksys::SystemTools::GetFilenameLastExtension(INfilename) ==

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -734,7 +734,7 @@ protected:
   unsigned int m_NumberOfCellPixelComponents{0};
 
   /** The number of independent dimensions in the point. */
-  SizeValueType m_PointDimension{0};
+  SizeValueType m_PointDimension{3};
 
   /** The number of points and cells */
   SizeValueType m_NumberOfPoints;

--- a/Modules/IO/MeshBase/itk-module.cmake
+++ b/Modules/IO/MeshBase/itk-module.cmake
@@ -13,6 +13,8 @@ itk_module(ITKIOMeshBase
     ITKQuadEdgeMesh
     ITKMesh
     ITKVoronoi
+  TEST_DEPENDS
+    ITKTestKernel
   DESCRIPTION
     "${DOCUMENTATION}"
 )

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -165,11 +165,11 @@ MeshIOBase
     case LDOUBLE:
       return std::string( "long_double" );
     case UNKNOWNCOMPONENTTYPE:
-      break;
+      return std::string( "unknown" );
     default:
       break;
     }
-  return std::string( "unknown" );
+  itkExceptionMacro ("Unknown component type: " << t);
 }
 
 std::string
@@ -198,8 +198,18 @@ MeshIOBase
       return std::string( "diffusion_tensor_3D" );
     case COMPLEX:
       return std::string( "complex" );
+    case FIXEDARRAY:
+      return std::string( "fixed_array" );
+    case ARRAY:
+      return std::string( "array" );
+    case MATRIX:
+      return std::string( "matrix" );
+    case VARIABLELENGTHVECTOR:
+      return std::string( "variable_length_vector" );
+    case VARIABLESIZEMATRIX:
+      return std::string( "variable_size_matrix" );
     case UNKNOWNPIXELTYPE:
-      break;
+      return std::string( "unknown" );
     default:
       break;
     }


### PR DESCRIPTION
Fixes the Gifti mesh IO PointDimension. The MeshIO's support a
PointDimension of 3 by default.

Add testing code and fix related bugs.