### PR TITLE
BUG: Disable Python tests if `ITK_BUILD_DEFAULT_MODULES` is OFF

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -965,7 +965,7 @@ endmacro()
 if(NOT EXTERNAL_WRAP_ITK_PROJECT)
 
   # Add the Python tests
-  if(BUILD_TESTING AND ITK_SOURCE_DIR)
+  if(BUILD_TESTING AND ITK_SOURCE_DIR AND ITK_BUILD_DEFAULT_MODULES)
     add_subdirectory(Tests)
   endif()
 


### PR DESCRIPTION
In ITK 4.13, the Python tests have not been moved to their corresponding
module. This means that if the module the test is testing has been
disabled, the test will fail. To avoid that problem, the Python tests
are disabled if `ITK_BUILD_DEFAULT_MODULES` is OFF.