### PR TITLE
COMP: itkLegacyMacro should encompass inline definition (fixes ea784ea)

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -494,11 +494,11 @@ public:
   bool Evaluate(const PointType & point) const
   { return this->IsInsideInWorldSpace(point); }
 
-  itkLegacyMacro( void ComputeObjectToWorldTransform() )
-  { this->Update(); /* Update() should be used instead of ProtectedComputeObjectToWorldTransform() */ }
+  itkLegacyMacro( void ComputeObjectToWorldTransform()
+  { this->Update(); /* Update() should be used instead of ProtectedComputeObjectToWorldTransform() */ } )
 
-  itkLegacyMacro( void ComputeMyBoundingBox() )
-  { this->Update(); /* Update() should be used instead of ProtectedComputeMyBoundingBox() */}
+  itkLegacyMacro( void ComputeMyBoundingBox()
+  { this->Update(); /* Update() should be used instead of ProtectedComputeMyBoundingBox() */} )
 
 protected:
 


### PR DESCRIPTION
This patch fixes RTK's compilation with -DITK_LEGACY_REMOVE=ON, see [RTK dashboard](https://my.cdash.org/viewBuildError.php?buildid=1629970) for the errors that showed up.
@hjmjohnson 