### PR TITLE
BUG: Initialize array with expected number of elements

### DIFF
--- a/Modules/Core/Mesh/test/itkMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshTest.cxx
@@ -476,7 +476,7 @@ int itkMeshTest(int, char* [] )
 
     // Now we can construct a new cell and overwrite the id
     testCell.TakeOwnership(new QuadraticTriangleCellType); // polymorphism;
-    MeshType::PointIdentifier quadraticTrianglePoints[3] = {0,1,2};
+    MeshType::PointIdentifier quadraticTrianglePoints[6] = {0,1,2,3,4,5};
     testCell->SetPointIds(quadraticTrianglePoints);
     mesh->SetCell(2, testCell ); // Internally transfers ownership to the mesh
     std::cout << "QuadraticTriangleCell pointer = " << (void*)testCell.GetPointer() << std::endl;


### PR DESCRIPTION
Fix for #438.

When using `-O3`, GCC attempts to directly allocate an array by copying the values provided. However, a quadratic triangle expects 6 points so it reads out of bounds.