### PR TITLE
Pass direction between itk and vtk images

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageExport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.h
@@ -98,6 +98,8 @@ protected:
 
   double * OriginCallback() override;
 
+  double * DirectionCallback() override;
+
   float * FloatSpacingCallback() override;
 
   float * FloatOriginCallback() override;
@@ -118,6 +120,7 @@ private:
   int         m_DataExtent[6];
   double      m_DataSpacing[3];
   double      m_DataOrigin[3];
+  double      m_DataDirection[9];
   float       m_FloatDataSpacing[3];
   float       m_FloatDataOrigin[3];
 };

--- a/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
@@ -267,6 +267,41 @@ float *VTKImageExport< TInputImage >::FloatOriginCallback()
 }
 
 /**
+ * Implements the DirectionCallback.  This returns a pointer to an array
+ * of nine floating point values describing the direction of the image.
+ */
+template< typename TInputImage >
+double *VTKImageExport< TInputImage >::DirectionCallback()
+{
+  InputImagePointer input = this->GetInput();
+
+  if ( !input )
+    {
+    itkExceptionMacro(<< "Need to set an input");
+    }
+
+  const typename TInputImage::DirectionType & direction = input->GetDirection();
+
+  // Fill in the direction.
+  for (unsigned int i = 0; i < 3; ++i )
+    {
+    for (unsigned int j = 0; j < 3; ++j )
+      {
+      if (i >= InputImageDimension || j >= InputImageDimension)
+        {
+        // Fill up with defaults up to three dimensions.
+        m_DataDirection[i*3+j] = (i == j) ? 1.0 : 0.0;
+        }
+      else
+        {
+        m_DataDirection[i*3+j] = static_cast< double >( direction[i][j] );
+        }
+      }
+    }
+  return m_DataDirection;
+}
+
+/**
  * Implements the ScalarTypeCallback.  This returns the name of the
  * scalar value type of the image.
  */

--- a/Modules/Bridge/VTK/include/itkVTKImageExportBase.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageExportBase.h
@@ -57,6 +57,7 @@ public:
   using WholeExtentCallbackType = int *(*)(void *);
   using SpacingCallbackType = double *(*)(void *);
   using OriginCallbackType = double *(*)(void *);
+  using DirectionCallbackType = double *(*)(void *);
   using ScalarTypeCallbackType = const char *(*)(void *);
   using NumberOfComponentsCallbackType = int (*)(void *);
   using PropagateUpdateExtentCallbackType = void (*)(void *, int *);
@@ -105,6 +106,8 @@ private:
 
   CallbackTypeProxy                 GetOriginCallback() const;
 
+  DirectionCallbackType             GetDirectionCallback() const;
+
   ScalarTypeCallbackType            GetScalarTypeCallback() const;
 
   NumberOfComponentsCallbackType    GetNumberOfComponentsCallback() const;
@@ -138,6 +141,8 @@ protected:
 
   virtual double * OriginCallback() = 0;
 
+  virtual double * DirectionCallback() = 0;
+
   virtual float * FloatSpacingCallback() = 0;
 
   virtual float * FloatOriginCallback() = 0;
@@ -165,6 +170,8 @@ private:
   static double * SpacingCallbackFunction(void *);
 
   static double * OriginCallbackFunction(void *);
+
+  static double * DirectionCallbackFunction(void *);
 
   static float * FloatSpacingCallbackFunction(void *);
 

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.h
@@ -87,6 +87,7 @@ public:
   using WholeExtentCallbackType = int * ( * )(void *);
   using SpacingCallbackType = double * ( * )(void *);
   using OriginCallbackType = double * ( * )(void *);
+  using DirectionCallbackType = double * ( * )(void *);
   using ScalarTypeCallbackType = const char * ( * )(void *);
   using NumberOfComponentsCallbackType = int ( * )(void *);
   using PropagateUpdateExtentCallbackType = void ( * )(void *, int *);
@@ -125,6 +126,10 @@ public:
   itkGetConstMacro(FloatOriginCallback, FloatOriginCallbackType);
   void SetOriginCallback(FloatOriginCallbackType f)
   { this->SetFloatOriginCallback(f); }
+
+  /** What to do when receiving SetDirection(). */
+  itkSetMacro(DirectionCallback, DirectionCallbackType);
+  itkGetConstMacro(DirectionCallback, DirectionCallbackType);
 
   /** What to do when receiving UpdateInformation(). */
   itkSetMacro(ScalarTypeCallback, ScalarTypeCallbackType);
@@ -176,6 +181,7 @@ private:
   FloatSpacingCallbackType          m_FloatSpacingCallback;
   OriginCallbackType                m_OriginCallback;
   FloatOriginCallbackType           m_FloatOriginCallback;
+  DirectionCallbackType             m_DirectionCallback;
   ScalarTypeCallbackType            m_ScalarTypeCallback;
   NumberOfComponentsCallbackType    m_NumberOfComponentsCallback;
   PropagateUpdateExtentCallbackType m_PropagateUpdateExtentCallback;

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -98,6 +98,7 @@ VTKImageImport< TOutputImage >
   m_FloatSpacingCallback = nullptr;
   m_OriginCallback = nullptr;
   m_FloatOriginCallback = nullptr;
+  m_DirectionCallback = nullptr;
   m_UpdateInformationCallback = nullptr;
   m_ScalarTypeCallback = nullptr;
   m_DataExtentCallback = nullptr;
@@ -235,6 +236,19 @@ VTKImageImport< TOutputImage >
       }
     output->SetOrigin(outOrigin);
     }
+  if ( m_DirectionCallback )
+    {
+    double *inDirection = (m_DirectionCallback)( m_CallbackUserData );
+    typename TOutputImage::DirectionType outDirection;
+    for ( unsigned int i = 0; i < OutputImageDimension; ++i )
+      {
+      for ( unsigned int j = 0; j < OutputImageDimension; ++j )
+        {
+        outDirection[i][j] = inDirection[i*3+j];
+        }
+      }
+    output->SetDirection(outDirection);
+    }
   if ( m_NumberOfComponentsCallback )
     {
     const unsigned int components =
@@ -356,6 +370,10 @@ VTKImageImport< TOutputImage >
   if ( m_FloatOriginCallback )
     {
     os << "FloatOriginCallback: " << m_FloatOriginCallback << std::endl;
+    }
+  if ( m_DirectionCallback )
+    {
+    os << "DirectionCallback: " << m_DirectionCallback << std::endl;
     }
   if ( m_UpdateInformationCallback )
     {

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -240,11 +240,30 @@ VTKImageImport< TOutputImage >
     {
     double *inDirection = (m_DirectionCallback)( m_CallbackUserData );
     typename TOutputImage::DirectionType outDirection;
-    for ( unsigned int i = 0; i < OutputImageDimension; ++i )
+    for ( unsigned int i = 0; i < 3; ++i )
       {
-      for ( unsigned int j = 0; j < OutputImageDimension; ++j )
+      for ( unsigned int j = 0; j < 3; ++j )
         {
-        outDirection[i][j] = inDirection[i*3+j];
+        if (i < OutputImageDimension && j < OutputImageDimension)
+          {
+          outDirection[i][j] = inDirection[i*3+j];
+          }
+        else if ((i != j) && (inDirection[i*3+j] != 0.0))
+          {
+            std::string ijk = "IJK";
+            std::string xyz = "XYZ";
+            itkExceptionMacro(<< "Cannot convert a VTK image to an ITK image of dimension "
+            << OutputImageDimension << " since the VTK image direction matrix element at ("
+            << i << "," << j << ") is not equal to 0.0:\n"
+            << "   I  J  K\n"
+            << "X  " << inDirection[0] << ", " << inDirection[1] << ", " << inDirection[2] << "\n"
+            << "Y  " << inDirection[3] << ", " << inDirection[4] << ", " << inDirection[5] << "\n"
+            << "Z  " << inDirection[6] << ", " << inDirection[7] << ", " << inDirection[8] << "\n"
+            << "This means that the " << ijk[j] << " data axis has a " << xyz[i]
+            << " component in physical space, but the ITK image can only represent values"
+            << " along " << ijk.substr(0,OutputImageDimension) << " projected on "
+            << xyz.substr(0,OutputImageDimension) << "." << std::endl);
+          }
         }
       }
     output->SetDirection(outDirection);

--- a/Modules/Bridge/VTK/src/itkVTKImageExportBase.cxx
+++ b/Modules/Bridge/VTK/src/itkVTKImageExportBase.cxx
@@ -67,6 +67,12 @@ VTKImageExportBase::GetOriginCallback() const
           &VTKImageExportBase::FloatOriginCallbackFunction};
 }
 
+VTKImageExportBase::DirectionCallbackType
+VTKImageExportBase::GetDirectionCallback() const
+{
+  return VTKImageExportBase::DirectionCallbackFunction;
+}
+
 VTKImageExportBase::CallbackTypeProxy
 VTKImageExportBase::GetSpacingCallback() const
 {
@@ -226,6 +232,12 @@ float * VTKImageExportBase::FloatSpacingCallbackFunction(void *userData)
 {
   return static_cast< VTKImageExportBase * >
          ( userData )->FloatSpacingCallback();
+}
+
+double * VTKImageExportBase::DirectionCallbackFunction(void *userData)
+{
+  return static_cast< VTKImageExportBase * >
+         ( userData )->DirectionCallback();
 }
 
 const char * VTKImageExportBase::ScalarTypeCallbackFunction(void *userData)

--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -38,7 +38,9 @@ ImageToVTKImageFilter<TInputImage>
   m_Importer->SetWholeExtentCallback(m_Exporter->GetWholeExtentCallback());
   m_Importer->SetSpacingCallback(m_Exporter->GetSpacingCallback());
   m_Importer->SetOriginCallback(m_Exporter->GetOriginCallback());
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 90)
   m_Importer->SetDirectionCallback(m_Exporter->GetDirectionCallback());
+#endif
   m_Importer->SetScalarTypeCallback(m_Exporter->GetScalarTypeCallback());
   m_Importer->SetNumberOfComponentsCallback(m_Exporter->GetNumberOfComponentsCallback());
   m_Importer->SetPropagateUpdateExtentCallback(m_Exporter->GetPropagateUpdateExtentCallback());

--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -38,6 +38,7 @@ ImageToVTKImageFilter<TInputImage>
   m_Importer->SetWholeExtentCallback(m_Exporter->GetWholeExtentCallback());
   m_Importer->SetSpacingCallback(m_Exporter->GetSpacingCallback());
   m_Importer->SetOriginCallback(m_Exporter->GetOriginCallback());
+  m_Importer->SetDirectionCallback(m_Exporter->GetDirectionCallback());
   m_Importer->SetScalarTypeCallback(m_Exporter->GetScalarTypeCallback());
   m_Importer->SetNumberOfComponentsCallback(m_Exporter->GetNumberOfComponentsCallback());
   m_Importer->SetPropagateUpdateExtentCallback(m_Exporter->GetPropagateUpdateExtentCallback());

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
@@ -41,6 +41,7 @@ VTKImageToImageFilter<TOutputImage>
   this->SetWholeExtentCallback( m_Exporter->GetWholeExtentCallback());
   this->SetSpacingCallback( m_Exporter->GetSpacingCallback());
   this->SetOriginCallback( m_Exporter->GetOriginCallback());
+  this->SetDirectionCallback( m_Exporter->GetDirectionCallback());
   this->SetScalarTypeCallback( m_Exporter->GetScalarTypeCallback());
   this->SetNumberOfComponentsCallback( m_Exporter->GetNumberOfComponentsCallback());
   this->SetPropagateUpdateExtentCallback( m_Exporter->GetPropagateUpdateExtentCallback());

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
@@ -41,7 +41,9 @@ VTKImageToImageFilter<TOutputImage>
   this->SetWholeExtentCallback( m_Exporter->GetWholeExtentCallback());
   this->SetSpacingCallback( m_Exporter->GetSpacingCallback());
   this->SetOriginCallback( m_Exporter->GetOriginCallback());
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 90)
   this->SetDirectionCallback( m_Exporter->GetDirectionCallback());
+#endif
   this->SetScalarTypeCallback( m_Exporter->GetScalarTypeCallback());
   this->SetNumberOfComponentsCallback( m_Exporter->GetNumberOfComponentsCallback());
   this->SetPropagateUpdateExtentCallback( m_Exporter->GetPropagateUpdateExtentCallback());

--- a/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
@@ -85,6 +85,7 @@ int itkImageToVTKImageFilterTest(int, char *[])
       std::cerr << "Error: origins do not match for component (" << i << ")." << std::endl;
       return EXIT_FAILURE;
     }
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 90)
     for (int j = 0; j < dim; ++j)
     {
       if (input->GetDirection()[i][j] != output->GetDirectionMatrix()->GetData()[i*3+j])
@@ -93,6 +94,7 @@ int itkImageToVTKImageFilterTest(int, char *[])
         return EXIT_FAILURE;
       }
     }
+#endif
   }
 
   return EXIT_SUCCESS;

--- a/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
@@ -20,29 +20,80 @@
 
 #include "itkRandomImageSource.h"
 
+#include "vtkMatrix3x3.h"
+
 int itkImageToVTKImageFilterTest(int, char *[])
 {
-  using ImageType = itk::Image<float, 2 >;
+  const int dim = 3;
+  using ImageType = itk::Image<float, dim >;
   using SourceType = itk::RandomImageSource<ImageType>;
+  using SpacingType = SourceType::SpacingType;
+  using OriginType = SourceType::PointType;
+  using DirectionType = SourceType::DirectionType;
   using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
 
   ImageType::SizeType size;
-  size.Fill(20);
+  size[0] = 40;
+  size[1] = 10;
+  size[2] = 20;
   SourceType::Pointer source = SourceType::New();
   source->SetSize(size);
 
+  SpacingType spacing;
+  spacing[0] = 0.5;
+  spacing[1] = -2;
+  spacing[2] = 1;
+  OriginType origin;
+  origin[0] = -1.5;
+  origin[1] = 0.222;
+  origin[2] = 0;
+  DirectionType direction;
+  direction.Fill(0.0);
+  direction[0][1] = 1;
+  direction[1][0] = -1;
+  direction[2][2] = 0.7;
+  source->SetSpacing(spacing);
+  source->SetOrigin(origin);
+  source->SetDirection(direction);
+
+  source->Update();
+  auto input = source->GetOutput();
+  input->Print(std::cout);
+
   ConnectorType::Pointer connector = ConnectorType::New();
-  connector->SetInput(source->GetOutput());
-
+  connector->SetInput(input);
   connector->UpdateLargestPossibleRegion();
-
-  connector->GetOutput()->Print(std::cout);
-  connector->GetImporter()->Print(std::cout);
-  connector->GetExporter()->Print(std::cout);
-
-  connector->Print(std::cout);
-
   connector->Update();
+
+  auto output = connector->GetOutput();
+  output->Print(std::cout);
+
+  for (int i = 0; i < dim; ++i)
+  {
+    if (input->GetLargestPossibleRegion().GetSize()[i] != static_cast<itk::SizeValueType>(output->GetDimensions()[i]))
+    {
+      std::cerr << "Error: sizes do not match for component (" << i << ")." << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (input->GetSpacing()[i] != output->GetSpacing()[i])
+    {
+      std::cerr << "Error: spacings do not match for component (" << i << ")." << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (input->GetOrigin()[i] != output->GetOrigin()[i])
+    {
+      std::cerr << "Error: origins do not match for component (" << i << ")." << std::endl;
+      return EXIT_FAILURE;
+    }
+    for (int j = 0; j < dim; ++j)
+    {
+      if (input->GetDirection()[i][j] != output->GetDirectionMatrix()->GetData()[i*3+j])
+      {
+        std::cerr << "Error: directions do not match for component (" << i << "," << j << ")." << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Bridge/VtkGlue/test/itkVTKImageToImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVTKImageToImageFilterTest.cxx
@@ -75,5 +75,25 @@ int itkVTKImageToImageFilterTest(int, char*[])
     }
   }
 
-  return EXIT_SUCCESS;
+  // Try again with an direction matrix that isn't supported
+  // and ensure it throws an exception
+  input->SetDirectionMatrix(0, 1, 0, 0, 0, 1, 1, 0, 0);
+  try
+    {
+    connector->Update();
+    }
+  catch (itk::ExceptionObject & e)
+    {
+    std::string expectedErrorSubString = "is not equal to 0.0";
+    std::string fullErrorString = e.GetDescription();
+    if (fullErrorString.find(expectedErrorSubString) != std::string::npos)
+      {
+      std::cout << "\nTest passed: the expected exception was thrown: " << e << std::endl;
+      return EXIT_SUCCESS;
+      }
+    std::cerr << "\nTest failed: an unexpected exception was thrown: " << e << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Bridge/VtkGlue/test/itkVTKImageToImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVTKImageToImageFilterTest.cxx
@@ -38,7 +38,9 @@ int itkVTKImageToImageFilterTest(int, char*[])
   auto input = noise_source->GetOutput();
   input->SetSpacing(0.1, 2.0, 0.0);
   input->SetOrigin(-0.1, -10, 0.0);
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 90)
   input->SetDirectionMatrix(0, 1, 0, -1, 0, 0, 0, 0, 1);
+#endif
   input->Print(std::cout);
 
   ConnectorType::Pointer connector = ConnectorType::New();
@@ -47,6 +49,7 @@ int itkVTKImageToImageFilterTest(int, char*[])
 
   auto output = connector->GetOutput();
   output->Print(std::cout);
+
 
   for (int i = 0; i < dim; ++i)
   {
@@ -65,6 +68,7 @@ int itkVTKImageToImageFilterTest(int, char*[])
       std::cerr << "Error: origins do not match for component (" << i << ")." << std::endl;
       return EXIT_FAILURE;
     }
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 90)
     for (int j = 0; j < dim; ++j)
     {
       if (output->GetDirection()[i][j] != input->GetDirectionMatrix()->GetData()[i*3+j])
@@ -73,8 +77,10 @@ int itkVTKImageToImageFilterTest(int, char*[])
         return EXIT_FAILURE;
       }
     }
+#endif
   }
 
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 90)
   // Try again with an direction matrix that isn't supported
   // and ensure it throws an exception
   input->SetDirectionMatrix(0, 1, 0, 0, 0, 1, 1, 0, 0);
@@ -96,4 +102,7 @@ int itkVTKImageToImageFilterTest(int, char*[])
     }
 
   return EXIT_FAILURE;
+#else
+  return EXIT_SUCCESS;
+#endif
 }


### PR DESCRIPTION
Address #772:

- [x] Improve VTKImage import/export tests to check for correct image properties
- [x] Pass directions in VTKImage import/export classes
- [x] Improve `itkVTKImageImport` to ~~consider which direction vectors to conserve when importing a VTK image (always in a 3D coordinate system) to an ITK image of dimension lower than 3. Currently picking the top left submatrix. (but that's already an issue for origin, spacing, and size?)~~ throw an exception when the direction matrix cannot be converted down to a lower dimension in ITK.
- [x] Check VTK version and add preprocessor definitions to only call VTK's direction API if it exists (past [868ba30c](https://gitlab.kitware.com/vtk/vtk/commits/868ba30c))

Thanks to @fbudin69500 for helping me getting acclimated to the ITK way 🙏