### PR TITLE
ENH: Add explicit constructors Point and FixedArray for C++11 std::array

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -20,6 +20,7 @@
 
 #include "itkMacro.h"
 #include <algorithm>
+#include <array>
 
 namespace itk
 {
@@ -141,6 +142,12 @@ public:
   /** Conversion constructors */
   FixedArray(const ValueType r[VLength]);
   FixedArray(const ValueType & );
+
+  /** Explicit constructor for std::array. */
+  explicit FixedArray(const std::array<ValueType, VLength>& stdArray)
+  {
+    std::copy_n(stdArray.cbegin(), VLength, m_InternalArray);
+  }
 
   /** Constructor to initialize a fixed array from another of any data type */
   template< typename TFixedArrayValueType >

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -97,6 +97,13 @@ public:
   Point(const TPointValueType & v):BaseArray(v) {}
   Point(const ValueType & v):BaseArray(v) {}
 
+  /** Explicit constructor for std::array. */
+  explicit Point(const std::array<ValueType, NPointDimension>& stdArray)
+    :
+    BaseArray(stdArray)
+  {
+  }
+
   /** Pass-through assignment operator for a plain array. */
   Point & operator=(const ValueType r[NPointDimension]);
 

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -616,6 +616,7 @@ set(ITKCommonGTests
       itkImageNeighborhoodOffsetsGTest.cxx
       itkImageBufferRangeGTest.cxx
       itkIndexRangeGTest.cxx
+      itkPointGTest.cxx
       itkShapedImageNeighborhoodRangeGTest.cxx
       itkSizeGTest.cxx
       itkSmartPointerGTest.cxx

--- a/Modules/Core/Common/test/itkPointGTest.cxx
+++ b/Modules/Core/Common/test/itkPointGTest.cxx
@@ -1,0 +1,55 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+ // First include the header file to be tested:
+#include "itkPoint.h"
+#include <gtest/gtest.h>
+
+#include <iterator>  // For begin and end.
+#include <numeric>  // For iota.
+
+namespace
+{
+  template <unsigned VDimension>
+  void Expect_Point_can_be_constructed_by_std_array()
+  {
+    using ValueType = double;
+    using PointType = itk::Point<ValueType, VDimension>;
+
+    std::array<ValueType, VDimension> stdArray;
+
+    // Assign a different value (0, 1, 2, ...) to each element.
+    std::iota(std::begin(stdArray), std::end(stdArray), 0.0);
+
+    // Now construct the point (using the explicit Point constructor for std::array).
+    const PointType point(stdArray);
+
+    // Check that the values of all element are copied.
+    EXPECT_TRUE(std::equal(point.Begin(), point.End(), stdArray.cbegin()));
+  }
+}
+
+
+// Tests that a Point can be constructed by specifying
+// its coordinates by an std::array<ValueType, VDimension>.
+TEST(Point, CanBeConstructedByStdArray)
+{
+  // Test for 2-D and 3-D.
+  Expect_Point_can_be_constructed_by_std_array<2>();
+  Expect_Point_can_be_constructed_by_std_array<3>();
+}


### PR DESCRIPTION
Added `explicit` `Point` and `FixedArray` constructors, allowing to specify
their elements by a C++11 `std::array`. Added `itkPointGTest` to test this
new feature.