### PR TITLE
Streaming for itkResampleImageFilter in case of linear transforms

### DIFF
--- a/Modules/Core/Common/include/itkImageAlgorithm.h
+++ b/Modules/Core/Common/include/itkImageAlgorithm.h
@@ -110,11 +110,12 @@ struct ImageAlgorithm
    * the physical space covered by the input
    * region of the input image
    */
-  template<typename InputImageType, typename OutputImageType>
+  template<typename InputImageType, typename OutputImageType, typename TransformType>
   static typename OutputImageType::RegionType
   EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,
                        const InputImageType* inputImage,
-                       const OutputImageType* outputImage);
+                       const OutputImageType* outputImage,
+                       const TransformType* transform = nullptr);
 
 private:
 

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -167,11 +167,12 @@ void ImageAlgorithm::DispatchedCopy( const InputImageType *inImage,
     }
 }
 
-template<typename InputImageType, typename OutputImageType>
+template<typename InputImageType, typename OutputImageType, typename TransformType>
 typename OutputImageType::RegionType
 ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,
                                      const InputImageType* inputImage,
-                                     const OutputImageType* outputImage)
+                                     const OutputImageType* outputImage,
+                                     const TransformType* transform)
 {
   typename OutputImageType::RegionType outputRegion;
 
@@ -217,8 +218,12 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
 
     using PointType = Point< SpacePrecisionType, OutputImageType::ImageDimension >;
     PointType point;
-    inputImage->TransformContinuousIndexToPhysicalPoint(currentCornerIndex, point);
-    outputImage->TransformPhysicalPointToContinuousIndex(point, corners[count]);
+    inputImage->TransformContinuousIndexToPhysicalPoint( currentCornerIndex, point );
+    if( transform != nullptr )
+      {
+      point = transform->TransformPoint( point );
+      }
+    outputImage->TransformPhysicalPointToContinuousIndex( point, corners[count] );
     }
 
   // Compute a rectangular region from the vector of corner indexes

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImage.h"
 #include "itkFixedArray.h"
 #include "itkImageAlgorithm.h"
+#include "itkTransform.h"
 
 int itkImageTest(int, char* [] )
 {
@@ -122,9 +123,12 @@ int itkImageTest(int, char* [] )
   regionRef.SetSize(sizeRef);
   imageRef->SetRegions(regionRef);
 
+  typedef itk::Transform< double, Image::ImageDimension, Image::ImageDimension > TransformType;
+
   Image::RegionType boxRegion = itk::ImageAlgorithm::EnlargeRegionOverBox(image->GetLargestPossibleRegion(),
                                                                           image.GetPointer(),
-                                                                          imageRef.GetPointer());
+                                                                          imageRef.GetPointer(),
+                                                                          static_cast< TransformType *>(nullptr) );
   Image::IndexType correctIndex; correctIndex.Fill(0);
   Image::SizeType correctSize; correctSize.Fill(3);
   if( !(boxRegion.GetIndex() == correctIndex) ||

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -27,6 +27,8 @@
 #include "itkProgressReporter.h"
 #include "itkContinuousIndex.h"
 #include "itkMath.h"
+#include "itkTransform.h"
+
 namespace itk
 {
 template< typename TInputImage, typename TOutputImage, typename TDisplacementField >
@@ -410,10 +412,12 @@ WarpImageFilter< TInputImage, TOutputImage, TDisplacementField >
     else
       {
       using DisplacementRegionType = typename TDisplacementField::RegionType;
+      using TransformType = itk::Transform< SpacePrecisionType, OutputImageType::ImageDimension, OutputImageType::ImageDimension >;
 
       DisplacementRegionType fieldRequestedRegion = ImageAlgorithm::EnlargeRegionOverBox(outputPtr->GetRequestedRegion(),
                                                                                          outputPtr,
-                                                                                         fieldPtr);
+                                                                                         fieldPtr,
+                                                                                         static_cast< TransformType *>(nullptr));
       fieldPtr->SetRequestedRegion( fieldRequestedRegion );
       }
     if ( !fieldPtr->VerifyRequestedRegion() )

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -276,7 +276,6 @@ itk_add_test(NAME itkResampleImageTest2Streaming
                           ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bStreaming.mha
                           ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cStreaming.mha
                           ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dStreaming.mha)
-set_tests_properties(itkResampleImageTest2Streaming PROPERTIES WILL_FAIL TRUE) # should fail as long as itkResampleFilter does not support streaming for linear transforms GH PR #82
 itk_add_test(NAME itkResampleImageTest3
       COMMAND ITKImageGridTestDriver
     --compare DATA{Baseline/ResampleImageTest3.png}
@@ -297,7 +296,6 @@ itk_add_test(NAME itkResampleImageTest6
     itkResampleImageTest6 10 ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest6.png)
 itk_add_test(NAME itkResampleImageTest7
       COMMAND ITKImageGridTestDriver itkResampleImageTest7)
-set_tests_properties(itkResampleImageTest7 PROPERTIES WILL_FAIL TRUE) # should fail as long as itkResampleFilter does not support streaming for linear transforms GH PR #82
 itk_add_test(NAME itkResamplePhasedArray3DSpecialCoordinatesImageTest
       COMMAND ITKImageGridTestDriver itkResamplePhasedArray3DSpecialCoordinatesImageTest)
 itk_add_test(NAME itkPushPopTileImageFilterTest

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
@@ -56,8 +56,7 @@ int itkResampleImageTest4(int argc, char * argv [] )
   ImageRegionType region;
   region.SetSize ( size );
   region.SetIndex( index );
-  image->SetLargestPossibleRegion( region );
-  image->SetBufferedRegion( region );
+  image->SetRegions( region );
   image->Allocate();
 
   auto newDims = static_cast<unsigned int>( 64*scaling );
@@ -120,7 +119,8 @@ int itkResampleImageTest4(int argc, char * argv [] )
   // Run the resampling filter
   itk::TimeProbe clock;
   clock.Start();
-  resample->Update();
+  std::cout << "Input: " << image << std::endl;
+  resample->UpdateLargestPossibleRegion();
   clock.Stop();
 
   std::cout << "Resampling from " << size << " to " << osize << " took " << clock.GetMean() << " s" << std::endl;


### PR DESCRIPTION
This PR corresponds to #82, rebased onto master, meant for inclusion into master (ITK-5 instead of ITK-4.13.1). 
Inspired by the discussion of the discourse topic [Why ResampleImageFilter is slow?](https://discourse.itk.org/t/why-resampleimagefilter-is-slow/1217), this PR is a try to realize streaming for at least some transforms for the `itkResampleImageFilter`. 
It is one of the most general filters in ITK and much used and the essential one for isotropic down-sampling of large datasets. Especially for that case it would be very helpful to have streaming capabilities, in order to generate smaller datasets for filters that cannot stream. Apart from a reduced memory footprint, streaming can lead to a significant speed up because a chunk can be processed while the next is loaded from disc, drastically reducing loading latencies.

As the filter is of great importance, some new tests cases (failing with the current implementation) were created (#392, now merged) that are expected to succeed (partially) when streaming is realized. With these tests (and possibly #468) master is equipped for testing the new contributions to `itkResampleImageFilter`, which enable streaming for linear transforms. Manual test showed that streaming already works but (even for an identity transform) the result's extent is larger than without streaming.

Therefore, `itkResampleImageTest7` is meant to compare the current results of `itkResampleImageFilter` in various cases with those obtained when streaming is employed. There, a reader and a writer are avoided to rule out any interference concerning streaming limitations in respect to a chosen file format.
`itkResampleImageTest2s` is based on `itkResampleImageTest2` adjusted to write MHAs, which support streaming.