### PR TITLE
BUG: Address valgrid defects related to the PointSpatialObject

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -158,7 +158,10 @@ protected:
   /** Color of the point */
   ColorType m_Color;
 
-  typename SpatialObjectType::Pointer m_SpatialObject;
+  // The SpatialObjectPoint keeps a reference to its owning parent
+  // spatial object for its spatial context. A WeakPointer is used to
+  // avoid a memory leak.
+  WeakPointer<SpatialObjectType> m_SpatialObject;
 };
 
 } // end of namespace itk


### PR DESCRIPTION
The PointSpatialObject keeps a reference to its parent spatial object
for the spatial context. This created additional reference counts for
the parent class not released. A WeakPointer is now used.
