### PR TITLE
COMP: Add missing const to dircos_comp::operator()

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/gdcmIPPSorter.cxx
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/gdcmIPPSorter.cxx
@@ -48,7 +48,7 @@ struct dircos_key {
 };
 
 struct dircos_comp {
-  bool operator()( dircos_key const & lhs, dircos_key const & rhs ) {
+  bool operator()( dircos_key const & lhs, dircos_key const & rhs ) const {
     const double *iop1 = lhs.dircos;
     const double *iop2 = rhs.dircos;
     return std::lexicographical_compare(iop1, iop1+6,


### PR DESCRIPTION
This enables compilation with Visual Studio 2019 Update 2 nightly builds.