### PR TITLE
COMP: Support ITK_FUTURE_LEGACY_REMOVE for SpatialObjects

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -494,11 +494,13 @@ public:
   bool Evaluate(const PointType & point) const
   { return this->IsInsideInWorldSpace(point); }
 
+#if ! defined ( ITK_LEGACY_REMOVE )
   itkLegacyMacro( void ComputeObjectToWorldTransform() )
   { this->Update(); /* Update() should be used instead of ProtectedComputeObjectToWorldTransform() */ }
 
   itkLegacyMacro( void ComputeMyBoundingBox() )
   { this->Update(); /* Update() should be used instead of ProtectedComputeMyBoundingBox() */}
+#endif
 
 protected:
 


### PR DESCRIPTION
When building with ITK_FUTURE_LEGACY_REMOVE option, the
itkLegacyMacro leads to incorrect syntax when the code
is not explicitly skipped.
