### PR TITLE
BUG: Add Clear() to spatial objects

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -352,6 +352,7 @@ As implied above, the changes to SpatialObject are extensive.   They include the
 * `RemoveChild()` and `RemoveAllChildren()` fixed to remove all pointers to / from those children to / from the tree
 * Helper functions simplify the specification of `IsInsideInObjectSpace()`, `ValueAtInObjectSpace()`, and other computations that potentially traverse an SO tree.
 * Derived classes typically only need to implement `IsInsideInObjectSpace()` and `ComputeMyBoundingBoxInObjectSpace()` member functions. Logic for `ValueAtInObjectSpace()`, `IsInsideInWorldSpace()` and such is improved.
+* PointBasedSpatialObjects had a PointListType type declaration.  This was confusing because it refered to a list of SpatialObjectPoints and not ITK::Points.  So, to avoid such confusion, now TubeSpatialObjects define TubePointListType, BlobSpatialObjects define BlobPointListType, and so forth.
 * `ImageMaskSpatialObject::GetAxisAlignedBoundingBoxRegion()` was removed.   `GetMyBoundingBoxInObjectSpace()` or `GetMyBoundingBoxInWorldSpace()` should be used instead.  If a region in IndexSpace is needed, then consider ITK's LabelMap classes and the [LabelImageToShapelLabelMapFilter](https://itk.org/Doxygen/html/classitk_1_1LabelImageToShapeLabelMapFilter.html).
 ```
   //REPLACE typename FixedImageType::RegionType roiRegion = roiMask->GetAxisAlignedBoundingBoxRegion();

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -56,6 +56,10 @@ public:
   /** Method for creation through the object factory. */
   itkTypeMacro(ArrowSpatialObject, SpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Set the position of the arrow : this is the point of the arrow */
   itkSetMacro( PositionInObjectSpace, PointType );
 

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -28,6 +28,19 @@ ArrowSpatialObject< TDimension >
 ::ArrowSpatialObject()
 {
   this->SetTypeName("ArrowSpatialObject");
+
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension >
+void
+ArrowSpatialObject< TDimension >
+::Clear( void )
+{
+  Superclass::Clear();
+
   this->GetProperty().SetRed(1);
   this->GetProperty().SetGreen(0);
   this->GetProperty().SetBlue(0);
@@ -38,7 +51,7 @@ ArrowSpatialObject< TDimension >
   m_PositionInObjectSpace.Fill(0);
   m_LengthInObjectSpace = 1;
 
-  this->Update();
+  this->Modified();
 }
 
 /** Compute the bounding box */

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -54,6 +54,10 @@ public:
   itkNewMacro(Self);
   itkTypeMacro(BoxSpatialObject, SpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Set the size of the box spatial object in object space. */
   itkSetMacro( SizeInObjectSpace, SizeType );
 

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -29,10 +29,23 @@ BoxSpatialObject< TDimension >
 ::BoxSpatialObject()
 {
   this->SetTypeName("BoxSpatialObject");
+
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension >
+void
+BoxSpatialObject< TDimension >
+::Clear( void )
+{
+  Superclass::Clear();
+
   m_SizeInObjectSpace.Fill(1);
   m_PositionInObjectSpace.Fill(0);
 
-  this->Update();
+  this->Modified();
 }
 
 /** Test whether a point is inside or outside the object */

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -75,6 +75,10 @@ public:
   /** Method for creation through the object factory. */
   itkTypeMacro(ContourSpatialObject, PointBasedSpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Returns a reference to the list of the control points. */
   ControlPointListType & GetControlPoints()
   { return m_ControlPoints; }

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -47,10 +47,16 @@ ContourSpatialObject< TDimension >
   this->GetProperty().SetBlue(0);
   this->GetProperty().SetAlpha(1);
 
+  m_ControlPoints.clear();
+
   m_InterpolationMethod = NO_INTERPOLATION;
+  m_InterpolationFactor = 2.0;
+
   m_IsClosed = false;
+
   m_OrientationInObjectSpace = -1;
   m_OrientationInObjectSpaceMTime = this->GetMyMTime();
+
   m_AttachedToSlice = -1;
 
   this->Modified();

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -30,6 +30,18 @@ ContourSpatialObject< TDimension >
 {
   this->SetTypeName("ContourSpatialObject");
 
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension >
+void
+ContourSpatialObject< TDimension >
+::Clear( void )
+{
+  Superclass::Clear();
+
   this->GetProperty().SetRed(1);
   this->GetProperty().SetGreen(0);
   this->GetProperty().SetBlue(0);
@@ -40,6 +52,8 @@ ContourSpatialObject< TDimension >
   m_OrientationInObjectSpace = -1;
   m_OrientationInObjectSpaceMTime = this->GetMyMTime();
   m_AttachedToSlice = -1;
+
+  this->Modified();
 }
 
 template< unsigned int TDimension >

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -62,6 +62,10 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(EllipseSpatialObject, SpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Set all radii to the same radius value.  Each radius is
    *  half the length of one axis of the ellipse.  */
   void SetRadiusInObjectSpace(double radius);

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -28,9 +28,23 @@ EllipseSpatialObject< TDimension >
 ::EllipseSpatialObject()
 {
   this->SetTypeName("EllipseSpatialObject");
+
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension >
+void
+EllipseSpatialObject< TDimension >
+::Clear( void )
+{
+  Superclass::Clear();
+
   m_RadiusInObjectSpace.Fill(1.0);
   m_CenterInObjectSpace.Fill(0.0);
-  this->Update();
+
+  this->Modified();
 }
 
 /** Define the radius of the circle in object space.

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -61,6 +61,10 @@ public:
   itkNewMacro(Self);
   itkTypeMacro(GaussianSpatialObject, SpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** The Radius determines the bounding box, and which points are
    * considered to be inside the SpatialObject.  All points with
    * z-score less than the radius are in the object.  */

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -29,12 +29,25 @@ GaussianSpatialObject< TDimension >
 ::GaussianSpatialObject()
 {
   this->SetTypeName("GaussianSpatialObject");
+
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension >
+void
+GaussianSpatialObject< TDimension >
+::Clear( void )
+{
+  Superclass::Clear();
+
   m_CenterInObjectSpace.Fill( 0.0 );
   m_RadiusInObjectSpace = 1.0;
   m_SigmaInObjectSpace = 1.0;
   m_Maximum = 1.0;
 
-  this->Update();
+  this->Modified();
 }
 
 /** The z-score is the root mean square of the z-scores along

--- a/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.hxx
@@ -29,10 +29,6 @@ GroupSpatialObject< TDimension >
 ::GroupSpatialObject()
 {
   this->SetTypeName("GroupSpatialObject");
-  this->GetProperty().SetRed(1);
-  this->GetProperty().SetGreen(0);
-  this->GetProperty().SetBlue(0);
-  this->GetProperty().SetAlpha(1);
 }
 
 /** InternalClone */

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -74,6 +74,10 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ImageSpatialObject, SpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Set the image. */
   void SetImage(const ImageType *image);
 

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -30,6 +30,26 @@ ImageSpatialObject< TDimension,  PixelType >
 ::ImageSpatialObject()
 {
   this->SetTypeName("ImageSpatialObject");
+
+  this->Clear();
+
+  this->Update();
+}
+
+/** Destructor */
+template< unsigned int TDimension, typename PixelType >
+ImageSpatialObject< TDimension,  PixelType >
+::~ImageSpatialObject()
+{
+}
+
+template< unsigned int TDimension, typename PixelType >
+void
+ImageSpatialObject< TDimension,  PixelType >
+::Clear( void )
+{
+  Superclass::Clear();
+
   m_Image = ImageType::New();
   m_SliceNumber.Fill( 0 );
 
@@ -38,13 +58,8 @@ ImageSpatialObject< TDimension,  PixelType >
 #endif
 
   m_Interpolator = NNInterpolatorType::New();
-}
 
-/** Destructor */
-template< unsigned int TDimension, typename PixelType >
-ImageSpatialObject< TDimension,  PixelType >
-::~ImageSpatialObject()
-{
+  this->Modified();
 }
 
 /** Set the interpolator */

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -63,6 +63,10 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(MeshSpatialObject, SpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Set the Mesh. */
   void SetMesh(MeshType *Mesh);
 

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -29,11 +29,26 @@ MeshSpatialObject< TMesh >
 ::MeshSpatialObject()
 {
   this->SetTypeName("MeshSpatialObject");
+
+  this->Clear();
+
+  this->Update();
+}
+
+template< typename TMesh >
+void
+MeshSpatialObject< TMesh >
+::Clear( void )
+{
+  Superclass::Clear();
+
   m_Mesh = MeshType::New();
 #if !defined(ITK_LEGACY_REMOVE)
   m_PixelType = typeid( typename TMesh::PixelType ).name();
 #endif
   m_IsInsidePrecisionInObjectSpace = 1;
+
+  this->Modified();
 }
 
 /** Test whether a point is inside or outside the object

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -62,6 +62,10 @@ public:
   /** Method for creation through the object factory. */
   itkTypeMacro(PointBasedSpatialObject, SpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Assign points to this object, and assigned this object to
    * each point (for computing world coordinates) */
   virtual void AddPoint( const SpatialObjectPointType & newPoints );

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -30,7 +30,22 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
   SpatialObject< TDimension >()
 {
   this->SetTypeName("PointBasedSpatialObject");
+
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension, class TSpatialObjectPointType >
+void
+PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
+::Clear( void )
+{
+  Superclass::Clear();
+
   m_Points.clear();
+
+  this->Modified();
 }
 
 /** Set Points from a list */

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -178,7 +178,12 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 
   if ( it == end )
     {
-    itkExceptionMacro(<< "Blob bounding box computation failed.")
+    typename BoundingBoxType::PointType pnt;
+    pnt.Fill( NumericTraits< typename BoundingBoxType::PointType::ValueType >::
+      ZeroValue() );
+    this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pnt);
+    this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pnt);
+    return;
     }
 
   PointType pt = ( *it ).GetPositionInObjectSpace();

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
@@ -55,6 +55,10 @@ public:
   /** Method for creation through the object factory. */
   itkTypeMacro(PolygonSpatialObject, PointBasedSpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Method returning plane alignment of strand */
   int GetOrientationInObjectSpace() const;
 

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -30,10 +30,25 @@ PolygonSpatialObject< TDimension >
 ::PolygonSpatialObject()
 {
   this->SetTypeName( "PolygonSpatialObject" );
+
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension >
+void
+PolygonSpatialObject< TDimension >
+::Clear( void )
+{
+  Superclass::Clear();
+
   m_IsClosed = false;
   m_OrientationInObjectSpace = -1;
   m_OrientationInObjectSpaceMTime = this->GetMyMTime();
   m_ThicknessInObjectSpace = 0.0;
+
+  this->Modified();
 }
 
 template< unsigned int TDimension >

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -144,6 +144,10 @@ public:
   /** Get the class name with the dimension of the spatial object appended */
   virtual std::string GetClassNameAndDimension( void ) const;
 
+  /** Restore a spatial object to its initial state, yet preserves Id as well as
+   *   parent and children relationships */
+  virtual void Clear( void );
+
   /** Set the property applied to the object. */
   void SetProperty( const PropertyType & property )
   { this->m_Property = property; this->Modified(); }

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -78,6 +78,39 @@ SpatialObject< TDimension >
   this->RemoveAllChildren(0);
 }
 
+
+template< unsigned int TDimension >
+void
+SpatialObject< TDimension >
+::Clear( void )
+{
+  typename BoundingBoxType::PointType pnt;
+  pnt.Fill( NumericTraits< typename BoundingBoxType::PointType::ValueType >::
+    ZeroValue() );
+  m_FamilyBoundingBoxInObjectSpace->SetMinimum(pnt);
+  m_FamilyBoundingBoxInObjectSpace->SetMaximum(pnt);
+  m_FamilyBoundingBoxInWorldSpace->SetMinimum(pnt);
+  m_FamilyBoundingBoxInWorldSpace->SetMaximum(pnt);
+
+  m_MyBoundingBoxInObjectSpace->SetMinimum(pnt);
+  m_MyBoundingBoxInObjectSpace->SetMaximum(pnt);
+  m_MyBoundingBoxInWorldSpace->SetMinimum(pnt);
+  m_MyBoundingBoxInWorldSpace->SetMaximum(pnt);
+
+  m_ObjectToWorldTransform->SetIdentity();
+  m_ObjectToWorldTransformInverse->SetIdentity();
+
+  m_ObjectToParentTransform->SetIdentity();
+  m_ObjectToParentTransformInverse->SetIdentity();
+
+  m_DefaultInsideValue = 1.0;
+  m_DefaultOutsideValue  = 0.0;
+
+  m_Property.Clear();
+
+  this->Modified();
+}
+
 template< unsigned int TDimension >
 void
 SpatialObject< TDimension >

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
@@ -45,6 +45,8 @@ public:
 
   using ColorType = RGBAPixel< double >;
 
+  virtual void Clear( void );
+
   void SetColor( const ColorType & color )
   { m_Color = color; }
 

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -70,7 +70,7 @@ public:
 
   /** Restore a spatial object to its initial state, yet preserves Id as well as
    *   parent and children relationships */
-  virtual void Clear( void );
+  virtual void Clear( void ) override;
 
   /** Compute the normals to the surface from neighboring points */
   bool Approximate3DNormals();

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -68,6 +68,10 @@ public:
   /** Method for creation through the object factory. */
   itkTypeMacro(SurfaceSpatialObject, PointBasedSpatialObject);
 
+  /** Restore a spatial object to its initial state, yet preserves Id as well as
+   *   parent and children relationships */
+  virtual void Clear( void );
+
   /** Compute the normals to the surface from neighboring points */
   bool Approximate3DNormals();
 

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -31,10 +31,24 @@ SurfaceSpatialObject< TDimension >
 {
   this->SetTypeName("SurfaceSpatialObject");
 
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension >
+void
+SurfaceSpatialObject< TDimension >
+::Clear( void )
+{
+  Superclass::Clear();
+
   this->GetProperty().SetRed(1);
   this->GetProperty().SetGreen(0);
   this->GetProperty().SetBlue(0);
   this->GetProperty().SetAlpha(1);
+
+  this->Modified();
 }
 
 /** InternalClone */

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -72,6 +72,10 @@ public:
   /** Method for creation through the object factory. */
   itkTypeMacro(TubeSpatialObject, PointBasedSpatialObject);
 
+  /** Reset the spatial object to its initial condition, yet preserves
+   *   Id, Parent, and Child information */
+  void Clear( void ) override;
+
   /** Set the type of tube end-type: false = flat, true = rounded */
   itkSetMacro(EndRounded, bool);
   itkGetConstMacro(EndRounded, bool);

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -30,6 +30,19 @@ TubeSpatialObject< TDimension, TTubePointType >
 ::TubeSpatialObject()
 {
   this->SetTypeName("TubeSpatialObject");
+
+  this->Clear();
+
+  this->Update();
+}
+
+template< unsigned int TDimension, typename TTubePointType >
+void
+TubeSpatialObject< TDimension, TTubePointType >
+::Clear( void )
+{
+  Superclass::Clear();
+
   this->GetProperty().SetRed(1);
   this->GetProperty().SetGreen(0);
   this->GetProperty().SetBlue(0);
@@ -38,6 +51,8 @@ TubeSpatialObject< TDimension, TTubePointType >
   m_Root = false;
   m_ParentPoint = -1;
   m_EndRounded = false; // default end-type is flat
+
+  this->Modified();
 }
 
 /** InternalClone */

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -107,7 +107,12 @@ TubeSpatialObject< TDimension, TTubePointType >
 
   if ( it == end )
     {
-      itkExceptionMacro(<< "Tube bounding box computation failed.")
+    typename BoundingBoxType::PointType pnt;
+    pnt.Fill( NumericTraits< typename BoundingBoxType::PointType::ValueType >::
+      ZeroValue() );
+    this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum(pnt);
+    this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum(pnt);
+    return;
     }
 
   PointType pt = it->GetPositionInObjectSpace();

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -25,6 +25,13 @@ namespace itk
 SpatialObjectProperty
 ::SpatialObjectProperty()
 {
+  this->Clear();
+}
+
+void
+SpatialObjectProperty
+::Clear( void )
+{
   m_Color.SetRed(1);
   m_Color.SetGreen(1);
   m_Color.SetBlue(1);

--- a/Modules/Core/SpatialObjects/test/SpatialObjectTest.py
+++ b/Modules/Core/SpatialObjects/test/SpatialObjectTest.py
@@ -30,16 +30,16 @@ OutputImageType = itk.Image[OutputPixelType, dim]
 
 ellipse = itk.EllipseSpatialObject[dim].New(RadiusInObjectSpace=[10, 5])
 ellipse.GetObjectToParentTransform().SetOffset([20, 20])
-ellipse.ComputeObjectToWorldTransform()
+ellipse.Update()
 
 box = itk.BoxSpatialObject[dim].New(SizeInObjectSpace=20)
 box.GetObjectToParentTransform().SetOffset([20, 40])
-box.ComputeObjectToWorldTransform()
+box.Update()
 
 gaussian = itk.GaussianSpatialObject[dim].New(RadiusInObjectSpace=100)
 gaussian.GetObjectToParentTransform().SetOffset([60, 60])
 gaussian.GetObjectToParentTransform().Scale(10)
-gaussian.ComputeObjectToWorldTransform()
+gaussian.Update()
 
 group = itk.GroupSpatialObject[dim].New()
 group.AddChild(ellipse)


### PR DESCRIPTION
This PR resolves #691 by adding the Clear() function to ITK's SpatialObjects.   The Clear() function resets the spatial object to its initial state, except for the object's Id, Parent, and Children.