### PR TITLE
BUG: Implement but hide MetaDataDictionary iterator methods

### DIFF
--- a/Modules/Core/Common/include/itkMetaDataDictionary.h
+++ b/Modules/Core/Common/include/itkMetaDataDictionary.h
@@ -102,28 +102,22 @@ public:
    * context cannot be dereferenced safely */
 
   /** Returns an iterator to the beginning of the map */
-#if !defined( ITK_WRAPPING_PARSER )
+  // Blacklisted by igenerator.py
   Iterator  Begin();
-
+  // Blacklisted by igenerator.py
   ConstIterator  Begin() const;
 
-#endif
-
   /** Returns an iterator to the end of the map */
-#if !defined( ITK_WRAPPING_PARSER )
+  // Blacklisted by igenerator.py
   Iterator  End();
-
+  // Blacklisted by igenerator.py
   ConstIterator  End() const;
 
-#endif
-
   /** Returns an iterator matching the string key */
-#if !defined( ITK_WRAPPING_PARSER )
   Iterator  Find(const std::string & key);
 
   ConstIterator  Find(const std::string & key) const;
 
-#endif
   /** remove all MetaObjects from dictionary */
   void Clear();
 

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -160,6 +160,7 @@ str = str
 
 
 %extend itkMetaDataDictionary {
+    %ignore Find;
     std::string __str__() {
         std::ostringstream msg;
         self->Print( msg );


### PR DESCRIPTION
MetaDataDictionary methods are used inside the MetaDataObject class
since PR#455 so these methods need to be defined. To keep the
API the same it used to be, we do not expose them when the code is wrapped.