### PR TITLE
BUG: Fix IsInsideObjectSpace function in PolygonSpatialObject

### DIFF
--- a/Examples/Filtering/SpatialObjectToImage3.cxx
+++ b/Examples/Filtering/SpatialObjectToImage3.cxx
@@ -167,6 +167,7 @@ int main( int argc, char *argv[] )
     polygonPoint.SetPositionInObjectSpace( point );
     polygon->GetPoints().push_back( polygonPoint );
     }
+  polygon->SetIsClosed(true);
   polygon->Update();
   // Software Guide : EndCodeSnippet
 


### PR DESCRIPTION
The new implementation now defaults to "IsClosed" being true and
appropriately computes IsInside.  Previously variables (node1 and
node2) were not correctly initialized.

This PR superseeds #747 to address one comment.