### PR TITLE
STYLE: Remove globals, ProcessObject MakeNameFromIndex use std to_string

### DIFF
--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -31,30 +31,10 @@
 #include <cstdio>
 #include <sstream>
 #include <algorithm>
+#include <string>
 
 namespace itk
 {
-
-
-namespace
-{ // local namespace for managing globals
-constexpr size_t ITK_GLOBAL_INDEX_NAMES_NUMBER  = 100;
-constexpr size_t ITK_GLOBAL_INDEX_NAMES_LENGTH = 4;
-constexpr char globalIndexNames[ITK_GLOBAL_INDEX_NAMES_NUMBER][ITK_GLOBAL_INDEX_NAMES_LENGTH] =
-{ "_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9",
-  "_10", "_11", "_12", "_13", "_14", "_15", "_16", "_17", "_18", "_19",
-  "_20", "_21", "_22", "_23", "_24", "_25", "_26", "_27", "_28", "_29",
-  "_30", "_31", "_32", "_33", "_34", "_35", "_36", "_37", "_38", "_39",
-  "_40", "_41", "_42", "_43", "_44", "_45", "_46", "_47", "_48", "_49",
-  "_50", "_51", "_52", "_53", "_54", "_55", "_56", "_57", "_58", "_59",
-  "_60", "_61", "_62", "_63", "_64", "_65", "_66", "_67", "_68", "_69",
-  "_70", "_71", "_72", "_73", "_74", "_75", "_76", "_77", "_78", "_79",
-  "_80", "_81", "_82", "_83", "_84", "_85", "_86", "_87", "_88", "_89",
-  "_90", "_91", "_92", "_93", "_94", "_95", "_96", "_97", "_98", "_99"
-};
-
-}
-
 
 ProcessObject
 ::ProcessObject() :
@@ -1115,16 +1095,7 @@ ProcessObject::DataObjectIdentifierType
 ProcessObject
 ::MakeNameFromIndex(DataObjectPointerArraySizeType idx) const
 {
-  if ( idx < ITK_GLOBAL_INDEX_NAMES_NUMBER )
-    {
-    return ProcessObject::DataObjectIdentifierType( globalIndexNames[idx] );
-    }
-  else
-    {
-    char buf[2+21]; // a 64-bit integer is ~20 decimal places max
-    sprintf(buf, "_%u", static_cast<unsigned int>(idx));
-    return buf;
-    }
+  return '_' + std::to_string(idx);
 }
 
 


### PR DESCRIPTION
Removed `ITK_GLOBAL_INDEX_NAMES_NUMBER`, `ITK_GLOBAL_INDEX_NAMES_LENGTH`, and
`globalIndexNames` from the unnamed namespace of itkProcessObject.cxx.
Simplified `ProcessObject::MakeNameFromIndex` by calling `std::to_string`,
instead of using `globalIndexNames`.

Triggered by forum topic "Build ITK 5.0 in Windows", started by Sandro Queiros,
who reported compile errors from VS2015 (before installing VS updates), at
https://discourse.itk.org/t/build-itk-5-0-in-windows/1748 saying:

    itkProcessObject.cxx(54): error C2440: ‘initializing’: cannot convert from ‘const char [3]’ to ‘const char’.