### PR TITLE
STYLE: Deprecated FixedArray member functions rBegin() and rEnd()

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -402,6 +402,9 @@ b40f74e07d74614c75be4aceac63b87e80e589d1 on 2018-11-14.
 
 `itk::Barrier` has been moved to `ITKDeprecated` module.
 
+`FixedArray` member functions `rBegin()` and `rEnd()` are replaced by `rbegin()` and `rend()`,
+which return a `reverse_iterator`, compatible with the Standard C++ Library.
+
 Python changes
 --------------
 

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -260,13 +260,13 @@ public:
 
   ConstIterator End() const;
 
-  ReverseIterator      rBegin();
+  itkLegacyMacro(ReverseIterator      rBegin());
 
-  ConstReverseIterator rBegin() const;
+  itkLegacyMacro(ConstReverseIterator rBegin() const);
 
-  ReverseIterator      rEnd();
+  itkLegacyMacro(ReverseIterator      rEnd());
 
-  ConstReverseIterator rEnd() const;
+  itkLegacyMacro(ConstReverseIterator rEnd() const);
 
   const_iterator cbegin() const noexcept
   {

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -146,6 +146,8 @@ FixedArray< TValue, VLength >
   return ConstIterator(m_InternalArray + VLength);
 }
 
+#if !defined ( ITK_LEGACY_REMOVE )
+
 /**
  * Get a begin ReverseIterator.
  */
@@ -189,6 +191,8 @@ FixedArray< TValue, VLength >
 {
   return ConstReverseIterator(m_InternalArray);
 }
+
+#endif // defined ( ITK_LEGACY_REMOVE )
 
 /**
  * Get the size of the FixedArray.

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -16,6 +16,9 @@
  *
  *=========================================================================*/
 
+// Enable testing legacy member functions rBegin() and rEnd().
+#define ITK_LEGACY_TEST
+
  // First include the header file to be tested:
 #include "itkFixedArray.h"
 #include <gtest/gtest.h>
@@ -91,6 +94,7 @@ namespace
   }
 
 
+#if ! defined (ITK_LEGACY_REMOVE)
   template< typename TValue, unsigned int VLength >
   void Check_new_reverse_iterator_behaves_like_old_ReverseIterator()
   {
@@ -115,7 +119,7 @@ namespace
     EXPECT_EQ(newIterator, newEnd);
     EXPECT_EQ(oldIterator, oldEnd);
   }
-
+#endif
 
   template< typename TValue, unsigned int VLength >
   void Check_const_and_non_const_reverse_iterators_retrieve_same_values()
@@ -172,7 +176,9 @@ namespace
     typename FixedArrayType::iterator newIterator = fixedArray.begin();
     typename FixedArrayType::Iterator oldIterator = fixedArray.Begin();
     typename FixedArrayType::reverse_iterator newReverseIterator = fixedArray.rbegin();
+#if ! defined (ITK_LEGACY_REMOVE)
     typename FixedArrayType::ReverseIterator oldReverseIterator = fixedArray.rBegin();
+#endif
 
     unsigned int index = 0;
     unsigned int reverseIndex = VLength - 1;
@@ -180,7 +186,9 @@ namespace
       EXPECT_EQ(*newIterator++, fixedArray[index]);
       EXPECT_EQ(*newReverseIterator++, fixedArray[reverseIndex]);
       EXPECT_EQ(*oldIterator++, fixedArray[index]);
+#if ! defined (ITK_LEGACY_REMOVE)
       EXPECT_EQ(*oldReverseIterator++, fixedArray[reverseIndex]);
+#endif
       index++;
       reverseIndex--;
     }
@@ -188,7 +196,9 @@ namespace
     newIterator = fixedArray.begin();
     oldIterator = fixedArray.Begin();
     newReverseIterator = fixedArray.rbegin();
+#if ! defined (ITK_LEGACY_REMOVE)
     oldReverseIterator = fixedArray.rBegin();
+#endif
 
     index = 0;
     reverseIndex = VLength - 1;
@@ -198,7 +208,9 @@ namespace
       EXPECT_EQ(*++newIterator, fixedArray[index]);
       EXPECT_EQ(*++newReverseIterator, fixedArray[reverseIndex]);
       EXPECT_EQ(*++oldIterator, fixedArray[index]);
+#if ! defined (ITK_LEGACY_REMOVE)
       EXPECT_EQ(*++oldReverseIterator, fixedArray[reverseIndex]);
+#endif
     }
   }
 
@@ -222,6 +234,7 @@ TEST(FixedArray, SupportsModifyingElementsByRangeBasedForLoop)
 }
 
 
+#if ! defined (ITK_LEGACY_REMOVE)
 // Tests that the new reverse iterators (`rbegin()` and `rend()`, introduced with ITK 5.0)
 // behave just like the old ones (`rBegin()` and `rEnd()`, originally from 2002).
 TEST(FixedArray, NewReverseIteratorBehavesLikeOldReverseIterator)
@@ -229,7 +242,7 @@ TEST(FixedArray, NewReverseIteratorBehavesLikeOldReverseIterator)
   Check_new_reverse_iterator_behaves_like_old_ReverseIterator<double, 2>();
   Check_new_reverse_iterator_behaves_like_old_ReverseIterator<int, 3>();
 }
-
+#endif
 
 // Tests that const and non-const reverse iterators retrieve exactly the same values.
 TEST(FixedArray, ConstAndNonConstReverseIteratorRetrieveSameValues)

--- a/Modules/Core/Common/test/itkFixedArrayTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest.cxx
@@ -114,17 +114,17 @@ int itkFixedArrayTest(int, char* [] )
     ++cit;
     }
 
-  std::cout << "FixedArray<unsigned int, 20>::ReverseIterator rit = array20.rBegin();" << std::endl;
-  itk::FixedArray<unsigned int, 20>::ReverseIterator rit = array20.rBegin();
-  while (rit != array20.rEnd())
+  std::cout << "FixedArray<unsigned int, 20>::reverse_iterator rit = array20.rbegin();" << std::endl;
+  itk::FixedArray<unsigned int, 20>::reverse_iterator rit = array20.rbegin();
+  while (rit != array20.rend())
     {
     std::cout << *rit << std::endl;
     ++rit;
     }
 
-  std::cout << "FixedArray<unsigned int, 20>::ConstReverseIterator crit = array20.rBegin();" << std::endl;
-  itk::FixedArray<unsigned int, 20>::ConstReverseIterator crit = array20.rBegin();
-  while (crit != array20.rEnd())
+  std::cout << "FixedArray<unsigned int, 20>::const_reverse_iterator crit = array20.rbegin();" << std::endl;
+  itk::FixedArray<unsigned int, 20>::const_reverse_iterator crit = array20.rbegin();
+  while (crit != array20.rend())
     {
     std::cout << *crit << std::endl;
     ++crit;


### PR DESCRIPTION
Declared `FixedArray` member functions `rBegin()` and `rEnd()`
legacy-only, as they are superseded by `rbegin()` and `rend()'.

The new reverse iterators can be passed directly to an `std` algorithm,
e.g., `std::sort(fixedArray.rbegin(), fixedArray.rend())`. Unlike the
old reverse iterators, the new ones support random access iteration.

Deprecation suggested by @dzenanz while discussing pull request #850