### PR TITLE
ENH: Add environmental override for git tag of remote module

### DIFF
--- a/Modules/Remote/WikiExamples.remote.cmake
+++ b/Modules/Remote/WikiExamples.remote.cmake
@@ -1,16 +1,8 @@
 #
 # ITK WikiExamples
 #
-
-# If the environment var WikiExamplesTag exists, use it
-if (NOT DEFINED ENV{WikiExamplesTag})
-  set(GIT_TAG 07f0e1622ca3eeed8b9c5b9665b066b785af86e8)
-else()
-  set(GIT_TAG $ENV{WikiExamplesTag})
-endif()
-
 itk_fetch_module(WikiExamples
   "A collection of examples that illustrate how to use ITK."
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKWikiExamples.git
-  GIT_TAG ${GIT_TAG}
+  GIT_TAG 07f0e1622ca3eeed8b9c5b9665b066b785af86e8
   )


### PR DESCRIPTION
An environmental variable ${_name}_GIT_TAG_OVERRIDE can be set
in the environment to override the value in the remote module.
The intent of the environmental variable override is to
facilitate testing of remote module branch behaviors without
requiring changes to the ITK code base.

