### PR TITLE
Fix cast for explicit cast for release

### DIFF
--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
@@ -138,6 +138,21 @@ protected:
 
   template<typename TInputPixelType>
     void DynamicThreadedGenerateDataDispatched(const OutputImageRegionType & outputRegionForThread, std::false_type isConvertible);
+
+private:
+
+  template <typename TFromType, typename TToType, typename TNoDeclType = TToType>
+    struct is_static_castable
+    : std::false_type
+  {};
+
+  template <typename TFromType, typename TToType>
+    struct is_static_castable<TFromType,
+                              TToType,
+                              decltype(static_cast<TToType>(std::declval<TFromType>()))>
+    : std::true_type
+  {};
+
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
@@ -91,7 +91,8 @@ CastImageFilter< TInputImage, TOutputImage >
 ::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
   DynamicThreadedGenerateDataDispatched<InputPixelType>(outputRegionForThread,
-                                               std::is_convertible<InputPixelType, OutputPixelType>());
+                                                        is_static_castable<InputPixelType,OutputPixelType>() );
+
 }
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -25,6 +25,8 @@
 #include "itkRandomImageSource.h"
 #include "itkVectorImage.h"
 #include "itkFloatingPointExceptions.h"
+#include "itkRGBPixel.h"
+#include "itkRGBAPixel.h"
 
 
 // Better name demanging for gcc
@@ -37,6 +39,23 @@
 #include <cxxabi.h>
 #include "itkMath.h"
 #endif
+
+
+
+// Compile time check
+template class itk::CastImageFilter<itk::Image<std::complex<float> >, itk::Image<std::complex<float> > >;
+template class itk::CastImageFilter<itk::Image<std::complex<double> >, itk::Image<std::complex<double> > >;
+template class itk::CastImageFilter<itk::Image<std::complex<float> >, itk::Image<std::complex<double> > >;
+
+
+template class itk::CastImageFilter<itk::Image<itk::RGBPixel<unsigned char> >, itk::Image<itk::RGBPixel<unsigned short> > >;
+template class itk::CastImageFilter<itk::Image<itk::RGBPixel<unsigned char> >, itk::Image<itk::Vector<float,3> > >;
+template class itk::CastImageFilter<itk::Image<itk::Vector<float,3> >, itk::Image<itk::RGBPixel<unsigned char> > >;
+template class itk::CastImageFilter<itk::Image<itk::RGBAPixel<unsigned char> >, itk::Image<itk::RGBAPixel<unsigned short> > >;
+template class itk::CastImageFilter<itk::Image<itk::RGBAPixel<unsigned char> >, itk::Image<itk::Vector<float,4> > >;
+template class itk::CastImageFilter<itk::Image<itk::Vector<float,4> >, itk::Image<itk::RGBAPixel<unsigned char> > >;
+
+template class itk::CastImageFilter<itk::VectorImage<short>, itk::VectorImage<double> >;
 
 template< typename T >
 std::string GetCastTypeName()

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -28,6 +28,7 @@
 #include "itkRGBPixel.h"
 #include "itkRGBAPixel.h"
 
+namespace itk {}
 
 // Better name demanging for gcc
 #if defined( __GNUC__ ) && !defined( __EMSCRIPTEN__ )
@@ -41,11 +42,11 @@
 #endif
 
 
-
 // Compile time check
 template class itk::CastImageFilter<itk::Image<std::complex<float> >, itk::Image<std::complex<float> > >;
 template class itk::CastImageFilter<itk::Image<std::complex<double> >, itk::Image<std::complex<double> > >;
 template class itk::CastImageFilter<itk::Image<std::complex<float> >, itk::Image<std::complex<double> > >;
+template class itk::CastImageFilter<itk::Image<std::complex<double> >, itk::Image<std::complex<float> > >;
 
 
 template class itk::CastImageFilter<itk::Image<itk::RGBPixel<unsigned char> >, itk::Image<itk::RGBPixel<unsigned short> > >;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
