### PR TITLE
ENH: Add static member function Size<VDimension>::Filled(SizeValueType)

### DIFF
--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -360,6 +360,17 @@ private:
       }
   }
 
+public:
+
+  /** Returns a Size object, filled with the specified value for each element.
+   */
+  static Self Filled(const SizeValueType value)
+  {
+    Self result;
+    result.Fill(value);
+    return result;
+  }
+
 };  //------------ End struct Size
 
 

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -618,6 +618,7 @@ set(ITKCommonGTests
       itkImageBufferRangeGTest.cxx
       itkIndexRangeGTest.cxx
       itkShapedImageNeighborhoodRangeGTest.cxx
+      itkSizeGTest.cxx
       itkSmartPointerGTest.cxx
       itkVectorContainerGTest.cxx
       itkCommonTypeTraitsGTest.cxx

--- a/Modules/Core/Common/test/itkSizeGTest.cxx
+++ b/Modules/Core/Common/test/itkSizeGTest.cxx
@@ -1,0 +1,59 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+ // First include the header file to be tested:
+#include "itkSize.h"
+#include <gtest/gtest.h>
+#include <limits>
+
+namespace
+{
+  template <unsigned VDimension>
+  void Expect_Filled_returns_Size_with_specified_value_for_each_element()
+  {
+    using itk::SizeValueType;
+    using SizeType = itk::Size<VDimension>;
+
+    // Tests that all elements from SizeType::Filled(sizeValue) get the specified value.
+    const auto Expect_Filled_with_value = [](const SizeValueType sizeValue)
+    {
+      for (const auto filledSizeValue : SizeType::Filled(sizeValue))
+      {
+        EXPECT_EQ(filledSizeValue, sizeValue);
+      }
+    };
+
+    // Test for sizeValue 0, 1, 2, and its maximum.
+    for (SizeValueType sizeValue = 0; sizeValue < 3; ++sizeValue)
+    {
+      Expect_Filled_with_value(sizeValue);
+    }
+    Expect_Filled_with_value(std::numeric_limits<SizeValueType>::max());
+  }
+}
+
+
+// Tests that itk::Size::Filled(value) returns an itk::Size with the
+// specified value for each element.
+TEST(Size, FilledReturnsSizeWithSpecifiedValueForEachDimension)
+{
+  // Test for 1-D, 2-D, and 3-D.
+  Expect_Filled_returns_Size_with_specified_value_for_each_element<1>();
+  Expect_Filled_returns_Size_with_specified_value_for_each_element<2>();
+  Expect_Filled_returns_Size_with_specified_value_for_each_element<3>();
+}


### PR DESCRIPTION
Added static `itk::Size<VDimension>` member function `Filled(value)`,
analogue to `FixedArray::Filled(value)`.

This convenience function should ease, for example, creating an NxN
image, or an NxNxN volume.