### PR TITLE
ENH: Add probot-stale GitHub bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 120
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - 'Good first issue'
+# Label to use when marking an issue as stale
+staleLabel: 'status:Backlog'
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This is the configuration for the probot-stale GitHub App:

  https://probot.github.io/apps/stale/

that automatically close stale Issues and Pull Requests that tend to accumulate during a project.