### PR TITLE
ENH: Add test result analysis to Azure Pipelines web interface

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -20,27 +20,27 @@ jobs:
         if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
           git checkout $(System.PullRequest.SourceCommitId)
         fi
+      displayName: 'Checkout pull request HEAD'
 
-      displayName: Checkout pull request HEAD
     - bash: |
         set -x
-
         sudo pip3 install ninja
         sudo apt-get update
         sudo apt-get install -y python3-venv
+        sudo python3 -m pip install --upgrade setuptools
+        sudo python3 -m pip install scikit-ci-addons
+      displayName: 'Install dependencies'
 
-      displayName: Install dependencies
     - bash: |
         set -x
-
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
         curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
-
-      displayName: Download dashboard script and testing data
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: 'Download dashboard script and testing data'
+
     - bash: |
         set -x
 
@@ -52,5 +52,17 @@ jobs:
         export CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: 'Build and test'
+
+    - script: |
+        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
+      condition: succeededOrFailed()
+      displayName: 'Format CTest output in JUnit format'
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
+        testRunTitle: 'CTest $(Agent.OS)'
+      condition: succeededOrFailed()
+      displayName: 'Publish test results'

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -20,16 +20,17 @@ jobs:
         if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
           git checkout $(System.PullRequest.SourceCommitId)
         fi
-
       displayName: Checkout pull request HEAD
+
     - bash: |
         set -x
-
-        sudo pip3 install ninja
+        sudo python3 -m pip install ninja
         sudo apt-get update
         sudo apt-get install -y python3-venv python3-numpy python-numpy
-
+        sudo python3 -m pip install --upgrade setuptools
+        sudo python3 -m pip install scikit-ci-addons
       displayName: Install dependencies
+
     - bash: |
         set -x
 
@@ -38,9 +39,9 @@ jobs:
         curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
-
-      displayName: Download dashboard script and testing data
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Download dashboard script and testing data
+
     - script: |
         set -x
 
@@ -57,5 +58,17 @@ jobs:
         export CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Build and test
+
+    - script: |
+        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
+      condition: succeededOrFailed()
+      displayName: 'Format CTest output in JUnit format'
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
+        testRunTitle: 'CTest $(Agent.OS)'
+      condition: succeededOrFailed()
+      displayName: 'Publish test results'

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -20,25 +20,25 @@ jobs:
         if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
           git checkout $(System.PullRequest.SourceCommitId)
         fi
-
       displayName: Checkout pull request HEAD
+
     - bash: |
         set -x
-
-        sudo pip3 install ninja
-
+        sudo python3 -m pip install ninja
+        sudo python3 -m pip install --upgrade setuptools
+        sudo python3 -m pip install scikit-ci-addons
       displayName: Install dependencies
+
     - bash: |
         set -x
-
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
         curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
-
-      displayName: Download dashboard script and testing data
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Download dashboard script and testing data
+
     - script: |
         set -x
 
@@ -49,5 +49,17 @@ jobs:
         export CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Build and test
+
+    - script: |
+        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
+      condition: succeededOrFailed()
+      displayName: 'Format CTest output in JUnit format'
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
+        testRunTitle: 'CTest $(Agent.OS)'
+      condition: succeededOrFailed()
+      displayName: 'Publish test results'

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -20,14 +20,15 @@ jobs:
         if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
           git checkout $(System.PullRequest.SourceCommitId)
         fi
-
       displayName: Checkout pull request HEAD
+
     - bash: |
         set -x
-
         sudo pip3 install ninja numpy
-
+        sudo python3 -m pip install --upgrade setuptools
+        sudo python3 -m pip install scikit-ci-addons
       displayName: Install dependencies
+
     - bash: |
         set -x
 
@@ -36,12 +37,11 @@ jobs:
         curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
-
-      displayName: Download dashboard script and testing data
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Download dashboard script and testing data
+
     - bash: |
         set -x
-
         c++ --version
         cmake --version
 
@@ -51,5 +51,17 @@ jobs:
         export CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Build and test
+
+    - script: |
+        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
+      condition: succeededOrFailed()
+      displayName: 'Format CTest output in JUnit format'
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
+        testRunTitle: 'CTest $(Agent.OS)'
+      condition: succeededOrFailed()
+      displayName: 'Publish test results'

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -15,23 +15,26 @@ jobs:
     - checkout: self
       clean: true
       fetchDepth: 5
+
     - script: |
         if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
       displayName: Checkout pull request HEAD
+
     - script: |
-
         pip3 install ninja
-
+        pip3 install --upgrade setuptools
+        pip3 install scikit-ci-addons
       displayName: Install dependencies
+
     - script: |
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
         curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
-
-      displayName: Download dashboard script and testing data
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Download dashboard script and testing data
+
     - script: |
         cmake --version
 
@@ -44,5 +47,17 @@ jobs:
         set CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Build and test
+
+    - script: |
+        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
+      condition: succeededOrFailed()
+      displayName: 'Format CTest output in JUnit format'
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
+        testRunTitle: 'CTest $(Agent.OS)'
+      condition: succeededOrFailed()
+      displayName: 'Publish test results'

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -15,22 +15,26 @@ jobs:
     - checkout: self
       clean: true
       fetchDepth: 5
+
     - script: |
         if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
       displayName: Checkout pull request HEAD
+
     - script: |
         pip3 install ninja numpy
-
+        pip3 install --upgrade setuptools
+        pip3 install scikit-ci-addons
       displayName: Install dependencies
+
     - script: |
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
         curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
-
-      displayName: Download dashboard script and testing data
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Download dashboard script and testing data
+
     - script: |
         cmake --version
 
@@ -45,5 +49,17 @@ jobs:
         set CTEST_OUTPUT_ON_FAILURE=1
 
         ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      displayName: Build and test
       workingDirectory: $(Agent.BuildDirectory)
+      displayName: Build and test
+
+    - script: |
+        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
+      condition: succeededOrFailed()
+      displayName: 'Format CTest output in JUnit format'
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
+        testRunTitle: 'CTest $(Agent.OS)'
+      condition: succeededOrFailed()
+      displayName: 'Publish test results'


### PR DESCRIPTION
Using scikit-ci-addons `ctest_junit_formatter`, test result
visualizations are available in the Azure Pipelines web interface in a
build's interface under the "Tests" tab.