### PR TITLE
BUG: Half a pixel margin ImageMaskSpatialObject::ComputeMyBoundingBox()

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -31,6 +31,11 @@ namespace itk
  * method.  One of the common uses of this class is to serve as Mask for the
  * Image Registration Metrics.
  *
+ * \note The bounding box of an image mask is defined in such a way that
+ * any point whose nearest pixel has a non-zero value is inside the
+ * bounding box. When all the pixels of an image are zero, the bounding box
+ * of the image mask is empty, and its bounds are all zero.
+ *
  * \sa ImageSpatialObject SpatialObject CompositeSpatialObject
  * \ingroup ITKSpatialObjects
  */
@@ -67,7 +72,8 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ImageMaskSpatialObject, ImageSpatialObject);
 
-  /** Returns true if the point is inside, false otherwise. */
+  /** Returns true if the point is inside, false otherwise. According to this function,
+   * a point is inside the image mask when the value of its nearest pixel is non-zero. */
   bool IsInsideInObjectSpace(const PointType & point) const override;
 
   /* Avoid hiding the overload that supports depth and name arguments */

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -23,6 +23,8 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 
+#include <cstdint> // For uintmax_t.
+
 namespace itk
 {
 /** Constructor */
@@ -60,76 +62,76 @@ ImageMaskSpatialObject< TDimension, TPixel >
   return false;
 }
 
+
 template< unsigned int TDimension, typename TPixel >
 void
 ImageMaskSpatialObject< TDimension, TPixel >
 ::ComputeMyBoundingBox()
 {
-  using IteratorType = ImageRegionConstIteratorWithIndex< ImageType >;
-  IteratorType it( this->GetImage(),
-    this->GetImage()->GetLargestPossibleRegion() );
-  IteratorType prevIt( this->GetImage(),
-    this->GetImage()->GetLargestPossibleRegion() );
-  it.GoToBegin();
-  prevIt = it;
+  const ImageType* const image = this->GetImage();
+  itkAssertOrThrowMacro(image != nullptr, "Ensure that SetImage has been called!");
 
-  bool first = true;
-  PixelType outsideValue = NumericTraits< PixelType >::ZeroValue();
-  PixelType value = outsideValue;
-  PixelType prevValue = outsideValue;
-  IndexType tmpIndex;
-  PointType tmpPoint;
-  int count = 0;
-  int rowSize
-    = this->GetImage()->GetLargestPossibleRegion().GetSize()[0];
-  while ( !it.IsAtEnd() )
+  const RegionType boundingBoxInIndexSpace{ this->ComputeMyBoundingBoxInIndexSpace() };
+
+  BoundingBoxType* const boundingBoxInObjectSpace = this->GetModifiableMyBoundingBoxInObjectSpace();
+
+  // Assert should never fail as SpatialObject takes care of creating the BoundingBox.
+  assert(boundingBoxInObjectSpace != nullptr);
+
+  if (boundingBoxInIndexSpace.GetNumberOfPixels() == 0)
+  {
+    boundingBoxInObjectSpace->SetMinimum(PointType());
+    boundingBoxInObjectSpace->SetMaximum(PointType());
+  }
+  else
+  {
+    using ContinuousIndexType = typename Superclass::ContinuousIndexType;
+    using VectorType = typename SpatialObject<TDimension>::VectorType;
+
+    const IndexType minIndex = boundingBoxInIndexSpace.GetIndex();
+
+    ContinuousIndexType minContinuousIndex{ minIndex };
+    ContinuousIndexType maxContinuousIndex{ minIndex + boundingBoxInIndexSpace.GetSize() };
+
+    // Allow a margin of half a pixel in each direction.
+    minContinuousIndex -= VectorType{ 0.5 };
+    maxContinuousIndex -= VectorType{ 0.5 };
+
+    // Initially set the corner point corresponding to the minimum index as
+    // both the minimum and maximum of the bounding box (in object space).
+    // Afterwards, all other corners are considered.
+    PointType firstPoint;
+    image->TransformContinuousIndexToPhysicalPoint(minContinuousIndex, firstPoint);
+    boundingBoxInObjectSpace->SetMinimum(firstPoint);
+    boundingBoxInObjectSpace->SetMaximum(firstPoint);
+
+    // The total number of corner points of the bounding box.
+    constexpr auto numberOfCorners = std::uintmax_t{ 1 } << TDimension;
+
+    for (std::uintmax_t cornerNumber{1}; cornerNumber < numberOfCorners; ++cornerNumber)
     {
-    value = it.Get();
-    if ( value != prevValue || ( count == rowSize-1 && value != outsideValue ) )
+      // For each corner, estimate the n-dimensional index.
+
+      auto continuousIndex = minContinuousIndex;
+
+      for (unsigned dim{}; dim < TDimension; ++dim)
       {
-      prevValue = value;
-      if( value == outsideValue )
+        const std::uintmax_t bitMask{ std::uintmax_t{ 1 } << dim };
+
+        if ((cornerNumber & bitMask) != 0)
         {
-        tmpIndex = prevIt.GetIndex();
-        }
-      else
-        {
-        tmpIndex = it.GetIndex();
-        }
-      this->GetImage()->TransformIndexToPhysicalPoint( tmpIndex, tmpPoint );
-      if( first )
-        {
-        first = false;
-        this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum( tmpPoint );
-        this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum( tmpPoint );
-        }
-      else
-        {
-        this->GetModifiableMyBoundingBoxInObjectSpace()->ConsiderPoint( tmpPoint );
+          continuousIndex[dim] = maxContinuousIndex[dim];
         }
       }
-    prevIt = it;
-    ++it;
-    ++count;
-    if( count == rowSize )
-      {
-      count = 0;
-      prevValue = outsideValue;
-      }
+
+      // Consider the corner point that corresponds to this n-dimensional index.
+      PointType cornerPoint;
+      image->TransformContinuousIndexToPhysicalPoint(continuousIndex, cornerPoint);
+      boundingBoxInObjectSpace->ConsiderPoint(cornerPoint);
     }
-
-  if( first )
-    {
-    tmpPoint.Fill(
-      NumericTraits< typename BoundingBoxType::PointType::ValueType >::ZeroValue() );
-
-    this->GetModifiableMyBoundingBoxInObjectSpace()->SetMinimum( tmpPoint );
-    this->GetModifiableMyBoundingBoxInObjectSpace()->SetMaximum( tmpPoint );
-
-    // NOT AN EXCEPTION!!!, used to return false, but never checked
-    // itkExceptionMacro(<< "ImageMask bounding box computation failed.")
-    }
+  }
 }
+
 
 /** InternalClone */
 template< unsigned int TDimension, typename TPixel >

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -88,12 +88,12 @@ int itkImageMaskSpatialObjectTest3(int, char* [])
   for( unsigned int i=0; i<NDimensions; ++i )
     {
     regionIndex[i] = bndMinI[i];
-    regionSize[i] = bndMaxI[i] - bndMinI[i] + 1;
+    regionSize[i] = bndMaxI[i] - bndMinI[i];
     }
 
   for(unsigned int i = 0; i < 3; i++)
     {
-    if(regionSize[i] != 1)
+    if(regionSize[i] != 0)
       {
       std::cout << "Invalid Region Size " << regionSize << std::endl;
       return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
@@ -124,7 +124,8 @@ int Test3dImageMask()
   maskSpatialObject->SetImage(imageFilter->GetOutput());
   maskSpatialObject->Update();
 
-  const ImageMaskSpatialObjectType::BoundingBoxType::BoundsArrayType maskBounds
+  using MaskBoundsArrayType = ImageMaskSpatialObjectType::BoundingBoxType::BoundsArrayType;
+  const MaskBoundsArrayType maskBounds
     = maskSpatialObject->GetMyBoundingBoxInWorldSpace()->GetBounds();
 
   //Test a few points...
@@ -162,18 +163,21 @@ int Test3dImageMask()
   std::cout << "   " << point << " isInside?  : "
     << maskSpatialObject->IsInsideInWorldSpace(point) << std::endl;
 
-  if(    itk::Math::NotAlmostEquals(maskBounds[0], 7.0)
-      || itk::Math::NotAlmostEquals(maskBounds[1], 8.0)
-      || itk::Math::NotAlmostEquals(maskBounds[2], 7.0)
-      || itk::Math::NotAlmostEquals(maskBounds[3], 8.0)
-      || itk::Math::NotAlmostEquals(maskBounds[4], 7.0)
-      || itk::Math::NotAlmostEquals(maskBounds[5], 8.0) )
+  constexpr std::array<double, MaskBoundsArrayType::Length> expectedBounds
+  {
+    { 6.75, 8.25, 6.75, 8.25, 6.75, 8.25 }
+  };
+
+  for (unsigned i = 0; i < MaskBoundsArrayType::Length; ++i)
+  {
+    if (itk::Math::NotAlmostEquals(maskBounds[i], expectedBounds[i]))
     {
-    std::cout << "[FAILED] " << std::endl;
-    std::cout << "Test returned : " << maskSpatialObject->GetMyBoundingBoxInWorldSpace()->GetBounds() << std::endl;
-    std::cout << "Instead of    : [7, 8, 7, 8, 7, 8]" << std::endl;
-    return EXIT_FAILURE;
+      std::cout << "[FAILED] " << std::endl;
+      std::cout << "Test returned : " << maskSpatialObject->GetMyBoundingBoxInWorldSpace()->GetBounds() << std::endl;
+      std::cout << "Instead of    : " << MaskBoundsArrayType{ expectedBounds }<< std::endl;
+      return EXIT_FAILURE;
     }
+  }
   std::cout << "[Passed] -- 3D test" << std::endl;
   return EXIT_SUCCESS;
 }
@@ -259,7 +263,8 @@ int Test2dImageMask()
 
   maskSpatialObject->Update();
 
-  const ImageMaskSpatialObjectType::BoundingBoxType::BoundsArrayType maskBounds
+  using MaskBoundsArrayType = ImageMaskSpatialObjectType::BoundingBoxType::BoundsArrayType;
+  const MaskBoundsArrayType maskBounds
     = maskSpatialObject->GetMyBoundingBoxInWorldSpace()->GetBounds();
 
   //Test a few points...
@@ -291,18 +296,23 @@ int Test2dImageMask()
   std::cout << "   " << point << " isInside?  : "
     << maskSpatialObject->IsInsideInWorldSpace(point) << std::endl;
 
-  if(    itk::Math::NotAlmostEquals(maskBounds[0], 7.1)
-      || itk::Math::NotAlmostEquals(maskBounds[1], 7.8)
-      || itk::Math::NotAlmostEquals(maskBounds[2], 7.1)
-      || itk::Math::NotAlmostEquals(maskBounds[3], 7.8))
+  constexpr std::array<double, MaskBoundsArrayType::Length> expectedBounds
+  {
+    { 6.75, 8.15, 6.75, 8.15 }
+  };
+
+  for (unsigned i = 0; i < MaskBoundsArrayType::Length; ++i)
+  {
+    if (itk::Math::NotAlmostEquals(maskBounds[i], expectedBounds[i]))
     {
-    std::cout << "[FAILED] " << std::endl;
-    std::cout << "Test returned : "
-      << maskSpatialObject->GetMyBoundingBoxInWorldSpace()->GetBounds()
-      << std::endl;
-    std::cout << "Instead of    : [7.1, 7.8, 7.1, 7.8]" << std::endl;
-    return EXIT_FAILURE;
+      std::cout << "[FAILED] " << std::endl;
+      std::cout << "Test returned : "
+        << maskSpatialObject->GetMyBoundingBoxInWorldSpace()->GetBounds()
+        << std::endl;
+      std::cout << "Instead of    : " << MaskBoundsArrayType{ expectedBounds } << std::endl;
+      return EXIT_FAILURE;
     }
+  }
 
   std::cout << "[Passed] -- 2D test" << std::endl;
   return EXIT_SUCCESS;


### PR DESCRIPTION
Enlarges the bounding box by half a pixel in each direction, to ensure
that a point (in object space) whose nearest pixel has a non-zero
value is always treated as being inside the object.

Fixes issue #753 (ImageMaskSpatialObject BoundingBox smaller than before
Spatial Object update) and issue #785 (ImageMaskSpatialObject IsInside
should not depend on distant pixels). Related to discussion topic
"ImageMaskSpatialObject IsInside less than half a pixel away?",
https://discourse.itk.org/t/imagemaskspatialobject-isinside-less-than-half-a-pixel-away/1807