### PR TITLE
COMP: Correct continuous index type

### DIFF
--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -595,14 +595,15 @@ HexahedronCell< TCellInterface >
                    CoordRepType x[Self::CellDimension], InterpolationWeightType *weights)
 {
   this->InterpolationFunctions(pcoords, weights);
-  x[0] = x[1] = x[2] = 0.0;
+  std::fill_n(x, Self::CellDimension, 0.0);
   for ( unsigned int i = 0; i < Self::NumberOfPoints; i++ )
     {
     PointType pt = points->GetElement(m_PointIds[i]);
 
     for ( unsigned int j = 0; j < Self::CellDimension; j++ )
       {
-      x[j] += pt[j] * weights[i];
+      const CoordRepType t = pt[j] * weights[i];
+      x[j] += t;
       }
     }
 }

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -169,7 +169,7 @@ public:
 
   /** Input pixel continuous index typdef */
   using ContinuousInputIndexType =
-      ContinuousIndex< TTransformPrecisionType, ImageDimension >;
+      ContinuousIndex< TInterpolatorPrecisionType, ImageDimension >;
 
   /** Typedef to describe the output image region type. */
   using OutputImageRegionType = typename TOutputImage::RegionType;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
@@ -66,6 +66,11 @@ void Expect_ResampleImageFilter_preserves_pixel_value(const TPixel inputPixel)
 
 } // namespace
 
+// Compile time check of mixing transform and precision types
+template class itk::ResampleImageFilter<itk::Image<int>, itk::Image<int>, float, float >;
+template class itk::ResampleImageFilter<itk::Image<int>, itk::Image<int>, double, float >;
+template class itk::ResampleImageFilter<itk::Image<int>, itk::Image<int>, float , double >;
+template class itk::ResampleImageFilter<itk::Image<int>, itk::Image<int>, double, double >;
 
 TEST(ResampleImageFilter, FilterPreservesAnyDoublePixelValueByDefault)
 {


### PR DESCRIPTION
Support when the interpolator precision is a different type than then
transform precision type.
