### PR TITLE
STYLE: HoughTransform2DCircles, GaussianDerivativeImageFunc member init.

### DIFF
--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
@@ -167,7 +167,7 @@ private:
   double                            m_Extent[ImageDimension2];
 
   /** Flag to indicate whether to use image spacing. */
-  bool m_UseImageSpacing;
+  bool m_UseImageSpacing{ true };
 
   /** Neighborhood Image Function. */
   const GaussianDerivativeFunctionPointer m_GaussianDerivativeFunction;

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -34,7 +34,6 @@ template< typename TInputImage, typename TOutput >
 GaussianDerivativeImageFunction< TInputImage, TOutput >
 ::GaussianDerivativeImageFunction()
   :
-  m_UseImageSpacing{true},
   m_GaussianDerivativeFunction{ GaussianDerivativeFunctionType::New() }
 {
   std::fill_n(m_Sigma, Self::ImageDimension2, 1.0);

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -210,7 +210,7 @@ private:
   double                m_MinimumRadius{ 0.0 };
   double                m_MaximumRadius{ 10.0 };
   double                m_Threshold{ 0.0 };
-  double                m_GradientNormThreshold;
+  double                m_GradientNormThreshold{ 1.0 };
   double                m_SigmaGradient{ 1.0 };
 
   RadiusImagePointer    m_RadiusImage;
@@ -218,7 +218,7 @@ private:
   CirclesListSizeType   m_NumberOfCircles{ 1 };
   double                m_DiscRadiusRatio{ 1 };
   double                m_Variance{ 10 };
-  bool                  m_UseImageSpacing;
+  bool                  m_UseImageSpacing{ true };
   ModifiedTimeType      m_OldModifiedTime{ 0 };
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -29,10 +29,7 @@ namespace itk
 {
 template< typename TInputPixelType, typename TOutputPixelType, typename TRadiusPixelType >
 HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPixelType >
-::HoughTransform2DCirclesImageFilter() :
-  m_GradientNormThreshold{ 1.0 },
-  m_UseImageSpacing{ true }
-
+::HoughTransform2DCirclesImageFilter()
 {
   this->SetNumberOfRequiredInputs( 1 );
 }


### PR DESCRIPTION
Now using C++11 in-class default member initializers, instead of constructor
member-initializer-lists, for `m_GradientNormThreshold` and `m_UseImageSpacing`,
in `HoughTransform2DCirclesImageFilter` and `GaussianDerivativeImageFunction`.

This has the advantage the initial (default) values will appear in Doxygen
generated ITK documentation.

Follow-up to b21dbbb2938911206d9259d3777b163d257031cd
(@hjmjohnson, December 17, 2018, "STYLE: Use default member initialization")