### PR TITLE
STYLE: Instance variables should be private

### DIFF
--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -138,6 +138,14 @@ protected:
 
   void CreateTransform(TransformPointer & ptr, const std::string & ClassName);
 
+  /* The following struct returns the string name of computation type */
+  /* default implementation */
+  static inline const std::string GetTypeNameString()
+    {
+    itkGenericExceptionMacro(<< "Unknown ScalarType" << typeid(ScalarType).name());
+    }
+
+private:
   std::string            m_FileName;
   TransformListType      m_ReadTransformList;
   ConstTransformListType m_WriteTransformList;
@@ -145,12 +153,6 @@ protected:
   /** Should we compress the data? */
   bool                   m_UseCompression{false};
 
-  /* The following struct returns the string name of computation type */
-  /* default implementation */
-  static inline const std::string GetTypeNameString()
-    {
-    itkGenericExceptionMacro(<< "Unknown ScalarType" << typeid(ScalarType).name());
-    }
 };
 
 

--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.hxx
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.hxx
@@ -142,7 +142,7 @@ HDF5TransformIOTemplate<TParametersValueType>
 
   // Set the storage format type
   const H5::PredType h5StorageIdentifier{ GetH5TypeFromString( ) };
-  if(this->m_UseCompression)
+  if(this->GetUseCompression())
   {
     // Set compression information
     // set up properties for chunked, compressed writes.


### PR DESCRIPTION
Class instance variables should be private, unless well documented
performance issues can be overcome by allowing them to be protected.

The one location were derived class used instance variable directly
was not benefiting (performance wise) significantly to justify
making the variables protected.