### PR TITLE
BUG: resample filter no longer triggers unnecessary exception

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -122,7 +122,6 @@ void
 ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType >
 ::BeforeThreadedGenerateData()
 {
-  // Connect input image to interpolator
   m_Interpolator->SetInputImage( this->GetInput() );
 
   // Connect input image to extrapolator
@@ -508,6 +507,9 @@ ResampleImageFilter< TInputImage, TOutputImage, TInterpolatorPrecisionType, TTra
 
   // Get pointers to the input and output
   InputImageType * input  = const_cast< InputImageType * >( this->GetInput() );
+
+  // Some interpolators need to look at their images in GetRadius()
+  m_Interpolator->SetInputImage( input );
 
 #if !defined(ITKV4_COMPATIBILITY)
   // Check whether the input or the output is a


### PR DESCRIPTION
If interpolator's `GetRadius` required an image, and it was not set
outside of resample filter, an exception `Input image required!` was raised.

This is a clone of #958 which goes into `release` branch, slated for 5.0.1.
