### PR TITLE
STYLE: SpatialObject() = default, const BoundingBox, Transform members

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -522,8 +522,11 @@ protected:
   /** Compute bounding box for the object in world space */
   virtual void ComputeMyBoundingBox();
 
-  /** Constructor. */
-  SpatialObject();
+  /** Default constructor. Ensures that its bounding boxes are empty (all
+  * bounds zero-valued), its list of children is empty, and its transform
+  * objects identical to the identity transform, initially.
+  */
+  SpatialObject() = default;
 
   /** Destructor. */
   ~SpatialObject() override;
@@ -538,38 +541,38 @@ protected:
 private:
 
   /** Object Identification Number */
-  int             m_Id;
+  int             m_Id{ -1 };
 
   /** Type of spatial object */
-  std::string     m_TypeName;
+  std::string     m_TypeName{ "SpatialObject" };
 
   PropertyType    m_Property;
 
-  int             m_ParentId;
-  Self *          m_Parent;
+  int             m_ParentId{ -1 };
+  Self *          m_Parent{ nullptr };
 
   RegionType      m_LargestPossibleRegion;
   RegionType      m_RequestedRegion;
   RegionType      m_BufferedRegion;
 
-  BoundingBoxPointer m_MyBoundingBoxInObjectSpace;
-  BoundingBoxPointer m_MyBoundingBoxInWorldSpace;
-  BoundingBoxPointer m_FamilyBoundingBoxInObjectSpace;
-  BoundingBoxPointer m_FamilyBoundingBoxInWorldSpace;
+  const BoundingBoxPointer m_MyBoundingBoxInObjectSpace{ BoundingBoxType::New() };
+  const BoundingBoxPointer m_MyBoundingBoxInWorldSpace{ BoundingBoxType::New() };
+  const BoundingBoxPointer m_FamilyBoundingBoxInObjectSpace{ BoundingBoxType::New() };
+  const BoundingBoxPointer m_FamilyBoundingBoxInWorldSpace{ BoundingBoxType::New() };
 
-  TransformPointer m_ObjectToParentTransform;
-  TransformPointer m_ObjectToParentTransformInverse;
+  const TransformPointer m_ObjectToParentTransform{ TransformType::New() };
+  const TransformPointer m_ObjectToParentTransformInverse{ TransformType::New() };
 
-  TransformPointer m_ObjectToWorldTransform;
-  TransformPointer m_ObjectToWorldTransformInverse;
+  const TransformPointer m_ObjectToWorldTransform{ TransformType::New() };
+  const TransformPointer m_ObjectToWorldTransformInverse{ TransformType::New() };
 
   ChildrenListType m_ChildrenList;
 
   /** Default inside value for the ValueAtInWorldSpace() */
-  double m_DefaultInsideValue;
+  double m_DefaultInsideValue{ 1.0 };
 
   /** Default outside value for the ValueAtInWorldSpace() */
-  double m_DefaultOutsideValue;
+  double m_DefaultOutsideValue{ 0.0 };
 
 };
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -27,48 +27,6 @@
 
 namespace itk
 {
-/** Constructor */
-template< unsigned int TDimension >
-SpatialObject< TDimension >
-::SpatialObject()
-{
-  m_TypeName = "SpatialObject";
-
-  typename BoundingBoxType::PointType pnt;
-  pnt.Fill( NumericTraits< typename BoundingBoxType::PointType::ValueType >::
-    ZeroValue() );
-  m_FamilyBoundingBoxInObjectSpace = BoundingBoxType::New();
-  m_FamilyBoundingBoxInObjectSpace->SetMinimum(pnt);
-  m_FamilyBoundingBoxInObjectSpace->SetMaximum(pnt);
-  m_FamilyBoundingBoxInWorldSpace = BoundingBoxType::New();
-  m_FamilyBoundingBoxInWorldSpace->SetMinimum(pnt);
-  m_FamilyBoundingBoxInWorldSpace->SetMaximum(pnt);
-
-  m_MyBoundingBoxInObjectSpace = BoundingBoxType::New();
-  m_MyBoundingBoxInObjectSpace->SetMinimum(pnt);
-  m_MyBoundingBoxInObjectSpace->SetMaximum(pnt);
-  m_MyBoundingBoxInWorldSpace = BoundingBoxType::New();
-  m_MyBoundingBoxInWorldSpace->SetMinimum(pnt);
-  m_MyBoundingBoxInWorldSpace->SetMaximum(pnt);
-
-  m_ObjectToWorldTransform = TransformType::New();
-  m_ObjectToWorldTransform->SetIdentity();
-  m_ObjectToWorldTransformInverse = TransformType::New();
-  m_ObjectToWorldTransformInverse->SetIdentity();
-
-  m_ObjectToParentTransform = TransformType::New();
-  m_ObjectToParentTransform->SetIdentity();
-  m_ObjectToParentTransformInverse = TransformType::New();
-  m_ObjectToParentTransformInverse->SetIdentity();
-
-  m_Id = -1;
-  m_Parent = nullptr;
-  m_ParentId = -1;
-  m_DefaultInsideValue = 1.0;
-  m_DefaultOutsideValue  = 0.0;
-
-  m_ChildrenList.clear();
-}
 
 /** Destructor */
 template< unsigned int TDimension >


### PR DESCRIPTION
Explicitly-defaulted `SpatialObject()` default-constructor.

Added `const` to `BoundingBoxPointer` and `TransformPointer` data
members of `SpatialObject`. The aim is to ensure that these pointer
are always valid (never null) during the lifetime of the spatial object.