### PR TITLE
ENH: use double-conversion's CMake targets

### DIFF
--- a/Modules/ThirdParty/DoubleConversion/CMakeLists.txt
+++ b/Modules/ThirdParty/DoubleConversion/CMakeLists.txt
@@ -7,19 +7,9 @@ option(ITK_USE_SYSTEM_DOUBLECONVERSION
 mark_as_advanced(ITK_USE_SYSTEM_DOUBLECONVERSION)
 
 if(ITK_USE_SYSTEM_DOUBLECONVERSION)
-  find_library(double-conversion_LIBRARIES double-conversion)
-  find_path(double-conversion_INCLUDE_DIRS double-conversion.h
-    PATH_SUFFIXES double-conversion
-    )
-
-  if (double-conversion_LIBRARIES AND double-conversion_INCLUDE_DIRS)
-    set(ITKDoubleConversion_SYSTEM_INCLUDE_DIRS
-      ${double-conversion_INCLUDE_DIRS}/..)
-    set(ITKDoubleConversion_LIBRARIES
-      "${double-conversion_LIBRARIES}")
-  else()
-    message(ERROR "double-conversion system library not found")
-  endif()
+  find_package(double-conversion REQUIRED)
+  get_target_property(ITKDoubleConversion_INCLUDE_DIRS double-conversion::double-conversion INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(ITKDoubleConversion_LIBRARIES double-conversion::double-conversion LOCATION)
 else()
   set(ITKDoubleConversion_INCLUDE_DIRS
     ${ITKDoubleConversion_SOURCE_DIR}/src


### PR DESCRIPTION
This will support multiple system versions of double-conversion.
Suggested by Alexander Neumann. Closes #579. Aimed to be back-ported to 4.13.x release to address #912.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

