### PR TITLE
ENH: colorspace for DICOM YBR greenish-blue images

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -342,8 +342,7 @@ void GDCMImageIO::Read(void *pointer)
               pi == gdcm::PhotometricInterpretation::YBR_FULL ) &&
             ( pixeltype == gdcm::PixelFormat::UINT8 ||
               pixeltype == gdcm::PixelFormat::INT8 ) &&
-            ( len%3 == 0 ) &&
-            m_NumberOfComponents == 3 )
+            len%3 == 0 && m_NumberOfComponents == 3 )
     {
     unsigned char * copy = reinterpret_cast<unsigned char *>(pointer);
     for (unsigned long long x = 0; x < len; x+=3)

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -342,7 +342,7 @@ void GDCMImageIO::Read(void *pointer)
               pi == gdcm::PhotometricInterpretation::YBR_FULL ) &&
             ( pixeltype == gdcm::PixelFormat::UINT8 ||
               pixeltype == gdcm::PixelFormat::INT8 ) &&
-            len%3 == 0 && m_NumberOfComponents == 3 )
+            ( len%3 == 0 ) && m_NumberOfComponents == 3 )
     {
     unsigned char * copy = reinterpret_cast<unsigned char *>(pointer);
     for (unsigned long long x = 0; x < len; x+=3)

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -338,16 +338,15 @@ void GDCMImageIO::Read(void *pointer)
     // WARNING: sizeof(Real World Value) != sizeof(Stored Pixel)
     len = len * outputpt.GetPixelSize() / pixeltype.GetPixelSize();
     }
-
-  if ( ( pi == gdcm::PhotometricInterpretation::YBR_FULL_422 ||
-         pi == gdcm::PhotometricInterpretation::YBR_FULL ) &&
-       ( pixeltype == gdcm::PixelFormat::UINT8 ||
-         pixeltype == gdcm::PixelFormat::INT8 ) &&
-       m_NumberOfComponents == 3 )
-  {
-    unsigned char * copy = reinterpret_cast<unsigned char *>(pointer);
-    for (unsigned long x = 0; x < len; x+=3)
+  else if ( ( pi == gdcm::PhotometricInterpretation::YBR_FULL_422 ||
+              pi == gdcm::PhotometricInterpretation::YBR_FULL ) &&
+            ( pixeltype == gdcm::PixelFormat::UINT8 ||
+              pixeltype == gdcm::PixelFormat::INT8 ) &&
+            m_NumberOfComponents == 3 )
     {
+    unsigned char * copy = reinterpret_cast<unsigned char *>(pointer);
+    for (unsigned long long x = 0; x < len; x+=3)
+      {
       const unsigned char a = copy[x  ];
       const unsigned char b = copy[x+1];
       const unsigned char c = copy[x+2];
@@ -366,8 +365,8 @@ void GDCMImageIO::Read(void *pointer)
       copy[x  ]=(unsigned char)(R);
       copy[x+1]=(unsigned char)(G);
       copy[x+2]=(unsigned char)(B);
+      }
     }
-  }
 
 #ifndef NDEBUG
   // \postcondition

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -342,6 +342,7 @@ void GDCMImageIO::Read(void *pointer)
               pi == gdcm::PhotometricInterpretation::YBR_FULL ) &&
             ( pixeltype == gdcm::PixelFormat::UINT8 ||
               pixeltype == gdcm::PixelFormat::INT8 ) &&
+            ( len%3 == 0 ) &&
             m_NumberOfComponents == 3 )
     {
     unsigned char * copy = reinterpret_cast<unsigned char *>(pointer);


### PR DESCRIPTION
@thewtex  @dzenanz 

Correct color for YBR_FULL_422 (usually JPEG lossy compressed Ultrasound) and YBR_FULL (usually RLE compressed Ultrasound). GDCM IO is highly likely the right place to do.

Sample [data sets](https://drive.google.com/file/d/1WHlKAaryx5ujD2HhWPTppfJtSY8aNNAQ/view?usp=sharing).

![20190506-001823](https://user-images.githubusercontent.com/1494580/57201103-7cbb3f80-6f94-11e9-9bc1-f7ebab59ec81.jpg)
![20190506-001654](https://user-images.githubusercontent.com/1494580/57201104-80e75d00-6f94-11e9-92b6-8e5d202af77f.jpg)
