### PR TITLE
Follow up commit to fix itkBoundingBox with LEGACY support

### DIFF
--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -121,8 +121,8 @@ const typename BoundingBox< TPointIdentifier, VPointDimension, TCoordRep,
 BoundingBox< TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer >
 ::GetCorners()
 {
-  m_CornersContainer->clear();
-  m_CornersContainer->reserve(NumberOfCorners);
+  m_CornersContainer->Initialize();
+  m_CornersContainer->Reserve(NumberOfCorners);
 
   for (const PointType& pnt: this->ComputeCorners())
     {


### PR DESCRIPTION
When compiling ITK with ITK_LEGACY_SILENT set to ON, e.g. when compiling
with Python wrapping ON, ITK was not compiling because itkVectorContainer
class does not have a member function called `clear()` or a function called
`reserve()`. This regression was introduced in [1] and the PR is was a
follow up of.

[1] 5b508a5e88bb70ec6667569f6adcf9c915225f08
