### PR TITLE
BUG: Fix export for ITKDeprecated classes

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkConditionVariable.h
+++ b/Modules/Compatibility/Deprecated/include/itkConditionVariable.h
@@ -55,7 +55,7 @@ namespace itk
  *
  * \ingroup ITKDeprecated
  */
-class ITKCommon_EXPORT ConditionVariable:public LightObject
+class ITKDeprecated_EXPORT ConditionVariable:public LightObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(ConditionVariable);

--- a/Modules/Compatibility/Deprecated/include/itkFastMutexLock.h
+++ b/Modules/Compatibility/Deprecated/include/itkFastMutexLock.h
@@ -56,7 +56,7 @@ namespace itk
  * \ingroup OSSystemObjects
  * \ingroup ITKDeprecated
  */
-class ITKCommon_EXPORT FastMutexLock:public Object
+class ITKDeprecated_EXPORT FastMutexLock:public Object
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(FastMutexLock);

--- a/Modules/Compatibility/Deprecated/include/itkMutexLock.h
+++ b/Modules/Compatibility/Deprecated/include/itkMutexLock.h
@@ -31,6 +31,7 @@
 #include "itkObject.h"
 #include "itkObjectFactory.h"
 #include "itkThreadSupport.h"
+#include "ITKDeprecatedExport.h"
 
 namespace itk
 {
@@ -45,7 +46,7 @@ namespace itk
  * \ingroup OSSystemObjects
  * \ingroup ITKDeprecated
  */
-class ITKCommon_EXPORT SimpleMutexLock
+class ITKDeprecated_EXPORT SimpleMutexLock
 {
 public:
   /** Standard class type aliases.  */
@@ -99,7 +100,7 @@ protected:
  * \ingroup OSSystemObjects
  * \ingroup ITKDeprecated
  */
-class ITKCommon_EXPORT MutexLock:public Object
+class ITKDeprecated_EXPORT MutexLock:public Object
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(MutexLock);

--- a/Modules/Compatibility/Deprecated/include/itkSimpleFastMutexLock.h
+++ b/Modules/Compatibility/Deprecated/include/itkSimpleFastMutexLock.h
@@ -30,6 +30,7 @@
 
 #include "itkMacro.h"
 #include "itkThreadSupport.h"
+#include "ITKDeprecatedExport.h"
 
 namespace itk
 {
@@ -46,7 +47,7 @@ namespace itk
  */
 
 // Critical Section object that is not a itkObject.
-class ITKCommon_EXPORT SimpleFastMutexLock
+class ITKDeprecated_EXPORT SimpleFastMutexLock
 {
 public:
   /** Standard class type aliases.  */


### PR DESCRIPTION
It was using the export macros from their old `Common` module.

Errors:

```
ITK-build\Modules\Compatibility\Deprecated\src\ITKDeprecated.vcxproj" (default target) (32) ->
         (Link target) ->
    10>itkConditionVariable.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) const itk::ConditionVariable::`vftable'" (__imp_??_7ConditionVariable@itk@@6B@) referenced in function "protected: __cdecl itk::ConditionVariable::ConditionVariable(void)" (??0ConditionVariable@itk@@IEAA@XZ) [ITK-build\Modules\Compatibility\Deprecated\src\ITKDeprecated.vcxproj] [ITK.vcxproj]
    10>itkMutexLock.obj : error LNK2001: unresolved external symbol "public: virtual char const * __cdecl itk::SimpleMutexLock::GetNameOfClass(void)" (?GetNameOfClass@SimpleMutexLock@itk@@UEAAPEBDXZ) [ITK-build\Modules\Compatibility\Deprecated\src\ITKDeprecated.vcxproj] [ITK.vcxproj]
    10>itkMutexLock.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) const itk::SimpleMutexLock::`vftable'" (__imp_??_7SimpleMutexLock@itk@@6B@) referenced in function "public: __cdecl itk::SimpleMutexLock::SimpleMutexLock(void)" (??0SimpleMutexLock@itk@@QEAA@XZ) [ITK-build\Modules\Compatibility\Deprecated\src\ITKDeprecated.vcxproj] [ITK.vcxproj]
    10>ITK-build\bin\Release\ITKDeprecated-5.0.dll : fatal error LNK1120: 3 unresolved externals [ITK-build\Modules\Compatibility\Deprecated\src\ITKDeprecated.vcxproj] [ITK.vcxproj]

```
Closes #577