### PR TITLE
COMP: Fix support itk::VectorContainer<TElementIdentifier, bool>

### DIFF
--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -81,7 +81,7 @@ protected:
   VectorContainer(size_type n, const Element & x):
     Object(), VectorType(n, x) {}
   VectorContainer(const Self & r):
-    Object(), VectorType(r) {}
+    Object(), VectorType(r.CastToSTLConstContainer()) {}
   template< typename TInputIterator >
   VectorContainer(TInputIterator first, TInputIterator last):
     Object(), VectorType(first, last) {}
@@ -134,7 +134,6 @@ public:
   using STLContainerType::at;
   using STLContainerType::front;
   using STLContainerType::back;
-  using STLContainerType::data;
 
   using STLContainerType::assign;
   using STLContainerType::push_back;
@@ -143,8 +142,6 @@ public:
   using STLContainerType::erase;
   using STLContainerType::swap;
   using STLContainerType::clear;
-  using STLContainerType::emplace;
-  using STLContainerType::emplace_back;
 
   using STLContainerType::get_allocator;
 
@@ -208,7 +205,7 @@ public:
     ElementIdentifier Index() const { return static_cast< ElementIdentifier >( m_Pos ); }
 
     /** Get the value at this iterator's location in the VectorContainer.   */
-    Element & Value() const { return *m_Iter; }
+    reference Value() const { return *m_Iter; }
 
 private:
     size_type      m_Pos;
@@ -258,7 +255,7 @@ public:
         */
     ElementIdentifier Index() const { return static_cast< ElementIdentifier >( m_Pos ); }
     /** Get the value at this iterator's location in the VectorContainer.   */
-    const Element & Value() const { return *m_Iter; }
+    const_reference Value() const { return *m_Iter; }
 
 private:
     size_type           m_Pos;
@@ -276,7 +273,7 @@ private:
    * It is assumed that the value of the element is modified through the
    * reference.
    */
-  Element & ElementAt(ElementIdentifier);
+  reference ElementAt(ElementIdentifier);
 
   /**
    * Get a reference to the element at the given index.
@@ -284,7 +281,7 @@ private:
    * be created.
    *
    */
-  const Element & ElementAt(ElementIdentifier) const;
+  const_reference ElementAt(ElementIdentifier) const;
 
   /**
    * Get a reference to the element at the given index.
@@ -294,7 +291,7 @@ private:
    * It is assumed that the value of the element is modified through the
    * reference.
    */
-  Element & CreateElementAt(ElementIdentifier);
+  reference CreateElementAt(ElementIdentifier);
 
   /**
    * Read the element from the given index.

--- a/Modules/Core/Common/include/itkVectorContainer.hxx
+++ b/Modules/Core/Common/include/itkVectorContainer.hxx
@@ -32,7 +32,7 @@ namespace itk
  * reference.
  */
 template< typename TElementIdentifier, typename TElement >
-typename VectorContainer< TElementIdentifier, TElement >::Element &
+typename VectorContainer< TElementIdentifier, TElement >::reference
 VectorContainer< TElementIdentifier, TElement >
 ::ElementAt(ElementIdentifier id)
 {
@@ -47,7 +47,7 @@ VectorContainer< TElementIdentifier, TElement >
  *
  */
 template< typename TElementIdentifier, typename TElement >
-const typename VectorContainer< TElementIdentifier, TElement >::Element &
+typename VectorContainer< TElementIdentifier, TElement >::const_reference
 VectorContainer< TElementIdentifier, TElement >
 ::ElementAt(ElementIdentifier id) const
 {
@@ -63,7 +63,7 @@ VectorContainer< TElementIdentifier, TElement >
  * reference.
  */
 template< typename TElementIdentifier, typename TElement >
-typename VectorContainer< TElementIdentifier, TElement >::Element &
+typename VectorContainer< TElementIdentifier, TElement >::reference
 VectorContainer< TElementIdentifier, TElement >
 ::CreateElementAt(ElementIdentifier id)
 {

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -633,6 +633,7 @@ set(ITKCommonGTests
       itkIndexRangeGTest.cxx
       itkShapedImageNeighborhoodRangeGTest.cxx
       itkSmartPointerGTest.cxx
+      itkVectorContainerGTest.cxx
       itkCommonTypeTraitsGTest.cxx
       itkMetaDataDictionaryGTest.cxx
 )

--- a/Modules/Core/Common/test/itkVectorContainerGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerGTest.cxx
@@ -1,0 +1,65 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+ // First include the header file to be tested:
+#include "itkVectorContainer.h"
+
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <string>
+
+// The tested ElementIdentifier type.
+using TestedElementIdentifierType = std::size_t;
+
+// Test template instantiations for various TElement template arguments:
+template class itk::VectorContainer<TestedElementIdentifierType, int>;
+template class itk::VectorContainer<TestedElementIdentifierType, bool>;
+template class itk::VectorContainer<TestedElementIdentifierType, std::string>;
+
+
+namespace
+{
+  template <typename TElementIdentifier, typename TElement>
+  void ExpectContainerHasValueOfCreatedElementAtIdentifier(
+    const TElementIdentifier identifier,
+    const TElement value)
+  {
+    const auto vectorContainer = itk::VectorContainer<TElementIdentifier, TElement>::New();
+
+    vectorContainer->CreateElementAt(identifier) = value;
+
+    EXPECT_EQ(vectorContainer->ElementAt(identifier), value);
+  }
+}
+
+
+// Tests that a VectorContainer has the value of an element created by
+// CreateElementAt(identifier) at the position specified by the identifier.
+TEST(VectorContainer, HasValueOfCreatedElementAtIdentifier)
+{
+  // Just pick a "pseudo-random" (magic) number as ElementIdentifier.
+  constexpr TestedElementIdentifierType magicIdentifier = 42;
+
+  ExpectContainerHasValueOfCreatedElementAtIdentifier(magicIdentifier, true);
+  ExpectContainerHasValueOfCreatedElementAtIdentifier(magicIdentifier, false);
+
+  for (int i = 0; i < 3; ++i)
+  {
+    ExpectContainerHasValueOfCreatedElementAtIdentifier(magicIdentifier, i);
+  }
+}


### PR DESCRIPTION
Fixed `itk::VectorContainer<TElementIdentifier, TElement>` compile errors
for `TElement` = `bool`:

    itkVectorContainer.h(137): error C2039: 'data': is not a member of 'std::vector<TElement,std::allocator<_Ty>>'
    itkVectorContainer.h(210): error C2440: 'return': cannot convert from 'std::_Vb_reference<std::_Wrap_alloc<std::allocator<std::_Vbase>>>' to 'bool &'
    itkVectorContainer.hxx(40): error C2440: 'return': cannot convert from 'std::_Vb_reference<std::_Wrap_alloc<std::allocator<std::_Vbase>>>' to 'bool &'

Note: These compile errors are from Visual C++ 2017, trying to compile the added GTest before fixing `itk::VectorContainer`.

Also fixes Azure.Mac-531/Darwin-Build961 errors:

    no member named 'emplace' in 'std::vector<bool>'
    no member named 'emplace_back' in 'std::vector<bool>'
    no matching constructor for initialization of 'std::vector<bool>'