### PR TITLE
COMP: Fixed GCC4 missing-field-initializers warning on `{}` in GTest

### DIFF
--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -32,7 +32,7 @@ namespace
   template< typename TValue, unsigned int VLength >
   void Check_FixedArray_supports_retrieving_values_by_range_based_for_loop()
   {
-    std::array<TValue, VLength> stdArray{};
+    std::array<TValue, VLength> stdArray;
 
     // Assign a different value (1, 2, 3, ...) to each element.
     std::iota(stdArray.begin(), stdArray.end(), 1);


### PR DESCRIPTION
Removed a pair of curly braces, `{}`, from the declaration of a local
`std::array` variable in itkFixedArrayGTest, to avoid a warning from
GCC4, reported by @dzenanz:

> itkFixedArrayGTest.cxx:35:42: warning: missing initializer for member
> 'std::array<double, 2ul>::_M_elems' [-Wmissing-field-initializers]

After removing those curly braces, the array may no longer be initialized.
Fortunately the array does not really need to be initialized at the point
of declaration, as each array element is assigned a new value directly
after the declaration.