### PR TITLE
COMP: Specify type in LiThresholdCalculator min call

### DIFF
--- a/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.hxx
@@ -22,6 +22,7 @@
 #include "itkLiThresholdCalculator.h"
 #include "itkProgressReporter.h"
 #include "itkMath.h"
+#include <algorithm>
 
 namespace itk
 {
@@ -61,7 +62,7 @@ LiThresholdCalculator<THistogram, TOutput>
   double temp;
 
   // If there are negative values then shift the values to zero.
-  const double bin_min = std::min(histogram->GetBinMin(0,0), 0.0);
+  const double bin_min = std::min(static_cast<double>(histogram->GetBinMin(0,0)), 0.0);
 
   tolerance = 0.5;
   num_pixels = histogram->GetTotalFrequency();


### PR DESCRIPTION
This is a follow-up to:

  https://github.com/InsightSoftwareConsortium/ITK/pull/135

To address:

  In file included from /home/kitware/mattm/ITK/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.h:87:0,
                 from Wrapping/Typedefs/itkLiThresholdCalculatorSwigInterface.h:19,
                 from Wrapping/Modules/ITKThresholding/itkLiThresholdCalculatorPython.cpp:3371:
/home/kitware/mattm/ITK/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.hxx: In instantiation of ‘void itk::LiThresholdCalculator<THistogram, TOutput>::GenerateData() [with THistogram = itk::Statistics::Histogram<float>; TOutput = float]’:
Wrapping/Modules/ITKThresholding/itkLiThresholdCalculatorPython.cpp:8112:1:   required from here
/home/kitware/mattm/ITK/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.hxx:65:34: error: no matching function for call to ‘min(const MeasurementType&, double)’
   const double bin_min = std::min(histogram->GetBinMin(0,0), 0.0);