### PR TITLE
BUG: Remove outdated class declaration

### DIFF
--- a/Modules/Segmentation/LevelSets/test/itkImplicitManifoldNormalVectorFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkImplicitManifoldNormalVectorFilterTest.cxx
@@ -17,32 +17,9 @@
  *=========================================================================*/
 
 #include <iostream>
+#include "itkSparseFieldFourthOrderLevelSetImageFilter.h"
 #include "itkImplicitManifoldNormalVectorFilter.h"
 #include "itkNormalVectorDiffusionFunction.h"
-
-namespace itk
-{
-
-template <typename TImageType>
-class NormalBandNode
-{
-public:
-  using LevelSetImageType = TImageType;
-  using NodeValueType = typename LevelSetImageType::PixelType;
-  using IndexType = typename LevelSetImageType::IndexType;
-  using NodeDataType = Vector <NodeValueType,
-                  TImageType::ImageDimension>;
-
-  NodeDataType m_Data, m_InputData, m_Update;
-  NodeDataType m_ManifoldNormal [TImageType::ImageDimension];
-  NodeDataType m_Flux [TImageType::ImageDimension];
-
-  IndexType       m_Index;
-  NormalBandNode *Next;
-  NormalBandNode *Previous;
-};
-
-}
 
 int itkImplicitManifoldNormalVectorFilterTest(int, char* [] )
 {


### PR DESCRIPTION
This is a fix for the segfaults in #713.

This test was redeclaring `NormalBandNode` but the class had since been updated. It seems that when using MinSizeRel, AppleClang was favoring this outdated declaration, causing segmentation faults when confusing attributes.

Concerning the two tests failing without segfaults in #713, I was never able to reproduce the problem.