### PR TITLE
STYLE: Remove GetPixelTypeName() from both Image and Mesh SpatialObject

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -104,8 +104,10 @@ public:
   int GetSliceNumber(unsigned int dimension)
   { return m_SliceNumber[dimension]; }
 
-  const char * GetPixelTypeName()
+#if !defined(ITK_LEGACY_REMOVE)
+  itkLegacyMacro(const char * GetPixelTypeName())
   { return m_PixelType.c_str(); }
+#endif
 
   /** Set/Get the interpolator */
   void SetInterpolator(InterpolatorType *interpolator);
@@ -125,10 +127,14 @@ private:
   ImagePointer    m_Image;
 
   IndexType       m_SliceNumber;
+
+#if !defined(ITK_LEGACY_REMOVE)
   std::string     m_PixelType;
+#endif
 
   typename InterpolatorType::Pointer m_Interpolator;
 
+#if !defined(ITK_LEGACY_REMOVE)
   template <typename T>
   void SetPixelTypeName(const T *)
   { itkWarningMacro("itk::ImageSpatialObject() : PixelType not recognized"); }
@@ -147,6 +153,7 @@ private:
 
   void SetPixelTypeName(const double *)
   { m_PixelType = "double"; }
+#endif
 
 };
 } // end of namespace itk

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -33,7 +33,9 @@ ImageSpatialObject< TDimension,  PixelType >
   m_Image = ImageType::New();
   m_SliceNumber.Fill( 0 );
 
+#if !defined(ITK_LEGACY_REMOVE)
   this->SetPixelTypeName(static_cast<const PixelType *>(nullptr));
+#endif
 
   m_Interpolator = NNInterpolatorType::New();
 }
@@ -228,7 +230,9 @@ ImageSpatialObject< TDimension,  PixelType >
   os << indent << "Interpolator: " << std::endl;
   os << indent << m_Interpolator << std::endl;
   os << indent << "SliceNumber: " << m_SliceNumber << std::endl;
+#if !defined(ITK_LEGACY_REMOVE)
   os << indent << "PixelType: " << m_PixelType << std::endl;
+#endif
 }
 
 /** Get the modification time */

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -80,11 +80,13 @@ public:
   /** Returns the latest modified time of the object and its component. */
   ModifiedTimeType GetMTime() const override;
 
-  /** Return the type of pixel used */
-  const char * GetPixelTypeName()
+#if !defined(ITK_LEGACY_REMOVE)
+  /** \deprecated Return the type of pixel used */
+  itkLegacyMacro(const char * GetPixelTypeName())
   {
     return m_PixelType.c_str();
   }
+#endif
 
   /** Set/Get the precision for the IsInsideInObjectSpace function.
    *  This is used when the cell is a triangle, in this case, it's more likely
@@ -106,7 +108,9 @@ protected:
 
 private:
   MeshPointer m_Mesh;
+#if !defined(ITK_LEGACY_REMOVE)
   std::string m_PixelType;
+#endif
   double      m_IsInsidePrecisionInObjectSpace;
 
 };

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -30,7 +30,9 @@ MeshSpatialObject< TMesh >
 {
   this->SetTypeName("MeshSpatialObject");
   m_Mesh = MeshType::New();
+#if !defined(ITK_LEGACY_REMOVE)
   m_PixelType = typeid( typename TMesh::PixelType ).name();
+#endif
   m_IsInsidePrecisionInObjectSpace = 1;
 }
 


### PR DESCRIPTION
Deprecates the `GetPixelTypeName()` member functions of both
`ImageSpatialObject` and `MeshSpatialObject`. Removes their `m_PixelType` data
members, when `ITK_LEGACY_REMOVE` is enabled.

It appears that there was an inconsistency between these two member functions,
as the one for `Mesh` returned `typeid(PixelType).name()`, which is compiler
dependent, while the one for `Image` depended on a set of overloaded
`SetPixelTypeName` member functions. Both added unnecessary overhead by storing
an `std::string`. It seems that `GetPixelTypeName()` was rarely used.