### PR TITLE
BUG: Use compatible ITKv4 computation

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -307,9 +307,10 @@ have multiple `ParallelizeRegion` calls or a long single-threaded section.
 An example of how to add progress reporting can be found in
 [this commit](https://github.com/InsightSoftwareConsortium/ITK/commit/dd0b0d128d6c0760cefd8a958107cb0e841b51b4).
 
-Otsu filters now return correct threshold (bin's maximum value instead of mid-point) by default.
-To keep old behavior, use `filter->SetReturnBinMidpoint( true );`.
-This change should be relevant only in tests.
+Otsu filters now return the correct threshold (bin's maximum value instead of mid-point) with ITKv5.
+The old behavior is kept when ITKV4_COMPATIBILITY is enabled by setting `ReturnBinMidpoint` to true by default.
+It is recommended when migrating to ITKv5 to explicitly set the `ReturnBinMidpoint` value to false.
+This change may effect computations which rely on the results of an Otsu threshold filter.
 
 `HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPixelType>` no longer
 has a default argument for its last template parameter. Instead, users of the filter should now

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
@@ -115,7 +115,11 @@ private:
   SizeValueType m_NumberOfThresholds{ 1 };
   OutputType    m_Output;
   bool          m_ValleyEmphasis{ false };
-  bool          m_ReturnBinMidpoint{ false };
+#if defined(ITKV4_COMPATIBILITY)
+  bool                m_ReturnBinMidpoint{ true };
+#else
+  bool                m_ReturnBinMidpoint{ false };
+#endif
 };
 } // end of namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
@@ -150,7 +150,11 @@ private:
   OutputPixelType     m_LabelOffset;
   ThresholdVectorType m_Thresholds;
   bool                m_ValleyEmphasis{ false };
+#if defined(ITKV4_COMPATIBILITY)
+  bool                m_ReturnBinMidpoint{ true };
+#else
   bool                m_ReturnBinMidpoint{ false };
+#endif
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.h
@@ -86,8 +86,11 @@ protected:
 
 private:
   typename OtsuMultipleThresholdsCalculator<THistogram>::Pointer m_OtsuMultipleThresholdsCalculator;
-
-  bool m_ReturnBinMidpoint{ false };
+#if defined(ITKV4_COMPATIBILITY)
+  bool                m_ReturnBinMidpoint{ true };
+#else
+  bool                m_ReturnBinMidpoint{ false };
+#endif
 };
 
 } // end namespace itk

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -121,7 +121,13 @@ protected:
     calc->SetReturnBinMidpoint(m_ReturnBinMidpoint);
     this->Superclass::GenerateData();
   }
-  bool m_ReturnBinMidpoint{ false };
+private:
+
+#if defined(ITKV4_COMPATIBILITY)
+  bool                m_ReturnBinMidpoint{ true };
+#else
+  bool                m_ReturnBinMidpoint{ false };
+#endif
 };
 
 } // end namespace itk

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkOtsuMultipleThresholdsCalculator.h"
+#include "itkTestingMacros.h"
 
 int itkOtsuMultipleThresholdsCalculatorTest(int, char*[])
 {
@@ -68,6 +69,12 @@ int itkOtsuMultipleThresholdsCalculatorTest(int, char*[])
   using OtsuMultipleThresholdCalculatorType = itk::OtsuMultipleThresholdsCalculator<HistogramType>;
 
   OtsuMultipleThresholdCalculatorType::Pointer otsuThresholdCalculator = OtsuMultipleThresholdCalculatorType::New();
+
+#if defined(ITKV4_COMPATIBILITY)
+  TEST_EXPECT_TRUE( otsuThresholdCalculator->GetReturnBinMidpoint());
+#else
+  TEST_EXPECT_TRUE( !otsuThresholdCalculator->GetReturnBinMidpoint());
+#endif
 
   otsuThresholdCalculator->SetInputHistogram(histogram);
   otsuThresholdCalculator->SetNumberOfThresholds(numberOfThresholds);

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest2.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest2.cxx
@@ -63,6 +63,7 @@ int itkOtsuMultipleThresholdsCalculatorTest2(int, char*[])
     OtsuMultipleThresholdCalculatorType::OutputType thMid;
     try
       {
+      otsuThresholdCalculator->SetReturnBinMidpoint(false);
       otsuThresholdCalculator->Compute();
       thMax = otsuThresholdCalculator->GetOutput();
 

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
@@ -64,6 +64,14 @@ int itkOtsuMultipleThresholdsImageFilterTest(int argc, char* argv[] )
   // Set up the reader
   reader->SetFileName( argv[1] );
 
+
+#if defined(ITKV4_COMPATIBILITY)
+  TEST_EXPECT_TRUE( filter->GetReturnBinMidpoint() );
+#else
+  TEST_EXPECT_TRUE( !filter->GetReturnBinMidpoint() );
+#endif
+  filter->ReturnBinMidpointOff();
+
   // Set up the filter parameters
   filter->SetInput( reader->GetOutput() );
 

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdImageFilterTest.cxx
@@ -52,6 +52,12 @@ int itkOtsuThresholdImageFilterTest(int argc, char* argv[] )
 
   itk::SimpleFilterWatcher watcher(filter);
 
+#if defined(ITKV4_COMPATIBILITY)
+  TEST_EXPECT_TRUE( filter->GetReturnBinMidpoint() );
+#else
+  TEST_EXPECT_TRUE( !filter->GetReturnBinMidpoint() );
+#endif
+
   reader->SetFileName( argv[1] );
   filter->SetInput( reader->GetOutput() );
   if( argc > 3 )


### PR DESCRIPTION
Keep the behavior of Otsu's filters and calculators consistent with
ITKv4 when compatibility is requested with the ITKV4_COMPATIBILITY
CMake variable is enabled.