### PR TITLE
ENH: Deprecate VectorCastImageFilter

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -400,7 +400,7 @@ you should use macro `ITKv5_CONST` instead of `const` keyword.
 This macro is present in ITKv4 since commit
 b40f74e07d74614c75be4aceac63b87e80e589d1 on 2018-11-14.
 
-`itk::Barrier` has been moved to `ITKDeprecated` module.
+`itk::Barrier`, `itk::VectorResampleImageFilter` and  `itk::VectorCastImageFilter` have been moved to `ITKDeprecated` module.
 
 `FixedArray` member functions `rBegin()` and `rEnd()` are replaced by `rbegin()` and `rend()`,
 which return a `reverse_iterator`, compatible with the Standard C++ Library.

--- a/Examples/Filtering/RGBCurvatureAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/RGBCurvatureAnisotropicDiffusionImageFilter.cxx
@@ -74,7 +74,7 @@
 // Software Guide : BeginCodeSnippet
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 // Software Guide : EndCodeSnippet
 
 
@@ -164,18 +164,18 @@ int main( int argc, char * argv[] )
   //  Software Guide : BeginLatex
   //
   //  The filter output is now cast to \code{unsigned char} RGB components by
-  //  using the \doxygen{VectorCastImageFilter}.
+  //  using the \doxygen{CastImageFilter}.
   //
-  //  \index{itk::VectorCastImageFilter!instantiation}
-  //  \index{itk::VectorCastImageFilter!New()}
-  //  \index{itk::VectorCastImageFilter!Pointer}
+  //  \index{itk::CastImageFilter!instantiation}
+  //  \index{itk::CastImageFilter!New()}
+  //  \index{itk::CastImageFilter!Pointer}
   //
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
   using WritePixelType = itk::RGBPixel< unsigned char >;
   using WriteImageType = itk::Image< WritePixelType, 2 >;
-  using CasterType = itk::VectorCastImageFilter<
+  using CasterType = itk::CastImageFilter<
                 InputImageType, WriteImageType >;
   CasterType::Pointer caster = CasterType::New();
   // Software Guide : EndCodeSnippet

--- a/Examples/Filtering/RGBGradientAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/RGBGradientAnisotropicDiffusionImageFilter.cxx
@@ -74,7 +74,7 @@
 // Software Guide : BeginCodeSnippet
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 // Software Guide : EndCodeSnippet
 
 
@@ -164,18 +164,18 @@ int main( int argc, char * argv[] )
   //  Software Guide : BeginLatex
   //
   //  The filter output is now cast to \code{unsigned char} RGB components by
-  //  using the \doxygen{VectorCastImageFilter}.
+  //  using the \doxygen{CastImageFilter}.
   //
-  //  \index{itk::VectorCastImageFilter!instantiation}
-  //  \index{itk::VectorCastImageFilter!New()}
-  //  \index{itk::VectorCastImageFilter!Pointer}
+  //  \index{itk::CastImageFilter!instantiation}
+  //  \index{itk::CastImageFilter!New()}
+  //  \index{itk::CastImageFilter!Pointer}
   //
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
   using WritePixelType = itk::RGBPixel< unsigned char >;
   using WriteImageType = itk::Image< WritePixelType, 2 >;
-  using CasterType = itk::VectorCastImageFilter<
+  using CasterType = itk::CastImageFilter<
                 InputImageType, WriteImageType >;
   CasterType::Pointer caster = CasterType::New();
   // Software Guide : EndCodeSnippet

--- a/Examples/IO/VisibleHumanPasteWrite.cxx
+++ b/Examples/IO/VisibleHumanPasteWrite.cxx
@@ -62,9 +62,12 @@ int main(int argc, char *argv[])
 // which works on vector images to produce a scalar output. Then a
 // color image is recreated by compositing the output as red, green,
 // and blue channels.
-  using GradientMagnitudeImageFilter = itk::VectorGradientMagnitudeImageFilter< RGB2DImageType >;
+  using ToVectorImageAdaptorType = itk::RGBToVectorImageAdaptor< RGB2DImageType >;
+  using GradientMagnitudeImageFilter = itk::VectorGradientMagnitudeImageFilter< ToVectorImageAdaptorType >;
+  ToVectorImageAdaptorType::Pointer adaptor = ToVectorImageAdaptorType::New();
+  adaptor->SetImage( reader->GetOutput() );
   GradientMagnitudeImageFilter::Pointer grad = GradientMagnitudeImageFilter::New();
-  grad->SetInput( reader->GetOutput() );
+  grad->SetInput( adaptor );
 
   grad->SetUseImageSpacingOn();
 
@@ -99,16 +102,15 @@ int main(int argc, char *argv[])
 // enable pasting, a call to SetIORegion is made with a valid
 // region. Finally, the pipeline is updated, causing the streaming of
 // regions
-  using ToVectorImageAdaptorType = itk::RGBToVectorImageAdaptor< RGB2DImageType >;
-  ToVectorImageAdaptorType::Pointer adaptor = ToVectorImageAdaptorType::New();
-  adaptor->SetImage( composeRGB->GetOutput() );
+  ToVectorImageAdaptorType::Pointer adaptor2 = ToVectorImageAdaptorType::New();
+  adaptor2->SetImage( composeRGB->GetOutput() );
 
   using ImageWriterType = itk::ImageFileWriter< ToVectorImageAdaptorType >;
   ImageWriterType::Pointer writer = ImageWriterType::New();
   writer->SetFileName( outputImageFile );
   writer->SetNumberOfStreamDivisions( 10 );
   writer->SetIORegion( halfIO );
-  writer->SetInput( adaptor );
+  writer->SetInput( adaptor2 );
 
   itk::SimpleFilterWatcher watcher1(writer, "stream pasting writing");
 

--- a/Examples/Segmentation/WatershedSegmentation1.cxx
+++ b/Examples/Segmentation/WatershedSegmentation1.cxx
@@ -62,6 +62,7 @@
 #include "itkImageFileWriter.h"
 #include "itkCastImageFilter.h"
 #include "itkScalarToRGBPixelFunctor.h"
+#include "itkRGBToVectorImageAdaptor.h"
 
 int main( int argc, char *argv[] )
 {
@@ -102,8 +103,9 @@ int main( int argc, char *argv[] )
 
   // Software Guide : BeginCodeSnippet
   using FileReaderType = itk::ImageFileReader< RGBImageType >;
+  using AdaptorType = itk::RGBToVectorImageAdaptor< RGBImageType >;
   using CastFilterType =
-      itk::CastImageFilter< RGBImageType, VectorImageType >;
+      itk::CastImageFilter< AdaptorType, VectorImageType >;
   using DiffusionFilterType =
     itk::VectorGradientAnisotropicDiffusionImageFilter<
                         VectorImageType, VectorImageType >;
@@ -117,6 +119,7 @@ int main( int argc, char *argv[] )
   FileReaderType::Pointer reader = FileReaderType::New();
   reader->SetFileName(argv[1]);
 
+  AdaptorType::Pointer adaptor = AdaptorType::New();
   CastFilterType::Pointer caster = CastFilterType::New();
 
   // Software Guide : BeginLatex
@@ -207,7 +210,8 @@ int main( int argc, char *argv[] )
   // Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  caster->SetInput(reader->GetOutput());
+  adaptor->SetImage(reader->GetOutput());
+  caster->SetInput(adaptor);
   diffusion->SetInput(caster->GetOutput());
   gradient->SetInput(diffusion->GetOutput());
   watershed->SetInput(gradient->GetOutput());

--- a/Examples/Segmentation/WatershedSegmentation1.cxx
+++ b/Examples/Segmentation/WatershedSegmentation1.cxx
@@ -60,7 +60,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkScalarToRGBPixelFunctor.h"
 
 int main( int argc, char *argv[] )
@@ -80,7 +80,7 @@ int main( int argc, char *argv[] )
   // work properly.  The preprocessing stages are applied directly to the
   // vector-valued data and the segmentation uses floating point
   // scalar data.  Images are converted from RGB pixel type to
-  // numerical vector type using \doxygen{VectorCastImageFilter}.
+  // numerical vector type using \doxygen{CastImageFilter}.
   //
   // Software Guide : EndLatex
 
@@ -103,7 +103,7 @@ int main( int argc, char *argv[] )
   // Software Guide : BeginCodeSnippet
   using FileReaderType = itk::ImageFileReader< RGBImageType >;
   using CastFilterType =
-      itk::VectorCastImageFilter< RGBImageType, VectorImageType >;
+      itk::CastImageFilter< RGBImageType, VectorImageType >;
   using DiffusionFilterType =
     itk::VectorGradientAnisotropicDiffusionImageFilter<
                         VectorImageType, VectorImageType >;

--- a/Modules/Compatibility/Deprecated/include/itkVectorCastImageFilter.h
+++ b/Modules/Compatibility/Deprecated/include/itkVectorCastImageFilter.h
@@ -37,7 +37,7 @@ namespace itk
  * \sa Vector
  *
  * \ingroup IntensityImageFilters  MultiThreaded
- * \ingroup ITKImageFilterBase
+ * \ingroup ITKDeprecated
  */
 namespace Functor
 {

--- a/Modules/Compatibility/Deprecated/test/CMakeLists.txt
+++ b/Modules/Compatibility/Deprecated/test/CMakeLists.txt
@@ -33,7 +33,7 @@ if (NOT ITK_LEGACY_REMOVE)
 endif()
 
 itk_add_test(NAME itkVectorResampleImageFilterTest
-      COMMAND ITKImageGridTestDriver
+      COMMAND ITKDeprecatedTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/VectorResampleImageFilterTest.png}
               ${ITK_TEST_OUTPUT_DIR}/VectorResampleImageFilterTest.png
     itkVectorResampleImageFilterTest ${ITK_TEST_OUTPUT_DIR}/VectorResampleImageFilterTest.png)

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -24,7 +24,7 @@
 #endif
 
 #include "itkIndent.h"
-#include "itkFixedArray.h"
+#include "itkVector.h"
 #include "itkMath.h"
 
 namespace itk
@@ -109,6 +109,18 @@ public:
   bool operator<(const Self & vec) const;
 
   bool operator==(const Self & vec) const;
+
+  /** Implicit casting operator. Return an equivalent itk::Vector. */
+  template< typename TPixelOutput >
+  operator Vector< TPixelOutput, 4 >() const
+  {
+    Vector< TPixelOutput, 4 > v;
+    v[0] = static_cast< TPixelOutput >( this->operator[](0) );
+    v[1] = static_cast< TPixelOutput >( this->operator[](1) );
+    v[2] = static_cast< TPixelOutput >( this->operator[](2) );
+    v[3] = static_cast< TPixelOutput >( this->operator[](3) );
+    return v;
+  }
 
   /** Return the number of components. */
   static unsigned int GetNumberOfComponents() { return 4; }

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -24,7 +24,7 @@
 #endif
 
 #include "itkIndent.h"
-#include "itkVector.h"
+#include "itkFixedArray.h"
 #include "itkMath.h"
 
 namespace itk

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -110,18 +110,6 @@ public:
 
   bool operator==(const Self & vec) const;
 
-  /** Implicit casting operator. Return an equivalent itk::Vector. */
-  template< typename TPixelOutput >
-  operator Vector< TPixelOutput, 4 >() const
-  {
-    Vector< TPixelOutput, 4 > v;
-    v[0] = static_cast< TPixelOutput >( this->operator[](0) );
-    v[1] = static_cast< TPixelOutput >( this->operator[](1) );
-    v[2] = static_cast< TPixelOutput >( this->operator[](2) );
-    v[3] = static_cast< TPixelOutput >( this->operator[](3) );
-    return v;
-  }
-
   /** Return the number of components. */
   static unsigned int GetNumberOfComponents() { return 4; }
 

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -24,7 +24,7 @@
 #endif
 
 #include "itkIndent.h"
-#include "itkFixedArray.h"
+#include "itkVector.h"
 #include "itkMath.h"
 
 namespace itk
@@ -102,7 +102,6 @@ public:
   Self & operator=(const ComponentType r[3]);
 
   /** Aritmetic operations between pixels. Return a new RGBPixel. */
-  /** Aritmetic operations between pixels. Return a new RGBAPixel. */
   Self operator+(const Self & vec) const;
   Self operator-(const Self & vec) const;
   Self operator *(const ComponentType & f) const;
@@ -118,6 +117,17 @@ public:
   bool operator<(const Self & vec) const;
 
   bool operator==(const Self & vec) const;
+
+  /** Implicit casting operator. Return an equivalent itk::Vector. */
+  template< typename TPixelOutput >
+  operator Vector< TPixelOutput, 3 >() const
+  {
+    Vector< TPixelOutput, 3 > v;
+    v[0] = static_cast< TPixelOutput >( this->operator[](0) );
+    v[1] = static_cast< TPixelOutput >( this->operator[](1) );
+    v[2] = static_cast< TPixelOutput >( this->operator[](2) );
+    return v;
+  }
 
   /** Return the number of components. */
   static unsigned int GetNumberOfComponents(){ return 3; }

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -118,17 +118,6 @@ public:
 
   bool operator==(const Self & vec) const;
 
-  /** Implicit casting operator. Return an equivalent itk::Vector. */
-  template< typename TPixelOutput >
-  operator Vector< TPixelOutput, 3 >() const
-  {
-    Vector< TPixelOutput, 3 > v;
-    v[0] = static_cast< TPixelOutput >( this->operator[](0) );
-    v[1] = static_cast< TPixelOutput >( this->operator[](1) );
-    v[2] = static_cast< TPixelOutput >( this->operator[](2) );
-    return v;
-  }
-
   /** Return the number of components. */
   static unsigned int GetNumberOfComponents(){ return 3; }
 

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -24,7 +24,7 @@
 #endif
 
 #include "itkIndent.h"
-#include "itkVector.h"
+#include "itkFixedArray.h"
 #include "itkMath.h"
 
 namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkZeroFluxNeumannBoundaryCondition.h"
 #include "itkProgressReporter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 
 #include "itkMath.h"
 #include "itkMath.h"
@@ -166,8 +166,8 @@ DisplacementFieldJacobianDeterminantFilter< TInputImage, TRealType, TOutputImage
   //
   // cast might not be necessary, but CastImagefilter is optimized for
   // the case where the InputImageType == OutputImageType
-  typename VectorCastImageFilter< TInputImage, RealVectorImageType >::Pointer
-    caster = VectorCastImageFilter< TInputImage, RealVectorImageType >::New();
+  typename CastImageFilter< TInputImage, RealVectorImageType >::Pointer
+    caster = CastImageFilter< TInputImage, RealVectorImageType >::New();
   caster->SetInput( this->GetInput() );
   caster->Update();
   m_RealValuedInputImage = caster->GetOutput();

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -58,10 +58,10 @@ namespace itk
  * \par Template Parameters (Input and Output)
  * This filter has one required template parameter which defines the input
  * image type.  The pixel type of the input image is assumed to be a vector
- * (e.g., itk::Vector, itk::RGBPixel, itk::FixedArray).  The scalar type of the
+ * (e.g., itk::Vector, itk::FixedArray).  The scalar type of the
  * vector components must be castable to floating point.  Instantiating with an
- * image of RGBPixel<unsigned short>, for example, is allowed, but the filter
- * will convert it to an image of Vector<float,3> for processing.
+ * image of RGBPixel is not allowed but the image can be converted/adapted
+ * to Vector for processing.
  *
  * The second template parameter, TRealType, can be optionally specified to define the
  * scalar numerical type used in calculations.  This is the component type of
@@ -284,7 +284,7 @@ protected:
   using ImageBaseType = typename InputImageType::Superclass;
 
   /** Get access to the input image casted as real pixel values */
-  itkGetConstObjectMacro(RealValuedInputImage, ImageBaseType);
+  itkGetConstObjectMacro(RealValuedInputImage, RealVectorImageType);
 
   TRealType NonPCEvaluateAtNeighborhood(const ConstNeighborhoodIteratorType & it) const
   {
@@ -472,7 +472,7 @@ private:
 
   ThreadIdType m_RequestedNumberOfThreads;
 
-  typename ImageBaseType::ConstPointer m_RealValuedInputImage;
+  typename RealVectorImageType::ConstPointer m_RealValuedInputImage;
 
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkZeroFluxNeumannBoundaryCondition.h"
 #include "itkProgressReporter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 
 #include "itkMath.h"
 
@@ -201,8 +201,8 @@ VectorGradientMagnitudeImageFilter< TInputImage, TRealType, TOutputImage >
   //
   // cast might not be necessary, but CastImagefilter is optimized for
   // the case where the InputImageType == OutputImageType
-  typename VectorCastImageFilter< TInputImage, RealVectorImageType >::Pointer
-    caster = VectorCastImageFilter< TInputImage, RealVectorImageType >::New();
+  typename CastImageFilter< TInputImage, RealVectorImageType >::Pointer
+    caster = CastImageFilter< TInputImage, RealVectorImageType >::New();
   caster->SetInput( this->GetInput() );
   caster->GetOutput()->SetRequestedRegion( this->GetInput()->GetRequestedRegion() );
   caster->Update();

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
@@ -21,13 +21,15 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkRescaleIntensityImageFilter.h"
+#include "itkRGBToVectorImageAdaptor.h"
 
 int itkVectorGradientMagnitudeImageFilterTest1(int ac, char* av[] )
 {
   using RGBPixelType = itk::RGBPixel<unsigned short>;
   using CharImageType = itk::Image<unsigned char, 2>;
   using RGBImageType = itk::Image<RGBPixelType, 2>;
-  using FilterType = itk::VectorGradientMagnitudeImageFilter<RGBImageType>;
+  using AdaptorType = itk::RGBToVectorImageAdaptor<RGBImageType>;
+  using FilterType = itk::VectorGradientMagnitudeImageFilter<AdaptorType>;
   using ReaderType = itk::ImageFileReader<RGBImageType>;
   using RescaleFilterType = itk::RescaleIntensityImageFilter<FilterType::OutputImageType,
     CharImageType>;
@@ -42,9 +44,11 @@ int itkVectorGradientMagnitudeImageFilterTest1(int ac, char* av[] )
   // Create a reader and filter
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(av[1]);
+  AdaptorType::Pointer adaptor = AdaptorType::New();
+  adaptor->SetImage(reader->GetOutput());
   FilterType::Pointer filter = FilterType::New();
 
-  filter->SetInput(reader->GetOutput());
+  filter->SetInput(adaptor);
 
   int mode = ::std::stoi( av[3] );
   if ( mode == 1)

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
@@ -21,6 +21,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkRescaleIntensityImageFilter.h"
+#include "itkRGBToVectorImageAdaptor.h"
 
 
 int itkVectorGradientMagnitudeImageFilterTest2(int ac, char* av[] )
@@ -29,7 +30,8 @@ int itkVectorGradientMagnitudeImageFilterTest2(int ac, char* av[] )
   using RGBImageType = itk::Image<RGBPixelType, 3>;
   using CharImage3Type = itk::Image<unsigned char, 3>;
   using CharImage2Type = itk::Image<unsigned char, 2>;
-  using FilterType = itk::VectorGradientMagnitudeImageFilter<RGBImageType>;
+  using AdaptorType = itk::RGBToVectorImageAdaptor<RGBImageType>;
+  using FilterType = itk::VectorGradientMagnitudeImageFilter<AdaptorType>;
   using ReaderType = itk::ImageFileReader<RGBImageType>;
   using RescaleFilterType =
       itk::RescaleIntensityImageFilter<FilterType::OutputImageType, CharImage3Type>;
@@ -45,8 +47,10 @@ int itkVectorGradientMagnitudeImageFilterTest2(int ac, char* av[] )
   // Create a reader and filter
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(av[1]);
+  AdaptorType::Pointer adaptor = AdaptorType::New();
+  adaptor->SetImage(reader->GetOutput());
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput(reader->GetOutput());
+  filter->SetInput(adaptor);
 
   const int mode = ::std::stoi( av[3] );
 

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
@@ -20,14 +20,15 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkPipelineMonitorImageFilter.h"
+#include "itkRGBToVectorImageAdaptor.h"
 
 int itkVectorGradientMagnitudeImageFilterTest3(int ac, char* av[] )
 {
   using RGBPixelType = itk::RGBPixel<unsigned char>;
   using RGBImageType = itk::Image<RGBPixelType, 3>;
-
   using Monitor1Filter = itk::PipelineMonitorImageFilter<RGBImageType>;
-  using FilterType = itk::VectorGradientMagnitudeImageFilter<RGBImageType>;
+  using AdaptorType = itk::RGBToVectorImageAdaptor<RGBImageType>;
+  using FilterType = itk::VectorGradientMagnitudeImageFilter<AdaptorType>;
   using ReaderType = itk::ImageFileReader<RGBImageType>;
   using Monitor2Filter = itk::PipelineMonitorImageFilter<FilterType::OutputImageType>;
   using WriterType = itk::ImageFileWriter<FilterType::OutputImageType>;
@@ -46,8 +47,11 @@ int itkVectorGradientMagnitudeImageFilterTest3(int ac, char* av[] )
   monitor1->SetInput( reader->GetOutput() );
   monitor1->ClearPipelineOnGenerateOutputInformationOff();
 
+  AdaptorType::Pointer adaptor = AdaptorType::New();
+  adaptor->SetImage( monitor1->GetOutput() );
+
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( monitor1->GetOutput() );
+  filter->SetInput( adaptor );
 
   const int mode = ::std::stoi( av[3] );
 

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -20,7 +20,7 @@
 
 #include "itkMath.h"
 #include "itkWarpImageFilter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkStreamingImageFilter.h"
 #include "itkVectorImage.h"
 #include "itkMath.h"
@@ -306,7 +306,7 @@ int itkWarpImageFilterTest(int, char* [] )
   std::cout << "Run ExpandImageFilter with streamer";
   std::cout << std::endl;
 
-  using VectorCasterType = itk::VectorCastImageFilter<FieldType,FieldType>;
+  using VectorCasterType = itk::CastImageFilter<FieldType,FieldType>;
   VectorCasterType::Pointer vcaster = VectorCasterType::New();
 
   vcaster->SetInput( warper->GetDisplacementField() );

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -19,7 +19,7 @@
 #include <iostream>
 
 #include "itkWarpVectorImageFilter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkStreamingImageFilter.h"
 
 // class to produce a linear image pattern
@@ -298,7 +298,7 @@ int itkWarpVectorImageFilterTest(int, char* [] )
   std::cout << "Run ExpandImageFilter with streamer";
   std::cout << std::endl;
 
-  using VectorCasterType = itk::VectorCastImageFilter<FieldType,FieldType>;
+  using VectorCasterType = itk::CastImageFilter<FieldType,FieldType>;
   VectorCasterType::Pointer vcaster = VectorCasterType::New();
 
   vcaster->SetInput( warper->GetDisplacementField() );

--- a/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
@@ -20,7 +20,7 @@
 
 #include "itkVectorExpandImageFilter.h"
 #include "itkVectorNearestNeighborInterpolateImageFunction.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkStreamingImageFilter.h"
 #include "itkMath.h"
 
@@ -218,7 +218,7 @@ int itkVectorExpandImageFilterTest(int, char* [] )
   std::cout << "Run ExpandImageFilter with streamer";
   std::cout << std::endl;
 
-  using CasterType = itk::VectorCastImageFilter<ImageType,ImageType>;
+  using CasterType = itk::CastImageFilter<ImageType,ImageType>;
   CasterType::Pointer caster = CasterType::New();
 
   caster->SetInput( expander->GetInput() );

--- a/Modules/Nonunit/IntegratedTest/test/itkBasicFiltersPrintTest2.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBasicFiltersPrintTest2.cxx
@@ -83,7 +83,6 @@
 #include "itkTwoOutputExampleImageFilter.h"
 #include "ITKVTKImageExport.h"
 #include "itkVTKImageImport.h"
-#include "itkVectorCastImageFilter.h"
 #include "itkVectorCurvatureAnisotropicDiffusionImageFilter.h"
 #include "itkVectorExpandImageFilter.h"
 #include "itkVectorGradientAnisotropicDiffusionImageFilter.h"
@@ -394,10 +393,6 @@ int itkBasicFiltersPrintTest2(int , char* [])
   itk::VTKImageImport<OutputType>::Pointer VTKImageImportObj =
     itk::VTKImageImport<OutputType>::New();
   std::cout << "-------------VTKImageImport" << VTKImageImportObj;
-
-  itk::VectorCastImageFilter<VectorImageType,VectorImageType>::Pointer VectorCastImageFilterObj =
-    itk::VectorCastImageFilter<VectorImageType,VectorImageType>::New();
-  std::cout << "-------------VectorCastImageFilter" << VectorCastImageFilterObj;
 
   itk::VectorCurvatureAnisotropicDiffusionImageFilter<VectorImageType,VectorImageType>::Pointer VectorCurvatureAnisotropicDiffusionImageFilterObj =
     itk::VectorCurvatureAnisotropicDiffusionImageFilter<VectorImageType,VectorImageType>::New();

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -31,7 +31,7 @@
 #include "itkVector.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageToRectilinearFEMObjectFilter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkVectorIndexSelectionCastImageFilter.h"
 #include "itkWarpImageFilter.h"
 #include "itkImageToImageMetric.h"

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -22,7 +22,7 @@
 #include "itkWarpImageFilter.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itkCommand.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkImageFileWriter.h"
 
 
@@ -169,7 +169,7 @@ int itkGPUDemonsRegistrationFilterTest2(int argc, char* argv[] )
   zeroVec.Fill( 0.0 );
   initField->FillBuffer( zeroVec );
 
-  using CasterType = itk::VectorCastImageFilter<FieldType,FieldType>;
+  using CasterType = itk::CastImageFilter<FieldType,FieldType>;
   CasterType::Pointer caster = CasterType::New();
   caster->SetInput( initField );
   caster->InPlaceOff();

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -21,7 +21,7 @@
 #include "itkWarpImageFilter.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itkCommand.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 
 
 namespace{
@@ -158,7 +158,7 @@ int itkDemonsRegistrationFilterTest(int, char* [] )
   zeroVec.Fill( 0.0 );
   initField->FillBuffer( zeroVec );
 
-  using CasterType = itk::VectorCastImageFilter<FieldType,FieldType>;
+  using CasterType = itk::CastImageFilter<FieldType,FieldType>;
   CasterType::Pointer caster = CasterType::New();
   caster->SetInput( initField );
   caster->InPlaceOff();

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -19,7 +19,7 @@
 #include "itkDiffeomorphicDemonsRegistrationFilter.h"
 
 #include "itkNearestNeighborInterpolateImageFunction.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkImageFileWriter.h"
 #include "itkTestingMacros.h"
 
@@ -179,7 +179,7 @@ int itkDiffeomorphicDemonsRegistrationFilterTest(int argc, char * argv [] )
   zeroVec.Fill( 0.0 );
   initField->FillBuffer( zeroVec );
 
-  using CasterType = itk::VectorCastImageFilter<FieldType,FieldType>;
+  using CasterType = itk::CastImageFilter<FieldType,FieldType>;
   CasterType::Pointer caster = CasterType::New();
   caster->SetInput( initField );
   caster->InPlaceOff();

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -20,7 +20,7 @@
 
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itkCommand.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 
 
 namespace{
@@ -157,7 +157,7 @@ int itkFastSymmetricForcesDemonsRegistrationFilterTest(int, char* [] )
   zeroVec.Fill( 0.0 );
   initField->FillBuffer( zeroVec );
 
-  using CasterType = itk::VectorCastImageFilter<FieldType,FieldType>;
+  using CasterType = itk::CastImageFilter<FieldType,FieldType>;
   CasterType::Pointer caster = CasterType::New();
   caster->SetInput( initField );
   caster->InPlaceOff();

--- a/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
@@ -20,7 +20,7 @@
 
 #include "itkWarpImageFilter.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkImageFileWriter.h"
 #include "itkMath.h"
 
@@ -178,7 +178,7 @@ int itkLevelSetMotionRegistrationFilterTest(int argc, char * argv [] )
   zeroVec.Fill( 0.0 );
   initField->FillBuffer( zeroVec );
 
-  using CasterType = itk::VectorCastImageFilter<FieldType,FieldType>;
+  using CasterType = itk::CastImageFilter<FieldType,FieldType>;
   CasterType::Pointer caster = CasterType::New();
   caster->SetInput( initField );
   caster->InPlaceOff();

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.hxx
@@ -23,7 +23,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkGradientRecursiveGaussianImageFilter.h"
 #include "itkGradientImageFilter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkImageAlgorithm.h"
 
 namespace itk
@@ -82,7 +82,7 @@ void CurvesLevelSetFunction< TImageType, TFeatureImageType >
     derivative->Update();
 
     using DerivativeOutputImageType = typename DerivativeFilterType::OutputImageType;
-    using GradientCasterType = VectorCastImageFilter< DerivativeOutputImageType, VectorImageType >;
+    using GradientCasterType = CastImageFilter< DerivativeOutputImageType, VectorImageType >;
 
     typename GradientCasterType::Pointer caster = GradientCasterType::New();
     caster->SetInput( derivative->GetOutput() );

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.hxx
@@ -22,7 +22,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkGradientRecursiveGaussianImageFilter.h"
 #include "itkGradientImageFilter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkImageAlgorithm.h"
 #include "itkMath.h"
 
@@ -69,7 +69,7 @@ void GeodesicActiveContourLevelSetFunction< TImageType, TFeatureImageType >
     derivative->Update();
 
     using DerivativeOutputImageType = typename DerivativeFilterType::OutputImageType;
-    using GradientCasterType = VectorCastImageFilter< DerivativeOutputImageType, VectorImageType >;
+    using GradientCasterType = CastImageFilter< DerivativeOutputImageType, VectorImageType >;
 
     typename GradientCasterType::Pointer caster = GradientCasterType::New();
     caster->SetInput( derivative->GetOutput() );

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.hxx
@@ -69,7 +69,7 @@ void GeodesicActiveContourShapePriorLevelSetFunction< TImageType, TFeatureImageT
     derivative->Update();
 
     using DerivativeOutputImageType = typename DerivativeFilterType::OutputImageType;
-    using GradientCasterType = VectorCastImageFilter< DerivativeOutputImageType, VectorImageType >;
+    using GradientCasterType = CastImageFilter< DerivativeOutputImageType, VectorImageType >;
 
     typename GradientCasterType::Pointer caster = GradientCasterType::New();
     caster->SetInput( derivative->GetOutput() );

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.h
@@ -21,7 +21,7 @@
 #include "itkLevelSetFunction.h"
 #include "itkLinearInterpolateImageFunction.h"
 #include "itkVectorLinearInterpolateImageFunction.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 
 namespace itk
 {
@@ -151,7 +151,7 @@ protected:
   typename VectorImageType::Pointer m_AdvectionImage;
 
   /** A casting functor to convert between vector types.  */
-  Functor::VectorCast< typename VectorInterpolatorType::OutputType,
+  Functor::Cast< typename VectorInterpolatorType::OutputType,
                        VectorType > m_VectorCast;
 
   /** Returns the propagation speed from the precalculated speed image.*/

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -23,7 +23,7 @@
 #include "itkLevelSetEquationAdvectionTerm.h"
 #include "itkGradientRecursiveGaussianImageFilter.h"
 #include "itkGradientImageFilter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 
 namespace itk
 {
@@ -100,7 +100,7 @@ LevelSetEquationAdvectionTerm< TInput, TLevelSetContainer >
     derivative->Update();
 
     using DerivativeOutputImageType = typename DerivativeFilterType::OutputImageType;
-    using GradientCasterType = VectorCastImageFilter< DerivativeOutputImageType, AdvectionImageType >;
+    using GradientCasterType = CastImageFilter< DerivativeOutputImageType, AdvectionImageType >;
 
     typename GradientCasterType::Pointer caster = GradientCasterType::New();
     caster->SetInput( derivative->GetOutput() );


### PR DESCRIPTION
Replace VectorCastImageFilter with the generic CastImageFilter.

I only had to implement a converter from RGBPixel to Vector.

I also fixed a small mistake from the VectorResampleImageFilter deprecation.