### PR TITLE
BUG: InterpolateImageFunction::GetRadius hidden in ITKV4_COMPATIBILITY

### DIFF
--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -315,10 +315,12 @@ public:
   itkGetConstMacro(UseImageDirection, bool);
   itkBooleanMacro(UseImageDirection);
 
+#if !defined(ITKV4_COMPATIBILITY)
   SizeType GetRadius() const override
     {
     return SizeType::Filled(m_SplineOrder + 1);
     }
+#endif
 
 protected:
 

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.h
@@ -147,7 +147,9 @@ public:
     return this->EvaluateAtContinuousIndex( cindex, nullptr );
     }
 
+#if !defined(ITKV4_COMPATIBILITY)
   SizeType GetRadius() const override;
+#endif
 
 protected:
   GaussianInterpolateImageFunction();

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -223,6 +223,7 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>
 }
 
 
+#if !defined(ITKV4_COMPATIBILITY)
 template<typename TImageType, typename TCoordRep>
 typename GaussianInterpolateImageFunction<TImageType, TCoordRep>::SizeType
 GaussianInterpolateImageFunction<TImageType, TCoordRep>
@@ -244,6 +245,7 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>
     }
   return radius;
 }
+#endif
 
 
 template<typename TImageType, typename TCoordRep>

--- a/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
@@ -19,6 +19,8 @@
 #define itkInterpolateImageFunction_h
 
 #include "itkImageFunction.h"
+#include "itkConfigure.h"
+
 
 namespace itk
 {
@@ -127,12 +129,14 @@ public:
     return ( static_cast< RealType >( this->GetInputImage()->GetPixel(index) ) );
   }
 
+#if !defined(ITKV4_COMPATIBILITY)
   /** Get the radius required for interpolation.
    *
    * This defines the number of surrounding pixels required to interpolate at
    * a given point.
    */
   virtual SizeType GetRadius() const = 0;
+#endif
 
 protected:
   InterpolateImageFunction()= default;

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -104,10 +104,12 @@ public:
     return this->EvaluateOptimized(Dispatch< ImageDimension >(), index);
   }
 
+#if !defined(ITKV4_COMPATIBILITY)
   SizeType GetRadius() const override
     {
     return SizeType::Filled(1);
     }
+#endif
 
 protected:
   LinearInterpolateImageFunction() = default;

--- a/Modules/Core/ImageFunction/include/itkNearestNeighborInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborInterpolateImageFunction.h
@@ -89,10 +89,12 @@ public:
     return static_cast< OutputType >( this->GetInputImage()->GetPixel(nindex) );
   }
 
+#if !defined(ITKV4_COMPATIBILITY)
   SizeType GetRadius() const override
     {
     return SizeType(); // zeroes by default
     }
+#endif
 
 protected:
   NearestNeighborInterpolateImageFunction()= default;

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.h
@@ -165,6 +165,7 @@ public:
     return true;
   }
 
+#if !defined(ITKV4_COMPATIBILITY)
   SizeType GetRadius() const override
     {
     const InputImageType* input = this->GetInputImage();
@@ -174,6 +175,7 @@ public:
       }
     return input->GetLargestPossibleRegion().GetSize();
     }
+#endif
 
 protected:
   RayCastInterpolateImageFunction();

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -311,12 +311,14 @@ public:
   OutputType EvaluateAtContinuousIndex(
     const ContinuousIndexType & index) const override;
 
+#if !defined(ITKV4_COMPATIBILITY)
   SizeType GetRadius() const override
     {
     SizeType radius;
     radius.Fill( VRadius );
     return radius;
     }
+#endif
 
 protected:
   WindowedSincInterpolateImageFunction();

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -72,12 +72,14 @@ int itkGaussianInterpolateImageFunctionTest( int, char*[] )
 
   interpolator->SetInputImage(image);
 
+#if !defined(ITKV4_COMPATIBILITY)
   typename ImageType::SizeType radius;
   radius.Fill( 1 );
   for ( unsigned int d = 0; d < ImageType::ImageDimension; d++ )
     {
       TEST_SET_GET_VALUE( radius[d], interpolator->GetRadius()[d] );
     }
+#endif
 
   InterpolatorType::OutputType expectedValues[5][5] =
     {{0.773964, 0.886982, 1.38698, 1.88698, 2.0},

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -171,12 +171,14 @@ int RunLinearInterpolateTest()
   variablevectorinterpolator = VariableVectorInterpolatorType::New();
  variablevectorinterpolator->SetInputImage( variablevectorimage );
 
+#if !defined(ITKV4_COMPATIBILITY)
  typename ImageType::SizeType radius;
  radius.Fill( 1 );
  for( unsigned int d = 0; d < Dimensions; ++d )
    {
    TEST_SET_GET_VALUE( radius[d], interpolator->GetRadius()[d] );
    }
+#endif
 
  constexpr AccumulatorType incr  = 0.2;
 

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -133,12 +133,14 @@ int itkNearestNeighborInterpolateImageFunctionTest( int , char*[] )
  InterpolatorType::Pointer interpolator = InterpolatorType::New();
  interpolator->SetInputImage( image );
 
+#if !defined(ITKV4_COMPATIBILITY)
  typename ImageType::SizeType radius;
  radius.Fill( 0 );
  for( unsigned int d = 0; d < Dimension; ++d )
    {
    TEST_SET_GET_VALUE( radius[d], interpolator->GetRadius()[d] );
    }
+#endif
 
  VectorInterpolatorType::Pointer
   vectorinterpolator = VectorInterpolatorType::New();

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -130,10 +130,12 @@ itkRayCastInterpolateImageFunctionTest(
 
     std::cout << "Integral = " << integral << std::endl;
 
+#if !defined(ITKV4_COMPATIBILITY)
     for( unsigned int d = 0; d < ImageDimension; ++d )
       {
       TEST_SET_GET_VALUE( size[d], interp->GetRadius()[d] );
       }
+#endif
 
     TEST_EXPECT_TRUE( itk::Math::FloatAlmostEqual( integral, 1247. ) );
 

--- a/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
@@ -186,10 +186,12 @@ int itkWindowedSincInterpolateImageFunctionTest(int, char* [] )
   interp->SetInputImage( image );
   interp->Print( std::cout );
 
+#if !defined(ITKV4_COMPATIBILITY)
   for( unsigned int d = 0; d < ImageDimension; ++d )
     {
     TEST_SET_GET_VALUE( 2, interp->GetRadius()[d] );
     }
+#endif
 
   /* Test evaluation at continuous indices and corresponding
      gemetric points */

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -509,6 +509,7 @@ ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTra
   // Get pointers to the input and output
   InputImageType * input  = const_cast< InputImageType * >( this->GetInput() );
 
+#if !defined(ITKV4_COMPATIBILITY)
   // Check whether the input or the output is a
   // SpecialCoordinatesImage. If either are, then we cannot use the
   // fast path since index mapping will definitely not be linear.
@@ -554,6 +555,7 @@ ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTra
       }
     return;
     }
+#endif
 
   // Otherwise, determining the actual input region is non-trivial, especially
   // when we cannot assume anything about the transform being used.

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -262,22 +262,24 @@ itk_add_test(NAME itkResampleImageTest2UseRefImageOn
                           ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cUseRefImageOn.png
                           ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dUseRefImageOn.png
                           1)
-itk_add_test(NAME itkResampleImageTest2Streaming
-      COMMAND ITKImageGridTestDriver
-    --compare DATA{Baseline/ResampleImageTest2.mha}
-              ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2aStreaming.mha
-    --compare DATA{Baseline/ResampleImageTest2.mha}
-              ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bStreaming.mha
-    --compare DATA{Baseline/ResampleImageTest2NearestExtrapolate.mha}
-              ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cStreaming.mha
-    --compare DATA{Baseline/ResampleImageTest2NearestExtrapolate.mha}
-              ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dStreaming.mha
-    itkResampleImageTest2Streaming DATA{Input/cthead1.mha}
-                          DATA{Input/circle.png}
-                          ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2aStreaming.mha
-                          ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bStreaming.mha
-                          ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cStreaming.mha
-                          ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dStreaming.mha)
+if(NOT ITKV4_COMPATIBILITY)
+  itk_add_test(NAME itkResampleImageTest2Streaming
+        COMMAND ITKImageGridTestDriver
+      --compare DATA{Baseline/ResampleImageTest2.mha}
+                ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2aStreaming.mha
+      --compare DATA{Baseline/ResampleImageTest2.mha}
+                ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bStreaming.mha
+      --compare DATA{Baseline/ResampleImageTest2NearestExtrapolate.mha}
+                ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cStreaming.mha
+      --compare DATA{Baseline/ResampleImageTest2NearestExtrapolate.mha}
+                ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dStreaming.mha
+      itkResampleImageTest2Streaming DATA{Input/cthead1.mha}
+                            DATA{Input/circle.png}
+                            ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2aStreaming.mha
+                            ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bStreaming.mha
+                            ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cStreaming.mha
+                            ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dStreaming.mha)
+endif()
 itk_add_test(NAME itkResampleImageTest3
       COMMAND ITKImageGridTestDriver
     --compare DATA{Baseline/ResampleImageTest3.png}
@@ -296,8 +298,10 @@ itk_add_test(NAME itkResampleImageTest6
     --compare DATA{Baseline/ResampleImageTest6.png}
               ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest6.png
     itkResampleImageTest6 10 ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest6.png)
-itk_add_test(NAME itkResampleImageTest7
-      COMMAND ITKImageGridTestDriver itkResampleImageTest7)
+if(NOT ITKV4_COMPATIBILITY)
+  itk_add_test(NAME itkResampleImageTest7
+        COMMAND ITKImageGridTestDriver itkResampleImageTest7)
+endif()
 itk_add_test(NAME itkResamplePhasedArray3DSpecialCoordinatesImageTest
       COMMAND ITKImageGridTestDriver itkResamplePhasedArray3DSpecialCoordinatesImageTest)
 itk_add_test(NAME itkPushPopTileImageFilterTest


### PR DESCRIPTION
This function is required for streaming with ResampleImageFilter in ITK
5.0. The abstract method is hidden with ITKV4_COMPATIBILITY so classes
that derive from InterpolateImageFunction do not encounter build errors.
When compatibility is turned off interpolator authors with get a compile
time error until the method is defined to ensure correct behavior when
resampling.