### PR TITLE
BUG: Fix OFFIS_DMCTK_VERSION_NUMBER where wrunlock was introduced

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -1488,10 +1488,10 @@ DCMTKFileReader
 {
   DcmDataDictionary &dict = dcmDataDict.wrlock();
   dict.addEntry(entry);
-#if OFFIS_DCMTK_VERSION_NUMBER > 362
-  dcmDataDict.wrunlock();
-#else
+#if OFFIS_DCMTK_VERSION_NUMBER < 364
   dcmDataDict.unlock();
+#else
+  dcmDataDict.wrunlock();
 #endif
 }
 


### PR DESCRIPTION
The change in the API of DcmDataDictionary was introduced in the commit:
https://github.com/DCMTK/dcmtk/commit/1e6aefdf8081263d192a9ed6a8241dac31401b47#diff-7f734e6993454e7b234c1f352bad0fb6

This corresponds to version 364 of DCMTK