### PR TITLE
ENH: Add a PrintHelper file to overload vector printing.

### DIFF
--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -1,0 +1,49 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkPrintHelper_h
+#define itkPrintHelper_h
+
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+
+namespace itk
+{
+
+namespace print_helper
+{
+
+template< typename T >
+std::ostream & operator<<( std::ostream & os, const std::vector< T >& v )
+{
+  if( v.empty() )
+    {
+    return os << "()";
+    }
+
+  os << "(";
+  std::copy( v.begin(), v.end() - 1, std::ostream_iterator< T >( os, ", " ) );
+  return os << v.back() << ")";
+}
+
+} // end namespace print_helper
+} // end namespace itk
+
+#endif // itkPrintHelper_h

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -31,6 +31,7 @@
 #include "itkImageAlgorithm.h"
 #include "itkProgressReporter.h"
 #include "itkVector.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -55,20 +56,14 @@ void
 BSplineDecompositionImageFilter< TInputImage, TOutputImage >
 ::PrintSelf( std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Scratch: " << std::endl;
-  for( unsigned int i = 0; i < m_Scratch.size(); ++i )
-    {
-    os << indent << "[" << i << "]: " << m_Scratch[i] << std::endl;
-    }
+  os << indent << "Scratch: " << m_Scratch << std::endl;
   os << indent << "Data Length: " << m_DataLength << std::endl;
   os << indent << "Spline Order: " << m_SplineOrder << std::endl;
-  os << indent << "SplinePoles: " << std::endl;
-  for( unsigned int i = 0; i < m_SplinePoles.size(); ++i )
-    {
-    os << indent << "[" << i << "]" << m_SplinePoles[i] << std::endl;
-    }
+  os << indent << "SplinePoles: " << m_SplinePoles << std::endl;
   os << indent << "Number Of Poles: " << m_NumberOfPoles << std::endl;
   os << indent << "Tolerance: " << m_Tolerance << std::endl;
   os << indent << "Iterator Direction: " << m_IteratorDirection << std::endl;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkCastImageFilter.h"
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 #include "itkMath.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
@@ -1212,6 +1213,8 @@ void
 BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>
 ::PrintSelf( std::ostream & os, Indent indent ) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf( os, indent );
 
   os << indent << "Do multi level: " << this->m_DoMultilevel << std::endl;
@@ -1251,17 +1254,8 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>
   itkPrintSelfObjectMacro( KernelOrder2 );
   itkPrintSelfObjectMacro( KernelOrder3 );
 
-  os << indent << "Omega lattice per thread: " << std::endl;
-  for( unsigned int i = 0; i < m_OmegaLatticePerThread.size(); i++ )
-    {
-    os << indent << "[" << i <<"]: " << this->m_OmegaLatticePerThread[i] << std::endl;
-    }
-
-  os << indent << "Delta lattice per thread: " << std::endl;
-  for( unsigned int i = 0; i < m_DeltaLatticePerThread.size(); i++ )
-    {
-    os << indent << "[" << i <<"]: " << this->m_DeltaLatticePerThread[i] << std::endl;
-    }
+  os << indent << "Omega lattice per thread: " << m_OmegaLatticePerThread << std::endl;
+  os << indent << "Delta lattice per thread: " << m_DeltaLatticePerThread << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.hxx
@@ -29,6 +29,7 @@
 #define itkThresholdLabelerImageFilter_hxx
 
 #include "itkThresholdLabelerImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -67,24 +68,12 @@ void
 ThresholdLabelerImageFilter< TInputImage, TOutputImage >
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Thresholds: ";
-  auto thresholdsSize = static_cast<SizeValueType>( m_Thresholds.size() );
-  for ( SizeValueType j = 0; j < thresholdsSize; j++ )
-    {
-    os << m_Thresholds[j] << " ";
-    }
-  os << std::endl;
-
-  os << indent << "Real Thresholds: ";
-  auto realThresholdsSize = static_cast<SizeValueType>( m_RealThresholds.size() );
-  for ( SizeValueType i = 0; i < realThresholdsSize; i++ )
-    {
-    os << m_RealThresholds[i] << " ";
-    }
-  os << std::endl;
-
+  os << indent << "Thresholds: " << m_Thresholds << std::endl;
+  os << indent << "Real Thresholds: " << m_RealThresholds << std::endl;
   os << indent << "LabelOffset: " << m_LabelOffset << std::endl;
 }
 } // end namespace itk

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -20,8 +20,8 @@
 #include "itkImageRegionSplitterSlowDimension.h"
 #include <mutex>
 #include "itksys/SystemTools.hxx"
+#include "itkPrintHelper.h"
 
-#include <iterator>
 
 namespace itk
 {
@@ -1131,24 +1131,10 @@ ImageIOBase
   return axis;
 }
 
-namespace
-{
-template <typename T>
-std::ostream & operator<<( std::ostream & os, const std::vector<T>& v)
-{
-  if ( v.empty() )
-    {
-    return os << "( )";
-    }
-
-  os << "( ";
-  std::copy( v.begin(), v.end()-1, std::ostream_iterator<T>(os, ", ") );
-  return os << v.back() << " )";
-}
-}
-
 void ImageIOBase::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
 
   os << indent << "FileName: " << m_FileName << std::endl;

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -18,6 +18,7 @@
 #ifndef itkMRFImageFilter_hxx
 #define itkMRFImageFilter_hxx
 #include "itkMRFImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -51,8 +52,9 @@ void
 MRFImageFilter< TInputImage, TClassifiedImage >
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
+  using namespace print_helper;
+
   Superclass::PrintSelf(os, indent);
-  unsigned int i;
 
   os << indent << " MRF Image filter object " << std::endl;
 
@@ -70,13 +72,7 @@ MRFImageFilter< TInputImage, TClassifiedImage >
   os << indent << " Number of elements in MRF neighborhood :"
      << static_cast< SizeValueType >( m_MRFNeighborhoodWeight.size() ) << std::endl;
 
-  os << indent << " Neighborhood weight : [";
-  const auto neighborhoodWeightSize = static_cast< unsigned int >( m_MRFNeighborhoodWeight.size() );
-  for ( i = 0; i + 1 < neighborhoodWeightSize; i++ )
-    {
-    os << m_MRFNeighborhoodWeight[i] << ", ";
-    }
-  os << m_MRFNeighborhoodWeight[i] << "]" << std::endl;
+  os << indent << " Neighborhood weight : " << m_MRFNeighborhoodWeight << std::endl;
 
   os << indent << " Smoothing factor for the MRF neighborhood:"
      << m_SmoothingFactor << std::endl;


### PR DESCRIPTION
Add a new `itkPrintHelper.h` file to help in printing `std::vector`s.

Change-Id: I2306c8bf44cd0cec9661c3515c0a77cfbc34ea88