### PR TITLE
MI sample point histogram setting

### DIFF
--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -180,7 +180,7 @@ bool TestCastFromTo()
     /** Warning:
      * expectedValue == static_cast< TOutputPixelType( inValue ) is
      * false on some systems and compilers with some values of inValue. */
-#if defined(__MINGW32__)  // NOTE:  This may be thee same problem identified above related to 'undefined' behavior
+#if defined(__MINGW32__)  // NOTE:  This may be the same problem identified above related to 'undefined' behavior
     if ( itk::Math::NotAlmostEquals(outValue, expectedValue) )
 #else
     if ( itk::Math::NotExactlyEquals(outValue, expectedValue) )

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -274,7 +274,7 @@ public:
   using MovingImageMaskConstPointer = typename MovingImageMaskType::ConstPointer;
 
   /** Type of the point set used for sparse sampling. */
-  using FixedSampledPointSetType =
+    using FixedSampledPointSetType =
       PointSet<typename FixedImageType::PixelType, Self::FixedImageDimension>;
   using FixedSampledPointSetPointer = typename FixedSampledPointSetType::Pointer;
   using FixedSampledPointSetConstPointer = typename FixedSampledPointSetType::ConstPointer;

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
@@ -139,7 +139,7 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
   Superclass::Initialize();
 
   /* Map the fixed samples into the virtual domain and store in
-   * a searpate point set. */
+   * a seperate point set. */
   if( this->m_UseSampledPointSet && !this->m_UseVirtualSampledPointSet)
     {
     this->MapFixedSampledPointSetToVirtual();


### PR DESCRIPTION
    ENH: Identify histogram min/max for UseSampledPointSet
    
    When UseSampledPointSet is true (i.e. A sparse sampling point set is
    explicitly requested), compute the joint histogram range for the fixed
    image axis from those explicilty specified points.
    
    If m_UseSampledPointSet is true, then *ONLY* the sparse sampled points
    are used for analysis of the metric, and the fixed space intensity range
    values will be fixed to those values identified in the sparse sampled
    points.  The fixed masked value items are not relevant when the sparse
    sampling is set.