### PR TITLE
ENH: Add legacy interface to SpatialObjects

### DIFF
--- a/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
@@ -220,7 +220,7 @@ int main( int argc, char *argv[] )
     std::cout << "Center: ";
     std::cout << (*itCircles)->GetCenterInObjectSpace()
               << std::endl;
-    std::cout << "Radius: " << (*itCircles)->GetRadiiInObjectSpace()[0]
+    std::cout << "Radius: " << (*itCircles)->GetRadiusInObjectSpace()[0]
       << std::endl;
     // Software Guide : EndCodeSnippet
 
@@ -240,10 +240,10 @@ int main( int argc, char *argv[] )
       using IndexValueType = ImageType::IndexType::IndexValueType;
       localIndex[0] =
          itk::Math::Round<IndexValueType>(centerPoint[0]
-                  + (*itCircles)->GetRadiiInObjectSpace()[0]*std::cos(angle));
+                  + (*itCircles)->GetRadiusInObjectSpace()[0]*std::cos(angle));
       localIndex[1] =
          itk::Math::Round<IndexValueType>(centerPoint[1]
-                  + (*itCircles)->GetRadiiInObjectSpace()[0]*std::sin(angle));
+                  + (*itCircles)->GetRadiusInObjectSpace()[0]*std::sin(angle));
       OutputImageType::RegionType outputRegion =
                                   localOutputImage->GetLargestPossibleRegion();
 

--- a/Examples/SpatialObjects/EllipseSpatialObject.cxx
+++ b/Examples/SpatialObjects/EllipseSpatialObject.cxx
@@ -57,7 +57,7 @@ int main( int , char *[] )
     radius[i] = i;
     }
 
-  myEllipse->SetRadiiInObjectSpace(radius);
+  myEllipse->SetRadiusInObjectSpace(radius);
 // Software Guide : EndCodeSnippet
 // Software Guide : BeginLatex
 //
@@ -70,12 +70,12 @@ int main( int , char *[] )
 
 // Software Guide : BeginLatex
 //
-// We can then display the current radius by using the \code{GetRadiiInObjectSpace()}
+// We can then display the current radius by using the \code{GetRadiusInObjectSpace()}
 // function:
 //
 // Software Guide : EndLatex
 // Software Guide : BeginCodeSnippet
-  EllipseType::ArrayType myCurrentRadius = myEllipse->GetRadiiInObjectSpace();
+  EllipseType::ArrayType myCurrentRadius = myEllipse->GetRadiusInObjectSpace();
   std::cout << "Current radius is " << myCurrentRadius << std::endl;
 // Software Guide : EndCodeSnippet
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -67,10 +67,10 @@ public:
   void SetRadiusInObjectSpace(double radius);
 
   /** Set radii via an array of radius values */
-  itkSetMacro(RadiiInObjectSpace, ArrayType);
+  itkSetMacro(RadiusInObjectSpace, ArrayType);
 
   /** Get radii via an array of radius values */
-  itkGetConstReferenceMacro(RadiiInObjectSpace, ArrayType);
+  itkGetConstReferenceMacro(RadiusInObjectSpace, ArrayType);
 
   /** Set center point in object space. */
   itkSetMacro( CenterInObjectSpace, PointType );
@@ -82,6 +82,19 @@ public:
   bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
     const std::string & name="" ) const override;
 
+#if ! defined ( ITK_LEGACY_REMOVE )
+    itkLegacyMacro( void SetRadius( double radius) )
+    { this->SetRadiusInObjectSpace(radius); }
+
+    itkLegacyMacro( void SetRadius( ArrayType radii) )
+    { this->SetRadiusInObjectSpace(radii); }
+
+    itkLegacyMacro( ArrayType GetRadius( ) const )
+    { return this->GetRadiusInObjectSpace(); }
+
+    itkLegacyMacro( void SetRadiiInObjectSpace( ArrayType radii) )
+    { this->SetRadiusInObjectSpace(radii); }
+#endif
 protected:
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
@@ -99,7 +112,7 @@ protected:
 private:
 
   /* object space */
-  ArrayType m_RadiiInObjectSpace;
+  ArrayType m_RadiusInObjectSpace;
   PointType m_CenterInObjectSpace;
 };
 

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -28,7 +28,7 @@ EllipseSpatialObject< TDimension >
 ::EllipseSpatialObject()
 {
   this->SetTypeName("EllipseSpatialObject");
-  m_RadiiInObjectSpace.Fill(1.0);
+  m_RadiusInObjectSpace.Fill(1.0);
   m_CenterInObjectSpace.Fill(0.0);
   this->Update();
 }
@@ -43,9 +43,9 @@ EllipseSpatialObject< TDimension >
   bool changes = false;
   for( unsigned int i=0; i<ObjectDimension; ++i )
     {
-    if( m_RadiiInObjectSpace[i] != radius )
+    if( m_RadiusInObjectSpace[i] != radius )
       {
-      m_RadiiInObjectSpace[i] = radius;
+      m_RadiusInObjectSpace[i] = radius;
       changes = true;
       }
     }
@@ -70,13 +70,13 @@ EllipseSpatialObject< TDimension >
     double r = 0;
     for ( unsigned int i = 0; i < TDimension; i++ )
       {
-      if ( m_RadiiInObjectSpace[i] > 0.0 )
+      if ( m_RadiusInObjectSpace[i] > 0.0 )
         {
         d = point[i] - m_CenterInObjectSpace[i];
         r += ( d * d )
-          / ( m_RadiiInObjectSpace[i] * m_RadiiInObjectSpace[i] );
+          / ( m_RadiusInObjectSpace[i] * m_RadiusInObjectSpace[i] );
         }
-      else if ( point[i] != 0.0 || m_RadiiInObjectSpace[i] < 0 )
+      else if ( point[i] != 0.0 || m_RadiusInObjectSpace[i] < 0 )
         // Deal with an ellipse with 0 or negative radius;
         {
         r = 2; // Keeps function from returning true here
@@ -110,8 +110,8 @@ EllipseSpatialObject< TDimension >
   PointType    pnt2;
   for ( unsigned int i = 0; i < TDimension; i++ )
     {
-    pnt1[i] = m_CenterInObjectSpace[i] - m_RadiiInObjectSpace[i];
-    pnt2[i] = m_CenterInObjectSpace[i] + m_RadiiInObjectSpace[i];
+    pnt1[i] = m_CenterInObjectSpace[i] - m_RadiusInObjectSpace[i];
+    pnt2[i] = m_CenterInObjectSpace[i] + m_RadiusInObjectSpace[i];
     }
 
   this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pnt1);
@@ -134,7 +134,7 @@ EllipseSpatialObject< TDimension >
     itkExceptionMacro(<< "Downcast to type " << this->GetNameOfClass()
       << " failed.");
     }
-  rval->SetRadiiInObjectSpace( this->GetRadiiInObjectSpace() );
+  rval->SetRadiusInObjectSpace( this->GetRadiusInObjectSpace() );
   rval->SetCenterInObjectSpace( this->GetCenterInObjectSpace() );
 
   return loPtr;
@@ -148,7 +148,7 @@ EllipseSpatialObject< TDimension >
 {
   os << indent << "EllipseSpatialObject(" << this << ")" << std::endl;
   Superclass::PrintSelf(os, indent);
-  os << "Object Radii: " << m_RadiiInObjectSpace << std::endl;
+  os << "Object Radii: " << m_RadiusInObjectSpace << std::endl;
   os << "Object Center: " << m_CenterInObjectSpace << std::endl;
 }
 

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -96,6 +96,13 @@ public:
    * EllipseSpatialObject.  */
   typename EllipseSpatialObject< TDimension >::Pointer GetEllipsoid() const;
 
+#if ! defined ( ITK_LEGACY_REMOVE )
+  itkLegacyMacro( void SetSigma(double sigma) )
+  { return this->SetSigmaInObjectSpace(sigma); }
+
+  itkLegacyMacro( double GetSigma() const )
+  { return this->GetSigmaInObjectSpace(); }
+#endif
 protected:
   /** This function needs to be called every time one of the object's
    *  components is changed. */

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -71,6 +71,20 @@ public:
   bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
     const std::string & name="") const override;
 
+#if ! defined ( ITK_LEGACY_REMOVE )
+  /** Compute axis aligned bounding box from the image mask. The bounding box
+   * is returned as an image region. Each call to this function will recompute
+   * the region.
+   * This function is useful in cases, where you may have a mask image
+   * resulting from say a segmentation and you want to get the smallest box
+   * region that encapsulates the mask image. Currently this is done only for 3D
+   * volumes. */
+  //NOTE: THIS IS THE HISTORICAL IMPLEMETNATION COMPATIBLE WITH PRE 5.0.0
+  //      BEHAVIORS.
+  itkLegacyMacro( RegionType GetAxisAlignedBoundingBoxRegion() const );
+
+#endif
+
 protected:
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is

--- a/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
@@ -51,7 +51,7 @@ MetaEllipseConverter< NDimensions >
     radii[i] = ellipseMO->Radius()[i];
     }
 
-  ellipseSO->SetRadiiInObjectSpace(radii);
+  ellipseSO->SetRadiusInObjectSpace(radii);
   ellipseSO->GetProperty().SetName( ellipseMO->Name() );
   ellipseSO->SetId( ellipseMO->ID() );
   ellipseSO->SetParentId( ellipseMO->ParentID() );
@@ -82,7 +82,7 @@ MetaEllipseConverter< NDimensions >
 
   for ( unsigned int i = 0; i < NDimensions; i++ )
     {
-    radii[i] = ellipseSO->GetRadiiInObjectSpace()[i];
+    radii[i] = ellipseSO->GetRadiusInObjectSpace()[i];
     }
 
   if ( ellipseSO->GetParent() )

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -500,6 +500,15 @@ public:
 
   itkLegacyMacro( void ComputeMyBoundingBox() )
   { this->Update(); /* Update() should be used instead of ProtectedComputeMyBoundingBox() */}
+
+  itkLegacyMacro( void ComputeBoundingBox() )
+  { this->Update(); /* Update() should be used instead of outdated ComputeBoundingBox() */}
+
+  /** Returns true if a point is inside the object in world space. */
+  itkLegacyMacro( virtual bool IsInside(const PointType & point,
+                        unsigned int depth = 0,
+                        const std::string & name = "") const )
+  { return IsInsideInObjectSpace(point, depth, name); };
 #endif
 
 protected:

--- a/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
@@ -40,9 +40,9 @@ int itkEllipseSpatialObjectTest(int, char* [])
 
   std::cout << "Testing radii : ";
 
-  myEllipse->SetRadiiInObjectSpace(radii);
+  myEllipse->SetRadiusInObjectSpace(radii);
   myEllipse->Update();
-  EllipseType::ArrayType radii2 = myEllipse->GetRadiiInObjectSpace();
+  EllipseType::ArrayType radii2 = myEllipse->GetRadiusInObjectSpace();
   for(unsigned int i = 0; i<4;i++)
   {
     if(itk::Math::NotExactlyEquals(radii2[i],i))
@@ -55,7 +55,7 @@ int itkEllipseSpatialObjectTest(int, char* [])
 
   myEllipse->SetRadiusInObjectSpace(3);
   myEllipse->Update();
-  EllipseType::ArrayType radii3 = myEllipse->GetRadiiInObjectSpace();
+  EllipseType::ArrayType radii3 = myEllipse->GetRadiusInObjectSpace();
   std::cout << "Testing Global radii : ";
   for(unsigned int i = 0; i<4;i++)
   {

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -39,7 +39,7 @@ int itkSpatialObjectDuplicatorTest(int, char* [])
 
   EllipseType::Pointer ellipse_copy = duplicator->GetOutput();
 
-  std::cout << ellipse_copy->GetRadiiInObjectSpace() << std::endl;
+  std::cout << ellipse_copy->GetRadiusInObjectSpace() << std::endl;
   std::cout << ellipse_copy->GetProperty().GetColor() << std::endl;
 
   // Test with a group
@@ -56,7 +56,7 @@ int itkSpatialObjectDuplicatorTest(int, char* [])
   GroupType::ChildrenListType* children = group_copy->GetChildren();
 
   EllipseType::Pointer ellipse_copy2 = static_cast<EllipseType*>((*(children->begin())).GetPointer());
-  std::cout << ellipse_copy2->GetRadiiInObjectSpace() << std::endl;
+  std::cout << ellipse_copy2->GetRadiusInObjectSpace() << std::endl;
 
   delete children;
 

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -177,7 +177,7 @@ int itkSpatialObjectToImageStatisticsCalculatorTest(int, char * [] )
   radii[0] = 10;
   radii[1] = 10;
   radii[2] = 0;
-  ellipse3D->SetRadiiInObjectSpace(radii);
+  ellipse3D->SetRadiusInObjectSpace(radii);
 
   Ellipse3DType::VectorType offset3D;
   offset3D.Fill(25);

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -274,7 +274,7 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
       for ( double angle = 0; angle <= 2 * itk::Math::pi; angle += itk::Math::pi / 1000 )
         {
         for ( double length = 0; length < m_DiscRadiusRatio *
-          Circle->GetRadiiInObjectSpace()[0]; length += 1 )
+          Circle->GetRadiusInObjectSpace()[0]; length += 1 )
           {
           const Index< 2 > index =
             {{

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -216,8 +216,8 @@ namespace
       success = false;
     }
 
-    const double radius1 = circle1->GetRadiiInObjectSpace()[0];
-    const double radius2 = circle2->GetRadiiInObjectSpace()[0];
+    const double radius1 = circle1->GetRadiusInObjectSpace()[0];
+    const double radius2 = circle2->GetRadiusInObjectSpace()[0];
 
     if ( radius2 < radius1 )
     {
@@ -444,21 +444,21 @@ int itkHoughTransform2DCirclesImageTest( int, char* [] )
   while( it != circleList.end() )
     {
       if( !itk::Math::FloatAlmostEqual(
-          (double)( it->GetPointer()->GetRadiiInObjectSpace()[0] ),
+          (double)( it->GetPointer()->GetRadiusInObjectSpace()[0] ),
         radius[i], 10, radiusTolerance ) &&
         !itk::Math::FloatAlmostEqual(
-          (double)( it->GetPointer()->GetRadiiInObjectSpace()[0] ),
+          (double)( it->GetPointer()->GetRadiusInObjectSpace()[0] ),
         radius[i] * discRadiusRatio, 10, radiusTolerance ) )
       {
       std::cout << "Failure for circle #" << i << std::endl;
       std::cout << "Expected radius: " << radius[i] << ", found "
-        << it->GetPointer()->GetRadiiInObjectSpace() << std::endl;
+        << it->GetPointer()->GetRadiusInObjectSpace() << std::endl;
       success = false;
       }
     else
       {
       std::cout << "Circle #" << i << " radius: "
-        << it->GetPointer()->GetRadiiInObjectSpace() << std::endl;
+        << it->GetPointer()->GetRadiusInObjectSpace() << std::endl;
       }
     ++it;
     ++i;

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -819,7 +819,7 @@ int itkReadWriteSpatialObjectTest(int argc, char* argv[])
       for(unsigned int jj=0;jj<3;jj++)
         {
         if (dynamic_cast<EllipseType*>((*obj).GetPointer())->
-          GetRadiiInObjectSpace()[jj] != 9.0)
+          GetRadiusInObjectSpace()[jj] != 9.0)
           {
           std::cout<<" [FAILED]"<< std::endl;
           delete mySceneChildren;


### PR DESCRIPTION
Provide an easier path to upgrade by providing
the legacy interfaces to the SpatialObjects.

Providing warnings during initial builds allow
for more gradual migration, and fewer errors
during conversion to the new API.
