### PR TITLE
Global variable global synchronization

### DIFF
--- a/Modules/Core/Common/ITKKWStyleOverwrite.txt
+++ b/Modules/Core/Common/ITKKWStyleOverwrite.txt
@@ -28,3 +28,4 @@ itkIndex\.h SemicolonSpace Disable
 itkSize\.h SemicolonSpace Disable
 itkOffset\.h SemicolonSpace Disable
 itkMultiThreaderBase.h Comments Disable
+itkSingleton\.cxx Namespace Disable

--- a/Modules/Core/Common/include/itkBuildInformation.h
+++ b/Modules/Core/Common/include/itkBuildInformation.h
@@ -21,6 +21,7 @@
 #include "itkMacro.h"
 #include "itkObject.h"
 #include <mutex>
+#include "itkSingletonMacro.h"
 
 namespace itk
 {
@@ -41,6 +42,8 @@ namespace itk
  * \ingroup ITKCommon
  *
  */
+struct BuildInformationGlobals;
+
 class ITKCommon_EXPORT BuildInformation final: public Object
 {
 public:
@@ -90,10 +93,9 @@ public:
 private:
   BuildInformation();
 
-  /** To lock on the internal variables */
-  static std::mutex m_Mutex;
-  static Pointer    m_InformationInstance;
-  static MapType    m_Map;
+  itkGetGlobalDeclarationMacro(BuildInformationGlobals, PimplGlobals);
+  static BuildInformationGlobals * m_PimplGlobals;
+
 };  // end of class
 } // end namespace itk
 #endif

--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -30,6 +30,7 @@
 
 #include "itkObject.h"
 #include "itkMacro.h"
+#include "itkSingletonMacro.h"
 #include "itkWeakPointer.h"
 #include "itkRealTimeStamp.h"
 
@@ -504,7 +505,7 @@ private:
   ModifiedTimeType m_PipelineMTime;
 
   /** Static member that controls global data release after use by filter. */
-  static bool m_GlobalReleaseDataFlag;
+  static bool *m_GlobalReleaseDataFlag;
 
   /** Connect the specified process object to the data object. This
    * should only be called from a process object. The second parameter
@@ -521,6 +522,10 @@ private:
    * match the name cached when the data object was connected to the
    * pipeline (see ConnectSource), then nothing is done. */
   bool DisconnectSource(ProcessObject *s, const DataObjectIdentifierType & name);
+
+  /** Only used to synchronize the global variable across static libraries.*/
+  itkGetGlobalDeclarationMacro(bool, GlobalReleaseDataFlag);
+
 
   /** Friends of DataObject */
   friend class ProcessObject;

--- a/Modules/Core/Common/include/itkFloatingPointExceptions.h
+++ b/Modules/Core/Common/include/itkFloatingPointExceptions.h
@@ -19,6 +19,7 @@
 #define itkFloatingPointExceptions_h
 
 #include "itkMacro.h" // for ITKCommon_EXPORT
+#include "itkSingletonMacro.h"
 
 namespace itk
 {
@@ -28,6 +29,9 @@ namespace itk
  * Allows floating point exceptions to be caught during program execution.
  * \ingroup ITKCommon
  */
+
+struct ExceptionGlobals;
+
 class ITKCommon_EXPORT FloatingPointExceptions
 {
 public:
@@ -76,9 +80,9 @@ private:
   FloatingPointExceptions(const FloatingPointExceptions &) = delete;
   void operator=(const FloatingPointExceptions &) = delete;
 
+  itkGetGlobalDeclarationMacro(ExceptionGlobals, PimplGlobals);
   /** static member that controls what happens during an exception */
-  static ExceptionAction m_ExceptionAction;
-  static bool            m_Enabled;
+  static ExceptionGlobals * m_PimplGlobals;
 };
 }
 

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -24,7 +24,7 @@
 #include "itkIntTypes.h"
 #include "itkMath.h"
 #include <mutex>
-#include <mutex>
+#include "itkSingletonMacro.h"
 #include <climits>
 #include <ctime>
 
@@ -119,6 +119,9 @@ namespace Statistics
  * \wikiexample{Utilities/MersenneTwisterRandomVariateGenerator,Random number generator}
  * \endwiki
  */
+
+struct MersenneTwisterGlobals;
+
 class ITKCommon_EXPORT MersenneTwisterRandomVariateGenerator:
   public RandomVariateGeneratorBase
 {
@@ -278,6 +281,9 @@ protected:
 
 private:
 
+  /** Only used to synchronize the global variable across static libraries.*/
+  itkGetGlobalDeclarationMacro(MersenneTwisterGlobals, PimplGlobals);
+
   /** Internal method to actually create a new object. */
   static Pointer CreateInstance();
 
@@ -285,9 +291,8 @@ private:
   std::mutex m_InstanceLock;
 
   // Static/Global Variable need to be thread-safely accessed
-  static Pointer              m_StaticInstance;
-  static std::recursive_mutex m_StaticInstanceLock;
-  static IntegerType          m_StaticDiffer;
+
+  static MersenneTwisterGlobals *m_PimplGlobals;
 
 };  // end of class
 

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -34,6 +34,7 @@
 #include "itkIntTypes.h"
 #include "itkImageRegion.h"
 #include "itkImageIORegion.h"
+#include "itkSingletonMacro.h"
 #include <functional>
 #include <thread>
 
@@ -55,7 +56,6 @@ namespace itk
  */
 
 struct MultiThreaderBaseGlobals;
-
 class ProcessObject;
 
 class ITKCommon_EXPORT MultiThreaderBase : public Object
@@ -340,14 +340,6 @@ INTEL_PRAGMA_WARN_POP
       ThreadingFunctorType funcP,
       ProcessObject* filter);
 
-  /** Set/Get the pointer to MultiThreaderBaseGlobals.
-   * Note that these functions are not part of the public API and should not be
-   * used outside of ITK. They are an implementation detail and will be
-   * removed in the future. Also note that SetMultiThreaderBaseGlobals is not
-   * concurrent thread safe. */
-  static MultiThreaderBaseGlobals *GetMultiThreaderBaseGlobals();
-  static void SetMultiThreaderBaseGlobals(MultiThreaderBaseGlobals * multiThreaderBaseGlobals);
-
   /** Updates progress if progress is non-negative and checks for abort.
    * If "abort generate data" is set, throws the ProcessAborted exception. */
   static void HandleFilterProgress(ProcessObject *filter, float progress = -1.0f);
@@ -411,7 +403,11 @@ protected:
   void *m_SingleData;
 
 private:
-  static MultiThreaderBaseGlobals * m_MultiThreaderBaseGlobals;
+
+  /** Only used to synchronize the global variable across static libraries.*/
+  itkGetGlobalDeclarationMacro(MultiThreaderBaseGlobals, PimplGlobals);
+
+  static MultiThreaderBaseGlobals * m_PimplGlobals;
   /** Friends of Multithreader.
    * ProcessObject is a friend so that it can call PrintSelf() on its
    * Multithreader. */

--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -31,6 +31,7 @@
 #include "itkLightObject.h"
 #include "itkEventObject.h"
 #include "itkMetaDataDictionary.h"
+#include "itkSingletonMacro.h"
 
 namespace itk
 {
@@ -202,6 +203,9 @@ protected:
   virtual void SetTimeStamp( const TimeStamp & time );
 
 private:
+  /** Only used to synchronize the global variable across static libraries.*/
+  itkGetGlobalDeclarationMacro(bool, GlobalWarningDisplay);
+
   /** Enable/Disable debug messages. */
   mutable bool m_Debug{false};
 
@@ -209,7 +213,7 @@ private:
   mutable TimeStamp m_MTime;
 
   /** Global object debug flag. */
-  static bool m_GlobalWarningDisplay;
+  static bool *m_GlobalWarningDisplay;
 
   /** Implementation class for Subject/Observer Pattern.
    * This is only allocated if used. */

--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -29,6 +29,7 @@
 #define itkObjectFactoryBase_h
 
 #include "itkCreateObjectFunction.h"
+#include "itkSingletonMacro.h"
 #include <list>
 #include <vector>
 
@@ -198,14 +199,6 @@ public:
     CreateObjectFunctionBase::Pointer m_CreateObject;
   };
 
-  /** Set/Get the pointer to ObjectFactoryBasePrivate.
-   * Note that these functions are not part of the public API and should not be
-   * used outside of ITK. They are an implementation detail and will be
-   * removed in the future. Also note that SetObjectFactoryBasePrivate is not
-   * concurrent thread safe. */
-  static ObjectFactoryBasePrivate *GetObjectFactoryBase();
-  static void SynchronizeObjectFactoryBase(ObjectFactoryBasePrivate * objectFactoryBasePrivate);
-
 protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -231,6 +224,12 @@ protected:
   ~ObjectFactoryBase() override;
 
 private:
+
+  /** Set/Get the pointer to ObjectFactoryBasePrivate.
+   * No concurrent thread safe. */
+  static void SynchronizeObjectFactoryBase(void * objectFactoryBasePrivate);
+  itkGetGlobalDeclarationMacro(ObjectFactoryBasePrivate, PimplGlobals);
+
   OverRideMap *m_OverrideMap;
 
   /** Initialize the static list of Factories. */
@@ -257,11 +256,10 @@ private:
   unsigned long m_LibraryDate;
   std::string   m_LibraryPath;
 
-  static  bool  m_StrictVersionChecking;
-
-  // This variable should NOT be accessed directly, but through GetObjectFactoryBase
-  static ObjectFactoryBasePrivate * m_ObjectFactoryBasePrivate;
+  static ObjectFactoryBasePrivate * m_PimplGlobals;
 };
+
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -1,0 +1,115 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkSingleton_h
+#define itkSingleton_h
+
+#include "itkMacro.h"
+#include "itkSingletonMacro.h"
+#include <map>
+#include <functional>
+
+/** \brief A function which does nothing
+ *
+ * This function is to be used to mark parameters as unused to suppress
+ * compiler warning. It can be used when the parameter needs to be named
+ * (i.e. itkNotUsed cannot be used) but is not always used. It ensures
+ * that the parameter is not optimized out.
+ */
+template <typename T>
+inline void Unused( const T &) {};
+
+namespace itk
+{
+/** \class SingletonIndex
+ * \brief Implementation detail.
+ *
+ * \ingroup ITKCommon
+ */
+
+class ITKCommon_EXPORT SingletonIndex
+{
+public:
+  /** Standard class typedefs. */
+  typedef SingletonIndex Self;
+  typedef std::map<std::string, std::tuple<void*, std::function<void(void*)>, std::function<void(void)> > > SingletonData;
+
+  // obtain a global registered in the singleton index under the
+  // globalName, if unknown then nullptr will be returned.
+  template<typename T>
+  T *GetGlobalInstance( const char *globalName )
+    { return static_cast<T*>(this->GetGlobalInstancePrivate(globalName)); }
+
+
+  // returns true if the globalName has not been registered yet.
+  //
+  // It is assumed that the global will remain valid until the start
+  // of globals being destroyed.
+  template<typename T>
+  bool SetGlobalInstance( const char * globalName, T * global, std::function<void(void*)> func, std::function<void(void)> deleteFunc)
+    { return this->SetGlobalInstancePrivate(globalName, global, func, deleteFunc);}
+
+  /** Set/Get the pointer to GlobalSingleton.
+   * Note that SetGlobalSingleton is not concurrent thread safe. */
+  static Self* GetInstance();
+  static void SetInstance(Self *SingletonIndex);
+  ~SingletonIndex();
+
+private:
+
+  // may return nullptr if string is not registered already
+  //
+  // access something like a std::map<std::string, void *> or
+  // registered globals, it may be possible to restrict the held
+  // classes to be derived from itk::LightObject, so dynamic cast can
+  // work, and could use some type of Holder<T> class for intrinsic types
+  void * GetGlobalInstancePrivate( const char *globalName );
+  // If globalName is already registered than false is return,
+  // otherwise global is added to the singleton index under globalName
+  bool SetGlobalInstancePrivate( const char * globalName, void * global, std::function<void(void*)> func, std::function<void(void)> deleteFunc);
+
+  /** The static GlobalSingleton. This is initialized to nullptr as the first
+   * stage of static initialization. It is then populated on the first call to
+   * itk::Singleton::Modified() but it can be overridden with SetGlobalSingleton().
+   * */
+  SingletonData m_GlobalObjects;
+  static Self*  m_Instance;
+//  static SingletonIndexPrivate * m_GlobalSingleton;
+};
+
+
+// A wrapper for a global variable registered in the singleton index.
+template<typename T>
+T* Singleton(const char *globalName, std::function<void(void*)> func, std::function<void(void)> deleteFunc)
+{
+  static SingletonIndex * singletonIndex = SingletonIndex::GetInstance();
+  Unused(singletonIndex);
+  T* instance = SingletonIndex::GetInstance()->GetGlobalInstance<T>(globalName);
+  if( instance == nullptr )
+    {
+    instance = new T;
+    if (!SingletonIndex::GetInstance()->SetGlobalInstance<T>(globalName, instance, func, deleteFunc))
+      {
+      delete instance;
+      instance = nullptr;
+      }
+    }
+  return instance;
+}
+} // end namespace itk
+
+#endif

--- a/Modules/Core/Common/include/itkSingletonMacro.h
+++ b/Modules/Core/Common/include/itkSingletonMacro.h
@@ -1,0 +1,68 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+/**
+ * itkSingletonMacro.h defines macros that are used to declare and define
+ * global variables across ITK with a global map that is used to synchronize
+ * this variables across multiple instantiations of ITK if necessary.
+ * Note: this is rarely necessary.
+ */
+
+#ifndef itkSingletonMacro_h
+#define itkSingletonMacro_h
+
+#define itkInitGlobalsMacro(VarName) \
+  { \
+  static auto * staticGlobals = Get##VarName##Pointer (); \
+  (void) staticGlobals; \
+  }
+
+#define itkGetGlobalDeclarationMacro(Type, VarName) \
+static Type * Get##VarName##Pointer();
+
+#define itkGetGlobalSimpleMacro(Class, Type, Name) \
+  itkGetGlobalInitializeMacro(Class, Type, Name, Class, (void)0)
+
+#define itkGetGlobalValueMacro(Class, Type, Name, Value) \
+  itkGetGlobalInitializeMacro(Class, Type, Name, Name, *m_##Name = Value)
+
+#define itkGetGlobalInitializeMacro(Class, Type, VarName, SingletonName, Init) \
+Type * Class::Get##VarName##Pointer() \
+{ \
+    if( m_##VarName == nullptr ) \
+      { \
+      static auto setLambda = [](void * a) \
+        { \
+        delete m_##VarName; \
+        m_##VarName = static_cast<Type*>(a); \
+        }; \
+      static auto deleteLambda = []() \
+        { \
+        delete m_##VarName; \
+        m_##VarName = nullptr; \
+        }; \
+      auto* old_instance = SingletonIndex::GetInstance()->GetGlobalInstance<Type>(#SingletonName); \
+      m_##VarName = Singleton<Type>( #SingletonName , setLambda, deleteLambda); \
+      if( old_instance == nullptr) \
+        { \
+        Init; \
+        }\
+    } \
+  return m_##VarName; \
+}
+
+#endif

--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -29,6 +29,8 @@
 
 #include "itkObject.h"
 #include "itkObjectFactory.h"
+#include "itkSingletonMacro.h"
+
 
 namespace itk
 {
@@ -113,11 +115,6 @@ public:
   static bool GetDoNotWaitForThreads();
   static void SetDoNotWaitForThreads(bool doNotWaitForThreads);
 
-  /** Set/Get the pointer to ThreadPoolGlobals.
-   * Note that SetThreadPoolGlobals is not concurrent thread safe. */
-  static ThreadPoolGlobals * GetThreadPoolGlobals();
-  static void SetThreadPoolGlobals(::itk::ThreadPoolGlobals * globals);
-
 protected:
 
   /* We need access to the mutex in AddWork, and the variable is only
@@ -128,6 +125,9 @@ protected:
   ~ThreadPool() override;
 
 private:
+
+  /** Only used to synchronize the global variable across static libraries.*/
+  itkGetGlobalDeclarationMacro(ThreadPoolGlobals, PimplGlobals);
 
   /** This is a list of jobs submitted to the thread pool.
    * This is the only place where the jobs are submitted.
@@ -146,7 +146,7 @@ private:
   bool m_Stopping{ false };
 
   /** To lock on the internal variables */
-  static ThreadPoolGlobals * m_ThreadPoolGlobals;
+  static ThreadPoolGlobals * m_PimplGlobals;
 
   /** The continuously running thread function */
   static void ThreadExecute();

--- a/Modules/Core/Common/include/itkTimeStamp.h
+++ b/Modules/Core/Common/include/itkTimeStamp.h
@@ -31,6 +31,7 @@
 #include "itkMacro.h"
 #include "itkIntTypes.h"
 #include <atomic>
+#include "itkSingletonMacro.h"
 
 namespace itk
 {
@@ -108,19 +109,18 @@ public:
    * another. */
   Self & operator=( const Self & other ) = default;
 
+private:
   /** Set/Get the pointer to GlobalTimeStamp.
    * Note that SetGlobalTimeStamp is not concurrent thread safe. */
-  static GlobalTimeStampType * GetGlobalTimeStamp();
-  static void SetGlobalTimeStamp( GlobalTimeStampType * timeStamp );
+  itkGetGlobalDeclarationMacro(GlobalTimeStampType, GlobalTimeStamp);
 
-private:
   ModifiedTimeType m_ModifiedTime;
 
   /** The static GlobalTimeStamp. This is initialized to NULL as the first
    * stage of static initialization. It is then populated on the first call to
    * itk::TimeStamp::Modified() but it can be overridden with SetGlobalTimeStamp().
    * */
-  static GlobalTimeStampType * m_GlobalTimeStamp;
+  static GlobalTimeStampType *m_GlobalTimeStamp;
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -120,6 +120,7 @@ set(ITKCommon_SRCS
   itkTimeProbe.cxx
   itkNumericTraitsRGBPixel.cxx
   itkTimeStamp.cxx
+  itkSingleton.cxx
   itkTetrahedronCellTopology.cxx
   itkThreadedIndexedContainerPartitioner.cxx
   itkObjectFactoryBase.cxx
@@ -141,7 +142,6 @@ set(ITKCommon_SRCS
 if(WIN32)
   list(APPEND ITKCommon_SRCS itkWin32OutputWindow.cxx)
 endif()
-
 if(ITK_USE_WIN32_THREADS OR ITK_USE_PTHREADS)
   list(APPEND ITKCommon_SRCS itkPoolMultiThreader.cxx itkThreadPool.cxx)
 endif()

--- a/Modules/Core/Common/src/itkBuildInformation.cxx.in
+++ b/Modules/Core/Common/src/itkBuildInformation.cxx.in
@@ -18,13 +18,14 @@
 
 #include "itkBuildInformation.h"
 #include "itkObjectFactory.h"
+#include "itkSingleton.h"
 
 #include <algorithm>
 
 // Construct const versions via the emplace method.  This macro simplifies the text
 // written in ITK/Modules/Core/Common/src/CMakeLists.txt.
 #define MAKE_MAP_ENTRY(KEY, VALUE, DESCRIPTION )                                          \
-m_Map.emplace(                                                                            \
+m_PimplGlobals->m_Map.emplace(                                                                            \
   std::pair< MapKeyType, InformationValueType>(                                           \
     MapKeyType{ KEY },                                                                    \
     InformationValueType{ MapValueType{ VALUE }, MapValueDescriptionType{ DESCRIPTION } } \
@@ -33,9 +34,19 @@ m_Map.emplace(                                                                  
 
 namespace itk {
 
-std::mutex BuildInformation::m_Mutex;
-BuildInformation::Pointer BuildInformation::m_InformationInstance;
-BuildInformation::MapType BuildInformation::m_Map;
+struct BuildInformationGlobals
+{
+  BuildInformationGlobals():m_InformationInstance(nullptr)
+  {}
+/** To lock on the internal variables */
+  std::mutex m_Mutex;
+  BuildInformation::Pointer m_InformationInstance;
+  BuildInformation::MapType m_Map;
+};
+
+itkGetGlobalSimpleMacro(BuildInformation, BuildInformationGlobals, PimplGlobals);
+
+BuildInformationGlobals * BuildInformation::m_PimplGlobals;
 
 BuildInformation::Pointer
 BuildInformation
@@ -48,21 +59,22 @@ BuildInformation::Pointer
 BuildInformation
 ::GetInstance()
 {
-  std::lock_guard<std::mutex> mutexHolder(m_Mutex);
-  if (m_InformationInstance.IsNull())
+  itkInitGlobalsMacro(PimplGlobals);
+  std::lock_guard<std::mutex> mutexHolder(m_PimplGlobals->m_Mutex);
+  if (m_PimplGlobals->m_InformationInstance.IsNull())
   {
-    m_InformationInstance = ObjectFactory<Self>::Create();
+    m_PimplGlobals->m_InformationInstance = ObjectFactory<Self>::Create();
     {
       new BuildInformation(); //constructor sets m_InformationInstance
     }
   }
-  return m_InformationInstance;
+  return m_PimplGlobals->m_InformationInstance;
 }
 
 const BuildInformation::MapType &
 BuildInformation::GetMap()
 {
-  return BuildInformation::GetInstance()->m_Map;
+  return BuildInformation::GetInstance()->m_PimplGlobals->m_Map;
 }
 
 const BuildInformation::MapValueType
@@ -96,7 +108,7 @@ BuildInformation::GetAllKeys()
 {
   std::vector< BuildInformation::MapKeyType > keyVector;
   keyVector.reserve(30);
-  for( auto elem : BuildInformation::GetInstance()->m_Map )
+  for( auto elem : BuildInformation::GetInstance()->m_PimplGlobals->m_Map )
   {
     keyVector.emplace_back( elem.first );
   }
@@ -106,8 +118,8 @@ BuildInformation::GetAllKeys()
 BuildInformation
 ::BuildInformation()
 {
-  m_InformationInstance = this; //threads need this
-  m_InformationInstance->UnRegister(); // Remove extra reference
+  m_PimplGlobals->m_InformationInstance = this; //threads need this
+  m_PimplGlobals->m_InformationInstance->UnRegister(); // Remove extra reference
 
   @MAPPING_VALUES@
 }

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -26,11 +26,14 @@
  *
  *=========================================================================*/
 #include "itkProcessObject.h"
+#include "itkSingleton.h"
 
 namespace itk
 {
+
+itkGetGlobalValueMacro(DataObject, bool, GlobalReleaseDataFlag, false);
 // after use by filter
-bool DataObject:: m_GlobalReleaseDataFlag = false;
+bool * DataObject::m_GlobalReleaseDataFlag;
 
 DataObjectError
 ::DataObjectError() noexcept:
@@ -152,11 +155,12 @@ void
 DataObject
 ::SetGlobalReleaseDataFlag(bool val)
 {
-  if ( val == m_GlobalReleaseDataFlag )
+  itkInitGlobalsMacro(GlobalReleaseDataFlag);
+  if ( val == *m_GlobalReleaseDataFlag )
     {
     return;
     }
-  m_GlobalReleaseDataFlag = val;
+  *m_GlobalReleaseDataFlag = val;
 }
 
 //----------------------------------------------------------------------------
@@ -164,7 +168,7 @@ bool
 DataObject
 ::GetGlobalReleaseDataFlag()
 {
-  return m_GlobalReleaseDataFlag;
+  return *DataObject::GetGlobalReleaseDataFlagPointer();
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Core/Common/src/itkFloatingPointExceptions.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkFloatingPointExceptions.h"
 #include <iostream>
+#include "itkSingleton.h"
 
 //
 // invariant over all targets -- set a preference for what
@@ -31,35 +32,43 @@
 namespace itk
 {
 
-FloatingPointExceptions::ExceptionAction
-FloatingPointExceptions::m_ExceptionAction =
-  FloatingPointExceptions::ABORT;
-bool FloatingPointExceptions::m_Enabled(false);
+struct ExceptionGlobals
+{
+  ExceptionGlobals():m_ExceptionAction(FloatingPointExceptions::ABORT),
+  m_Enabled(false)
+  {};
+  FloatingPointExceptions::ExceptionAction m_ExceptionAction;
+  bool m_Enabled;
+};
 
 void
 FloatingPointExceptions
 ::SetExceptionAction(ExceptionAction a)
 {
-  FloatingPointExceptions::m_ExceptionAction = a;
+  itkInitGlobalsMacro(PimplGlobals);
+  FloatingPointExceptions::m_PimplGlobals->m_ExceptionAction = a;
 }
 
 FloatingPointExceptions::ExceptionAction
 FloatingPointExceptions::GetExceptionAction()
 {
-  return FloatingPointExceptions::m_ExceptionAction;
+  itkInitGlobalsMacro(PimplGlobals);
+  return FloatingPointExceptions::m_PimplGlobals->m_ExceptionAction;
 }
 
 bool
 FloatingPointExceptions::
 GetEnabled()
 {
-  return FloatingPointExceptions::m_Enabled;
+  itkInitGlobalsMacro(PimplGlobals);
+  return FloatingPointExceptions::m_PimplGlobals->m_Enabled;
 }
 
 void
 FloatingPointExceptions::
 SetEnabled(bool val)
 {
+  itkInitGlobalsMacro(PimplGlobals);
   if(val)
     {
     FloatingPointExceptions::Enable();
@@ -69,6 +78,10 @@ SetEnabled(bool val)
     FloatingPointExceptions::Disable();
     }
 }
+
+itkGetGlobalSimpleMacro(FloatingPointExceptions, ExceptionGlobals, PimplGlobals);
+
+ExceptionGlobals * FloatingPointExceptions::m_PimplGlobals;
 
 } // end of itk namespace
 

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -135,6 +135,7 @@ void
 FloatingPointExceptions
 ::Enable()
 {
+  itkInitGlobalsMacro(PimplGlobals);
 #if defined(ITK_HAS_FPE_CAPABILITY)
   itk_feenableexcept (FE_DIVBYZERO);
   itk_feenableexcept (FE_INVALID);
@@ -146,7 +147,7 @@ FloatingPointExceptions
   act.sa_flags = SA_SIGINFO;
   sigaction(SIGFPE,&act,nullptr);
 #endif
-  FloatingPointExceptions::m_Enabled = true;
+ FloatingPointExceptions::m_PimplGlobals->m_Enabled = true;
   (void)itkFloatingPointExceptionsNotSupported; // avoid unused-function warning
 #else
   itkFloatingPointExceptionsNotSupported();
@@ -157,10 +158,11 @@ void
 FloatingPointExceptions
 ::Disable()
 {
+  itkInitGlobalsMacro(PimplGlobals);
 #if defined(ITK_HAS_FPE_CAPABILITY)
   itk_fedisableexcept (FE_DIVBYZERO);
   itk_fedisableexcept (FE_INVALID);
-  FloatingPointExceptions::m_Enabled = false;
+  FloatingPointExceptions::m_PimplGlobals->m_Enabled = false;
 #else
   itkFloatingPointExceptionsNotSupported();
 #endif
@@ -169,6 +171,7 @@ FloatingPointExceptions
 bool FloatingPointExceptions
 ::HasFloatingPointExceptionsSupport()
 {
+  itkInitGlobalsMacro(PimplGlobals);
 #if defined(ITK_HAS_FPE_CAPABILITY)
   return true;
 #else

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_win.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_win.cxx
@@ -32,23 +32,26 @@ namespace itk
 void FloatingPointExceptions
 ::Enable()
 {
+  itkInitGlobalsMacro(PimplGlobals);
   // enable floating point exceptions on MSVC
   _controlfp(_EM_DENORMAL | _EM_UNDERFLOW | _EM_INEXACT, _MCW_EM);
-  FloatingPointExceptions::m_Enabled = true;
+  FloatingPointExceptions::m_PimplGlobals->m_Enabled = true;
 }
 
 void FloatingPointExceptions
 ::Disable()
 {
+  itkInitGlobalsMacro(PimplGlobals);
   // disable floating point exceptions on MSVC
   _controlfp(_EM_INVALID | _EM_DENORMAL | _EM_ZERODIVIDE | _EM_OVERFLOW |
              _EM_UNDERFLOW | _EM_INEXACT, _MCW_EM);
-  FloatingPointExceptions::m_Enabled = false;
+  FloatingPointExceptions::m_PimplGlobals->m_Enabled = false;
 }
 
 bool FloatingPointExceptions
 ::HasFloatingPointExceptionsSupport()
 {
+  itkInitGlobalsMacro(PimplGlobals);
   return true;
 }
 
@@ -59,18 +62,21 @@ bool FloatingPointExceptions
 void FloatingPointExceptions
 ::Enable()
 {
+  itkInitGlobalsMacro(PimplGlobals);
   itkFloatingPointExceptionsNotSupported();
 }
 
 void FloatingPointExceptions
 ::Disable()
 {
+  itkInitGlobalsMacro(PimplGlobals);
   itkFloatingPointExceptionsNotSupported();
 }
 
 bool FloatingPointExceptions
 ::HasFloatingPointExceptionsSupport()
 {
+  itkInitGlobalsMacro(PimplGlobals);
   return false;
 }
 

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -37,6 +37,7 @@
 #include "itksys/SystemTools.hxx"
 #include "itksys/SystemInformation.hxx"
 #include "itkImageSourceCommon.h"
+#include "itkSingleton.h"
 #include "itkProcessObject.h"
 #include <iostream>
 #include <string>
@@ -47,143 +48,58 @@
 #include "itkTBBMultiThreader.h"
 #endif
 
-
 namespace itk
 {
-  struct MultiThreaderBaseGlobals
-  {
-    // Initialize static members.
-    MultiThreaderBaseGlobals()
-    {};
-    // GlobalDefaultThreaderTypeIsInitialized is used only in this
-    // file to ensure that the ITK_GLOBAL_DEFAULT_THREADER or
-    // ITK_USE_THREADPOOL environmenal variables are
-    // only used as a fall back option.  If the SetGlobalDefaultThreaderType
-    // API is ever used by the developer, the developers choice is
-    // respected over the environmental variable.
-    bool GlobalDefaultThreaderTypeIsInitialized{false};
-    std::mutex globalDefaultInitializerLock;
 
+struct MultiThreaderBaseGlobals
+{
+  // Initialize static members.
+  MultiThreaderBaseGlobals():GlobalDefaultThreaderTypeIsInitialized(false),
     // Global value to control weather the threadpool implementation should
     // be used. This defaults to the environmental variable
     // ITK_GLOBAL_DEFAULT_THREADER. If that is not present, then
     // ITK_USE_THREADPOOL is examined.
-    MultiThreaderBase::ThreaderType m_GlobalDefaultThreader{
 #if defined(ITK_USE_TBB)
-    MultiThreaderBase::ThreaderType::TBB
+    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderType::TBB),
 #elif defined(POOL_MULTI_THREADER_AVAILABLE)
-    MultiThreaderBase::ThreaderType::Pool
+    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderType::Pool),
 #else
-    MultiThreaderBase::ThreaderType::Platform
+    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderType::Platform),
 #endif
+  m_GlobalMaximumNumberOfThreads(ITK_MAX_THREADS),
+  // Global default number of threads : 0 => Not initialized.
+  m_GlobalDefaultNumberOfThreads(0)
+  {};
+  // GlobalDefaultThreaderTypeIsInitialized is used only in this
+  // file to ensure that the ITK_GLOBAL_DEFAULT_THREADER or
+  // ITK_USE_THREADPOOL environmenal variables are
+  // only used as a fall back option.  If the SetGlobalDefaultThreaderType
+  // API is ever used by the developer, the developers choice is
+  // respected over the environmental variable.
+  bool GlobalDefaultThreaderTypeIsInitialized;
+  std::mutex globalDefaultInitializerLock;
+
+  // Global value to control weather the threadpool implementation should
+  // be used. This defaults to the environmental variable
+  // ITK_GLOBAL_DEFAULT_THREADER. If that is not present, then
+  // ITK_USE_THREADPOOL is examined.
+  MultiThreaderBase::ThreaderType m_GlobalDefaultThreader;
+
+  // Global variable defining the maximum number of threads that can be used.
+  //  The m_GlobalMaximumNumberOfThreads must always be less than or equal to
+  //  ITK_MAX_THREADS and greater than zero. */
+  ThreadIdType m_GlobalMaximumNumberOfThreads;
+
+  //  Global variable defining the default number of threads to set at
+  //  construction time of a MultiThreaderBase instance.  The
+  //  m_GlobalDefaultNumberOfThreads must always be less than or equal to the
+  //  m_GlobalMaximumNumberOfThreads and larger or equal to 1 once it has been
+  //  initialized in the constructor of the first MultiThreaderBase instantiation.
+  ThreadIdType m_GlobalDefaultNumberOfThreads;
 };
 
-    // Global variable defining the maximum number of threads that can be used.
-    //  The m_GlobalMaximumNumberOfThreads must always be less than or equal to
-    //  ITK_MAX_THREADS and greater than zero. */
-    ThreadIdType m_GlobalMaximumNumberOfThreads{ITK_MAX_THREADS};
+itkGetGlobalSimpleMacro(MultiThreaderBase, MultiThreaderBaseGlobals, PimplGlobals);
 
-    //  Global variable defining the default number of threads to set at
-    //  construction time of a MultiThreaderBase instance.  The
-    //  m_GlobalDefaultNumberOfThreads must always be less than or equal to the
-    //  m_GlobalMaximumNumberOfThreads and larger or equal to 1 once it has been
-    //  initialized in the constructor of the first MultiThreaderBase instantiation.
-    // Global default number of threads : 0 => Not initialized.
-    ThreadIdType m_GlobalDefaultNumberOfThreads{0};
-  };
-}//end of itk namespace
-
-namespace
-{
-static std::mutex globalInitializerLock;
-
-/** \brief A function which does nothing
- *
- * This function is to be used to mark parameters as unused to suppress
- * compiler warning. It can be used when the parameter needs to be named
- * (i.e. itkNotUsed cannot be used) but is not always used. It ensures
- * that the parameter is not optimized out.
- */
-template <typename T>
-void Unused( const T &) {};
-
-// This ensures that m_MultiThreaderBaseGlobals is has been initialized once the library
-// has been loaded. In some cases, this call will perform the initialization.
-// In other cases, static initializers like the IO factory initialization code
-// will have done the initialization.
-static ::itk::MultiThreaderBaseGlobals * initializedMultiThreaderBaseGlobals = ::itk::MultiThreaderBase::GetMultiThreaderBaseGlobals();
-
-/** \class MultiThreaderBaseGlobalsInitializer
- *
- * \brief Initialize a MultiThreaderBaseGlobals and delete it on program
- * completion.
- * */
-class MultiThreaderBaseGlobalsInitializer
-{
-public:
-  using Self = MultiThreaderBaseGlobalsInitializer;
-
-  MultiThreaderBaseGlobalsInitializer() = default;
-
-  /** Delete the time stamp if it was created. */
-  ~MultiThreaderBaseGlobalsInitializer()
-    {
-    delete m_MultiThreaderBaseGlobals;
-    m_MultiThreaderBaseGlobals = nullptr;
-    }
-
-  /** Create the MultiThreaderBaseGlobals if needed and return it. */
-  static ::itk::MultiThreaderBaseGlobals * GetMultiThreaderBaseGlobals()
-    {
-    if( !m_MultiThreaderBaseGlobals )
-      {
-      // GetGlobalDefaultThreaderType() must be thread safe and can potentially call
-      // this method, even though it is very unlikely.
-      std::lock_guard< std::mutex > lock(globalInitializerLock);
-      if( !m_MultiThreaderBaseGlobals )
-        {
-        m_MultiThreaderBaseGlobals = new ::itk::MultiThreaderBaseGlobals;
-        // To avoid being optimized out. The compiler does not like this
-        // statement at a higher scope.
-        Unused(initializedMultiThreaderBaseGlobals);
-        }
-      }
-    return m_MultiThreaderBaseGlobals;
-    }
-
-private:
-  static ::itk::MultiThreaderBaseGlobals * m_MultiThreaderBaseGlobals;
-};
-
-// Takes care of cleaning up the MultiThreaderBaseGlobals
-static MultiThreaderBaseGlobalsInitializer MultiThreaderBaseGlobalsInitializerInstance;
-// Initialized by the compiler to zero
-::itk::MultiThreaderBaseGlobals * MultiThreaderBaseGlobalsInitializer::m_MultiThreaderBaseGlobals;
-
-} // end anonymous namespace
-
-
-namespace itk
-{
-
-::itk::MultiThreaderBaseGlobals *
-MultiThreaderBase
-::GetMultiThreaderBaseGlobals()
-{
-  if( m_MultiThreaderBaseGlobals == nullptr )
-    {
-    m_MultiThreaderBaseGlobals = MultiThreaderBaseGlobalsInitializer::GetMultiThreaderBaseGlobals();
-    }
-  return m_MultiThreaderBaseGlobals;
-}
-
-
-void
-MultiThreaderBase
-::SetMultiThreaderBaseGlobals( MultiThreaderBaseGlobals * multiThreaderBaseGlobals )
-{
-  m_MultiThreaderBaseGlobals = multiThreaderBaseGlobals;
-}
 
 #if ! defined (ITK_LEGACY_REMOVE)
 void MultiThreaderBase::SetGlobalDefaultUseThreadPool( const bool GlobalDefaultUseThreadPool )
@@ -206,12 +122,10 @@ bool MultiThreaderBase::GetGlobalDefaultUseThreadPool( )
 
 void MultiThreaderBase::SetGlobalDefaultThreader(ThreaderType threaderType)
 {
-  // This is called once, on-demand to ensure that m_MultiThreaderBaseGlobals is
-  // initialized.
-  static MultiThreaderBaseGlobals * multiThreaderBaseGlobals = GetMultiThreaderBaseGlobals();
-  Unused(multiThreaderBaseGlobals);
-  m_MultiThreaderBaseGlobals->m_GlobalDefaultThreader = threaderType;
-  m_MultiThreaderBaseGlobals->GlobalDefaultThreaderTypeIsInitialized = true;
+  itkInitGlobalsMacro(PimplGlobals);
+
+  m_PimplGlobals->m_GlobalDefaultThreader = threaderType;
+  m_PimplGlobals->GlobalDefaultThreaderTypeIsInitialized = true;
 }
 
 MultiThreaderBase::ThreaderType
@@ -219,19 +133,15 @@ MultiThreaderBase
 ::GetGlobalDefaultThreader()
 {
   // This method must be concurrent thread safe
+  itkInitGlobalsMacro(PimplGlobals);
 
-  // This is called once, on-demand to ensure that m_MultiThreaderBaseGlobals is
-  // initialized.
-  static MultiThreaderBaseGlobals * multiThreaderBaseGlobals = GetMultiThreaderBaseGlobals();
-  Unused(multiThreaderBaseGlobals);
-
-  if( !m_MultiThreaderBaseGlobals->GlobalDefaultThreaderTypeIsInitialized )
+  if( !m_PimplGlobals->GlobalDefaultThreaderTypeIsInitialized )
     {
-    std::lock_guard< std::mutex > lock(m_MultiThreaderBaseGlobals->globalDefaultInitializerLock);
+    std::lock_guard< std::mutex > lock(m_PimplGlobals->globalDefaultInitializerLock);
 
     // After we have the lock, double check the initialization
     // flag to ensure it hasn't been changed by another thread.
-    if (!m_MultiThreaderBaseGlobals->GlobalDefaultThreaderTypeIsInitialized )
+    if (!m_PimplGlobals->GlobalDefaultThreaderTypeIsInitialized )
       {
       std::string envVar;
       // first check ITK_GLOBAL_DEFAULT_THREADER
@@ -245,7 +155,7 @@ MultiThreaderBase
           }
         }
       // if that was not set check ITK_USE_THREADPOOL (deprecated)
-      else if( !m_MultiThreaderBaseGlobals->GlobalDefaultThreaderTypeIsInitialized
+      else if( !m_PimplGlobals->GlobalDefaultThreaderTypeIsInitialized
           && itksys::SystemTools::GetEnv("ITK_USE_THREADPOOL",envVar) )
         {
         envVar = itksys::SystemTools::UpperCase(envVar);
@@ -268,10 +178,10 @@ You should now use ITK_GLOBAL_DEFAULT_THREADER\
         }
 
       // always set that we are initialized
-      m_MultiThreaderBaseGlobals->GlobalDefaultThreaderTypeIsInitialized=true;
+      m_PimplGlobals->GlobalDefaultThreaderTypeIsInitialized=true;
       }
     }
-  return m_MultiThreaderBaseGlobals->m_GlobalDefaultThreader;
+  return m_PimplGlobals->m_GlobalDefaultThreader;
 }
 
 MultiThreaderBase::ThreaderType
@@ -299,51 +209,42 @@ MultiThreaderBase
 
 void MultiThreaderBase::SetGlobalMaximumNumberOfThreads(ThreadIdType val)
 {
-  // This is called once, on-demand to ensure that m_MultiThreaderBaseGlobals is
-  // initialized.
-  static MultiThreaderBaseGlobals * multiThreaderBaseGlobals = GetMultiThreaderBaseGlobals();
-  Unused(multiThreaderBaseGlobals);
+  itkInitGlobalsMacro(PimplGlobals);
 
-  m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads = val;
+  m_PimplGlobals->m_GlobalMaximumNumberOfThreads = val;
 
   // clamp between 1 and ITK_MAX_THREADS
-  m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads =
-    std::min( m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads,
+  m_PimplGlobals->m_GlobalMaximumNumberOfThreads =
+    std::min( m_PimplGlobals->m_GlobalMaximumNumberOfThreads,
              (ThreadIdType) ITK_MAX_THREADS );
-  m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads =
-    std::max( m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads,
+  m_PimplGlobals->m_GlobalMaximumNumberOfThreads =
+    std::max( m_PimplGlobals->m_GlobalMaximumNumberOfThreads,
               NumericTraits<ThreadIdType>::OneValue() );
 
   // If necessary reset the default to be used from now on.
-  m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads =
-    std::min( m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads,
-              m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads);
+  m_PimplGlobals->m_GlobalDefaultNumberOfThreads =
+    std::min( m_PimplGlobals->m_GlobalDefaultNumberOfThreads,
+              m_PimplGlobals->m_GlobalMaximumNumberOfThreads);
 }
 
 ThreadIdType MultiThreaderBase::GetGlobalMaximumNumberOfThreads()
 {
-  // This is called once, on-demand to ensure that m_MultiThreaderBaseGlobals is
-  // initialized.
-  static MultiThreaderBaseGlobals * multiThreaderBaseGlobals = GetMultiThreaderBaseGlobals();
-  Unused(multiThreaderBaseGlobals);
-  return m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads;
+  itkInitGlobalsMacro(PimplGlobals);
+  return m_PimplGlobals->m_GlobalMaximumNumberOfThreads;
 }
 
 void MultiThreaderBase::SetGlobalDefaultNumberOfThreads(ThreadIdType val)
 {
-  // This is called once, on-demand to ensure that m_MultiThreaderBaseGlobals is
-  // initialized.
-  static MultiThreaderBaseGlobals * multiThreaderBaseGlobals = GetMultiThreaderBaseGlobals();
-  Unused(multiThreaderBaseGlobals);
+  itkInitGlobalsMacro(PimplGlobals);
 
-  m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads = val;
+  m_PimplGlobals->m_GlobalDefaultNumberOfThreads = val;
 
-  // clamp between 1 and m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads
-  m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads  =
-    std::min( m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads,
-              m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads );
-  m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads  =
-    std::max( m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads,
+  // clamp between 1 and m_PimplGlobals->m_GlobalMaximumNumberOfThreads
+  m_PimplGlobals->m_GlobalDefaultNumberOfThreads  =
+    std::min( m_PimplGlobals->m_GlobalDefaultNumberOfThreads,
+              m_PimplGlobals->m_GlobalMaximumNumberOfThreads );
+  m_PimplGlobals->m_GlobalDefaultNumberOfThreads  =
+    std::max( m_PimplGlobals->m_GlobalDefaultNumberOfThreads,
               NumericTraits<ThreadIdType>::OneValue() );
 
 }
@@ -351,7 +252,7 @@ void MultiThreaderBase::SetGlobalDefaultNumberOfThreads(ThreadIdType val)
 void MultiThreaderBase::SetMaximumNumberOfThreads( ThreadIdType numberOfThreads )
 {
   if( m_MaximumNumberOfThreads == numberOfThreads &&
-      numberOfThreads <= m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads )
+      numberOfThreads <= m_PimplGlobals->m_GlobalMaximumNumberOfThreads )
     {
     return;
     }
@@ -359,14 +260,14 @@ void MultiThreaderBase::SetMaximumNumberOfThreads( ThreadIdType numberOfThreads 
   m_MaximumNumberOfThreads = numberOfThreads;
 
   // clamp between 1 and m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads
-  m_MaximumNumberOfThreads = std::min( m_MaximumNumberOfThreads, m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads );
+  m_MaximumNumberOfThreads = std::min( m_MaximumNumberOfThreads, m_PimplGlobals->m_GlobalMaximumNumberOfThreads );
   m_MaximumNumberOfThreads = std::max( m_MaximumNumberOfThreads, NumericTraits< ThreadIdType >::OneValue() );
 }
 
 void MultiThreaderBase::SetNumberOfWorkUnits(ThreadIdType numberOfWorkUnits)
 {
   if( m_NumberOfWorkUnits == numberOfWorkUnits &&
-      numberOfWorkUnits <= m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads )
+      numberOfWorkUnits <= m_PimplGlobals->m_GlobalMaximumNumberOfThreads )
     {
     return;
     }
@@ -375,20 +276,15 @@ void MultiThreaderBase::SetNumberOfWorkUnits(ThreadIdType numberOfWorkUnits)
 
   // clamp between 1 and m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads
   m_NumberOfWorkUnits  = std::min( m_NumberOfWorkUnits,
-                                 m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads );
+                                   m_PimplGlobals->m_GlobalMaximumNumberOfThreads );
   m_NumberOfWorkUnits  = std::max( m_NumberOfWorkUnits, NumericTraits<ThreadIdType>::OneValue() );
-
 }
 
 ThreadIdType MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
 {
-  // This is called once, on-demand to ensure that m_MultiThreaderBaseGlobals is
-  // initialized.
-  static MultiThreaderBaseGlobals * multiThreaderBaseGlobals =
-    GetMultiThreaderBaseGlobals();
-  Unused(multiThreaderBaseGlobals);
+  itkInitGlobalsMacro(PimplGlobals);
 
-  if( m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads == 0 ) //need to initialize
+  if( m_PimplGlobals->m_GlobalDefaultNumberOfThreads == 0 ) //need to initialize
     {
     ThreadIdType threadCount = 0;
     /* The ITK_NUMBER_OF_THREADS_ENV_LIST contains is an
@@ -454,9 +350,9 @@ ThreadIdType MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
     // verify that the default number of threads is larger than zero
     threadCount  = std::max( threadCount, NumericTraits<ThreadIdType>::OneValue() );
 
-    m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads = threadCount;
+    m_PimplGlobals->m_GlobalDefaultNumberOfThreads = threadCount;
     }
-  return m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads;
+  return m_PimplGlobals->m_GlobalDefaultNumberOfThreads;
 }
 
 ThreadIdType
@@ -759,15 +655,15 @@ void MultiThreaderBase::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Number of Work Units: " << m_NumberOfWorkUnits << "\n";
   os << indent << "Number of Threads: " << m_MaximumNumberOfThreads << "\n";
   os << indent << "Global Maximum Number Of Threads: "
-     << m_MultiThreaderBaseGlobals->m_GlobalMaximumNumberOfThreads << std::endl;
+     << m_PimplGlobals->m_GlobalMaximumNumberOfThreads << std::endl;
   os << indent << "Global Default Number Of Threads: "
-     << m_MultiThreaderBaseGlobals->m_GlobalDefaultNumberOfThreads << std::endl;
+     << m_PimplGlobals->m_GlobalDefaultNumberOfThreads << std::endl;
   os << indent << "Global Default Threader Type: "
-     << m_MultiThreaderBaseGlobals->m_GlobalDefaultThreader << std::endl;
+     << m_PimplGlobals->m_GlobalDefaultThreader << std::endl;
   os << indent << "SingleMethod: " << m_SingleMethod << std::endl;
   os << indent << "SingleData: " << m_SingleData << std::endl;
 }
 
-MultiThreaderBaseGlobals * MultiThreaderBase::m_MultiThreaderBaseGlobals;
+MultiThreaderBaseGlobals * MultiThreaderBase::m_PimplGlobals;
 
 }

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -28,12 +28,16 @@
 #include "itkCommand.h"
 #include <algorithm>
 
+#include "itkSingleton.h"
+
 namespace itk
 {
 /**
  * Initialize static member that controls warning display.
  */
-bool Object:: m_GlobalWarningDisplay = true;
+itkGetGlobalValueMacro(Object, bool, GlobalWarningDisplay, true);
+
+bool * Object::m_GlobalWarningDisplay;
 
 class ITKCommon_HIDDEN Observer
 {
@@ -477,7 +481,8 @@ void
 Object
 ::SetGlobalWarningDisplay(bool val)
 {
-  m_GlobalWarningDisplay = val;
+  itkInitGlobalsMacro(GlobalWarningDisplay);
+  *m_GlobalWarningDisplay = val;
 }
 
 /**
@@ -487,7 +492,7 @@ bool
 Object
 ::GetGlobalWarningDisplay()
 {
-  return m_GlobalWarningDisplay;
+  return *Object::GetGlobalWarningDisplayPointer();
 }
 
 unsigned long

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -1,0 +1,136 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkSingleton.h"
+
+
+namespace
+{
+// This ensures that m_GlobalSingletonIndex has been initialized once the library
+// has been loaded. In some cases, this call will perform the initialization.
+// In other cases, static initializers like the IO factory initialization code
+// will have done the initialization.
+::itk::SingletonIndex * initializedGlobalSingletonIndex = ::itk::SingletonIndex::GetInstance();
+
+/** \class GlobalSingletonIndexInitializer
+ *
+ * \brief Initialize a GlobalSingletonIndex and delete it on program
+ * completion.
+ * */
+class GlobalSingletonIndexInitializer
+{
+public:
+  typedef GlobalSingletonIndexInitializer            Self;
+  typedef ::itk::SingletonIndex                      SingletonIndex;
+
+  GlobalSingletonIndexInitializer() {}
+
+  /** Delete the time stamp if it was created. */
+  ~GlobalSingletonIndexInitializer()
+    {
+      delete m_GlobalSingletonIndex;
+      m_GlobalSingletonIndex = nullptr;
+    }
+
+  /** Create the GlobalSingletonIndex if needed and return it. */
+  static SingletonIndex * GetGlobalSingletonIndex()
+    {
+    if ( m_GlobalSingletonIndex == nullptr )
+      {
+      m_GlobalSingletonIndex = new SingletonIndex;
+      // To avoid being optimized out. The compiler does not like this
+      // statement at a higher scope.
+      Unused(initializedGlobalSingletonIndex);
+      }
+    return m_GlobalSingletonIndex;
+    }
+
+private:
+  static SingletonIndex * m_GlobalSingletonIndex;
+};
+
+// Takes care of cleaning up the GlobalSingletonIndex
+static GlobalSingletonIndexInitializer GlobalSingletonIndexInitializerInstance;
+// Initialized by the compiler to zero
+GlobalSingletonIndexInitializer::SingletonIndex * GlobalSingletonIndexInitializer::m_GlobalSingletonIndex;
+
+} // end anonymous namespace
+
+
+// may return NULL if string is not registered already
+//
+// access something like a std::map<std::string, void *> or
+// registered globals, it may be possible to restrict the held
+// classes to be derived from itk::LightObject, so dynamic cast can
+// work, and could use some type of Holder<T> class for intrinsic types
+namespace itk
+{
+void *
+SingletonIndex
+::GetGlobalInstancePrivate( const char *globalName )
+{
+  SingletonData::iterator it;
+  it = m_GlobalObjects.find(globalName);
+  if (it == m_GlobalObjects.end())
+    {
+    return nullptr;
+    }
+  return std::get<0>(it->second);
+}
+
+// If globalName is already registered remove it from map,
+// otherwise global is added to the singleton index under globalName
+bool
+SingletonIndex
+::SetGlobalInstancePrivate( const char * globalName, void * global, std::function<void(void*)> func, std::function<void(void)> deleteFunc)
+{
+  m_GlobalObjects.erase(globalName);
+  m_GlobalObjects.insert(std::make_pair(globalName, std::make_tuple(global, func, deleteFunc) ) );
+  return true;
+}
+
+SingletonIndex *
+SingletonIndex
+::GetInstance()
+{
+  if( m_Instance == nullptr )
+    {
+    m_Instance = GlobalSingletonIndexInitializer::GetGlobalSingletonIndex();
+    }
+  return m_Instance;
+}
+
+void
+SingletonIndex
+::SetInstance(Self *instance)
+{
+  m_Instance = instance;
+}
+
+
+SingletonIndex::~SingletonIndex()
+{
+  for(auto &pair: m_GlobalObjects)
+    {
+    std::get<2>(pair.second)();
+    }
+}
+
+SingletonIndex::Self * SingletonIndex::m_Instance;
+
+
+} // end namespace itk

--- a/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
+++ b/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
@@ -25,7 +25,7 @@
 
 #include "ITKFFTExport.h"
 #include <mutex>
-
+#include "itkSingletonMacro.h"
 #include "itksys/SystemTools.hxx"
 #include "itksys/SystemInformation.hxx"
 #if defined( ITK_USE_CUFFTW )
@@ -35,6 +35,8 @@
 #endif
 #include <algorithm>
 #include <cctype>
+
+struct FFTWGlobalConfigurationGlobals;
 
 //* The fftw utilities help control the various strategies
 //available for controlling optimizations for the FFTW library.
@@ -64,6 +66,9 @@ namespace itk
  * A set of functions for defining wisdom filename
  * generation strategies.
  */
+
+struct FFTWGlobalConfigurationGlobals;
+
 #ifdef _WIN32
 #define FFTWPathSep "\\"
 #else
@@ -297,14 +302,16 @@ private:
   /** Return the singleton instance with no reference counting. */
   static Pointer GetInstance();
 
+  itkGetGlobalDeclarationMacro(FFTWGlobalConfigurationGlobals, PimplGlobals);
+
+
   /** This is a singleton pattern New.  There will only be ONE
    * reference to a FFTWGlobalConfiguration object per process.
    * The single instance will be unreferenced when
    * the program exits. */
   itkFactorylessNewMacro(Self);
 
-  static Pointer                m_Instance;
-  static std::mutex    m_CreationLock;
+  static FFTWGlobalConfigurationGlobals *m_PimplGlobals;
 
   std::mutex           m_Lock;
   bool                          m_NewWisdomAvailable;

--- a/Modules/IO/Meta/include/itkMetaImageIO.h
+++ b/Modules/IO/Meta/include/itkMetaImageIO.h
@@ -22,6 +22,7 @@
 
 #include <fstream>
 #include "itkImageIOBase.h"
+#include "itkSingletonMacro.h"
 #include "metaObject.h"
 #include "metaImage.h"
 
@@ -171,12 +172,14 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
+  /** Only used to synchronize the global variable across static libraries.*/
+  itkGetGlobalDeclarationMacro(unsigned int, DefaultDoublePrecision);
 
   MetaImage m_MetaImage;
 
   unsigned int m_SubSamplingFactor;
 
-  static unsigned int m_DefaultDoublePrecision;
+  static unsigned int * m_DefaultDoublePrecision;
 };
 } // end namespace itk
 

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -22,15 +22,19 @@
 #include "itkIOCommon.h"
 #include "itksys/SystemTools.hxx"
 #include "itkMath.h"
+#include "itkSingleton.h"
 
 namespace itk
 {
 // Explicitly set std::numeric_limits<double>::max_digits10 this will provide
 // better accuracy when writing out floating point number in MetaImage header.
-unsigned int MetaImageIO::m_DefaultDoublePrecision = 17;
+itkGetGlobalValueMacro(MetaImageIO, unsigned int, DefaultDoublePrecision, 17);
+
+unsigned int * MetaImageIO::m_DefaultDoublePrecision;
 
 MetaImageIO::MetaImageIO()
 {
+  itkInitGlobalsMacro(DefaultDoublePrecision);
   m_FileType = Binary;
   m_SubSamplingFactor = 1;
   if ( MET_SystemByteOrderMSB() )
@@ -1298,12 +1302,14 @@ MetaImageIO::GetSplitRegionForWriting( unsigned int ithPiece,
 
 void MetaImageIO::SetDefaultDoublePrecision(unsigned int precision)
 {
-  m_DefaultDoublePrecision = precision;
+  itkInitGlobalsMacro(DefaultDoublePrecision);
+  *m_DefaultDoublePrecision = precision;
 }
 
 unsigned int MetaImageIO::GetDefaultDoublePrecision()
 {
-  return m_DefaultDoublePrecision;
+  itkInitGlobalsMacro(DefaultDoublePrecision);
+  return *MetaImageIO::GetDefaultDoublePrecisionPointer();
 }
 
 } // end namespace itk

--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -399,56 +399,32 @@ macro(itk_end_wrap_module_python)
   set(ITK_WRAP_PYTHON_GLOBAL_TIMESTAMP_CALLS )
   if(NOT BUILD_SHARED_LIBS)
     if(WRAPPER_LIBRARY_NAME STREQUAL "ITKCommon")
+
+      if(WIN32)
+        set(DO_NOT_WAIT_FOR_THREADS_DECLS "#include \"itkThreadPool.h\"")
+        set(DO_NOT_WAIT_FOR_THREADS_CALLS "itk::ThreadPool::SetDoNotWaitForThreads( true );")
+      endif()
+
       set(ITK_WRAP_PYTHON_GLOBAL_TIMESTAMP_DECLS "
 #define _ITKCommonPython_MODULE
 #include \"itkPyITKCommonCAPI.h\"
+${DO_NOT_WAIT_FOR_THREADS_DECLS}
 
 static
-_ITKCommonPython_GetGlobalTimeStamp_RETURN
-_ITKCommonPython_GetGlobalTimeStamp
-_ITKCommonPython_GetGlobalTimeStamp_PROTO
+_ITKCommonPython_GetGlobalSingletonIndex_RETURN
+_ITKCommonPython_GetGlobalSingletonIndex
+_ITKCommonPython_GetGlobalSingletonIndex_PROTO
 {
-  return itk::TimeStamp::GetGlobalTimeStamp();
-}
-
-static
-_ITKCommonPython_GetObjectFactoryBase_RETURN
-_ITKCommonPython_GetObjectFactoryBase
-_ITKCommonPython_GetObjectFactoryBase_PROTO
-{
-  return itk::ObjectFactoryBase::GetObjectFactoryBase();
-}
-
-static
-_ITKCommonPython_GetThreadPoolGlobals_RETURN
-_ITKCommonPython_GetThreadPoolGlobals
-_ITKCommonPython_GetThreadPoolGlobals_PROTO
-{
-  return itk::ThreadPool::GetThreadPoolGlobals();
-}
-
-static
-_ITKCommonPython_GetMultiThreaderBaseGlobals_RETURN
-_ITKCommonPython_GetMultiThreaderBaseGlobals
-_ITKCommonPython_GetMultiThreaderBaseGlobals_PROTO
-{
-  return itk::MultiThreaderBase::GetMultiThreaderBaseGlobals();
+  return itk::SingletonIndex::GetInstance();
 }
 
 ")
-
-if(WIN32)
-  set(DO_NOT_WAIT_FOR_THREADS "itk::ThreadPool::SetDoNotWaitForThreads( true );")
-endif()
 
       set(ITK_WRAP_PYTHON_GLOBAL_TIMESTAMP_CALLS "
   static void * _ITKCommonPython_API[_ITKCommonPython_API_pointers];
 
   /* Initialize the C API pointer array */
-  _ITKCommonPython_API[_ITKCommonPython_GetGlobalTimeStamp_NUM] = (void *)_ITKCommonPython_GetGlobalTimeStamp;
-  _ITKCommonPython_API[_ITKCommonPython_GetObjectFactoryBase_NUM] = (void *)_ITKCommonPython_GetObjectFactoryBase;
-  _ITKCommonPython_API[_ITKCommonPython_GetThreadPoolGlobals_NUM] = (void *)_ITKCommonPython_GetThreadPoolGlobals;
-  _ITKCommonPython_API[_ITKCommonPython_GetMultiThreaderBaseGlobals_NUM] = (void *)_ITKCommonPython_GetMultiThreaderBaseGlobals;
+  _ITKCommonPython_API[_ITKCommonPython_GetGlobalSingletonIndex_NUM] = (void *)_ITKCommonPython_GetGlobalSingletonIndex;
 
   /* Create a Capsule containing the API pointer array's address */
   PyObject * cAPIObject = PyCapsule_New((void *)_ITKCommonPython_API,
@@ -458,11 +434,12 @@ endif()
     {
     PyModule_AddObject( m, \"_C_API\", cAPIObject );
     }
-  ${DO_NOT_WAIT_FOR_THREADS}
+  ${DO_NOT_WAIT_FOR_THREADS_CALLS}
 ")
     elseif("ITKCommon" IN_LIST WRAPPER_LIBRARY_LINK_LIBRARIES)
       set(ITK_WRAP_PYTHON_GLOBAL_TIMESTAMP_DECLS "
 #include \"itkPyITKCommonCAPI.h\"
+${DO_NOT_WAIT_FOR_THREADS_DECLS}
 ")
       set(ITK_WRAP_PYTHON_GLOBAL_TIMESTAMP_CALLS "
   if( import__ITKCommonPython() < 0 )
@@ -473,11 +450,8 @@ endif()
     return;
 #endif
     }
-  itk::TimeStamp::SetGlobalTimeStamp( _ITKCommonPython_GetGlobalTimeStamp() );
-  itk::ObjectFactoryBase::SynchronizeObjectFactoryBase( _ITKCommonPython_GetObjectFactoryBase() );
-  itk::ThreadPool::SetThreadPoolGlobals( _ITKCommonPython_GetThreadPoolGlobals() );
-  itk::MultiThreaderBase::SetMultiThreaderBaseGlobals( _ITKCommonPython_GetMultiThreaderBaseGlobals() );
-  ${DO_NOT_WAIT_FOR_THREADS}
+  itk::SingletonIndex::SetInstance( _ITKCommonPython_GetGlobalSingletonIndex() );
+  ${DO_NOT_WAIT_FOR_THREADS_CALLS}
 ")
     endif()
   endif()

--- a/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
+++ b/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
@@ -18,10 +18,7 @@
 #ifndef itkPyITKCommonCAPI_h
 #define itkPyITKCommonCAPI_h
 
-#include "itkTimeStamp.h"
-#include "itkObjectFactoryBase.h"
-#include "itkThreadPool.h"
-#include "itkMultiThreaderBase.h"
+#include "itkSingleton.h"
 
 /* Header file for the _ITKCommonPython C API exposed via an PyCapsule.
  *
@@ -40,47 +37,26 @@ extern "C" {
 #endif
 
 /* C API functions */
-#define _ITKCommonPython_GetGlobalTimeStamp_NUM 0
-#define _ITKCommonPython_GetGlobalTimeStamp_RETURN itk::TimeStamp::GlobalTimeStampType *
-#define _ITKCommonPython_GetGlobalTimeStamp_PROTO ()
+#define _ITKCommonPython_GetGlobalSingletonIndex_NUM 0
+#define _ITKCommonPython_GetGlobalSingletonIndex_RETURN itk::SingletonIndex *
+#define _ITKCommonPython_GetGlobalSingletonIndex_PROTO ()
 
-#define _ITKCommonPython_GetObjectFactoryBase_NUM 1
-#define _ITKCommonPython_GetObjectFactoryBase_RETURN itk::ObjectFactoryBasePrivate *
-#define _ITKCommonPython_GetObjectFactoryBase_PROTO ()
-
-#define _ITKCommonPython_GetThreadPoolGlobals_NUM 2
-#define _ITKCommonPython_GetThreadPoolGlobals_RETURN itk::ThreadPoolGlobals *
-#define _ITKCommonPython_GetThreadPoolGlobals_PROTO ()
-
-#define _ITKCommonPython_GetMultiThreaderBaseGlobals_NUM 3
-#define _ITKCommonPython_GetMultiThreaderBaseGlobals_RETURN itk::MultiThreaderBaseGlobals *
-#define _ITKCommonPython_GetMultiThreaderBaseGlobals_PROTO ()
 /* Total number of C API pointers */
-#define _ITKCommonPython_API_pointers 4
+#define _ITKCommonPython_API_pointers 1
 
 
 #ifdef _ITKCommonPython_MODULE
 /* This section is used when compiling ITKCommonPython.cpp */
 
-static _ITKCommonPython_GetGlobalTimeStamp_RETURN _ITKCommonPython_GetGlobalTimeStamp _ITKCommonPython_GetGlobalTimeStamp_PROTO;
-static _ITKCommonPython_GetObjectFactoryBase_RETURN _ITKCommonPython_GetObjectFactoryBase _ITKCommonPython_GetObjectFactoryBase_PROTO;
-static _ITKCommonPython_GetThreadPoolGlobals_RETURN _ITKCommonPython_GetThreadPoolGlobals _ITKCommonPython_GetThreadPoolGlobals_PROTO;
-static _ITKCommonPython_GetMultiThreaderBaseGlobals_RETURN _ITKCommonPython_GetMultiThreaderBaseGlobals _ITKCommonPython_GetMultiThreaderBaseGlobals_PROTO;
+static _ITKCommonPython_GetGlobalSingletonIndex_RETURN _ITKCommonPython_GetInstance _ITKCommonPython_GetGlobalSingletonIndex_PROTO;
 
 #else
 /* This section is used in modules that use _ITKCommonPython's C API */
 
 static void **_ITKCommonPython_API;
 
-#define _ITKCommonPython_GetGlobalTimeStamp \
- (*(_ITKCommonPython_GetGlobalTimeStamp_RETURN (*)_ITKCommonPython_GetGlobalTimeStamp_PROTO) _ITKCommonPython_API[_ITKCommonPython_GetGlobalTimeStamp_NUM])
-#define _ITKCommonPython_GetObjectFactoryBase \
- (*(_ITKCommonPython_GetObjectFactoryBase_RETURN (*)_ITKCommonPython_GetObjectFactoryBase_PROTO) _ITKCommonPython_API[_ITKCommonPython_GetObjectFactoryBase_NUM])
-#define _ITKCommonPython_GetThreadPoolGlobals \
- (*(_ITKCommonPython_GetThreadPoolGlobals_RETURN (*)_ITKCommonPython_GetThreadPoolGlobals_PROTO) _ITKCommonPython_API[_ITKCommonPython_GetThreadPoolGlobals_NUM])
-#define _ITKCommonPython_GetMultiThreaderBaseGlobals \
- (*(_ITKCommonPython_GetMultiThreaderBaseGlobals_RETURN (*)_ITKCommonPython_GetMultiThreaderBaseGlobals_PROTO) _ITKCommonPython_API[_ITKCommonPython_GetMultiThreaderBaseGlobals_NUM])
-
+#define _ITKCommonPython_GetGlobalSingletonIndex \
+ (*(_ITKCommonPython_GetGlobalSingletonIndex_RETURN (*)_ITKCommonPython_GetGlobalSingletonIndex_PROTO) _ITKCommonPython_API[_ITKCommonPython_GetGlobalSingletonIndex_NUM])
 /* Return -1 on error, 0 on success.
  * PyCapsule_Import will set an exception if there's an error.
  */


### PR DESCRIPTION
Replaces individual synchronization mechanisms across modules for each global
variables used in ITK by a central mechanism in which all these variables
are registered and which gives a single entry point to synchronize
all global variables.

Global variables are registered in a map, with a key that is their name and
a value that is a pair of their pointer and a pointer to a synchronization
function. The synchronization function will be called to synchronize
these global variables across the different modules. Different global
variables may have different synchronization functions: Some variables
will just override the previous value in all modules whereas some
others will need to actually synchronize their values.

Change-Id: Ib6ebc9b3f9acd93ce8319f00579f6bf4982ca6b8