### PR TITLE
ENH: Add NumberOfCorners and ComputeCorners() to BoundingBox

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -410,6 +410,9 @@ b40f74e07d74614c75be4aceac63b87e80e589d1 on 2018-11-14.
 `FixedArray` member functions `rBegin()` and `rEnd()` are replaced by `rbegin()` and `rend()`,
 which return a `reverse_iterator`, compatible with the Standard C++ Library.
 
+`BoundingBox` member function `GetCorners()` is replaced by `ComputeCorners()`, which return an
+`std::array<PointType, NumberOfCorners>`, instead of a pointer to a `PointsContainer`.
+
 `itk::ImageTransformer` has been moved to `ITKDeprecated` module. The new `itk::ImageSink` filter can be used in its place.
 
 `itk::StatisticsImageFilter`, `itk::LabelStatisticsImageFilter` and

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -127,7 +127,7 @@ public:
   std::array<PointType, NumberOfCorners> ComputeCorners() const;
 
   /** Compute and return the corners of the bounding box */
-  const PointsContainer * GetCorners();
+  itkLegacyMacro( const PointsContainer * GetCorners() );
 
   /** Method that actually computes bounding box. */
   bool ComputeBoundingBox() const;
@@ -191,7 +191,9 @@ protected:
 
 private:
   PointsContainerConstPointer m_PointsContainer;
-  PointsContainerPointer      m_CornersContainer;
+#if !defined(ITK_LEGACY_REMOVE)
+  PointsContainerPointer      m_CornersContainer{ PointsContainer::New() };
+#endif
   mutable BoundsArrayType     m_Bounds;
   mutable TimeStamp           m_BoundsMTime; // The last time the bounds
                                              // were computed.

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -32,6 +32,8 @@
 #include "itkVectorContainer.h"
 #include "itkIntTypes.h"
 
+#include <array>
+
 namespace itk
 {
 /** \class BoundingBox
@@ -91,6 +93,9 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
+  /* Number of corners of this bounding box. Equals `pow(2, VPointDimension)` */
+  static constexpr SizeValueType NumberOfCorners = SizeValueType{ 1 } << VPointDimension;
+
   /** Hold on to the type information specified by the template parameters. */
   using PointIdentifier = TPointIdentifier;
   using CoordRepType = TCoordRep;
@@ -114,6 +119,12 @@ public:
   void SetPoints(const PointsContainer *);
 
   const PointsContainer * GetPoints() const;
+
+  /** Compute and return the corners of the bounding box.
+   *\note This function returns the same points as `GetCorners()`, but it is
+   * `const`, and it avoids dynamic memory allocation by using `std::array`.
+  */
+  std::array<PointType, NumberOfCorners> ComputeCorners() const;
 
   /** Compute and return the corners of the bounding box */
   const PointsContainer * GetCorners();

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -112,6 +112,7 @@ BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
   return result;
 }
 
+#if !defined(ITK_LEGACY_REMOVE)
 /** Compute and get the corners of the bounding box */
 template< typename TPointIdentifier, int VPointDimension,
           typename TCoordRep, typename TPointsContainer >
@@ -131,6 +132,7 @@ BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
 
   return m_CornersContainer.GetPointer();
 }
+#endif
 
 /** */
 template< typename TPointIdentifier, int VPointDimension,
@@ -139,7 +141,6 @@ BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
 ::BoundingBox():m_PointsContainer(nullptr)
 {
   m_Bounds.Fill(NumericTraits< CoordRepType >::ZeroValue());
-  m_CornersContainer = PointsContainer::New();
 }
 
 template< typename TPointIdentifier, int VPointDimension,

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -83,12 +83,11 @@ BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
 /** Compute and get the corners of the bounding box */
 template< typename TPointIdentifier, int VPointDimension,
           typename TCoordRep, typename TPointsContainer >
-const typename BoundingBox< TPointIdentifier, VPointDimension, TCoordRep,
-                            TPointsContainer >::PointsContainer *
+auto
 BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
-::GetCorners()
+::ComputeCorners() const -> std::array<PointType, NumberOfCorners>
 {
-  m_CornersContainer->clear();
+  std::array<PointType, NumberOfCorners> result;
 
   PointType center = this->GetCenter();
   PointType radius;
@@ -98,7 +97,7 @@ BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
     radius[i] = m_Bounds[2 * i + 1] - center[i];
     }
 
-  for ( unsigned int j = 0; j < std::pow(2.0, (double)VPointDimension); j++ )
+  for ( unsigned int j = 0; j < NumberOfCorners; j++ )
     {
     PointType pnt;
     for ( unsigned int i = 0; i < VPointDimension; i++ )
@@ -107,6 +106,25 @@ BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
                * radius[i];
       }
 
+    result[j] = pnt;
+    }
+
+  return result;
+}
+
+/** Compute and get the corners of the bounding box */
+template< typename TPointIdentifier, int VPointDimension,
+          typename TCoordRep, typename TPointsContainer >
+const typename BoundingBox< TPointIdentifier, VPointDimension, TCoordRep,
+                            TPointsContainer >::PointsContainer *
+BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
+::GetCorners()
+{
+  m_CornersContainer->clear();
+  m_CornersContainer->reserve(NumberOfCorners);
+
+  for (const PointType& pnt: this->ComputeCorners())
+    {
     // Push back is not defined so we insert at the end of the list
     m_CornersContainer->InsertElement(m_CornersContainer->Size(), pnt);
     }

--- a/Modules/Core/Common/test/itkBoundingBoxTest.cxx
+++ b/Modules/Core/Common/test/itkBoundingBoxTest.cxx
@@ -168,11 +168,11 @@ int itkBoundingBoxTest (int, char*[])
     }
 
   // Testing the corners
-  std::cout << "Testing GetCorners() : ";
-  const CC::PointsContainer * corners = my3DBox->GetCorners();
-  auto it = corners->begin();
+  std::cout << "Testing ComputeCorners() : ";
+  const auto corners = my3DBox->ComputeCorners();
+  auto it = corners.begin();
   unsigned int j=0;
-  while(it != corners->end())
+  while(it != corners.end())
     {
     for(unsigned int i=0; i<3;i++)
       {

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -431,17 +431,17 @@ SpatialObject< TDimension >
 {
     // Next Transform the corners of the bounding box
   using PointsContainer = typename BoundingBoxType::PointsContainer;
-  const PointsContainer *corners
-    = m_FamilyBoundingBoxInObjectSpace->GetCorners();
+  const auto corners
+    = m_FamilyBoundingBoxInObjectSpace->ComputeCorners();
   typename PointsContainer::Pointer transformedCorners =
     PointsContainer::New();
   transformedCorners->Reserve(
     static_cast<typename PointsContainer::ElementIdentifier>(
-      corners->size() ) );
+      corners.size() ) );
 
-  auto it = corners->begin();
+  auto it = corners.begin();
   auto itTrans = transformedCorners->begin();
-  while ( it != corners->end() )
+  while ( it != corners.end() )
     {
     PointType pnt = this->GetObjectToWorldTransform()->TransformPoint(*it);
     *itTrans = pnt;
@@ -723,17 +723,17 @@ SpatialObject< TDimension >
 {
     // Next Transform the corners of the bounding box
   using PointsContainer = typename BoundingBoxType::PointsContainer;
-  const PointsContainer *corners
-    = m_MyBoundingBoxInObjectSpace->GetCorners();
+  const auto corners
+    = m_MyBoundingBoxInObjectSpace->ComputeCorners();
   typename PointsContainer::Pointer transformedCorners =
     PointsContainer::New();
   transformedCorners->Reserve(
     static_cast<typename PointsContainer::ElementIdentifier>(
-      corners->size() ) );
+      corners.size() ) );
 
-  auto it = corners->begin();
+  auto it = corners.begin();
   auto itTrans = transformedCorners->begin();
-  while ( it != corners->end() )
+  while ( it != corners.end() )
     {
     PointType pnt = this->GetObjectToWorldTransform()->TransformPoint(*it);
     *itTrans = pnt;


### PR DESCRIPTION
Added `BoundingBox::NumberOfCorners`, evaluated at compile time, which
was used to replace a run-time `std::pow(2.0, VPointDimension)` call.

Added `BoundingBox::ComputeCorners()`, returning an `std::array` of
points, to allow users to get the corners of a bounding box without
the performance cost of dynamic memory allocation of a point container.

Adapted `GetCorners()`, now doing a `reserve` of the expected number of
points, and calling `ComputeCorners()` to compute those corner points.

Replaced calls to `GetCorners()` by `ComputeCorners()`, in the
implementation of `SpatialObject`.