### PR TITLE
COMP: Address missing fftw include in CurvatureRegistrationFilter

### DIFF
--- a/Modules/Registration/PDEDeformable/itk-module.cmake
+++ b/Modules/Registration/PDEDeformable/itk-module.cmake
@@ -2,8 +2,15 @@ set(DOCUMENTATION "This module contains classes for deformable image
 registration based on intensity differences by solving the PDE, optical flow
 problem.  This includes Thirion's popular \"demons\" algorithm.")
 
+
+set(_FFTW_DEPENDS )
+if( ITK_USE_FFTWF OR ITK_USE_FFTWD )
+  set(_FFTW_DEPENDS "ITKFFT")
+endif()
+
 itk_module(ITKPDEDeformableRegistration
   DEPENDS
+    ${_FFTW_DEPENDS}
     ITKRegistrationCommon
     ITKFiniteDifference
   TEST_DEPENDS


### PR DESCRIPTION
When FFTW is enable the CurvatureRegistrationFilter is dependent upon
the ITKFFTW module.
