### PR TITLE
ENH: use double-conversion's CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ foreach(p
     CMP0025 # CMake 3.0
     CMP0028
     CMP0042 # CMake 3.0
+    CMP0045
     CMP0048
     CMP0054 # CMake 3.1
     CMP0056 # CMake 3.2

--- a/Modules/Core/Common/src/itkNumberToString.cxx
+++ b/Modules/Core/Common/src/itkNumberToString.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 #include "itkNumberToString.h"
 #include "itkNumericTraits.h"
-#include "double-conversion.h"
+#include "double-conversion/double-conversion.h"
 
 #include <sstream>
 

--- a/Modules/ThirdParty/DoubleConversion/CMakeLists.txt
+++ b/Modules/ThirdParty/DoubleConversion/CMakeLists.txt
@@ -7,19 +7,9 @@ option(ITK_USE_SYSTEM_DOUBLECONVERSION
 mark_as_advanced(ITK_USE_SYSTEM_DOUBLECONVERSION)
 
 if(ITK_USE_SYSTEM_DOUBLECONVERSION)
-  find_library(double-conversion_LIBRARIES double-conversion)
-  find_path(double-conversion_INCLUDE_DIRS double-conversion.h
-    PATH_SUFFIXES double-conversion
-    )
-
-  if (double-conversion_LIBRARIES AND double-conversion_INCLUDE_DIRS)
-    set(ITKDoubleConversion_SYSTEM_INCLUDE_DIRS
-      ${double-conversion_INCLUDE_DIRS})
-    set(ITKDoubleConversion_LIBRARIES
-      "${double-conversion_LIBRARIES}")
-  else()
-    message(ERROR "double-conversion system library not found")
-  endif()
+  find_package(double-conversion REQUIRED)
+  get_target_property(ITKDoubleConversion_INCLUDE_DIRS double-conversion::double-conversion INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(ITKDoubleConversion_LIBRARIES double-conversion::double-conversion LOCATION)
 else()
   set(ITKDoubleConversion_INCLUDE_DIRS
     ${ITKDoubleConversion_SOURCE_DIR}/src/double-conversion


### PR DESCRIPTION
This will support multiple system versions of double-conversion.
Suggested by Alexander Neumann.
Closes #579. Closes #912.

This is a clone of #915, which goes into `release-4.13` branch.
