### PR TITLE
BUG: Returns a copy of the VNL matrix instead of a reference

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -764,6 +764,9 @@ macro(itk_wrap_simple_type_python wrap_class swig_name)
 
 
   # and now, generate the typemaps and other customizations
+  if("${cpp_name}" STREQUAL "itk::Matrix")
+    set(ITK_WRAP_PYTHON_SWIG_EXT "${ITK_WRAP_PYTHON_SWIG_EXT}DECL_PYTHON_ITK_MATRIX(${swig_name})\n")
+  endif()
 
   if("${cpp_name}" STREQUAL "std::complex")
     set(ITK_WRAP_PYTHON_SWIG_EXT "${ITK_WRAP_PYTHON_SWIG_EXT}DECL_PYTHON_STD_COMPLEX_CLASS(${swig_name})\n")

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -424,6 +424,23 @@ str = str
 %enddef
 
 
+%define DECL_PYTHON_ITK_MATRIX(class_name)
+  %rename(__GetVnlMatrix_orig__) class_name::GetVnlMatrix;
+  %extend class_name {
+        %pythoncode %{
+            def GetVnlMatrix(self):
+                vnl_reference = self.__GetVnlMatrix_orig__()
+                vnl_copy = type(vnl_reference)(vnl_reference)
+                return vnl_copy
+            %}
+        }
+
+  %pythoncode %{
+    def class_name##_New():
+      return class_name.New()
+  %}
+%enddef
+
 %define DECL_PYTHON_STD_COMPLEX_CLASS(swig_name)
 
 %extend swig_name {


### PR DESCRIPTION
When getting a VNL matrix from an ITK matrix, a reference is returned. This
creates problem in Python if on uses the variable multiple times in one line
(e.g. m2=m*m).
To work araound this problem, we define a Python function that copies the
VNL matrix. Another solution would have been to use a SWIG `typemap`.