### PR TITLE
DOC: Improve diagnostic message from ExtractImageFilter

### DIFF
--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -68,6 +68,7 @@ void
 ExtractImageFilter< TInputImage, TOutputImage >
 ::SetExtractionRegion(InputImageRegionType extractRegion)
 {
+  static_assert(InputImageDimension >= OutputImageDimension, "InputImageDimension must be greater than OutputImageDimension");
   m_ExtractionRegion = extractRegion;
 
   unsigned int         nonzeroSizeCount = 0;
@@ -93,8 +94,10 @@ ExtractImageFilter< TInputImage, TOutputImage >
 
   if ( nonzeroSizeCount != OutputImageDimension )
     {
-    itkExceptionMacro("Extraction Region not consistent with output image, "
-                      << "expected " << OutputImageDimension-InputImageDimension
+    itkExceptionMacro("The number of zero sized dimensions in the input image Extraction Region\n"
+                      << "is not consistent with the dimensionality of the output image.\n"
+                      << "Expected the extraction region size (" << extractRegion.GetSize()
+                      << ") to contain " << InputImageDimension-OutputImageDimension
                       << " zero sized dimensions to collapse." );
     }
 

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -67,6 +67,8 @@ void
 ExtractSliceImageFilter< TInputImage, TOutputImage >
 ::SetExtractionRegion(InputImageRegionType extractRegion)
 {
+  static_assert(InputImageDimension >= OutputImageDimension, "InputImageDimension must be greater than OutputImageDimension");
+  m_ExtractionRegion = extractRegion;
 
   unsigned int         nonzeroSizeCount = 0;
   InputImageSizeType   inputSize = extractRegion.GetSize();
@@ -93,10 +95,13 @@ ExtractSliceImageFilter< TInputImage, TOutputImage >
     }
   if ( nonzeroSizeCount != OutputImageDimension )
     {
-    itkExceptionMacro("Extraction Region not consistent with output image");
+    itkExceptionMacro("The number of zero sized dimensions in the input image Extraction Region\n"
+                      << "is not consistent with the dimensionality of the output image.\n"
+                      << "Expected the extraction region size ("<< extractRegion.GetSize()
+                      << ") to contain " << InputImageDimension-OutputImageDimension
+                      << " zero sized dimensions to collapse." );
     }
 
-  m_ExtractionRegion = extractRegion;
   m_OutputImageRegion.SetSize(outputSize);
   m_OutputImageRegion.SetIndex(outputIndex);
   this->Modified();


### PR DESCRIPTION
The original "OutputImageDimension-InputImageDimension" computation
resulted in underflow error and a very confusing message when the output
dimension was less than the input dimension.  Provide an expanded
diagnostic message to improve the understanding of what the failure
was."
