### PR TITLE
ENH: `isinstance()` can be called without template parameters of clas…

### DIFF
--- a/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
@@ -48,6 +48,11 @@ assert readerType == readerType2 == readerType3
 assert tpl == itk.Image
 assert parameters == (PixelType, dim)
 
+# test that `isinstance` works
+obj = itk.ImageFileReader[ImageType].New()
+assert isinstance(obj, itk.ImageFileReader.IUC2)
+assert isinstance(obj, itk.ImageFileReader)
+
 # the template must raise a KeyError exception if the template parameter
 # is unknown
 try:

--- a/Wrapping/Generators/Python/itkTemplate.py
+++ b/Wrapping/Generators/Python/itkTemplate.py
@@ -165,6 +165,19 @@ class itkTemplate(object):
         # add the attribute to this object
         self.__dict__[attributeName] = cl
 
+    def __instancecheck__(self, instance):
+        """Overloads `isinstance()` when called on an `itkTemplate` object.
+
+        This function allows to compare an object to a filter without
+        specifying the actual template arguments of the class. It will
+        test all available template parameters that have been wrapped
+        and return `True` if one that corresponds to the object is found.
+        """
+        for k in self.keys():
+            if isinstance(instance, self[k]):
+                return True
+        return False
+
     def __find_param__(self, paramSetString):
         """Find the parameters of the template.
 


### PR DESCRIPTION
…sinfo

`isinstance()` could already be called on ITK objects if the developer
was correctly comparing the object to a class with template arguments:

obj = itk.MedianImageFilter.IF2IF2.New()
isinstance(obj, itk.MedianImageFilter.IF2IF2)

Now, a developer can simply write:

obj = itk.MedianImageFilter.IF2IF2.New()
isinstance(obj, itk.MedianImageFilter)

This is especially convenient when trying to abstract from the template
parameters like when using `imread()` or calling filters using
template parameter deduction.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

<!-- **Thanks for contributing to ITK!** -->
