### PR TITLE
ENH: Add `fallback_only` parameter to `imread()` Python function

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -136,6 +136,18 @@ image=itk.imread(fileName)
 assert type(image) == itk.Image[itk.RGBPixel[itk.UC],2]
 image=itk.imread(fileName, itk.F)
 assert type(image) == itk.Image[itk.F,2]
+image=itk.imread(fileName, itk.F, fallback_only=True)
+assert type(image) == itk.Image[itk.RGBPixel[itk.UC],2]
+try:
+  image=itk.imread(fileName, fallback_only=True)
+  # Should never reach this point if test passes since an exception
+  # is expected.
+  raise Exception('`itk.imread()` fallback_only should have failed')
+except Exception as e:
+  if str(e) == "`pixel_type` must be set when using `fallback_only` option":
+    pass
+  else:
+    raise e
 
 # test search
 res = itk.search("Index")

--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -468,15 +468,29 @@ def imwrite(image_or_filter, filename, compression=False):
     auto_pipeline.current = tmp_auto_pipeline
     writer.Update()
 
-def imread(filename, pixel_type=None):
+def imread(filename, pixel_type=None, fallback_only=False):
     """Read an image from a file or series of files and return an itk.Image.
 
     The reader is instantiated with the image type of the image file if
     `pixel_type` is not provided (default). The dimension of the image is
     automatically found. If the given filename is a list or a tuple, the
     reader will use an itk.ImageSeriesReader object to read the files.
+
+    If `fallback_only` is set to `True`, `imread()` will first try to
+    automatically deduce the image pixel_type, and only use the given
+    `pixel_type` if the automatic deduction fail. Failures typically
+    happen if the pixel type is not supported (e.g. it is not currently
+    wrapped).
     """
     import itk
+    if fallback_only == True:
+        if pixel_type is None:
+            raise Exception("`pixel_type` must be set when using `fallback_only`"
+                " option")
+        try:
+            return imread(filename)
+        except KeyError:
+            pass
     if type(filename) in [list, tuple]:
         TemplateReaderType=itk.ImageSeriesReader
         io_filename=filename[0]


### PR DESCRIPTION
`imread()` Python function allows to read an image, either by letting the
function deduce the input image pixel type or by manually selecting the
pixel type used to read it. The image dimension is always automatically
deduced.

In certain case, the user want to use the actual image pixel type if
that is possible, and use a fallback type if the input image type is
not supported. The new `fallback_only` parameter allows this.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [x] Adds tests.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
