### PR TITLE
COMP: ImageMaskSpatialObjectGTest array initialization

### DIFF
--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -153,13 +153,13 @@ TEST(ImageMaskSpatialObject, AxisAlignedBoundingBoxIsEmptyWhenAllPixelsAreZero)
 {
   // Test 2D images:
   Expect_AxisAlignedBoundingBoxRegion_is_empty_when_all_pixel_values_are_zero<double>(
-    itk::ImageRegion<2>{ itk::Index<2>{}, itk::Size<2>::Filled(1) });
+    itk::ImageRegion<2>{ itk::Index<2>(), itk::Size<2>::Filled(1) });
   Expect_AxisAlignedBoundingBoxRegion_is_empty_when_all_pixel_values_are_zero<double>(
     itk::ImageRegion<2>{ itk::Index<2>{{-1, -2}}, itk::Size<2>{{3, 4}} });
 
   // Test 3D images:
   Expect_AxisAlignedBoundingBoxRegion_is_empty_when_all_pixel_values_are_zero<unsigned char>(
-    itk::ImageRegion<3>{ itk::Index<3>{}, itk::Size<3>::Filled(1) });
+    itk::ImageRegion<3>{ itk::Index<3>(), itk::Size<3>::Filled(1) });
   Expect_AxisAlignedBoundingBoxRegion_is_empty_when_all_pixel_values_are_zero<unsigned char>(
     itk::ImageRegion<3>{ itk::Index<3>{{-1, -2, -3}}, itk::Size<3>{{3, 4, 5}} });
 }
@@ -170,13 +170,13 @@ TEST(ImageMaskSpatialObject, AxisAlignedBoundingBoxRegionIsImageRegionWhenAllPix
 {
   // Test 2D images:
   Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_all_pixel_values_are_non_zero<double>(
-    itk::ImageRegion<2>{ itk::Index<2>{}, itk::Size<2>::Filled(1) });
+    itk::ImageRegion<2>{ itk::Index<2>(), itk::Size<2>::Filled(1) });
   Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_all_pixel_values_are_non_zero<double>(
     itk::ImageRegion<2>{ itk::Index<2>{{-1, -2}}, itk::Size<2>{{3, 4}} });
 
   // Test 3D images:
   Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_all_pixel_values_are_non_zero<unsigned char>(
-    itk::ImageRegion<3>{ itk::Index<3>{}, itk::Size<3>::Filled(1) });
+    itk::ImageRegion<3>{ itk::Index<3>(), itk::Size<3>::Filled(1) });
   Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_all_pixel_values_are_non_zero<unsigned char>(
     itk::ImageRegion<3>{ itk::Index<3>{{-1, -2, -3}}, itk::Size<3>{{3, 4, 5}} });
 }
@@ -187,13 +187,13 @@ TEST(ImageMaskSpatialObject, AxisAlignedBoundingBoxRegionIsRegionOfSinglePixelWh
 {
   // Test 2D images:
   Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the_only_non_zero_pixel<double>(
-    itk::ImageRegion<2>{ itk::Index<2>{}, itk::Size<2>::Filled(1) });
+    itk::ImageRegion<2>{ itk::Index<2>(), itk::Size<2>::Filled(1) });
   Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the_only_non_zero_pixel<double>(
     itk::ImageRegion<2>{ itk::Index<2>{{-1, -2}}, itk::Size<2>{{3, 4}} });
 
   // Test 3D images:
   Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the_only_non_zero_pixel<unsigned char>(
-    itk::ImageRegion<3>{ itk::Index<3>{}, itk::Size<3>::Filled(1) });
+    itk::ImageRegion<3>{ itk::Index<3>(), itk::Size<3>::Filled(1) });
   Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the_only_non_zero_pixel<unsigned char>(
     itk::ImageRegion<3>{ itk::Index<3>{{-1, -2, -3}}, itk::Size<3>{{3, 4, 5}} });
 }
@@ -205,13 +205,13 @@ TEST(ImageMaskSpatialObject, AxisAlignedBoundingBoxRegionIsImageRegionWhenOnlyOn
 {
   // Test 2D images:
   Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_only_a_single_pixel_has_value_zero<double>(
-    itk::ImageRegion<2>{ itk::Index<2>{}, itk::Size<2>::Filled(2) });
+    itk::ImageRegion<2>{ itk::Index<2>(), itk::Size<2>::Filled(2) });
   Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_only_a_single_pixel_has_value_zero<double>(
     itk::ImageRegion<2>{ itk::Index<2>{{-1, -2}}, itk::Size<2>{{3, 4}} });
 
   // Test 3D images:
   Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_only_a_single_pixel_has_value_zero<unsigned char>(
-    itk::ImageRegion<3>{ itk::Index<3>{}, itk::Size<3>::Filled(2) });
+    itk::ImageRegion<3>{ itk::Index<3>(), itk::Size<3>::Filled(2) });
   Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_only_a_single_pixel_has_value_zero<unsigned char>(
     itk::ImageRegion<3>{ itk::Index<3>{{-1, -2, -3}}, itk::Size<3>{{3, 4, 5}} });
 }


### PR DESCRIPTION
To address:

  home/kitware/Dashboards/Tests/ITK/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx: In member function 'virtual void ImageMaskSpatialObject_AxisAlignedBoundingBoxIsEmptyWhenAllPixelsAreZero_Test::TestBody()':
[CTest: warning matched] /home/kitware/Dashboards/TestsModules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx:156:40: warning: missing initializer for member 'itk::Index<2u>::m_InternalArray' [-Wmissing-field-initializers]
     itk::ImageRegion<2>{ itk::Index<2>{}, itk::Size<2>::Filled(1) });
                                        ^
[CTest: warning matched] /home/kitware/Dashboards/TestsModules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx:162:40: warning: missing initializer for member 'itk::Index<3u>::m_InternalArray' [-Wmissing-field-initializers]
     itk::ImageRegion<3>{ itk::Index<3>{}, itk::Size<3>::Filled(1) });