### PR TITLE
BUG: Add test/CMakeLists.txt stub to NumPy bridge

### DIFF
--- a/Modules/Bridge/NumPy/test/CMakeLists.txt
+++ b/Modules/Bridge/NumPy/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+itk_module_test()


### PR DESCRIPTION
To address:

  CMake Error at CMake/ITKModuleEnablement.cmake:319 (add_subdirectory):
     The source directory

       /home/matt/src/ITK/Modules/Bridge/NumPy/test

     does not contain a CMakeLists.txt file.
   Call Stack (most recent call first):
     CMakeLists.txt:433 (include)

When BUILD_EXAMPLES, ITK_WRAP_PYTHON, and BUILD_TESTING are enabled.