### PR TITLE
BUG: number of work units was greater than 1 even for 1 thread

### DIFF
--- a/Modules/Core/Common/src/itkPoolMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPoolMultiThreader.cxx
@@ -47,7 +47,10 @@ PoolMultiThreader::PoolMultiThreader() :
 
   ThreadIdType defaultThreads = std::max(1u, GetGlobalDefaultNumberOfThreads());
 #if !defined( ITKV4_COMPATIBILITY )
-  defaultThreads *= 4;
+  if ( defaultThreads > 1 ) // one work unit for only one thread
+    {
+    defaultThreads *= 4;
+    }
 #endif
   m_NumberOfWorkUnits = std::min< ThreadIdType >( ITK_MAX_THREADS, defaultThreads );
   m_MaximumNumberOfThreads = m_ThreadPool->GetMaximumNumberOfThreads();

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -34,7 +34,10 @@ TBBMultiThreader::TBBMultiThreader()
 #if defined( ITKV4_COMPATIBILITY )
   m_NumberOfWorkUnits = defaultThreads;
 #else
-  m_NumberOfWorkUnits = 16 * defaultThreads;
+  if ( defaultThreads > 1 ) // one work unit for only one thread
+    {
+    m_NumberOfWorkUnits = 16 * defaultThreads;
+    }
 #endif
 }
 

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest3.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest3.cxx
@@ -266,7 +266,7 @@ int itkThreadedIteratorRangePartitionerTest3(int, char* [])
   using DomainContainerType = IteratorRangeDomainThreaderAssociate::DomainContainerType;
   DomainContainerType::Pointer container = DomainContainerType::New();
 
-  for( unsigned int i = 0; i < 256; ++i )
+  for ( unsigned int i = 0; i < ITK_DEFAULT_MAX_THREADS + 10; ++i )
     {
     container->SetElement( static_cast< int >( i * 2 ), 2 * i + 1 );
     }


### PR DESCRIPTION
Closes #943.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

