### PR TITLE
BUG: the clang version check was overly strict on Apple platforms

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -162,8 +162,8 @@ namespace itk
   #error "The SGI compiler is not supported under ITKv4 and above"
 #endif
 #if defined(__APPLE__)
-  #if defined( __clang__ ) && (( __clang_major__ < 8 ) || (( __clang_major__ == 8 ) && ( __clang_minor__ < 1 )))
-    #error "Apple LLVM < 8.1 is not supported under ITKv5"
+  #if defined( __clang__ ) && ( __cplusplus < 201103L )
+    #error "Apple LLVM < 5.0 (clang < 3.3) is not supported under ITKv5"
   #endif
 #elif defined( __clang__ ) && (( __clang_major__ < 3 ) || (( __clang_major__ == 3 ) && ( __clang_minor__ < 3 )))
   #error "Clang < 3.3 is not supported under ITKv5"


### PR DESCRIPTION
https://stackoverflow.com/a/36000632/276168 says that Apple versioning
diverged from mainline at version 7.0.

The bug was introduced by f6dd46be8a7cd3b39dd03fbe23900d27abddf6aa.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.
