### PR TITLE
BUG: Fix `ìtkResmapleImageTest2` test failing on 32-bit systems.

### DIFF
--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
@@ -175,8 +175,8 @@ int itkResampleImageTest2(int argc, char * argv[])
     typedef typename ImageType::SizeType::SizeValueType SizeValueType;
     for( unsigned int i = 0; i < NDimensions; ++i )
       {
-      outputSize[i] = static_cast< SizeValueType >(
-        (double)inputSize[i] * inputSpacing[i] / outputSpacing[i]);
+      outputSize[i] = itk::Math::Ceil< SizeValueType >(
+        (double)inputSize[i] * inputSpacing[i] / outputSpacing[i] );
       }
 
     typename ImageType::DirectionType outputDirection =


### PR DESCRIPTION
Fix `ìtkResmapleImageTest2` test failing on 32-bit systems. Fixes:
https://open.cdash.org/testDetails.php?test=728564967&build=5731782
