### PR TITLE
Move CI configuration into Azure YML files

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -36,23 +36,29 @@ jobs:
         workingDirectory: $(Agent.BuildDirectory)
         displayName: 'Download dashboard script and testing data'
       - bash: |
-          ctest -V -S ITK-dashboard/azure_dashboard.cmake
-        displayName: Build and test with coverage
+          cat > dashboard.cmake << EOF
+          set(CTEST_BUILD_CONFIGURATION "Debug")
+          set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+          set(CTEST_BUILD_FLAGS -j2)
+          set(dashboard_cache "
+            BUILD_TESTING:BOOL=ON
+            BUILD_SHARED_LIBS:BOOL=OFF
+            BUILD_EXAMPLES:BOOL=OFF
+            BUILD_DOCUMENTS:BOOL=OFF
+            ITK_WRAP_PYTHON:BOOL=OFF
+            CMAKE_CXX_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage
+            CMAKE_C_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage
+            CMAKE_EXE_LINKER_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage
+            COVERAGE_COMMAND:PATH=/usr/bin/gcov
+          ")
+          include($(Agent.BuildDirectory)/ITK-dashboard/azure_dashboard.cmake)
+          EOF
+          cat dashboard.cmake
+        workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+        displayName: 'Configure CTest script'
+      - bash: |
+          ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV
+        displayName: 'Build and test with coverage'
         env:
-          CTEST_BUILD_CONFIGURATION: Debug
-          CTEST_BUILD_FLAGS: -j 2
-          CTEST_OUTPUT_ON_FALURE: 1
-          CTEST_CMAKE_GENERATOR: "Unix Makefiles"
-          CTEST_COVERAGE_COMMAND: /usr/bin/gcov
-          CTEST_CACHE: |
-              BUILD_DOCUMENTS:BOOL=OFF
-              BUILD_EXAMPLES:BOOL=OFF
-              BUILD_SHARED_LIBS:BOOL=OFF
-              BUILD_TESTING:BOOL=ON
-              CMAKE_CXX_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage
-              CMAKE_C_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage
-              CMAKE_EXE_LINKER_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage
-              COVERAGE_COMMAND:PATH=/usr/bin/gcov
-          DASHBOARD_DO_COVERAGE: 1
+          CTEST_OUTPUT_ON_FAILURE: 1
           ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS: 2
-        workingDirectory: $(Agent.BuildDirectory)

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -42,18 +42,30 @@ jobs:
       displayName: 'Download dashboard script and testing data'
 
     - bash: |
+        cat > dashboard.cmake << EOF
+        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(dashboard_cache "
+          BUILD_SHARED_LIBS:BOOL=OFF
+          BUILD_EXAMPLES:BOOL=OFF
+          ITK_WRAP_PYTHON:BOOL=OFF
+        ")
+        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
+        EOF
+        cat dashboard.cmake
+      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+      displayName: 'Configure CTest script'
+
+    - bash: |
         set -x
 
         c++ --version
         cmake --version
 
-        export BUILD_EXAMPLES=OFF
-        export CTEST_BUILD_CONFIGURATION=MinSizeRel
-        export CTEST_OUTPUT_ON_FAILURE=1
-
-        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      workingDirectory: $(Agent.BuildDirectory)
+        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
       displayName: 'Build and test'
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -20,7 +20,7 @@ jobs:
         if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
           git checkout $(System.PullRequest.SourceCommitId)
         fi
-      displayName: Checkout pull request HEAD
+      displayName: 'Checkout pull request HEAD'
 
     - bash: |
         set -x
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get install -y python3-venv python3-numpy python-numpy
         sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install scikit-ci-addons
-      displayName: Install dependencies
+      displayName: 'Install dependencies'
 
     - bash: |
         set -x
@@ -40,26 +40,34 @@ jobs:
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: Download dashboard script and testing data
+      displayName: 'Download dashboard script and testing data'
 
-    - script: |
+    - bash: |
+        cat > dashboard.cmake << EOF
+        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(BUILD_NAME_SUFFIX "-Python")
+        set(dashboard_cache "
+          BUILD_SHARED_LIBS:BOOL=OFF
+          BUILD_EXAMPLES:BOOL=OFF
+          ITK_WRAP_PYTHON:BOOL=ON
+        ")
+        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
+        EOF
+        cat dashboard.cmake
+      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+      displayName: 'Configure CTest script'
+
+    - bash: |
         set -x
-
-        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
-          git checkout $(System.PullRequest.SourceCommitId)
-        fi
 
         c++ --version
         cmake --version
 
-        export BUILD_EXAMPLES=OFF
-        export CTEST_BUILD_CONFIGURATION=MinSizeRel
-        export ITK_WRAP_PYTHON=ON
-        export CTEST_OUTPUT_ON_FAILURE=1
-
-        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      workingDirectory: $(Agent.BuildDirectory)
-      displayName: Build and test
+        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
+      displayName: 'Build and test'
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -37,20 +37,33 @@ jobs:
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: Download dashboard script and testing data
+      displayName: 'Download dashboard script and testing data'
 
-    - script: |
+    - bash: |
+        cat > dashboard.cmake << EOF
+        set(CTEST_BUILD_CONFIGURATION "Release")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(dashboard_cache "
+          BUILD_SHARED_LIBS:BOOL=ON
+          BUILD_EXAMPLES:BOOL=ON
+          ITK_WRAP_PYTHON:BOOL=OFF
+        ")
+        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
+        EOF
+        cat dashboard.cmake
+      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+      displayName: 'Configure CTest script'
+
+    - bash: |
         set -x
 
         c++ --version
         cmake --version
 
-        export BUILD_SHARED_LIBS=ON
-        export CTEST_OUTPUT_ON_FAILURE=1
-
-        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      workingDirectory: $(Agent.BuildDirectory)
-      displayName: Build and test
+        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
+      displayName: 'Build and test'
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -20,14 +20,14 @@ jobs:
         if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
           git checkout $(System.PullRequest.SourceCommitId)
         fi
-      displayName: Checkout pull request HEAD
+      displayName: 'Checkout pull request HEAD'
 
     - bash: |
         set -x
         sudo pip3 install ninja numpy
         sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install scikit-ci-addons
-      displayName: Install dependencies
+      displayName: 'Install dependencies'
 
     - bash: |
         set -x
@@ -38,21 +38,34 @@ jobs:
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: Download dashboard script and testing data
+      displayName: 'Download dashboard script and testing data'
+
+    - bash: |
+        cat > dashboard.cmake << EOF
+        set(CTEST_BUILD_CONFIGURATION "Release")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(BUILD_NAME_SUFFIX "-Python")
+        set(dashboard_cache "
+          BUILD_SHARED_LIBS:BOOL=OFF
+          BUILD_EXAMPLES:BOOL=OFF
+          ITK_WRAP_PYTHON:BOOL=ON
+        ")
+        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
+        EOF
+        cat dashboard.cmake
+      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+      displayName: 'Configure CTest script'
 
     - bash: |
         set -x
+
         c++ --version
         cmake --version
 
-        export BUILD_EXAMPLES=OFF
-        export CTEST_BUILD_CONFIGURATION=Release
-        export ITK_WRAP_PYTHON=ON
-        export CTEST_OUTPUT_ON_FAILURE=1
-
-        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      workingDirectory: $(Agent.BuildDirectory)
-      displayName: Build and test
+        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
+      displayName: 'Build and test'
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -24,7 +24,7 @@ jobs:
         pip3 install ninja
         pip3 install --upgrade setuptools
         pip3 install scikit-ci-addons
-      displayName: Install dependencies
+      displayName: 'Install dependencies'
 
     - script: |
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
@@ -33,22 +33,32 @@ jobs:
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: Download dashboard script and testing data
+      displayName: 'Download dashboard script and testing data'
+
+    - bash: |
+        cat > dashboard.cmake << EOF
+        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(ENV{CC} cl.exe)
+        set(ENV{CXX} cl.exe)
+        set(dashboard_cache "
+          BUILD_SHARED_LIBS:BOOL=ON
+          BUILD_EXAMPLES:BOOL=OFF
+          ITK_WRAP_PYTHON:BOOL=OFF
+        ")
+        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
+        EOF
+        cat dashboard.cmake
+      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+      displayName: 'Configure CTest script'
 
     - script: |
         cmake --version
-
         call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        set BUILD_SHARED_LIBS=ON
-        set BUILD_EXAMPLES=OFF
-        set CTEST_BUILD_CONFIGURATION=MinSizeRel
-        set CC=cl.exe
-        set CXX=cl.exe
-        set CTEST_OUTPUT_ON_FAILURE=1
-
-        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      workingDirectory: $(Agent.BuildDirectory)
-      displayName: Build and test
+        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
+      displayName: 'Build and test'
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -24,7 +24,7 @@ jobs:
         pip3 install ninja numpy
         pip3 install --upgrade setuptools
         pip3 install scikit-ci-addons
-      displayName: Install dependencies
+      displayName: 'Install dependencies'
 
     - script: |
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
@@ -33,24 +33,35 @@ jobs:
         cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
         cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: Download dashboard script and testing data
+      displayName: 'Download dashboard script and testing data'
+
+    - bash: |
+        cat > dashboard.cmake << EOF
+        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(BUILD_NAME_SUFFIX "-Python")
+        set(ENV{CC} cl.exe)
+        set(ENV{CXX} cl.exe)
+        set(dashboard_cache "
+          BUILD_SHARED_LIBS:BOOL=ON
+          BUILD_EXAMPLES:BOOL=OFF
+          ITK_WRAP_PYTHON:BOOL=ON
+          ITK_BUILD_DEFAULT_MODULES:BOOL=OFF
+          ITKGroup_Core:BOOL=ON
+        ")
+        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
+        EOF
+        cat dashboard.cmake
+      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+      displayName: 'Configure CTest script'
 
     - script: |
         cmake --version
-
         call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        set BUILD_EXAMPLES=OFF
-        set CTEST_BUILD_CONFIGURATION=MinSizeRel
-        set BUILD_SHARED_LIBS=ON
-        set ITK_WRAP_PYTHON=ON
-        set ITK_BUILD_DEFAULT_MODULES=OFF
-        set CC=cl.exe
-        set CXX=cl.exe
-        set CTEST_OUTPUT_ON_FAILURE=1
-
-        ctest -S ITK-dashboard/azure_dashboard.cmake -V -j 4
-      workingDirectory: $(Agent.BuildDirectory)
-      displayName: Build and test
+        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
+      displayName: 'Build and test'
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml


### PR DESCRIPTION
CI configuration was done through environment variables that were then
interpreted in a CTest configuration script shipped in the dashboard branch
of ITK. This implementation required to modified both the master branch
and the dashboard branch if new options had to be controled from the YML
configuration files. For ITK remote modules, the configuration is already
done directly inside the YML configuration file. This patch moves the CI
configuration for ITK inside the master branch the same way it is done for
remote modules.