### PR TITLE
ENH: Update compiler macros

### DIFF
--- a/Modules/Core/Common/CMake/itkCheckHasGNUAttributeAligned.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasGNUAttributeAligned.cxx
@@ -14,10 +14,6 @@ struct B
   char b;
 } __attribute__ ((aligned (64)));
 
-// fail for gcc 4.1
-#if __GNUC__ == 4 && __GNUC_MINOR__ == 1
-#error This version of GCC is know to have a internal compilation error with this feature in ITK.
-#endif
 
 // BUG DETECTION: This following usage may generate a segfault during
 // compilation.

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -115,12 +115,10 @@ namespace itk
 //
 // These macros respectively push and pop the diagnostic context
 //
-// Define macro ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
 #if defined( __GNUC__ ) && !defined( __INTEL_COMPILER )
   #define ITK_GCC_PRAGMA_DIAG(x) ITK_PRAGMA(GCC diagnostic x)
   #define ITK_GCC_PRAGMA_DIAG_PUSH() ITK_GCC_PRAGMA_DIAG(push)
   #define ITK_GCC_PRAGMA_DIAG_POP() ITK_GCC_PRAGMA_DIAG(pop)
-  #define ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
 #else
   #define ITK_GCC_PRAGMA_DIAG(x)
   #define ITK_GCC_PRAGMA_DIAG_PUSH()
@@ -128,7 +126,7 @@ namespace itk
 #endif
 
 /*
- * ITK only supports MSVC++ 10.0 and greater
+ * ITK only supports MSVC++ 14.0 and greater
  * MSVC++ 14.0 _MSVC_VER = 1900
  * MSVC++ 12.0 _MSC_VER = 1800
  * MSVC++ 11.0 _MSC_VER = 1700
@@ -140,11 +138,11 @@ namespace itk
  * MSVC++ 6.0 _MSC_VER = 1200
  * MSVC++ 5.0 _MSC_VER = 1100
 */
-#if defined( _MSC_VER ) && ( _MSC_VER < 1600 )
-  #error "MSVC++ < 10.0 is not supported under ITKv5"
+#if defined( _MSC_VER ) && ( _MSC_VER < 1900 )
+  #error "Visual Studio < 2015 is not supported under ITKv5"
 #endif
-#if defined( __SUNPRO_CC ) && ( __SUNPRO_CC < 0x590 )
-  #error "SUNPro C++ < 0x590 is not supported under ITKv4 and above"
+#if defined( __SUNPRO_CC ) && ( __SUNPRO_CC < 0x5140 )
+  #error "SUNPro C++ < 5.14.0 is not supported under ITKv4 and above"
 #endif
 #if defined( __CYGWIN__ )
   #error "The Cygwin compiler is not supported in ITKv4 and above"
@@ -171,8 +169,8 @@ namespace itk
 #elif defined( __clang__ ) && (( __clang_major < 3 ) || (( __clang_major__ == 3 ) && ( __clang_minor__ < 3 )))
   #error "Clang < 3.3 is not supported under ITKv5"
 #endif
-#if defined( __INTEL_COMPILER ) && ( __INTEL_COMPILER < 1600 )
-  #error "Intel C++ < 16.0 is not supported under ITKv5"
+#if defined( __INTEL_COMPILER ) && ( __INTEL_COMPILER < 1504 )
+  #error "Intel C++ < 15.0.4 is not supported under ITKv5"
 #endif
 
 // Setup symbol exports
@@ -563,7 +561,7 @@ itkTypeMacro(newexcp, parentexcp);                                \
 #else
 // Setup compile-time warnings for uses of deprecated methods if
 // possible on this compiler.
-#if defined( __GNUC__ ) && !defined( __INTEL_COMPILER ) && ( __GNUC__ > 3 || ( __GNUC__ == 3 && __GNUC_MINOR__ >= 1 ) )
+#if defined( __GNUC__ ) && !defined( __INTEL_COMPILER )
 #define itkLegacyMacro(method) method __attribute__( ( deprecated ) )
 #elif defined( _MSC_VER )
 #define itkLegacyMacro(method) __declspec(deprecated) method
@@ -762,11 +760,7 @@ compilers.
  * and is beneficial in other cases where a value can be constant.
  *
  * \ingroup ITKCommon */
-#if defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__ ) < 405 && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
-#  define itkStaticConstMacro(name,type,value) enum { name = value }
-#else
-#  define itkStaticConstMacro(name,type,value) static constexpr type name = value
-#endif
+#define itkStaticConstMacro(name,type,value) static constexpr type name = value
 
 #define itkGetStaticConstMacro(name) (Self::name)
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -127,22 +127,21 @@ namespace itk
 
 /*
  * ITK only supports MSVC++ 14.0 and greater
- * MSVC++ 14.0 _MSVC_VER = 1900
- * MSVC++ 12.0 _MSC_VER = 1800
- * MSVC++ 11.0 _MSC_VER = 1700
- * MSVC++ 10.0 _MSC_VER = 1600
- * MSVC++ 9.0 _MSC_VER = 1500
- * MSVC++ 8.0 _MSC_VER = 1400
- * MSVC++ 7.1 _MSC_VER = 1310
- * MSVC++ 7.0 _MSC_VER = 1300
- * MSVC++ 6.0 _MSC_VER = 1200
- * MSVC++ 5.0 _MSC_VER = 1100
+ * MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015 version 14.0)
+ * MSVC++ 14.1 _MSC_VER == 1910 (Visual Studio 2017 version 15.0)
+ * MSVC++ 14.11 _MSC_VER == 1911 (Visual Studio 2017 version 15.3)
+ * MSVC++ 14.12 _MSC_VER == 1912 (Visual Studio 2017 version 15.5)
+ * MSVC++ 14.13 _MSC_VER == 1913 (Visual Studio 2017 version 15.6)
+ * MSVC++ 14.14 _MSC_VER == 1914 (Visual Studio 2017 version 15.7)
+ * MSVC++ 14.15 _MSC_VER == 1915 (Visual Studio 2017 version 15.8)
+ * MSVC++ 14.16 _MSC_VER == 1916 (Visual Studio 2017 version 15.9)
+ * MSVC++ 14.2 _MSC_VER == 1920 (Visual Studio 2019 Version 16.0)
 */
 #if defined( _MSC_VER ) && ( _MSC_VER < 1900 )
   #error "Visual Studio < 2015 is not supported under ITKv5"
 #endif
 #if defined( __SUNPRO_CC ) && ( __SUNPRO_CC < 0x5140 )
-  #error "SUNPro C++ < 5.14.0 is not supported under ITKv4 and above"
+  #error "SUNPro C++ < 5.14.0 is not supported under ITKv5 and above"
 #endif
 #if defined( __CYGWIN__ )
   #error "The Cygwin compiler is not supported in ITKv4 and above"

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -77,77 +77,60 @@ namespace itk
 // The following set of defines allows us to suppress false positives
 // and still track down suspicious code
 #if defined(__clang__) && defined(__has_warning)
-#define CLANG_PRAGMA_PUSH ITK_PRAGMA(clang diagnostic push)
-#define CLANG_PRAGMA_POP  ITK_PRAGMA(clang diagnostic pop)
-#if __has_warning("-Wfloat-equal")
-#define CLANG_SUPPRESS_Wfloat_equal ITK_PRAGMA( clang diagnostic ignored "-Wfloat-equal" )
+  #define CLANG_PRAGMA_PUSH ITK_PRAGMA(clang diagnostic push)
+  #define CLANG_PRAGMA_POP  ITK_PRAGMA(clang diagnostic pop)
+  #if __has_warning("-Wfloat-equal")
+    #define CLANG_SUPPRESS_Wfloat_equal ITK_PRAGMA( clang diagnostic ignored "-Wfloat-equal" )
+  #else
+    #define CLANG_SUPPRESS_Wfloat_equal
+  #endif
+  #if __has_warning( "-Wc++14-extensions" )
+    #define CLANG_SUPPRESS_Wc__14_extensions ITK_PRAGMA( clang diagnostic ignored "-Wc++14-extensions" )
+  #else
+    #define CLANG_SUPPRESS_Wc__14_extensions
+  #endif
 #else
-#define CLANG_SUPPRESS_Wfloat_equal
-#endif
-#if __has_warning( "-Wc++14-extensions" )
-#define CLANG_SUPPRESS_Wc__14_extensions ITK_PRAGMA( clang diagnostic ignored "-Wc++14-extensions" )
-#else
-#define CLANG_SUPPRESS_Wc__14_extensions
-#endif
-#else
-#define CLANG_PRAGMA_PUSH
-#define CLANG_PRAGMA_POP
-#define CLANG_SUPPRESS_Wfloat_equal
-#define CLANG_SUPPRESS_Wc__14_extensions
+  #define CLANG_PRAGMA_PUSH
+  #define CLANG_PRAGMA_POP
+  #define CLANG_SUPPRESS_Wfloat_equal
+  #define CLANG_SUPPRESS_Wc__14_extensions
 #endif
 
 // Intel compiler convenience macros
 #if defined(__INTEL_COMPILER)
-#define INTEL_PRAGMA_WARN_PUSH ITK_PRAGMA(warning push)
-#define INTEL_PRAGMA_WARN_POP  ITK_PRAGMA(warning pop)
-#define INTEL_SUPPRESS_warning_1292  ITK_PRAGMA(warning disable 1292)
+  #define INTEL_PRAGMA_WARN_PUSH ITK_PRAGMA(warning push)
+  #define INTEL_PRAGMA_WARN_POP  ITK_PRAGMA(warning pop)
+  #define INTEL_SUPPRESS_warning_1292  ITK_PRAGMA(warning disable 1292)
 #else
-#define INTEL_PRAGMA_WARN_PUSH
-#define INTEL_PRAGMA_WARN_POP
-#define INTEL_SUPPRESS_warning_1292
+  #define INTEL_PRAGMA_WARN_PUSH
+  #define INTEL_PRAGMA_WARN_POP
+  #define INTEL_SUPPRESS_warning_1292
 #endif
 
 // Define ITK_GCC_PRAGMA_DIAG(param1 [param2 [...]]) macro.
 //
-// This macros sets a pragma diagnostic if it supported by the version
-// of GCC being used otherwise it is a no-op.
+// This macro sets a pragma diagnostic
 //
-// GCC diagnostics pragma supported only with GCC >= 4.2
-#if defined( __GNUC__ ) && !defined( __INTEL_COMPILER )
-#  if ( __GNUC__ > 4 ) || (( __GNUC__ >= 4 ) && ( __GNUC_MINOR__ >= 2 ))
-#    define ITK_GCC_PRAGMA_DIAG(x) ITK_PRAGMA(GCC diagnostic x)
-#  else
-#    define ITK_GCC_PRAGMA_DIAG(x)
-#  endif
-#else
-#  define ITK_GCC_PRAGMA_DIAG(x)
-#endif
-
 // Define ITK_GCC_PRAGMA_DIAG_(PUSH|POP) macros.
 //
 // These macros respectively push and pop the diagnostic context
-// if it is supported by the version of GCC being used
-// otherwise it is a no-op.
 //
-// GCC push/pop diagnostics pragma are supported only with GCC >= 4.6
-//
-// Define macro ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP if it is supported.
+// Define macro ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
 #if defined( __GNUC__ ) && !defined( __INTEL_COMPILER )
-#  if ( __GNUC__ > 4 ) || (( __GNUC__ >= 4 ) && ( __GNUC_MINOR__ >= 6 ))
-#    define ITK_GCC_PRAGMA_DIAG_PUSH() ITK_GCC_PRAGMA_DIAG(push)
-#    define ITK_GCC_PRAGMA_DIAG_POP() ITK_GCC_PRAGMA_DIAG(pop)
-#    define ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-#  else
-#    define ITK_GCC_PRAGMA_DIAG_PUSH()
-#    define ITK_GCC_PRAGMA_DIAG_POP()
-#  endif
+  #define ITK_GCC_PRAGMA_DIAG(x) ITK_PRAGMA(GCC diagnostic x)
+  #define ITK_GCC_PRAGMA_DIAG_PUSH() ITK_GCC_PRAGMA_DIAG(push)
+  #define ITK_GCC_PRAGMA_DIAG_POP() ITK_GCC_PRAGMA_DIAG(pop)
+  #define ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
 #else
-#  define ITK_GCC_PRAGMA_DIAG_PUSH()
-#  define ITK_GCC_PRAGMA_DIAG_POP()
+  #define ITK_GCC_PRAGMA_DIAG(x)
+  #define ITK_GCC_PRAGMA_DIAG_PUSH()
+  #define ITK_GCC_PRAGMA_DIAG_POP()
 #endif
 
 /*
- * ITK only supports MSVC++ 7.1 and greater
+ * ITK only supports MSVC++ 10.0 and greater
+ * MSVC++ 14.0 _MSVC_VER = 1900
+ * MSVC++ 12.0 _MSC_VER = 1800
  * MSVC++ 11.0 _MSC_VER = 1700
  * MSVC++ 10.0 _MSC_VER = 1600
  * MSVC++ 9.0 _MSC_VER = 1500
@@ -157,29 +140,39 @@ namespace itk
  * MSVC++ 6.0 _MSC_VER = 1200
  * MSVC++ 5.0 _MSC_VER = 1100
 */
-#if defined( _MSC_VER ) && ( _MSC_VER < 1310 )
-//#error "_MSC_VER < 1310 (MSVC++ 7.1) not supported under ITKv4"
+#if defined( _MSC_VER ) && ( _MSC_VER < 1600 )
+  #error "MSVC++ < 10.0 is not supported under ITKv5"
 #endif
 #if defined( __SUNPRO_CC ) && ( __SUNPRO_CC < 0x590 )
-#error "__SUNPRO_CC < 0x590 not supported under ITKv4"
+  #error "SUNPro C++ < 0x590 is not supported under ITKv4 and above"
 #endif
 #if defined( __CYGWIN__ )
-#error "The Cygwin compiler is not supported in ITKv4 and above"
+  #error "The Cygwin compiler is not supported in ITKv4 and above"
 #endif
 #if defined( __BORLANDC__ )
-#error "The Borland C compiler is not supported in ITKv4 and above"
+  #error "The Borland C compiler is not supported in ITKv4 and above"
 #endif
 #if defined( __MWERKS__ )
-#error "The MetroWerks compiler is not supported in ITKv4 and above"
+  #error "The MetroWerks compiler is not supported in ITKv4 and above"
 #endif
-#if defined( __GNUC__ ) && ( __GNUC__ < 3 )
-#error "The __GNUC__ version 2.95 compiler is not supprted under ITKv4 and above"
+#if defined( __GNUC__ ) && !defined(__clang__) && !defined(__INTEL_COMPILER) && (( __GNUC__ < 4 ) || (( __GNUC__ == 4 ) && ( __GNUC_MINOR__ < 8 )))
+  #error "GCC < 4.8 is not supported under ITKv5"
+#endif
 #if defined( __sgi )
-//This is true for IRIX 6.5.18m with MIPSPro 7.3.1.3m.
-//TODO: At some future point, it may be necessary to
-//define a minimum __sgi version that will work.
-#error "The __sgi compiler is not supprted under ITKv4 and above"
+  //This is true for IRIX 6.5.18m with MIPSPro 7.3.1.3m.
+  //TODO: At some future point, it may be necessary to
+  //define a minimum __sgi version that will work.
+  #error "The SGI compiler is not supprted under ITKv4 and above"
 #endif
+#if defined(__APPLE__)
+  #if defined( __clang__ ) && (( __clang_major__ < 8 ) || (( __clang_major__ == 8 ) && ( __clang_minor__ < 1 )))
+    #error "Apple LLVM < 8.1 is not supported under ITKv5"
+  #endif
+#elif defined( __clang__ ) && (( __clang_major < 3 ) || (( __clang_major__ == 3 ) && ( __clang_minor__ < 3 )))
+  #error "Clang < 3.3 is not supported under ITKv5"
+#endif
+#if defined( __INTEL_COMPILER ) && ( __INTEL_COMPILER < 1600 )
+  #error "Intel C++ < 16.0 is not supported under ITKv5"
 #endif
 
 // Setup symbol exports

--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -264,9 +264,7 @@ inline bool ExposeMetaData(const MetaDataDictionary & Dictionary, const std::str
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject< bool >;
@@ -294,11 +292,7 @@ extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject< Array<float> >;
 extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject< Array<double> >;
 extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject< Matrix<double> >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKCommon_EXPORT_EXPLICIT

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -173,9 +173,7 @@ public:
    * (void *)arg passed into the SetSingleMethod.
    *
    * DEPRECATED! Use WorkUnitInfo instead. */
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 INTEL_PRAGMA_WARN_PUSH
 INTEL_SUPPRESS_warning_1292
@@ -195,11 +193,7 @@ INTEL_PRAGMA_WARN_POP
     ThreadFunctionType ThreadFunction;
     enum { SUCCESS, ITK_EXCEPTION, ITK_PROCESS_ABORTED_EXCEPTION, STD_EXCEPTION, UNKNOWN } ThreadExitCode;
     };
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 #endif //ITK_LEGACY_REMOVE
 
   /** This is the structure that is passed to the thread that is

--- a/Modules/Core/Common/include/itkSimpleDataObjectDecorator.hxx
+++ b/Modules/Core/Common/include/itkSimpleDataObjectDecorator.hxx
@@ -41,18 +41,12 @@ SimpleDataObjectDecorator< T >
 ::SimpleDataObjectDecorator()
 {
 #if defined( __GNUC__ ) && ( __GNUC__ > 6 )
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wmaybe-uninitialized")
 #endif // defined( __GNUC__ ) && ( __GNUC__ > 6 )
   this->m_Component = ComponentType(); // initialize here to avoid Purify UMR
 #if defined( __GNUC__ ) && ( __GNUC__ > 6 )
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wmaybe-uninitialized")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 #endif // defined( __GNUC__ ) && ( __GNUC__ > 6 )
   this->m_Initialized = false;         // Still needed since not all objects
                                        // are initialized at construction time.

--- a/Modules/Core/Common/include/itkStaticAssert.h
+++ b/Modules/Core/Common/include/itkStaticAssert.h
@@ -33,9 +33,8 @@
  * \ingroup ITKCommon
  */
 #   define itkStaticAssert(expr, str) static_assert(expr, str)
-#elif defined(__GNUC__) && ((__GNUC__ * 100) + __GNUC_MINOR__ ) >= 403 && !defined(__clang__) && !defined( __INTEL_COMPILER )
-//  GCC 4.3 is enough for this trick
-//  But it restricts the static assertion to non global contexts (-> functions)
+#elif defined(__GNUC__) && !defined( __INTEL_COMPILER )
+//  This trick restricts the static assertion to non global contexts (-> functions)
 #   define itkStaticAssert(expr,str)                                  \
       ({extern int __attribute__((error(str))) StaticAssertFailure(); \
        ((void)((expr) ? 0: StaticAssertFailure()), 0);                \

--- a/Modules/Core/Common/src/itkLightObject.cxx
+++ b/Modules/Core/Common/src/itkLightObject.cxx
@@ -20,10 +20,8 @@
 #include <mutex>
 
 // Better name demanging for gcc
-#if __GNUC__ > 3 || ( __GNUC__ == 3 && __GNUC_MINOR__ > 0 )
 #ifndef __EMSCRIPTEN__
 #define GCC_USEDEMANGLE
-#endif
 #endif
 
 #ifdef GCC_USEDEMANGLE

--- a/Modules/Core/Common/src/itkLightObject.cxx
+++ b/Modules/Core/Common/src/itkLightObject.cxx
@@ -20,7 +20,7 @@
 #include <mutex>
 
 // Better name demanging for gcc
-#ifndef __EMSCRIPTEN__
+#if defined( __GNUC__ ) && !defined( __EMSCRIPTEN__ )
 #define GCC_USEDEMANGLE
 #endif
 

--- a/Modules/Core/Common/src/itkMetaDataObject.cxx
+++ b/Modules/Core/Common/src/itkMetaDataObject.cxx
@@ -21,9 +21,7 @@
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKCommon_EXPORT MetaDataObject< bool >;
@@ -51,10 +49,6 @@ template class ITKCommon_EXPORT MetaDataObject< std::vector<double> >;
 template class ITKCommon_EXPORT MetaDataObject< std::vector<std::vector<double> > >;
 template class ITKCommon_EXPORT MetaDataObject< std::vector<std::vector<float> > >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk

--- a/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
@@ -72,8 +72,6 @@ int itkMetaDataDictionaryTest(int , char * [])
   MyDictionary.Print(std::cout);
 
 
-  // Iterator are broken on VS6
-#if !(defined(_MSC_VER) && _MSC_VER < 1300)
   std::cout << "Exercise the Iterator access" << std::endl;
   try
     {
@@ -165,7 +163,6 @@ int itkMetaDataDictionaryTest(int , char * [])
     }
 
 
-#endif
 
   //NOTE: Must clean up memory allocated with char * StrandedMemory=new char[2345];
   delete[] StrandedMemory;

--- a/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
@@ -163,7 +163,6 @@ int itkMetaDataDictionaryTest(int , char * [])
     }
 
 
-
   //NOTE: Must clean up memory allocated with char * StrandedMemory=new char[2345];
   delete[] StrandedMemory;
 

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -20,10 +20,8 @@
 #include <cstddef>
 
 // Better name demanging for gcc
-#if __GNUC__ > 3 || ( __GNUC__ == 3 && __GNUC_MINOR__ > 0 )
 #ifndef __EMSCRIPTEN__
 #define GCC_USEDEMANGLE
-#endif
 #endif
 
 #ifdef GCC_USEDEMANGLE

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -20,7 +20,7 @@
 #include <cstddef>
 
 // Better name demanging for gcc
-#ifndef __EMSCRIPTEN__
+#if defined( __GNUC__ ) && !defined( __EMSCRIPTEN__ )
 #define GCC_USEDEMANGLE
 #endif
 

--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -143,11 +143,6 @@ TEST(SmartPointer, EmptyAndNull)
 //  EXPECT_TRUE( 0 == ptr );
 
 }
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wconversion-null")
-#endif
 
 
 TEST(SmartPointer,Converting)

--- a/Modules/Core/Transform/include/itkTransformBase.h
+++ b/Modules/Core/Transform/include/itkTransformBase.h
@@ -165,17 +165,11 @@ using TransformBase = TransformBaseTemplate< double >;
 #  endif
 namespace itk
 {
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 extern template class ITKTransform_EXPORT_EXPLICIT TransformBaseTemplate< double >;
 extern template class ITKTransform_EXPORT_EXPLICIT TransformBaseTemplate< float >;
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 } // end namespace itk
 #  undef ITKTransform_EXPORT_EXPLICIT
 #endif

--- a/Modules/Core/Transform/src/itkTransformBase.cxx
+++ b/Modules/Core/Transform/src/itkTransformBase.cxx
@@ -22,18 +22,12 @@
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKTransform_EXPORT TransformBaseTemplate< double >;
 template class ITKTransform_EXPORT TransformBaseTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }  // end namespace itk

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -28,7 +28,7 @@
 
 
 // Better name demanging for gcc
-#ifndef __EMSCRIPTEN__
+#if defined( __GNUC__ ) && !defined( __EMSCRIPTEN__ )
 #define GCC_USEDEMANGLE
 #endif
 

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -28,10 +28,8 @@
 
 
 // Better name demanging for gcc
-#if __GNUC__ > 3 || ( __GNUC__ == 3 && __GNUC_MINOR__ > 0 )
 #ifndef __EMSCRIPTEN__
 #define GCC_USEDEMANGLE
-#endif
 #endif
 
 #ifdef GCC_USEDEMANGLE

--- a/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
@@ -26,10 +26,8 @@
 #include <type_traits>
 
 // Better name demanging for gcc
-#if __GNUC__ > 3 || ( __GNUC__ == 3 && __GNUC_MINOR__ > 0 )
 #ifndef __EMSCRIPTEN__
 #define GCC_USEDEMANGLE
-#endif
 #endif
 
 #ifdef GCC_USEDEMANGLE

--- a/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
@@ -26,7 +26,7 @@
 #include <type_traits>
 
 // Better name demanging for gcc
-#ifndef __EMSCRIPTEN__
+#if defined( __GNUC__ ) && !defined( __EMSCRIPTEN__ )
 #define GCC_USEDEMANGLE
 #endif
 

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -160,11 +160,7 @@ int itkReadWriteImageWithDictionaryTest(int argc, char* argv[])
   std::cout<<std::endl<<"Number of missing metadata = "<<numMissingMetaData<<std::endl;
   std::cout<<"Number of wrong metadata = "<<numWrongMetaData<<std::endl<<std::endl;
 
-  /** the visual studio 6 compiler cannot dereference iterator outside
-   * of the dll */
-#if defined(_MSC_VER) && (_MSC_VER <= 1300) && !defined(ITKSTATIC)
-  return EXIT_SUCCESS;
-#else
+
   // Perform a weaker but more exhaustive test
   int numMissingMetaData2 = 0;
   int numWrongMetaData2 = 0;
@@ -213,5 +209,4 @@ int itkReadWriteImageWithDictionaryTest(int argc, char* argv[])
     }
 
   return EXIT_SUCCESS;
-#endif
 }

--- a/Modules/IO/TransformBase/include/itkCompositeTransformIOHelper.h
+++ b/Modules/IO/TransformBase/include/itkCompositeTransformIOHelper.h
@@ -118,19 +118,13 @@ using CompositeTransformIOHelper = CompositeTransformIOHelperTemplate<double>;
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
   extern template class ITKIOTransformBase_EXPORT_EXPLICIT CompositeTransformIOHelperTemplate< double >;
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT CompositeTransformIOHelperTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKIOTransformBase_EXPORT_EXPLICIT

--- a/Modules/IO/TransformBase/include/itkTransformFileReader.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileReader.h
@@ -127,19 +127,13 @@ using TransformFileReader = itk::TransformFileReaderTemplate<double>;
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT TransformFileReaderTemplate< double >;
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT TransformFileReaderTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKIOTransformBase_EXPORT_EXPLICIT

--- a/Modules/IO/TransformBase/include/itkTransformFileWriter.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileWriter.h
@@ -117,20 +117,14 @@ private:
 /** This helps to meet backward compatibility */
 using TransformFileWriter = itk::TransformFileWriterTemplate<double>;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 /** Declare specializations */
 template<> void ITKIOTransformBase_TEMPLATE_EXPORT TransformFileWriterTemplate< double >::PushBackTransformList(const Object *transObj);
 template<> void ITKIOTransformBase_TEMPLATE_EXPORT TransformFileWriterTemplate< float >::PushBackTransformList(const Object *transObj);
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // namespace itk
 
@@ -162,19 +156,13 @@ template<> void ITKIOTransformBase_TEMPLATE_EXPORT TransformFileWriterTemplate< 
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT TransformFileWriterTemplate< double >;
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT TransformFileWriterTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKIOTransformBase_EXPORT_EXPLICIT

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -225,19 +225,13 @@ using TransformIOBase = itk::TransformIOBaseTemplate<double>;
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT TransformIOBaseTemplate< double >;
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT TransformIOBaseTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKIOTransformBase_EXPORT_EXPLICIT

--- a/Modules/IO/TransformBase/include/itkTransformIOFactory.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOFactory.h
@@ -93,19 +93,13 @@ using TransformIOFactory = TransformIOFactoryTemplate<double>;
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT TransformIOFactoryTemplate< double >;
 extern template class ITKIOTransformBase_EXPORT_EXPLICIT TransformIOFactoryTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKIOTransformBase_EXPORT_EXPLICIT

--- a/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
+++ b/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
@@ -32,9 +32,7 @@ namespace
     return rval;
   }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wunused-function")
   template<>
   std::string GetTransformDimensionAsString<2>()
@@ -91,11 +89,7 @@ ITK_GCC_PRAGMA_DIAG(ignored "-Wunused-function")
     std::string rval("9_9");
     return rval;
   }
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wunused-function")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }
 
@@ -211,18 +205,12 @@ CompositeTransformIOHelperTemplate<TParametersValueType>
   return 1;
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformBase_EXPORT CompositeTransformIOHelperTemplate< double >;
 template class ITKIOTransformBase_EXPORT CompositeTransformIOHelperTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }  // end namespace itk

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -203,18 +203,12 @@ void TransformFileReaderTemplate<TParametersValueType>
   os << indent << "FileName: " << m_FileName << std::endl;
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformBase_EXPORT TransformFileReaderTemplate< double >;
 template class ITKIOTransformBase_EXPORT TransformFileReaderTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }  // end namespace itk

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -399,18 +399,12 @@ void TransformFileWriterTemplate<float>
     }
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformBase_EXPORT TransformFileWriterTemplate< double >;
 template class ITKIOTransformBase_EXPORT TransformFileWriterTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }

--- a/Modules/IO/TransformBase/src/itkTransformIOBase.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformIOBase.cxx
@@ -131,18 +131,12 @@ if ( !m_WriteTransformList.empty() )
   }
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformBase_EXPORT TransformIOBaseTemplate< double >;
 template class ITKIOTransformBase_EXPORT TransformIOBaseTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }  // end namespace itk

--- a/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
@@ -64,18 +64,12 @@ TransformIOFactoryTemplate<TParametersValueType>
   return nullptr;
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformBase_EXPORT TransformIOFactoryTemplate< double >;
 template class ITKIOTransformBase_EXPORT TransformIOFactoryTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }  // end namespace itk

--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
@@ -182,19 +182,13 @@ using HDF5TransformIO = HDF5TransformIOTemplate<double>;
 #  endif
 namespace itk
 {
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 extern template class ITKIOTransformHDF5_EXPORT_EXPLICIT HDF5TransformIOTemplate< double >;
 extern template class ITKIOTransformHDF5_EXPORT_EXPLICIT HDF5TransformIOTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKIOTransformHDF5_EXPORT_EXPLICIT

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -550,18 +550,12 @@ GetTransformName(int i)
   return s.str();
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformHDF5_EXPORT HDF5TransformIOTemplate< double >;
 template class ITKIOTransformHDF5_EXPORT HDF5TransformIOTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk

--- a/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIO.h
+++ b/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIO.h
@@ -107,19 +107,13 @@ using TxtTransformIO = TxtTransformIOTemplate<double>;
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 extern template class ITKIOTransformInsightLegacy_EXPORT_EXPLICIT TxtTransformIOTemplate< double >;
 extern template class ITKIOTransformInsightLegacy_EXPORT_EXPLICIT TxtTransformIOTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKIOTransformInsightLegacy_EXPORT_EXPLICIT

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
@@ -365,18 +365,12 @@ TxtTransformIOTemplate<TParametersValueType>
   out.close();
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformInsightLegacy_EXPORT TxtTransformIOTemplate< double >;
 template class ITKIOTransformInsightLegacy_EXPORT TxtTransformIOTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }  // end namespace itk

--- a/Modules/IO/TransformMINC/include/itkMINCTransformIO.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformIO.h
@@ -122,19 +122,13 @@ using MINCTransformIO = MINCTransformIOTemplate<double>;
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
   extern template class ITKIOTransformMINC_EXPORT_EXPLICIT MINCTransformIOTemplate< double >;
 extern template class ITKIOTransformMINC_EXPORT_EXPLICIT MINCTransformIOTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKIOTransformMINC_EXPORT_EXPLICIT

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -355,18 +355,12 @@ MINCTransformIOTemplate<TParametersValueType>
     }
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformMINC_EXPORT MINCTransformIOTemplate< double >;
 template class ITKIOTransformMINC_EXPORT MINCTransformIOTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }  // end namespace itk

--- a/Modules/IO/TransformMatlab/include/itkMatlabTransformIO.h
+++ b/Modules/IO/TransformMatlab/include/itkMatlabTransformIO.h
@@ -95,17 +95,11 @@ using MatlabTransformIO = MatlabTransformIOTemplate<double>;
 #  endif
 namespace itk
 {
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 extern template class ITKIOTransformMatlab_EXPORT_EXPLICIT MatlabTransformIOTemplate< double >;
 extern template class ITKIOTransformMatlab_EXPORT_EXPLICIT MatlabTransformIOTemplate< float >;
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 } // end namespace itk
 #  undef ITKIOTransformMatlab_EXPORT_EXPLICIT
 #endif

--- a/Modules/IO/TransformMatlab/src/itkMatlabTransformIO.cxx
+++ b/Modules/IO/TransformMatlab/src/itkMatlabTransformIO.cxx
@@ -150,18 +150,12 @@ MatlabTransformIOTemplate<ParametersValueType>
   out.close();
 }
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKIOTransformMatlab_EXPORT MatlabTransformIOTemplate< double >;
 template class ITKIOTransformMatlab_EXPORT MatlabTransformIOTemplate< float >;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 }  // end namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -303,19 +303,13 @@ using ObjectToObjectOptimizerBase = ObjectToObjectOptimizerBaseTemplate<double>;
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 extern template class ITKOptimizersv4_EXPORT_EXPLICIT ObjectToObjectOptimizerBaseTemplate<double>;
 extern template class ITKOptimizersv4_EXPORT_EXPLICIT ObjectToObjectOptimizerBaseTemplate<float>;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #  undef ITKOptimizersv4_EXPORT_EXPLICIT

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
@@ -21,18 +21,12 @@
 namespace itk
 {
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_PUSH()
-#endif
+ITK_GCC_PRAGMA_DIAG_PUSH()
 ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 
 template class ITKOptimizersv4_EXPORT ObjectToObjectOptimizerBaseTemplate<double>;
 template class ITKOptimizersv4_EXPORT ObjectToObjectOptimizerBaseTemplate<float>;
 
-#ifdef ITK_HAS_GCC_PRAGMA_DIAG_PUSHPOP
-  ITK_GCC_PRAGMA_DIAG_POP()
-#else
-  ITK_GCC_PRAGMA_DIAG(warning "-Wattributes")
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
@@ -243,9 +243,7 @@ public:
       return *this;
       }
 
-#if !(defined(_MSC_VER) && (_MSC_VER <= 1200))
   protected:
-#endif
     //This copy constructor is actually used in Iterator Begin()!
     Iterator(NeighborhoodIteratorType iter, InstanceIdentifier iid):ConstIterator( iter, iid )
       {

--- a/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
@@ -123,9 +123,7 @@ int itkMeasurementVectorTraitsTest(int, char* [] )
   itk::NumericTraits< MeasurementVectorType4b >::SetLength( measure4b, length2 );
 
   // against each other
-#if !(defined(_MSC_VER) && (_MSC_VER <= 1200))
   itkAssertSameLengthTest( measure1b, measure1b );
-#endif
   itkAssertSameLengthTest( measure2b, measure2b );
   itkAssertSameLengthTest( measure3b, measure3b );
   itkAssertSameLengthTest( measure4b, measure4b );
@@ -143,9 +141,7 @@ int itkMeasurementVectorTraitsTest(int, char* [] )
 
 
   // against each other
-#if !(defined(_MSC_VER) && (_MSC_VER <= 1200))
   itkAssertLengthExceptionMacro( measure1b, measure1bb );
-#endif
   itkAssertLengthExceptionMacro( measure2b, measure2bb );
   itkAssertLengthExceptionMacro( measure3b, measure3bb );
   itkAssertLengthExceptionMacro( measure4b, measure4bb );

--- a/Wrapping/Generators/Python/PatchedPython27pyconfig.h
+++ b/Wrapping/Generators/Python/PatchedPython27pyconfig.h
@@ -233,8 +233,7 @@ typedef int pid_t;
 #endif /* _MSC_VER */
 
 /* define some ANSI types that are not defined in earlier Win headers */
-#if defined(_MSC_VER) && _MSC_VER >= 1200
-/* This file only exists in VC 6.0 or higher */
+#if defined(_MSC_VER)
 #include <basetsd.h>
 #endif
 
@@ -272,13 +271,6 @@ typedef int pid_t;
 #if defined(__GNUC__) && defined(_WIN32)
 /* XXX These defines are likely incomplete, but should be easy to fix.
    They should be complete enough to build extension modules. */
-/* Suggested by Rene Liebscher <R.Liebscher@gmx.de> to avoid a GCC 2.91.*
-   bug that requires structure imports.  More recent versions of the
-   compiler don't exhibit this bug.
-*/
-#if (__GNUC__==2) && (__GNUC_MINOR__<=91)
-#warning "Please use an up-to-date version of gcc! (>2.91 recommended)"
-#endif
 
 #define COMPILER "[gcc]"
 #define PY_LONG_LONG long long
@@ -366,12 +358,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #	define SIZEOF_FPOS_T 8
 #	define SIZEOF_HKEY 4
 #	define SIZEOF_SIZE_T 4
-	/* MS VS2005 changes time_t to a 64-bit type on all platforms */
-#	if defined(_MSC_VER) && _MSC_VER >= 1400
-#	define SIZEOF_TIME_T 8
-#	else
 #	define SIZEOF_TIME_T 4
-#	endif
 #endif
 
 #ifdef _DEBUG
@@ -388,18 +375,10 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #define SIZEOF_DOUBLE 8
 #define SIZEOF_FLOAT 4
 
-/* VC 7.1 has them and VC 6.0 does not.  VC 6.0 has a version number of 1200.
-   Microsoft eMbedded Visual C++ 4.0 has a version number of 1201 and doesn't
-   define these.
-   If some compiler does not provide them, modify the #if appropriately. */
+/* If some compiler does not provide them, modify the #if appropriately. */
 #if defined(_MSC_VER)
-#if _MSC_VER > 1300
 #define HAVE_UINTPTR_T 1
 #define HAVE_INTPTR_T 1
-#else
-/* VC6, VS 2002 and eVC4 don't support the C99 LL suffix for 64-bit integer literals */
-#define Py_LL(x) x##I64
-#endif  /* _MSC_VER > 1200  */
 #endif  /* _MSC_VER */
 
 #endif
@@ -446,9 +425,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #define HAVE_COPYSIGN 1
 
 /* Define to 1 if you have the `round' function. */
-#if _MSC_VER >= 1800
 #define HAVE_ROUND 1
-#endif
 
 /* Define to 1 if you have the `isinf' macro. */
 #define HAVE_DECL_ISINF 1


### PR DESCRIPTION
Implements #543.

The required compiler versions come from the ITK Software Guide, book 1, chapter 2. For the Intel compiler I picked the [last version compatible with Visual Studio 2010](https://software.intel.com/en-us/intel-parallel-studio-xe-compilers-required-microsoft-visual-studio).