### PR TITLE
COMP: Add backwards compatible EnlargeRegionOverBox

### DIFF
--- a/Modules/Core/Common/include/itkImageAlgorithm.h
+++ b/Modules/Core/Common/include/itkImageAlgorithm.h
@@ -110,12 +110,18 @@ struct ImageAlgorithm
    * the physical space covered by the input
    * region of the input image
    */
+  template<typename InputImageType, typename OutputImageType>
+  static typename OutputImageType::RegionType
+  EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,
+                       const InputImageType* inputImage,
+                       const OutputImageType* outputImage);
+
   template<typename InputImageType, typename OutputImageType, typename TransformType>
   static typename OutputImageType::RegionType
   EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,
                        const InputImageType* inputImage,
                        const OutputImageType* outputImage,
-                       const TransformType* transform = nullptr);
+                       const TransformType* transform);
 
 private:
 

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -167,6 +167,22 @@ void ImageAlgorithm::DispatchedCopy( const InputImageType *inImage,
     }
 }
 
+
+template<typename InputImageType, typename OutputImageType>
+typename OutputImageType::RegionType
+ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,
+                                     const InputImageType* inputImage,
+                                     const OutputImageType* outputImage)
+{
+  class DummyTransform
+    {
+    public:
+      using PointType = Point< SpacePrecisionType, OutputImageType::ImageDimension >;
+      PointType TransformPoint(const PointType &p) const {return p;}
+    };
+  return EnlargeRegionOverBox<InputImageType, OutputImageType, DummyTransform>(inputRegion, inputImage, outputImage, nullptr);
+}
+
 template<typename InputImageType, typename OutputImageType, typename TransformType>
 typename OutputImageType::RegionType
 ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType & inputRegion,


### PR DESCRIPTION
This PR modifies PR #674 and now compiles in RTK, see [dashboard](https://my.cdash.org/buildSummary.php?buildid=1630838) . I don't think the solution is very elegant but I could not find a better solution. Other options:
- use a default template argument (e.g., itk::IdentityTransform) but no Transform is available in this module (Core/Common).
- add another templated function containing the TransformPoint line with a specialization doing nothing for a dummy type (e.g. nullptr_t).
Please have a look @thewtex @romangrothausmann. If you have another suggestion, don't hesitate! BTW, the problem does not seem to arise on linux, see [dashboard](https://my.cdash.org/buildSummary.php?buildid=1630585), I really don't know why.