### PR TITLE
ENH: run large image IO tests serially

### DIFF
--- a/Modules/IO/TIFF/test/CMakeLists.txt
+++ b/Modules/IO/TIFF/test/CMakeLists.txt
@@ -235,8 +235,11 @@ if( "${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5 )
                        RESOURCE_LOCK MEMORY_SIZE
                       )
   set_property(TEST itkLargeTIFFImageWriteReadTest1 APPEND PROPERTY LABELS RUNS_LONG)
+  set_property(TEST itkLargeTIFFImageWriteReadTest1 APPEND PROPERTY RUN_SERIAL True)
   set_property(TEST itkLargeTIFFImageWriteReadTest2 APPEND PROPERTY LABELS RUNS_LONG)
+  set_property(TEST itkLargeTIFFImageWriteReadTest2 APPEND PROPERTY RUN_SERIAL True)
   set_property(TEST itkLargeTIFFImageWriteReadTest3 APPEND PROPERTY LABELS RUNS_LONG)
+  set_property(TEST itkLargeTIFFImageWriteReadTest3 APPEND PROPERTY RUN_SERIAL True)
 endif()
 
 


### PR DESCRIPTION
When running the test in parallel, which is the norm, computer can
run out of memory. This change ensures that large TIFF tests are run
serially, in order to minimize the chance of allocation failures.
Example failure message:
```text
Trying to allocate an image of size 9346 MiB
ITK test driver caught an ITK exception:

itk::MemoryAllocationError (000000B95A0FF7D8)
Location: "unknown"
File: c:\dashboard\itk\modules\core\common\include\itkImportImageContainer.hxx
Line: 199
Description: Failed to allocate memory for image.
```
## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.
