### PR TITLE
ENH: Add advanced CMake option `ITK_DO_NOT_BUILD_TESTDRIVERS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,12 @@ mark_as_advanced(ITK_COMPUTER_MEMORY_SIZE)
 option(ITK_USE_FLOAT_SPACE_PRECISION "Use single precision for origin/spacing/directions in itk::Image" OFF)
 mark_as_advanced(ITK_USE_FLOAT_SPACE_PRECISION)
 
+# This flag allows to not build itkTestDrivers while still configuring all the tests and disable all
+# tests that do not explicitely override this function (such as the Python tests).
+# This is used by dashboards to speed up compilation and testing on certain platforms.
+option(ITK_DISABLE_ALL_TESTS_BUT_OVERRIDEN "Disable all tests except the ones that override this option" OFF)
+mark_as_advanced(ITK_DISABLE_ALL_TESTS_BUT_OVERRIDEN)
+
 #----------------------------------------------------------------------
 # Make sure remote modules are downloaded before sorting out the module
 # dependencies.


### PR DESCRIPTION
This option allows to skip building the itkTestDrivers and therefore
can speed up compilation time. This is especially useful on CI
where the tests using these itkTestDrivers can be run for certain
builds that do not risk to time out (i.e. no wrapping).