### PR TITLE
ENH: compare outputs of itkResampleImageTest2Streaming to determine success

### DIFF
--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -270,8 +270,16 @@ itk_add_test(NAME itkResampleImageTest2UseRefImageOn
                           1)
 itk_add_test(NAME itkResampleImageTest2Streaming
       COMMAND ITKImageGridTestDriver
+    --compare DATA{Baseline/ResampleImageTest2.mha}
+              ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2a.mha
+    --compare DATA{Baseline/ResampleImageTest2.mha}
+              ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2b.mha
+    --compare DATA{Baseline/ResampleImageTest2NearestExtrapolate.mha}
+              ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2c.mha
+    --compare DATA{Baseline/ResampleImageTest2NearestExtrapolate.mha}
+              ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2d.mha
     itkResampleImageTest2Streaming DATA{Input/cthead1.mha}
-                          DATA{Input/cthead1.mha}
+                          DATA{Input/circle.png}
                           ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2aStreaming.mha
                           ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bStreaming.mha
                           ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cStreaming.mha


### PR DESCRIPTION
relates to #0392 
and intends to not only take the return value into account but also the comparison of the output with the expected results.

@thewtex in relation to https://github.com/InsightSoftwareConsortium/ITK/pull/392#issuecomment-460892360: Since it is necessary for streaming to write to MHAs (not PNGs as originally the case), the output is uncoupled from `itkResampleImageTest2`, so I guess we do not need the `DEPENDS` property.
I am not sure though if it is critical that the second input comes from PNG `circle.png`, which is not available as MHA. I noticed that you changed the first input from PNG to MHA `cthead1.mha`. Is that necessary for successful streaming and would the same apply for the reference image?
Just using `cthead1.mha` as second input again is probably not good in conjunction with the comparison because there would be no resampling if the reference image is the same as the main input.
