### PR TITLE
COMP: fix GDCM warnings

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/Common/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/Common/CMakeLists.txt
@@ -131,33 +131,21 @@ set(Common_SRCS
   gdcmRegion.cxx
   gdcmBoxRegion.cxx
   gdcmEvent.cxx
-  gdcmDataEvent.cxx
-  gdcmProgressEvent.cxx
-  gdcmFileNameEvent.cxx
   gdcmCommand.cxx
   gdcmMD5.cxx
   gdcmBase64.cxx
   gdcmSHA1.cxx
   gdcmDummyValueGenerator.cxx
-  #gdcmCryptographicMessageSyntax.cxx
-
-  gdcmCryptographicMessageSyntax.cxx
   gdcmCryptoFactory.cxx
-
   gdcmASN1.cxx
-  gdcmObject.cxx
   gdcmSubject.cxx
   gdcmDirectory.cxx
   gdcmTerminal.cxx
-  gdcmString.cxx
   gdcmFilename.cxx
   gdcmFilenameGenerator.cxx
   gdcmSwapCode.cxx
   gdcmSystem.cxx
   gdcmTrace.cxx
-  gdcmException.cxx
-  gdcmDeflateStream.cxx
-  gdcmByteSwap.cxx
   gdcmUnpacker12Bits.cxx
   )
 

--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/CMakeLists.txt
@@ -12,7 +12,6 @@ set(DSED2_SRCS
   gdcmFileMetaInformation.cxx # subclass of DataSet
   gdcmFragment.cxx
   gdcmImplicitDataElement.cxx
-  gdcmItem.cxx
   gdcmMediaStorage.cxx # SetFromModality takes a DataSet
   gdcmPrivateTag.cxx
   gdcmReader.cxx
@@ -58,7 +57,6 @@ set(DSED_SRCS
   gdcmVM.cxx
   gdcmVR.cxx
   gdcmPreamble.cxx
-  gdcmParseException.cxx
   gdcmUNExplicitDataElement.cxx
   gdcmCP246ExplicitDataElement.cxx
   gdcmExplicitImplicitDataElement.cxx

--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/gdcmDataElement.h
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/gdcmDataElement.h
@@ -163,7 +163,7 @@ public:
     {
     return GetTag() < de.GetTag();
     }
-  DataElement &operator=(const DataElement &de)
+  DataElement &operator=(const DataElement &)
     = default;
 
   bool operator==(const DataElement &de) const

--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/gdcmDataSet.h
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/gdcmDataSet.h
@@ -227,7 +227,7 @@ public:
   /// Returns if the dataset is empty
   bool IsEmpty() const { return DES.empty(); };
 
-  DataSet& operator=(DataSet const &val)
+  DataSet& operator=(DataSet const &)
   = default;
 
 /*
@@ -307,7 +307,7 @@ protected:
 private:
   DataElementSet DES;
   static DataElement DEEnd;
-  friend std::ostream& operator<<(std::ostream &_os, const DataSet &val);
+  friend std::ostream& operator<<(std::ostream &_os, const DataSet &);
 };
 //-----------------------------------------------------------------------------
 inline std::ostream& operator<<(std::ostream &os, const DataSet &val)

--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/gdcmElement.h
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/DataStructureAndEncodingDefinition/gdcmElement.h
@@ -655,7 +655,7 @@ public:
     assert( bv ); // That would be bad...
     if( (VR::VRType)(VRToEncoding<TVR>::Mode) == VR::VRBINARY )
       {
-      const Type* array = (const Type*)bv->GetPointer();
+      const Type* array = (const Type*)(void*)bv->GetPointer();
       if( array ) {
         assert( array ); // That would be bad...
         assert( Internal == 0 );

--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/InformationObjectDefinition/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/InformationObjectDefinition/CMakeLists.txt
@@ -3,18 +3,9 @@
 set(IOD_SRCS
   gdcmModule.cxx
   gdcmMacro.cxx
-  gdcmModules.cxx
-  gdcmMacros.cxx
-  gdcmNestedModuleEntries.cxx
   gdcmIODEntry.cxx
   gdcmTableReader.cxx
-  gdcmTable.cxx
-  gdcmSeries.cxx
   gdcmDefs.cxx
-  gdcmDefinedTerms.cxx
-  gdcmEnumeratedValues.cxx
-  gdcmStudy.cxx
-  gdcmPatient.cxx
   gdcmType.cxx
   gdcmUsage.cxx
   gdcmIOD.cxx

--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/CMakeLists.txt
@@ -17,7 +17,6 @@ set(MSFF_SRCS
   gdcmImageFragmentSplitter.cxx
   gdcmTagPath.cxx
   gdcmSimpleSubjectWatcher.cxx
-  gdcmAnonymizeEvent.cxx
   gdcmPixmap.cxx
   gdcmBitmap.cxx
   gdcmRescaler.cxx
@@ -35,15 +34,7 @@ set(MSFF_SRCS
   gdcmSorter.cxx
   gdcmSerieHelper.cxx
   gdcmIPPSorter.cxx
-  gdcmApplicationEntity.cxx
-  gdcmDICOMDIR.cxx
-  gdcmSpectroscopy.cxx
-  gdcmEncapsulatedDocument.cxx
   gdcmSplitMosaicFilter.cxx
-  gdcmFiducials.cxx
-  gdcmWaveform.cxx
-  gdcmPersonName.cxx
-  gdcmIconImage.cxx
   gdcmUIDGenerator.cxx
   gdcmUUIDGenerator.cxx
   gdcmPrinter.cxx
@@ -58,7 +49,6 @@ set(MSFF_SRCS
   gdcmStringFilter.cxx
   gdcmImageHelper.cxx
   gdcmValidate.cxx
-  gdcmDumper.cxx
   gdcmImage.cxx
   gdcmImageConverter.cxx
   gdcmImageCodec.cxx


### PR DESCRIPTION
Warnings were of three types:
.* GCC 4.8.5: "warning: unused parameter"
* AppleClang 10.0.0.10001145: warning: cast from 'const char *' to 'const gdcm::Element<256, 218367>::Type *' (aka 'const float *') increases required alignment from 1 to 4 [-Wcast-align]
* AppleClang 10.0.0.10001145: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: (...) has no symbols

See issue GH-925, please review @malaterre.