### PR TITLE
BUG: Fixes crashes in unit tests when argv[0] == nullptr

### DIFF
--- a/Modules/Core/Common/test/itkColorTableTest.cxx
+++ b/Modules/Core/Common/test/itkColorTableTest.cxx
@@ -176,7 +176,7 @@ int itkColorTableTest( int argc, char* argv[] )
 {
   if( argc != 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " numberOfColors" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " numberOfColors" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Core/Common/test/itkDirectoryTest.cxx
+++ b/Modules/Core/Common/test/itkDirectoryTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkDirectory.h"
+#include "itkTestingMacros.h"
 
 int itkDirectoryTest(int argc, char *argv[])
 {
@@ -24,7 +25,7 @@ int itkDirectoryTest(int argc, char *argv[])
 
   if (argc < 2)
     {
-    std::cerr << "Usage: " << argv[0] << " directory" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " directory" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Core/Common/test/itkGaussianDerivativeOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkGaussianDerivativeOperatorTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkGaussianDerivativeOperator.h"
 #include "itkStdStreamStateSave.h"
+#include "itkTestingMacros.h"
 
 namespace
 {
@@ -100,7 +101,7 @@ int itkGaussianDerivativeOperatorTest( int argc, char *argv[] )
     }
   else if ( argc > 1 )
     {
-    std::cerr << "Usage: " << argv[0] << " [ variance error width order ]" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " [ variance error width order ]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Core/Common/test/itkGaussianSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkGaussianSpatialFunctionTest.cxx
@@ -24,7 +24,7 @@ int itkGaussianSpatialFunctionTest( int argc, char* argv[] )
 {
   if ( argc < 3 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " scale normalized" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Core/Common/test/itkImageFillBufferTest.cxx
+++ b/Modules/Core/Common/test/itkImageFillBufferTest.cxx
@@ -18,12 +18,13 @@
 
 #include <iostream>
 #include "itkImage.h"
+#include "itkTestingMacros.h"
 
 int itkImageFillBufferTest(int argc, char * argv[])
 {
   if( argc != 2 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " imageSize (GB). It can be a decimal value.";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -22,6 +22,7 @@
 #include <fstream>
 #include "itkLineIterator.h"
 #include "itkTimeProbe.h"
+#include "itkTestingMacros.h"
 
 
 int itkLineIteratorTest(int argc, char*argv[])
@@ -34,7 +35,7 @@ int itkLineIteratorTest(int argc, char*argv[])
  if (argc < 2)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "   baselinefilename" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "   baselinefilename" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Core/Common/test/itkLoggerManagerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerManagerTest.cxx
@@ -20,6 +20,7 @@
 #include <fstream>
 #include "itkStdStreamLogOutput.h"
 #include "itkLoggerManager.h"
+#include "itkTestingMacros.h"
 
 class LogTester
 {
@@ -55,7 +56,7 @@ int itkLoggerManagerTest( int argc, char *argv [] )
     {
     if (argc < 2)
       {
-      std::cout << "Usage: " << argv[0] << " logFilename" << std::endl;
+      std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " logFilename" << std::endl;
       return EXIT_FAILURE;
       }
 

--- a/Modules/Core/Common/test/itkLoggerOutputTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerOutputTest.cxx
@@ -20,6 +20,7 @@
 #include <fstream>
 #include "itkStdStreamLogOutput.h"
 #include "itkLoggerOutput.h"
+#include "itkTestingMacros.h"
 
 
 int itkLoggerOutputTest( int argc, char *argv [] )
@@ -28,7 +29,7 @@ int itkLoggerOutputTest( int argc, char *argv [] )
     {
     if (argc < 2)
       {
-      std::cout << "Usage: " << argv[0] << " logFilename" << std::endl;
+      std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " logFilename" << std::endl;
       return EXIT_FAILURE;
       }
 

--- a/Modules/Core/Common/test/itkLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerTest.cxx
@@ -20,6 +20,7 @@
 #include <fstream>
 #include "itkStdStreamLogOutput.h"
 #include "itkLogger.h"
+#include "itkTestingMacros.h"
 
 class LogTester
 {
@@ -55,7 +56,7 @@ int itkLoggerTest( int argc, char *argv [] )
     {
     if (argc < 2)
       {
-      std::cout << "Usage: " << argv[0] << " logFilename" << std::endl;
+      std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " logFilename" << std::endl;
       return EXIT_FAILURE;
       }
 

--- a/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
@@ -22,6 +22,7 @@
 #include "itkStdStreamLogOutput.h"
 #include "itkLoggerBase.h"
 #include "itkMultiThreaderBase.h"
+#include "itkTestingMacros.h"
 
 /** \class SimpleLogger
  *  \brief Class SimpleLogger is meant to demonstrate how to change the formatting of the LoggerBase mechanism
@@ -180,7 +181,7 @@ int itkLoggerThreadWrapperTest( int argc, char * argv[] )
     {
     if (argc < 2)
       {
-      std::cout << "Usage: " << argv[0] << " logFilename [num threads, default = 10]" << std::endl;
+      std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " logFilename [num threads, default = 10]" << std::endl;
       return EXIT_FAILURE;
       }
 

--- a/Modules/Core/Common/test/itkMultipleLogOutputTest.cxx
+++ b/Modules/Core/Common/test/itkMultipleLogOutputTest.cxx
@@ -20,6 +20,7 @@
 #include <fstream>
 #include "itkStdStreamLogOutput.h"
 #include "itkMultipleLogOutput.h"
+#include "itkTestingMacros.h"
 
 
 int itkMultipleLogOutputTest( int argc, char *argv [] )
@@ -28,7 +29,7 @@ int itkMultipleLogOutputTest( int argc, char *argv [] )
     {
     if (argc < 2)
       {
-      std::cout << "Usage: " << argv[0] << " logFilename" << std::endl;
+      std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " logFilename" << std::endl;
       return EXIT_FAILURE;
       }
 

--- a/Modules/Core/Common/test/itkStdStreamLogOutputTest.cxx
+++ b/Modules/Core/Common/test/itkStdStreamLogOutputTest.cxx
@@ -20,6 +20,7 @@
 #include <fstream>
 #include "itkStdStreamLogOutput.h"
 #include "itkStdStreamStateSave.h"
+#include "itkTestingMacros.h"
 
 int itkStdStreamLogOutputTest( int argc, char *argv [] )
 {
@@ -33,7 +34,7 @@ int itkStdStreamLogOutputTest( int argc, char *argv [] )
 
     if (argc < 2)
       {
-      std::cout << "Usage: " << argv[0] << " logFilename" << std::endl;
+      std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " logFilename" << std::endl;
       return EXIT_FAILURE;
       }
 

--- a/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
@@ -22,6 +22,7 @@
 #include "itkArray2D.h"
 #include <iomanip>
 #include <array>
+#include "itkTestingMacros.h"
 
 
 // Test template instantiations for various supported template arguments:
@@ -36,7 +37,7 @@ int itkSymmetricEigenAnalysisTest(int argc, char* argv[] )
   std::array<unsigned int, 2> testUseEigenLibraryIndices{{0, 2}};
   if(argc > 2)
     {
-    std::cerr << "Usage: " << argv[0] << "[onlyEigen|onlyLegacy]\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << "[onlyEigen|onlyLegacy]\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/Core/Common/test/itkThreadLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadLoggerTest.cxx
@@ -21,6 +21,7 @@
 #include "itkStdStreamLogOutput.h"
 #include "itkThreadLogger.h"
 #include "itkMultiThreaderBase.h"
+#include "itkTestingMacros.h"
 
 
 struct ThreadDataStruct
@@ -113,7 +114,7 @@ int itkThreadLoggerTest( int argc, char * argv[] )
     {
     if (argc < 2)
       {
-      std::cout << "Usage: " << argv[0] << " logFilename [num threads, default = 10]" << std::endl;
+      std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " logFilename [num threads, default = 10]" << std::endl;
       return EXIT_FAILURE;
       }
 

--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -72,7 +72,7 @@ int itkBSplineDecompositionImageFilterTest( int argc, char* argv[] )
 {
   if( argc != 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " splineOrder";
     std::cerr << " splinePoles(e.g. 0.12753,-0.48673,0.76439,\
                  [0.12753,-0.48673,0.76439],\

--- a/Modules/Core/Mesh/test/itkMeshFstreamTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshFstreamTest.cxx
@@ -18,12 +18,13 @@
 
 #include <fstream>
 #include "itkMesh.h"
+#include "itkTestingMacros.h"
 
 int itkMeshFstreamTest(int argc, char* argv[] )
 {
   if (argc < 2)
     {
-    std::cout << "Usage: " << argv[0] << " logFilename" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " logFilename" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkMesh.h"
 #include "itkParametricSpaceToImageSpaceMeshFilter.h"
+#include "itkTestingMacros.h"
 
 template< class TPosition >
 struct helper
@@ -64,7 +65,7 @@ int InternalTest(int argc, char* argv[])
 {
   if( argc != 2 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input ";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
@@ -23,12 +23,13 @@
 #include "itkGroupSpatialObject.h"
 #include "itkSpatialObjectToImageFilter.h"
 #include "itkBoxSpatialObject.h"
+#include "itkTestingMacros.h"
 
 int itkBoxSpatialObjectTest( int argc, char *argv[] )
 {
   if (argc < 2)
     {
-    std::cerr << "Missing Parameters: Usage " << argv[0] << "OutputImageFile"
+    std::cerr << "Missing Parameters: Usage " << itkNameOfTestExecutableMacro(argv) << "OutputImageFile"
                                         << std::endl;
     }
 

--- a/Modules/Core/SpatialObjects/test/itkMetaGaussianConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaGaussianConverterTest.cxx
@@ -43,7 +43,7 @@ int itkMetaGaussianConverterTest(int argc, char* argv[])
   // Check number of arguments
   if (argc != 2)
     {
-    std::cerr << "Usage: " << argv[0] << " output" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Core/TestKernel/include/itkTestingMacros.h
+++ b/Modules/Core/TestKernel/include/itkTestingMacros.h
@@ -215,4 +215,14 @@ CLANG_PRAGMA_POP    \
     return EXIT_FAILURE; \
   } \
   object->Set##variable( value );
+
+/** The name of the executable, argv[0], is not always available as argv[0] may be null.
+ * In that case, use the name of the test function.
+*/
+#define itkNameOfTestExecutableMacro(argv) [argv](const std::string& functionName) \
+  { \
+    return ((argv == nullptr) || (argv[0] == nullptr) || (argv[0][0] == '\0')) ? \
+      ("<" + functionName + " executable>") : argv[0]; \
+  }(__func__)
+
 #endif

--- a/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
@@ -19,6 +19,7 @@
 #include <iostream>
 
 #include "itkCenteredRigid2DTransform.h"
+#include "itkTestingMacros.h"
 
 
 namespace
@@ -47,7 +48,7 @@ int itkCenteredRigid2DTransformTest(int argc, char *argv[] )
 {
   if( argc < 1 )
     {
-    std::cout << "Usage: " << argv[0] << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -20,6 +20,7 @@
 
 #include "itkEuler2DTransform.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 
 namespace
@@ -48,7 +49,7 @@ int itkEuler2DTransformTest(int argc, char *argv[] )
 {
   if( argc < 1 )
     {
-    std::cout << "Usage: " << argv[0] << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/AntiAlias/test/itkAntiAliasBinaryImageFilterTest.cxx
+++ b/Modules/Filtering/AntiAlias/test/itkAntiAliasBinaryImageFilterTest.cxx
@@ -79,7 +79,7 @@ int itkAntiAliasBinaryImageFilterTest(int argc, char * argv [] )
     {
     std::cerr << "Missing arguments." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " outputImage " << std::endl;
     return EXIT_FAILURE;
     }
   const char * outputImage = argv[1];

--- a/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkN4BiasFieldCorrectionImageFilter.h"
 #include "itkOtsuThresholdImageFilter.h"
 #include "itkShrinkImageFilter.h"
+#include "itkTestingMacros.h"
 
 template<typename TFilter>
 class CommandIterationUpdate : public itk::Command
@@ -329,7 +330,7 @@ int itkN4BiasFieldCorrectionImageFilterTest( int argc, char *argv[] )
 {
   if ( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0] << " imageDimension inputImage "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " imageDimension inputImage "
               << "outputLogControlPointLattice [shrinkFactor,default=1] "
               << "[numberOfIterations,default=100x50x50] "
               << " [maskImageWithLabelEqualTo1] [splineDistance,default=200]"

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryClosingByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryClosingByReconstructionImageFilterTest.cxx
@@ -21,6 +21,7 @@
 
 #include "itkBinaryBallStructuringElement.h"
 #include "itkBinaryClosingByReconstructionImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkBinaryClosingByReconstructionImageFilterTest(int argc, char * argv[])
@@ -28,7 +29,7 @@ int itkBinaryClosingByReconstructionImageFilterTest(int argc, char * argv[])
 
   if( argc != 6 )
     {
-    std::cerr << "usage: " << argv[0] << " input output conn fg kernelSize" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output conn fg kernelSize" << std::endl;
     // std::cerr << "  : " << std::endl;
     exit(1);
     }

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalClosingImageFilterTest.cxx
@@ -21,13 +21,14 @@
 
 #include "itkBinaryMorphologicalClosingImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int itkBinaryMorphologicalClosingImageFilterTest(int argc, char * argv[])
 {
   if( argc < 6 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage Radius SafeBorder Foreground" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalOpeningImageFilterTest.cxx
@@ -21,13 +21,14 @@
 
 #include "itkBinaryMorphologicalOpeningImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int itkBinaryMorphologicalOpeningImageFilterTest(int argc, char * argv[])
 {
   if( argc < 6 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage Radius Background Foreground" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
@@ -21,6 +21,7 @@
 
 #include "itkBinaryBallStructuringElement.h"
 #include "itkBinaryOpeningByReconstructionImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkBinaryOpeningByReconstructionImageFilterTest(int argc, char * argv[])
@@ -28,7 +29,7 @@ int itkBinaryOpeningByReconstructionImageFilterTest(int argc, char * argv[])
 
   if( argc != 6 )
     {
-    std::cerr << "usage: " << argv[0] << " input output conn fg kernelSize" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output conn fg kernelSize" << std::endl;
     // std::cerr << "  : " << std::endl;
     exit(1);
     }

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryThinningImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryThinningImageFilterTest.cxx
@@ -20,12 +20,13 @@
 #include "itkBinaryThinningImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int itkBinaryThinningImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
@@ -108,7 +108,7 @@ int itkCustomColormapFunctionTest( int argc, char* argv[] )
 
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0] <<
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) <<
       " customColormapFile scalarValue" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterTest.cxx
@@ -31,7 +31,7 @@ int itkScalarToRGBColormapImageFilterTest( int argc, char *argv[] )
 {
   if ( argc < 4 )
     {
-    std::cout << "Usage: " << argv[0] <<
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) <<
       " inputImage outputImage colormap [customColormapFile]" << std::endl;
     std::cout <<
       "  Possible colormaps: grey, red, green, blue, copper, jet, hsv, ";

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
@@ -19,12 +19,13 @@
 #include "itkConvolutionImageFilter.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int itkConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
 {
   if ( argc < 3 )
     {
-    std::cout << "Usage: " << argv[0] << " kernelImage outputImage" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " kernelImage outputImage" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
@@ -20,13 +20,14 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkConvolutionImageFilterTest(int argc, char * argv[])
 {
 
   if ( argc < 4 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImage kernelImage outputImage [normalizeImage]" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
@@ -26,7 +26,7 @@ int itkFFTConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
 {
   if ( argc < 3 )
     {
-    std::cout << "Usage: " << argv[0] << " kernelImage outputImage sizeGreatestPrimeFactor" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " kernelImage outputImage sizeGreatestPrimeFactor" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
@@ -31,7 +31,7 @@ int itkFFTConvolutionImageFilterTest( int argc, char * argv[] )
 
   if ( argc < 4 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImage "
       << "kernelImage "
       << "outputImage "

--- a/Modules/Filtering/Convolution/test/itkFFTNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTNormalizedCorrelationImageFilterTest.cxx
@@ -21,13 +21,14 @@
 #include "itkImageFileWriter.h"
 #include "itkShiftScaleImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkFFTNormalizedCorrelationImageFilterTest(int argc, char * argv[] )
 {
   if( argc < 4 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " fixedImageName movingImageName outputImageName [requiredFractionOfOverlappingPixels]" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " fixedImageName movingImageName outputImageName [requiredFractionOfOverlappingPixels]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
@@ -21,13 +21,14 @@
 #include "itkImageFileWriter.h"
 #include "itkShiftScaleImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkMaskedFFTNormalizedCorrelationImageFilterTest(int argc, char * argv[] )
 {
   if( argc < 4 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " fixedImageName movingImageName outputImageName [requiredFractionOfOverlappingPixels] [fixedMaskName] [movingMaskName]" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " fixedImageName movingImageName outputImageName [requiredFractionOfOverlappingPixels] [fixedMaskName] [movingMaskName]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowTest.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkCastImageFilter.h"
 #include "itkStreamingImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 namespace
@@ -87,7 +88,7 @@ int itkCurvatureFlowTest(int argc, char* argv[] )
   if( argc < 2 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  outputFile" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  outputFile" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/Deconvolution/test/itkInverseDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkInverseDeconvolutionImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkInverseDeconvolutionImageFilterTest(int argc, char * argv[])
 
   if ( argc < 4 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImage kernelImage outputImage [normalizeImage]" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/Deconvolution/test/itkLandweberDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkLandweberDeconvolutionImageFilterTest.cxx
@@ -24,12 +24,13 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkMacro.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int itkLandweberDeconvolutionImageFilterTest(int argc, char* argv[])
 {
   if ( argc < 5 )
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " <input image> <kernel image> <output image> <iterations> [convolution image]"
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
@@ -109,7 +109,7 @@ int itkParametricBlindLeastSquaresDeconvolutionImageFilterTest(int argc, char* a
 {
   if ( argc < 6 )
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " <input image> <output image> <iterations> <alpha> <beta> [convolution image]"
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Deconvolution/test/itkProjectedLandweberDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkProjectedLandweberDeconvolutionImageFilterTest.cxx
@@ -20,12 +20,13 @@
 #include "itkImageFileWriter.h"
 #include "itkProjectedLandweberDeconvolutionImageFilter.h"
 #include "itkDeconvolutionIterationCommand.h"
+#include "itkTestingMacros.h"
 
 int itkProjectedLandweberDeconvolutionImageFilterTest(int argc, char* argv[])
 {
   if ( argc < 5 )
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " <input image> <kernel image> <output image> <iterations> [convolution image]"
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Deconvolution/test/itkRichardsonLucyDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkRichardsonLucyDeconvolutionImageFilterTest.cxx
@@ -22,12 +22,13 @@
 #include "itkRichardsonLucyDeconvolutionImageFilter.h"
 #include "itkDeconvolutionIterationCommand.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkRichardsonLucyDeconvolutionImageFilterTest(int argc, char* argv[])
 {
   if ( argc < 5 )
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " <input image> <kernel image> <output image> <iterations> [convolution image]"
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Deconvolution/test/itkTikhonovDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkTikhonovDeconvolutionImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkTikhonovDeconvolutionImageFilterTest(int argc, char * argv[])
 
   if ( argc < 4 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImage kernelImage outputImage [normalizeImage]" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/Deconvolution/test/itkWienerDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkWienerDeconvolutionImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkWienerDeconvolutionImageFilterTest(int argc, char * argv[])
 
   if ( argc < 4 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImage kernelImage outputImage [normalizeImage]" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
@@ -68,7 +68,7 @@ int itkPatchBasedDenoisingImageFilterDefaultTest( int argc, char * argv [] )
   if( argc < 3 )
   {
     std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage : " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " inputImageFileName outputImageFileName"
               << " numDimensions"
               << std::endl;

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -302,7 +302,7 @@ int itkPatchBasedDenoisingImageFilterTest( int argc, char * argv [] )
   if( argc < 6 )
     {
     std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage : " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " inputImageFileName outputImageFileName"
               << " numDimensions numComponents"
               << " kernelBandwithSigma"

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -160,7 +160,7 @@ int itkDisplacementFieldTransformTest( int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " coordinateTolerance directionTolerance";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkInverseDisplacementFieldImageFilter.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkInverseDisplacementFieldImageFilterTest( int argc, char * argv[] )
 {
@@ -26,7 +27,7 @@ int itkInverseDisplacementFieldImageFilterTest( int argc, char * argv[] )
   if( argc < 2 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkIterativeInverseDisplacementFieldImageFilter.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 
 int itkIterativeInverseDisplacementFieldImageFilterTest( int argc, char * argv[] )
@@ -27,7 +28,7 @@ int itkIterativeInverseDisplacementFieldImageFilterTest( int argc, char * argv[]
   if( argc < 2 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
@@ -21,6 +21,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include <fstream>
+#include "itkTestingMacros.h"
 
 
 int itkLandmarkDisplacementFieldSourceTest( int argc, char * argv[] )
@@ -29,7 +30,7 @@ int itkLandmarkDisplacementFieldSourceTest( int argc, char * argv[] )
   if( argc < 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " landmarksFile outputImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkBSplineTransform.h"
 #include "itkTransformToDisplacementFieldFilter.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int itkTransformToDisplacementFieldFilterTest( int argc, char * argv [] )
 {
@@ -27,7 +28,7 @@ int itkTransformToDisplacementFieldFilterTest( int argc, char * argv [] )
   if( argc < 3 )
     {
     std::cerr << "Usage: ";
-    std::cerr << argv[0] << "<transformName> <displacementFieldFileName> [bSplineParametersFile]" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "<transformName> <displacementFieldFileName> [bSplineParametersFile]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterTest.cxx
@@ -52,7 +52,7 @@ int itkApproximateSignedDistanceMapImageFilterTest( int argc, char* argv[] )
   if(argc < 3)
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " insideValue outputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " insideValue outputImage" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileWriter.h"
 
 #include "itkSignedMaurerDistanceMapImageFilter.h"
+#include "itkTestingMacros.h"
 
 // Convenience function to template over dimension and avoid code duplication.
 template< unsigned int ImageDimension>
@@ -60,7 +61,7 @@ int itkSignedMaurerDistanceMapImageFilterTest( int argc, char * argv[] )
 {
   if( argc < 3 )
   {
-    std::cerr << "Usage: " << argv[0] << " InputImage OutputImage [ImageDimension]\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage [ImageDimension]\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
@@ -37,6 +37,7 @@
 #include "itkComplexToComplexFFTImageFilter.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
+#include "itkTestingMacros.h"
 
 template< typename TPixel, unsigned int VDimension >
 int transformImage( const char * inputImageFileName, const char * outputImageFileName )
@@ -93,7 +94,7 @@ int itkComplexToComplexFFTImageFilterTest( int argc, char * argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0] << " <InputImage> <OutputImage> <float|double>" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <InputImage> <OutputImage> <float|double>" << std::endl;
     return EXIT_FAILURE;
     }
   const char * inputImageFileName = argv[1];

--- a/Modules/Filtering/FFT/test/itkFFTPadImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTPadImageFilterTest.cxx
@@ -25,13 +25,14 @@
 #include "itkZeroFluxNeumannBoundaryCondition.h"
 #include "itkPeriodicBoundaryCondition.h"
 #include "itkConstantBoundaryCondition.h"
+#include "itkTestingMacros.h"
 
 int itkFFTPadImageFilterTest( int argc, char * argv[] )
 {
   if( argc < 5 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile outputImageFile greatestPrimeFactor padType" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile outputImageFile greatestPrimeFactor padType" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/FFT/test/itkFFTShiftImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTShiftImageFilterTest.cxx
@@ -21,13 +21,14 @@
 
 #include "itkSimpleFilterWatcher.h"
 #include "itkFFTShiftImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkFFTShiftImageFilterTest(int argc, char * argv[])
 {
 
   if( argc != 4 )
     {
-    std::cerr << "usage: " << argv[0] << " inputImage outputImage inverse" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage inverse" << std::endl;
     std::cerr << "  inputImage: The input image." << std::endl;
     std::cerr << "  outputImage: The output image." << std::endl;
     std::cerr << "  inverse: 0, to perform a forward transform, or 1 to perform" << std::endl;

--- a/Modules/Filtering/FFT/test/itkForwardInverseFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkForwardInverseFFTImageFilterTest.cxx
@@ -28,12 +28,13 @@
 #endif
 
 #include "itkForwardInverseFFTTest.h"
+#include "itkTestingMacros.h"
 
 int itkForwardInverseFFTImageFilterTest(int argc, char* argv[])
 {
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0] << " <input file> " << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <input file> " << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/FFT/test/itkFullToHalfHermitianImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFullToHalfHermitianImageFilterTest.cxx
@@ -23,13 +23,14 @@
 #include "itkFullToHalfHermitianImageFilter.h"
 #include "itkRandomImageSource.h"
 #include "itkRealToHalfHermitianForwardFFTImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkFullToHalfHermitianImageFilterTest(int argc, char *argv[])
 {
   // Print usage information.
   if ( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << " <test image size x> <test image size y>"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <test image size x> <test image size y>"
               << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
@@ -22,13 +22,14 @@
 #include "itkHalfToFullHermitianImageFilter.h"
 #include "itkRandomImageSource.h"
 #include "itkRealToHalfHermitianForwardFFTImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkHalfToFullHermitianImageFilterTest(int argc, char *argv[])
 {
   // Print usage information.
   if ( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << " <test image size x> <test image size y>"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <test image size x> <test image size y>"
               << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkVnlComplexToComplexFFTImageFilter.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
+#include "itkTestingMacros.h"
 
 template< typename TPixel, unsigned int VDimension >
 int transformImage( const char * inputImageFileName, const char * outputImageFileName )
@@ -75,7 +76,7 @@ int itkVnlComplexToComplexFFTImageFilterTest( int argc, char * argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0] << " <InputImage> <OutputImage> <float|double>" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <InputImage> <OutputImage> <float|double>" << std::endl;
     return EXIT_FAILURE;
     }
   const char * inputImageFileName = argv[1];

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageTopologicalTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageTopologicalTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkLabelContourImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 template <unsigned int VDimension>
@@ -258,7 +259,7 @@ int itkFastMarchingImageTopologicalTest( int argc, char *argv[] )
 {
   if( argc < 6 )
     {
-    std::cerr << "Usage: " << argv[0] << " imageDimension";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " imageDimension";
     std::cerr << " speedImage outputImage seedImage ";
     std::cerr << " stoppingValue [checkTopology] [otherFilePrefix]"
       << std::endl;

--- a/Modules/Filtering/ImageCompare/test/itkCheckerBoardImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkCheckerBoardImageFilterTest.cxx
@@ -26,7 +26,7 @@ int itkCheckerBoardImageFilterTest( int argc, char* argv[] )
 {
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " outputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
@@ -25,7 +25,7 @@ int itkConstrainedValueDifferenceImageFilterTest( int argc, char* argv[] )
 {
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << "outputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkSTAPLEImageFilter.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 class StaplerBase
 {
@@ -158,7 +159,7 @@ int itkSTAPLEImageFilterTest( int argc, char * argv[])
 
   if (argc < 5)
     {
-    std::cerr << "Use: " << argv[0] <<
+    std::cerr << "Use: " << itkNameOfTestExecutableMacro(argv) <<
       " file_dimensionality output.mhd foreground_value confidence_weight "
       "file1 file2 ... fileN" << std::endl;
     return -1;

--- a/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkTestingComparisonImageFilterTest(int argc, char *argv [] )
   if( argc < 7 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0];
+    std::cerr << itkNameOfTestExecutableMacro(argv);
     std::cerr << "  inputImageFile1 inputImageFile2 outputImage threshold radius numberOfPixelsWithDifferences" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageCompose/test/itkComposeRGBAImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkComposeRGBAImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkComposeImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkComposeRGBAImageFilterTest(int argc, char* argv[])
 {
@@ -31,7 +32,7 @@ int itkComposeRGBAImageFilterTest(int argc, char* argv[])
     {
     std::cerr << "Error: missing arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " outputFile inputFileR inputFileG inputFileB inputFileA" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " outputFile inputFileR inputFileG inputFileB inputFileA" << std::endl;
     }
 
   try

--- a/Modules/Filtering/ImageCompose/test/itkImageReadRealAndImaginaryWriteComplexTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkImageReadRealAndImaginaryWriteComplexTest.cxx
@@ -33,12 +33,13 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkComposeImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkImageReadRealAndImaginaryWriteComplexTest( int argc, char * argv[] )
 {
   if( argc != 4 )
     {
-    std::cerr << "Usage: " << argv[0] << " inputReal inputImaginary outputComplex" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputReal inputImaginary outputComplex" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageCompose/test/itkImageToVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkImageToVectorImageFilterTest.cxx
@@ -20,6 +20,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageSeriesWriter.h"
+#include "itkTestingMacros.h"
 
 int itkImageToVectorImageFilterTest(int argc, char *argv[] )
 {
@@ -37,7 +38,7 @@ int itkImageToVectorImageFilterTest(int argc, char *argv[] )
   if (argc < 3)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  input1 input2 ... inputn output" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  input1 input2 ... inputn output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterStreamingTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterStreamingTest.cxx
@@ -22,6 +22,7 @@
 #include "itkJoinSeriesImageFilter.h"
 #include "itkExtractImageFilter.h"
 #include "itkPipelineMonitorImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkJoinSeriesImageFilterStreamingTest(int argc, char* argv[] )
 {
@@ -36,7 +37,7 @@ int itkJoinSeriesImageFilterStreamingTest(int argc, char* argv[] )
 
   if ( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << " InputImage OutputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest.cxx
@@ -30,7 +30,7 @@ int itkCannyEdgeDetectionImageFilterTest( int argc, char * argv[] )
 {
   if(argc < 3)
     {
-    std::cerr << "Usage: " << argv[0] << " InputImage OutputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageFeature/test/itkDerivativeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkDerivativeImageFilterTest.cxx
@@ -22,13 +22,14 @@
 #include "itkImageFileWriter.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkDerivativeImageFilterTest(int argc, char *argv [] )
 {
   if( argc < 5 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile normalizedOutputImageFile ";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile normalizedOutputImageFile ";
     std::cerr << " derivativeOrder direction" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterTest.cxx
@@ -34,7 +34,7 @@ int itkDiscreteGaussianDerivativeImageFilterTest( int argc, char* argv[] )
   if( argc < 6 )
     {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << "inputFileName"
         " outputFileName"
         " orderX"

--- a/Modules/Filtering/ImageFeature/test/itkHessianToObjectnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianToObjectnessMeasureImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkHessianToObjectnessMeasureImageFilterTest( int argc, char *argv[] )
   if ( argc < 3 )
     {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " inputImage"
               << " outputImage [ObjectDimension] [Bright/Dark]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/ImageFeature/test/itkLaplacianRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianRecursiveGaussianImageFilterTest.cxx
@@ -22,13 +22,14 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkZeroCrossingImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkLaplacianRecursiveGaussianImageFilterTest(int argc, char* argv[])
 {
   if( argc < 3)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage " << std::endl;
     return -1;
     }
 

--- a/Modules/Filtering/ImageFeature/test/itkMultiScaleHessianBasedMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkMultiScaleHessianBasedMeasureImageFilterTest.cxx
@@ -21,13 +21,14 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkMultiScaleHessianBasedMeasureImageFilterTest( int argc, char *argv[] )
 {
   if ( argc < 4 )
     {
     std::cerr << "Missing Parameters: "
-              << argv[0]
+              << itkNameOfTestExecutableMacro(argv)
               << " InputImage"
               << " EnhancedOutputImage ScalesOutputImage "
               << " [SigmaMin SigmaMax NumberOfScales ObjectDimension Bright/Dark EnhancedOutputImage2 ScalesOutputImage3]" << std::endl;

--- a/Modules/Filtering/ImageFeature/test/itkSimpleContourExtractorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkSimpleContourExtractorImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkSimpleContourExtractorImageFilterTest( int argc, char* argv [] )
     {
     std::cerr << "Missing arguments." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage " << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
@@ -81,7 +81,7 @@ itkFrequencyBandImageFilterTest( int argc, char* argv[] )
 
   if ( argc != 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " Even|Odd" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Even|Odd" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageFusion/test/itkLabelOverlayImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelOverlayImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkLabelOverlayImageFilter.h"
 #include "itkVectorImage.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 
 int itkLabelOverlayImageFilterTest(int argc, char * argv[])
@@ -31,7 +32,7 @@ int itkLabelOverlayImageFilterTest(int argc, char * argv[])
   if( argc < 5 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage  LabelImage Opacity OutputImage" << std::endl;
     return 1;
     }

--- a/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkLabelToRGBImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkLabelToRGBImageFilterTest(int argc, char * argv[])
@@ -29,7 +30,7 @@ int itkLabelToRGBImageFilterTest(int argc, char * argv[])
   if( argc < 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " LabelImage OutputImage" << std::endl;
     return 1;
     }

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
@@ -136,7 +136,7 @@ int itkBSplineControlPointImageFilterTest( int argc, char *argv[] )
 {
   if ( argc < 5 )
     {
-    std::cerr << "Usage: " << argv[0] << " imageDimension inputControlPointImage"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " imageDimension inputControlPointImage"
               << " outputSampledBSplineObject outputSampledBSplineObjectRefined"
               << std::endl;
     exit( EXIT_FAILURE );

--- a/Modules/Filtering/ImageGrid/test/itkBSplineDownsampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineDownsampleImageFilterTest.cxx
@@ -32,6 +32,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkBSplineDownsampleImageFilterTest( int argc, char * argv [] )
 {
@@ -40,7 +41,7 @@ int itkBSplineDownsampleImageFilterTest( int argc, char * argv [] )
     {
     std::cerr << "Error: Missing arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "inputImage outputImage splineOrder" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "inputImage outputImage splineOrder" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
@@ -33,7 +33,7 @@ int itkBSplineScatteredDataPointSetToImageFilterTest( int argc, char * argv [] )
 
   if ( argc != 3 )
     {
-    std::cout << "Usage: " << argv[0] << " inputImage outputImage" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineUpsampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineUpsampleImageFilterTest.cxx
@@ -32,6 +32,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkBSplineUpsampleImageFilterTest( int argc, char * argv [] )
 {
@@ -40,7 +41,7 @@ int itkBSplineUpsampleImageFilterTest( int argc, char * argv [] )
     {
     std::cerr << "Error: Missing arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "inputImage outputImage splineOrder" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "inputImage outputImage splineOrder" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "itkCoxDeBoorBSplineKernelFunction.h"
+#include "itkTestingMacros.h"
 
 /**
  * In this test, we check to see that the coefficients that are
@@ -25,7 +26,7 @@ int itkCoxDeBoorBSplineKernelFunctionTest( int argc, char * argv [] )
 {
   if ( argc < 1 )
     {
-    std::cerr << "Usage: " << argv[0] << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkCyclicShiftImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCyclicShiftImageFilterTest.cxx
@@ -21,12 +21,13 @@
 #include "itkImageFileReader.h"
 
 #include <iostream>
+#include "itkTestingMacros.h"
 
 int itkCyclicShiftImageFilterTest(int argc, char * argv[])
 {
   if ( argc != 4 )
     {
-    std::cerr << "Usage: " << argv[0] << " inputImage shiftX shiftY" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputImage shiftX shiftY" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkFlipImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkFlipImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkFlipImageFilterTest( int argc, char* argv[] )
   if( argc != 2 )
     {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0] << " FlipAboutOrigin" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " FlipAboutOrigin" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkPasteImageFilterTest( int argc, char* argv[] )
 {
   if(argc < 4)
     {
-    std::cerr << "Usage: " << argv[0] << " DestinationImage SourceImage OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DestinationImage SourceImage OutputImage\n";
     return -1;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkPushPopTileImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPushPopTileImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkTileImageFilter.h"
 #include "itkImageFileReader.h"
 #include "itkImageSeriesWriter.h"
+#include "itkTestingMacros.h"
 
 int itkPushPopTileImageFilterTest(int argc, char *argv[] )
 {
@@ -36,7 +37,7 @@ int itkPushPopTileImageFilterTest(int argc, char *argv[] )
   if (argc != 6)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  input1 input2 input3 input4 output" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  input1 input2 input3 input4 output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
@@ -54,7 +54,7 @@ int itkSliceBySliceImageFilterTest(int argc, char * argv[])
 
   if( argc != 4 )
     {
-    std::cerr << "usage: " << argv[0] << " input output slicingDimension" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output slicingDimension" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkTileImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkTileImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageSeriesWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkTileImageFilterTest(int argc, char *argv[] )
 {
@@ -37,7 +38,7 @@ int itkTileImageFilterTest(int argc, char *argv[] )
   if (argc < 6)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  iSize jSize kSize input1 input2 ... inputn output" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  iSize jSize kSize input1 input2 ... inputn output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkVectorResampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkVectorResampleImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkVectorResampleImageFilterTest( int argc, char * argv[] )
   if( argc < 2 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageIntensity/test/itkAndImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAndImageFilterTest.cxx
@@ -25,7 +25,7 @@ int itkAndImageFilterTest( int argc, char* argv[] )
 {
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << "outputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageIntensity/test/itkConstrainedValueAdditionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkConstrainedValueAdditionImageFilterTest.cxx
@@ -26,7 +26,7 @@ int itkConstrainedValueAdditionImageFilterTest( int argc, char* argv[] )
 {
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << "outputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageIntensity/test/itkInvertIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkInvertIntensityImageFilterTest.cxx
@@ -30,7 +30,7 @@ int itkInvertIntensityImageFilterTest( int argc, char * argv[] )
   {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageIntensity/test/itkMagnitudeAndPhaseToComplexImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMagnitudeAndPhaseToComplexImageFilterTest.cxx
@@ -39,7 +39,7 @@ int itkMagnitudeAndPhaseToComplexImageFilterTest( int argc, char * argv[] )
 {
   if( argc != 4 )
     {
-    std::cerr << "Usage: " << argv[0] << " inputMagnitude inputPhase outputComplex" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputMagnitude inputPhase outputComplex" << std::endl;
     return EXIT_FAILURE;
     }
   const char * magnitudeImageFileName = argv[1];

--- a/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
@@ -26,7 +26,7 @@ int itkMatrixIndexSelectionImageFilterTest( int argc, char* argv[] )
   if( argc < 1 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageIntensity/test/itkModulusImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkModulusImageFilterTest.cxx
@@ -30,7 +30,7 @@ int itkModulusImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageIntensity/test/itkOrImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkOrImageFilterTest.cxx
@@ -26,7 +26,7 @@ int itkOrImageFilterTest( int argc, char* argv[] )
 {
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << "outputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageIntensity/test/itkPolylineMask2DImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPolylineMask2DImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkPolyLineParametricPath.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int itkPolylineMask2DImageFilterTest(int argc, char * argv [] )
 {
@@ -28,7 +29,7 @@ int itkPolylineMask2DImageFilterTest(int argc, char * argv [] )
     {
     std::cerr << "Error: missing arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputFilename outputFilename " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename outputFilename " << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
@@ -31,7 +31,7 @@ int itkPolylineMaskImageFilterTest( int argc, char * argv[] )
 
   if ( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputFilename" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageIntensity/test/itkPromoteDimensionImageTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPromoteDimensionImageTest.cxx
@@ -20,13 +20,14 @@
 #include "itkImageFileWriter.h"
 #include "itkCastImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkPromoteDimensionImageTest(int argc, char* argv[])
 {
   if( argc < 3)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage " << std::endl;
     return -1;
     }
 

--- a/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
@@ -304,7 +304,7 @@ int itkSymmetricEigenAnalysisImageFilterTest( int argc, char* argv[] )
 
   if ( argc < 4 )
   {
-  std::cout << "Usage: " << argv[0]
+  std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
     << "outputImage order outputImageFixedDimension" << std::endl;
   return EXIT_FAILURE;
   }

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeImageFilterTest.cxx
@@ -24,7 +24,7 @@ int itkTernaryMagnitudeImageFilterTest( int argc, char* argv[] )
 {
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << "outputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageIntensity/test/itkXorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkXorImageFilterTest.cxx
@@ -26,7 +26,7 @@ int itkXorImageFilterTest( int argc, char* argv[] )
 {
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << "outputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageLabel/test/itkBinaryContourImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkBinaryContourImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkBinaryContourImageFilterTest(int argc, char * argv[])
 {
   if( argc != 6 )
     {
-    std::cerr << "usage: " << argv[0] << " intput output fullyConnected fg bg" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " intput output fullyConnected fg bg" << std::endl;
     std::cerr << " input: the input image" << std::endl;
     std::cerr << " output: the output image" << std::endl;
     std::cerr << " fullyConnected: 0 or 1" << std::endl;

--- a/Modules/Filtering/ImageLabel/test/itkLabelContourImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkLabelContourImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkLabelContourImageFilterTest(int argc, char * argv[])
 {
   if( argc != 5 )
     {
-    std::cerr << "usage: " << argv[0] << " intput output fullyConnected bg" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " intput output fullyConnected bg" << std::endl;
     std::cerr << " input: the input image" << std::endl;
     std::cerr << " output: the output image" << std::endl;
     std::cerr << " fullyConnected: 0 or 1" << std::endl;

--- a/Modules/Filtering/ImageNoise/test/itkAdditiveGaussianNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkAdditiveGaussianNoiseImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkAdditiveGaussianNoiseImageFilterTest(int argc, char * argv[])
 
   if( argc < 3 )
     {
-    std::cerr << "usage: " << argv[0] << " input output [std_dev [mean]]" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output [std_dev [mean]]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculatorTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculatorTest.cxx
@@ -27,7 +27,7 @@ int itkPeakSignalToNoiseRatioCalculatorTest(int argc, char * argv[])
 
   if( argc < 3 )
     {
-    std::cerr << "usage: " << argv[0] << " intput noisy [expectedValue tolerance]" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " intput noisy [expectedValue tolerance]" << std::endl;
     std::cerr << " input: the input image" << std::endl;
     std::cerr << " noisy: noise with the input image" << std::endl;
     // std::cerr << "  : " << std::endl;

--- a/Modules/Filtering/ImageNoise/test/itkSaltAndPepperNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkSaltAndPepperNoiseImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkSaltAndPepperNoiseImageFilterTest(int argc, char * argv[])
 
   if( argc < 3 )
     {
-    std::cerr << "usage: " << argv[0] << " intput output Probability" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " intput output Probability" << std::endl;
     std::cerr << " input: the input image" << std::endl;
     std::cerr << " output: the output image" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/ImageNoise/test/itkShotNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkShotNoiseImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkShotNoiseImageFilterTest(int argc, char * argv[])
 
   if( argc < 3 )
     {
-    std::cerr << "usage: " << argv[0] << " input output [scale]" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output [scale]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageNoise/test/itkSpeckleNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkSpeckleNoiseImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkSpeckleNoiseImageFilterTest(int argc, char * argv[])
 
   if( argc < 3 )
     {
-    std::cerr << "usage: " << argv[0] << " input output [standardDeviation]" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output [standardDeviation]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
@@ -90,7 +90,7 @@ int itkGaborImageSourceTest( int argc, char *argv[] )
 {
   if ( argc < 3 )
     {
-    std::cout << "Usage: " << argv[0] << " outputImage whichTest" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputImage whichTest" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
@@ -26,7 +26,7 @@ int itkGaussianImageSourceTest( int argc, char* argv[] )
 {
   if ( argc < 3 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " outputImage normalized" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
@@ -26,7 +26,7 @@ int itkGridImageSourceTest( int argc, char *argv[] )
 {
   if ( argc != 12 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " outputImage"
       << " imageSize"
       << " sigma"

--- a/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
@@ -73,7 +73,7 @@ int itkPhysicalPointImageSourceTest( int argc, char *argv[] )
 {
   if ( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << " outputImage whichTest [ theta ]" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputImage whichTest [ theta ]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageStatistics/test/itkAccumulateImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkAccumulateImageFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkImageSeriesWriter.h"
 #include "itkGDCMImageIO.h"
 #include "itkGDCMSeriesFileNames.h"
+#include "itkTestingMacros.h"
 
 int itkAccumulateImageFilterTest(int argc, char *argv[] )
 {
@@ -41,7 +42,7 @@ int itkAccumulateImageFilterTest(int argc, char *argv[] )
   if (argc < 3)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputDICOMDirectory outputFile" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputDICOMDirectory outputFile" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkAdaptiveHistogramEqualizationImageFilterTest( int argc, char * argv[] )
   if( argc < 6 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile  outputImageFile radius alpha beta" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile  outputImageFile radius alpha beta" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageStatistics/test/itkBinaryProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkBinaryProjectionImageFilterTest.cxx
@@ -22,13 +22,14 @@
 #include "itkChangeLabelImageFilter.h"
 
 #include "itkBinaryProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkBinaryProjectionImageFilterTest(int argc, char * argv[])
 {
   if( argc < 5 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage Foreground Background" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageStatistics/test/itkGetAverageSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkGetAverageSliceImageFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkImageSeriesWriter.h"
 #include "itkGDCMImageIO.h"
 #include "itkGDCMSeriesFileNames.h"
+#include "itkTestingMacros.h"
 
 int itkGetAverageSliceImageFilterTest(int argc, char *argv[] )
 {
@@ -41,7 +42,7 @@ int itkGetAverageSliceImageFilterTest(int argc, char *argv[] )
   if (argc < 3)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputDICOMDirectory outputFile" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputDICOMDirectory outputFile" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
@@ -158,7 +158,7 @@ int itkLabelOverlapMeasuresImageFilterTest( int argc, char *argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0] << " imageDimension sourceImage "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " imageDimension sourceImage "
               << "targetImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageStatistics/test/itkLabelStatisticsImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelStatisticsImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileReader.h"
 
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 
 int itkLabelStatisticsImageFilterTest(int argc, char* argv [] )
@@ -32,7 +33,7 @@ int itkLabelStatisticsImageFilterTest(int argc, char* argv [] )
   {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImage labeledImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage labeledImage " << std::endl;
     return EXIT_FAILURE;
   }
   using ImageType = itk::Image<unsigned char,2>;

--- a/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkMaximumProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkMaximumProjectionImageFilterTest(int argc, char * argv[])
@@ -27,7 +28,7 @@ int itkMaximumProjectionImageFilterTest(int argc, char * argv[])
   if( argc < 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageStatistics/test/itkMeanProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMeanProjectionImageFilterTest.cxx
@@ -20,13 +20,14 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkMeanProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkMeanProjectionImageFilterTest(int argc, char * argv[])
 {
   if( argc < 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage  " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageStatistics/test/itkMedianProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMedianProjectionImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkMedianProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkMedianProjectionImageFilterTest(int argc, char * argv[])
@@ -27,7 +28,7 @@ int itkMedianProjectionImageFilterTest(int argc, char * argv[])
   if( argc < 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageStatistics/test/itkMinimumProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMinimumProjectionImageFilterTest.cxx
@@ -20,13 +20,14 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkMinimumProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkMinimumProjectionImageFilterTest(int argc, char * argv[])
 {
   if( argc < 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkChangeLabelImageFilter.h"
 
 #include "itkProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 namespace itk
 {
@@ -74,7 +75,7 @@ int itkProjectionImageFilterTest(int argc, char * argv[])
   if( argc < 5 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage Foreground Background" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageStatistics/test/itkStandardDeviationProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkStandardDeviationProjectionImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkStandardDeviationProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkStandardDeviationProjectionImageFilterTest(int argc, char * argv[])
@@ -27,7 +28,7 @@ int itkStandardDeviationProjectionImageFilterTest(int argc, char * argv[])
   if( argc < 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/ImageStatistics/test/itkSumProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkSumProjectionImageFilterTest.cxx
@@ -20,13 +20,14 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkSumProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkSumProjectionImageFilterTest(int argc, char * argv[])
 {
   if( argc < 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage  " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/LabelMap/test/itkAggregateLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAggregateLabelMapFilterTest.cxx
@@ -31,7 +31,7 @@ int itkAggregateLabelMapFilterTest(int argc, char * argv[])
 
   if( argc != 3 )
     {
-    std::cerr << "usage: " << argv[0] << " input output" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest.cxx
@@ -30,7 +30,7 @@ int itkBinaryImageToLabelMapFilterTest( int argc, char * argv [] )
 
   if( argc != 7 )
     {
-    std::cerr << "usage: " << argv[0];
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputBinaryImage outputLabelImage";
     std::cerr << " fullyConnected(0/1)  foregroundValue backgroundValue expectfailure";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkBinaryReconstructionByDilationImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryReconstructionByDilationImageFilterTest.cxx
@@ -26,7 +26,7 @@ int itkBinaryReconstructionByDilationImageFilterTest(int argc, char * argv[])
 {
   if( argc != 6 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input marker output";
     std::cerr << " fg bg";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkBinaryReconstructionByErosionImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryReconstructionByErosionImageFilterTest.cxx
@@ -26,7 +26,7 @@ int itkBinaryReconstructionByErosionImageFilterTest(int argc, char * argv[])
 {
   if( argc != 6 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " mask marker output fg bg";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkBinaryReconstructionLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryReconstructionLabelMapFilterTest.cxx
@@ -31,7 +31,7 @@ int itkBinaryReconstructionLabelMapFilterTest(int argc, char * argv[])
 {
   if( argc != 5 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input marker output";
     std::cerr << " fg";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkChangeLabelLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkChangeLabelLabelMapFilterTest.cxx
@@ -29,7 +29,7 @@ int itkChangeLabelLabelMapFilterTest( int argc, char * argv [] )
 {
   if( argc < 5 )
     {
-    std::cerr << "usage: " << argv[0] << " inputLabelImage outputLabelImage ";
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " inputLabelImage outputLabelImage ";
     std::cerr << "  old_label_1 new_label_1" << std::endl;
     std::cerr << " [old_label_2 new_label_2]" << std::endl;
     std::cerr << " [old_label_3 new_label_3]" << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -18,13 +18,14 @@
 
 #include <iostream>
 #include "itkLabelImageToLabelMapFilter.h"
+#include "itkTestingMacros.h"
 
 int itkLabelImageToLabelMapFilterTest(int argc, char * argv[])
 {
 
   if( argc != 1 )
     {
-    std::cerr << "usage: " << argv[0] << "" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << "" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/LabelMap/test/itkLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapFilterTest.cxx
@@ -20,13 +20,14 @@
 #include "itkLabelMap.h"
 #include "itkLabelObject.h"
 #include "itkLabelMapFilter.h"
+#include "itkTestingMacros.h"
 
 int itkLabelMapFilterTest(int argc, char * argv[])
 {
 
   if( argc != 1 )
     {
-    std::cerr << "usage: " << argv[0] << "" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << "" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/LabelMap/test/itkLabelMapMaskImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapMaskImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkLabelMapMaskImageFilterTest( int argc, char * argv[] )
 
   if( argc != 9 )
     {
-    std::cerr << "usage: " << argv[0] << " labelImage input output label bg neg crop cropBorder" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " labelImage input output label bg neg crop cropBorder" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/LabelMap/test/itkLabelMapTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapTest.cxx
@@ -19,13 +19,14 @@
 #include <iostream>
 #include "itkLabelMap.h"
 #include "itkLabelObject.h"
+#include "itkTestingMacros.h"
 
 int itkLabelMapTest(int argc, char * argv[])
 {
 
   if( argc != 1 )
     {
-    std::cerr << "usage: " << argv[0] << "" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << "" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/LabelMap/test/itkLabelMapToBinaryImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapToBinaryImageFilterTest.cxx
@@ -30,7 +30,7 @@ int itkLabelMapToBinaryImageFilterTest( int argc, char * argv [] )
 
   if( argc != 5 )
     {
-    std::cerr << "usage: " << argv[0];
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputLabelImage outputBinaryImage";
     std::cerr << " foregroundValue backgroundValue";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkLabelMapToLabelImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapToLabelImageFilterTest.cxx
@@ -20,13 +20,14 @@
 #include "itkLabelMap.h"
 #include "itkLabelObject.h"
 #include "itkLabelMapToLabelImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkLabelMapToLabelImageFilterTest(int argc, char * argv[])
 {
 
   if( argc != 1 )
     {
-    std::cerr << "usage: " << argv[0] << "" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << "" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/LabelMap/test/itkLabelObjectTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelObjectTest.cxx
@@ -18,13 +18,14 @@
 
 #include <iostream>
 #include "itkLabelObject.h"
+#include "itkTestingMacros.h"
 
 int itkLabelObjectTest(int argc, char * argv[])
 {
 
   if( argc != 1 )
     {
-    std::cerr << "usage: " << argv[0] << "" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << "" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/LabelMap/test/itkLabelSelectionLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelSelectionLabelMapFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkLabelImageToLabelMapFilter.h"
 #include "itkLabelSelectionLabelMapFilter.h"
 #include "itkLabelMapToLabelImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkLabelSelectionLabelMapFilterTest(int argc, char * argv[])
@@ -29,7 +30,7 @@ int itkLabelSelectionLabelMapFilterTest(int argc, char * argv[])
 
   if( argc != 5 )
     {
-    std::cerr << "usage: " << argv[0] << " input output exclude label" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output exclude label" << std::endl;
     // std::cerr << "  : " << std::endl;
     exit(1);
     }

--- a/Modules/Filtering/LabelMap/test/itkObjectByObjectLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkObjectByObjectLabelMapFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkObjectByObjectLabelMapFilter.h"
 #include "itkFlatStructuringElement.h"
 #include "itkBinaryDilateImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkObjectByObjectLabelMapFilterTest(int argc, char * argv[])
@@ -29,7 +30,7 @@ int itkObjectByObjectLabelMapFilterTest(int argc, char * argv[])
 
   if( argc != 4 )
     {
-    std::cerr << "usage: " << argv[0] << " input output keepLabel" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output keepLabel" << std::endl;
     // std::cerr << "  : " << std::endl;
     exit(1);
     }

--- a/Modules/Filtering/LabelMap/test/itkShiftLabelObjectTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShiftLabelObjectTest.cxx
@@ -18,13 +18,14 @@
 
 #include <iostream>
 #include "itkLabelImageToLabelMapFilter.h"
+#include "itkTestingMacros.h"
 
 int itkShiftLabelObjectTest(int argc, char * argv[])
 {
 
   if( argc != 1 )
     {
-    std::cerr << "usage: " << argv[0] << "" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << "" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkClosingByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkClosingByReconstructionImageFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkImageFileWriter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSubtractImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkClosingByReconstructionImageFilterTest(int argc, char* argv [] )
@@ -28,7 +29,7 @@ int itkClosingByReconstructionImageFilterTest(int argc, char* argv [] )
  if ( argc < 5 )
   {
     std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " Inputimage OutputImage Radius PreserveIntensities(0,1) [Diffmage]" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Inputimage OutputImage Radius PreserveIntensities(0,1) [Diffmage]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkDoubleThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkDoubleThresholdImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkDoubleThresholdImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkDoubleThresholdImageFilterTest( int argc, char * argv[] )
@@ -30,7 +31,7 @@ int itkDoubleThresholdImageFilterTest( int argc, char * argv[] )
   if( argc < 7 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile  ";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile  ";
     std::cerr << " outputImageFile threshold1 threshold2 threshold3 threshold4 " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedClosingImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkGrayscaleConnectedClosingImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkGrayscaleConnectedClosingImageFilterTest( int argc, char * argv[] )
@@ -30,7 +31,7 @@ int itkGrayscaleConnectedClosingImageFilterTest( int argc, char * argv[] )
   if( argc < 5 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile  ";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile  ";
     std::cerr << " outputImageFile seedX seedY " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedOpeningImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkGrayscaleConnectedOpeningImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkGrayscaleConnectedOpeningImageFilterTest( int argc, char * argv[] )
@@ -30,7 +31,7 @@ int itkGrayscaleConnectedOpeningImageFilterTest( int argc, char * argv[] )
   if( argc < 5 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile  ";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile  ";
     std::cerr << " outputImageFile seedX seedY " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFillholeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFillholeImageFilterTest.cxx
@@ -31,7 +31,7 @@ int itkGrayscaleFillholeImageFilterTest( int argc, char * argv[] )
   if( argc < 4 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile  ";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile  ";
     std::cerr << " outputImageFile  " << std::endl;
     std::cerr << " fullyConnected " << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleGeodesicErodeDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleGeodesicErodeDilateImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkShiftScaleImageFilter.h"
+#include "itkTestingMacros.h"
 
 // This test should produce the same results as the
 // itkHMaximaMinimaImageFilterTest.
@@ -31,7 +32,7 @@ int itkGrayscaleGeodesicErodeDilateImageFilterTest(int argc, char* argv [] )
   if ( argc < 4 )
   {
     std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " Inputimage OutputImage Height" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Inputimage OutputImage Height" << std::endl;
     return EXIT_FAILURE;
   }
   constexpr int Dimension = 2;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkGrayscaleMorphologicalClosingImageFilterTest(int argc, char* argv [] )
     {
     std::cerr << "Missing arguments." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImage outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImage outputImage " << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkGrayscaleMorphologicalOpeningImageFilterTest(int argc, char* argv [] )
     {
     std::cerr << "Missing arguments." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImage outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImage outputImage " << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkHConcaveImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHConcaveImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkHConcaveImageFilterTest( int argc, char * argv[] )
     {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0]
+    std::cerr << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile"
       << " height"

--- a/Modules/Filtering/MathematicalMorphology/test/itkHConvexConcaveImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHConvexConcaveImageFilterTest.cxx
@@ -31,7 +31,7 @@ int itkHConvexConcaveImageFilterTest( int argc, char * argv[] )
   if( argc < 4 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImageFile";
     std::cerr << " outputImageFile height" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/MathematicalMorphology/test/itkHConvexImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHConvexImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkHConvexImageFilterTest( int argc, char * argv[] )
     {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0]
+    std::cerr << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile"
       << " height"

--- a/Modules/Filtering/MathematicalMorphology/test/itkHMaximaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHMaximaImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkHMaximaImageFilterTest( int argc, char * argv[] )
     {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0]
+    std::cerr << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile"
       << " height"

--- a/Modules/Filtering/MathematicalMorphology/test/itkHMaximaMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHMaximaMinimaImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkHMaximaMinimaImageFilterTest( int argc, char * argv[] )
     {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImageFile";
     std::cerr << " outputImageFile height" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/MathematicalMorphology/test/itkHMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHMinimaImageFilterTest.cxx
@@ -28,7 +28,7 @@ int itkHMinimaImageFilterTest( int argc, char * argv[] )
     {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0]
+    std::cerr << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile"
       << " height"

--- a/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkMorphologicalGradientImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkMorphologicalGradientImageFilterTest(int argc, char * argv[])
 {
@@ -27,7 +28,7 @@ int itkMorphologicalGradientImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest.cxx
@@ -21,13 +21,14 @@
 #include "itkImageFileWriter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkOpeningByReconstructionImageFilterTest(int argc, char* argv [] )
 {
  if ( argc < 5 )
   {
     std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " Inputimage OutputImage Radius PreserveIntensities(0,1) [Diffmage]" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Inputimage OutputImage Radius PreserveIntensities(0,1) [Diffmage]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkRegionalMaximaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRegionalMaximaImageFilterTest.cxx
@@ -100,7 +100,7 @@ int itkRegionalMaximaImageFilterTest( int argc, char * argv[] )
   if( argc < 7 )
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile"
       << " outputImageFile2"

--- a/Modules/Filtering/MathematicalMorphology/test/itkRegionalMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRegionalMinimaImageFilterTest.cxx
@@ -100,7 +100,7 @@ int itkRegionalMinimaImageFilterTest( int argc, char * argv[] )
   if( argc < 7 )
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile"
       << " outputImageFile2"

--- a/Modules/Filtering/MathematicalMorphology/test/itkRemoveBoundaryObjectsTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRemoveBoundaryObjectsTest.cxx
@@ -25,13 +25,14 @@
 #include "itkXorImageFilter.h"
 #include "itkNotImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkRemoveBoundaryObjectsTest( int argc, char * argv[] )
 {
   if( argc < 3 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile  ";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile  ";
     std::cerr << " outputImageFile  " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int itkTopHatImageFilterTest(int argc, char* argv [] )
 {
@@ -29,7 +30,7 @@ int itkTopHatImageFilterTest(int argc, char* argv [] )
     {
     std::cerr << "Missing arguments." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImage outputImage 0/1(Black/White) radius" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImage outputImage 0/1(Black/White) radius" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkValuedRegionalMaximaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkValuedRegionalMaximaImageFilterTest.cxx
@@ -32,7 +32,7 @@ int itkValuedRegionalMaximaImageFilterTest( int argc, char * argv[] )
   if( argc < 5 )
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile1"
       << " outputImageFile2"

--- a/Modules/Filtering/MathematicalMorphology/test/itkValuedRegionalMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkValuedRegionalMinimaImageFilterTest.cxx
@@ -34,7 +34,7 @@ int itkValuedRegionalMinimaImageFilterTest( int argc, char * argv[] )
   if( argc < 5 )
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile1"
       << " outputImageFile2"

--- a/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkImageFileReader.h"
 #include "itkContourExtractor2DImageFilter.h"
+#include "itkTestingMacros.h"
 
 namespace itkContourExtractor2DImageFilterTestNamespace
 {
@@ -441,7 +442,7 @@ int itkContourExtractor2DImageFilterTest(int argc, char *argv[])
   if( argc < 2 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " Input Test Image  " << std::endl;
     return 1;
     }

--- a/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
@@ -30,7 +30,7 @@ int itkExtractOrthogonalSwath2DImageFilterTest( int argc, char* argv[] )
   if( argc != 2)
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " outputImage " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " outputImage " << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkRegularSphereQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkRegularSphereQuadEdgeMeshSourceTest.cxx
@@ -21,12 +21,13 @@
 #include "itkMeshFileWriter.h"
 
 #include <iostream>
+#include "itkTestingMacros.h"
 
 int itkRegularSphereQuadEdgeMeshSourceTest(int argc, char * argv [] )
 {
   if( argc != 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " outputFileName.vtk" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputFileName.vtk" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -102,7 +102,7 @@ int itkSmoothingRecursiveGaussianImageFilterTest( int argc, char* argv[] )
     {
     std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile outputImageFile normalizeAcrossScale sigma" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImageFile outputImageFile normalizeAcrossScale sigma" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdProjectionImageFilterTest.cxx
@@ -20,13 +20,14 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkBinaryThresholdProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkBinaryThresholdProjectionImageFilterTest(int argc, char * argv[])
 {
   if( argc < 6 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage Threshold Foreground Background"
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkHuangMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkHuangMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkHuangMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkHuangThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkHuangThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkHuangThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkIntermodesMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIntermodesMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkIntermodesMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkIntermodesThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIntermodesThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkIntermodesThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkIsoDataMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIsoDataMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkIsoDataMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkIsoDataThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIsoDataThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkIsoDataThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageCalculatorTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkKappaSigmaThresholdImageCalculator.h"
 #include "itkImageFileReader.h"
+#include "itkTestingMacros.h"
 
 
 int itkKappaSigmaThresholdImageCalculatorTest( int argc, char * argv [] )
@@ -26,7 +27,7 @@ int itkKappaSigmaThresholdImageCalculatorTest( int argc, char * argv [] )
     {
     std::cerr << "Missing arguments" << std::endl;
     std::cerr << "Usage:" << std::endl;
-    std::cerr << argv[0] << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << std::endl;
     std::cerr << "inputImage numberOfIterations sigmaFactor expectedThreshold" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageFilterTest.cxx
@@ -21,13 +21,14 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkKappaSigmaThresholdImageFilterTest(int argc, char* argv[] )
 {
 
   if( argc < 5 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile iterations sigmaFactor";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkKittlerIllingworthMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKittlerIllingworthMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkKittlerIllingworthMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkKittlerIllingworthThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKittlerIllingworthThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkKittlerIllingworthThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkLiMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkLiMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkLiMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkLiThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkLiThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkLiThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkMaximumEntropyMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMaximumEntropyMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkMaximumEntropyMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkMaximumEntropyThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMaximumEntropyThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkMaximumEntropyThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkMomentsMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMomentsMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkMomentsMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkMomentsThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMomentsThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkMomentsThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkOtsuMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkOtsuMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkOtsuMultipleThresholdsImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 6 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << " numberOfHistogramBins";
     std::cerr << " numberOfThresholds";

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorVersusOtsuMultipleThresholdsCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorVersusOtsuMultipleThresholdsCalculatorTest.cxx
@@ -22,12 +22,13 @@
 #include "itkScalarImageToHistogramGenerator.h"
 #include "itkOtsuThresholdCalculator.h"
 #include "itkOtsuMultipleThresholdsCalculator.h"
+#include "itkTestingMacros.h"
 
 int itkOtsuThresholdCalculatorVersusOtsuMultipleThresholdsCalculatorTest(int argc, char* argv[] )
 {
   if( argc < 2 )
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile ";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkOtsuThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile [numberOfHistogramBins flipOutputIntensities]";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkRenyiEntropyMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkRenyiEntropyMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkRenyiEntropyMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkRenyiEntropyThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkRenyiEntropyThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkRenyiEntropyThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkShanbhagMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkShanbhagMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkShanbhagMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkShanbhagThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkShanbhagThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkShanbhagThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkTriangleMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkTriangleMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkTriangleMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkTriangleThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkTriangleThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkTriangleThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkYenMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkYenMaskedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkYenMaskedThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile maskImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Thresholding/test/itkYenThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkYenThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkYenThresholdImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImageFile outputImageFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/IO/BMP/test/itkBMPImageIOTest.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest.cxx
@@ -28,7 +28,7 @@ int itkBMPImageIOTest( int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << " input output" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/BioRad/test/itkBioRadImageIOTest.cxx
+++ b/Modules/IO/BioRad/test/itkBioRadImageIOTest.cxx
@@ -19,6 +19,7 @@
 #include "itkBioRadImageIOFactory.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -26,7 +27,7 @@ int itkBioRadImageIOTest(int argc, char* argv[])
 {
   if(argc < 3)
     {
-    std::cerr << "Usage: " << argv[0] << " BioRad.pic OutputImage.pic\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " BioRad.pic OutputImage.pic\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/Bruker/test/itkBrukerImageTest.cxx
+++ b/Modules/IO/Bruker/test/itkBrukerImageTest.cxx
@@ -28,7 +28,7 @@ int itkBrukerImageTest( int argc, char *argv[] )
   if( argc < 3 )
     {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImage outputImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkCSVArray2DFileReader.h"
+#include "itkTestingMacros.h"
 
 const double epsilon = 1e-10;
 
@@ -107,7 +108,7 @@ int itkCSVArray2DFileReaderTest (int argc, char *argv[])
 {
  if ( argc < 2 )
    {
-   std::cerr << "Usage: " << argv[0] << " Filename" << std::endl;
+   std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Filename" << std::endl;
    return EXIT_FAILURE;
    }
 

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderWriterTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderWriterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkCSVNumericObjectFileWriter.h"
 #include <iostream>
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 const double epsilon = 1e-20;
 
@@ -179,7 +180,7 @@ int itkCSVArray2DFileReaderWriterTest(int argc, char *argv[])
 {
   if ( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " Filename" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Filename" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/CSV/test/itkCSVNumericObjectFileWriterTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVNumericObjectFileWriterTest.cxx
@@ -24,7 +24,7 @@ int itkCSVNumericObjectFileWriterTest( int argc, char *argv[] )
 {
   if ( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " Filename" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Filename" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/GDCM/test/itkGDCMImageIOTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOTest.cxx
@@ -21,6 +21,7 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkGDCMImageIO.h"
 #include "itkMetaDataObject.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -29,7 +30,7 @@ int itkGDCMImageIOTest(int argc, char* argv[])
 
   if(argc < 6)
     {
-    std::cerr << "Usage: " << argv[0] << " DicomImage OutputDicomImage OutputImage RescaledDicomImage RescaledOutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DicomImage OutputDicomImage OutputImage RescaledDicomImage RescaledOutputImage\n";
     return EXIT_FAILURE;
     }
   const char * dicomImageFileName = argv[1];

--- a/Modules/IO/GDCM/test/itkGDCMImageOrientationPatientTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageOrientationPatientTest.cxx
@@ -25,13 +25,14 @@
 #include <sstream>
 #include <vector>
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int itkGDCMImageOrientationPatientTest( int argc, char* argv[] )
 {
 
   if( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0] <<
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) <<
       " OutputTestDirectory" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/GDCM/test/itkGDCMImagePositionPatientTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImagePositionPatientTest.cxx
@@ -25,13 +25,14 @@
 #include <sstream>
 #include <vector>
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int itkGDCMImagePositionPatientTest( int argc, char* argv[] )
 {
 
   if( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0] <<
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) <<
       " OutputTestDirectory" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
@@ -30,7 +30,7 @@ int itkGDCMImageReadSeriesWriteTest( int argc, char* argv[] )
 {
   if( argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputDicomDirectory SingleOutputImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/GDCM/test/itkGDCMLegacyMultiFrameTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMLegacyMultiFrameTest.cxx
@@ -19,6 +19,7 @@
 #include "itkGDCMImageIO.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 // This test verifies that we obtain the correct origin and spacing for a
 // Legacy MultiFrame DICOM file with IOD
@@ -28,7 +29,7 @@ int itkGDCMLegacyMultiFrameTest(int argc, char *argv[])
 {
   if(argc < 3)
     {
-    std::cerr << "Usage: " << argv[0] << " <InputLegacyMultiFrameDICOM> <OutputFile>" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <InputLegacyMultiFrameDICOM> <OutputFile>" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/GDCM/test/itkGDCMLoadImageSpacingTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMLoadImageSpacingTest.cxx
@@ -20,6 +20,7 @@
 #include "itkGDCMImageIO.h"
 #include "itkImageFileReader.h"
 #include "gdcmImageHelper.h"
+#include "itkTestingMacros.h"
 
 //
 // This test is specifically for a problem detected in GDCMImageIO
@@ -38,7 +39,7 @@ int itkGDCMLoadImageSpacingTest(int argc, char *argv[])
 {
   if(argc < 4)
     {
-    std::cerr << "Usage: " << argv[0] << " Image Spacing0 Spacing1" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Image Spacing0 Spacing1" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/GDCM/test/itkGDCMSeriesMissingDicomTagTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMSeriesMissingDicomTagTest.cxx
@@ -29,12 +29,13 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkGDCMImageIO.h"
 #include "itkGDCMSeriesFileNames.h"
+#include "itkTestingMacros.h"
 
 int itkGDCMSeriesMissingDicomTagTest( int argc, char* argv[] )
 {
   if( argc < 2)
     {
-    std::cerr << "Usage: " << argv[0] <<
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) <<
       " DicomDirectory" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/GDCM/test/itkGDCMSeriesReadImageWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMSeriesReadImageWriteTest.cxx
@@ -29,12 +29,13 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkGDCMImageIO.h"
 #include "itkGDCMSeriesFileNames.h"
+#include "itkTestingMacros.h"
 
 int itkGDCMSeriesReadImageWriteTest( int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] <<
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) <<
       " DicomDirectory  outputFile OutputDicomDirectory" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/GDCM/test/itkGDCMSeriesStreamReadImageWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMSeriesStreamReadImageWriteTest.cxx
@@ -22,6 +22,7 @@
 #include "itkGDCMSeriesFileNames.h"
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkStreamingImageFilter.h"
+#include "itkTestingMacros.h"
 
 /// \brief is comparison with a percentage tollerance
 ///
@@ -46,7 +47,7 @@ int itkGDCMSeriesStreamReadImageWriteTest( int argc, char* argv[] )
 {
   if( argc < 6 )
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " DicomDirectory  outputFile ";
     std::cerr << " spacingX spacingY spacingZ [ force-no-streaming 1|0]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/IO/ImageBase/test/itk64bitTest.cxx
+++ b/Modules/IO/ImageBase/test/itk64bitTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkNumericTraits.h"
 #include <iostream>
+#include "itkTestingMacros.h"
 
 using PixelType = unsigned long long;
 using ImageType = itk::Image<PixelType, 3>;
@@ -53,7 +54,7 @@ int itk64bitTest(int argc, char *argv[])
 {
   if (argc < 3)
     {
-    std::cerr << "Invocation syntax:\n\t" << argv[0];
+    std::cerr << "Invocation syntax:\n\t" << itkNameOfTestExecutableMacro(argv);
     std::cerr << " Test64bit.nrrd Test64bit.mha" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/ImageBase/test/itkArchetypeSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkArchetypeSeriesFileNamesTest.cxx
@@ -17,13 +17,14 @@
  *=========================================================================*/
 
 #include "itkArchetypeSeriesFileNames.h"
+#include "itkTestingMacros.h"
 
 int itkArchetypeSeriesFileNamesTest(int argc, char* argv[])
 {
 
   if(argc < 2)
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << "One or more filenames (with directory)";
     return EXIT_FAILURE;
     }

--- a/Modules/IO/ImageBase/test/itkIOPluginTest.cxx
+++ b/Modules/IO/ImageBase/test/itkIOPluginTest.cxx
@@ -18,12 +18,13 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int itkIOPluginTest(int argc, char *argv[])
 {
   if (argc < 4)
     {
-    std::cout << "Usage: " << argv[0] << " FactoryPath FileName Output" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " FactoryPath FileName Output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest.cxx
@@ -20,12 +20,13 @@
 #include "itkImageFileReader.h"
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkStreamingImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkImageFileReaderStreamingTest(int argc, char* argv[])
 {
   if( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " input [expected-to-stream 1|0 [ force-no-streaming 1|0] ]" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input [expected-to-stream 1|0 [ force-no-streaming 1|0] ]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
@@ -18,12 +18,13 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int itkImageFileWriterUpdateLargestPossibleRegionTest(int argc, char* argv[])
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << " input output" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -20,12 +20,13 @@
 #include "itkIOCommon.h"
 #include "itkMetaDataObject.h"
 #include "itkSpatialOrientationAdapter.h"
+#include "itkTestingMacros.h"
 
 int itkReadWriteImageWithDictionaryTest(int argc, char* argv[])
 {
   if( argc != 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/LSM/test/itkLSMImageIOTest.cxx
+++ b/Modules/IO/LSM/test/itkLSMImageIOTest.cxx
@@ -18,6 +18,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkLSMImageIO.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -26,7 +27,7 @@ int itkLSMImageIOTest(int argc, char* argv[])
 {
   if(argc < 3)
     {
-    std::cerr << "Usage: " << argv[0] << " LSM.lsm OutputImage.lsm\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " LSM.lsm OutputImage.lsm\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
@@ -281,7 +281,7 @@ int itkMRCImageIOTest(int argc, char* argv[])
 
   if( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " outputPath" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputPath" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshCanReadImageTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshCanReadImageTest.cxx
@@ -24,7 +24,7 @@ int itkVTKPolyDataMeshCanReadImageTest(int argc, char * argv[])
   if( argc != 2 )
     {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputVTKImageFile" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
@@ -20,12 +20,13 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkMetaImageIO.h"
+#include "itkTestingMacros.h"
 
 int itkMetaImageStreamingWriterIOTest(int argc, char*  argv[])
 {
   if( argc < 3)
     {
-    std::cerr << "Usage: " <<  argv[0] << " input output" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -30,7 +30,7 @@ int itkPNGImageIOTest( int argc, char * argv[] )
 
   if( argc < 5 )
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " input"
       << " output"
       << " useCompression"

--- a/Modules/IO/RAW/test/itkRawImageIOTest.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest.cxx
@@ -21,6 +21,7 @@
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
 #include "itkRawImageIO.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -32,7 +33,7 @@ int itkRawImageIOTest(int argc, char* argv[])
   using ImageIteratorType = itk::ImageRegionConstIterator<ImageType>;
   if(argc < 3)
     {
-    std::cerr << "Usage: " << argv[0] << " Output1 Output2\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Output1 Output2\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/SpatialObjects/test/itkReadVesselTubeSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadVesselTubeSpatialObjectTest.cxx
@@ -17,13 +17,14 @@
  *=========================================================================*/
 
 #include "itkSpatialObjectReader.h"
+#include "itkTestingMacros.h"
 
 int itkReadVesselTubeSpatialObjectTest( int argc, char * argv[] )
 {
   if( argc < 2 )
     {
     std::cerr << "Usage: "
-              << argv[0]
+              << itkNameOfTestExecutableMacro(argv)
               << " <inputVessel.tre>"
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/IO/Stimulate/test/itkStimulateImageIOTest.cxx
+++ b/Modules/IO/Stimulate/test/itkStimulateImageIOTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
 #include "itkStimulateImageIO.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -33,7 +34,7 @@ int itkStimulateImageIOTest(int argc, char* argv[] )
   if( argc < 3 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  output1 output2 " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  output1 output2 " << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
+++ b/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
@@ -161,7 +161,7 @@ int itkLargeTIFFImageWriteReadTest( int argc, char* argv[] )
 {
   if( argc < 3 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " outputFileName"
       << " numberOfPixelsInOneDimension"
       << " [numberOfZslices]" << std::endl;

--- a/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
@@ -93,7 +93,7 @@ int itkTIFFImageIOCompressionTest( int argc, char* argv[] )
   int JPEGQuality = 75;
   if (argc < 4 )
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputFile"
       << " outputFile"
       << "compression"

--- a/Modules/IO/TIFF/test/itkTIFFImageIOInfoTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOInfoTest.cxx
@@ -29,7 +29,7 @@ int itkTIFFImageIOInfoTest( int argc, char * argv[] )
 
   if( argc != 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " input" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest.cxx
@@ -103,7 +103,7 @@ int itkTIFFImageIOTest( int argc, char* argv[] )
 
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " Input Output [dimensionality (default: 2)]"
               << "[pixeltype: 1:RBG<char>(default); 2:RBG<ushort>; 3:short; 4:float; 5:ushort]" << std::endl;
     return EXIT_FAILURE;
@@ -168,7 +168,7 @@ int itkTIFFImageIOTest( int argc, char* argv[] )
     }
   else
     {
-    std::cerr << "Test failed!" << argv[0] << std::endl;
+    std::cerr << "Test failed!" << itkNameOfTestExecutableMacro(argv) << std::endl;
     std::cerr << " Unsupported dimensionality or pixelType provided." << std::endl;
     std::cerr << " Supported dimensionality: [2-4]; (default: 2)" << std::endl;
     std::cerr << " Supported pixelType: [1:uchar(default); 2:ushort; 3:short; 4:float]" << std::endl;

--- a/Modules/IO/TransformBase/test/itkTransformFileReaderTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileReaderTest.cxx
@@ -18,12 +18,13 @@
 
 
 #include "itkTransformFileReader.h"
+#include "itkTestingMacros.h"
 
 int itkTransformFileReaderTest( int argc, char *argv[] )
 {
   if( argc < 1 )
     {
-    std::cerr << "Usage:" <<argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/TransformBase/test/itkTransformFileWriterTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileWriterTest.cxx
@@ -18,12 +18,13 @@
 
 
 #include "itkTransformFileWriter.h"
+#include "itkTestingMacros.h"
 
 int itkTransformFileWriterTest( int argc, char *argv[] )
 {
   if( argc < 1 )
     {
-    std::cerr << "Usage:" << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/IO/TransformHDF5/test/itkThinPlateTransformWriteReadTest.cxx
+++ b/Modules/IO/TransformHDF5/test/itkThinPlateTransformWriteReadTest.cxx
@@ -148,7 +148,7 @@ int itkThinPlateTransformWriteReadTest( int argc, char *argv[] )
 {
   if( argc != 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " outputDirectory" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputDirectory" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/TransformInsightLegacy/test/itkIOEuler3DTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOEuler3DTransformTxtTest.cxx
@@ -22,13 +22,14 @@
 #include "itkTxtTransformIOFactory.h"
 #include "itkEuler3DTransform.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int itkIOEuler3DTransformTxtTest(int argc, char *argv[])
 {
   if( argc != 3 )
     {
     std::cerr<< "Usage: "
-             << argv[0]
+             << itkNameOfTestExecutableMacro(argv)
              <<" inputFileName outputFileName"
              << std::endl;
     return EXIT_FAILURE;

--- a/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
@@ -256,7 +256,7 @@ int itkIOTransformTxtTest(int argc, char* argv[])
   if (argc < 2)
     {
     std::cerr << "Usage: "
-              << argv[0]
+              << itkNameOfTestExecutableMacro(argv)
               << " outputDirectory"
               << std::endl;
 

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
@@ -368,7 +368,7 @@ int itkVTKImageIO2Test(int argc, char* argv[])
 
   if( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " outputPath" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputPath" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/VTK/test/itkVTKImageIOFileReadTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOFileReadTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileWriter.h"
 #include "itkImageIOBase.h"
 #include "itkVTKImageIO.h"
+#include "itkTestingMacros.h"
 
 template< class TImage >
 int ReadImage( const std::string fileName,
@@ -60,7 +61,7 @@ int itkVTKImageIOFileReadTest( int argc, char* argv[] )
   if( argc != 3 )
     {
     std::cerr << "Usage: "<< std::endl;
-    std::cerr << argv[0];
+    std::cerr << itkNameOfTestExecutableMacro(argv);
     std::cerr << "matrix.vtk ironProt.vtk";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <algorithm>
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 namespace itk
 {
@@ -279,7 +280,7 @@ int itkVTKImageIOStreamTest(int argc, char* argv[] )
   if( argc < 2 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  output" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  output" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/IO/VTK/test/itkVTKImageIOTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOTest.cxx
@@ -23,6 +23,7 @@
 
 #include <fstream>
 #include <iostream>
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -131,7 +132,7 @@ int itkVTKImageIOTest(int argc, char* argv[] )
   if( argc < 3 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  output1 output2 " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "  output1 output2 " << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -23,6 +23,7 @@
 #include "itkRandomImageSource.h"
 #include "itkAddImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
+#include "itkTestingMacros.h"
 
 namespace itk
 {
@@ -112,7 +113,7 @@ int itkNarrowBandImageFilterBaseTest(int argc, char* argv[])
 {
   if(argc < 2)
     {
-    std::cerr << "Usage: " << argv[0] << " OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " OutputImage\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -24,6 +24,7 @@
 #include "itkExceptionObject.h"
 #include "itkImageRegistrationMethodImageSource.h"
 #include "itkVectorImageToImageMetricTraitsv4.h"
+#include "itkTestingMacros.h"
 
 /**
  *  This is a test using GradientDescentOptimizerv4 and parameter scales
@@ -211,7 +212,7 @@ int itkAutoScaledGradientDescentRegistrationOnVectorTest(int argc, char ** const
   if( argc > 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " [numberOfIterations=30 shiftOfStep=1.0] ";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
@@ -25,6 +25,7 @@
 #include "itkExceptionObject.h"
 #include "itkImageRegistrationMethodImageSource.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 /**
  *  This is a test using GradientDescentOptimizerv4 and parameter scales
@@ -281,7 +282,7 @@ int itkAutoScaledGradientDescentRegistrationTest(int argc, char ** const argv)
   if( argc > 6 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " [numberOfIterations=30 shiftOfStep=1.0] ";
     std::cerr << " [estimateLearningRateOnce = true] ";
     std::cerr << " [estimateLearningRateAtEachIteration = false] ";

--- a/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
@@ -26,6 +26,7 @@
 #include "itkIdentityTransform.h"
 #include "itkAffineTransform.h"
 #include "itkTranslationTransform.h"
+#include "itkTestingMacros.h"
 
 /**
  *  This is a test using GradientDescentOptimizerv4 and parameter scales
@@ -227,7 +228,7 @@ int itkQuasiNewtonOptimizerv4Test(int argc, char ** const argv)
   if( argc > 3 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " [numberOfIterations=50 shiftOfStep=1] ";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/Statistics/test/itkKdTreeBasedKmeansEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeBasedKmeansEstimatorTest.cxx
@@ -22,6 +22,7 @@
 #include "itkPointSetToListSampleAdaptor.h"
 #include "itkWeightedCentroidKdTreeGenerator.h"
 #include "itkKdTreeBasedKmeansEstimator.h"
+#include "itkTestingMacros.h"
 
 int itkKdTreeBasedKmeansEstimatorTest(int argc, char* argv[] )
 {
@@ -31,7 +32,7 @@ int itkKdTreeBasedKmeansEstimatorTest(int argc, char* argv[] )
     {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "inputFileName  bucketSize minStandardDeviation tolerancePercent" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << "inputFileName  bucketSize minStandardDeviation tolerancePercent" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Registration/Common/test/itkEuclideanDistancePointMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkEuclideanDistancePointMetricTest.cxx
@@ -88,7 +88,7 @@ int itkEuclideanDistancePointMetricTest( int argc, char* argv [] )
 
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0]
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " computeSquaredDistance " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Registration/Common/test/itkMatchCardinalityImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMatchCardinalityImageToImageMetricTest.cxx
@@ -22,13 +22,14 @@
 #include "itkImageFileReader.h"
 
 #include <iostream>
+#include "itkTestingMacros.h"
 
 int itkMatchCardinalityImageToImageMetricTest(int argc, char* argv[] )
 {
 
   if (argc < 2)
     {
-    std::cout << "Usage: " << argv[0] << " InputFile" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputFile" << std::endl;
     exit (1);
     }
 

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
@@ -34,6 +34,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 namespace{
 // The following class is used to support callbacks
@@ -64,7 +65,7 @@ int itkANTSNeighborhoodCorrelationImageToImageRegistrationTest(int argc, char *a
   if( argc < 4 || argc > 8)
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [numberOfIterations] ";

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
@@ -43,6 +43,7 @@
 
 #include <iostream>
 #include <fstream>
+#include "itkTestingMacros.h"
 
 template<typename TFilter>
 class itkDemonsImageToImageMetricv4RegistrationTestCommandIterationUpdate : public itk::Command
@@ -83,7 +84,7 @@ int itkDemonsImageToImageMetricv4RegistrationTest(int argc, char *argv[])
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [numberOfIterations = 10] ";

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
@@ -37,6 +37,7 @@
 #include "itkImageFileWriter.h"
 
 #include <iomanip>
+#include "itkTestingMacros.h"
 
 namespace{
 
@@ -138,7 +139,7 @@ int itkJointHistogramMutualInformationImageToImageRegistrationTest(int argc, cha
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [numberOfIterations numberOfDisplacementIterations] ";

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
@@ -37,6 +37,7 @@
 #include "itkImageFileWriter.h"
 
 #include <iomanip>
+#include "itkTestingMacros.h"
 
 int itkMattesMutualInformationImageToImageMetricv4RegistrationTest(int argc, char *argv[])
 {
@@ -44,7 +45,7 @@ int itkMattesMutualInformationImageToImageMetricv4RegistrationTest(int argc, cha
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [numberOfIterations = 10] [numberOfDisplacementIterations = 10] ";

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
@@ -37,6 +37,7 @@
 #include "itkImageFileWriter.h"
 
 #include <iomanip>
+#include "itkTestingMacros.h"
 
 int itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char *argv[])
 {
@@ -44,7 +45,7 @@ int itkMeanSquaresImageToImageMetricv4RegistrationTest(int argc, char *argv[])
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [numberOfIterations numberOfDisplacementIterations] ";

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkMeanSquaresImageToImageMetricv4.h"
 #include "itkTranslationTransform.h"
+#include "itkTestingMacros.h"
 
 /*
  * Simple test to run using unix 'time' function for speed test.
@@ -26,7 +27,7 @@ int itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char *argv[] )
 {
   if( argc < 3 )
     {
-    std::cerr << "usage: " << argv[0] << ": image-dimension number-of-reps" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << ": image-dimension number-of-reps" << std::endl;
     return EXIT_FAILURE;
     }
   int imageSize = std::stoi( argv[1] );

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -39,6 +39,7 @@
 #include "itkImageFileWriter.h"
 
 #include <iomanip>
+#include "itkTestingMacros.h"
 
 int itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char *argv[])
 {
@@ -46,7 +47,7 @@ int itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char *arg
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [numberOfAffineIterations numberOfDisplacementIterations] ";

--- a/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
@@ -38,6 +38,7 @@
 #include "itkImageFileWriter.h"
 
 #include <iomanip>
+#include "itkTestingMacros.h"
 
 int itkMultiGradientImageToImageMetricv4RegistrationTest(int argc, char *argv[])
 {
@@ -45,7 +46,7 @@ int itkMultiGradientImageToImageMetricv4RegistrationTest(int argc, char *argv[])
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [numberOfIterations initialAffine ] ";

--- a/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
@@ -40,6 +40,7 @@
 #include "itkImageFileWriter.h"
 
 #include <iomanip>
+#include "itkTestingMacros.h"
 
 int itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char *argv[])
 {
@@ -47,7 +48,7 @@ int itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char *argv[])
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [numberOfIterations bool_rotate_input_image_by_180 ] ";

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itkVectorCastImageFilter.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 // The following class is used to support callbacks
@@ -100,7 +101,7 @@ int itkDiffeomorphicDemonsRegistrationFilterTest(int argc, char * argv [] )
     {
     std::cerr << "Missing arguments" << std::endl;
     std::cerr << "Usage:" << std::endl;
-    std::cerr << argv[0] << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << std::endl;
     std::cerr << "GradientType [0=Symmetric,1=Fixed,2=WarpedMoving,3=MappedMoving]" << std::endl;
     std::cerr << "UseFirstOrderExp [0=No,1=Yes]" << std::endl;
     std::cerr << "Intensity Difference Threshold (double)" << std::endl;

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -23,6 +23,7 @@
 #include "itkImageFileWriter.h"
 
 #include <iostream>
+#include "itkTestingMacros.h"
 
 namespace
 {
@@ -152,7 +153,7 @@ int itkMultiResolutionPDEDeformableRegistrationTest(int argc, char* argv[] )
 
   if(argc < 2)
     {
-    std::cerr << "Usage: " << argv[0] << " WarpedImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " WarpedImage\n";
     return -1;
     }
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
@@ -28,6 +28,7 @@
 #include "itkComposeDisplacementFieldsImageFilter.h"
 #include "itkVectorMagnitudeImageFilter.h"
 #include "itkStatisticsImageFilter.h"
+#include "itkTestingMacros.h"
 
 template<typename TFilter>
 class CommandIterationUpdate : public itk::Command
@@ -107,7 +108,7 @@ int PerformBSplineExpImageRegistration( int argc, char *argv[] )
 {
   if( argc < 6 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
     exit( 1 );
     }
 
@@ -400,7 +401,7 @@ int itkBSplineExponentialImageRegistrationTest( int argc, char *argv[] )
 {
   if( argc < 6 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
     exit( 1 );
     }
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
@@ -25,6 +25,7 @@
 #include "itkANTSNeighborhoodCorrelationImageToImageMetricv4.h"
 #include "itkBSplineTransform.h"
 #include "itkBSplineTransformParametersAdaptor.h"
+#include "itkTestingMacros.h"
 
 template<typename TFilter>
 class CommandIterationUpdate : public itk::Command
@@ -94,7 +95,7 @@ int PerformBSplineImageRegistration( int argc, char *argv[] )
 {
   if( argc < 6 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
     exit( 1 );
     }
 
@@ -349,7 +350,7 @@ int itkBSplineImageRegistrationTest( int argc, char *argv[] )
 {
   if( argc < 6 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
     exit( 1 );
     }
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
@@ -362,7 +362,7 @@ int itkBSplineSyNImageRegistrationTest( int argc, char *argv[] )
 {
   if ( argc < 5 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputPrefix numberOfDeformableIterations learningRate" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputPrefix numberOfDeformableIterations learningRate" << std::endl;
     exit( 1 );
     }
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
@@ -30,6 +30,7 @@
 #include "itkStatisticsImageFilter.h"
 
 #include "itkTimeProbesCollectorBase.h"
+#include "itkTestingMacros.h"
 
 template<typename TFilter>
 class CommandIterationUpdate : public itk::Command
@@ -108,7 +109,7 @@ int PerformExpImageRegistration( int argc, char *argv[] )
 {
   if( argc < 6 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
     exit( 1 );
     }
 
@@ -422,7 +423,7 @@ int itkExponentialImageRegistrationTest( int argc, char *argv[] )
 {
   if( argc < 6 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
     exit( 1 );
     }
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
@@ -47,6 +47,7 @@
 #include "itkCommand.h"
 #include "itksys/SystemTools.hxx"
 #include "itkResampleImageFilter.h"
+#include "itkTestingMacros.h"
 
 template<unsigned int Dimension, typename TAffineTransform>
 int itkQuasiNewtonOptimizerv4RegistrationTestMain(int argc, char *argv[])
@@ -316,7 +317,7 @@ int itkQuasiNewtonOptimizerv4RegistrationTest(int argc, char *argv[])
   if( argc < 5 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " dimension";
     std::cerr << " metric-type{ms|mi|anc}";
     std::cerr << " fixedImageFile movingImageFile ";

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -27,6 +27,7 @@
 #include "itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.h"
 #include "itkJointHistogramMutualInformationImageToImageMetricv4.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
+#include "itkTestingMacros.h"
 
 template<typename TFilter>
 class CommandIterationUpdate : public itk::Command
@@ -109,7 +110,7 @@ int PerformSimpleImageRegistration( int argc, char *argv[] )
 {
   if( argc < 7 )
     {
-    std::cout << argv[0] << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
     exit( 1 );
     }
 
@@ -393,7 +394,7 @@ int itkSimpleImageRegistrationTest( int argc, char *argv[] )
 {
   if( argc < 7 )
     {
-    std::cout << argv[0] << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations" << std::endl;
     exit( 1 );
     }
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -427,7 +427,7 @@ int itkSyNImageRegistrationTest( int argc, char *argv[] )
 {
   if ( argc < 5 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputPrefix numberOfDeformableIterations learningRate" << std::endl;
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputPrefix numberOfDeformableIterations learningRate" << std::endl;
     exit( 1 );
     }
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
@@ -438,7 +438,7 @@ int itkTimeVaryingBSplineVelocityFieldImageRegistrationTest( int argc, char *arg
 {
   if ( argc < 4 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputPrefix [numberOfAffineIterations = 100] "
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputPrefix [numberOfAffineIterations = 100] "
               << "[numberOfDeformableIterationsLevel0 = 10] [numberOfDeformableIterationsLevel1 = 20] [numberOfDeformableIterationsLevel2 = 11 ] [learningRate = 0.5]" << std::endl;
     exit( 1 );
     }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
@@ -408,7 +408,7 @@ int itkTimeVaryingVelocityFieldImageRegistrationTest( int argc, char *argv[] )
 {
   if ( argc < 4 )
     {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputPrefix [numberOfAffineIterations = 100] "
+    std::cout << itkNameOfTestExecutableMacro(argv) << " imageDimension fixedImage movingImage outputPrefix [numberOfAffineIterations = 100] "
               << "[numberOfDeformableIterationsLevel0 = 10] [numberOfDeformableIterationsLevel1 = 20] [numberOfDeformableIterationsLevel2 = 11 ] [learningRate = 0.5]" << std::endl;
     exit( 1 );
     }

--- a/Modules/Segmentation/Classifiers/test/itkBayesianClassifierImageFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkBayesianClassifierImageFilterTest.cxx
@@ -168,7 +168,7 @@ int itkBayesianClassifierImageFilterTest( int argc, char* argv[] )
   if( argc < 6 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile outputImageFile numberOfClasses smoothingIterations testPriors" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImageFile outputImageFile numberOfClasses smoothingIterations testPriors" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkImageToListSampleAdaptor.h"
 #include "itkNormalVariateGenerator.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 //This program tests the ImageClassifierFilter. The test uses the
 //ExpectationMaximizationMixtureModelEstimator to estimaete membership
@@ -32,7 +33,7 @@ int itkImageClassifierFilterTest(int argc, char* argv[] )
   if( argc < 2 )
     {
     std::cerr << "Missing command line arguments: "
-              << argv[0] << "\t" << "ClassifiedOutputImage name" << std::endl;
+              << itkNameOfTestExecutableMacro(argv) << "\t" << "ClassifiedOutputImage name" << std::endl;
     return EXIT_FAILURE;
     }
   constexpr unsigned int MeasurementVectorSize = 1;

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
@@ -25,6 +25,7 @@
 #include "itkMaskImageFilter.h"
 #include "itkNotImageFilter.h"
 #include "itkScalarImageKmeansImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkScalarImageKmeansImageFilter3DTest (int argc, char *argv[])
 {
@@ -32,7 +33,7 @@ int itkScalarImageKmeansImageFilter3DTest (int argc, char *argv[])
   if( argc < 4 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0];
+    std::cerr << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputVolume input3DSkullStripVolume outputLabelMapVolume " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkScalarImageKmeansImageFilterTest(int argc, char* argv [] )
   if( argc < 5 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0];
+    std::cerr << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputScalarImage outputLabeledImage numberOfClasses mean1 mean2... meanN " << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterBackgroundTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterBackgroundTest.cxx
@@ -19,13 +19,14 @@
 #include "itkConnectedComponentImageFilter.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int itkConnectedComponentImageFilterBackgroundTest( int argc, char* argv[] )
 {
 
   if ( argc < 2 )
     {
-    std::cout << "Usage: " << argv[0] << " <background value>\n";
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <background value>\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -23,13 +23,14 @@
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
 #include "vnl/vnl_sample.h"
+#include "itkTestingMacros.h"
 
 int itkConnectedComponentImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 5 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImage  outputImage threshold_low threshold_hi [fully_connected] [minimum_object_size]" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -19,13 +19,14 @@
 #include "itkHardConnectedComponentImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 template< typename TPixel >
 int DoIt( int argc, char* argv[], const std::string pixelType )
 {
   if( argc < 2 )
     {
-    std::cerr << "Usage: " << argv[0] << " outputImagePrefix" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputImagePrefix" << std::endl;
     return EXIT_FAILURE;
     }
   const char * outputImageFileName = argv[1];

--- a/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
@@ -23,13 +23,14 @@
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
+#include "itkTestingMacros.h"
 
 int itkMaskConnectedComponentImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 5 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImage  outputImage threshold_low threshold_hi [fully_connected] [minimum_object_size]" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
@@ -24,6 +24,7 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkChangeInformationImageFilter.h"
 #include "itkLabelStatisticsImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int itkRelabelComponentImageFilterTest(int argc, char* argv[] )
@@ -31,7 +32,7 @@ int itkRelabelComponentImageFilterTest(int argc, char* argv[] )
   if( argc < 5 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImage  outputImage threshold_low threshold_hi" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
@@ -22,13 +22,14 @@
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
+#include "itkTestingMacros.h"
 
 int itkScalarConnectedComponentImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImage  outputImage distance_threshold [fully_connected] [minimum_object_size]" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Segmentation/ConnectedComponents/test/itkThresholdMaximumConnectedComponentsImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkThresholdMaximumConnectedComponentsImageFilterTest.cxx
@@ -33,13 +33,14 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkThresholdMaximumConnectedComponentsImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkThresholdMaximumConnectedComponentsImageFilterTest( int argc,
                                                            char * argv [] )
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     std::cerr << " 1: InputImage Name 2:OutputImage Name" << std::endl;
     std::cerr << " 3: minimumPixelArea" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Segmentation/ConnectedComponents/test/itkVectorConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkVectorConnectedComponentImageFilterTest.cxx
@@ -22,13 +22,14 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkVectorImage.h"
+#include "itkTestingMacros.h"
 
 int itkVectorConnectedComponentImageFilterTest(int argc, char* argv[] )
 {
   if( argc < 1 )
     {
     std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputImage" << std::endl;
     return EXIT_FAILURE;
     }

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryHoleFillingImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryHoleFillingImageFilterTest.cxx
@@ -31,7 +31,7 @@ int itkVotingBinaryHoleFillingImageFilterTest( int argc, char* argv[] )
   if ( argc != 3 )
   {
     std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " Inputimage OutputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Inputimage OutputImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
@@ -86,7 +86,7 @@ int itkVotingBinaryImageFilterTest(int argc, char* argv[] )
   if ( argc < 6 )
   {
     std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " Inputimage OutputImage radius ForegroundValue BackgroundValue" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Inputimage OutputImage radius ForegroundValue BackgroundValue" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
@@ -29,6 +29,7 @@
 
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 int itkNarrowBandCurvesLevelSetImageFilterTest(int argc, char* argv[] )
@@ -36,7 +37,7 @@ int itkNarrowBandCurvesLevelSetImageFilterTest(int argc, char* argv[] )
 
   if(argc < 2)
     {
-    std::cerr << "Usage: " << argv[0] << " OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " OutputImage\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkParallelSparseFieldLevelSetImageFilter.h"
 
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 /*
  * This test exercises the dense p.d.e. solver framework
@@ -216,7 +217,7 @@ int itkParallelSparseFieldLevelSetImageFilterTest(int argc, char* argv[])
 {
   if (argc < 2)
     {
-    std::cerr << "Usage: " << argv[0] << " OutputImage [InitImage [TargetImage]]\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " OutputImage [InitImage [TargetImage]]\n";
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetDomainPartitionImage.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetDomainPartitionImageTest( int argc, char* argv[] )
 {
@@ -25,7 +26,7 @@ int itkLevelSetDomainPartitionImageTest( int argc, char* argv[] )
   if( argc < 1 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetDomainPartitionImageWithKdTree.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetDomainPartitionImageWithKdTreeTest( int argc, char* argv[] )
 {
@@ -25,7 +26,7 @@ int itkLevelSetDomainPartitionImageWithKdTreeTest( int argc, char* argv[] )
   if( argc < 1 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -22,6 +22,7 @@
 #include "itkLevelSetEquationBinaryMaskTerm.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationBinaryMaskTermTest( int argc, char* argv[] )
 {
@@ -29,7 +30,7 @@ int itkLevelSetEquationBinaryMaskTermTest( int argc, char* argv[] )
   if( argc < 1 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
@@ -22,6 +22,7 @@
 #include "itkLevelSetEquationChanAndVeseExternalTerm.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationChanAndVeseExternalTermTest( int argc, char* argv[] )
 {
@@ -29,7 +30,7 @@ int itkLevelSetEquationChanAndVeseExternalTermTest( int argc, char* argv[] )
   if( argc < 2 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -22,6 +22,7 @@
 #include "itkLevelSetEquationChanAndVeseInternalTerm.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationChanAndVeseInternalTermTest( int argc, char* argv[] )
 {
@@ -29,7 +30,7 @@ int itkLevelSetEquationChanAndVeseInternalTermTest( int argc, char* argv[] )
   if( argc < 2 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
@@ -22,13 +22,14 @@
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkNumericTraits.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationCurvatureTermTest( int argc, char* argv[] )
 {
   if( argc < 2 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
@@ -20,13 +20,14 @@
 #include "itkLevelSetEquationLaplacianTerm.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationLaplacianTermTest( int argc, char* argv[] )
 {
   if( argc < 2 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -22,6 +22,7 @@
 #include "itkLevelSetEquationOverlapPenaltyTerm.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationOverlapPenaltyTermTest( int argc, char* argv[] )
 {
@@ -29,7 +30,7 @@ int itkLevelSetEquationOverlapPenaltyTermTest( int argc, char* argv[] )
   if( argc < 1 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
@@ -20,13 +20,14 @@
 #include "itkLevelSetEquationPropagationTerm.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationPropagationTermTest( int argc, char* argv[] )
 {
   if( argc < 2 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationRegionTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationRegionTermTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkLevelSetEquationRegionTerm.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationRegionTermTest( int argc, char* argv[] )
 {
@@ -24,7 +25,7 @@ int itkLevelSetEquationRegionTermTest( int argc, char* argv[] )
   if( argc < 2 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermBaseTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermBaseTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkLevelSetEquationTermBase.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationTermBaseTest( int argc, char* argv[] )
 {
@@ -24,7 +25,7 @@ int itkLevelSetEquationTermBaseTest( int argc, char* argv[] )
   if( argc < 2 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -22,13 +22,14 @@
 #include "itkLevelSetEquationTermContainer.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int itkLevelSetEquationTermContainerTest( int argc, char* argv[] )
 {
   if( argc < 2 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << argv[0] << std::endl;
+    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -27,12 +27,13 @@
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 #include "itkLevelSetDomainMapImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkMultiLevelSetDenseImageSubset2DTest( int argc, char* argv[] )
 {
   if( argc < 1 )
     {
-    std::cerr << "Missing Arguments: " << argv[0] << std::endl;
+    std::cerr << "Missing Arguments: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -28,12 +28,13 @@
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 #include "itkLevelSetDomainMapImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkMultiLevelSetMalcolmImageSubset2DTest( int argc, char* argv[] )
 {
   if( argc < 1 )
     {
-    std::cerr << "Missing Arguments: " << argv[0] << std::endl;
+    std::cerr << "Missing Arguments: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -28,12 +28,13 @@
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 #include "itkLevelSetDomainMapImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkMultiLevelSetShiImageSubset2DTest( int argc, char* argv[] )
 {
   if( argc < 1 )
     {
-    std::cerr << "Missing Arguments: " << argv[0] << std::endl;
+    std::cerr << "Missing Arguments: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -28,12 +28,13 @@
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 #include "itkLevelSetDomainMapImageFilter.h"
+#include "itkTestingMacros.h"
 
 int itkMultiLevelSetWhitakerImageSubset2DTest( int argc, char* argv[] )
 {
   if( argc < 1 )
     {
-    std::cerr << "Missing Arguments: " << argv[0] << std::endl;
+    std::cerr << "Missing Arguments: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Segmentation/RegionGrowing/test/itkConnectedThresholdImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConnectedThresholdImageFilterTest.cxx
@@ -27,7 +27,7 @@ int itkConnectedThresholdImageFilterTest( int argc, char* argv[] )
 {
   if( argc < 7 )
     {
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " InputImage OutputImage "
       << "seed_x seed_y "
       << "LowerConnectedThreshold UpperConnectedThreshold "

--- a/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkIsolatedWatershedImageFilterTest( int argc, char* argv[] )
   if( argc < 9 )
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " InputImage"
       << " OutputImage"
       << " seed1_x"

--- a/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
@@ -29,7 +29,7 @@ int itkMorphologicalWatershedFromMarkersImageFilterTest( int argc, char * argv[]
   if( argc < 6 )
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " markerImageFile"
       << " outputImageFile"

--- a/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedImageFilterTest.cxx
@@ -30,7 +30,7 @@ int itkMorphologicalWatershedImageFilterTest( int argc, char * argv[] )
   if( argc < 6 )
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
       << " inputImageFile"
       << " outputImageFile"
       << " markWatershedLine"

--- a/Modules/Segmentation/Watersheds/test/itkTobogganImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkTobogganImageFilterTest.cxx
@@ -30,7 +30,7 @@ int itkTobogganImageFilterTest( int argc, char* argv[] )
   if( argc < 3 )
     {
     std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " InputImage OutputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Video/Filtering/test/itkDecimateFramesVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkDecimateFramesVideoFilterTest.cxx
@@ -24,6 +24,7 @@
 #include "itkFileListVideoIO.h"
 #include "itkImageFileReader.h"
 #include "itkImageRegionConstIterator.h"
+#include "itkTestingMacros.h"
 
 // type alias
 constexpr unsigned int Dimension = 2;
@@ -76,7 +77,7 @@ int itkDecimateFramesVideoFilterTest( int argc, char* argv[] )
   //////
   if (argc < 3)
     {
-    std::cout << "Usage: " << argv[0] << " input_file_string output_file_string" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input_file_string output_file_string" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkVideoFileReader.h"
 #include "itkVideoFileWriter.h"
 #include "itkFileListVideoIOFactory.h"
+#include "itkTestingMacros.h"
 
 
 // Set up type alias for test
@@ -87,7 +88,7 @@ int itkFrameAverageVideoFilterTest( int argc, char* argv[] )
   //////
   if (argc < 3)
     {
-    std::cout << "Usage: " << argv[0] << " input_file_string output_file_string" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input_file_string output_file_string" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Video/Filtering/test/itkImageFilterToVideoFilterWrapperTest.cxx
+++ b/Modules/Video/Filtering/test/itkImageFilterToVideoFilterWrapperTest.cxx
@@ -26,6 +26,7 @@
 #include "itkFileListVideoIO.h"
 #include "itkFileListVideoIOFactory.h"
 #include "itkTestingComparisonImageFilter.h"
+#include "itkTestingMacros.h"
 
 /**
  * Main test
@@ -35,7 +36,7 @@ int itkImageFilterToVideoFilterWrapperTest( int argc, char* argv[] )
   // Check parameters
   if (argc < 3)
     {
-    std::cerr << "Usage: " << argv[0] << " input_video output_video" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input_video output_video" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Modules/Video/IO/test/itkFileListVideoIOTest.cxx
+++ b/Modules/Video/IO/test/itkFileListVideoIOTest.cxx
@@ -286,7 +286,7 @@ int itkFileListVideoIOTest( int argc, char *argv[] )
 {
   if (argc != 13)
     {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " videoInput(5 files) non-VideoInput videoOutput webcamOutput";
     std::cerr << " width height numFrames FpS" << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
Many unit tests could crash (or have undefined behavior), when doing something
like the following with `argv[0] == nullptr`:

    std::cerr << "Usage: " << argv[0] << std::endl;

This commit prevents such crashes by using a new macro,
`itkNameOfTestExecutableMacro(argv)`, instead of `argv[0]`.