### PR TITLE
COMP: follow up to 814419a (bounding box m_CornersContainer removal)

### DIFF
--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -390,6 +390,7 @@ BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
   // Connect the same points container into the clone
   clone->SetPoints(this->m_PointsContainer);
 
+#if !defined( ITK_LEGACY_REMOVE )
   // Copy the corners into the clone.
   clone->m_CornersContainer->clear();
 
@@ -404,6 +405,7 @@ BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
     dest.Value() = itr.Value();
     ++itr;
     }
+#endif
 
   // Copy the bounds into the clone
   for ( unsigned int i = 0; i < 2 * PointDimension; i++ )


### PR DESCRIPTION
Enable compiling in ITK_LEGACY_REMOVE mode. The problem was
introduced by 814419ae9f989c10c597a5e913166d3e8c949267.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.
