### PR TITLE
STYLE: Rename ITK macro EXPECT_VECTOR_NEAR to ITK_EXPECT_VECTOR_NEAR

### DIFF
--- a/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
+++ b/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
@@ -152,27 +152,27 @@ public:
     index1.at(1)  = 6; //non-const at()
     index1.m_InternalArray[2] = 6; //Direct access
     index1.SetElement(3,6); //SetElement
-    EXPECT_VECTOR_NEAR(index1, knownAll6s, 0);
+    ITK_EXPECT_VECTOR_NEAR(index1, knownAll6s, 0);
 
     AggregateType index2 = index1; // Copy constructor
-    EXPECT_VECTOR_NEAR(index2, index1, 0);
+    ITK_EXPECT_VECTOR_NEAR(index2, index1, 0);
 
     index2.assign(4); // Use std::array like syntax
-    EXPECT_VECTOR_NEAR(index2, knownAll4s, 0);
+    ITK_EXPECT_VECTOR_NEAR(index2, knownAll4s, 0);
     index2.front() = 6;  //Non const ref
     index2.data()[1] = 6; //Test non-const data
     index2.data()[2] = 6;
     index2.back() = 6;  //Non const ref
-    EXPECT_VECTOR_NEAR(index2, knownAll6s, 0);
+    ITK_EXPECT_VECTOR_NEAR(index2, knownAll6s, 0);
     index2.Fill(7);
     EXPECT_EQ( index2.back() , 7);
     EXPECT_EQ( index2.back() , 7);
     EXPECT_EQ( index2.data()[3], 7); //Test const data access
 
     index2.swap(index1);
-    EXPECT_VECTOR_NEAR(index1, knownAll7s, 0);
+    ITK_EXPECT_VECTOR_NEAR(index1, knownAll7s, 0);
     swap(index1, index2);
-    EXPECT_VECTOR_NEAR(index1, knownAll6s, 0);
+    ITK_EXPECT_VECTOR_NEAR(index1, knownAll6s, 0);
 
     {
       auto rit = knownInitValues.rbegin(); // test const reverse_iterator
@@ -183,11 +183,11 @@ public:
         ++rit;
         ++it;
       }
-      EXPECT_VECTOR_NEAR(index2,knownInitValues,0);
+      ITK_EXPECT_VECTOR_NEAR(index2,knownInitValues,0);
     }
 
     index2.Fill(6);
-    EXPECT_VECTOR_NEAR(index2, knownAll6s, 0);
+    ITK_EXPECT_VECTOR_NEAR(index2, knownAll6s, 0);
 
     index2 = index1;
     EXPECT_EQ( index2 == index1 , true);
@@ -235,25 +235,25 @@ public:
       const SizeType knownAll4s{{4, 4, 4, 4}};
 
       index2 += knownAll1s;  //operator+= SizeType
-      EXPECT_VECTOR_NEAR(index2, knownInitValuesPlus1, 0);
+      ITK_EXPECT_VECTOR_NEAR(index2, knownInitValuesPlus1, 0);
 
       index3 = index1 + knownAll1s; //operator+ SizeType
-      EXPECT_VECTOR_NEAR(index3, knownInitValuesPlus1, 0);
+      ITK_EXPECT_VECTOR_NEAR(index3, knownInitValuesPlus1, 0);
 
       index3 = index2 - knownAll1s; //operator- SizeType
-      EXPECT_VECTOR_NEAR(index3, index1, 0);
+      ITK_EXPECT_VECTOR_NEAR(index3, index1, 0);
 
       index2 -= knownAll1s; //operator-= SizeType
-      EXPECT_VECTOR_NEAR(index2, index1, 0);
+      ITK_EXPECT_VECTOR_NEAR(index2, index1, 0);
 
       index1.Fill(2);   // Use ITK syntax
-      EXPECT_VECTOR_NEAR(index1, knownAll2s, 0);
+      ITK_EXPECT_VECTOR_NEAR(index1, knownAll2s, 0);
 
       index3 = index1 * knownAll2s;
-      EXPECT_VECTOR_NEAR(index3, knownAll4s, 0);
+      ITK_EXPECT_VECTOR_NEAR(index3, knownAll4s, 0);
 
       index3 = index1 * knownAll2s;
-      EXPECT_VECTOR_NEAR(index3, knownAll4s, 0);
+      ITK_EXPECT_VECTOR_NEAR(index3, knownAll4s, 0);
 
     }
 
@@ -263,17 +263,17 @@ public:
 
       index2 = knownInitValues;
       index2 += knownAll1sOffset;  //operator+= SizeType
-      EXPECT_VECTOR_NEAR(index2, knownInitValuesPlus1, 0);
+      ITK_EXPECT_VECTOR_NEAR(index2, knownInitValuesPlus1, 0);
 
       index1 = knownInitValues;
       index3 = index1 + knownAll1sOffset; //operator+ SizeType
-      EXPECT_VECTOR_NEAR(index3, knownInitValuesPlus1, 0);
+      ITK_EXPECT_VECTOR_NEAR(index3, knownInitValuesPlus1, 0);
 
       index3 = index2 - knownAll1sOffset; //operator- SizeType
-      EXPECT_VECTOR_NEAR(index3, index1, 0);
+      ITK_EXPECT_VECTOR_NEAR(index3, index1, 0);
 
       index2 -= knownAll1sOffset; //operator-= SizeType
-      EXPECT_VECTOR_NEAR(index2, index1, 0);
+      ITK_EXPECT_VECTOR_NEAR(index2, index1, 0);
     }
 
     //============ Test math with Aggregate Type ====================================
@@ -281,7 +281,7 @@ public:
       const AggregateType knownAll2sAgg{{2, 2, 2, 2}};
       const AggregateType knownAll4sAgg{{4, 4, 4, 4}};
       const typename AggregateType::OffsetType knownOffset = {{ -2, -2, -2, -2 }};
-      EXPECT_VECTOR_NEAR( knownAll2sAgg - knownAll4sAgg, knownOffset, 0);
+      ITK_EXPECT_VECTOR_NEAR( knownAll2sAgg - knownAll4sAgg, knownOffset, 0);
     }
 
     //============ Test Copy with Round/Cast Type ====================================
@@ -294,11 +294,11 @@ public:
       itk::Point<double, 4> p1;
       p1.Fill( 3.5 );
       threes.CopyWithRound(p1);
-      EXPECT_VECTOR_NEAR( threes, known4s, 0 );
+      ITK_EXPECT_VECTOR_NEAR( threes, known4s, 0 );
 
       threes.Fill(0);
       threes.CopyWithCast(p1);
-      EXPECT_VECTOR_NEAR( threes, known3s, 0 );
+      ITK_EXPECT_VECTOR_NEAR( threes, known3s, 0 );
 
     }
   }
@@ -336,16 +336,16 @@ TEST(Specialized, Index  )
   const IndexType oneBasis = {{ 0, 1, 0, 0 }};
   const IndexType twoBasis = {{ 0, 0, 1, 0 }};
   const IndexType threeBasis = {{ 0, 0, 0, 1 }};
-  EXPECT_VECTOR_NEAR( IndexType::GetBasisIndex( 0 ), zeroBasis, 0 );
-  EXPECT_VECTOR_NEAR( IndexType::GetBasisIndex( 1 ), oneBasis, 0 );
-  EXPECT_VECTOR_NEAR( IndexType::GetBasisIndex( 2 ), twoBasis, 0 );
-  EXPECT_VECTOR_NEAR( IndexType::GetBasisIndex( 3 ), threeBasis, 0 );
+  ITK_EXPECT_VECTOR_NEAR( IndexType::GetBasisIndex( 0 ), zeroBasis, 0 );
+  ITK_EXPECT_VECTOR_NEAR( IndexType::GetBasisIndex( 1 ), oneBasis, 0 );
+  ITK_EXPECT_VECTOR_NEAR( IndexType::GetBasisIndex( 2 ), twoBasis, 0 );
+  ITK_EXPECT_VECTOR_NEAR( IndexType::GetBasisIndex( 3 ), threeBasis, 0 );
 
   IndexType known3s{{ 3,3,3,3}};
   IndexType threes;
   IndexType::IndexValueType raw3s[4] = {3,3,3,3};
   threes.SetIndex(raw3s);
-  EXPECT_VECTOR_NEAR( threes, known3s, 0 );
+  ITK_EXPECT_VECTOR_NEAR( threes, known3s, 0 );
 }
 
 TEST(Specialized, Offset  ) {
@@ -359,16 +359,16 @@ TEST(Specialized, Offset  ) {
   const OffsetType oneBasis = {{ 0, 1, 0, 0 }};
   const OffsetType twoBasis = {{ 0, 0, 1, 0 }};
   const OffsetType threeBasis = {{ 0, 0, 0, 1 }};
-  EXPECT_VECTOR_NEAR( OffsetType::GetBasisOffset( 0 ), zeroBasis, 0 );
-  EXPECT_VECTOR_NEAR( OffsetType::GetBasisOffset( 1 ), oneBasis, 0 );
-  EXPECT_VECTOR_NEAR( OffsetType::GetBasisOffset( 2 ), twoBasis, 0 );
-  EXPECT_VECTOR_NEAR( OffsetType::GetBasisOffset( 3 ), threeBasis, 0 );
+  ITK_EXPECT_VECTOR_NEAR( OffsetType::GetBasisOffset( 0 ), zeroBasis, 0 );
+  ITK_EXPECT_VECTOR_NEAR( OffsetType::GetBasisOffset( 1 ), oneBasis, 0 );
+  ITK_EXPECT_VECTOR_NEAR( OffsetType::GetBasisOffset( 2 ), twoBasis, 0 );
+  ITK_EXPECT_VECTOR_NEAR( OffsetType::GetBasisOffset( 3 ), threeBasis, 0 );
 
   OffsetType known3s{{ 3,3,3,3}};
   OffsetType threes;
   OffsetType::OffsetValueType raw3s[4] = {3,3,3,3};
   threes.SetOffset(raw3s);
-  EXPECT_VECTOR_NEAR( threes, known3s, 0 );
+  ITK_EXPECT_VECTOR_NEAR( threes, known3s, 0 );
 }
 
 TEST(Specialized, Size  ) {
@@ -380,5 +380,5 @@ TEST(Specialized, Size  ) {
   SizeType threes;
   SizeType::SizeValueType raw3s[4] = {3,3,3,3};
   threes.SetSize(raw3s);
-  EXPECT_VECTOR_NEAR( threes, known3s, 0 );
+  ITK_EXPECT_VECTOR_NEAR( threes, known3s, 0 );
 }

--- a/Modules/Core/TestKernel/include/itkGTestPredicate.h
+++ b/Modules/Core/TestKernel/include/itkGTestPredicate.h
@@ -30,7 +30,7 @@
  * verifies that the root mean squares error between the two array-like
  * objects doesn't exceed the given error.
  */
-#define EXPECT_VECTOR_NEAR(val1, val2, rmsError)       \
+#define ITK_EXPECT_VECTOR_NEAR(val1, val2, rmsError)       \
   EXPECT_PRED_FORMAT3(itk::GTest::Predicate::VectorDoubleRMSPredFormat, \
                       val1, val2, rmsError)
 
@@ -48,7 +48,7 @@ namespace GTest
 namespace Predicate
 {
 
-/** Implements GTest Predicate Formatter for EXPECT_VECTOR_NEAR
+/** Implements GTest Predicate Formatter for ITK_EXPECT_VECTOR_NEAR
  * macro. This macro and formatter work with any combination of ITK
  * array-like objects which are supported by itk::NumericTraits. The
  * arrays must be the same length, and the root mean squares error is

--- a/Modules/Core/TestKernel/test/itkGoogleTest.cxx
+++ b/Modules/Core/TestKernel/test/itkGoogleTest.cxx
@@ -36,28 +36,28 @@ TEST(GoogleTest,TypedefsAndConstructors_Dimension2) {
   pt1[1] = 2.2;
   const PointType pt2 = MakePoint(1.1, 2.2);
   EXPECT_TRUE(pt1 == pt2);
-  EXPECT_VECTOR_NEAR(pt1, pt2, 1e-10);
-  EXPECT_VECTOR_NEAR(pt1, MakePoint(1.1, 2.2), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(pt1, pt2, 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(pt1, MakePoint(1.1, 2.2), 1e-10);
 
   VectorType vec1;
   vec1[0] = 1.1;
   vec1[1] = 2.2;
   const VectorType vec2 = MakeVector(1.1, 2.2);
   EXPECT_TRUE(vec1 == vec2);
-  EXPECT_VECTOR_NEAR(vec1, vec2, 1e-10);
-  EXPECT_VECTOR_NEAR(vec1, MakeVector(1.1, 2.2), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(vec1, vec2, 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(vec1, MakeVector(1.1, 2.2), 1e-10);
 
   const IndexType idx1 = {{0,1}};
   const IndexType idx2 = MakeIndex(0,1);
   EXPECT_TRUE(idx1 == idx2);
-  EXPECT_VECTOR_NEAR(idx1, idx2, 1e-10);
-  EXPECT_VECTOR_NEAR(idx1, MakeIndex(0,1), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(idx1, idx2, 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(idx1, MakeIndex(0,1), 1e-10);
 
   const SizeType sz1 = {{0u,1u}};
   const SizeType sz2 = MakeSize(0u,1u);
   EXPECT_TRUE(sz1 == sz2);
-  EXPECT_VECTOR_NEAR(sz1, sz2, 1e-10);
-  EXPECT_VECTOR_NEAR(sz1, MakeSize(0u,1u), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(sz1, sz2, 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(sz1, MakeSize(0u,1u), 1e-10);
 }
 
 
@@ -72,8 +72,8 @@ TEST(GoogleTest,TypedefsAndConstructors_Dimension3) {
   pt1[2] = 3.3;
   const PointType pt2 = MakePoint(1.1, 2.2, 3.3);
   EXPECT_TRUE(pt1 == pt2);
-  EXPECT_VECTOR_NEAR(pt1, pt2, 1e-10);
-  EXPECT_VECTOR_NEAR(pt1,  MakePoint(1.1, 2.2, 3.3), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(pt1, pt2, 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(pt1,  MakePoint(1.1, 2.2, 3.3), 1e-10);
 
   VectorType vec1;
   vec1[0] = 1.1;
@@ -81,16 +81,16 @@ TEST(GoogleTest,TypedefsAndConstructors_Dimension3) {
   vec1[2] = 3.3;
   const VectorType vec2 = MakeVector(1.1, 2.2, 3.3);
   EXPECT_TRUE(vec1 == vec2);
-  EXPECT_VECTOR_NEAR(vec1, vec2, 1e-10);
-  EXPECT_VECTOR_NEAR(vec1, MakeVector(1.1, 2.2, 3.3), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(vec1, vec2, 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(vec1, MakeVector(1.1, 2.2, 3.3), 1e-10);
 
   const IndexType idx1 = {{0,1,2}};
   const IndexType idx2 = MakeIndex(0,1,2);
   EXPECT_TRUE(idx1 == idx2);
-  EXPECT_VECTOR_NEAR(idx1, idx2, 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(idx1, idx2, 1e-10);
 
   const SizeType sz1 = {{0u,1u,2u}};
   const SizeType sz2 = MakeSize(0u,1u,2u);
   EXPECT_TRUE(sz1 == sz2);
-  EXPECT_VECTOR_NEAR(sz1, MakeSize(0u,1u,2u), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(sz1, MakeSize(0u,1u,2u), 1e-10);
 }

--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -37,14 +37,14 @@ void bspline_eq( const itk::BSplineTransform<TParametersValueType, NDimensions, 
   // Compare Transform Domain interface
 
   EXPECT_EQ( bspline1->GetNumberOfFixedParameters(), bspline2->GetNumberOfFixedParameters() ) << description;
-  EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainOrigin(), bspline2->GetTransformDomainOrigin(), tolerance  ) << description;
+  ITK_EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainOrigin(), bspline2->GetTransformDomainOrigin(), tolerance  ) << description;
   EXPECT_EQ( bspline1->GetTransformDomainDirection(), bspline2->GetTransformDomainDirection()) << description;
   EXPECT_EQ( bspline1->GetTransformDomainMeshSize(), bspline2->GetTransformDomainMeshSize() ) << description;
-  EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainPhysicalDimensions(), bspline2->GetTransformDomainPhysicalDimensions(), tolerance  ) << description;
+  ITK_EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainPhysicalDimensions(), bspline2->GetTransformDomainPhysicalDimensions(), tolerance  ) << description;
 
   // check transform parameters interface
-  EXPECT_VECTOR_NEAR( bspline1->GetParameters(), bspline2->GetParameters(), tolerance  ) << description;
-  EXPECT_VECTOR_NEAR( bspline1->GetFixedParameters(), bspline2->GetFixedParameters(), tolerance  ) << description;
+  ITK_EXPECT_VECTOR_NEAR( bspline1->GetParameters(), bspline2->GetParameters(), tolerance  ) << description;
+  ITK_EXPECT_VECTOR_NEAR( bspline1->GetFixedParameters(), bspline2->GetFixedParameters(), tolerance  ) << description;
 
   ASSERT_EQ( bspline1->GetCoefficientImages().Size(), NDimensions ) << description;
   ASSERT_EQ( bspline2->GetCoefficientImages().Size(), NDimensions ) << description;
@@ -57,9 +57,9 @@ void bspline_eq( const itk::BSplineTransform<TParametersValueType, NDimensions, 
     typename ImageType::Pointer coeffImage1 = bspline1->GetCoefficientImages()[i];
     typename ImageType::Pointer coeffImage2 = bspline2->GetCoefficientImages()[i];
 
-    EXPECT_VECTOR_NEAR( coeffImage1->GetOrigin(), coeffImage2->GetOrigin(), tolerance ) << description;
+    ITK_EXPECT_VECTOR_NEAR( coeffImage1->GetOrigin(), coeffImage2->GetOrigin(), tolerance ) << description;
     EXPECT_EQ( coeffImage1->GetDirection(), coeffImage2->GetDirection()) << description;
-    EXPECT_VECTOR_NEAR( coeffImage1->GetSpacing(), coeffImage2->GetSpacing(), tolerance  ) << description;
+    ITK_EXPECT_VECTOR_NEAR( coeffImage1->GetSpacing(), coeffImage2->GetSpacing(), tolerance  ) << description;
     EXPECT_EQ( coeffImage1->GetLargestPossibleRegion(), coeffImage2->GetLargestPossibleRegion() ) << description;
     EXPECT_EQ( coeffImage1->GetBufferedRegion(), coeffImage2->GetBufferedRegion() ) << description;
 
@@ -151,10 +151,10 @@ TEST(ITKBSplineTransform, Copying_Clone) {
 
   bspline_eq(bspline1.GetPointer(), bspline1.GetPointer(), "Check after initialization by coefficient images.");
 
-  EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainOrigin(), MakePoint(-0.3, 1.9), 1e-15 );
+  ITK_EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainOrigin(), MakePoint(-0.3, 1.9), 1e-15 );
   EXPECT_EQ( bspline1->GetTransformDomainDirection(), imageDirection );
   EXPECT_EQ( bspline1->GetTransformDomainMeshSize(), MakeSize(7, 7) );
-  EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainPhysicalDimensions(), MakeVector( 7.7, 8.4 ), 1e-15 );
+  ITK_EXPECT_VECTOR_NEAR( bspline1->GetTransformDomainPhysicalDimensions(), MakeVector( 7.7, 8.4 ), 1e-15 );
 
   BSplineType::Pointer bspline2 = BSplineType::New();
   bspline2->SetFixedParameters( bspline1->GetFixedParameters() );

--- a/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
@@ -104,7 +104,7 @@ TEST_F(TileImageFixture, SetGetPrint)
   Utils::FilterType::LayoutArrayType layout(99);
 
   EXPECT_NO_THROW(filter->SetLayout(layout));
-  EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
+  ITK_EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
 
 
   EXPECT_NO_THROW(filter->SetDefaultPixelValue(99));
@@ -148,7 +148,7 @@ TEST_F(TileImageFixture, VectorImage)
   FilterType::LayoutArrayType layout(2);
 
   EXPECT_NO_THROW(filter->SetLayout(layout));
-  EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
+  ITK_EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
 
   filter->SetInput(0, image);
   filter->SetInput(1, image);
@@ -162,7 +162,7 @@ TEST_F(TileImageFixture, VectorImage)
   layout[0] = 4;
   layout[1] = 1;
   EXPECT_NO_THROW(filter->SetLayout(layout));
-  EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
+  ITK_EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
 
   EXPECT_NO_THROW(filter->UpdateLargestPossibleRegion());
   EXPECT_EQ("2258f8cfbd7395bea0bc09ab3f69b058", MD5Hash(filter->GetOutput()));
@@ -172,7 +172,7 @@ TEST_F(TileImageFixture, VectorImage)
   layout[0] = 1;
   layout[1] = 4;
   EXPECT_NO_THROW(filter->SetLayout(layout));
-  EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
+  ITK_EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
 
   EXPECT_NO_THROW(filter->UpdateLargestPossibleRegion());
   EXPECT_EQ("2258f8cfbd7395bea0bc09ab3f69b058", MD5Hash(filter->GetOutput()));
@@ -182,7 +182,7 @@ TEST_F(TileImageFixture, VectorImage)
   layout[0] = 1;
   layout[1] = 10;
   EXPECT_NO_THROW(filter->SetLayout(layout));
-  EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
+  ITK_EXPECT_VECTOR_NEAR(layout, filter->GetLayout(), 0);
 
   EXPECT_NO_THROW(filter->UpdateLargestPossibleRegion());
   EXPECT_EQ("dd8552dd79d605d653872af827f2d1a5", MD5Hash(filter->GetOutput()));

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -101,19 +101,19 @@ TEST_F(ShapeLabelMapFixture,3D_T1x1x1)
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  EXPECT_VECTOR_NEAR(MakeIndex(5,7,9), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakeSize(1,1,1), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakePoint(5.0,7.0,9.0), labelObject->GetCentroid(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5,7,9), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakeSize(1,1,1), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(5.0,7.0,9.0), labelObject->GetCentroid(), 1e-10);
   EXPECT_EQ(0.0, labelObject->GetElongation());
-  EXPECT_VECTOR_NEAR(MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
   EXPECT_NEAR(4.83598, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
   EXPECT_NEAR(0.62035, labelObject->GetEquivalentSphericalRadius(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetFeretDiameter());
   EXPECT_EQ(0.0, labelObject->GetFlatness());
   EXPECT_EQ(1u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  EXPECT_VECTOR_NEAR(MakeVector(1u,1u,1u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  EXPECT_VECTOR_NEAR(MakePoint(4.5,6.5,8.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(1u,1u,1u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(4.5,6.5,8.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
   EXPECT_NEAR(3.004, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
@@ -147,25 +147,25 @@ TEST_F(ShapeLabelMapFixture,3D_T3x2x1)
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  EXPECT_VECTOR_NEAR(MakeIndex(5,9,11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakeSize(3,2,1), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5,9,11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakeSize(3,2,1), labelObject->GetBoundingBox().GetSize(), 1e-99);
   EXPECT_EQ(MakePoint(6,9.5,11.0), labelObject->GetCentroid());
   EXPECT_NEAR(1.63299, labelObject->GetElongation(), 1e-4);
-  EXPECT_VECTOR_NEAR(MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
   EXPECT_NEAR(15.96804, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
   EXPECT_NEAR(1.12725, labelObject->GetEquivalentSphericalRadius(), 1e-4); // resulting value
   EXPECT_NEAR(2.23606, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_EQ(0.0, labelObject->GetFlatness());
   EXPECT_EQ(6u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  EXPECT_VECTOR_NEAR(MakeVector(1u,2u,3u), labelObject->GetOrientedBoundingBoxSize(),1e-10);
-  EXPECT_VECTOR_NEAR(MakePoint(7.5, 8.5, 10.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(1u,2u,3u), labelObject->GetOrientedBoundingBoxSize(),1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(7.5, 8.5, 10.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
   EXPECT_NEAR(14.62414, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_EQ(6.0, labelObject->GetPhysicalSize());
   // labelObject->GetPrincipalAxes(); omitted
-  EXPECT_VECTOR_NEAR(MakeVector(0, 0.25, 0.666667), labelObject->GetPrincipalMoments(),1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(0, 0.25, 0.666667), labelObject->GetPrincipalMoments(),1e-4);
   EXPECT_NEAR(1.09189, labelObject->GetRoundness(), 1e-4); // resulting value
 
   EXPECT_EQ(labelObject->GetBoundingBox(), labelObject->GetRegion());
@@ -204,25 +204,25 @@ TEST_F(ShapeLabelMapFixture,3D_T3x2x1_Direction)
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  EXPECT_VECTOR_NEAR(MakeIndex(5,9,11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakeSize(3,2,1), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakePoint(5.06906, -3.25286, -14.5249), labelObject->GetCentroid(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5,9,11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakeSize(3,2,1), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(5.06906, -3.25286, -14.5249), labelObject->GetCentroid(), 1e-4);
   EXPECT_NEAR(1.63299, labelObject->GetElongation(), 1e-4);
-  //EXPECT_VECTOR_NEAR(MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
+  //ITK_EXPECT_VECTOR_NEAR(MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
   EXPECT_NEAR(15.96804, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
   EXPECT_NEAR(1.12725, labelObject->GetEquivalentSphericalRadius(), 1e-4); // resulting value
   EXPECT_NEAR(2.23606, labelObject->GetFeretDiameter(), 1e-4);
   //EXPECT_EQ(0.0, labelObject->GetFlatness()); unstable due to division near zero
   EXPECT_EQ(6u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  EXPECT_VECTOR_NEAR(MakeVector(1u,2u,3u), labelObject->GetOrientedBoundingBoxSize(),1e-10);
-  EXPECT_VECTOR_NEAR(MakePoint(3.22524, -3.19685, -14.83670), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(1u,2u,3u), labelObject->GetOrientedBoundingBoxSize(),1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(3.22524, -3.19685, -14.83670), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
   EXPECT_NEAR(14.62414, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_EQ(6.0, labelObject->GetPhysicalSize());
   //labelObject->GetPrincipalAxes(); omitted
-  EXPECT_VECTOR_NEAR(MakeVector(0, 0.25, 0.666667), labelObject->GetPrincipalMoments(),1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(0, 0.25, 0.666667), labelObject->GetPrincipalMoments(),1e-4);
   EXPECT_NEAR(1.09189, labelObject->GetRoundness(), 1e-4); // resulting value
 
   if (::testing::Test::HasFailure())
@@ -254,18 +254,18 @@ TEST_F(ShapeLabelMapFixture,3D_T2x2x2_Spacing)
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  EXPECT_VECTOR_NEAR(MakeIndex(5,9,11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakeSize(2,2,2), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakePoint(5.5, 10.45, 25.3), labelObject->GetCentroid(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5,9,11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakeSize(2,2,2), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(5.5, 10.45, 25.3), labelObject->GetCentroid(), 1e-4);
   EXPECT_NEAR(2.0, labelObject->GetElongation(), 1e-4);
-  EXPECT_VECTOR_NEAR(MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
   EXPECT_NEAR(34.86751, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
   EXPECT_NEAR(1.66573, labelObject->GetEquivalentSphericalRadius(), 1e-4); // resulting value
   EXPECT_NEAR(2.65518, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_NEAR(1.1, labelObject->GetFlatness(), 1e-4);
   EXPECT_EQ(8u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  EXPECT_VECTOR_NEAR(MakeVector(2, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(),1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(2, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(),1e-10);
   EXPECT_NEAR(28.3919, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
@@ -273,9 +273,9 @@ TEST_F(ShapeLabelMapFixture,3D_T2x2x2_Spacing)
   // We are omitted these because the sign of the eigen vectors is not
   //unique, therefore the axes may not always point in the same
   //direction and the origin may not be the same corner
-  //EXPECT_VECTOR_NEAR(MakePoint(4.5, 9.35, 23.1), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  //ITK_EXPECT_VECTOR_NEAR(MakePoint(4.5, 9.35, 23.1), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
   //labelObject->GetPrincipalAxes(); omitted
-  EXPECT_VECTOR_NEAR(MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(),1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(),1e-4);
   EXPECT_NEAR( 1.22808, labelObject->GetRoundness(), 1e-4); // resulting value
 
   if (::testing::Test::HasFailure())
@@ -317,25 +317,25 @@ TEST_F(ShapeLabelMapFixture,3D_T2x2x2_Spacing_Direction)
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  EXPECT_VECTOR_NEAR(MakeIndex(5,9,11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakeSize(2,2,2), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakePoint(10.13655, 4.21035, -25.67227), labelObject->GetCentroid(), 1e-4); // resulting value
+  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5,9,11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakeSize(2,2,2), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(10.13655, 4.21035, -25.67227), labelObject->GetCentroid(), 1e-4); // resulting value
   EXPECT_NEAR(2.0, labelObject->GetElongation(), 1e-4);
-  EXPECT_VECTOR_NEAR(MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
   EXPECT_NEAR(34.86751, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
   EXPECT_NEAR(1.66573, labelObject->GetEquivalentSphericalRadius(), 1e-4); // resulting value
   EXPECT_NEAR(2.65518, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_NEAR(1.1, labelObject->GetFlatness(), 1e-4);
   EXPECT_EQ(8u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  EXPECT_VECTOR_NEAR(MakeVector(2, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(),1e-10);
-  EXPECT_VECTOR_NEAR(MakePoint(8.92548, 4.27240, -23.31018), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4); // resulting value
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(2, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(),1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(8.92548, 4.27240, -23.31018), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4); // resulting value
   EXPECT_NEAR(28.3919, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_NEAR(19.36, labelObject->GetPhysicalSize(), 1e-10);
   //labelObject->GetPrincipalAxes(); omitted
-  EXPECT_VECTOR_NEAR(MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(),1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(),1e-4);
   EXPECT_NEAR( 1.22808, labelObject->GetRoundness(), 1e-4); // resulting value
 
   if (::testing::Test::HasFailure())
@@ -357,8 +357,8 @@ TEST_F(ShapeLabelMapFixture,2D_T1x1)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
-  EXPECT_VECTOR_NEAR(MakeVector(1.0,1.0), labelObject->GetOrientedBoundingBoxSize(),1e-10);
-  EXPECT_VECTOR_NEAR(MakePoint(4.5, 6.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(1.0,1.0), labelObject->GetOrientedBoundingBoxSize(),1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(4.5, 6.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
 
   if (::testing::Test::HasFailure())
     {
@@ -380,9 +380,9 @@ TEST_F(ShapeLabelMapFixture,2D_T1_1)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
-  EXPECT_VECTOR_NEAR(MakeSize(2,2), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  EXPECT_VECTOR_NEAR(MakeVector(Math::sqrt2, 2.0*Math::sqrt2), labelObject->GetOrientedBoundingBoxSize(),1e-4);
-  EXPECT_VECTOR_NEAR(MakePoint(4.0, 7.0), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeSize(2,2), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(Math::sqrt2, 2.0*Math::sqrt2), labelObject->GetOrientedBoundingBoxSize(),1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(4.0, 7.0), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
 
   if (::testing::Test::HasFailure())
     {
@@ -414,8 +414,8 @@ TEST_F(ShapeLabelMapFixture,2D_T1_1_FlipDirection)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
-  EXPECT_VECTOR_NEAR(MakeVector(Math::sqrt2, 2.0*Math::sqrt2), labelObject->GetOrientedBoundingBoxSize(),1e-4);
-  EXPECT_VECTOR_NEAR(MakePoint(6.0, 5.0), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(Math::sqrt2, 2.0*Math::sqrt2), labelObject->GetOrientedBoundingBoxSize(),1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(6.0, 5.0), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
 
 
   if (::testing::Test::HasFailure())
@@ -443,8 +443,8 @@ TEST_F(ShapeLabelMapFixture,2D_T2x4)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
-  EXPECT_VECTOR_NEAR(MakeVector(2.0,4.0), labelObject->GetOrientedBoundingBoxSize(),1e-10);
-  EXPECT_VECTOR_NEAR(MakePoint(3.5, 2.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(MakeVector(2.0,4.0), labelObject->GetOrientedBoundingBoxSize(),1e-10);
+  ITK_EXPECT_VECTOR_NEAR(MakePoint(3.5, 2.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
 
   if (::testing::Test::HasFailure())
     {

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
@@ -104,10 +104,10 @@ TEST_F(SLICFixture, SetGetPrint)
 
   Utils::FilterType:: SuperGridSizeType gridSize3(3);
   EXPECT_NO_THROW(filter->SetSuperGridSize(gridSize3));
-  EXPECT_VECTOR_NEAR(gridSize3, filter->GetSuperGridSize(), 0);
+  ITK_EXPECT_VECTOR_NEAR(gridSize3, filter->GetSuperGridSize(), 0);
 
   EXPECT_NO_THROW(filter->SetSuperGridSize(4));
-  EXPECT_VECTOR_NEAR(Utils::FilterType:: SuperGridSizeType(4), filter->GetSuperGridSize(), 0);
+  ITK_EXPECT_VECTOR_NEAR(Utils::FilterType:: SuperGridSizeType(4), filter->GetSuperGridSize(), 0);
 
   EXPECT_NO_THROW(filter->SetMaximumNumberOfIterations(6));
   EXPECT_EQ(6, filter->GetMaximumNumberOfIterations());


### PR DESCRIPTION
Renamed the unit test macro `EXPECT_VECTOR_NEAR` to `ITK_EXPECT_VECTOR_NEAR`,
to explicitly indicate that it is an ITK specific extension to GTest.