### PR TITLE
ENH: Update remote module maintenance script

### DIFF
--- a/Utilities/Maintenance/UpdateRemoteModules.sh
+++ b/Utilities/Maintenance/UpdateRemoteModules.sh
@@ -56,8 +56,8 @@ for filename in ${remote_modules_path}/*.cmake; do
     fi
   fi
 
-  # Sed the the latest commit hash in the CMake file
-  sed -i "" "s/${curr_commit}/${latest_commit}/g" $filename
+  # Search and replace the latest commit hash in the CMake file
+  ex -sc "%s/${curr_commit}/${latest_commit}/g|x" $filename
 
   echo "$repository was updated to latest commit"
 

--- a/Utilities/Maintenance/UpdateRemoteModules.sh
+++ b/Utilities/Maintenance/UpdateRemoteModules.sh
@@ -37,11 +37,11 @@ for filename in ${remote_modules_path}/*.cmake; do
   echo -n "."
 
   # Get the current commit hash
-  curr_commit=$(grep -m 1 -o "[^#]GIT_TAG \(\w\|\.\|\-\|_\)*" $filename)
+  curr_commit=$(grep -v "\s*#" $filename | grep -m 1 -o "GIT_TAG \(\w\|\.\|\-\|_\)*")
   curr_commit=${curr_commit/*GIT_TAG /}
 
   # Read the git repository information
-  repository=$(grep -m 1 -o "[^#]GIT_REPOSITORY \${git_protocol}://github.com/\(\w\|\-\|_\|/\)*" $filename)
+  repository=$(grep -v "\s*#" $filename | grep -m 1 -o "GIT_REPOSITORY \${git_protocol}://github.com/\(\w\|\-\|_\|/\)*")
   repository=${repository/*GIT_REPOSITORY \${git_protocol\}:\/\/github.com\//}
 
   # Get the latest git commit hash of the remote module.


### PR DESCRIPTION
Fixes #682 and #685.

This updated version of `UpdateRemoteModules.sh` uses more constraining parsing rules to avoid issues and removes version specific syntax to be more portable.

It also adds the option `-ongreen` to update only if the latest build was successful.