### PR TITLE
PERF: Overload SpatialObject IsInsideInObjectSpace without name argument

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -79,8 +79,10 @@ public:
   itkGetConstReferenceMacro(LengthInObjectSpace, double);
 
   /** Returns true if the point is inside the line, false otherwise. */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
-    const std::string & name="") const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
   PointType GetPositionInWorldSpace() const;
   VectorType GetDirectionInWorldSpace() const;

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -72,33 +72,24 @@ ArrowSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 ArrowSpatialObject< TDimension >
-::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
-  const std::string & name) const
+::IsInsideInObjectSpace(const PointType & point) const
 {
   itkDebugMacro("Checking the point [" << point << "] is on the Line");
 
-  if( this->GetTypeName().find( name ) != std::string::npos )
-    {
-    PointType pnt = this->GetPositionInObjectSpace();
+  PointType pnt = this->GetPositionInObjectSpace();
 
-    bool isInside = true;
-    for ( unsigned int i = 0; i < TDimension; i++ )
+  bool isInside = true;
+  for ( unsigned int i = 0; i < TDimension; i++ )
+    {
+    if( Math::NotExactlyEquals( point[i], pnt[i] ) )
       {
-      if( Math::NotExactlyEquals( point[i], pnt[i] ) )
-        {
-        isInside = false;
-        break;
-        }
-      }
-    if( isInside )
-      {
-      return true;
+      isInside = false;
+      break;
       }
     }
-
-  if( depth > 0 )
+  if( isInside )
     {
-    return Superclass::IsInsideChildrenInObjectSpace( point, depth-1, name );
+    return true;
     }
 
   return false;

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -71,8 +71,10 @@ public:
   itkGetConstReferenceMacro(PositionInObjectSpace, PointType);
 
   /** Test whether a point is inside or outside the object */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth = 0,
-    const std::string & name = "" ) const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
 protected:
 

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -52,25 +52,11 @@ BoxSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 BoxSpatialObject< TDimension >
-::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
-  const std::string & name) const
+::IsInsideInObjectSpace(const PointType & point) const
 {
   itkDebugMacro("Checking the point [" << point << "] is in the box");
 
-  if( this->GetTypeName().find( name ) != std::string::npos )
-    {
-    if( this->GetMyBoundingBoxInObjectSpace()->IsInside( point ) )
-      {
-      return true;
-      }
-    }
-
-  if( depth > 0 )
-    {
-    return Superclass::IsInsideChildrenInObjectSpace(point, depth-1, name);
-    }
-
-  return false;
+  return this->GetMyBoundingBoxInObjectSpace()->IsInside( point );
 }
 
 /** Compute the bounds of the box */

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -83,8 +83,10 @@ public:
   itkGetConstReferenceMacro(CenterInObjectSpace, PointType);
 
   /** Test whether a point is inside or outside the object */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
-    const std::string & name="" ) const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
 #if ! defined ( ITK_LEGACY_REMOVE )
     itkLegacyMacro( void SetRadius( double radius) )

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -75,38 +75,29 @@ EllipseSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 EllipseSpatialObject< TDimension >
-::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
-  const std::string & name) const
+::IsInsideInObjectSpace(const PointType & point) const
 {
-  if( this->GetTypeName().find( name ) != std::string::npos )
+  double d;
+  double r = 0;
+  for ( unsigned int i = 0; i < TDimension; i++ )
     {
-    double d;
-    double r = 0;
-    for ( unsigned int i = 0; i < TDimension; i++ )
+    if ( m_RadiusInObjectSpace[i] > 0.0 )
       {
-      if ( m_RadiusInObjectSpace[i] > 0.0 )
-        {
-        d = point[i] - m_CenterInObjectSpace[i];
-        r += ( d * d )
-          / ( m_RadiusInObjectSpace[i] * m_RadiusInObjectSpace[i] );
-        }
-      else if ( point[i] != 0.0 || m_RadiusInObjectSpace[i] < 0 )
-        // Deal with an ellipse with 0 or negative radius;
-        {
-        r = 2; // Keeps function from returning true here
-        break;
-        }
+      d = point[i] - m_CenterInObjectSpace[i];
+      r += ( d * d )
+        / ( m_RadiusInObjectSpace[i] * m_RadiusInObjectSpace[i] );
       }
-
-    if ( r < 1 )
+    else if ( point[i] != 0.0 || m_RadiusInObjectSpace[i] < 0 )
+      // Deal with an ellipse with 0 or negative radius;
       {
-      return true;
+      r = 2; // Keeps function from returning true here
+      break;
       }
     }
 
-  if( depth > 0 )
+  if ( r < 1 )
     {
-    return Superclass::IsInsideChildrenInObjectSpace( point, depth-1, name );
+    return true;
     }
 
   return false;

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -89,8 +89,10 @@ public:
   ScalarType SquaredZScoreInWorldSpace(const PointType & point) const;
 
   /** Test whether a point is inside or outside the object */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth = 0,
-    const std::string & name = "") const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
   /** Returns the value of the Gaussian at the given point.  */
   bool ValueAtInObjectSpace(const PointType & point, double & value,

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -85,35 +85,26 @@ GaussianSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 GaussianSpatialObject< TDimension >
-::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
-  const std::string & name) const
+::IsInsideInObjectSpace(const PointType & point) const
 {
-  if ( this->GetTypeName().find( name ) != std::string::npos )
+  if ( m_RadiusInObjectSpace > itk::Math::eps )
     {
-    if ( m_RadiusInObjectSpace > itk::Math::eps )
+    if ( this->GetMyBoundingBoxInObjectSpace()->IsInside(point) )
       {
-      if ( this->GetMyBoundingBoxInObjectSpace()->IsInside(point) )
+      double r = 0;
+      for ( unsigned int i = 0; i < TDimension; i++ )
         {
-        double r = 0;
-        for ( unsigned int i = 0; i < TDimension; i++ )
-          {
-          r += (point[i] - m_CenterInObjectSpace[i])
-                * (point[i] - m_CenterInObjectSpace[i]);
-          }
+        r += (point[i] - m_CenterInObjectSpace[i])
+              * (point[i] - m_CenterInObjectSpace[i]);
+        }
 
-        r /= ( m_RadiusInObjectSpace * m_RadiusInObjectSpace );
+      r /= ( m_RadiusInObjectSpace * m_RadiusInObjectSpace );
 
-        if ( r <= 1.0 )
-          {
-          return true;
-          }
+      if ( r <= 1.0 )
+        {
+        return true;
         }
       }
-    }
-
-  if( depth > 0 )
-    {
-    return Superclass::IsInsideChildrenInObjectSpace(point, depth-1, name);
     }
 
   return false;

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -68,9 +68,10 @@ public:
   itkTypeMacro(ImageMaskSpatialObject, ImageSpatialObject);
 
   /** Returns true if the point is inside, false otherwise. */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
-    const std::string & name="") const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
 
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
   /** Computes the bounding box of the image mask, in the index space of the image.
    * The bounding box is returned as an image region. Each call to this function

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -39,30 +39,22 @@ ImageMaskSpatialObject< TDimension, TPixel >
 template< unsigned int TDimension, typename TPixel >
 bool
 ImageMaskSpatialObject< TDimension, TPixel >
-::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
-  const std::string & name ) const
+::IsInsideInObjectSpace(const PointType & point) const
 {
-  if( this->GetTypeName().find( name ) != std::string::npos )
+  typename Superclass::InterpolatorType::ContinuousIndexType index;
+  if( this->GetImage()->TransformPhysicalPointToContinuousIndex( point,
+      index ) )
     {
-    typename Superclass::InterpolatorType::ContinuousIndexType index;
-    if( this->GetImage()->TransformPhysicalPointToContinuousIndex( point,
-        index ) )
+    using InterpolatorOutputType = typename InterpolatorType::OutputType;
+    bool insideMask = (
+      Math::NotExactlyEquals(
+        DefaultConvertPixelTraits<InterpolatorOutputType>::GetScalarValue(
+          this->GetInterpolator()->EvaluateAtContinuousIndex(index)),
+        NumericTraits<PixelType>::ZeroValue() ) );
+    if( insideMask )
       {
-      using InterpolatorOutputType = typename InterpolatorType::OutputType;
-      bool insideMask = (
-        Math::NotExactlyEquals(
-          DefaultConvertPixelTraits<InterpolatorOutputType>::GetScalarValue(
-            this->GetInterpolator()->EvaluateAtContinuousIndex(index)),
-          NumericTraits<PixelType>::ZeroValue() ) );
-      if( insideMask )
-        {
-        return true;
-        }
+      return true;
       }
-    }
-  if( depth > 0 )
-    {
-    return Superclass::IsInsideChildrenInObjectSpace( point, depth, name );
     }
 
   return false;

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -79,8 +79,10 @@ public:
   const ImageType * GetImage() const;
 
   /** Returns true if the point is inside, false otherwise. */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
-    const std::string & name = "") const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
   /** Returns the value of the image at the requested point.
    *  Returns true if that value is valid */

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -84,25 +84,10 @@ ImageSpatialObject< TDimension,  PixelType >
 template< unsigned int TDimension, typename PixelType >
 bool
 ImageSpatialObject< TDimension,  PixelType >
-::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
-  const std::string & name) const
+::IsInsideInObjectSpace(const PointType & point) const
 {
-  if( this->GetTypeName().find( name ) != std::string::npos )
-    {
-    IndexType index;
-    bool isInside = m_Image->TransformPhysicalPointToIndex( point, index );
-    if( isInside )
-      {
-      return true;
-      }
-    }
-
-  if( depth > 0 )
-    {
-    return Superclass::IsInsideChildrenInObjectSpace(point, depth-1, name);
-    }
-
-  return false;
+  IndexType index;
+  return m_Image->TransformPhysicalPointToIndex( point, index );
 }
 
 /** Return the value of the image at a specified point

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
@@ -73,8 +73,10 @@ public:
 
   /** Returns true if the line is evaluable at the requested point,
    *  false otherwise. */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth = 0,
-   const std::string & name = "") const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
 protected:
   LineSpatialObject();

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
@@ -70,42 +70,32 @@ LineSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 LineSpatialObject< TDimension >
-::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
-  const std::string & name) const
+::IsInsideInObjectSpace(const PointType & point) const
 {
-  if( this->GetTypeName().find( name ) != std::string::npos )
-    {
-    auto it = this->m_Points.begin();
-    auto itEnd = this->m_Points.end();
+  auto it = this->m_Points.begin();
+  auto itEnd = this->m_Points.end();
 
-    if ( this->GetMyBoundingBoxInObjectSpace()->IsInside(point) )
+  if ( this->GetMyBoundingBoxInObjectSpace()->IsInside(point) )
+    {
+    while ( it != itEnd )
       {
-      while ( it != itEnd )
+      bool match = true;
+      for( unsigned int i=0; i<TDimension; ++i )
         {
-        bool match = true;
-        for( unsigned int i=0; i<TDimension; ++i )
+        if ( ! Math::AlmostEquals( ( *it ).GetPositionInObjectSpace()[i],
+                 point[i] ) )
           {
-          if ( ! Math::AlmostEquals( ( *it ).GetPositionInObjectSpace()[i],
-                   point[i] ) )
-            {
-            match = false;
-            break;
-            }
+          match = false;
+          break;
           }
-        if( match )
-          {
-          return true;
-          }
-        it++;
         }
+      if( match )
+        {
+        return true;
+        }
+      it++;
       }
     }
-
-  if( depth > 0 )
-    {
-    return Superclass::IsInsideChildrenInObjectSpace( point, depth-1, name );
-    }
-
 
   return false;
 }

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -75,8 +75,10 @@ public:
   const MeshType *GetMesh() const;
 
   /** Returns true if the point is inside, false otherwise. */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
-    const std::string & name="") const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
   /** Returns the latest modified time of the object and its component. */
   ModifiedTimeType GetMTime() const override;

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -106,8 +106,10 @@ public:
     const PointType & point) const;
 
   /** Returns true if the point is inside the Blob, false otherwise. */
-  bool IsInsideInObjectSpace(const PointType & worldPoint, unsigned int depth=0,
-    const std::string & name="") const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
 protected:
   /** Compute the boundaries of the Blob. */

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -205,40 +205,31 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 template< unsigned int TDimension, class TSpatialObjectPointType >
 bool
 PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
-::IsInsideInObjectSpace( const PointType & point, unsigned int depth,
-    const std::string & name) const
+::IsInsideInObjectSpace(const PointType & point) const
 {
-  if( this->GetTypeName().find( name ) != std::string::npos )
+  if( this->GetMyBoundingBoxInObjectSpace()->IsInside( point ) )
     {
-    if( this->GetMyBoundingBoxInObjectSpace()->IsInside( point ) )
+    auto it = m_Points.begin();
+    auto itEnd = m_Points.end();
+
+    while ( it != itEnd )
       {
-      auto it = m_Points.begin();
-      auto itEnd = m_Points.end();
-
-      while ( it != itEnd )
+      bool equals = true;
+      for( unsigned int i=0; i<TDimension; ++i )
         {
-        bool equals = true;
-        for( unsigned int i=0; i<TDimension; ++i )
+        if( ! Math::AlmostEquals( point[i],
+            it->GetPositionInObjectSpace()[i] ) )
           {
-          if( ! Math::AlmostEquals( point[i],
-              it->GetPositionInObjectSpace()[i] ) )
-            {
-            equals = false;
-            break;
-            }
+          equals = false;
+          break;
           }
-        if( equals )
-          {
-          return true;
-          }
-        it++;
         }
+      if( equals )
+        {
+        return true;
+        }
+      it++;
       }
-    }
-
-  if( depth > 0 )
-    {
-    return Superclass::IsInsideChildrenInObjectSpace(point, depth-1, name);
     }
 
   return false;

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
@@ -84,8 +84,10 @@ public:
   double MeasurePerimeterInObjectSpace() const;
 
   /** Test whether a point is inside or outside the object. */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth,
-    const std::string & name) const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
 protected:
   PolygonSpatialObject();

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -201,9 +201,13 @@ public:
   /**********************************************************************/
 
   /** Returns true if a point is inside the object in world space. */
-  virtual bool IsInsideInObjectSpace(const PointType & point,
-                        unsigned int depth = 0,
+  bool IsInsideInObjectSpace(const PointType & point,
+                        unsigned int depth,
                         const std::string & name = "") const;
+
+  /** Returns false by default, but is overridden in order to return true
+   * if a point is inside the object. */
+  virtual bool IsInsideInObjectSpace(const PointType & point) const;
 
   /** Update - Optionally used to compute a world-coordinate representation of
    *   the object.   Object-dependent implementation. */

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -162,14 +162,31 @@ SpatialObject< TDimension >
 ::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
   const std::string & name) const
 {
-  if( depth > 0 )
+  if (name.empty() || (this->GetTypeName().find(name) != std::string::npos))
     {
-    return IsInsideChildrenInObjectSpace( point, depth-1, name );
+    if (this->IsInsideInObjectSpace(point))
+      {
+      return true;
+      }
+    }
+
+  if (depth > 0)
+    {
+    return Self::IsInsideChildrenInObjectSpace(point, depth-1, name);
     }
   else
     {
     return false;
     }
+}
+
+template< unsigned int TDimension >
+bool
+SpatialObject< TDimension >
+::IsInsideInObjectSpace(const PointType & itkNotUsed(point)) const
+{
+  // This overload is virtual, and should be overridden.
+  return false;
 }
 
 /** Return if a point is inside the object or its children */

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -104,8 +104,10 @@ public:
   itkGetConstMacro(Root, bool);
 
   /** Returns true if the point is inside the tube, false otherwise. */
-  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth = 0,
-    const std::string & name = "") const override;
+  bool IsInsideInObjectSpace(const PointType & point) const override;
+
+  /* Avoid hiding the overload that supports depth and name arguments */
+  using Superclass::IsInsideInObjectSpace;
 
 protected:
 


### PR DESCRIPTION
Added virtual `IsInsideInObjectSpace(const PointType &)` member function
to `itk::SpatialObject`, as an overload of the original one,
`IsInsideInObjectSpace(const PointType&, unsigned depth, const std::string& name)`.
Removed the `virtual` keyword from the original member function.

Ensured that the 11 derived classes now override the new overload
(without the `name` parameter), instead of the original one. The
original member function now calls the new overload.

A major performance improvement was observed by this commit, especially
because it avoids many expensive `GetTypeName().find(name)` calls.
`IsInsideInObjectSpace` often appears more than twice (and sometimes
even more than 3 times) as fast as before.

Fixes issue #820 ("SpatialObject IsInsideInObjectSpace PERF penalty
GetTypeName().find"), based on a suggestion by Hans @hjmjohnson.