### PR TITLE
BUG: Remove setting `dashboard_cache` from environment variable.

### DIFF
--- a/azure_dashboard.cmake
+++ b/azure_dashboard.cmake
@@ -70,8 +70,6 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
   "ld: warning: text-based stub file"
   )
 
-set_from_env(dashboard_cache "CTEST_CACHE" DEFAULT ${_dashboard_cache})
-
 string(TIMESTAMP build_date "%Y-%m-%d")
 message("CDash Build Identifier: ${build_date} ${CTEST_BUILD_NAME}")
 message("CTEST_SITE = ${CTEST_SITE}")


### PR DESCRIPTION
This is a follow up PR for [1] which did not remove this line
of code, but should have removed it.

[1] https://github.com/InsightSoftwareConsortium/ITK/commit/1902ab7be33b7d8b42b78a5ac5b3b319153d33f6