### PR TITLE
COMP: ResampleImageFilter does not have SetDisplacementField method

### DIFF
--- a/Examples/RegistrationITKv4/DeformableRegistration10.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration10.cxx
@@ -26,6 +26,7 @@
 #include "itkImageFileWriter.h"
 
 #include "itkCurvatureRegistrationFilter.h"
+#include "itkDisplacementFieldTransform.h"
 #include "itkFastSymmetricForcesDemonsRegistrationFunction.h"
 #include "itkMultiResolutionPDEDeformableRegistration.h"
 
@@ -159,10 +160,12 @@ int main( int argc, char *argv[] )
   multires->SetNumberOfIterations( nIterations );
   multires->Update();
 
-  using WarperType = itk::ResampleImageFilter< MovingImageType, MovingImageType >;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<
-                                   MovingImageType,
-                                   double          >;
+  using DisplacementFieldTransformType = itk::DisplacementFieldTransform< InternalPixelType, Dimension >;
+  auto displacementTransform = DisplacementFieldTransformType::New();
+  displacementTransform->SetDisplacementField( multires->GetOutput() );
+
+  using WarperType = itk::ResampleImageFilter< MovingImageType, MovingImageType, InternalPixelType, InternalPixelType >;
+  using InterpolatorType = itk::LinearInterpolateImageFunction< MovingImageType, InternalPixelType >;
   WarperType::Pointer warper = WarperType::New();
   InterpolatorType::Pointer interpolator = InterpolatorType::New();
   FixedImageType::Pointer fixedImage = fixedImageReader->GetOutput();
@@ -172,7 +175,7 @@ int main( int argc, char *argv[] )
   warper->SetOutputSpacing( fixedImage->GetSpacing() );
   warper->SetOutputOrigin( fixedImage->GetOrigin() );
   warper->SetOutputDirection( fixedImage->GetDirection() );
-  warper->SetDisplacementField( multires->GetOutput() );
+  warper->SetTransform( displacementTransform );
 
   // Write warped image out to file
   using OutputPixelType = unsigned short;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to ITK!** -->
