### PR TITLE
For Release: BUG: Use ProcessObject GetInput to obtain base pointer

### DIFF
--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -162,24 +162,18 @@ ImageSink<TInputImage>
       {
       // Check whether the input is an image of the appropriate
       // dimension (use ProcessObject's version of the GetInput()
-      // method sink it returns the input as a pointer to a
+      // method since it returns the input as a pointer to a
       // DataObject as opposed to the subclass version which
       // static_casts the input to an TInputImage).
       using ImageBaseType = ImageBase< InputImageDimension >;
-      typename ImageBaseType::ConstPointer constInput =
-        dynamic_cast< ImageBaseType const * >( this->GetInput(inputName) );
+      auto * input = dynamic_cast< ImageBaseType  * >( this->ProcessObject::GetInput(inputName) );
 
-      // If not an image, skip it, and let a subclass of
-      // ImageToImageFilter handle this input.
-      if ( constInput.IsNull() )
+      // If not an image, skip it. A subclass can override this method
+      // for particular input types.
+      if ( input == nullptr )
         {
         continue;
         }
-
-      // Input is an image, cast away the constness so we can set
-      // the requested region.
-      InputImagePointer input = const_cast< TInputImage * >( this->GetInput(inputName) );
-
       // copy the requested region of the first input to the others
       InputImageRegionType inputRegion;
       input->SetRequestedRegion( m_CurrentInputRegion );


### PR DESCRIPTION
In ImageSinc::GenerateNthInputRequestedRegion, use superclass'
GetInput method to obtain a pointer to a DataObject then a
dynamic_cast can be used to determine if the image region can be
generated. This addresses runtime "Unable to convert input" warnings.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
