### PR TITLE
WIP: Imread fallback only

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -353,51 +353,7 @@ As implied above, the changes to SpatialObject are extensive.   They include the
 * Helper functions simplify the specification of `IsInsideInObjectSpace()`, `ValueAtInObjectSpace()`, and other computations that potentially traverse an SO tree.
 * Derived classes typically only need to implement `IsInsideInObjectSpace()` and `ComputeMyBoundingBoxInObjectSpace()` member functions. Logic for `ValueAtInObjectSpace()`, `IsInsideInWorldSpace()` and such is improved.
 * PointBasedSpatialObjects had a PointListType type declaration.  This was confusing because it refered to a list of SpatialObjectPoints and not ITK::Points.  So, to avoid such confusion, now TubeSpatialObjects define TubePointListType, BlobSpatialObjects define BlobPointListType, and so forth.
-* `ImageMaskSpatialObject::GetAxisAlignedBoundingBoxRegion()` was removed.   `GetMyBoundingBoxInObjectSpace()` or `GetMyBoundingBoxInWorldSpace()` should be used instead. If a region in IndexSpace is needed, then transfer the corners of the bounding box into Index Space.
-```
-  //REPLACE typename FixedImageType::RegionType roiRegion = roiMask->GetAxisAlignedBoundingBoxRegion();
-  // Transform the corners of the bounding box
-  using PointsContainer = typename BoundingBoxType::PointsContainer;
-  const PointsContainer *corners
-    = roiMask->GetMyBoundingBoxInObjectSpace()->GetCorners();
-  typename PointsContainer::Pointer transformedCorners =
-    PointsContainer::New();
-  transformedCorners->Reserve(
-    static_cast<typename PointsContainer::ElementIdentifier>(
-      corners->size() ) );
-
-  auto it = corners->begin();
-  auto itTrans = transformedCorners->begin();
-  while ( it != corners->end() )
-    {
-    ContinuousIndexType cIndx;
-    roiMask->GetImage()->TransformPhysicalPointToIndex(*it, cIndx);
-    PointType pnt;
-    for( unsigned int i=0; i<Dimensions; ++i )
-      {
-      pnt[i] = cIndx[i];
-      }
-    *itTrans = pnt;
-    ++it;
-    ++itTrans;
-    }
-
-  typename BoundingBoxType::Pointer indexBoundingBox =
-    BoundingBoxType::New();
-  indexBoundingBox->SetPoints(transformedCorners);
-  indexBoundingBox->ComputeBoundingBox();
-
-  RegionType boundingRegion;
-  RegionType::IndexType indx;
-  RegionType::SizeType size;
-  for( unsigned int i=0; i<Dimensions; ++i )
-      {
-      indx[i] = indexBoundingBox->GetMinimum()[i];
-      size[i] = indexBoundingBox->GetMaximum()[i] - indexBoundingBox->GetMinimum()[i] + 1;
-      }
-  boundingRegion.SetIndex( indx );
-  boundingRegion.SetSize( size );
-```
+* `ImageMaskSpatialObject::GetAxisAlignedBoundingBoxRegion()` was removed. `ImageMaskSpatialObject::ComputeMyBoundingBoxInIndexSpace()` should be used instead.
 
 Class changes
 -------------

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -71,16 +71,23 @@ public:
   bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
     const std::string & name="") const override;
 
-#if ! defined ( ITK_LEGACY_REMOVE )
-  /** Compute axis aligned bounding box from the image mask. The bounding box
-   * is returned as an image region. Each call to this function will recompute
-   * the region.
+
+  /** Computes the bounding box of the image mask, in the index space of the image.
+   * The bounding box is returned as an image region. Each call to this function
+   * will recompute the region.
    * This function is useful in cases, where you may have a mask image
    * resulting from say a segmentation and you want to get the smallest box
-   * region that encapsulates the mask image. Currently this is done only for 3D
-   * volumes. */
-  //NOTE: THIS IS THE HISTORICAL IMPLEMETNATION COMPATIBLE WITH PRE 5.0.0
-  //      BEHAVIORS.
+   * region that encapsulates the mask image.
+   *
+   * \note This function is introduced with ITK 5.0, replacing
+   * `GetAxisAlignedBoundingBoxRegion()`.
+   */
+  RegionType ComputeMyBoundingBoxInIndexSpace() const;
+
+#if ! defined ( ITK_LEGACY_REMOVE )
+  /** Compute axis aligned bounding box from the image mask.
+   * \note With ITK 5.0, this function is superseded by `ComputeMyBoundingBoxInIndexSpace()`
+  */
   itkLegacyMacro( RegionType GetAxisAlignedBoundingBoxRegion() const );
 
 #endif

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -173,11 +173,11 @@ ImageMaskSpatialObject< TDimension, TPixel >
   Superclass::PrintSelf(os, indent);
 }
 
-#if ! defined ( ITK_LEGACY_REMOVE )
+
 template< unsigned int TDimension, typename TPixel >
 typename ImageMaskSpatialObject< TDimension, TPixel >::RegionType
 ImageMaskSpatialObject< TDimension, TPixel >
-::GetAxisAlignedBoundingBoxRegion() const
+::ComputeMyBoundingBoxInIndexSpace() const
 {
   const ImagePointer imagePointer = this->GetImage();
 
@@ -260,6 +260,16 @@ ImageMaskSpatialObject< TDimension, TPixel >
     maxIndex[dim] = subregion.GetIndex(dim);
   }
   return CreateRegion(minIndex, maxIndex);
+}
+
+
+#if ! defined ( ITK_LEGACY_REMOVE )
+template< unsigned int TDimension, typename TPixel >
+typename ImageMaskSpatialObject< TDimension, TPixel >::RegionType
+ImageMaskSpatialObject< TDimension, TPixel >
+::GetAxisAlignedBoundingBoxRegion() const
+{
+  return ComputeMyBoundingBoxInIndexSpace();
 }
 #endif //ITK_LEGACY_REMOVE
 } // end namespace itk

--- a/Utilities/Maintenance/UpdateRemoteModules.sh
+++ b/Utilities/Maintenance/UpdateRemoteModules.sh
@@ -47,7 +47,7 @@ for filename in ${remote_modules_path}/*.cmake; do
   # Get the latest git commit hash of the remote module.
   # Remotes will usually not be tagged.
   latest_commit=$(git ls-remote git://github.com/$repository refs/heads/master)
-  latest_commit=${latest_commit/	refs\/heads\/master/}
+  latest_commit=${latest_commit/[[:space:]]refs\/heads\/master/}
 
   if [ $curr_commit = $latest_commit ]; then
     continue

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -136,6 +136,18 @@ image=itk.imread(fileName)
 assert type(image) == itk.Image[itk.RGBPixel[itk.UC],2]
 image=itk.imread(fileName, itk.F)
 assert type(image) == itk.Image[itk.F,2]
+image=itk.imread(fileName, itk.F, fallback_only=True)
+assert type(image) == itk.Image[itk.RGBPixel[itk.UC],2]
+try:
+  image=itk.imread(fileName, fallback_only=True)
+  # Should never reach this point if test passes since an exception
+  # is expected.
+  raise Exception('`itk.imread()` fallback_only should have failed')
+except Exception as e:
+  if str(e) == "`pixel_type` must be set when using `fallback_only` option":
+    pass
+  else:
+    raise e
 
 # test search
 res = itk.search("Index")

--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -468,15 +468,29 @@ def imwrite(image_or_filter, filename, compression=False):
     auto_pipeline.current = tmp_auto_pipeline
     writer.Update()
 
-def imread(filename, pixel_type=None):
+def imread(filename, pixel_type=None, fallback_only=False):
     """Read an image from a file or series of files and return an itk.Image.
 
     The reader is instantiated with the image type of the image file if
     `pixel_type` is not provided (default). The dimension of the image is
     automatically found. If the given filename is a list or a tuple, the
     reader will use an itk.ImageSeriesReader object to read the files.
+
+    If `fallback_only` is set to `True`, `imread()` will first try to
+    automatically deduce the image pixel_type, and only use the given
+    `pixel_type` if the automatic deduction fail. Failures typically
+    happen if the pixel type is not supported (e.g. it is not currently
+    wrapped).
     """
     import itk
+    if fallback_only == True:
+        if pixel_type is None:
+            raise Exception("`pixel_type` must be set when using `fallback_only`"
+                " option")
+        try:
+            return imread(filename)
+        except KeyError:
+            pass
     if type(filename) in [list, tuple]:
         TemplateReaderType=itk.ImageSeriesReader
         io_filename=filename[0]


### PR DESCRIPTION
`imread()` Python function allows to read an image, either by letting the
function deduce the input image pixel type or by manually selecting the
pixel type used to read it. The image dimension is always automatically
deduced.

In certain case, the user want to use the actual image pixel type if
that is possible, and use a fallback type if the input image type is
not supported. The new `fallback_only` parameter allows this.