### PR TITLE
BUG: itkConfigure.h defines ITK_DEFAULT_MAX_THREADS

### DIFF
--- a/Modules/Core/Common/include/itkThreadSupport.h
+++ b/Modules/Core/Common/include/itkThreadSupport.h
@@ -36,6 +36,7 @@
 #include "itkWindows.h"
 #include <winbase.h>
 #endif
+#include "itkConfigure.h"
 
 
 namespace itk


### PR DESCRIPTION
Missing header for definition of ITK_MAX_THREADS was affected by order
of include files in external programs using ITK.

ITK/Modules/Core/Common/include/itkThreadSupport.h:46:43: error: use of undeclared identifier 'ITK_DEFAULT_MAX_THREADS'
  constexpr std::size_t ITK_MAX_THREADS = ITK_DEFAULT_MAX_THREADS;
