### PR TITLE
BUG: corrected logic for checking that streaming was not used

### DIFF
--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -119,7 +119,6 @@ int itkResampleImageTest2Streaming( int argc, char * argv [] )
   EXERCISE_BASIC_OBJECT_METHODS( resample, ResampleImageFilter, ImageToImageFilter );
 
   monitor->SetInput( reader1->GetOutput() );
-  resample->SetInput( monitor->GetOutput() );
   TEST_SET_GET_VALUE( reader1->GetOutput(), monitor->GetInput() );
 
   resample->SetReferenceImage( reader2->GetOutput() );
@@ -135,6 +134,7 @@ int itkResampleImageTest2Streaming( int argc, char * argv [] )
   TEST_SET_GET_VALUE( interpolator, resample->GetInterpolator() );
 
   resample->SetInput( monitor->GetOutput() );
+  TEST_SET_GET_VALUE( monitor->GetOutput(), resample->GetInput() );
   writer1->SetInput( resample->GetOutput() );
 
   // Check GetReferenceImage
@@ -172,15 +172,15 @@ int itkResampleImageTest2Streaming( int argc, char * argv [] )
 
   nonlinearAffineTransform->Scale(2.0);
   resample->SetTransform( nonlinearAffineTransform );
-  writer2->SetInput( resample->GetOutput() );
   monitor->ClearPipelineSavedInformation();
+  writer2->SetInput( resample->GetOutput() );
   writer2->SetNumberOfStreamDivisions(8); //demand splitting into 8 pieces for streaming, but faked non-linearity will disable streaming
   TRY_EXPECT_NO_EXCEPTION( writer2->Update() );
 
   // check that streaming is not possible for non-linear case
-  if (!monitor->VerifyAllInputCanStream(8))
+  if (!monitor->VerifyAllInputCanStream(1))
     {
-    std::cerr << "Streaming succedded for non-linear transform which should not be the case!" << std::endl;
+    std::cerr << "Streaming succeeded for non-linear transform which should not be the case!" << std::endl;
     std::cerr << monitor;
     std::cerr << "Test failed." << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
There is a bug in the logic for checking if streaming did not succeed with the final commits of #392, see comments there (https://github.com/InsightSoftwareConsortium/ITK/pull/392#issuecomment-460582840).
`resample->SetInput( monitor->GetOutput() );` was called twice (https://github.com/InsightSoftwareConsortium/ITK/commit/e9f951d902f043a3eb314d7ad434735066408a26#diff-50f53fc01f72ba938548d64a1218589bL122 and https://github.com/InsightSoftwareConsortium/ITK/commit/e9f951d902f043a3eb314d7ad434735066408a26#diff-50f53fc01f72ba938548d64a1218589bL137), so removed one to avoid problems in future modifications.
Some minor changes are included as well.
