### PR TITLE
COMP: Allow compiler option fixed in gcc 4.1.0

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -292,21 +292,6 @@ macro(check_compiler_platform_flags)
     set(ITK_REQUIRED_LINK_FLAGS "${ITK_REQUIRED_LINK_FLAGS} -mthreads")
   endif()
 
-
-  #-----------------------------------------------------------------------------
-  # The frename-registers option does not work due to a bug in the gnu compiler.
-  # It must be removed or data errors will be produced and incorrect results
-  # will be produced.  This is first documented in the gcc4 man page.
-  if(CMAKE_COMPILER_IS_GNUCXX)
-    set(ALL_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} ${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_MODULE_LINKER_FLAGS}" )
-    separate_arguments(ALL_FLAGS)
-    foreach(COMP_OPTION ${ALL_FLAGS})
-      if("${COMP_OPTION}" STREQUAL "-frename-registers")
-        message(FATAL_ERROR "-frename-registers causes runtime bugs.  It must be removed from your compilation options.")
-      endif()
-    endforeach()
-  endif()
-
   #-----------------------------------------------------------------------------
   # Set the compiler-specific flag for disabling optimization.
   if(MSVC)


### PR DESCRIPTION
GCC version 4.0.4 had a bug in the -frename-registers
option used by -funroll-loops.

As of GCC version 4.1.0 and greater, this optimiation
was fixed.

ITK should no longer prohibit this optimization.

GCC 4.0.4 documentation
  -frename-registers
  Attempt to avoid false dependencies in scheduled code by making use of registers
  left over after register allocation. This optimization will most benefit processors
  with lots of registers. Depending on the debug information format adopted by
  the target, however, it can make debugging impossible, since variables will no
  longer stay in a “home register”.
 *** Not enabled by default at any level because it has known bugs.

GCC 4.1.0 documentation
  -frename-registers
  Attempt to avoid false dependencies in scheduled code by making use of registers
  left over after register allocation. This optimization will most benefit processors
  with lots of registers. Depending on the debug information format adopted by
  the target, however, it can make debugging impossible, since variables will no
  longer stay in a “home register”.
 *** Enabled by default with ‘-funroll-loops’.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

<!-- **Thanks for contributing to ITK!** -->
