### PR TITLE
STYLE: Replace std::swap_ranges by C++11 std::swap of m_InternalArray

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -334,7 +334,7 @@ public:
 
   void swap(FixedArray &other)
     {
-      std::swap_ranges(this->Begin(), this->End(), other.Begin());
+      std::swap(m_InternalArray, other.m_InternalArray);
     }
 
 private:

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -324,7 +324,7 @@ public:
 
   void swap(Index & other)
   {
-    std::swap_ranges(begin(), end(), other.begin() );
+    std::swap(m_InternalArray, other.m_InternalArray);
   }
 
   iterator begin()
@@ -520,7 +520,7 @@ template <unsigned int VDimension>
 inline void
 swap(Index<VDimension> & one, Index<VDimension> & two)
 {
-  std::swap_ranges(one.begin(), one.end(), two.begin() );
+  std::swap(one.m_InternalArray, two.m_InternalArray);
 }
 
 // static constexpr definition explicitly needed in C++11

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -280,7 +280,7 @@ public:
 
   void swap(Offset & other)
   {
-    std::swap_ranges(begin(), end(), other.begin() );
+    std::swap(m_InternalArray, other.m_InternalArray);
   }
 
   iterator begin()
@@ -478,7 +478,7 @@ template <unsigned int VDimension>
 inline void
 swap(Offset<VDimension> & one, Offset<VDimension> & two)
 {
-  std::swap_ranges(one.begin(), one.end(), two.begin() );
+  std::swap(one.m_InternalArray, two.m_InternalArray);
 }
 
 // static constexpr definition explicitly needed in C++11

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -243,7 +243,7 @@ public:
 
   void swap(Size & other)
   {
-    std::swap_ranges(begin(), end(), other.begin() );
+    std::swap(m_InternalArray, other.m_InternalArray);
   }
 
   iterator begin()
@@ -440,7 +440,7 @@ template <unsigned int VDimension>
 inline void
 swap(Size<VDimension> & one, Size<VDimension> & two)
 {
-  std::swap_ranges(one.begin(), one.end(), two.begin() );
+  std::swap(one.m_InternalArray, two.m_InternalArray);
 }
 
 // static constexpr definition explicitly needed in C++11


### PR DESCRIPTION
Instead of calling `std::swap_ranges`, it appears preferable to call
the dedicated C++11 `std::swap` overload for arrays, when swapping the
elements of one `m_InternalArray` and another.