### PR TITLE
ENH: add RTK as a remote module

### DIFF
--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -1,0 +1,6 @@
+# Contact: Simon Rit <simon.rit@creatis.insa-lyon.fr>
+itk_fetch_module(RTK
+    "Reconstruction Toolkit (RTK) http://www.openrtk.org/"
+  GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/RTK.git
+  GIT_TAG v2.0.0
+)


### PR DESCRIPTION
We (mainly @LucasGandel) have been working hard to make RTK a remote module of ITK for the new RTK v2.0.0 release (see SimonRit/RTK@68cb6b2). It would be an achievement to include this remote module file in the ITK repository to ease compilation of RTK for users. I'm looking forward to it!