### PR TITLE
COMP: fix wrong GDCM library name, gdcmopenjp2 -> itkgdcmopenjp2

### DIFF
--- a/Modules/ThirdParty/GDCM/src/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/CMakeLists.txt
@@ -78,8 +78,7 @@ foreach(lib
     gdcmjpeg12
     gdcmjpeg16
     gdcmjpeg8
-    gdcmopenjpeg
-    itkgdcmopenjp2
+    gdcmopenjp2
     gdcmsocketxx
     gdcmuuid
     )


### PR DESCRIPTION
I cannot link anymore since the latest changes (I'm guessing d230b36). See e.g. this [dashboard result](https://my.cdash.org/viewBuildError.php?buildid=1650863). I hope this is the right patch but please check @malaterre . Thanks!