### PR TITLE
DOC: Make use of checkboxes consistent with github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,14 +28,15 @@ close a related issues using keywords (https://help.github.com/articles/closing-
 of the person or team responsible for reviewing proposed changes. -->
 
 ## PR Checklist
-- [ ] [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
-- [ ] [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
-- [ ] Adds the License notice to new files.
-- [ ] Adds Python wrapping.
-- [ ] Adds tests and baseline comparison (quantitative).
-- [ ] [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
-- [ ] Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
-- [ ] Adds Documentation.
+<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
+- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
+- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
+- [X] :no_entry_sign: Adds the License notice to new files.
+- [X] :no_entry_sign: Adds Python wrapping.
+- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
+- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
+- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
+- [X] :no_entry_sign: Adds Documentation.
 
 Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
 further development details if necessary.


### PR DESCRIPTION
Github uses checkboxes to indicate subtask completions
in a PR.  The current use of checkboxes in a simple PR
causes a rendering in github that often indicates that
1/8 subtasks of the PR are complete.

The current proposal uses positive and negative indications
for each checklist statement.  The negative indications are
not part of the subtasks that the PR addresses, and the
positive indications are part of the checklist.

This convention provides an quick view of the complexity of
the PR and the number of PR checklist tasks that were
addressed in the top level github views.

## PR Checklist
- 🚫 [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- 🚫 [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- 🚫 Adds the License notice to new files.
- 🚫 Adds Python wrapping.
- 🚫 Adds tests and baseline comparison (quantitative).
- 🚫 [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- 🚫 Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X]  Adds Documentation.

