### PR TITLE
STYLE: SpatialObject GetModifiableMyBoundingBoxInObjectSpace() non-const

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -530,7 +530,7 @@ protected:
 
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
-  BoundingBoxType * GetModifiableMyBoundingBoxInObjectSpace() const
+  BoundingBoxType * GetModifiableMyBoundingBoxInObjectSpace()
   { return m_MyBoundingBoxInObjectSpace.GetPointer(); }
 
   typename LightObject::Pointer InternalClone() const override;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -750,7 +750,7 @@ SpatialObject< TDimension >
     // Next Transform the corners of the bounding box
   using PointsContainer = typename BoundingBoxType::PointsContainer;
   const PointsContainer *corners
-    = this->GetModifiableMyBoundingBoxInObjectSpace()->GetCorners();
+    = m_MyBoundingBoxInObjectSpace->GetCorners();
   typename PointsContainer::Pointer transformedCorners =
     PointsContainer::New();
   transformedCorners->Reserve(
@@ -795,9 +795,9 @@ SpatialObject< TDimension >
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
     PointType pointMin
-      = this->GetModifiableMyBoundingBoxInObjectSpace()->GetMinimum();
+      = m_MyBoundingBoxInObjectSpace->GetMinimum();
     PointType pointMax
-      = this->GetModifiableMyBoundingBoxInObjectSpace()->GetMaximum();
+      = m_MyBoundingBoxInObjectSpace->GetMaximum();
     for ( unsigned int i = 0; i < ObjectDimension; i++ )
       {
       if ( Math::NotExactlyEquals(pointMin[i], 0)


### PR DESCRIPTION
Removed `const` keyword from the protected `SpatialObject` member function
`GetModifiableMyBoundingBoxInObjectSpace()`, as it allows modifying the
bounding box of the spatial object.

This is consistent with the other `GetModifiable...` member functions in ITK,
which are all non-const as well.
