### PR TITLE
ENH: Add itk-module-init.cmake to Eigen3

### DIFF
--- a/Modules/ThirdParty/Eigen3/itk-module-init.cmake
+++ b/Modules/ThirdParty/Eigen3/itk-module-init.cmake
@@ -1,0 +1,3 @@
+if(ITK_USE_SYSTEM_EIGEN)
+  find_package(Eigen3 REQUIRED CONFIG)
+endif()


### PR DESCRIPTION
To handle missing call of find_package by other modules
in the case of ITK_USE_SYSTEM_EIGEN


Fix #357
