### PR TITLE
BUG: avoid overwriting output in 2nd run used for comparison in test:

### DIFF
--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -114,11 +114,13 @@ itkWarpImageFilterTest2(int, char * [])
   filter->SetInput(image);
   filter->SetOutputParametersFromImage(image);
   filter->Update();
-  ImageType::Pointer result1 = filter->GetOutput();
+  ImageType::Pointer result1 = filter->GetOutput(); // save output for later comparison
+  result1->DisconnectPipeline(); // disconnect to create new output
   // test with half res
   filter->SetDisplacementField(defField2);
   filter->SetInput(image);
   filter->SetOutputParametersFromImage(image);
+  filter->Modified(); // enforce re-execution just to be sure
   filter->Update();
   ImageType::Pointer result2 = filter->GetOutput();
   itk::ImageRegionIterator<ImageType>


### PR DESCRIPTION
In
https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx#L111-L138
the filter is executed twice (with a different displacement field) but the outputs of each run are not disconnected from the pipeline (DisconnectPipeline), so to my understanding `result1` and `result2` point to the very same output and will always match in the following comparison which determines success of the test.

See PS in https://discourse.itk.org/t/why-resampleimagefilter-is-slow/1217/36?u=grothausmann.roman
