### PR TITLE
WIP: Improve python error message if image file doesnt exist

### DIFF
--- a/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
@@ -76,18 +76,27 @@ reader2 = readerType.New()
 reader = readerType.New(FileName='test.png')
 assert reader.GetFileName() == 'test.png'
 
-# wwith a wrong attribute name
+# with a wrong attribute name
 try:
     reader = readerType.New(WrongName='test.png')
     raise Exception('no exception sent for wrong attribute name')
 except AttributeError:
     pass
 
-# wwith a wrong attribute type
+# with a wrong attribute type
 try:
     reader = readerType.New(FileName=1)
     raise Exception('no exception sent for wrong attribute type')
 except:
+    pass
+
+# with a wrong file name
+try:
+    reader = itk.ImageFileReader.New(FileName="wrong filename")
+    raise Exception('no exception sent for wrong file name')
+except RuntimeError as e:
+    if not "The file doesn't exist." in str(e):
+        raise e
     pass
 
 # pass filter as argument for input

--- a/Wrapping/Generators/Python/itkTemplate.py
+++ b/Wrapping/Generators/Python/itkTemplate.py
@@ -468,7 +468,11 @@ class itkTemplate(object):
         else:
             imageIO = itk.ImageIOFactory.CreateImageIO( inputFileName, itk.ImageIOFactory.ReadMode )
         if not imageIO:
-            raise RuntimeError("No ImageIO is registered to handle the given file.")
+            msg = ""
+            if not os.path.isfile(inputFileName):
+                msg += ("\nThe file doesn't exist. \n" +
+                       "Filename = %s" % inputFileName)
+            raise RuntimeError("Could not create IO object for reading file %s" % inputFileName + msg)
         componentTypeDic= {"float": itk.F, "double": itk.D,
         "unsigned_char": itk.UC, "unsigned_short": itk.US, "unsigned_int": itk.UI,
         "unsigned_long": itk.UL, "unsigned_long_long": itk.ULL, "char": itk.SC, "short": itk.SS,


### PR DESCRIPTION
… exist

When opening an image file in Python through the `itkTemplate` class (i.e.
`itk.ImageFileReader.New(FileName="my_file.png")`, the error message
warns the user that the file does not exist. The error message matches
the error message printed in C++ or when using directly the `ImageFileReader`
class (i.e. `itk.ImageFileReader[ImageType].New(FileName="my_file.png")`).