### PR TITLE
BUG: PythonFindEmptyClasses test for windowed-sinc functions

### DIFF
--- a/Modules/Core/ImageFunction/wrapping/itkWindowedSincInterpolateImageFunction.wrap
+++ b/Modules/Core/ImageFunction/wrapping/itkWindowedSincInterpolateImageFunction.wrap
@@ -11,7 +11,7 @@ foreach(function ${window_functions})
   itk_end_wrap_class()
 endforeach()
 
-itk_wrap_class("itk::WindowedSincInterpolateImageFunction" POINTER)
+itk_wrap_class("itk::WindowedSincInterpolateImageFunction")
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${WRAP_ITK_SCALAR})
       foreach(r ${radii}) # radius

--- a/Wrapping/Generators/Python/Tests/findEmptyClasses.py
+++ b/Wrapping/Generators/Python/Tests/findEmptyClasses.py
@@ -67,6 +67,10 @@ exclude = ["AuthalicMatrixCoefficients",
            "vnl_file_matrix",
            "vnl_file_vector",
            "vnl_fortran_copy",
+           "CosineWindowFunction",
+           "HammingWindowFunction",
+           "LanczosWindowFunction",
+           "WelchWindowFunction",
            ]
 
 total = 0


### PR DESCRIPTION
Exclude these classes because they only expose `operator()`.

Also do not wrap with POINTER because they do not inherit from
itk.LightObject.

Closes #797 