### PR TITLE
DOC: Change GitHub community template guidelines to HTML comment markup.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,53 +4,64 @@ labels: type:Bug
 about: File a bug report to help us improve ITK
 ---
 
-[Before submitting an issue, please check that your issue hasn't been already
-filed]
+<!-- The text within this markup is a comment, and is intended to provide
+guidelines to open an issue for the ITK repository. This text will not
+be part of the issue. -->
+
+
+<!-- Before submitting an issue, please check that your issue has not been
+already filed. -->
 
 ### Description
 
-[Description of the bug]
+<!-- Description of the bug. -->
 
 ### Steps to Reproduce
 
+<!--
 1. [First Step]
 2. [Second Step]
 3. [and so on...]
 
-[Provide a minimal, complete, compilable, and verifiable example (commonly
-abbreviated as MWE, minimal working example) or code snippet, either through a
-[GitHub gist](https://gist.github.com/) or providing your own files (including
-your source code, `CMakeLists.txt` file and your data) reproducing the issue or
-clearly showing where your concern lies.
+Provide a minimal, complete, compilable, and verifiable example (commonly
+abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSEE,
+Short, Self Contained, Correct (Compilable) Example, SSCCE) or code snippet,
+either through a GitHub gist (https://gist.github.com/) or providing your own
+files (including your source code, `CMakeLists.txt` file if applicable, and your
+data) reproducing the issue or showing an incorrect result. -->
 
 ### Expected behavior
 
-[What you expect to happen]
+<!-- What you expect to happen. -->
 
 ### Actual behavior
 
-[What actually happens]
+<!-- What actually happens. Include the relevant build error trace. -->
+```none
+```
 
 ### Reproducibility
 
-[What percentage of the time does it reproduce?]
+<!-- What percentage of the time does it reproduce? -->
 
 ### Versions
 
-[If a tagged version, you can get this information by inspecting the
+<!-- If a tagged version, you can get this information by inspecting the
 `ITK_VERSION_MAJOR` `ITK_VERSION_MINOR` and `ITK_VERSION_PATCH` variable
-values in the `ITKConfig.cmake` file]
+values in the `ITKConfig.cmake` file.
 
-[If the commit number is required, run `$ git rev-parse --short HEAD`]
+If the commit number is required, run `$ git rev-parse --short HEAD`. -->
 
 ### Environment
 
-[Which your OS and compiler are]
+<!-- Which your OS, CMake, and compiler versions are, or your Python and
+installed package versions are. -->
 
 ### Additional Information
 
-[Any additional information, configuration or data that might be necessary to reproduce the issue.]
+<!-- Any additional information, configuration or data that might be necessary
+to reproduce the issue. -->
 
 
-Note: Use issues for their purpose; issues are not for code help. Need help? Ask
-your question at [https://discourse.itk.org/](https://discourse.itk.org/)
+<!-- **Note**: Use issues for their purpose; issues are not for code help. Need
+help? Ask your question at ITK discourse (https://discourse.itk.org/). -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,25 +4,31 @@ labels: type:Enhancement
 about: Suggest a feature request or idea to improve ITK
 ---
 
-[Before submitting an issue, please check that your issue hasn't been already
-filed]
+<!-- The text within this markup is a comment, and is intended to provide
+guidelines to open an issue for the ITK repository. This text will not
+be part of the issue. -->
+
+
+<!-- Before submitting an issue, please check that your issue has not been
+already filed. -->
 
 ### Description
 
-[Description of the feature request]
+<!-- Description of the feature request. -->
 
 ### Expected behavior
 
-[What you expect to happen]
+<!-- What you expect to happen. -->
 
 ### Actual behavior
 
-[What actually happens]
+<!-- What actually happens. -->
 
 ### Additional Information
 
-[Any additional information, configuration or data that might be necessary to reproduce the issue.]
+<!-- Any additional information, configuration or data that might be necessary
+to reproduce the issue. -->
 
 
-Note: Use issues for their purpose; issues are not for code help. Need help? Ask
-your question at [https://discourse.itk.org/](https://discourse.itk.org/)
+<!-- **Note**: Use issues for their purpose; issues are not for code help. Need
+help? Ask your question at ITK discourse (https://discourse.itk.org/). -->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,7 +1,9 @@
+<!-- The text within this markup is a comment, and is intended to provide
+guidelines to open a Pull Request for the ITK repository. This text will not
+be part of the Pull Request. -->
 
-*This is a reminder of what a message in a pull request should minimally require. Please, **read the guidelines below**, and **delete** them so your pull request description only contains the intended message.*
 
-See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:
+<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:
 
 Start ITK commit messages with a standard prefix (and a space):
 
@@ -15,10 +17,14 @@ Start ITK commit messages with a standard prefix (and a space):
 
 Provide a short, meaningful message that describes the change you made.
 
-When the PR is based on a single commit, the commit message is usually left as the PR message.
+When the PR is based on a single commit, the commit message is usually left as
+the PR message.
 
-A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)
+A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
+in your repository. You can automatically
+close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)
 
-[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.
+@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
+of the person or team responsible for reviewing proposed changes. -->
 
-**Thanks for contributing to ITK!**
+<!-- **Thanks for contributing to ITK!** -->


### PR DESCRIPTION
Change GitHub community template guidelines to HTML comment markup. This
allows the guidelines to be displayed when opening a PR or an issue, but
will not be part of them.

Take advantage of the commit to improve the `bug_report.md` template
guidelines.