### PR TITLE
STYLE: Removed unused private EventObject::EventFactoryFunction type

### DIFF
--- a/Modules/Core/Common/include/itkEventObject.h
+++ b/Modules/Core/Common/include/itkEventObject.h
@@ -93,7 +93,6 @@ protected:
   virtual void PrintTrailer(std::ostream & os, Indent indent) const;
 
 private:
-  using EventFactoryFunction = EventObject *();
   void operator=(const EventObject &) = delete;
 };
 


### PR DESCRIPTION
Removed unused `EventFactoryFunction` type, in response to Sandro Queiros,
who reported VS2015 compile errors at forum topic "Build ITK 5.0 in Windows",
https://discourse.itk.org/t/build-itk-5-0-in-windows/1748 saying:

    itkEventObject.h(96): error C2071: ‘itk::EventObject::EventFactoryFunction’: illegal storage class

Follow-up to the removal of an `std::map< std::string, EventFactoryFunction >`,
by Luis Ibanez, 2001-11-12, commit 16b9d79d8837b62b1d51394614b2b10aa277c58e