### PR TITLE
BUG: Disable TIFF predictor

### DIFF
--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -679,7 +679,7 @@ void TIFFImageIO::InternalWrite(const void *buffer)
       }
     else if ( compression == COMPRESSION_DEFLATE )
       {
-      predictor = 2;
+      predictor = PREDICTOR_NONE;
       TIFFSetField(tif, TIFFTAG_PREDICTOR, predictor);
       }
 


### PR DESCRIPTION
Fixes #574.

This is a known bug from [Libtiff](http://bugzilla.maptools.org/show_bug.cgi?id=2073).