### PR TITLE
COMP: Update for changes to VTK target names

### DIFF
--- a/Modules/Bridge/VtkGlue/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/CMakeLists.txt
@@ -43,25 +43,29 @@ if(NOT VTK_RENDERING_BACKEND)
     set(VTK_RENDERING_BACKEND OpenGL)
   endif()
 endif()
+set(_target_prefix "vtk")
+if(VTK_VERSION VERSION_GREATER_EQUAL 8.90.0)
+  set(_target_prefix "VTK::")
+endif()
 set(_target_freetypeopengl)
-if(TARGET vtkRenderingFreeType${VTK_RENDERING_BACKEND})
-  set(_target_freetypeopengl vtkRenderingFreeType${VTK_RENDERING_BACKEND})
+if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+  set(_target_freetypeopengl ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
 endif()
 
 set(_required_vtk_libraries
-  vtkIOImage
-  vtkImagingSources
+  ${_target_prefix}IOImage
+  ${_target_prefix}ImagingSources
   )
 if(ITK_WRAP_PYTHON)
-  list(APPEND _required_vtk_libraries vtkWrappingPythonCore)
+  list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore)
 endif()
 if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
   list(APPEND _required_vtk_libraries
-    vtkRendering${VTK_RENDERING_BACKEND}
-    vtkRenderingFreeType
+    ${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
+    ${_target_prefix}RenderingFreeType
     ${_target_freetypeopengl}
-    vtkInteractionStyle
-    vtkInteractionWidgets
+    ${_target_prefix}InteractionStyle
+    ${_target_prefix}InteractionWidgets
   )
 endif()
 if (${VTK_VERSION} VERSION_LESS ${VERSION_MIN})
@@ -122,24 +126,24 @@ if(NOT VTK_RENDERING_BACKEND)
   endif()
 endif()
 set(_target_freetypeopengl)
-if(TARGET vtkRenderingFreeType${VTK_RENDERING_BACKEND})
-  set(_target_freetypeopengl vtkRenderingFreeType${VTK_RENDERING_BACKEND})
+if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+  set(_target_freetypeopengl ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
 endif()
 
 set(_required_vtk_libraries
-  vtkIOImage
-  vtkImagingSources
+  ${_target_prefix}IOImage
+  ${_target_prefix}ImagingSources
   )
 if(ITK_WRAP_PYTHON)
-  list(APPEND _required_vtk_libraries vtkWrappingPythonCore)
+  list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore)
 endif()
 if(NOT VTK_RENDERING_BACKEND STREQUAL \"None\")
   list(APPEND _required_vtk_libraries
-    vtkRendering${VTK_RENDERING_BACKEND}
-    vtkRenderingFreeType
+    ${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
+    ${_target_prefix}RenderingFreeType
     ${_target_freetypeopengl}
-    vtkInteractionStyle
-    vtkInteractionWidgets
+    ${_target_prefix}InteractionStyle
+    ${_target_prefix}InteractionWidgets
   )
 endif()
 if(${VTK_VERSION} VERSION_LESS 6.0.0)
@@ -182,24 +186,24 @@ if(NOT ITK_BINARY_DIR)
       set(VTK_RENDERING_BACKEND OpenGL)
     endif()
   endif()
-  if(TARGET vtkRenderingFreeType${VTK_RENDERING_BACKEND})
-    set(_target_freetypeopengl vtkRenderingFreeType${VTK_RENDERING_BACKEND})
+  if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+    set(_target_freetypeopengl ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
   endif()
 
   set(_required_vtk_libraries
-    vtkIOImage
-    vtkImagingSources
+    ${_target_prefix}IOImage
+    ${_target_prefix}ImagingSources
     )
   if(ITK_WRAP_PYTHON)
-    list(APPEND _required_vtk_libraries vtkWrappingPythonCore)
+    list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore)
   endif()
   if(NOT VTK_RENDERING_BACKEND STREQUAL \"None\")
     list(APPEND _required_vtk_libraries
-      vtkRendering${VTK_RENDERING_BACKEND}
-      vtkRenderingFreeType
+      ${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
+      ${_target_prefix}RenderingFreeType
       ${_target_freetypeopengl}
-      vtkInteractionStyle
-      vtkInteractionWidgets
+      ${_target_prefix}InteractionStyle
+      ${_target_prefix}InteractionWidgets
     )
   endif()
   if( ${VTK_VERSION} VERSION_LESS 6.0.0 )

--- a/Modules/Bridge/VtkGlue/test/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/test/CMakeLists.txt
@@ -19,6 +19,11 @@ if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
 endif()
 
 CreateTestDriver(ITKVtkGlue "${ITKVtkGlue-Test_LIBRARIES}" "${ITKVtkGlueTests}")
+if(VTK_VERSION VERSION_GREATER_EQUAL "8.90.0")
+  vtk_module_autoinit(
+    TARGETS ITKVtkGlueTestDriver
+  MODULES ${VTK_LIBRARIES})
+endif()
 
 itk_add_test(
   NAME itkImageToVTKImageFilterTest


### PR DESCRIPTION
The targets have changed in VTK Git master.

Also call "vtk_module_autoinit" on the test driver, which is required on
recent VTK to avoid runtime errors such as;

  vtkRenderWindow.cxx:35    WARN| Error: no override found for
  'vtkRenderWindow'.

Closes #739 