### PR TITLE
BUG: Adds RemovePoint() to PointBasedSpatialObjects

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -68,6 +68,10 @@ public:
 
   /** Assign points to this object, and assigned this object to
    * each point (for computing world coordinates) */
+  virtual void RemovePoint( IdentifierType id );
+
+  /** Assign points to this object, and assigned this object to
+   * each point (for computing world coordinates) */
   virtual void SetPoints( const SpatialObjectPointListType & newPoints );
 
   /** Get the list of points assigned to this object */

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -66,8 +66,7 @@ public:
    * each point (for computing world coordinates) */
   virtual void AddPoint( const SpatialObjectPointType & newPoints );
 
-  /** Assign points to this object, and assigned this object to
-   * each point (for computing world coordinates) */
+  /** Removes the indicated point from this object */
   virtual void RemovePoint( IdentifierType id );
 
   /** Assign points to this object, and assigned this object to

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -45,6 +45,22 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
   this->Modified();
 }
 
+/** Remove a Point from the list */
+template< unsigned int TDimension, class TSpatialObjectPointType >
+void
+PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
+::RemovePoint( IdentifierType id )
+{
+  if( id < m_Points.size() )
+    {
+    typename SpatialObjectPointListType::iterator it = m_Points.begin();
+    advance( it, id );
+    m_Points.erase( it );
+    }
+
+  this->Modified();
+}
+
 /** Set Points from a list */
 template< unsigned int TDimension, class TSpatialObjectPointType >
 void

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -484,6 +484,26 @@ int itkTubeSpatialObjectTest(int, char * [] )
   pBSO->Update();
   std::cout << "[PASSED]" << std::endl;
 
+  std::cout << "Testing PointBasedSO AddPoint: ";
+  pnt.SetPositionInObjectSpace( 1, 1, 1 );
+  pBSO->AddPoint( pnt );
+  if( pBSO->GetPoint(1)->GetPositionInObjectSpace()[0] != 1 )
+    {
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+    }
+  std::cout << "[PASSED]" << std::endl;
+
+  std::cout << "Testing PointBasedSO RemovePoint: ";
+  pBSO->RemovePoint( 0 );
+  if( pBSO->GetPoints().size() != 1 ||
+      pBSO->GetPoint(1)->GetPositionInObjectSpace()[0] != 1 )
+    {
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+    }
+  std::cout << "[PASSED]" << std::endl;
+
   std::cout << "[DONE]" << std::endl;
   return EXIT_SUCCESS;
 


### PR DESCRIPTION
This PR resolves #692 by adding the `RemovePoint( IdentifierType id )` function to `PointBasedSpatialObjects`.   Also adds tests to the `TubeSpatialObjectTest.cxx` file.