### PR TITLE
BUG: Missing `ci_addons` to convert ctest results to JUnit format

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -29,6 +29,13 @@ jobs:
         displayName: 'Checkout pull request HEAD'
       - bash: |
           set -x
+          sudo apt-get update
+          sudo apt-get install -y python3-venv
+          sudo python3 -m pip install --upgrade setuptools
+          sudo python3 -m pip install scikit-ci-addons
+        displayName: 'Install dependencies'
+      - bash: |
+          set -x
           git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
           curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O


### PR DESCRIPTION
In previous commit [1], a step calling `ci_addons` was added, but
`ci_addons` was not installed on the system.

[1] fdd0a6e0e06a85fae3d69a345b646da5f639315c