### PR TITLE
ENH: update RTK remote file with release tag v2.0.1

### DIFF
--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -2,5 +2,5 @@
 itk_fetch_module(RTK
     "Reconstruction Toolkit (RTK) http://www.openrtk.org/"
   GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/RTK.git
-  GIT_TAG db27af04eaf24bdbaa4c2c2020e067586d3c6341
+  GIT_TAG v2.0.1
 )


### PR DESCRIPTION
See [RTK release notes](https://github.com/SimonRit/RTK/releases/tag/v2.0.1). It would be nice to include it in ITK v5 if possible.