### PR TITLE
WIP: Improve python wrapping error messages

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -354,6 +354,7 @@ As implied above, the changes to SpatialObject are extensive.   They include the
 * Derived classes typically only need to implement `IsInsideInObjectSpace()` and `ComputeMyBoundingBoxInObjectSpace()` member functions. Logic for `ValueAtInObjectSpace()`, `IsInsideInWorldSpace()` and such is improved.
 * PointBasedSpatialObjects had a PointListType type declaration.  This was confusing because it refered to a list of SpatialObjectPoints and not ITK::Points.  So, to avoid such confusion, now TubeSpatialObjects define TubePointListType, BlobSpatialObjects define BlobPointListType, and so forth.
 * `ImageMaskSpatialObject::GetAxisAlignedBoundingBoxRegion()` was removed. `ImageMaskSpatialObject::ComputeMyBoundingBoxInIndexSpace()` should be used instead.
+* `SpatialObjectReader::GetScene` was renamed to `GetGroup` along with changing the type from `ScenePointer` to `GroupPointer`.
 
 Class changes
 -------------

--- a/Modules/Core/ImageFunction/wrapping/itkWindowedSincInterpolateImageFunction.wrap
+++ b/Modules/Core/ImageFunction/wrapping/itkWindowedSincInterpolateImageFunction.wrap
@@ -11,7 +11,7 @@ foreach(function ${window_functions})
   itk_end_wrap_class()
 endforeach()
 
-itk_wrap_class("itk::WindowedSincInterpolateImageFunction" POINTER)
+itk_wrap_class("itk::WindowedSincInterpolateImageFunction")
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${WRAP_ITK_SCALAR})
       foreach(r ${radii}) # radius

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearLineStressTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearLineStressTest.cxx
@@ -44,10 +44,10 @@ int itkFEMElement2DC0LinearLineStressTest(int argc, char *argv[])
 //  SpatialReader->SetFileName("C:/Research/ITKGit/ITK/Testing/Data/Input/FEM/2DC0LinearLineStressTest.meta");
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMElement2DC0LinearLineStressTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<2>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralMembraneTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement2DC0LinearQuadrilateralMembraneTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -55,7 +55,7 @@ int itkFEMElement2DC0LinearQuadrilateralMembraneTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<2>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStrainItpackTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStrainItpackTest.cxx
@@ -52,10 +52,10 @@ int itkFEMElement2DC0LinearQuadrilateralStrainItpackTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -68,7 +68,7 @@ int itkFEMElement2DC0LinearQuadrilateralStrainItpackTest(int argc, char *argv[])
   itk::fem::LinearSystemWrapperItpack WrapperItpack;
   WrapperItpack.SetMaximumNonZeroValuesInMatrix(1000);
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStrainTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement2DC0LinearQuadrilateralStrainTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMElement2DC0LinearQuadrilateralStrainTest(int argc, char *argv[])
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleMembraneTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement2DC0LinearTriangleMembraneTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMElement2DC0LinearTriangleMembraneTest(int argc, char *argv[])
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleStrainTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement2DC0LinearTriangleStrainTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMElement2DC0LinearTriangleStrainTest(int argc, char *argv[])
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleStressTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleStressTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement2DC0LinearTriangleStressTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMElement2DC0LinearTriangleStressTest(int argc, char *argv[])
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0QuadraticTriangleStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0QuadraticTriangleStrainTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement2DC0QuadraticTriangleStrainTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMElement2DC0QuadraticTriangleStrainTest(int argc, char *argv[])
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0QuadraticTriangleStressTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0QuadraticTriangleStressTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement2DC0QuadraticTriangleStressTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMElement2DC0QuadraticTriangleStressTest(int argc, char *argv[])
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC1BeamTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC1BeamTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement2DC1BeamTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMElement2DC1BeamTest(int argc, char *argv[])
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
@@ -53,10 +53,10 @@ int itkFEMElement2DTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
 
-  std::cout << "Scene Test: ";
-  if( !myScene )
+  std::cout << "Group Test: ";
+  if( !myGroup )
     {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -72,7 +72,7 @@ int itkFEMElement2DTest(int argc, char *argv[])
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
   std::cout << "FEM Spatial Object Test: ";
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearHexahedronMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearHexahedronMembraneTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement3DC0LinearHexahedronMembraneTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -55,7 +55,7 @@ int itkFEMElement3DC0LinearHexahedronMembraneTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<3>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearHexahedronStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearHexahedronStrainTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement3DC0LinearHexahedronStrainTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -55,7 +55,7 @@ int itkFEMElement3DC0LinearHexahedronStrainTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<3>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearTetrahedronMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearTetrahedronMembraneTest.cxx
@@ -43,10 +43,10 @@ int itkFEMElement3DC0LinearTetrahedronMembraneTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -55,7 +55,7 @@ int itkFEMElement3DC0LinearTetrahedronMembraneTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<3>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearTetrahedronStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearTetrahedronStrainTest.cxx
@@ -45,10 +45,10 @@ int itkFEMElement3DC0LinearTetrahedronStrainTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -57,7 +57,7 @@ int itkFEMElement3DC0LinearTetrahedronStrainTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<3>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
@@ -55,10 +55,10 @@ int itkFEMElement3DTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
 
-  std::cout << "Scene Test: ";
-  if( !myScene )
+  std::cout << "Group Test: ";
+  if( !myGroup )
     {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -74,7 +74,7 @@ int itkFEMElement3DTest(int argc, char *argv[])
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
   std::cout << "FEM Spatial Object Test: ";
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -257,7 +257,7 @@ int itkFEMElement3DTest(int argc, char *argv[])
     {
     std::cerr << "ITK exception detected: "  << err;
     std::cout << "Test FAILED" << std::endl;
-    myScene = nullptr;
+    myGroup = nullptr;
     return EXIT_FAILURE;
     }
 
@@ -265,10 +265,10 @@ int itkFEMElement3DTest(int argc, char *argv[])
   if( foundError )
     {
     std::cout << "Overall Test : [FAILED]" << std::endl;
-    myScene = nullptr;
+    myGroup = nullptr;
     return EXIT_FAILURE;
     }
-  myScene = nullptr;
+  myGroup = nullptr;
   std::cout << "Overall Test : [PASSED]" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Numerics/FEM/test/itkFEMLandmarkLoadImplementationTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLandmarkLoadImplementationTest.cxx
@@ -45,10 +45,10 @@ int itkFEMLandmarkLoadImplementationTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -57,7 +57,7 @@ int itkFEMLandmarkLoadImplementationTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<2>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMLoadBCMFCTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLoadBCMFCTest.cxx
@@ -44,10 +44,10 @@ int itkFEMLoadBCMFCTest(int argc, char *argv[])
 //  SpatialReader->SetFileName("C:/Research/ITKGit/ITK/Testing/Data/Input/FEM/LoadBCMFCTest.meta");
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -57,7 +57,7 @@ int itkFEMLoadBCMFCTest(int argc, char *argv[])
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
 
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/FEM/test/itkFEMLoadEdgeTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLoadEdgeTest.cxx
@@ -43,10 +43,10 @@ int itkFEMLoadEdgeTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -55,7 +55,7 @@ int itkFEMLoadEdgeTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<2>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -87,7 +87,7 @@ int itkFEMLoadEdgeTest(int argc, char *argv[])
   using FEMSpatialObjectWriterType = itk::FEMSpatialObjectWriter<2>;
   using FEMSpatialObjectWriterPointer = FEMSpatialObjectWriterType::Pointer;
   FEMSpatialObjectWriterPointer SpatialWriter = FEMSpatialObjectWriterType::New();
-  SpatialWriter->SetInput(SpatialReader->GetScene() );
+  SpatialWriter->SetInput(SpatialReader->GetGroup() );
   SpatialWriter->SetFileName( argv[2] );
   SpatialWriter->Update();
 

--- a/Modules/Numerics/FEM/test/itkFEMLoadGravConstTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLoadGravConstTest.cxx
@@ -43,10 +43,10 @@ int itkFEMLoadGravConstTest(int argc, char *argv[])
   SpatialReader->SetFileName( argv[1] );
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -55,7 +55,7 @@ int itkFEMLoadGravConstTest(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<2>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( (*(children->begin() ) )->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -86,7 +86,7 @@ int itkFEMLoadGravConstTest(int argc, char *argv[])
   using FEMSpatialObjectWriterType = itk::FEMSpatialObjectWriter<2>;
   using FEMSpatialObjectWriterPointer = FEMSpatialObjectWriterType::Pointer;
   FEMSpatialObjectWriterPointer SpatialWriter = FEMSpatialObjectWriterType::New();
-  SpatialWriter->SetInput(SpatialReader->GetScene() );
+  SpatialWriter->SetInput(SpatialReader->GetGroup() );
   SpatialWriter->SetFileName( argv[2] );
   SpatialWriter->Update();
 

--- a/Modules/Numerics/FEM/test/itkFEMSolverTest3D.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverTest3D.cxx
@@ -44,10 +44,10 @@ int itkFEMSolverTest3D(int argc, char *argv[])
 //  SpatialReader->SetFileName("C:/Research/ITKGit/ITK/Testing/Data/Input/FEM/3DC0LinearHexahedronMembraneTest.meta");
   SpatialReader->Update();
 
-  FEMSpatialObjectReaderType::ScenePointer myScene = SpatialReader->GetScene();
-  if( !myScene )
+  FEMSpatialObjectReaderType::GroupPointer myGroup = SpatialReader->GetGroup();
+  if( !myGroup )
     {
-    std::cout << "No Scene : [FAILED]" << std::endl;
+    std::cout << "No Group : [FAILED]" << std::endl;
     return EXIT_FAILURE;
     }
   std::cout << " [PASSED]" << std::endl;
@@ -56,7 +56,7 @@ int itkFEMSolverTest3D(int argc, char *argv[])
   using FEMObjectSpatialObjectType = itk::FEMObjectSpatialObject<3>;
 
   FEMObjectSpatialObjectType::ChildrenListType* children = SpatialReader->GetGroup()->GetChildren();
-  if( strcmp( (*(children->begin() ) )->GetTypeName(), "FEMObjectSpatialObject") )
+  if( children->front()->GetTypeName() != "FEMObjectSpatialObject" )
     {
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;

--- a/Wrapping/Generators/Python/Tests/CMakeLists.txt
+++ b/Wrapping/Generators/Python/Tests/CMakeLists.txt
@@ -14,6 +14,7 @@ itk_python_add_test(NAME PythonGetNameOfClass COMMAND getNameOfClass.py)
 itk_python_add_test(NAME PythonTiming COMMAND timing.py)
 itk_python_add_test(NAME PythonVerifyGetOutputAPIConsistency COMMAND verifyGetOutputAPIConsistency.py)
 itk_python_add_test(NAME PythonVerifyTTypeAPIConsistency COMMAND verifyTTypeAPIConsistency.py)
+itk_python_add_test(NAME PythonTypeTest COMMAND PythonTypeTest.py)
 itk_python_add_test(NAME PythonComplex COMMAND complex.py)
 itk_python_add_test(NAME PythonHelperFunctions COMMAND helpers.py)
 

--- a/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
@@ -58,7 +58,12 @@ assert isinstance(obj, itk.ImageFileReader)
 try:
     itk.ImageFileReader['unknown parameter']
     raise Exception('no exception sent for unknown parameter')
-except KeyError:
+except TypeError as e:
+    print("Exception caught!")
+    print(e)
+    if not "imread" in str(e):
+        raise Exception('Expected to find extra information about'
+                        ' `itk.imread()` in exception message.')
     pass
 
 # TODO: test the rest of the dict interface
@@ -264,6 +269,19 @@ if reader_error or other_error:
     print("Pixel Fill error: %s" % pixel_fill_error)
     print("Reader error: %s" % reader_error)
     raise AssertionError()
+
+# Try to instantiate a template type that does not exist that is
+# not an `itk.ImageFileReader` (tested above) since that object
+# is handled slightly differently.
+try:
+    itk.Image['unknown parameter'].New()
+    # We should never arrive to this point, so raise an exception if
+    # we do.
+    raise Exception('no exception sent for unknown parameter')
+except TypeError as e:
+    print("Exception caught!")
+    print(e)
+    pass
 
 # Test that ImageFileWriter can be called with filter given as input
 # with 'Input' keyword.

--- a/Wrapping/Generators/Python/Tests/PythonTypeTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTypeTest.py
@@ -1,0 +1,114 @@
+#==========================================================================
+#
+#   Copyright Insight Software Consortium
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+# a short program to check the value returned by the GetNameOfClass() methods
+
+from __future__ import print_function
+
+import itk
+import sys
+import types
+itk.auto_progress(2)
+
+# must force the load to return all the names with dir(itk)
+itk.force_load()
+
+wrongName = 0
+totalName = 0
+
+# a list of classes to exclude. Typically, the classes with a custom New()
+# method, which return a subclass of the current class
+exclude = [
+"ScanlineFilterCommon",  # Segfault
+"templated_class",
+"auto_pipeline",
+"pipeline"
+]
+
+
+def create_and_test(t, create_method):
+    wrongType = 0
+    # Local scope in which objects are created.
+    if create_method == 'New':
+        I = t.New()
+    elif create_method == 'call':
+        try:
+            I = t()
+        except:  # Call function needs parameters or class is abstract
+            return 0, 0
+    else:
+        return 0, 0  # Do not add anything to `totalName` and `wrongName`.
+    obj_type = itk.python_type(I)
+    # If class is virtual, actual type could be different from expected type
+    actual_type = type(I)
+    totalName = 1
+    # Check that there is no C++ character left in Python obj_type
+    if any(substring in obj_type for substring in ['<', ':', '>', 'class', 'itkTemplate', 'std', ' ', '(', ')', 'itkCType']):
+            msg = "%s: wrong Python class name: %s" % (t, obj_type)
+            wrongType = 1
+    else:
+        try:
+            if eval(obj_type) != actual_type:
+                msg = "%s: wrong Python class name: %s" % (actual_type, obj_type)
+                wrongType = 1
+        except Exception as e:
+            msg = ("%s: wrong Python class name: %s. "
+            "Exception while evaluating it: %s" %
+            (t, obj_type, e.message))
+            wrongType = 1
+    if wrongType:
+        print(msg, file=sys.stderr)
+    return totalName, wrongType
+
+def create_method(i):
+    if 'New' in dir(i):
+        return 'New'
+    elif '__call__' in dir(i) and not isinstance(i, types.FunctionType):
+        return 'call'
+    else:
+        return None
+
+for t in dir(itk):
+    if t not in exclude:
+        T = itk.__dict__[t]
+        # first case - that's a templated class
+        if isinstance(T, itk.Vector.__class__) and len(T) > 0:
+            for k in T.keys():
+                i = T[k]
+                # GetNameOfClass() is a virtual method of the LightObject class,
+                # so we must instantiate an object with the New() method
+                t, w = create_and_test(i, create_method(i))
+                wrongName += w
+                totalName += t
+        else:
+            t, w = create_and_test(T, create_method(T))
+            wrongName += w
+            totalName += t
+
+print("%s classes checked." % totalName)
+if wrongName:
+    print(
+        "%s classes are not providing the correct Python class name." % wrongName,
+        file=sys.stderr)
+    sys.exit(1)
+
+# Also test for Python types:
+assert "int" == itk.python_type(int)
+assert "int" == itk.python_type(3)
+assert "list" == itk.python_type(list)
+assert "list" == itk.python_type([])

--- a/Wrapping/Generators/Python/Tests/findEmptyClasses.py
+++ b/Wrapping/Generators/Python/Tests/findEmptyClasses.py
@@ -67,6 +67,10 @@ exclude = ["AuthalicMatrixCoefficients",
            "vnl_file_matrix",
            "vnl_file_vector",
            "vnl_fortran_copy",
+           "CosineWindowFunction",
+           "HammingWindowFunction",
+           "LanczosWindowFunction",
+           "WelchWindowFunction",
            ]
 
 total = 0

--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -429,6 +429,61 @@ def class_(obj):
     else:
         return obj.__class__
 
+def python_type(obj):
+    """Returns the Python type name of an object
+
+    The Python name corresponding to the given instantiated object is printed.
+    This includes both the Python name and the parameters of the object. A user
+    can copy and paste the printed value to instantiate a new object of the
+    same type."""
+    import itkTemplate
+    from itkTypes import itkCType
+
+    def in_itk(name):
+        import itk
+        # Remove "itk::" and "std::" from template name.
+        # Only happens for ITK objects.
+        shortname = name.split('::')[-1]
+        shortname = shortname.split('itk')[-1]
+
+        namespace = itk
+        # A type cannot be part of ITK if its name was not modified above. This
+        # check avoids having an input of type `list` and return `itk.list` that
+        # also exists.
+        likely_itk = (shortname != name or name[:3] == 'vnl')
+        if likely_itk and hasattr(namespace, shortname):
+            return namespace.__name__ + '.' + shortname  # Prepend name with 'itk.'
+        else:
+            return name
+
+    def recursive(obj, level):
+        try:
+            T, P = template(obj)
+            name = in_itk(T.__name__)
+            parameters = []
+            for t in P:
+                parameters.append(recursive(t, level+1))
+            return name + "[" + ",".join(parameters) + "]"
+        except KeyError:
+            if isinstance(obj, itkCType):  # Handles CTypes differently
+                return 'itk.' + obj.short_name
+            elif hasattr(obj, "__name__"):
+                # This should be where most ITK types end up.
+                return in_itk(obj.__name__)
+            elif (not isinstance(obj, type)
+                  and type(obj) != itkTemplate.itkTemplate and level != 0):
+                # obj should actually be considered a value, not a type,
+                # or it is already an itkTemplate type.
+                # A value can be an integer that is a template parameter.
+                # This does not happen at the first level of the recursion
+                # as it is not possible that this object would be a template
+                # parameter. Checking the level `0` allows e.g. to find the
+                # type of an object that is a `list` or an `int`.
+                return str(obj)
+            else:
+                return in_itk(type(obj).__name__)
+    return recursive(obj, 0)
+
 
 def range(image_or_filter):
     """Return the range of values in a image of in the output image of a filter

--- a/Wrapping/Generators/Python/itkTemplate.py
+++ b/Wrapping/Generators/Python/itkTemplate.py
@@ -57,6 +57,66 @@ def normalizeName(name):
     return name
 
 
+class TemplateTypeError(TypeError):
+    def __init__(self, template_type, input_type):
+        def tuple_to_string_type(t):
+            if type(t) == tuple:
+                return ", ".join(itk.python_type(x) for x in t)
+            else:
+                itk.python_type(t)
+
+        import itk
+        # Special case for ITK image readers: Add extra information.
+        extra_eg = ""
+        if template_type in [itk.ImageFileReader, itk.ImageSeriesReader]:
+            extra_eg="""
+
+or
+
+    e.g.: image = itk.imread(my_input_filename, itk.F)
+"""
+
+        python_template_type = itk.python_type(template_type)
+        python_input_type = tuple_to_string_type(input_type)
+        type_list = "\n".join([itk.python_type(x[0]) for x in template_type.keys()])
+        eg_type = ", ".join([itk.python_type(x) for x in list(template_type.keys())[0]])
+        msg = """{template_type} is not wrapped for input type `{input_type}`.
+
+To limit the size of the package, only a limited number of
+types are available in ITK Python. To print the supported
+types, run the following command in your python environment:
+
+    {template_type}.GetTypes()
+
+Possible solutions:
+* If you are an application user:
+** Convert your input image into a supported format (see below).
+** Contact developer to report the issue.
+* If you are an application developer, force input images to be
+loaded in a supported pixel type.
+
+    e.g.: instance = {template_type}[{eg_type}].New(my_input){extra_eg}
+
+* (Advanced) If you are an application developer, build ITK Python yourself and
+turned to `ON` the corresponding CMake option to wrap the pixel type or image
+dimension you need. When configuring ITK with CMake, you can set
+`ITK_WRAP_${{type}}` (replace ${{type}} with appropriate pixel type such as
+`double`). If you need to support images with 4 or 5 dimensions, you can add
+these dimensions to the list of dimensions in the CMake variable
+`ITK_WRAP_IMAGE_DIMS`.
+
+Supported input types:
+
+{type_list}
+""".format(template_type=python_template_type,
+           input_type=python_input_type,
+           type_list=type_list,
+           eg_type=eg_type,
+           extra_eg=extra_eg
+           )
+        TypeError.__init__(self, msg)
+
+
 class itkTemplate(object):
 
     """This class manages access to available template arguments of a C++ class.
@@ -277,9 +337,7 @@ class itkTemplate(object):
             try:
                 return(self.__template__[tuple(cleanParameters)])
             except:
-                raise KeyError(
-                    'itkTemplate : No template %s for the %s class' %
-                    (str(parameters), self.__name__))
+                raise TemplateTypeError(self, tuple(cleanParameters))
 
     def __repr__(self):
         return '<itkTemplate %s>' % self.__name__
@@ -445,7 +503,12 @@ class itkTemplate(object):
             keys = [k for k in keys if k[0] == input_type]
 
         if len(keys) == 0:
-            raise RuntimeError("No suitable template parameter can be found.")
+            if not input_type:
+                raise RuntimeError("""No suitable template parameter can be found.
+Please specify an input via the first argument or via one of the following
+keyword arguments: %s""" % ", ".join(primary_input_methods))
+            else:
+                raise TemplateTypeError(self, input_type)
         return self[list(keys)[0]].New(*args, **kwargs)
 
     def _NewImageReader(self, TemplateReaderType, increase_dimension, primaryInputMethod, *args, **kwargs):


### PR DESCRIPTION
This PR improves Python error messages when trying to instantiates an ITK object with template parameters that have not been wrapped. The error message relies on a new ITK Python function that prints the Python type of an ITK object in a way that can simply be copy/pasted by the user in Python instead of a C++ style.