### PR TITLE
COMP: Make ThirdParty Eigen3 COMPILE_DEPENDS

### DIFF
--- a/Modules/Core/Common/itk-module.cmake
+++ b/Modules/Core/Common/itk-module.cmake
@@ -13,12 +13,12 @@ endif()
 itk_module(ITKCommon
   ENABLE_SHARED
   DEPENDS
-    ITKEigen3
     ITKKWIML
     ${ITKCOMMON_TBB_DEPENDS}
   PRIVATE_DEPENDS
     ITKDoubleConversion
   COMPILE_DEPENDS
+    ITKEigen3
     ITKKWSys
     ITKVNLInstantiation
   TEST_DEPENDS


### PR DESCRIPTION
The public dependency was imposed to avoid bogus warnings
when using Eigen headers with gcc. See related:

http://eigen.tuxfamily.org/bz/show_bug.cgi?id=640
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66472

The public dependency propagates the use of the target defined in ITKEigen3_LIBRARIES
which treats Eigen3 headers as system headers, supressing these warnings.

I have not seen these warnings with the latest release of Eigen (3.3.7),
so changing it to COMPILE_DEPENDS.