### PR TITLE
BUG: Missing ITK_WRAP_rgba_* variables in WrapITKConfig.cmake.in

### DIFF
--- a/Wrapping/WrapITKConfig.cmake.in
+++ b/Wrapping/WrapITKConfig.cmake.in
@@ -39,6 +39,8 @@ set(ITK_WRAP_covariant_vector_float @ITK_WRAP_covariant_vector_float@ CACHE BOOL
 set(ITK_WRAP_covariant_vector_double @ITK_WRAP_covariant_vector_double@ CACHE BOOL "Wrap covariant vector double type")
 set(ITK_WRAP_rgb_unsigned_char @ITK_WRAP_rgb_unsigned_char@ CACHE BOOL "Wrap RGB< unsigned char > type")
 set(ITK_WRAP_rgb_unsigned_short @ITK_WRAP_rgb_unsigned_short@ CACHE BOOL "Wrap RGB< unsigned short > type")
+set(ITK_WRAP_rgba_unsigned_char @ITK_WRAP_rgba_unsigned_char@ CACHE BOOL "Wrap RGBA< unsigned char > type")
+set(ITK_WRAP_rgba_unsigned_short @ITK_WRAP_rgba_unsigned_short@ CACHE BOOL "Wrap RGBA< unsigned short > type")
 set(ITK_WRAP_complex_float @ITK_WRAP_complex_float@ CACHE BOOL "Wrap complex<float> type")
 set(ITK_WRAP_complex_double @ITK_WRAP_complex_double@ CACHE BOOL "Wrap complex<double> type")
 set(ITK_WRAP_IMAGE_DIMS "@ITK_WRAP_IMAGE_DIMS@" CACHE STRING "dimensions available separated by semicolons (;)")


### PR DESCRIPTION
`ITK_WRAP_rgba_unsigned_char` and `ITK_WRAP_rgba_unsigned_short`
were not set in `WrapITKConfig.cmake.in` which means that these variables
were not set in ITK remote modules.