### PR TITLE
DOC: Correct documented Canny Segmentation filter example

### DIFF
--- a/Examples/Segmentation/CannySegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/CannySegmentationLevelSetImageFilter.cxx
@@ -20,7 +20,7 @@
 //    INPUTS:  {BrainProtonDensitySlice.png}
 //    INPUTS:  {ThresholdSegmentationLevelSetImageFilterVentricle.png}
 //    OUTPUTS: {CannySegmentationLevelSetImageFilterVentricle1.png}
-//    ARGUMENTS:    7.0 0.1 10.0 127.5 15
+//    ARGUMENTS:    7.0 0.1 -10.0 127.5 15
 //  Software Guide : EndCommandLineArgs
 
 // Software Guide : BeginLatex


### PR DESCRIPTION
The advection term is negative in the test, which is require for
outward propagation of the level set.

