### PR TITLE
ENH: Wrap itkPCAShapeSignedDistanceFunction

### DIFF
--- a/Modules/Core/Common/wrapping/itkSpatialFunction.wrap
+++ b/Modules/Core/Common/wrapping/itkSpatialFunction.wrap
@@ -1,6 +1,7 @@
 itk_wrap_class("itk::SpatialFunction")
+UNIQUE(types "D;${WRAP_ITK_REAL}")
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_REAL})
+    foreach(t ${types})
       itk_wrap_template("${ITKM_${t}}${d}${ITKM_PD${d}}" "${ITKT_${t}},${d},${ITKT_PD${d}}")
     endforeach()
   endforeach()

--- a/Modules/Segmentation/SignedDistanceFunction/test/CMakeLists.txt
+++ b/Modules/Segmentation/SignedDistanceFunction/test/CMakeLists.txt
@@ -6,6 +6,8 @@ itkPCAShapeSignedDistanceFunctionTest.cxx
 
 CreateTestDriver(ITKSignedDistanceFunction  "${ITKSignedDistanceFunction-Test_LIBRARIES}" "${ITKSignedDistanceFunctionTests}")
 
+itk_python_expression_add_test(NAME itkPCAShapeSignedDistanceFunctionPythonTest EXPRESSION "itkPCAShapeSignedDistanceFunction = itk.PCAShapeSignedDistanceFunction.New()")
+
 itk_add_test(NAME itkSphereSignedDistanceFunctionTest
       COMMAND ITKSignedDistanceFunctionTestDriver itkSphereSignedDistanceFunctionTest)
 itk_add_test(NAME itkPCAShapeSignedDistanceFunctionTest

--- a/Modules/Segmentation/SignedDistanceFunction/wrapping/CMakeLists.txt
+++ b/Modules/Segmentation/SignedDistanceFunction/wrapping/CMakeLists.txt
@@ -1,0 +1,9 @@
+itk_wrap_module(ITKSignedDistanceFunction)
+
+set(WRAPPER_SUBMODULE_ORDER
+itkShapeSignedDistanceFunction
+itkPCAShapeSignedDistanceFunction
+)
+
+itk_auto_load_submodules()
+itk_end_wrap_module()

--- a/Modules/Segmentation/SignedDistanceFunction/wrapping/itkPCAShapeSignedDistanceFunction.wrap
+++ b/Modules/Segmentation/SignedDistanceFunction/wrapping/itkPCAShapeSignedDistanceFunction.wrap
@@ -1,0 +1,7 @@
+itk_wrap_class("itk::PCAShapeSignedDistanceFunction" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    # Can only be wrapped for `double` because of OptimizerParameters that
+    # is hardcoded as templated over `double`.
+    itk_wrap_template("${ITKM_D}${d}" "${ITKT_D},${d}")
+  endforeach()
+itk_end_wrap_class()

--- a/Modules/Segmentation/SignedDistanceFunction/wrapping/itkShapeSignedDistanceFunction.wrap
+++ b/Modules/Segmentation/SignedDistanceFunction/wrapping/itkShapeSignedDistanceFunction.wrap
@@ -1,0 +1,7 @@
+itk_wrap_include("itkSpatialFunction.h")
+
+itk_wrap_class("itk::ShapeSignedDistanceFunction" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    itk_wrap_template("${ITKM_D}${d}" "${ITKT_D},${d}")
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
`itkPCAShapeSignedDistanceFunction` was not wrapped. Wrap it for `double`
CoordRep (only type supported since OptimizerParameters is hardcoded as
templated over `double`)  and for the space dimensions that have been
selected by the user. It is only wrapped for the default image type which
is `itk::Image<double, VSpaceDimension>`.