### PR TITLE
WIP: HoughTransform2D GetLines(), GetCircles() return ListType by-value

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -148,7 +148,7 @@ public:
   * The pixel grid coordinates of the center of a circle from the list can
   * be retrieved by calling circle->GetCenterPoint().
   */
-  CirclesListType & GetCircles();
+  CirclesListType GetCircles();
 
   /** Set/Get the number of circles to extract. */
   itkSetMacro(NumberOfCircles, CirclesListSizeType);

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -188,7 +188,7 @@ HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPi
 }
 
 template< typename TInputPixelType, typename TOutputPixelType, typename TRadiusPixelType >
-typename HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPixelType >::CirclesListType &
+typename HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPixelType >::CirclesListType
 HoughTransform2DCirclesImageFilter< TInputPixelType, TOutputPixelType, TRadiusPixelType >
 ::GetCircles()
 {

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
@@ -132,7 +132,7 @@ public:
   itkGetModifiableObjectMacro( SimplifyAccumulator, OutputImageType );
 
   /** Get the list of lines. This recomputes the lines. */
-  LinesListType & GetLines();
+  LinesListType GetLines();
 
   /** Set/Get the number of lines to extract */
   itkSetMacro( NumberOfLines, LinesListSizeType );

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -227,7 +227,7 @@ HoughTransform2DLinesImageFilter< TInputPixelType, TOutputPixelType >
 
 
 template< typename TInputPixelType, typename TOutputPixelType >
-typename HoughTransform2DLinesImageFilter< TInputPixelType, TOutputPixelType >::LinesListType &
+typename HoughTransform2DLinesImageFilter< TInputPixelType, TOutputPixelType >::LinesListType
 HoughTransform2DLinesImageFilter< TInputPixelType, TOutputPixelType >
 ::GetLines()
 {

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -22,6 +22,13 @@
 #include "itkCastImageFilter.h"
 #include "itkMath.h"
 #include "itkTestingMacros.h"
+#include <type_traits> // For is_reference.
+
+
+// Check GetCircles() return type for a commonly used combination of template arguments.
+static_assert(! std::is_reference<decltype(
+  itk::HoughTransform2DCirclesImageFilter<unsigned short, unsigned, double>::New()->GetCircles())>::value,
+  "GetCircles() should return by-value, not by-reference!");
 
 
 // Define the dimension of the images

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -21,6 +21,14 @@
 #include "itkGradientMagnitudeImageFilter.h"
 #include "itkMath.h"
 #include "itkTestingMacros.h"
+#include <type_traits> // For is_reference.
+
+
+ // Check GetLines() return type for a commonly used combination of template arguments.
+static_assert(! std::is_reference<decltype(
+  itk::HoughTransform2DLinesImageFilter<int, double>::New()->GetLines())>::value,
+  "GetLines() should return by-value, not by-reference!");
+
 
 /**
  * This program looks for straight lines whithin an image


### PR DESCRIPTION
Changed return types of `HoughTransform2DLinesImageFilter::GetLines()`
and `HoughTransform2DCirclesImageFilter::GetCircles()` from
"by reference" (`ListType &`) to "by value" (`ListType`).

This commit improves encapsulation of the internal data of these
filters, and avoids segmentation faults in Python user code (ITK wrapped
by SWIG), when the result is returned by a Python function, as described
by Nick at the discussion form, 24 May 2019:
https://discourse.itk.org/t/how-to-deal-with-houghtransform2dlinesimagefilter-getlines-method-in-python/1861/16