### PR TITLE
ENH: Use Azure batch trigger mode for CI on branches

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: true
   branches:
     include:
     - master

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: true
   branches:
     include:
     - master

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: true
   branches:
     include:
     - master

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: true
   branches:
     include:
     - master

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: true
   branches:
     include:
     - master

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: true
   branches:
     include:
     - master


### PR DESCRIPTION
Reduce the number of tiggered builds on the branches by waiting to
queue another build untill the prior build is complete. Not every
merge into master will trigger a new build.
