### PR TITLE
COMP: Trailing return types (reference, const_reference) VectorContainer

### DIFF
--- a/Modules/Core/Common/include/itkVectorContainer.hxx
+++ b/Modules/Core/Common/include/itkVectorContainer.hxx
@@ -32,9 +32,9 @@ namespace itk
  * reference.
  */
 template< typename TElementIdentifier, typename TElement >
-typename VectorContainer< TElementIdentifier, TElement >::reference
+auto
 VectorContainer< TElementIdentifier, TElement >
-::ElementAt(ElementIdentifier id)
+::ElementAt(ElementIdentifier id) -> reference
 {
   this->Modified();
   return this->VectorType::operator[](id);
@@ -47,9 +47,9 @@ VectorContainer< TElementIdentifier, TElement >
  *
  */
 template< typename TElementIdentifier, typename TElement >
-typename VectorContainer< TElementIdentifier, TElement >::const_reference
+auto
 VectorContainer< TElementIdentifier, TElement >
-::ElementAt(ElementIdentifier id) const
+::ElementAt(ElementIdentifier id) const -> const_reference
 {
   return this->VectorType::operator[](id);
 }
@@ -63,9 +63,9 @@ VectorContainer< TElementIdentifier, TElement >
  * reference.
  */
 template< typename TElementIdentifier, typename TElement >
-typename VectorContainer< TElementIdentifier, TElement >::reference
+auto
 VectorContainer< TElementIdentifier, TElement >
-::CreateElementAt(ElementIdentifier id)
+::CreateElementAt(ElementIdentifier id) -> reference
 {
   if ( id >= this->VectorType::size() )
     {


### PR DESCRIPTION
Member function return types `typename VectorContainer::const_reference` and
`typename VectorContainer::reference` triggered compile errors on MSVC
(VS2017), when using /permissive- (Standards conformance), as reported by
@QuellaZhang issue #506:

    itkVectorContainer.hxx(38,1): error C2244: 'itk::VectorContainer<TElementIdentifier,TElement>::ElementAt': unable to match function definition to an existing declaration

This commit declares them as trailing return types, in order to fix this issue.