### PR TITLE
BUG: `dashboard_do_coverage` is not an environment variable anymore

### DIFF
--- a/azure_dashboard.cmake
+++ b/azure_dashboard.cmake
@@ -21,6 +21,13 @@ function(set_from_env var env_var)
   endif()
 endfunction()
 
+function(set_if_undef var default)
+  if(NOT DEFINED var)
+      set(${var} ${default} PARENT_SCOPE)
+  endif()
+endfunction()
+
+
 set_from_env(CTEST_SITE "AGENT_MACHINENAME" REQUIRED)
 set(CTEST_SITE "Azure.${CTEST_SITE}")
 set(CTEST_UPDATE_VERSION_ONLY 1)
@@ -33,8 +40,7 @@ set_from_env(workspace "AGENT_BUILDDIRECTORY" REQUIRED)
 file(TO_CMAKE_PATH "${workspace}" CTEST_DASHBOARD_ROOT)
 file(RELATIVE_PATH dashboard_source_name "${workspace}" "$ENV{BUILD_SOURCESDIRECTORY}")
 
-set_from_env(dashboard_do_coverage "DASHBOARD_DO_COVERAGE" DEFAULT 0)
-set_from_env(CTEST_COVERAGE_COMMAND "CTEST_COVERAGE_COMMAND")
+set_if_undef(dashboard_do_coverage 0)
 
 set(dashboard_loop 0)
 


### PR DESCRIPTION
In previous commit [1], several variables that were previously set through
environment variables were modified to be directly set in the ctest script
that starts the testing process. `dashboard_do_coverage` was one of these
variables and therefore should not be set through an environment variable
anymore. Its default value should be used if the variable has not been
defined before.

[1] 1902ab7be33b7d8b42b78a5ac5b3b319153d33f6