### PR TITLE
ENH: Expand ResampleImageFilter requested region by interpolator domain

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -392,6 +392,10 @@ The nested `GaussianDerivativeImageFunction` types `GaussianDerivativeFunctionTy
 `GaussianDerivativeFunctionPointer` are renamed to `GaussianDerivativeSpatialFunctionType` and
 `GaussianDerivativeSpatialFunctionPointer`, respectively.
 
+All descendents of `itk::InterpolateImageFunction` must implement
+`SizeType GetRadius() const` to indicate support radius of the interpolator.
+This is used in `itk::ResampleImageFilter` to support streaming.
+
 With ITK 5.0, `itk::ProcessObject::VerifyPreconditions()`  and
 `itk::ProcessObject::VerifyInputInformation` are now declared `const`,
 so if you have overridden these virtual member function, make sure that you

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -111,6 +111,9 @@ public:
   /** Index type alias support */
   using IndexType = typename Superclass::IndexType;
 
+  /** Size type alias support */
+  using SizeType = typename Superclass::SizeType;
+
   /** ContinuousIndex type alias support */
   using ContinuousIndexType = typename Superclass::ContinuousIndexType;
 
@@ -311,6 +314,11 @@ public:
   itkSetMacro(UseImageDirection, bool);
   itkGetConstMacro(UseImageDirection, bool);
   itkBooleanMacro(UseImageDirection);
+
+  SizeType GetRadius() const override
+    {
+    return SizeType::Filled(m_SplineOrder + 1);
+    }
 
 protected:
 

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.h
@@ -84,6 +84,9 @@ public:
   /** Index type alias support */
   using IndexType = typename Superclass::IndexType;
 
+  /** Size type alias support */
+  using SizeType = typename Superclass::SizeType;
+
   /** ContinuousIndex type alias support */
   using ContinuousIndexType = typename Superclass::ContinuousIndexType;
 
@@ -143,6 +146,8 @@ public:
     {
     return this->EvaluateAtContinuousIndex( cindex, nullptr );
     }
+
+  SizeType GetRadius() const override;
 
 protected:
   GaussianInterpolateImageFunction();

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -222,6 +222,30 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>
     }
 }
 
+
+template<typename TImageType, typename TCoordRep>
+typename GaussianInterpolateImageFunction<TImageType, TCoordRep>::SizeType
+GaussianInterpolateImageFunction<TImageType, TCoordRep>
+::GetRadius() const
+{
+  SizeType radius;
+
+  if( !this->GetInputImage() )
+    {
+    itkExceptionMacro("Input image required!");
+    }
+
+  const InputImageType * input = this->GetInputImage();
+  const typename InputImageType::SpacingType spacing = input->GetSpacing();
+
+  for( unsigned int dim = 0; dim < ImageDimension; ++dim )
+    {
+    radius[dim] = static_cast< SizeValueType >( Math::ceil( m_CutOffDistance[dim] / spacing[dim] ) );
+    }
+  return radius;
+}
+
+
 template<typename TImageType, typename TCoordRep>
 void
 GaussianInterpolateImageFunction<TImageType, TCoordRep>

--- a/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
@@ -76,6 +76,9 @@ public:
   using IndexType = typename Superclass::IndexType;
   using IndexValueType = typename Superclass::IndexValueType;
 
+  /** Size type alias support */
+  using SizeType = typename InputImageType::SizeType;
+
   /** ContinuousIndex type alias support */
   using ContinuousIndexType = typename Superclass::ContinuousIndexType;
 
@@ -123,6 +126,13 @@ public:
   {
     return ( static_cast< RealType >( this->GetInputImage()->GetPixel(index) ) );
   }
+
+  /** Get the radius required for interpolation.
+   *
+   * This defines the number of surrounding pixels required to interpolate at
+   * a given point.
+   */
+  virtual SizeType GetRadius() const = 0;
 
 protected:
   InterpolateImageFunction()= default;

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -82,6 +82,9 @@ public:
   /** Index type alias support */
   using IndexType = typename Superclass::IndexType;
 
+  /** Size type alias support */
+  using SizeType = typename Superclass::SizeType;
+
   /** ContinuousIndex type alias support */
   using ContinuousIndexType = typename Superclass::ContinuousIndexType;
   using InternalComputationType = typename ContinuousIndexType::ValueType;
@@ -100,6 +103,11 @@ public:
   {
     return this->EvaluateOptimized(Dispatch< ImageDimension >(), index);
   }
+
+  SizeType GetRadius() const override
+    {
+    return SizeType::Filled(1);
+    }
 
 protected:
   LinearInterpolateImageFunction() = default;

--- a/Modules/Core/ImageFunction/include/itkNearestNeighborInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborInterpolateImageFunction.h
@@ -66,6 +66,9 @@ public:
   /** Index type alias support */
   using IndexType = typename Superclass::IndexType;
 
+  /** Size type alias support */
+  using SizeType = typename Superclass::SizeType;
+
   /** ContinuousIndex type alias support */
   using ContinuousIndexType = typename Superclass::ContinuousIndexType;
 
@@ -85,6 +88,11 @@ public:
     this->ConvertContinuousIndexToNearestIndex(index, nindex);
     return static_cast< OutputType >( this->GetInputImage()->GetPixel(nindex) );
   }
+
+  SizeType GetRadius() const override
+    {
+    return SizeType(); // zeroes by default
+    }
 
 protected:
   NearestNeighborInterpolateImageFunction()= default;

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.h
@@ -20,6 +20,7 @@
 
 #include "itkInterpolateImageFunction.h"
 #include "itkTransform.h"
+#include "itkNumericTraits.h"
 
 namespace itk
 {
@@ -163,6 +164,16 @@ public:
   {
     return true;
   }
+
+  SizeType GetRadius() const override
+    {
+    const InputImageType* input = this->GetInputImage();
+    if ( !input )
+      {
+      itkExceptionMacro( "Input image required!" );
+      }
+    return input->GetLargestPossibleRegion().GetSize();
+    }
 
 protected:
   RayCastInterpolateImageFunction();

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -291,6 +291,9 @@ public:
   using IndexType = typename Superclass::IndexType;
   using IndexValueType = typename Superclass::IndexValueType;
 
+  /** Size type alias support */
+  using SizeType = typename Superclass::SizeType;
+
   /** Image type definition */
   using ImageType = TInputImage;
 
@@ -307,6 +310,13 @@ public:
    */
   OutputType EvaluateAtContinuousIndex(
     const ContinuousIndexType & index) const override;
+
+  SizeType GetRadius() const override
+    {
+    SizeType radius;
+    radius.Fill( VRadius );
+    return radius;
+    }
 
 protected:
   WindowedSincInterpolateImageFunction();

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -72,6 +72,13 @@ int itkGaussianInterpolateImageFunctionTest( int, char*[] )
 
   interpolator->SetInputImage(image);
 
+  typename ImageType::SizeType radius;
+  radius.Fill( 1 );
+  for ( unsigned int d = 0; d < ImageType::ImageDimension; d++ )
+    {
+      TEST_SET_GET_VALUE( radius[d], interpolator->GetRadius()[d] );
+    }
+
   InterpolatorType::OutputType expectedValues[5][5] =
     {{0.773964, 0.886982, 1.38698, 1.88698, 2.0},
      {0.886982, 1.0,      1.5,     2.0,     2.11302},

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -18,6 +18,7 @@
 
 #include <iostream>
 
+#include "itkTestingMacros.h"
 #include "itkImage.h"
 #include "itkVectorImage.h"
 #include "itkLinearInterpolateImageFunction.h"
@@ -169,6 +170,13 @@ int RunLinearInterpolateTest()
  typename VariableVectorInterpolatorType::Pointer
   variablevectorinterpolator = VariableVectorInterpolatorType::New();
  variablevectorinterpolator->SetInputImage( variablevectorimage );
+
+ typename ImageType::SizeType radius;
+ radius.Fill( 1 );
+ for( unsigned int d = 0; d < Dimensions; ++d )
+   {
+   TEST_SET_GET_VALUE( radius[d], interpolator->GetRadius()[d] );
+   }
 
  constexpr AccumulatorType incr  = 0.2;
 

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -18,6 +18,7 @@
 
 #include <iostream>
 
+#include "itkTestingMacros.h"
 #include "itkMath.h"
 #include "itkImage.h"
 #include "itkVectorImage.h"
@@ -131,6 +132,13 @@ int itkNearestNeighborInterpolateImageFunctionTest( int , char*[] )
 
  InterpolatorType::Pointer interpolator = InterpolatorType::New();
  interpolator->SetInputImage( image );
+
+ typename ImageType::SizeType radius;
+ radius.Fill( 0 );
+ for( unsigned int d = 0; d < Dimension; ++d )
+   {
+   TEST_SET_GET_VALUE( radius[d], interpolator->GetRadius()[d] );
+   }
 
  VectorInterpolatorType::Pointer
   vectorinterpolator = VectorInterpolatorType::New();

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -130,6 +130,11 @@ itkRayCastInterpolateImageFunctionTest(
 
     std::cout << "Integral = " << integral << std::endl;
 
+    for( unsigned int d = 0; d < ImageDimension; ++d )
+      {
+      TEST_SET_GET_VALUE( size[d], interp->GetRadius()[d] );
+      }
+
     TEST_EXPECT_TRUE( itk::Math::FloatAlmostEqual( integral, 1247. ) );
 
     return EXIT_SUCCESS;

--- a/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
@@ -16,7 +16,7 @@
  *
  *=========================================================================*/
 
-#include <iostream>
+#include "itkTestingMacros.h"
 #include "itkImage.h"
 #include "itkWindowedSincInterpolateImageFunction.h"
 #include "itkConstantBoundaryCondition.h"
@@ -185,6 +185,11 @@ int itkWindowedSincInterpolateImageFunctionTest(int, char* [] )
   InterpolatorType::Pointer interp = InterpolatorType::New();
   interp->SetInputImage( image );
   interp->Print( std::cout );
+
+  for( unsigned int d = 0; d < ImageDimension; ++d )
+    {
+    TEST_SET_GET_VALUE( 2, interp->GetRadius()[d] );
+    }
 
   /* Test evaluation at continuous indices and corresponding
      gemetric points */

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -122,12 +122,6 @@ void
 ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType >
 ::BeforeThreadedGenerateData()
 {
-
-  if ( !m_Interpolator )
-    {
-    itkExceptionMacro(<< "Interpolator not set");
-    }
-
   // Connect input image to interpolator
   m_Interpolator->SetInputImage( this->GetInput() );
 
@@ -507,6 +501,11 @@ void
 ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType >
 ::GenerateInputRequestedRegion()
 {
+  if ( !m_Interpolator )
+    {
+    itkExceptionMacro(<< "Interpolator not set");
+    }
+
   // Get pointers to the input and output
   InputImageType * input  = const_cast< InputImageType * >( this->GetInput() );
 
@@ -540,6 +539,8 @@ ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTra
       // Input requested region is partially outside the largest possible region.
       //   or
       // Input requested region is completely inside the largest possible region.
+      inputRequestedRegion.PadByRadius( m_Interpolator->GetRadius() );
+      inputRequestedRegion.Crop( inputLargestRegion );
       input->SetRequestedRegion( inputRequestedRegion );
       }
     else if( inputRequestedRegion.IsInside( inputLargestRegion ) )

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -132,9 +132,9 @@ int itkResampleImageTest7( int , char *[] )
   // Verify that we only requested a smaller chunk when streaming
   const ImageRegionType finalRequestedRegion( image->GetRequestedRegion() );
   TEST_SET_GET_VALUE( 0, finalRequestedRegion.GetIndex(0) );
-  TEST_SET_GET_VALUE( 49, finalRequestedRegion.GetIndex(1) );
-  TEST_SET_GET_VALUE( 59, finalRequestedRegion.GetSize(0) );
-  TEST_SET_GET_VALUE( 10, finalRequestedRegion.GetSize(1) );
+  TEST_SET_GET_VALUE( 48, finalRequestedRegion.GetIndex(1) );
+  TEST_SET_GET_VALUE( 60, finalRequestedRegion.GetSize(0) );
+  TEST_SET_GET_VALUE( 12, finalRequestedRegion.GetSize(1) );
 
   ImagePointerType outputSDI = streamer->GetOutput();
   outputSDI->DisconnectPipeline();

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
@@ -74,6 +74,9 @@ public:
   /** Index type alias support */
   using IndexType = typename Superclass::IndexType;
 
+  /** Size type alias support */
+  using SizeType = typename Superclass::SizeType;
+
   /** ContinuousIndex type alias support */
   using ContinuousIndexType = typename Superclass::ContinuousIndexType;
 
@@ -122,6 +125,12 @@ public:
   /** Set the input image.  This must be set by the user, after setting the
     spline order! */
   void SetInputImage(const TImageType *inputData) override;
+
+  SizeType
+  GetRadius() const override
+  {
+    return SizeType::Filled( m_SplineOrder + 1 );
+  }
 
 protected:
   ComplexBSplineInterpolateImageFunction();


### PR DESCRIPTION
When streaming during resampling, the requested region is extended by
the domain of the interpolator. This is especially important for
consistent resampling results with interpolators other than the nearest
neighbor or linear interpolator, which use many surrounding pixels to
determine their value.

A new, abstract GetRadius method is added to InterpolateImageFunction.
This method is used by the ResampleImageFilter to extend its required
input region.

Suggested-by: Bradley Lowekamp <blowekamp@mail.nih.gov>

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.