### PR TITLE
Eigen3 2019-03-05 (c7b6372d)

### DIFF
--- a/Modules/Core/Common/include/itkWin32Header.h
+++ b/Modules/Core/Common/include/itkWin32Header.h
@@ -43,19 +43,12 @@
 // decorated name length exceeded, name was truncated
 #pragma warning ( disable : 4503 )
 
-// 'type' : forcing value to bool 'true' or 'false' (performance warning)
-#pragma warning ( disable : 4800 )
-
 // 'identifier' : class 'type' needs to have dll-interface to be used by
 // clients of class 'type2'
 #pragma warning ( disable : 4251 )
 
 // non dll-interface class 'type' used as base for dll-interface class 'type2'
 #pragma warning ( disable : 4275 )
-
-// C++ exception specification ignored except to indicate a
-// function is not __declspec(nothrow)
-#pragma warning ( disable : 4290 )
 
 // 'type' : inconsistent dll linkage.  dllexport assumed.
 #pragma warning ( disable : 4273 )
@@ -65,9 +58,6 @@
 
 // unreferenced local function has been removed
 #pragma warning ( disable : 4505 )
-
-// 'identifier' : identifier was truncated to 'number' characters in the debug information
-#pragma warning ( disable : 4786 )
 
 // nonstandard extension used : 'extern' before template explicit instantiation
 #pragma warning ( disable : 4231 )

--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/Parallelizer.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/Parallelizer.h
@@ -17,7 +17,7 @@ namespace internal {
 /** \internal */
 inline void manage_multi_threading(Action action, int* v)
 {
-  static EIGEN_UNUSED int m_maxThreads = -1;
+  static int m_maxThreads = -1;
 
   if(action==SetAction)
   {


### PR DESCRIPTION
Code extracted from:

    https://gitlab.kitware.com/phcerdan/eigen.git

at commit c7b6372dbf1da565da04aa6fb1e0f86b73e54613 (for/itk).

Change-Id: Id65d642184411f52994adf33536e8fe694496373

Fix warning:
```
Eigen/src/Core/products/Parallelizer.h:25:5: warning:
'm_maxThreads' was marked unused but was used [-Wused-but-marked-unused]
 m_maxThreads = *v;
```
https://open.cdash.org/viewBuildError.php?type=1&buildid=5785448

This was reported upstream:
http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1689
