### PR TITLE
BUG: Fix issue #785 removing BoundingBox check from ImageMask IsInside

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -44,22 +44,19 @@ ImageMaskSpatialObject< TDimension, TPixel >
 {
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
-    if( this->GetMyBoundingBoxInObjectSpace()->IsInside(point) )
+    typename Superclass::InterpolatorType::ContinuousIndexType index;
+    if( this->GetImage()->TransformPhysicalPointToContinuousIndex( point,
+        index ) )
       {
-      typename Superclass::InterpolatorType::ContinuousIndexType index;
-      if( this->GetImage()->TransformPhysicalPointToContinuousIndex( point,
-          index ) )
+      using InterpolatorOutputType = typename InterpolatorType::OutputType;
+      bool insideMask = (
+        Math::NotExactlyEquals(
+          DefaultConvertPixelTraits<InterpolatorOutputType>::GetScalarValue(
+            this->GetInterpolator()->EvaluateAtContinuousIndex(index)),
+          NumericTraits<PixelType>::ZeroValue() ) );
+      if( insideMask )
         {
-        using InterpolatorOutputType = typename InterpolatorType::OutputType;
-        bool insideMask = (
-          Math::NotExactlyEquals(
-            DefaultConvertPixelTraits<InterpolatorOutputType>::GetScalarValue(
-              this->GetInterpolator()->EvaluateAtContinuousIndex(index)),
-            NumericTraits<PixelType>::ZeroValue() ) );
-        if( insideMask )
-          {
-          return true;
-          }
+        return true;
         }
       }
     }


### PR DESCRIPTION
Fixed issue #785 (ImageMaskSpatialObject IsInside should not depend on
distant pixels) by removing the BoundingBox check from
`ImageMask::IsInsideInObjectSpace`

Added various GTest unit tests for `ImageMaskSpatialObject::IsInside` 