### PR TITLE
BUG: Use VERSION_GREATER_EQUAL for PIE check

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -21,7 +21,7 @@
 
 include(ITK_CheckCCompilerFlag)
 include(ITK_CheckCXXCompilerFlag)
-if(CMAKE_VERSION GREATER_EQUAL 3.14.0)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14.0)
   include(CheckPIESupported)
   check_pie_supported()
 endif()

--- a/Modules/ThirdParty/VNL/src/vxl/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/CMakeLists.txt
@@ -60,7 +60,7 @@ CHECK_CXX_COMPILER_FLAG(-Wno-undefined-var-template HAS_NO_UNDEFINED_VAR_TEMPLAT
 if( HAS_NO_UNDEFINED_VAR_TEMPLATE )
   add_definitions( -Wno-undefined-var-template )
 endif()
-if(CMAKE_VERSION GREATER_EQUAL 3.14.0)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14.0)
   include(CheckPIESupported)
   check_pie_supported()
 endif()


### PR DESCRIPTION
String comparison is not necessarily correct.