### PR TITLE
STYLE: Improved GaussianDerivativeImageFunction identifiers

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -320,6 +320,9 @@ type (`TRadiusPixelType`), a floating point type is often preferred, whereas for
 output pixel type (`TOutputPixelType`), an unsigned integer type is often more appropriate.
 
 `GaussianDerivativeImageFunction::ImageDimension2` is renamed to `GaussianDerivativeImageFunction::ImageDimension`.
+The nested `GaussianDerivativeImageFunction` types `GaussianDerivativeFunctionType` and
+`GaussianDerivativeFunctionPointer` are renamed to `GaussianDerivativeSpatialFunctionType` and
+`GaussianDerivativeSpatialFunctionPointer`, respectively.
 
 With ITK 5.0, `itk::ProcessObject::VerifyPreconditions()`  and
 `itk::ProcessObject::VerifyInputInformation` are now declared `const`,

--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -319,6 +319,8 @@ pixel type should be the same as `TOutputPixelType`. However, it appears that fo
 type (`TRadiusPixelType`), a floating point type is often preferred, whereas for the accumulator
 output pixel type (`TOutputPixelType`), an unsigned integer type is often more appropriate.
 
+`GaussianDerivativeImageFunction::ImageDimension2` is renamed to `GaussianDerivativeImageFunction::ImageDimension`.
+
 With ITK 5.0, `itk::ProcessObject::VerifyPreconditions()`  and
 `itk::ProcessObject::VerifyInputInformation` are now declared `const`,
 so if you have overridden these virtual member function, make sure that you

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
@@ -91,8 +91,13 @@ public:
   using OutputType = typename Superclass::OutputType;
   using OperatorArrayType = FixedArray< OperatorNeighborhoodType, Self::ImageDimension >;
 
-  using GaussianDerivativeFunctionType = GaussianDerivativeSpatialFunction< TOutput, 1 >;
-  using GaussianDerivativeFunctionPointer = typename GaussianDerivativeFunctionType::Pointer;
+  using GaussianDerivativeSpatialFunctionType = GaussianDerivativeSpatialFunction< TOutput, 1 >;
+  using GaussianDerivativeSpatialFunctionPointer = typename GaussianDerivativeSpatialFunctionType::Pointer;
+
+#if !defined( ITK_LEGACY_REMOVE )
+  using GaussianDerivativeFunctionType = GaussianDerivativeSpatialFunctionType;
+  using GaussianDerivativeFunctionPointer = GaussianDerivativeSpatialFunctionPointer;
+#endif
 
   /** Point type alias support */
   // using PointType = Point< TOutput, Self::ImageDimension >;
@@ -174,7 +179,7 @@ private:
   bool m_UseImageSpacing{ true };
 
   /** Neighborhood Image Function. */
-  const GaussianDerivativeFunctionPointer m_GaussianDerivativeFunction;
+  const GaussianDerivativeSpatialFunctionPointer m_GaussianDerivativeSpatialFunction;
 };
 } // namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
@@ -75,23 +75,27 @@ public:
   using IndexType = typename InputImageType::IndexType;
 
   /** Dimension of the underlying image. */
-  static constexpr unsigned int ImageDimension2 = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+
+#if !defined( ITK_LEGACY_REMOVE )
+  static constexpr unsigned int ImageDimension2 = ImageDimension;
+#endif
 
   using ContinuousIndexType =
-      ContinuousIndex< SpacePrecisionType, Self::ImageDimension2 >;
+      ContinuousIndex< SpacePrecisionType, Self::ImageDimension >;
 
-  using NeighborhoodType = Neighborhood< InputPixelType, Self::ImageDimension2 >;
-  using OperatorNeighborhoodType = Neighborhood< TOutput, Self::ImageDimension2 >;
+  using NeighborhoodType = Neighborhood< InputPixelType, Self::ImageDimension >;
+  using OperatorNeighborhoodType = Neighborhood< TOutput, Self::ImageDimension >;
 
-  using VectorType = Vector< TOutput, Self::ImageDimension2 >;
+  using VectorType = Vector< TOutput, Self::ImageDimension >;
   using OutputType = typename Superclass::OutputType;
-  using OperatorArrayType = FixedArray< OperatorNeighborhoodType, Self::ImageDimension2 >;
+  using OperatorArrayType = FixedArray< OperatorNeighborhoodType, Self::ImageDimension >;
 
   using GaussianDerivativeFunctionType = GaussianDerivativeSpatialFunction< TOutput, 1 >;
   using GaussianDerivativeFunctionPointer = typename GaussianDerivativeFunctionType::Pointer;
 
   /** Point type alias support */
-  // using PointType = Point< TOutput, Self::ImageDimension2 >;
+  // using PointType = Point< TOutput, Self::ImageDimension >;
   using PointType = typename InputImageType::PointType;
 
   /** Evaluate the function at the specified point. */
@@ -155,16 +159,16 @@ protected:
 
 private:
 
-  double                            m_Sigma[ImageDimension2];
+  double                            m_Sigma[ImageDimension];
 
   /** Array of 1D operators. Contains a derivative kernel for
    * each dimension. Note: A future version of ITK could extend this array
    * to include a Gaussian blurring kernel for each dimension.*/
   OperatorArrayType         m_OperatorArray;
 
-  std::vector<Offset<ImageDimension2>> m_ImageNeighborhoodOffsets[ImageDimension2];
+  std::vector<Offset<ImageDimension>> m_ImageNeighborhoodOffsets[ImageDimension];
 
-  double                            m_Extent[ImageDimension2];
+  double                            m_Extent[ImageDimension];
 
   /** Flag to indicate whether to use image spacing. */
   bool m_UseImageSpacing{ true };

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -34,11 +34,11 @@ template< typename TInputImage, typename TOutput >
 GaussianDerivativeImageFunction< TInputImage, TOutput >
 ::GaussianDerivativeImageFunction()
   :
-  m_GaussianDerivativeFunction{ GaussianDerivativeFunctionType::New() }
+  m_GaussianDerivativeSpatialFunction{ GaussianDerivativeSpatialFunctionType::New() }
 {
   std::fill_n(m_Sigma, Self::ImageDimension, 1.0);
   std::fill_n(m_Extent, Self::ImageDimension, 1.0);
-  m_GaussianDerivativeFunction->SetNormalized(false); // faster
+  m_GaussianDerivativeSpatialFunction->SetNormalized(false); // faster
 }
 
 template< typename TInputImage, typename TOutput >
@@ -168,16 +168,16 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
       {
       // Set the derivative of the Gaussian first
       OperatorNeighborhoodType dogNeighborhood;
-      typename GaussianDerivativeFunctionType::InputType pt;
+      typename GaussianDerivativeSpatialFunctionType::InputType pt;
       typename NeighborhoodType::SizeType size;
       size.Fill(0);
       size[direction] = static_cast<SizeValueType>( m_Sigma[direction] * m_Extent[direction] );
       dogNeighborhood.SetRadius(size);
       m_ImageNeighborhoodOffsets[direction] = Experimental::GenerateRectangularImageNeighborhoodOffsets(size);
 
-      typename GaussianDerivativeFunctionType::ArrayType s;
+      typename GaussianDerivativeSpatialFunctionType::ArrayType s;
       s[0] = m_Sigma[direction];
-      m_GaussianDerivativeFunction->SetSigma(s);
+      m_GaussianDerivativeSpatialFunction->SetSigma(s);
 
       typename OperatorNeighborhoodType::Iterator it = dogNeighborhood.Begin();
 
@@ -189,7 +189,7 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
       while ( it != dogNeighborhood.End() )
         {
         pt[0] = dogNeighborhood.GetOffset(i)[direction] * directionSpacing;
-        ( *it ) = m_GaussianDerivativeFunction->Evaluate(pt);
+        ( *it ) = m_GaussianDerivativeSpatialFunction->Evaluate(pt);
         ++i;
         ++it;
         }
@@ -270,8 +270,8 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
   os << indent << "Extent: " << m_Extent << std::endl;
 
   os << indent << "OperatorArray: " << m_OperatorArray << std::endl;
-  os << indent << "GaussianDerivativeFunction: "
-     << m_GaussianDerivativeFunction << std::endl;
+  os << indent << "GaussianDerivativeSpatialFunction: "
+     << m_GaussianDerivativeSpatialFunction << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -36,8 +36,8 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
   :
   m_GaussianDerivativeFunction{ GaussianDerivativeFunctionType::New() }
 {
-  std::fill_n(m_Sigma, Self::ImageDimension2, 1.0);
-  std::fill_n(m_Extent, Self::ImageDimension2, 1.0);
+  std::fill_n(m_Sigma, Self::ImageDimension, 1.0);
+  std::fill_n(m_Extent, Self::ImageDimension, 1.0);
   m_GaussianDerivativeFunction->SetNormalized(false); // faster
 }
 
@@ -57,16 +57,16 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
 {
   unsigned int i;
 
-  for ( i = 0; i < Self::ImageDimension2; i++ )
+  for ( i = 0; i < Self::ImageDimension; i++ )
     {
     if ( sigma[i] != m_Sigma[i] )
       {
       break;
       }
     }
-  if ( i < Self::ImageDimension2 )
+  if ( i < Self::ImageDimension )
     {
-    for ( i = 0; i < Self::ImageDimension2; i++ )
+    for ( i = 0; i < Self::ImageDimension; i++ )
       {
       m_Sigma[i] = sigma[i];
       }
@@ -81,16 +81,16 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
 {
   unsigned int i;
 
-  for ( i = 0; i < Self::ImageDimension2; i++ )
+  for ( i = 0; i < Self::ImageDimension; i++ )
     {
     if ( Math::NotExactlyEquals(sigma, m_Sigma[i]) )
       {
       break;
       }
     }
-  if ( i < Self::ImageDimension2 )
+  if ( i < Self::ImageDimension )
     {
-    for ( i = 0; i < Self::ImageDimension2; i++ )
+    for ( i = 0; i < Self::ImageDimension; i++ )
       {
       m_Sigma[i] = sigma;
       }
@@ -105,16 +105,16 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
 {
   unsigned int i;
 
-  for ( i = 0; i < Self::ImageDimension2; i++ )
+  for ( i = 0; i < Self::ImageDimension; i++ )
     {
     if ( extent[i] != m_Extent[i] )
       {
       break;
       }
     }
-  if ( i < Self::ImageDimension2 )
+  if ( i < Self::ImageDimension )
     {
-    for ( i = 0; i < Self::ImageDimension2; i++ )
+    for ( i = 0; i < Self::ImageDimension; i++ )
       {
       m_Extent[i] = extent[i];
       }
@@ -129,16 +129,16 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
 {
   unsigned int i;
 
-  for ( i = 0; i < Self::ImageDimension2; i++ )
+  for ( i = 0; i < Self::ImageDimension; i++ )
     {
     if ( Math::NotExactlyEquals(extent, m_Extent[i]) )
       {
       break;
       }
     }
-  if ( i < Self::ImageDimension2 )
+  if ( i < Self::ImageDimension )
     {
-    for ( i = 0; i < Self::ImageDimension2; i++ )
+    for ( i = 0; i < Self::ImageDimension; i++ )
       {
       m_Extent[i] = extent;
       }
@@ -164,7 +164,7 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
     using SpacingType = typename TInputImage::SpacingType;
     const SpacingType spacing = m_UseImageSpacing ? inputImage->GetSpacing() : SpacingType(1);
 
-    for ( unsigned int direction = 0; direction < Self::ImageDimension2; ++direction )
+    for ( unsigned int direction = 0; direction < Self::ImageDimension; ++direction )
       {
       // Set the derivative of the Gaussian first
       OperatorNeighborhoodType dogNeighborhood;
@@ -211,7 +211,7 @@ GaussianDerivativeImageFunction< TInputImage, TOutput >
 
   const TInputImage* const image = this->GetInputImage();
 
-  for ( unsigned int direction = 0; direction < Self::ImageDimension2; ++direction )
+  for ( unsigned int direction = 0; direction < Self::ImageDimension; ++direction )
     {
     // Note: A future version of ITK should do Gaussian blurring here.
 

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -18,7 +18,7 @@
 
 #include "itkGaussianDerivativeImageFunction.h"
 #include "itkTestingMacros.h"
-
+#include <type_traits> // For std::is_same.
 
 template< typename TPixel >
 int TestGaussianDerivativeImageFunction()
@@ -158,6 +158,14 @@ int itkGaussianDerivativeImageFunctionTest( int, char* [] )
 #if !defined( ITK_LEGACY_REMOVE )
   static_assert(DoGFunctionType::ImageDimension2 == DoGFunctionType::ImageDimension,
     "Check legacy support for ImageDimension2");
+  static_assert(std::is_same<
+    DoGFunctionType::GaussianDerivativeFunctionType,
+    DoGFunctionType::GaussianDerivativeSpatialFunctionType>::value,
+    "Check legacy support for GaussianDerivativeFunctionType");
+  static_assert(std::is_same<
+    DoGFunctionType::GaussianDerivativeFunctionPointer,
+    DoGFunctionType::GaussianDerivativeSpatialFunctionPointer>::value,
+    "Check legacy support for GaussianDerivativeFunctionPointer");
 #endif
 
   DoGFunctionType::Pointer DoG = DoGFunctionType::New();

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -155,6 +155,11 @@ int itkGaussianDerivativeImageFunctionTest( int, char* [] )
 
   using DoGFunctionType = itk::GaussianDerivativeImageFunction< ImageType >;
 
+#if !defined( ITK_LEGACY_REMOVE )
+  static_assert(DoGFunctionType::ImageDimension2 == DoGFunctionType::ImageDimension,
+    "Check legacy support for ImageDimension2");
+#endif
+
   DoGFunctionType::Pointer DoG = DoGFunctionType::New();
 
   EXERCISE_BASIC_OBJECT_METHODS( DoG, GaussianDerivativeImageFunction, ImageFunction );


### PR DESCRIPTION
Renamed nested `GaussianDerivativeImageFunction` identifiers to improve code readability:

 * `ImageDimension2` to `ImageDimension`
 * `GaussianDerivativeFunctionType` to `GaussianDerivativeSpatialFunctionType`
 * `GaussianDerivativeFunctionPointer` to `GaussianDerivativeSpatialFunctionPointer`
 * `m_GaussianDerivativeFunction` to `m_GaussianDerivativeSpatialFunction`