### PR TITLE
WIP: Make LabelObject parent a template parameter

### DIFF
--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
@@ -49,23 +49,23 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 
-template< typename TImage, typename TLabelImage =
-            Image< typename TImage::PixelType,  TImage ::ImageDimension > >
+template< typename TLabelMap,
+          typename TLabelImage = Image< typename TLabelMap::PixelType,  TLabelMap ::ImageDimension >,
+          typename TParentLabelMapFilter =  InPlaceLabelMapFilter< TLabelMap > >
 class ITK_TEMPLATE_EXPORT ShapeLabelMapFilter:
-  public
-  InPlaceLabelMapFilter< TImage >
+  public TParentLabelMapFilter
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(ShapeLabelMapFilter);
 
   /** Standard class type aliases. */
   using Self = ShapeLabelMapFilter;
-  using Superclass = InPlaceLabelMapFilter< TImage >;
+  using Superclass = TParentLabelMapFilter;
   using Pointer = SmartPointer< Self >;
   using ConstPointer = SmartPointer< const Self >;
 
   /** Some convenient type alias. */
-  using ImageType = TImage;
+  using ImageType = TLabelMap;
   using ImagePointer = typename ImageType::Pointer;
   using ImageConstPointer = typename ImageType::ConstPointer;
   using PixelType = typename ImageType::PixelType;
@@ -83,7 +83,7 @@ public:
   using LabelPixelType = typename LabelImageType::PixelType;
 
   /** ImageDimension constants */
-  static constexpr unsigned int ImageDimension = TImage::ImageDimension;
+  static constexpr unsigned int ImageDimension = TLabelMap::ImageDimension;
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -35,8 +35,8 @@
 
 namespace itk
 {
-template< typename TImage, typename TLabelImage >
-ShapeLabelMapFilter< TImage, TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::ShapeLabelMapFilter()
 {
   m_ComputeFeretDiameter = false;
@@ -44,9 +44,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
   m_ComputeOrientedBoundingBox = false;
 }
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 void
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::BeforeThreadedGenerateData()
 {
   Superclass::BeforeThreadedGenerateData();
@@ -57,7 +57,7 @@ ShapeLabelMapFilter< TImage, TLabelImage >
     if ( !m_LabelImage )
       {
       // generate an image of the labelized image
-      using LCI2IType = LabelMapToLabelImageFilter< TImage, LabelImageType >;
+      using LCI2IType = LabelMapToLabelImageFilter< TLabelMap, LabelImageType >;
       typename LCI2IType::Pointer lci2i = LCI2IType::New();
       lci2i->SetInput( this->GetOutput() );
       // Respect the number of threads of the filter
@@ -68,9 +68,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
     }
 }
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 void
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::ThreadedProcessLabelObject(LabelObjectType *labelObject)
 {
   ImageType *            output = this->GetOutput();
@@ -431,9 +431,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
     }
 }
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 void
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::ComputeFeretDiameter(LabelObjectType *labelObject)
 {
   const LabelPixelType & label = labelObject->GetLabel();
@@ -505,9 +505,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
   labelObject->SetFeretDiameter(feretDiameter);
 }
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 void
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::ComputePerimeter(LabelObjectType *labelObject)
 {
   // store the lines in a N-1D image of vectors
@@ -675,10 +675,10 @@ ShapeLabelMapFilter< TImage, TLabelImage >
   labelObject->SetPerimeterOnBorderRatio( labelObject->GetPerimeterOnBorder() / perimeter );
 }
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 template<typename TMapIntercept, typename TSpacing>
 double
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::PerimeterFromInterceptCount( TMapIntercept & intercepts, const TSpacing & spacing )
 {
   // std::cout << "PerimeterFromInterceptCount<>" << std::endl;
@@ -706,9 +706,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
 }
 
 #if ! defined(ITK_DO_NOT_USE_PERIMETER_SPECIALIZATION)
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 double
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::PerimeterFromInterceptCount( MapIntercept2Type & intercepts, const Spacing2Type spacing )
 {
   // std::cout << "PerimeterFromInterceptCount2" << std::endl;
@@ -731,9 +731,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
   return perimeter;
 }
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 double
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::PerimeterFromInterceptCount( MapIntercept3Type & intercepts, const Spacing3Type spacing )
 {
   // std::cout << "PerimeterFromInterceptCount3" << std::endl;
@@ -788,9 +788,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
 #endif
 
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 void
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::ComputeOrientedBoundingBox(LabelObjectType *labelObject)
 {
 
@@ -917,9 +917,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
 
 }
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 void
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::AfterThreadedGenerateData()
 {
   Superclass::AfterThreadedGenerateData();
@@ -928,9 +928,9 @@ ShapeLabelMapFilter< TImage, TLabelImage >
   m_LabelImage = nullptr;
 }
 
-template< typename TImage, typename TLabelImage >
+template< typename TLabelMap, typename TLabelImage, typename TParentLabelMapFilter >
 void
-ShapeLabelMapFilter< TImage, TLabelImage >
+ShapeLabelMapFilter< TLabelMap, TLabelImage, TParentLabelMapFilter >
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -38,15 +38,17 @@ namespace itk
  * \ingroup DataRepresentation
  * \ingroup ITKLabelMap
  */
-template< typename TLabel, unsigned int VImageDimension >
-class ShapeLabelObject:public LabelObject< TLabel, VImageDimension >
+template< typename TLabel,
+          unsigned int VImageDimension,
+          typename TParentLabelObject = LabelObject< TLabel, VImageDimension >  >
+class ShapeLabelObject:public TParentLabelObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(ShapeLabelObject);
 
   /** Standard class type aliases */
   using Self = ShapeLabelObject;
-  using Superclass = LabelObject< TLabel, VImageDimension >;
+  using Superclass = TParentLabelObject;
   using LabelObjectType = typename Superclass::LabelObjectType;
   using Pointer = SmartPointer< Self >;
   using ConstPointer = SmartPointer< const Self >;

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -37,22 +37,24 @@ namespace itk
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKLabelMap
  */
-template< typename TImage, typename TFeatureImage >
+template< typename TLabelMap,
+          typename TFeatureImage,
+          typename TParentLabelMapFilter = ShapeLabelMapFilter< TLabelMap,
+                                                                Image< typename TLabelMap::PixelType,  TLabelMap ::ImageDimension > > >
 class ITK_TEMPLATE_EXPORT StatisticsLabelMapFilter:
-  public ShapeLabelMapFilter< TImage,
-                              Image< typename TImage::PixelType,  TImage ::ImageDimension > >
+  public TParentLabelMapFilter
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(StatisticsLabelMapFilter);
 
   /** Standard class type aliases. */
   using Self = StatisticsLabelMapFilter;
-  using Superclass = ShapeLabelMapFilter< TImage >;
+  using Superclass = TParentLabelMapFilter;
   using Pointer = SmartPointer< Self >;
   using ConstPointer = SmartPointer< const Self >;
 
   /** Some convenient type alias. */
-  using ImageType = TImage;
+  using ImageType = TLabelMap;
   using ImagePointer = typename ImageType::Pointer;
   using ImageConstPointer = typename ImageType::ConstPointer;
   using PixelType = typename ImageType::PixelType;
@@ -68,7 +70,7 @@ public:
   using FeatureImagePixelType = typename FeatureImageType::PixelType;
 
   /** ImageDimension constants */
-  static constexpr unsigned int ImageDimension = TImage::ImageDimension;
+  static constexpr unsigned int ImageDimension = TLabelMap::ImageDimension;
 
   /** Standard New method. */
   itkNewMacro(Self);
@@ -102,7 +104,7 @@ public:
   }
 
   /** Set the input image */
-  void SetInput1(TImage *input)
+  void SetInput1(TLabelMap *input)
   {
     this->SetInput(input);
   }

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -28,8 +28,8 @@
 
 namespace itk
 {
-template< typename TImage, typename TFeatureImage >
-StatisticsLabelMapFilter< TImage, TFeatureImage >
+template< typename TLabelMap, typename TFeatureImage, typename TParentLabelMapFilter >
+StatisticsLabelMapFilter< TLabelMap, TFeatureImage, TParentLabelMapFilter >
 ::StatisticsLabelMapFilter()
 {
   m_Minimum = NumericTraits< FeatureImagePixelType >::ZeroValue();
@@ -39,9 +39,9 @@ StatisticsLabelMapFilter< TImage, TFeatureImage >
   this->SetNumberOfRequiredInputs(2);
 }
 
-template< typename TImage, typename TFeatureImage >
+template< typename TLabelMap, typename TFeatureImage, typename TParentLabelMapFilter >
 void
-StatisticsLabelMapFilter< TImage, TFeatureImage >
+StatisticsLabelMapFilter< TLabelMap, TFeatureImage, TParentLabelMapFilter >
 ::BeforeThreadedGenerateData()
 {
   Superclass::BeforeThreadedGenerateData();
@@ -58,9 +58,9 @@ StatisticsLabelMapFilter< TImage, TFeatureImage >
   m_Maximum = minMax->GetMaximum();
 }
 
-template< typename TImage, typename TFeatureImage >
+template< typename TLabelMap, typename TFeatureImage, typename TParentLabelMapFilter >
 void
-StatisticsLabelMapFilter< TImage, TFeatureImage >
+StatisticsLabelMapFilter< TLabelMap, TFeatureImage, TParentLabelMapFilter >
 ::ThreadedProcessLabelObject(LabelObjectType *labelObject)
 {
   Superclass::ThreadedProcessLabelObject(labelObject);
@@ -303,9 +303,9 @@ StatisticsLabelMapFilter< TImage, TFeatureImage >
     }
 }
 
-template< typename TImage, typename TFeatureImage >
+template< typename TLabelMap, typename TFeatureImage, typename TParentLabelMapFilter >
 void
-StatisticsLabelMapFilter< TImage, TFeatureImage >
+StatisticsLabelMapFilter< TLabelMap, TFeatureImage, TParentLabelMapFilter >
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
@@ -37,15 +37,17 @@ namespace itk
  * \ingroup DataRepresentation
  * \ingroup ITKLabelMap
  */
-template< typename TLabel, unsigned int VImageDimension >
-class StatisticsLabelObject:public ShapeLabelObject< TLabel, VImageDimension >
+template< typename TLabel,
+          unsigned int VImageDimension,
+          typename TParentLabelObject = ShapeLabelObject< TLabel, VImageDimension > >
+class StatisticsLabelObject:public TParentLabelObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(StatisticsLabelObject);
 
   /** Standard class type aliases */
   using Self = StatisticsLabelObject;
-  using Superclass = ShapeLabelObject< TLabel, VImageDimension >;
+  using Superclass = TParentLabelObject;
   using LabelObjectType = typename Superclass::LabelObjectType;
   using Pointer = SmartPointer< Self >;
   using ConstPointer = SmartPointer< const Self >;
@@ -76,6 +78,9 @@ public:
   using VectorType = Vector< double, Self::ImageDimension >;
 
   using HistogramType = Statistics::Histogram< double >;
+
+  using CentroidType = Point< double, VImageDimension >;
+
 
   using AttributeType = typename Superclass::AttributeType;
   static constexpr AttributeType MINIMUM = 200;
@@ -241,8 +246,6 @@ public:
   }
 
   using RegionType = ImageRegion< Self::ImageDimension >;
-
-  using CentroidType = typename Superclass::CentroidType;
 
   template< typename TSourceLabelObject >
   void CopyAttributesFrom( const TSourceLabelObject * src )

--- a/Modules/Filtering/LabelMap/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/test/CMakeLists.txt
@@ -594,6 +594,8 @@ itk_add_test(NAME itkStatisticsUniqueLabelMapFilterTest2
       1 100)
 
 set(ITKLabelMapGTests
-  itkShapeLabelMapFilterGTest.cxx)
+  itkShapeLabelMapFilterGTest.cxx
+  itkStatisticsLabelMapFilterGTest.cxx
+  )
 
 CreateGoogleTestDriver(ITKLabelMap "${ITKLabelMap-Test_LIBRARIES}" "${ITKLabelMapGTests}")

--- a/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
@@ -1,0 +1,56 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+
+#include "itkImage.h"
+#include "itkLabelImageToStatisticsLabelMapFilter.h"
+
+
+
+// The expected results were verified for these tests cases, unless
+// the test is marked with the "resulting value" comment. In which
+// case the baseline value was just what was computed by the method.
+
+
+
+TEST(StatisticsLabelMap,T1)
+{
+  static const unsigned int Dimension = 3;
+
+  using PixelType = float;
+  using FeatureImageType = itk::Image<PixelType, Dimension>;
+
+  using LabelType = unsigned short;
+  using LabelImageType = itk::Image<LabelType, Dimension>;
+
+  using LabelObjectParentType = itk::LabelObject<LabelType, Dimension>;
+  using LabelObjectType = itk::StatisticsLabelObject<LabelType, Dimension, LabelObjectParentType>;
+  using StatisticsLabelMapType = itk::LabelMap<LabelObjectType>;
+
+
+  using LabelizerType = itk::LabelImageToLabelMapFilter< LabelImageType, StatisticsLabelMapType >;
+
+  using LabelObjectValuatorType = itk::StatisticsLabelMapFilter< StatisticsLabelMapType,
+                                                                 FeatureImageType,
+                                                                 itk::InPlaceLabelMapFilter< StatisticsLabelMapType > >;
+
+  auto labelizerFilter = LabelizerType::New();
+
+  auto labelObjectValuatorFilter = LabelObjectValuatorType::New();
+}


### PR DESCRIPTION
Add an additional template parameter to specify the parent of the
LabelObjects.

The StatisticsLabelObject is indepenent of it's default parent the
ShapeLabelObject. Using this pattern enable the creation of filters
which do not unwantedly compute the shape attributes.
