### PR TITLE
STYLE: Renamed array of radii EllipseSpatialObject to RadiiInObjectSpace

### DIFF
--- a/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
@@ -220,7 +220,7 @@ int main( int argc, char *argv[] )
     std::cout << "Center: ";
     std::cout << (*itCircles)->GetCenterInObjectSpace()
               << std::endl;
-    std::cout << "Radius: " << (*itCircles)->GetRadiusInObjectSpace()[0]
+    std::cout << "Radius: " << (*itCircles)->GetRadiiInObjectSpace()[0]
       << std::endl;
     // Software Guide : EndCodeSnippet
 
@@ -240,10 +240,10 @@ int main( int argc, char *argv[] )
       using IndexValueType = ImageType::IndexType::IndexValueType;
       localIndex[0] =
          itk::Math::Round<IndexValueType>(centerPoint[0]
-                  + (*itCircles)->GetRadiusInObjectSpace()[0]*std::cos(angle));
+                  + (*itCircles)->GetRadiiInObjectSpace()[0]*std::cos(angle));
       localIndex[1] =
          itk::Math::Round<IndexValueType>(centerPoint[1]
-                  + (*itCircles)->GetRadiusInObjectSpace()[0]*std::sin(angle));
+                  + (*itCircles)->GetRadiiInObjectSpace()[0]*std::sin(angle));
       OutputImageType::RegionType outputRegion =
                                   localOutputImage->GetLargestPossibleRegion();
 

--- a/Examples/SpatialObjects/EllipseSpatialObject.cxx
+++ b/Examples/SpatialObjects/EllipseSpatialObject.cxx
@@ -57,7 +57,7 @@ int main( int , char *[] )
     radius[i] = i;
     }
 
-  myEllipse->SetRadiusInObjectSpace(radius);
+  myEllipse->SetRadiiInObjectSpace(radius);
 // Software Guide : EndCodeSnippet
 // Software Guide : BeginLatex
 //
@@ -70,12 +70,12 @@ int main( int , char *[] )
 
 // Software Guide : BeginLatex
 //
-// We can then display the current radius by using the \code{GetRadius()}
+// We can then display the current radius by using the \code{GetRadiiInObjectSpace()}
 // function:
 //
 // Software Guide : EndLatex
 // Software Guide : BeginCodeSnippet
-  EllipseType::ArrayType myCurrentRadius = myEllipse->GetRadiusInObjectSpace();
+  EllipseType::ArrayType myCurrentRadius = myEllipse->GetRadiiInObjectSpace();
   std::cout << "Current radius is " << myCurrentRadius << std::endl;
 // Software Guide : EndCodeSnippet
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -67,10 +67,10 @@ public:
   void SetRadiusInObjectSpace(double radius);
 
   /** Set radii via an array of radius values */
-  itkSetMacro(RadiusInObjectSpace, ArrayType);
+  itkSetMacro(RadiiInObjectSpace, ArrayType);
 
   /** Get radii via an array of radius values */
-  itkGetConstReferenceMacro(RadiusInObjectSpace, ArrayType);
+  itkGetConstReferenceMacro(RadiiInObjectSpace, ArrayType);
 
   /** Set center point in object space. */
   itkSetMacro( CenterInObjectSpace, PointType );
@@ -99,7 +99,7 @@ protected:
 private:
 
   /* object space */
-  ArrayType m_RadiusInObjectSpace;
+  ArrayType m_RadiiInObjectSpace;
   PointType m_CenterInObjectSpace;
 };
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -28,7 +28,7 @@ EllipseSpatialObject< TDimension >
 ::EllipseSpatialObject()
 {
   this->SetTypeName("EllipseSpatialObject");
-  m_RadiusInObjectSpace.Fill(1.0);
+  m_RadiiInObjectSpace.Fill(1.0);
   m_CenterInObjectSpace.Fill(0.0);
   this->Update();
 }
@@ -43,9 +43,9 @@ EllipseSpatialObject< TDimension >
   bool changes = false;
   for( unsigned int i=0; i<ObjectDimension; ++i )
     {
-    if( m_RadiusInObjectSpace[i] != radius )
+    if( m_RadiiInObjectSpace[i] != radius )
       {
-      m_RadiusInObjectSpace[i] = radius;
+      m_RadiiInObjectSpace[i] = radius;
       changes = true;
       }
     }
@@ -70,13 +70,13 @@ EllipseSpatialObject< TDimension >
     double r = 0;
     for ( unsigned int i = 0; i < TDimension; i++ )
       {
-      if ( m_RadiusInObjectSpace[i] > 0.0 )
+      if ( m_RadiiInObjectSpace[i] > 0.0 )
         {
         d = point[i] - m_CenterInObjectSpace[i];
         r += ( d * d )
-          / ( m_RadiusInObjectSpace[i] * m_RadiusInObjectSpace[i] );
+          / ( m_RadiiInObjectSpace[i] * m_RadiiInObjectSpace[i] );
         }
-      else if ( point[i] != 0.0 || m_RadiusInObjectSpace[i] < 0 )
+      else if ( point[i] != 0.0 || m_RadiiInObjectSpace[i] < 0 )
         // Deal with an ellipse with 0 or negative radius;
         {
         r = 2; // Keeps function from returning true here
@@ -110,8 +110,8 @@ EllipseSpatialObject< TDimension >
   PointType    pnt2;
   for ( unsigned int i = 0; i < TDimension; i++ )
     {
-    pnt1[i] = m_CenterInObjectSpace[i] - m_RadiusInObjectSpace[i];
-    pnt2[i] = m_CenterInObjectSpace[i] + m_RadiusInObjectSpace[i];
+    pnt1[i] = m_CenterInObjectSpace[i] - m_RadiiInObjectSpace[i];
+    pnt2[i] = m_CenterInObjectSpace[i] + m_RadiiInObjectSpace[i];
     }
 
   this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pnt1);
@@ -136,7 +136,7 @@ EllipseSpatialObject< TDimension >
     itkExceptionMacro(<< "Downcast to type " << this->GetNameOfClass()
       << " failed.");
     }
-  rval->SetRadiusInObjectSpace( this->GetRadiusInObjectSpace() );
+  rval->SetRadiiInObjectSpace( this->GetRadiiInObjectSpace() );
   rval->SetCenterInObjectSpace( this->GetCenterInObjectSpace() );
 
   return loPtr;
@@ -150,7 +150,7 @@ EllipseSpatialObject< TDimension >
 {
   os << indent << "EllipseSpatialObject(" << this << ")" << std::endl;
   Superclass::PrintSelf(os, indent);
-  os << "Object Radius: " << m_RadiusInObjectSpace << std::endl;
+  os << "Object Radii: " << m_RadiiInObjectSpace << std::endl;
   os << "Object Center: " << m_CenterInObjectSpace << std::endl;
 }
 

--- a/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
@@ -45,13 +45,13 @@ MetaEllipseConverter< NDimensions >
 
   EllipseSpatialObjectPointer ellipseSO = EllipseSpatialObjectType::New();
 
-  typename EllipseSpatialObjectType::ArrayType radius;
+  typename EllipseSpatialObjectType::ArrayType radii;
   for ( unsigned int i = 0; i < NDimensions; i++ )
     {
-    radius[i] = ellipseMO->Radius()[i];
+    radii[i] = ellipseMO->Radius()[i];
     }
 
-  ellipseSO->SetRadiusInObjectSpace(radius);
+  ellipseSO->SetRadiiInObjectSpace(radii);
   ellipseSO->GetProperty().SetName( ellipseMO->Name() );
   ellipseSO->SetId( ellipseMO->ID() );
   ellipseSO->SetParentId( ellipseMO->ParentID() );
@@ -78,18 +78,18 @@ MetaEllipseConverter< NDimensions >
 
   auto * ellipseMO = new EllipseMetaObjectType(NDimensions);
 
-  auto * radius = new float[NDimensions];
+  auto * radii = new float[NDimensions];
 
   for ( unsigned int i = 0; i < NDimensions; i++ )
     {
-    radius[i] = ellipseSO->GetRadiusInObjectSpace()[i];
+    radii[i] = ellipseSO->GetRadiiInObjectSpace()[i];
     }
 
   if ( ellipseSO->GetParent() )
     {
     ellipseMO->ParentID( ellipseSO->GetParent()->GetId() );
     }
-  ellipseMO->Radius(radius);
+  ellipseMO->Radius(radii);
   ellipseMO->ID( ellipseSO->GetId() );
 
   ellipseMO->Color( ellipseSO->GetProperty().GetRed(),
@@ -97,7 +97,7 @@ MetaEllipseConverter< NDimensions >
                   ellipseSO->GetProperty().GetBlue(),
                   ellipseSO->GetProperty().GetAlpha() );
 
-  delete[] radius;
+  delete[] radii;
   return ellipseMO;
 }
 

--- a/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
@@ -31,21 +31,21 @@ int itkEllipseSpatialObjectTest(int, char* [])
   std::cout << "Testing Print after construction" << std::endl;
   myEllipse->Print(std::cout);
 
-  EllipseType::ArrayType radius;
+  EllipseType::ArrayType radii;
 
   for(unsigned int i = 0; i < 4; i++)
   {
-    radius[i] = i;
+    radii[i] = i;
   }
 
   std::cout << "Testing radii : ";
 
-  myEllipse->SetRadiusInObjectSpace(radius);
+  myEllipse->SetRadiiInObjectSpace(radii);
   myEllipse->Update();
-  EllipseType::ArrayType radius2 = myEllipse->GetRadiusInObjectSpace();
+  EllipseType::ArrayType radii2 = myEllipse->GetRadiiInObjectSpace();
   for(unsigned int i = 0; i<4;i++)
   {
-    if(itk::Math::NotExactlyEquals(radius2[i],i))
+    if(itk::Math::NotExactlyEquals(radii2[i],i))
     {
       std::cout << "[FAILURE]" << std::endl;
       return EXIT_FAILURE;
@@ -55,11 +55,11 @@ int itkEllipseSpatialObjectTest(int, char* [])
 
   myEllipse->SetRadiusInObjectSpace(3);
   myEllipse->Update();
-  EllipseType::ArrayType radius3 = myEllipse->GetRadiusInObjectSpace();
+  EllipseType::ArrayType radii3 = myEllipse->GetRadiiInObjectSpace();
   std::cout << "Testing Global radii : ";
   for(unsigned int i = 0; i<4;i++)
   {
-    if(itk::Math::NotExactlyEquals(radius3[i],3))
+    if(itk::Math::NotExactlyEquals(radii3[i],3))
     {
       std::cout << "[FAILURE]" << std::endl;
       return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -39,7 +39,7 @@ int itkSpatialObjectDuplicatorTest(int, char* [])
 
   EllipseType::Pointer ellipse_copy = duplicator->GetOutput();
 
-  std::cout << ellipse_copy->GetRadiusInObjectSpace() << std::endl;
+  std::cout << ellipse_copy->GetRadiiInObjectSpace() << std::endl;
   std::cout << ellipse_copy->GetProperty().GetColor() << std::endl;
 
   // Test with a group
@@ -56,7 +56,7 @@ int itkSpatialObjectDuplicatorTest(int, char* [])
   GroupType::ChildrenListType* children = group_copy->GetChildren();
 
   EllipseType::Pointer ellipse_copy2 = static_cast<EllipseType*>((*(children->begin())).GetPointer());
-  std::cout << ellipse_copy2->GetRadiusInObjectSpace() << std::endl;
+  std::cout << ellipse_copy2->GetRadiiInObjectSpace() << std::endl;
 
   delete children;
 

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -173,11 +173,11 @@ int itkSpatialObjectToImageStatisticsCalculatorTest(int, char * [] )
   std::cout << "Allocating spatial object." << std::endl;
   using Ellipse3DType = itk::EllipseSpatialObject<3>;
   Ellipse3DType::Pointer ellipse3D = Ellipse3DType::New();
-  double radius[3];
-  radius[0] = 10;
-  radius[1] = 10;
-  radius[2] = 0;
-  ellipse3D->SetRadiusInObjectSpace(radius);
+  double radii[3];
+  radii[0] = 10;
+  radii[1] = 10;
+  radii[2] = 0;
+  ellipse3D->SetRadiiInObjectSpace(radii);
 
   Ellipse3DType::VectorType offset3D;
   offset3D.Fill(25);

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -274,7 +274,7 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
       for ( double angle = 0; angle <= 2 * itk::Math::pi; angle += itk::Math::pi / 1000 )
         {
         for ( double length = 0; length < m_DiscRadiusRatio *
-          Circle->GetRadiusInObjectSpace()[0]; length += 1 )
+          Circle->GetRadiiInObjectSpace()[0]; length += 1 )
           {
           const Index< 2 > index =
             {{

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -216,8 +216,8 @@ namespace
       success = false;
     }
 
-    const double radius1 = circle1->GetRadiusInObjectSpace()[0];
-    const double radius2 = circle2->GetRadiusInObjectSpace()[0];
+    const double radius1 = circle1->GetRadiiInObjectSpace()[0];
+    const double radius2 = circle2->GetRadiiInObjectSpace()[0];
 
     if ( radius2 < radius1 )
     {
@@ -444,21 +444,21 @@ int itkHoughTransform2DCirclesImageTest( int, char* [] )
   while( it != circleList.end() )
     {
       if( !itk::Math::FloatAlmostEqual(
-          (double)( it->GetPointer()->GetRadiusInObjectSpace()[0] ),
+          (double)( it->GetPointer()->GetRadiiInObjectSpace()[0] ),
         radius[i], 10, radiusTolerance ) &&
         !itk::Math::FloatAlmostEqual(
-          (double)( it->GetPointer()->GetRadiusInObjectSpace()[0] ),
+          (double)( it->GetPointer()->GetRadiiInObjectSpace()[0] ),
         radius[i] * discRadiusRatio, 10, radiusTolerance ) )
       {
       std::cout << "Failure for circle #" << i << std::endl;
       std::cout << "Expected radius: " << radius[i] << ", found "
-        << it->GetPointer()->GetRadiusInObjectSpace() << std::endl;
+        << it->GetPointer()->GetRadiiInObjectSpace() << std::endl;
       success = false;
       }
     else
       {
       std::cout << "Circle #" << i << " radius: "
-        << it->GetPointer()->GetRadiusInObjectSpace() << std::endl;
+        << it->GetPointer()->GetRadiiInObjectSpace() << std::endl;
       }
     ++it;
     ++i;

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -819,7 +819,7 @@ int itkReadWriteSpatialObjectTest(int argc, char* argv[])
       for(unsigned int jj=0;jj<3;jj++)
         {
         if (dynamic_cast<EllipseType*>((*obj).GetPointer())->
-          GetRadiusInObjectSpace()[jj] != 9.0)
+          GetRadiiInObjectSpace()[jj] != 9.0)
           {
           std::cout<<" [FAILED]"<< std::endl;
           delete mySceneChildren;


### PR DESCRIPTION
Renamed the array of radii of `EllipseSpatialObject` from
`RadiusInObjectSpace` to `RadiiInObjectSpace`.

Thereby it can be distinguished more clearly from use cases where
there is only one radius.