### PR TITLE
PERF: ImageMaskSpatialObject::GetAxisAlignedBoundingBoxRegion() faster

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMath.h"
 #include "itkImageMaskSpatialObject.h"
+#include "itkImageRegionConstIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 
 namespace itk
@@ -178,140 +179,87 @@ typename ImageMaskSpatialObject< TDimension, TPixel >::RegionType
 ImageMaskSpatialObject< TDimension, TPixel >
 ::GetAxisAlignedBoundingBoxRegion() const
 {
-  // We will use a slice iterator to iterate through slices orthogonal
-  // to each of the axis of the image to find the bounding box. Each
-  // slice iterator iterates from the outermost slice towards the image
-  // center till it finds a mask pixel. For a 3D image, there will be six
-  // slice iterators, iterating from the periphery inwards till the bounds
-  // along each axes are found. The slice iterators save time and avoid
-  // having to walk the whole image. Since we are using slice iterators,
-  // we will implement this only for 3D images.
+  const ImagePointer imagePointer = this->GetImage();
 
-  PixelType  outsideValue = NumericTraits< PixelType >::ZeroValue();
-  RegionType region;
+  if (imagePointer == nullptr)
+  {
+    return {};
+  }
 
-  ImagePointer image = this->GetImage();
-  const RegionType imageRegion = image->GetRequestedRegion();
+  const ImageType& image = *imagePointer;
 
-  IndexType index;
-  SizeType  size;
-
-  for(unsigned int i(0); i < ImageType::ImageDimension; i++)
+  const auto HasForegroundPixels = [&image](const RegionType& region)
+  {
+    for (ImageRegionConstIterator<ImageType> it{ &image, region }; !it.IsAtEnd(); ++it)
     {
-    index[i] = 0;
-    size[i] = 0;
+      constexpr auto zeroValue = NumericTraits<PixelType>::ZeroValue();
+
+      if (it.Get() != zeroValue)
+      {
+        return true;
+      }
     }
+    return false;
+  };
 
-  if ( ImageType::ImageDimension == 3 )
+  const auto CreateRegion = [](const IndexType& minIndex, const IndexType& maxIndex)
+  {
+    SizeType regionSize;
+
+    for (unsigned dim = 0; dim < SizeType::Dimension; ++dim)
     {
-    for ( unsigned int axis = 0; axis < ImageType::ImageDimension; axis++ )
-      {
-      // Two slice iterators along each axis...
-      // Find the orthogonal planes for the slices
-      unsigned int i, j;
-      unsigned int direction[2];
-      for ( i = 0, j = 0; i < 3; ++i )
-        {
-        if ( i != axis )
-          {
-          direction[j] = i;
-          j++;
-          }
-        }
-
-      // Create the forward iterator to find lower bound
-      SliceIteratorType fit( image,  imageRegion );
-      fit.SetFirstDirection(direction[1]);
-      fit.SetSecondDirection(direction[0]);
-
-      fit.GoToBegin();
-      while ( !fit.IsAtEnd() )
-        {
-        while ( !fit.IsAtEndOfSlice() )
-          {
-          while ( !fit.IsAtEndOfLine() )
-            {
-            if ( fit.Get() != outsideValue )
-              {
-              index[axis] = fit.GetIndex()[axis];
-              fit.GoToReverseBegin(); // skip to the end
-              break;
-              }
-            ++fit;
-            }
-          fit.NextLine();
-          }
-        fit.NextSlice();
-        }
-
-      // Create the reverse iterator to find upper bound
-      SliceIteratorType rit( image,  imageRegion );
-      rit.SetFirstDirection(direction[1]);
-      rit.SetSecondDirection(direction[0]);
-
-      rit.GoToReverseBegin();
-      while ( !rit.IsAtReverseEnd() )
-        {
-        while ( !rit.IsAtReverseEndOfSlice() )
-          {
-          while ( !rit.IsAtReverseEndOfLine() )
-            {
-            if ( rit.Get() != outsideValue )
-              {
-              size[axis] = rit.GetIndex()[axis] - index[axis] + 1;
-              rit.GoToBegin(); //Skip to reverse end
-              break;
-              }
-            --rit;
-            }
-          rit.PreviousLine();
-          }
-        rit.PreviousSlice();
-        }
-      }
-
-    region.SetIndex(index);
-    region.SetSize(size);
+      regionSize[dim] = static_cast<SizeValueType>(maxIndex[dim] + 1 - minIndex[dim]);
     }
-  else
+    return RegionType{ minIndex, regionSize };
+  };
+
+  const RegionType requestedRegion = image.GetRequestedRegion();
+
+  if (requestedRegion.GetNumberOfPixels() == 0)
+  {
+    return {};
+  }
+
+  const SizeType imageSize = requestedRegion.GetSize();
+
+  IndexType minIndex = requestedRegion.GetIndex();
+  IndexType maxIndex = minIndex + imageSize;
+
+  for (auto& maxIndexValue : maxIndex)
+  {
+    --maxIndexValue;
+  }
+
+  // Iterate from high to low (for significant performance reasons).
+  for (int dim = TDimension - 1; dim >= 0; --dim)
+  {
+    auto subregion = CreateRegion(minIndex, maxIndex);
+    subregion.SetSize(dim, 1);
+    const auto initialMaxIndexValue = maxIndex[dim];
+
+    // Estimate minIndex[dim]
+    while (!HasForegroundPixels(subregion))
     {
-    using IteratorType = ImageRegionConstIteratorWithIndex< ImageType >;
-    IteratorType it( image, imageRegion );
-    it.GoToBegin();
+      const auto indexValue = subregion.GetIndex(dim) + 1;
 
-    IndexType minBoundingBoxIndex = imageRegion.GetIndex() + imageRegion.GetSize();
-    IndexType maxBoundingBoxIndex = imageRegion.GetIndex();
-
-    while ( !it.IsAtEnd() )
+      if (indexValue > initialMaxIndexValue)
       {
-      if ( it.Get() != outsideValue )
-        {
-        IndexType tmpIndex = it.GetIndex();
-        for ( unsigned int i = 0; i < ImageType::ImageDimension; ++i )
-          {
-          minBoundingBoxIndex[i] = std::min(minBoundingBoxIndex[i], tmpIndex[i]);
-          maxBoundingBoxIndex[i] = std::max(maxBoundingBoxIndex[i], tmpIndex[i]);
-          }
-        }
-      ++it;
+        // The requested image region has only zero-valued pixels.
+        return {};
       }
+      subregion.SetIndex(dim, indexValue);
+    }
+    minIndex[dim] = subregion.GetIndex(dim);
 
-    if (maxBoundingBoxIndex[0] < minBoundingBoxIndex[0])
-      {
-      // In this case, the image region is entirely black (all pixels are zero),
-      // so the bounding box must be empty.
-      return RegionType{};
-      }
-
-    for ( unsigned int i = 0; i < ImageType::ImageDimension; ++i )
-      {
-      size[i] = maxBoundingBoxIndex[i] - minBoundingBoxIndex[i] + 1;
-      }
-    region.SetIndex(minBoundingBoxIndex);
-    region.SetSize(size);
-    } // end else
-
-  return region;
+    // Estimate maxIndex[dim]
+    subregion.SetIndex(dim, initialMaxIndexValue);
+    while (!HasForegroundPixels(subregion))
+    {
+      subregion.SetIndex(dim, subregion.GetIndex(dim) - 1);
+    }
+    maxIndex[dim] = subregion.GetIndex(dim);
+  }
+  return CreateRegion(minIndex, maxIndex);
 }
 #endif //ITK_LEGACY_REMOVE
 } // end namespace itk


### PR DESCRIPTION
Made `ImageMaskSpatialObject::GetAxisAlignedBoundingBoxRegion()` many times (!)
faster than before.

The amount of the speed improvement depends on the input image: For a black 3D
image of 256x256x256, it was observed than the function runs more than 10 x
faster than before. For a 2D image of 1024x1024 with non-zero border pixels,
it was observed than the function runs even more than 100 x faster!