### PR TITLE
COMP: SpatialObjectsHierarchy Software Guide newline

### DIFF
--- a/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
+++ b/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
@@ -62,6 +62,7 @@ int main( int , char *[] )
 // Software Guide : EndCodeSnippet
 
 // Software Guide : BeginLatex
+//
 // Whenever the parameters of an object, including its parent-child
 // relationships are changed, we must then call the \code{Update()}
 // method so that the object-to-parent


### PR DESCRIPTION
To address:

  Examples/SpatialObjects/SpatialObjectHierarchy.cxx:65: warning: Line
  after start of LaTeX block should be a newline -- instead got Whenever
  the parameters of an object, including its parent-child
