### PR TITLE
COMP: Remove casts away qualifiers warning

### DIFF
--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -499,13 +499,9 @@ public:
   bool                       m_WithinThreadPreProcess{false};
   bool                       m_WithinThreadPostProcess{false};
 
-  void                           GetValueMultiThreadedPreProcessInitiate() const;
-
   void                           GetValueMultiThreadedInitiate() const;
 
   void                           GetValueMultiThreadedPostProcessInitiate() const;
-
-  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION  GetValueMultiThreadedPreProcess(void *arg);
 
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION  GetValueMultiThreaded(void *arg);
 
@@ -528,13 +524,9 @@ public:
     bool itkNotUsed(withinSampleThread) ) const
   {}
 
-  void                          GetValueAndDerivativeMultiThreadedPreProcessInitiate() const;
-
   void                          GetValueAndDerivativeMultiThreadedInitiate() const;
 
   void                          GetValueAndDerivativeMultiThreadedPostProcessInitiate() const;
-
-  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION GetValueAndDerivativeMultiThreadedPreProcess(void *arg);
 
   static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION GetValueAndDerivativeMultiThreaded(void *arg);
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -1134,18 +1134,6 @@ ImageToImageMetric< TFixedImage, TMovingImage >
 template< typename TFixedImage, typename TMovingImage  >
 void
 ImageToImageMetric< TFixedImage, TMovingImage >
-::GetValueMultiThreadedPreProcessInitiate() const
-{
-  this->SynchronizeTransforms();
-
-  m_Threader->SetSingleMethod( GetValueMultiThreadedPreProcess,
-                               (void *)( &m_ThreaderParameter ) );
-  m_Threader->SingleMethodExecute();
-}
-
-template< typename TFixedImage, typename TMovingImage  >
-void
-ImageToImageMetric< TFixedImage, TMovingImage >
 ::GetValueMultiThreadedInitiate() const
 {
   this->SynchronizeTransforms();
@@ -1170,26 +1158,6 @@ ImageToImageMetric< TFixedImage, TMovingImage >
   m_Threader->SingleMethodExecute();
 }
 
-/**
- * Get the match Measure
- */
-template< typename TFixedImage, typename TMovingImage  >
-ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
-ImageToImageMetric< TFixedImage, TMovingImage >
-::GetValueMultiThreadedPreProcess(void *arg)
-{
-  ThreadIdType                threadId;
-  MultiThreaderParameterType *mtParam;
-
-  threadId = ( (MultiThreaderType::WorkUnitInfo *)( arg ) )->WorkUnitID;
-
-  mtParam = (MultiThreaderParameterType *)
-            ( ( (MultiThreaderType::WorkUnitInfo *)( arg ) )->UserData );
-
-  mtParam->metric->GetValueThreadPreProcess(threadId, false);
-
-  return ITK_THREAD_RETURN_DEFAULT_VALUE;
-}
 
 /**
  * Get the match Measure
@@ -1297,18 +1265,6 @@ ImageToImageMetric< TFixedImage, TMovingImage >
 template< typename TFixedImage, typename TMovingImage  >
 void
 ImageToImageMetric< TFixedImage, TMovingImage >
-::GetValueAndDerivativeMultiThreadedPreProcessInitiate() const
-{
-  this->SynchronizeTransforms();
-
-  m_Threader->SetSingleMethod( GetValueAndDerivativeMultiThreadedPreProcess,
-                               (void *)( &m_ThreaderParameter ) );
-  m_Threader->SingleMethodExecute();
-}
-
-template< typename TFixedImage, typename TMovingImage  >
-void
-ImageToImageMetric< TFixedImage, TMovingImage >
 ::GetValueAndDerivativeMultiThreadedInitiate() const
 {
   this->SynchronizeTransforms();
@@ -1331,27 +1287,6 @@ ImageToImageMetric< TFixedImage, TMovingImage >
   m_Threader->SetSingleMethod( GetValueAndDerivativeMultiThreadedPostProcess,
                                (void *)( &m_ThreaderParameter ) );
   m_Threader->SingleMethodExecute();
-}
-
-/**
- * Get the match Measure
- */
-template< typename TFixedImage, typename TMovingImage  >
-ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
-ImageToImageMetric< TFixedImage, TMovingImage >
-::GetValueAndDerivativeMultiThreadedPreProcess(void *arg)
-{
-  ThreadIdType                threadId;
-  MultiThreaderParameterType *mtParam;
-
-  threadId = ( (MultiThreaderType::WorkUnitInfo *)( arg ) )->WorkUnitID;
-
-  mtParam = (MultiThreaderParameterType *)
-            ( ( (MultiThreaderType::WorkUnitInfo *)( arg ) )->UserData );
-
-  mtParam->metric->GetValueAndDerivativeThreadPreProcess(threadId, false);
-
-  return ITK_THREAD_RETURN_DEFAULT_VALUE;
 }
 
 /**

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -214,6 +214,31 @@ int TestMattesMetricWithAffineTransform(
   metric->SetUseCachingOfBSplineWeights( useCachingBSplineWeights );
   metric->ReinitializeSeed(121212);
 
+  metric->SetFixedImageSamplesIntensityThreshold(100);
+  if( metric->GetFixedImageSamplesIntensityThreshold() != 100 )
+  {
+    std::cout << "ERROR: SetFixedImageSamplesIntensityThreshold(100) failed: " << __FILE__ << " " << __LINE__ << std::endl;
+    return EXIT_FAILURE;
+  }
+  metric->SetFixedImageSamplesIntensityThreshold(0); //This should be the default, but exercise the function explicitly.
+  if( metric->GetFixedImageSamplesIntensityThreshold() != 0 )
+  {
+    std::cout << "ERROR: SetFixedImageSamplesIntensityThreshold(0) failed: " << __FILE__ << " " << __LINE__ << std::endl;
+    return EXIT_FAILURE;
+  }
+  metric->UseAllPixelsOn();
+  if( metric->GetUseAllPixels() != true )
+  {
+    std::cout << "ERROR: UseAllPixelsOn() failed: " << __FILE__ << " " << __LINE__ << std::endl;
+    return EXIT_FAILURE;
+  }
+  metric->UseAllPixelsOff(); //This should be the default, but exercise this function explicitly.
+  if( metric->GetUseAllPixels() != false )
+  {
+    std::cout << "ERROR: UseAllPixelsOff() failed: " << __FILE__ << " " << __LINE__ << std::endl;
+    return EXIT_FAILURE;
+  }
+
   if( useSampling )
     {
     // set the number of samples to use


### PR DESCRIPTION
Modules/Registration/Common/include/itkImageToImageMetric.hxx:1331:3:
warning: cast from type 'const itk::ImageToImageMetric<itk::Image<float, 2u>, itk::Image<float, 2u> >::MultiThreaderParameterType*' to type 'void*' casts away qualifiers [-Wcast-qual]