### PR TITLE
BUG: Fix ownership of environment variable value

### DIFF
--- a/Examples/IO/IOPlugin.cxx
+++ b/Examples/IO/IOPlugin.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itksys/SystemTools.hxx"
 
 int main( int argc, char *argv[] )
 {
@@ -45,7 +46,7 @@ int main( int argc, char *argv[] )
 #endif
       }
     myenv += std::string(argv[3]);
-    putenv (const_cast<char *>(myenv.c_str()));
+    itksys::SystemTools::PutEnv(myenv.c_str());
 
     itk::ObjectFactoryBase::ReHash();
     }


### PR DESCRIPTION
Address valgrind defect of accessing environment variable string after
memory is freed. POSIX putenv uses the provided string for
storage. Change to using portable KWSys::PutEnv which does not retain
assess to the argument.

This patch addressed the following defect:
https://open.cdash.org/viewDynamicAnalysisFile.php?id=6194649