### PR TITLE
ENH: Add begin() and end() to FixedArray, support range-based for-loops

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -128,6 +128,12 @@ public:
   /** A const reference to the ValueType. */
   using const_reference = const ValueType &;
 
+  /** The return type of the non-const overloads of begin() and end(). */
+  using iterator = ValueType *;
+
+  /** The return type of cbegin() and cend(), and the const overloads of begin() and end(). */
+  using const_iterator = const ValueType *;
+
   using SizeType = unsigned int;
 
 public:
@@ -257,6 +263,36 @@ public:
   ReverseIterator      rEnd();
 
   ConstReverseIterator rEnd() const;
+
+  const_iterator cbegin() const noexcept
+  {
+    return m_InternalArray;
+  }
+
+  iterator begin() noexcept
+  {
+    return m_InternalArray;
+  }
+
+  const_iterator begin() const noexcept
+  {
+    return this->cbegin();
+  }
+
+  const_iterator cend() const noexcept
+  {
+    return m_InternalArray + VLength;
+  }
+
+  iterator end() noexcept
+  {
+    return m_InternalArray + VLength;
+  }
+
+  const_iterator end() const noexcept
+  {
+    return this->cend();
+  }
 
   SizeType      Size() const;
 

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -613,6 +613,7 @@ set(ITKCommonGTests
       itkBuildInformationGTest.cxx
       itkConnectedImageNeighborhoodShapeGTest.cxx
       itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
+      itkFixedArrayGTest.cxx
       itkImageNeighborhoodOffsetsGTest.cxx
       itkImageBufferRangeGTest.cxx
       itkIndexRangeGTest.cxx

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -1,0 +1,110 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+ // First include the header file to be tested:
+#include "itkFixedArray.h"
+#include <gtest/gtest.h>
+
+#include <array>
+#include <numeric>  // For iota.
+
+
+namespace
+{
+  template< typename TValue, unsigned int VLength >
+  void Check_FixedArray_supports_retrieving_values_by_range_based_for_loop()
+  {
+    std::array<TValue, VLength> stdArray{};
+
+    // Assign a different value (1, 2, 3, ...) to each element.
+    std::iota(stdArray.begin(), stdArray.end(), 1);
+
+    // Test retrieving the values from a const FixedArray:
+    const itk::FixedArray<TValue, VLength> constFixedArray{ stdArray };
+
+    auto stdArrayIterator = stdArray.cbegin();
+
+    for (auto value : constFixedArray)
+    {
+      // Expect the same value as the corresponding std::array element.
+      EXPECT_EQ(value, *stdArrayIterator);
+      ++stdArrayIterator;
+    }
+
+    // Expect that all values are checked, "up to the end".
+    EXPECT_EQ(stdArrayIterator, stdArray.cend());
+
+    // Now test retrieving the values from a non-const FixedArray:
+    itk::FixedArray<TValue, VLength> nonConstFixedArray{ stdArray };
+
+    stdArrayIterator = stdArray.cbegin();
+
+    for (auto value : nonConstFixedArray)
+    {
+      // Again, expect the same value as the corresponding std::array element.
+      EXPECT_EQ(value, *stdArrayIterator);
+      ++stdArrayIterator;
+    }
+
+    // Again, expect that all values are checked.
+    EXPECT_EQ(stdArrayIterator, stdArray.cend());
+  }
+
+
+  template< typename TValue, unsigned int VLength >
+  void Check_FixedArray_supports_modifying_elements_by_range_based_for_loop()
+  {
+    itk::FixedArray<TValue, VLength> fixedArray{};
+
+    TValue value{};
+
+    // Assign the values 1, 2, 3, etc.
+    for (auto& ref : fixedArray)
+    {
+      ++value;
+      ref = value;
+    }
+
+    // Now check if the array has got the expected values.
+    TValue expectedValue{};
+
+    for (std::size_t i = 0; i < VLength; ++i)
+    {
+      ++expectedValue;
+      EXPECT_EQ(fixedArray[i], expectedValue);
+    }
+  }
+
+} // End of namespace
+
+
+// Tests that the values of a FixedArray (either const or non-const) can be retrieved by a
+// range-based for-loop.
+TEST(FixedArray, SupportsRetrievingValuesByRangeBasedForLoop)
+{
+  Check_FixedArray_supports_retrieving_values_by_range_based_for_loop<double, 2>();
+  Check_FixedArray_supports_retrieving_values_by_range_based_for_loop<int, 3>();
+}
+
+
+// Tests that FixedArray supports modifying its elements by a range-based for-loop.
+TEST(FixedArray, SupportsModifyingElementsByRangeBasedForLoop)
+{
+  Check_FixedArray_supports_modifying_elements_by_range_based_for_loop<double, 2>();
+  Check_FixedArray_supports_modifying_elements_by_range_based_for_loop<int, 3>();
+}


### PR DESCRIPTION
Added `begin()`, `end()`, `cbegin()`, `cend()`, `iterator`, and
`const_iterator` to `itk::FixedArray`. Included GTest unit tests.

This commit allows iteration over a `FixedArray` by means of a
C++11 range-based for-loop.