### PR TITLE
BUG: Add casting for vector pixel types

### DIFF
--- a/Modules/Filtering/ImageFilterBase/wrapping/itkCastImageFilter.wrap
+++ b/Modules/Filtering/ImageFilterBase/wrapping/itkCastImageFilter.wrap
@@ -4,6 +4,17 @@ itk_wrap_class("itk::CastImageFilter" POINTER_WITH_SUPERCLASS)
   UNIQUE(types "${WRAP_ITK_SCALAR};UC")
   itk_wrap_image_filter_combinations("${types}" "${types}")
 
+  # vector <-> vector
+  itk_wrap_image_filter_combinations("${WRAP_ITK_VECTOR}" "${WRAP_ITK_VECTOR}")
+
+  # RGB <-> RGB
+  UNIQUE(rgb "RGBUC;${WRAP_ITK_RGB}")
+  itk_wrap_image_filter_combinations("${rgb}" "${rgb}")
+
+  # vector <-> RGB
+  # itk_wrap_image_filter_combinations("${WRAP_ITK_VECTOR}" "${WRAP_ITK_RGB}" 3)
+  # itk_wrap_image_filter_combinations("${WRAP_ITK_RGB}" "${WRAP_ITK_VECTOR}" 3)
+
   # Wrap from ulong to other integral types, even if ulong isn't wrapped. This
   # is needed for the relabel components image filter output.
   if(NOT ITK_WRAP_unsigned_long)


### PR DESCRIPTION
A transfer of types wrapped for the VectorCastImageFilter to
the CastImageFilter.
