### PR TITLE
WIP: Explicitly give Python library path to ITK Python targets for MSVC

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -252,6 +252,13 @@ macro(itk_wrap_module_python library_name)
   set(ITK_WRAP_PYTHON_LIBRARY_DECLS )
   set(ITK_WRAP_PYTHON_LIBRARY_CALLS )
   set(ITK_WRAP_PYTHON_CXX_FILES )
+  if(MSVC)
+    get_filename_component(python_library_directory ${PYTHON_LIBRARY} DIRECTORY)
+    # It should use the following code inside `itk_end_wrap_module_python` but
+    # `target_link_directories()` was only added to CMake 3.13.
+    # target_link_directories(${lib} PUBLIC ${python_library_directory})
+    link_directories(${python_library_directory})
+  endif()
 endmacro()
 
 


### PR DESCRIPTION
If Python library directory is not given, ITK will not find the debug Python
library when linking. It is required as this library addition is hardcoded in
pyconfig.h in the Python source code.
See https://github.com/python/cpython/blob/master/PC/pyconfig.h#L280
In theory this is only required for the debug build. But since we don't
know at configuration time if this is going to be a debug build or not,
we would need to use generator expressions which would give an empty
path if the build type is not debug. However, this is interpreted as
a relative path by CMake and is not allowed (CMP0081).
Since adding this extra path for non-debug builds is not breaking anything
we add this extra path in all cases.