### PR TITLE
BUG: Fix IsInsideObjectSpace function in PolygonSpatialObject

### DIFF
--- a/Examples/Filtering/SpatialObjectToImage3.cxx
+++ b/Examples/Filtering/SpatialObjectToImage3.cxx
@@ -166,7 +166,9 @@ int main( int argc, char *argv[] )
     point = center + radial;
     polygonPoint.SetPositionInObjectSpace( point );
     polygon->GetPoints().push_back( polygonPoint );
+    std::cout << point[0] << ", " << point[1] << std::endl;
     }
+  polygon->SetIsClosed(true);
   polygon->Update();
   // Software Guide : EndCodeSnippet
 


### PR DESCRIPTION
The new implementation now defaults to "IsClosed" being true and
appropriately computes IsInside.  Previously variables (node1 and
node2) were not correctly initialized.