### PR TITLE
COMP: Fix warning in IO/DCMTK about unused variable

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -248,7 +248,7 @@ bool DCMTKImageIO::CanReadFile(const char *filename)
   return DCMTKFileReader::IsImageFile(filename);
 }
 
-bool DCMTKImageIO::CanWriteFile(const char * itkNotUsed( name ))
+bool DCMTKImageIO::CanWriteFile(const char *)
 {
   // writing is currently not implemented
   return false;


### PR DESCRIPTION
```
Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx:153:45: warning: unused parameter ‘name’ [-Wunused-parameter]
 bool DCMTKImageIO::CanWriteFile(const char *name)
```