### PR TITLE
DOC: Remove documentation references to VectorResampleImageFilter

### DIFF
--- a/Examples/Filtering/RGBCurvatureAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/RGBCurvatureAnisotropicDiffusionImageFilter.cxx
@@ -66,7 +66,7 @@
 //  \code{float} representation. However for input and output purposes
 //  \code{unsigned char} RGB components are commonly used. It is necessary to
 //  cast the type of color components in the pipeline before writing them to
-//  a file. The \doxygen{VectorCastImageFilter} is used to achieve this goal.
+//  a file. The \doxygen{CastImageFilter} is used to achieve this goal.
 //
 //  Software Guide : EndLatex
 

--- a/Examples/Filtering/RGBGradientAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/RGBGradientAnisotropicDiffusionImageFilter.cxx
@@ -66,7 +66,7 @@
 //  \code{float} representation. However for input and output purposes
 //  \code{unsigned char} RGB components are commonly used. It is necessary to
 //  cast the type of color components along the pipeline before writing them
-//  to a file. The \doxygen{VectorCastImageFilter} is used to achieve this
+//  to a file. The \doxygen{CastImageFilter} is used to achieve this
 //  goal.
 //
 //  Software Guide : EndLatex

--- a/Examples/Filtering/ResampleImageFilter6.cxx
+++ b/Examples/Filtering/ResampleImageFilter6.cxx
@@ -16,15 +16,6 @@
  *
  *=========================================================================*/
 
-//  Software Guide : BeginLatex
-//
-//  Resampling can also be performed in multi-component images.
-//
-//  \index{itk::VectorResampleImageFilter!Image internal transform}
-//
-//  Software Guide : EndLatex
-
-
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -35,7 +35,6 @@ namespace itk
  *
  * \wiki
  * \wikiexample{SimpleOperations/TranslationTransform,Translate an image}
- * \wikiexample{VectorImages/VectorResampleImageFilter,Translate a vector image}
  * \wikiexample{Registration/ImageRegistrationMethod,A basic global registration of two images}
  * \wikiexample{Registration/MutualInformation,Mutual Information}
  * \endwiki


### PR DESCRIPTION
The VectorResampleImageFilter has been deprecated, so remove
references to wiki pages and software guide.
