### PR TITLE
BUG: Remove error prone test case

### DIFF
--- a/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
@@ -45,21 +45,6 @@ int itkRegularExpressionSeriesFileNamesTest(int ac, char* av[])
     std::cout << "File: " << (*nit).c_str() << std::endl;
     }
 
-// numeric sort
-  fit->SetRegularExpression("[^0-9]*([0-9]*)");
-  fit->NumericSortOn();
-  fit->SetSubMatch(1);
-  names = fit->GetFileNames();
-  std::cout << "Numeric Sort--------" << std::endl;
-  for (nit = names.begin();
-       nit != names.end();
-       ++nit)
-    {
-    std::cout << "File: " << (*nit).c_str() << std::endl;
-    }
-
-  std::cout << fit;
-
   // Show only those files with numbers in the names
   fit->SetRegularExpression("([0-9]+)");
   fit->NumericSortOn();


### PR DESCRIPTION
This test requires filenames to have numbers for sorting. The input files all ended with `.sha512` so it worked but I had a hidden `.DS_Store` file crashing the test.

The next test filters filenames without numbers anyway so no need to keep the first one.