### PR TITLE
Update generic label interpolator

### DIFF
--- a/Modules/Remote/GenericLabelInterpolator.remote.cmake
+++ b/Modules/Remote/GenericLabelInterpolator.remote.cmake
@@ -1,5 +1,5 @@
 itk_fetch_module(GenericLabelInterpolator
   "A generic interpolator for multi-label images."
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKGenericLabelInterpolator.git
-  GIT_TAG 161b558c6e700e388d85a5fe07e455dcba4eefaf
+  GIT_TAG 187ab99b7d42718c99e5017f0acd3900d7469bd1
   )


### PR DESCRIPTION
Changes made necessary to build ANTs normalization tools against ITK.