### PR TITLE
BUG: resample filter no longer triggers unnecessary exception

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -122,7 +122,6 @@ void
 ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType >
 ::BeforeThreadedGenerateData()
 {
-  // Connect input image to interpolator
   m_Interpolator->SetInputImage( this->GetInput() );
 
   // Connect input image to extrapolator
@@ -508,6 +507,9 @@ ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTra
 
   // Get pointers to the input and output
   InputImageType * input  = const_cast< InputImageType * >( this->GetInput() );
+
+  // Some interpolators need to look at their images in GetRadius()
+  m_Interpolator->SetInputImage( input );
 
 #if !defined(ITKV4_COMPATIBILITY)
   // Check whether the input or the output is a


### PR DESCRIPTION
If interpolator's `GetRadius` required an image, and it was not set
outside of resample filter, an exception `Input image required!` was raised.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

