### PR TITLE
COMP: Revert "COMP: Make ThirdParty Eigen3 COMPILE_DEPENDS"

### DIFF
--- a/Modules/Core/Common/itk-module.cmake
+++ b/Modules/Core/Common/itk-module.cmake
@@ -13,12 +13,12 @@ endif()
 itk_module(ITKCommon
   ENABLE_SHARED
   DEPENDS
+    ITKEigen3
     ITKKWIML
     ${ITKCOMMON_TBB_DEPENDS}
   PRIVATE_DEPENDS
     ITKDoubleConversion
   COMPILE_DEPENDS
-    ITKEigen3
     ITKKWSys
     ITKVNLInstantiation
   TEST_DEPENDS


### PR DESCRIPTION
This reverts commit 1c49f4bba661d0aeb8c3734b2f14e38e3a2a073b.

GCC still complains about shadowed definitions.
Make the ITKEigen3 dependency PUBLIC, so the `-isystem` flag
is used, and the warnings suppressed.