### PR TITLE
COMP: Add backwards compatible EnlargeRegionOverBox

### DIFF
--- a/Modules/Core/Common/include/itkImageAlgorithm.h
+++ b/Modules/Core/Common/include/itkImageAlgorithm.h
@@ -114,8 +114,14 @@ struct ImageAlgorithm
   static typename OutputImageType::RegionType
   EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,
                        const InputImageType* inputImage,
+                       const OutputImageType* outputImage);
+
+  template<typename InputImageType, typename OutputImageType, typename TransformType>
+  static typename OutputImageType::RegionType
+  EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,
+                       const InputImageType* inputImage,
                        const OutputImageType* outputImage,
-                       const TransformType* transform = nullptr);
+                       const TransformType* transform);
 
 private:
 

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -167,6 +167,16 @@ void ImageAlgorithm::DispatchedCopy( const InputImageType *inImage,
     }
 }
 
+
+template<typename InputImageType, typename OutputImageType, typename TransformType>
+typename OutputImageType::RegionType
+ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,
+                                     const InputImageType* inputImage,
+                                     const OutputImageType* outputImage)
+{
+  return EnlargeRegionOverBox(inputRegion, inputImage, outputImage, nullptr);
+}
+
 template<typename InputImageType, typename OutputImageType, typename TransformType>
 typename OutputImageType::RegionType
 ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,


### PR DESCRIPTION
This adds a backwards compatible signature following the addition of
another argument in

  609319760ae5c8c780c4b9be156a4a865ab79439

@romangrothausmann please take a look.