### PR TITLE
BUG: Fix leak in SpatialObject InternalClone method

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -348,7 +348,6 @@ SpatialObject< TDimension >
   // Default implementation just copies the parameters from
   // this to new transform.
   typename LightObject::Pointer loPtr = CreateAnother();
-  loPtr->Register();
 
   typename Self::Pointer rval =
     dynamic_cast<Self *>(loPtr.GetPointer());

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
@@ -39,7 +39,7 @@ SpatialObjectDuplicator< TInputSpatialObject >
 {
   using SOType = itk::SpatialObject< TInputSpatialObject::ObjectDimension >;
 
-  SOType * newSO = source->Clone();
+  typename SOType::Pointer newSO = source->Clone();
   destination->AddChild(newSO);
   destination->Update();
 


### PR DESCRIPTION
A reference count was erroneously added when smart pointers being
used in InternalClone method. In SpatialObjectDuplicator::CopyObject
properly use a smart pointer to hold a cloned spatial object.

closes #777 