### PR TITLE
WIP: Test CI infrastructure speed

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -41,7 +41,7 @@ jobs:
 
     - bash: |
         cat > dashboard.cmake << EOF
-        set(CTEST_BUILD_CONFIGURATION "Release")
+        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
         set(CTEST_CMAKE_GENERATOR "Ninja")
         set(dashboard_cache "
           BUILD_SHARED_LIBS:BOOL=ON

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -42,11 +42,10 @@ jobs:
 
     - bash: |
         cat > dashboard.cmake << EOF
-        set(CTEST_BUILD_CONFIGURATION "Release")
+        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
         set(CTEST_CMAKE_GENERATOR "Ninja")
         set(BUILD_NAME_SUFFIX "-Python")
         set(dashboard_cache "
-          DISABLE_MODULE_TESTS:BOOL=ON
           BUILD_SHARED_LIBS:BOOL=OFF
           BUILD_EXAMPLES:BOOL=OFF
           ITK_WRAP_PYTHON:BOOL=ON

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -47,8 +47,7 @@ jobs:
           BUILD_SHARED_LIBS:BOOL=ON
           BUILD_EXAMPLES:BOOL=OFF
           ITK_WRAP_PYTHON:BOOL=ON
-          ITK_BUILD_DEFAULT_MODULES:BOOL=OFF
-          ITKGroup_Core:BOOL=ON
+          ITK_BUILD_DEFAULT_MODULES:BOOL=ON
         ")
         include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
         EOF


### PR DESCRIPTION
WARNING: Do not merge this PR: This is only a test.

* Checks if builds on MacOS (both Python ON and OFF) pass with "MinSizeRel" builds.
* Checks how long compilation on Windows takes now that module tests are disabled on CI for Python builds.