### PR TITLE
ENH: ITKVtkGlue only requires rendering libraries when needed

### DIFF
--- a/Modules/Bridge/VtkGlue/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(ITKVtkGlue)
-set(ITKVtkGlue_LIBRARIES ITKVtkGlue)
+if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
+  set(ITKVtkGlue_LIBRARIES ITKVtkGlue)
+endif()
 
 if(NOT COMMAND vtk_module_config)
   macro(vtk_module_config ns)
@@ -46,26 +48,32 @@ if(TARGET vtkRenderingFreeType${VTK_RENDERING_BACKEND})
   set(_target_freetypeopengl vtkRenderingFreeType${VTK_RENDERING_BACKEND})
 endif()
 
+set(_required_vtk_libraries
+  vtkIOImage
+  vtkImagingSources
+  )
+if(ITK_WRAP_PYTHON)
+  list(APPEND _required_vtk_libraries vtkWrappingPythonCore)
+endif()
+if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
+  list(APPEND _required_vtk_libraries
+    vtkRendering${VTK_RENDERING_BACKEND}
+    vtkRenderingFreeType
+    ${_target_freetypeopengl}
+    vtkInteractionStyle
+    vtkInteractionWidgets
+  )
+endif()
 if (${VTK_VERSION} VERSION_LESS ${VERSION_MIN})
   message(ERROR " VtkGlue requires VTK version ${VERSION_MIN} or newer but the current version is ${VTK_VERSION}")
 elseif( ${VTK_VERSION} VERSION_LESS 6.0.0 )
   set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
   set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
 else()
-  set(_wrap_module)
-  if(ITK_WRAP_PYTHON)
-    set(_wrap_module vtkWrappingPythonCore)
-  endif()
   vtk_module_config(ITKVtkGlue_VTK
-    vtkRendering${VTK_RENDERING_BACKEND}
-    vtkRenderingFreeType
-    ${_target_freetypeopengl}
-    vtkInteractionStyle
-    vtkInteractionWidgets
-    vtkIOImage
-    vtkImagingSources
-    ${_wrap_module}
+    ${_required_vtk_libraries}
     )
+  set(ITKVtkGlue_VTK_LIBRARIES ${_required_vtk_libraries})
 endif()
 
 # The VTK DICOMParser and vtkmetaio includes conflict with the ITK
@@ -118,25 +126,30 @@ if(TARGET vtkRenderingFreeType${VTK_RENDERING_BACKEND})
   set(_target_freetypeopengl vtkRenderingFreeType${VTK_RENDERING_BACKEND})
 endif()
 
-if( ${VTK_VERSION} VERSION_LESS 6.0.0 )
-  set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
-  set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
-else()
-  set(_wrap_module)
-  if(ITK_WRAP_PYTHON AND PYTHON_VERSION_STRING VERSION_LESS 3.0)
-    set(_wrap_module vtkWrappingPythonCore)
-  endif()
-  vtk_module_config(ITKVtkGlue_VTK
+set(_required_vtk_libraries
+  vtkIOImage
+  vtkImagingSources
+  )
+if(ITK_WRAP_PYTHON)
+  list(APPEND _required_vtk_libraries vtkWrappingPythonCore)
+endif()
+if(NOT VTK_RENDERING_BACKEND STREQUAL \"None\")
+  list(APPEND _required_vtk_libraries
     vtkRendering${VTK_RENDERING_BACKEND}
     vtkRenderingFreeType
     ${_target_freetypeopengl}
     vtkInteractionStyle
     vtkInteractionWidgets
-    vtkIOImage
-    vtkImagingSources
-    ${_wrap_module}
+  )
+endif()
+if(${VTK_VERSION} VERSION_LESS 6.0.0)
+  set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
+  set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
+else()
+  vtk_module_config(ITKVtkGlue_VTK
+    \${_required_vtk_libraries}
     )
-
+  set(ITKVtkGlue_VTK_LIBRARIES \${_required_vtk_libraries})
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS \${ITKVtkGlue_VTK_DEFINITIONS})
 endif()
 ")
@@ -173,28 +186,39 @@ if(NOT ITK_BINARY_DIR)
     set(_target_freetypeopengl vtkRenderingFreeType${VTK_RENDERING_BACKEND})
   endif()
 
-  if( ${VTK_VERSION} VERSION_LESS 6.0.0 )
-    set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
-    set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
-  else()
-    set(_wrap_module)
-    if(ITK_WRAP_PYTHON AND PYTHON_VERSION_STRING VERSION_LESS 3.0)
-      set(_wrap_module vtkWrappingPythonCore)
-    endif()
-    vtk_module_config(ITKVtkGlue_VTK
+  set(_required_vtk_libraries
+    vtkIOImage
+    vtkImagingSources
+    )
+  if(ITK_WRAP_PYTHON)
+    list(APPEND _required_vtk_libraries vtkWrappingPythonCore)
+  endif()
+  if(NOT VTK_RENDERING_BACKEND STREQUAL \"None\")
+    list(APPEND _required_vtk_libraries
       vtkRendering${VTK_RENDERING_BACKEND}
       vtkRenderingFreeType
       ${_target_freetypeopengl}
       vtkInteractionStyle
       vtkInteractionWidgets
-      vtkIOImage
-      vtkImagingSources
-      ${_wrap_module}
+    )
+  endif()
+  if( ${VTK_VERSION} VERSION_LESS 6.0.0 )
+    set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
+    set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
+  else()
+    vtk_module_config(ITKVtkGlue_VTK
+      \${_required_vtk_libraries}
       )
-
+    set(ITKVtkGlue_VTK_LIBRARIES \${_required_vtk_libraries})
     set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS \${ITKVtkGlue_VTK_DEFINITIONS})
   endif()
 endif()
 ")
+
+if(VTK_RENDERING_BACKEND STREQUAL "None")
+  set(ITKVtkGlue_LIBRARIES ${ITKVtkGlue_VTK_LIBRARIES})
+else()
+  set(ITKVtkGlue_LIBRARIES ITKVtkGlue)
+endif()
 
 itk_module_impl()

--- a/Modules/Bridge/VtkGlue/src/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/src/CMakeLists.txt
@@ -1,14 +1,10 @@
-set(ITKVtkGlue_SRCS
-QuickView.cxx
-)
+if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
+  set(ITKVtkGlue_SRCS
+    QuickView.cxx
+    )
 
-# VTK 5.8 and greater defines VTK_LIBRARIES
-if(NOT VTK_LIBRARIES)
-  set(ITKVtkGlue_VTK_LIBRARIES_EXPLICIT vtkIO;vtkHybrid;vtkVolumeRendering)
+  add_library(ITKVtkGlue ${ITKVtkGlue_SRCS})
+  itk_module_link_dependencies()
+  target_link_libraries(ITKVtkGlue LINK_PUBLIC ${ITKVtkGlue_VTK_LIBRARIES})
+  itk_module_target(ITKVtkGlue)
 endif()
-
-### generating libraries
-add_library( ITKVtkGlue ${ITKVtkGlue_SRCS})
-itk_module_link_dependencies()
-target_link_libraries(ITKVtkGlue LINK_PUBLIC ${ITKVtkGlue_VTK_LIBRARIES} ${ITKVtkGlue_VTK_LIBRARIES_EXPLICIT})
-itk_module_target(ITKVtkGlue)

--- a/Modules/Bridge/VtkGlue/test/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/test/CMakeLists.txt
@@ -1,26 +1,24 @@
 itk_module_test()
 set(ITKVtkGlueTests
-itkVtkConnectedComponentImageFilterTest
-itkVtkMedianFilterTest.cxx
-itkImageToVTKImageFilterTest.cxx
-itkImageToVTKImageFilterRGBTest.cxx
-itkVTKImageToImageFilterTest.cxx
-QuickViewTest.cxx
-# ### runViewImage ###
-# No test generated. Use it for view images (2D or 3D) with:
-# ITKVtkGlueTestDriver runViewImage image_file
-# or with a string to change title window, and change size of window
-# ITKVtkGlueTestDriver runViewImage image_file "MyImage"
-runViewImage.cxx
+  itkImageToVTKImageFilterTest.cxx
+  itkImageToVTKImageFilterRGBTest.cxx
+  itkVTKImageToImageFilterTest.cxx
 )
+if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
+  list(APPEND ITKVtkGlueTests
+    itkVtkMedianFilterTest.cxx
+    itkVtkConnectedComponentImageFilterTest.cxx
+    QuickViewTest.cxx
+    # ### runViewImage ###
+    # No test generated. Use it for view images (2D or 3D) with:
+    # ITKVtkGlueTestDriver runViewImage image_file
+    # or with a string to change title window, and change size of window
+    # ITKVtkGlueTestDriver runViewImage image_file "MyImage"
+    runViewImage.cxx
+    )
+endif()
 
 CreateTestDriver(ITKVtkGlue "${ITKVtkGlue-Test_LIBRARIES}" "${ITKVtkGlueTests}")
-
-itk_add_test(
-  NAME itkVtkMedianImageFilterTest
-  COMMAND ITKVtkGlueTestDriver
-    itkVtkMedianFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} 2)
-set_property(TEST itkVtkMedianImageFilterTest APPEND PROPERTY LABELS REQUIRES_DISPLAY)
 
 itk_add_test(
   NAME itkImageToVTKImageFilterTest
@@ -38,17 +36,25 @@ itk_add_test(
   COMMAND ITKVtkGlueTestDriver
     itkVTKImageToImageFilterTest)
 
-itk_add_test(
-  NAME QuickViewTest
-  COMMAND ITKVtkGlueTestDriver
-           --compare DATA{Baseline/QuickViewTest.png,:}
-                     ${ITK_TEST_OUTPUT_DIR}/QuickViewTest0.png
-           --compareNumberOfPixelsTolerance 1500
-    QuickViewTest DATA{${ITK_DATA_ROOT}/Input/peppers.png} ${ITK_TEST_OUTPUT_DIR})
-set_property(TEST QuickViewTest APPEND PROPERTY LABELS REQUIRES_DISPLAY)
+if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
+  itk_add_test(
+    NAME itkVtkMedianImageFilterTest
+    COMMAND ITKVtkGlueTestDriver
+      itkVtkMedianFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} 2)
+  set_property(TEST itkVtkMedianImageFilterTest APPEND PROPERTY LABELS REQUIRES_DISPLAY)
 
-itk_add_test(
-  NAME itkVtkConnectedComponentImageFilterTest
-  COMMAND ITKVtkGlueTestDriver
-    itkVtkConnectedComponentImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png})
-set_property(TEST itkVtkConnectedComponentImageFilterTest APPEND PROPERTY LABELS REQUIRES_DISPLAY)
+  itk_add_test(
+    NAME QuickViewTest
+    COMMAND ITKVtkGlueTestDriver
+             --compare DATA{Baseline/QuickViewTest.png,:}
+                       ${ITK_TEST_OUTPUT_DIR}/QuickViewTest0.png
+             --compareNumberOfPixelsTolerance 1500
+      QuickViewTest DATA{${ITK_DATA_ROOT}/Input/peppers.png} ${ITK_TEST_OUTPUT_DIR})
+  set_property(TEST QuickViewTest APPEND PROPERTY LABELS REQUIRES_DISPLAY)
+
+  itk_add_test(
+    NAME itkVtkConnectedComponentImageFilterTest
+    COMMAND ITKVtkGlueTestDriver
+      itkVtkConnectedComponentImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png})
+  set_property(TEST itkVtkConnectedComponentImageFilterTest APPEND PROPERTY LABELS REQUIRES_DISPLAY)
+endif()

--- a/Utilities/Maintenance/BuildHeaderTest.py
+++ b/Utilities/Maintenance/BuildHeaderTest.py
@@ -45,6 +45,8 @@ BANNED_HEADERS = set(('itkDynamicLoader.h', # This cannot be included when ITK_D
     'itkBSplineDeformableTransform.h',   # deprecated
     'vtkCaptureScreen.h',  # these includes require VTK
     'itkMultiThreader.h', # Compatibility file, it should not be used
+    'itkViewImage.h', # Depends on VTK_RENDERING_BACKEND
+    'QuickView.h', # Depends on VTK_RENDERING_BACKEND
     'itkBSplineDeformableTransformInitializer.h'))
 
 HEADER = """/*=========================================================================


### PR DESCRIPTION
Enable the use of ITKVtkGlue functionality that does not require
rendering when VTK was built with VTK_RENDERING_BACKEND set to None.

Addresses #714 

@romangrothausmann additional testing would be appreciated :bowing_man: .