### PR TITLE
BUG: Wrap itkImageDuplicator for all image types

### DIFF
--- a/Modules/Core/Common/wrapping/itkImageDuplicator.wrap
+++ b/Modules/Core/Common/wrapping/itkImageDuplicator.wrap
@@ -1,3 +1,37 @@
 itk_wrap_class("itk::ImageDuplicator" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_ALL_TYPES}" 1)
+  # Making sure that all types wrapped in PyBuffer are also wrapped for ImageDuplicator
+  # as this filter is used in the Python NumPy  bridge.
+  UNIQUE(types "${WRAP_ITK_SCALAR};UC;D;US;UI;UL;SC;SS;SI;SL;F")
+  foreach(t ${types})
+    string(REGEX MATCHALL "(V${t}|CV${t})" VectorTypes ${WRAP_ITK_VECTOR})
+    set(PixelType ${t})
+    foreach(d ${ITK_WRAP_DIMS})
+      if( DEFINED ITKT_I${t}${d} )
+        itk_wrap_template("${ITKM_I${t}${d}}" "${ITKT_I${t}${d}}")
+      endif()
+
+      # Wraps Symmetric Second Rank tensor images
+      if( DEFINED ITKM_ISSRT${t}${d}${d})
+        itk_wrap_template("${ITKM_ISSRT${t}${d}${d}}" "${ITKT_ISSRT${t}${d}${d}}")
+      endif()
+
+      # Wraps RGB and RGBA types that have been selected to be wrapped.
+      # We have to recompute them all to extract the pixel component type.
+      foreach(p RGB;RGBA)
+        set(WRAP_RGBA_RGB "${WRAP_ITK_RGB};${WRAP_ITK_RGBA}")
+        list(FIND WRAP_RGBA_RGB "${p}${t}" pos)
+        if( NOT ${pos} EQUAL -1 AND DEFINED ITKT_I${p}${t}${d})
+          itk_wrap_template("${ITKM_I${p}${t}${d}}" "${ITKT_I${p}${t}${d}}")
+        endif()
+      endforeach(p)
+      # Image Vector types
+      foreach(vec_dim ${ITK_WRAP_VECTOR_COMPONENTS})
+        foreach(vec_type ${VectorTypes})
+           if( DEFINED ITKM_I${vec_type}${vec_dim}${d})
+             itk_wrap_template("${ITKM_I${vec_type}${vec_dim}${d}}" "${ITKT_I${vec_type}${vec_dim}${d}}")
+             endif()
+          endforeach()
+       endforeach()
+    endforeach(d)
+  endforeach(t)
 itk_end_wrap_class()

--- a/Wrapping/WrapITKTypes.cmake
+++ b/Wrapping/WrapITKTypes.cmake
@@ -203,7 +203,11 @@ WRAP_TYPE("itk::Image" "I" "itkImage.h")
   # Make a list of all of the selected image pixel types and also double (for
   # BSplineDeformableTransform), uchar (for 8-bit image output), ulong
   # (for the watershed and relabel filters), bool for (FlatStructuringElement)
-  UNIQUE(wrap_image_types "${WRAP_ITK_ALL_TYPES};D;UC;UL;ULL;RGBUC;RGBAUC;VD;B;${ITKM_IT}")
+
+  # Wrap from ulong to other integral types, even if ulong isn't wrapped. This
+  # is needed for the relabel components image filter.
+  UNIQUE(WRAP_ITK_SCALAR_IMAGE_PIXEL_TYPES "${WRAP_ITK_SCALAR};D;UC;UL;ULL;B;${ITKM_IT}")
+  UNIQUE(wrap_image_types "${WRAP_ITK_ALL_TYPES};RGBUC;RGBAUC;VD;${WRAP_ITK_SCALAR_IMAGE_PIXEL_TYPES}")
 
   set(defined_vector_list )
   foreach(d ${ITK_WRAP_IMAGE_DIMS})


### PR DESCRIPTION
NumPyBridge uses the itkImageDuplicator filter to copy images, so all image
types need to be supported (wrapped) for this filter to be able to convert
all ITK images into NumPy arrays.