### PR TITLE
COMP: Consolodate duplicate LogTester code

### DIFF
--- a/Modules/Core/Common/test/itkLogTester.h
+++ b/Modules/Core/Common/test/itkLogTester.h
@@ -1,0 +1,57 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkLogTester_h
+#define itkLogTester_h
+
+#include "itkLoggerBase.h"
+#include "itkTestingMacros.h"
+
+namespace itk {
+namespace Testing {
+
+class LogTester
+{
+public:
+  LogTester(){ this->m_Logger = nullptr; }
+  itk::LoggerBase * GetLogger() { return m_Logger; }
+  void SetLogger(itk::LoggerBase * logger) { m_Logger = logger; }
+  void log() {
+    itkLogMacro( DEBUG, "DEBUG message by itkLogMacro\n" );
+    itkLogMacro( INFO, "INFO message by itkLogMacro\n" );
+    itkLogMacro( WARNING, "WARNING message by itkLogMacro\n" );
+    itkLogMacro( CRITICAL, "CRITICAL message by itkLogMacro\n" );
+    itkLogMacro( FATAL, "FATAL message by itkLogMacro\n" );
+    itkLogMacro( MUSTFLUSH, "MUSTFLUSH message by itkLogMacro\n" );
+  }
+  static void logStatic(LogTester* tester)
+  {
+    itkLogMacroStatic( tester, DEBUG, "DEBUG message by itkLogMacroStatic\n" );
+    itkLogMacroStatic( tester, INFO, "INFO message by itkLogMacroStatic\n" );
+    itkLogMacroStatic( tester, WARNING, "WARNING message by itkLogMacroStatic\n" );
+    itkLogMacroStatic( tester, CRITICAL, "CRITICAL message by itkLogMacroStatic\n" );
+    itkLogMacroStatic( tester, FATAL, "FATAL message by itkLogMacroStatic\n" );
+    itkLogMacroStatic( tester, MUSTFLUSH, "MUSTFLUSH message by itkLogMacroStatic\n" );
+  }
+
+private:
+  itk::LoggerBase * m_Logger;
+};
+}
+}
+
+#endif // itkLogTester_h

--- a/Modules/Core/Common/test/itkLoggerManagerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerManagerTest.cxx
@@ -20,35 +20,8 @@
 #include <fstream>
 #include "itkStdStreamLogOutput.h"
 #include "itkLoggerManager.h"
-#include "itkTestingMacros.h"
+#include "itkLogTester.h"
 
-class LogTester
-{
-public:
-  LogTester(){ this->m_Logger = nullptr; }
-  itk::Logger* GetLogger() { return m_Logger; }
-  void SetLogger(itk::Logger* logger) { m_Logger = logger; }
-  void log() {
-    itkLogMacro( DEBUG, "DEBUG message by itkLogMacro\n" );
-    itkLogMacro( INFO, "INFO message by itkLogMacro\n" );
-    itkLogMacro( WARNING, "WARNING message by itkLogMacro\n" );
-    itkLogMacro( CRITICAL, "CRITICAL message by itkLogMacro\n" );
-    itkLogMacro( FATAL, "FATAL message by itkLogMacro\n" );
-    itkLogMacro( MUSTFLUSH, "MUSTFLUSH message by itkLogMacro\n" );
-  }
-  static void logStatic(LogTester* tester)
-  {
-    itkLogMacroStatic( tester, DEBUG, "DEBUG message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, INFO, "INFO message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, WARNING, "WARNING message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, CRITICAL, "CRITICAL message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, FATAL, "FATAL message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, MUSTFLUSH, "MUSTFLUSH message by itkLogMacroStatic\n" );
-  }
-
-private:
-  itk::Logger* m_Logger;
-};
 
 int itkLoggerManagerTest( int argc, char *argv [] )
 {
@@ -83,11 +56,11 @@ int itkLoggerManagerTest( int argc, char *argv [] )
     t_logger->AddLogOutput(foutput);
 
     // Logging by the itkLogMacro from a class with itk::ThreadLogger
-    LogTester tester;
+    itk::Testing::LogTester tester;
     tester.SetLogger(logger);
     tester.log();
     // Logging by the itkLogMacroStatic from a class with itk::ThreadLogger
-    LogTester::logStatic(&tester);
+    itk::Testing::LogTester::logStatic(&tester);
 
     std::cout << "  The printed order of 'Messages ##' below might not be predictable because of multi-threaded logging" << std::endl;
     std::cout << "  But the logged messages will be in order." << std::endl;

--- a/Modules/Core/Common/test/itkLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerTest.cxx
@@ -21,34 +21,7 @@
 #include "itkStdStreamLogOutput.h"
 #include "itkLogger.h"
 #include "itkTestingMacros.h"
-
-class LogTester
-{
-public:
-  LogTester(){ this->m_Logger = nullptr; }
-  itk::Logger* GetLogger() { return m_Logger; }
-  void SetLogger(itk::Logger* logger) { m_Logger = logger; }
-  void log() {
-    itkLogMacro( DEBUG, "DEBUG message by itkLogMacro\n" );
-    itkLogMacro( INFO, "INFO message by itkLogMacro\n" );
-    itkLogMacro( WARNING, "WARNING message by itkLogMacro\n" );
-    itkLogMacro( CRITICAL, "CRITICAL message by itkLogMacro\n" );
-    itkLogMacro( FATAL, "FATAL message by itkLogMacro\n" );
-    itkLogMacro( MUSTFLUSH, "MUSTFLUSH message by itkLogMacro\n" );
-  }
-  static void logStatic(LogTester* tester)
-  {
-    itkLogMacroStatic(tester, DEBUG, "DEBUG message by itkLogMacroStatic\n" );
-    itkLogMacroStatic(tester, INFO, "INFO message by itkLogMacroStatic\n" );
-    itkLogMacroStatic(tester, WARNING, "WARNING message by itkLogMacroStatic\n" );
-    itkLogMacroStatic(tester, CRITICAL, "CRITICAL message by itkLogMacroStatic\n" );
-    itkLogMacroStatic(tester, FATAL, "FATAL message by itkLogMacroStatic\n" );
-    itkLogMacroStatic(tester, MUSTFLUSH, "MUSTFLUSH message by itkLogMacroStatic\n" );
-  }
-
-private:
-  itk::Logger* m_Logger;
-};
+#include "itkLogTester.h"
 
 int itkLoggerTest( int argc, char *argv [] )
 {
@@ -88,12 +61,12 @@ int itkLoggerTest( int argc, char *argv [] )
 
     // Logging by the itkLogMacro from a class with itk::Logger
     std::cout << "  Logging by the itkLogMacro from a class with itk::Logger" << std::endl;
-    LogTester tester;
+    itk::Testing::LogTester tester;
     tester.SetLogger(logger);
     tester.log();
     // Logging by the itkLogMacroStatic from a class with itk::Logger
     std::cout << "  Logging by the itkLogMacroStatic from a class with itk::Logger" << std::endl;
-    LogTester::logStatic(&tester);
+    itk::Testing::LogTester::logStatic(&tester);
 
     // Writing by the logger
     std::cout << "  Writing by itk::Logger" << std::endl;

--- a/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
@@ -22,7 +22,7 @@
 #include "itkStdStreamLogOutput.h"
 #include "itkLoggerBase.h"
 #include "itkMultiThreaderBase.h"
-#include "itkTestingMacros.h"
+#include "itkLogTester.h"
 
 /** \class SimpleLogger
  *  \brief Class SimpleLogger is meant to demonstrate how to change the formatting of the LoggerBase mechanism
@@ -96,34 +96,6 @@ protected:
   /** Destructor */
   ~SimpleLogger() override = default;
 };  // class Logger
-
-class LogTester
-{
-public:
-  LogTester(){ this->m_Logger = nullptr; }
-  itk::LoggerBase* GetLogger() { return m_Logger; }
-  void SetLogger(itk::LoggerBase* logger) { m_Logger = logger; }
-  void log() {
-    itkLogMacro( DEBUG, "DEBUG message by itkLogMacro\n" );
-    itkLogMacro( INFO, "INFO message by itkLogMacro\n" );
-    itkLogMacro( WARNING, "WARNING message by itkLogMacro\n" );
-    itkLogMacro( CRITICAL, "CRITICAL message by itkLogMacro\n" );
-    itkLogMacro( FATAL, "FATAL message by itkLogMacro\n" );
-    itkLogMacro( MUSTFLUSH, "MUSTFLUSH message by itkLogMacro\n" );
-  }
-  static void logStatic(LogTester* tester)
-    {
-    itkLogMacroStatic( tester, DEBUG, "DEBUG message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, INFO, "INFO message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, WARNING, "WARNING message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, CRITICAL, "CRITICAL message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, FATAL, "FATAL message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, MUSTFLUSH, "MUSTFLUSH message by itkLogMacroStatic\n" );
-    }
-
-private:
-  itk::LoggerBase* m_Logger;
-};
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION ThreadedGenerateLogMessages2(void* arg)
 {
@@ -223,11 +195,11 @@ int itkLoggerThreadWrapperTest( int argc, char * argv[] )
     std::cout << logger << std::endl;
 
     // Logging by the itkLogMacro from a class with itk::ThreadLogger
-    LogTester tester;
+    itk::Testing::LogTester tester;
     tester.SetLogger(logger);
     tester.log();
     // Logging by the itkLogMacroStatic from a class with itk::ThreadLogger
-    LogTester::logStatic(&tester);
+    itk::Testing::LogTester::logStatic(&tester);
 
     std::cout << "  The printed order of 'Messages ##' below might not be predictable because of multi-threaded logging" << std::endl;
     std::cout << "  But the logged messages will be in order." << std::endl;

--- a/Modules/Core/Common/test/itkThreadLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadLoggerTest.cxx
@@ -21,42 +21,13 @@
 #include "itkStdStreamLogOutput.h"
 #include "itkThreadLogger.h"
 #include "itkMultiThreaderBase.h"
-#include "itkTestingMacros.h"
-
+#include "itkLogTester.h"
 
 struct ThreadDataStruct
 {
   itk::LoggerBase* logger;
 };
 using ThreadDataVec = std::vector<ThreadDataStruct>;
-
-class LogTester
-{
-public:
-  LogTester(){ this->m_Logger = nullptr; }
-  itk::Logger* GetLogger() { return m_Logger; }
-  void SetLogger(itk::Logger* logger) { m_Logger = logger; }
-  void log() {
-    itkLogMacro( DEBUG, "DEBUG message by itkLogMacro\n" );
-    itkLogMacro( INFO, "INFO message by itkLogMacro\n" );
-    itkLogMacro( WARNING, "WARNING message by itkLogMacro\n" );
-    itkLogMacro( CRITICAL, "CRITICAL message by itkLogMacro\n" );
-    itkLogMacro( FATAL, "FATAL message by itkLogMacro\n" );
-    itkLogMacro( MUSTFLUSH, "MUSTFLUSH message by itkLogMacro\n" );
-  }
-  static void logStatic(LogTester* tester)
-  {
-    itkLogMacroStatic( tester, DEBUG, "DEBUG message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, INFO, "INFO message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, WARNING, "WARNING message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, CRITICAL, "CRITICAL message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, FATAL, "FATAL message by itkLogMacroStatic\n" );
-    itkLogMacroStatic( tester, MUSTFLUSH, "MUSTFLUSH message by itkLogMacroStatic\n" );
-  }
-
-private:
-  itk::Logger* m_Logger;
-};
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION ThreadedGenerateLogMessages(void* arg)
 {
@@ -153,11 +124,11 @@ int itkThreadLoggerTest( int argc, char * argv[] )
     std::cout << logger << std::endl;
 
     // Logging by the itkLogMacro from a class with itk::ThreadLogger
-    LogTester tester;
+    itk::Testing::LogTester tester;
     tester.SetLogger(logger);
     tester.log();
     // Logging by the itkLogMacroStatic from a class with itk::ThreadLogger
-    LogTester::logStatic(&tester);
+    itk::Testing::LogTester::logStatic(&tester);
 
     std::cout << "  The printed order of 'Messages ##' below might not be predictable because of multi-threaded logging" << std::endl;
     std::cout << "  But the logged messages will be in order." << std::endl;


### PR DESCRIPTION
ITK/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx:100:7: warning: type ‘struct LogTester’ violates the C++ One Definition Rule [-Wodr]
 class LogTester
       ^
ITK/Modules/Core/Common/test/itkThreadLoggerTest.cxx:33:7: note: a different type is defined in another translation unit
 class LogTester
       ^
ITK/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx:125:20: note: the first difference of corresponding definitions is field ‘m_Logger’
   itk::LoggerBase* m_Logger;
                    ^
