### PR TITLE
ENH: Add Thickness3D Remote module.

### DIFF
--- a/Modules/Remote/Thickness3D.remote.cmake
+++ b/Modules/Remote/Thickness3D.remote.cmake
@@ -1,0 +1,6 @@
+# Contact: Thomas Janvier <thomas.p.janvier@gmail.com>
+itk_fetch_module(Thickness3D
+  "Tools for 3D thickness measurement"
+  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKThickness3D.git
+  GIT_TAG 7b2de28581369586595fdd5e3b9bec2606a2d516
+)


### PR DESCRIPTION
This module implements filters that compute the skeleton and thickness transforms of a 3D image.

Details about the thinning/skeletonization algorithm can be found in the Insight Journal article:
Homann H.
Implementation of a 3D thinning algorithm
The Insight Journal - 2007 July - December.
http://hdl.handle.net/1926/1292
http://insight-journal.org/browse/publication/181

Medial thickness transform is a composite filter that mask the distance transform with the above thinning output.