### PR TITLE
STYLE: Remove const from SpatialObject::ComputeMyBoundingBox()

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -89,7 +89,7 @@ public:
 protected:
 
   /** Compute the Object bounding box */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   ArrowSpatialObject();
   ~ArrowSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -89,7 +89,7 @@ public:
 protected:
 
   /** Compute the Object bounding box */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   ArrowSpatialObject();
   ~ArrowSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -58,7 +58,7 @@ ArrowSpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 ArrowSpatialObject< TDimension >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   itkDebugMacro("Computing Rectangle bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -58,7 +58,7 @@ ArrowSpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 ArrowSpatialObject< TDimension >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing Rectangle bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -79,7 +79,7 @@ protected:
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   BoxSpatialObject();
   ~BoxSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -79,7 +79,7 @@ protected:
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   BoxSpatialObject();
   ~BoxSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -77,7 +77,7 @@ BoxSpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 BoxSpatialObject< TDimension >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   itkDebugMacro("Computing BoxSpatialObject bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -77,7 +77,7 @@ BoxSpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 BoxSpatialObject< TDimension >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing BoxSpatialObject bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -103,7 +103,7 @@ protected:
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   EllipseSpatialObject();
   ~EllipseSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -103,7 +103,7 @@ protected:
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   EllipseSpatialObject();
   ~EllipseSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -116,7 +116,7 @@ EllipseSpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 EllipseSpatialObject< TDimension >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing ellipse bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -116,7 +116,7 @@ EllipseSpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 EllipseSpatialObject< TDimension >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   itkDebugMacro("Computing ellipse bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -110,7 +110,7 @@ public:
 protected:
   /** This function needs to be called every time one of the object's
    *  components is changed. */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   GaussianSpatialObject();
   ~GaussianSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -110,7 +110,7 @@ public:
 protected:
   /** This function needs to be called every time one of the object's
    *  components is changed. */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   GaussianSpatialObject();
   ~GaussianSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -124,7 +124,7 @@ GaussianSpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 GaussianSpatialObject< TDimension >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing Guassian bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -124,7 +124,7 @@ GaussianSpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 GaussianSpatialObject< TDimension >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   itkDebugMacro("Computing Guassian bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -89,7 +89,7 @@ protected:
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   ImageMaskSpatialObject();
   ~ImageMaskSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -89,7 +89,7 @@ protected:
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   ImageMaskSpatialObject();
   ~ImageMaskSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -73,7 +73,7 @@ ImageMaskSpatialObject< TDimension, TPixel >
 template< unsigned int TDimension, typename TPixel >
 void
 ImageMaskSpatialObject< TDimension, TPixel >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   using IteratorType = ImageRegionConstIteratorWithIndex< ImageType >;
   IteratorType it( this->GetImage(),

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -73,7 +73,7 @@ ImageMaskSpatialObject< TDimension, TPixel >
 template< unsigned int TDimension, typename TPixel >
 void
 ImageMaskSpatialObject< TDimension, TPixel >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   using IteratorType = ImageRegionConstIteratorWithIndex< ImageType >;
   IteratorType it( this->GetImage(),

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -116,7 +116,7 @@ public:
 
 protected:
   /** Compute the boundaries of the image spatial object. */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   ImageSpatialObject();
   ~ImageSpatialObject() override;

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -116,7 +116,7 @@ public:
 
 protected:
   /** Compute the boundaries of the image spatial object. */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   ImageSpatialObject();
   ~ImageSpatialObject() override;

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -148,7 +148,7 @@ ImageSpatialObject< TDimension,  PixelType >
 template< unsigned int TDimension, typename PixelType >
 void
 ImageSpatialObject< TDimension,  PixelType >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   itkDebugMacro("Computing ImageSpatialObject bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -148,7 +148,7 @@ ImageSpatialObject< TDimension,  PixelType >
 template< unsigned int TDimension, typename PixelType >
 void
 ImageSpatialObject< TDimension,  PixelType >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing ImageSpatialObject bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -100,7 +100,7 @@ public:
 
 protected:
   /** Compute the boundaries of the iamge spatial object. */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   MeshSpatialObject();
   ~MeshSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -100,7 +100,7 @@ public:
 
 protected:
   /** Compute the boundaries of the iamge spatial object. */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   MeshSpatialObject();
   ~MeshSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -113,7 +113,7 @@ MeshSpatialObject< TMesh >
 template< typename TMesh >
 void
 MeshSpatialObject< TMesh >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   PointType pnt1;
   PointType pnt2;

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -113,7 +113,7 @@ MeshSpatialObject< TMesh >
 template< typename TMesh >
 void
 MeshSpatialObject< TMesh >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   PointType pnt1;
   PointType pnt2;

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -111,7 +111,7 @@ public:
 
 protected:
   /** Compute the boundaries of the Blob. */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   PointBasedSpatialObject();
   ~PointBasedSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -111,7 +111,7 @@ public:
 
 protected:
   /** Compute the boundaries of the Blob. */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   PointBasedSpatialObject();
   ~PointBasedSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -169,7 +169,7 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 template< unsigned int TDimension, class TSpatialObjectPointType >
 void
 PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   itkDebugMacro("Computing blob bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -169,7 +169,7 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 template< unsigned int TDimension, class TSpatialObjectPointType >
 void
 PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing blob bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -191,7 +191,7 @@ public:
   /**********************************************************************/
   /* These are the three member functions that a subclass will typically
    *    overwrite.
-   *    * ProtectedComputeMyBoundingBox (protected:)
+   *    * ComputeMyBoundingBox (protected:)
    *    * IsInsideInObjectSpace
    *    * Update
    *  Optionally, a subclass may also wish to overwrite
@@ -520,7 +520,7 @@ protected:
   void ProtectedComputeObjectToWorldTransform();
 
   /** Compute bounding box for the object in world space */
-  virtual void ProtectedComputeMyBoundingBox() const;
+  virtual void ComputeMyBoundingBox() const;
 
   /** Constructor. */
   SpatialObject();

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -502,9 +502,6 @@ public:
   itkLegacyMacro( void ComputeObjectToWorldTransform() )
   { this->Update(); /* Update() should be used instead of ProtectedComputeObjectToWorldTransform() */ }
 
-  itkLegacyMacro( void ComputeMyBoundingBox() )
-  { this->Update(); /* Update() should be used instead of ProtectedComputeMyBoundingBox() */}
-
   itkLegacyMacro( void ComputeBoundingBox() )
   { this->Update(); /* Update() should be used instead of outdated ComputeBoundingBox() */}
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -520,7 +520,7 @@ protected:
   void ProtectedComputeObjectToWorldTransform();
 
   /** Compute bounding box for the object in world space */
-  virtual void ComputeMyBoundingBox() const;
+  virtual void ComputeMyBoundingBox();
 
   /** Constructor. */
   SpatialObject();

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -726,7 +726,7 @@ SpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 SpatialObject< TDimension >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   typename BoundingBoxType::PointType pnt;
   pnt.Fill( NumericTraits< typename BoundingBoxType::PointType::ValueType >::
@@ -1351,7 +1351,7 @@ SpatialObject< TDimension >
 {
   Superclass::Update();
 
-  this->ProtectedComputeMyBoundingBox();
+  this->ComputeMyBoundingBox();
 
   m_FamilyBoundingBoxInObjectSpace->SetMinimum(
     m_MyBoundingBoxInObjectSpace->GetMinimum() );

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -726,7 +726,7 @@ SpatialObject< TDimension >
 template< unsigned int TDimension >
 void
 SpatialObject< TDimension >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   typename BoundingBoxType::PointType pnt;
   pnt.Fill( NumericTraits< typename BoundingBoxType::PointType::ValueType >::

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -110,7 +110,7 @@ public:
 protected:
 
   /** Compute the boundaries of the tube. */
-  void ProtectedComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() const override;
 
   TubeSpatialObject();
   ~TubeSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -110,7 +110,7 @@ public:
 protected:
 
   /** Compute the boundaries of the tube. */
-  void ComputeMyBoundingBox() const override;
+  void ComputeMyBoundingBox() override;
 
   TubeSpatialObject();
   ~TubeSpatialObject() override = default;

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -98,7 +98,7 @@ TubeSpatialObject< TDimension, TTubePointType >
 template< unsigned int TDimension, typename TTubePointType >
 void
 TubeSpatialObject< TDimension, TTubePointType >
-::ComputeMyBoundingBox() const
+::ComputeMyBoundingBox()
 {
   itkDebugMacro("Computing tube bounding box");
 

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -98,7 +98,7 @@ TubeSpatialObject< TDimension, TTubePointType >
 template< unsigned int TDimension, typename TTubePointType >
 void
 TubeSpatialObject< TDimension, TTubePointType >
-::ProtectedComputeMyBoundingBox() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing tube bounding box");
 


### PR DESCRIPTION
An essential property of the virtual member function `ComputeMyBoundingBox()`
is that it modifies the data of the `SpatialObject` (specifically, the member
function modifies its `MyBoundingBoxInObjectSpace` data member).

So even though the compiler "allows" the member function to be declared
`const`, the semantics of the member function (and its overrides) appear
logically non-const.