### PR TITLE
COMP: Fix SymmetricEigenAnalysis support TMatrix = itk::Array2D<T>

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -420,6 +420,12 @@ private:
    *
    * To use this function:
    * using ValueType = decltype(this->GetMatrixType(true));
+   *
+   * \note The two `GetMatrixValueType` overloads have different
+   * parameter declarations (`bool` and `...`), to avoid that both
+   * functions are equally good candidates during overload resolution,
+   * in case `element_type` and `ValueType` are both nested types of
+   * `TMatrix` (which is the case when `TMatrix` = `itk::Array2D`).
    */
   template<typename QMatrix = TMatrix >
   auto GetMatrixValueType(bool) const
@@ -428,7 +434,7 @@ private:
     return QMatrix::element_type();
     }
   template<typename QMatrix = TMatrix >
-  auto GetMatrixValueType(bool) const
+  auto GetMatrixValueType(...) const
   -> typename QMatrix::ValueType
     {
     return QMatrix::ValueType();

--- a/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
@@ -19,8 +19,14 @@
 #include <iostream>
 
 #include "itkSymmetricSecondRankTensor.h"
+#include "itkArray2D.h"
 #include <iomanip>
 #include <array>
+
+
+// Test template instantiations for various supported template arguments:
+template class itk::SymmetricEigenAnalysis<vnl_matrix<double>, itk::FixedArray<double, 6>, itk::Matrix<double, 6, 6>>;
+template class itk::SymmetricEigenAnalysis<itk::Array2D<double>, vnl_diag_matrix<double>>;
 
 
 int itkSymmetricEigenAnalysisTest(int argc, char* argv[] )


### PR DESCRIPTION
Fix `SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>` compile errors
when `TMatrix` = `itk::Array2D<T>`:

    error C2668: 'SymmetricEigenAnalysis::GetMatrixValueType': ambiguous call to overloaded function

ITK4 already supported `Array2D<T>` as SymmetricEigenAnalysis template argument.