### PR TITLE
PERF: Replace mutex by atomic in MersenneTwisterRandomVariateGenerator

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -23,8 +23,10 @@
 #include "itkRandomVariateGeneratorBase.h"
 #include "itkIntTypes.h"
 #include "itkMath.h"
-#include <mutex>
 #include "itkSingletonMacro.h"
+
+#include <atomic>
+#include <mutex>
 #include <climits>
 #include <ctime>
 
@@ -277,7 +279,7 @@ protected:
   int          m_Left;
 
   // Seed value
-  IntegerType  m_Seed;
+  std::atomic<IntegerType>  m_Seed;
 
 private:
 
@@ -372,9 +374,7 @@ MersenneTwisterRandomVariateGenerator::SetSeed()
 inline MersenneTwisterRandomVariateGenerator::IntegerType
 MersenneTwisterRandomVariateGenerator::GetSeed()
 {
-  std::lock_guard<std::mutex> mutexHolder(m_InstanceLock);
-  volatile IntegerType seed = this->m_Seed;
-  return seed;
+  return this->m_Seed;
 }
 
 /** Get an integer variate in [0, 2^32-1] */

--- a/Modules/Core/Common/src/itkImageSourceCommon.cxx
+++ b/Modules/Core/Common/src/itkImageSourceCommon.cxx
@@ -19,7 +19,6 @@
 #include "itkImageRegionSplitterSlowDimension.h"
 #include "itkImageSourceCommon.h"
 #include <mutex>
-#include <mutex>
 
 namespace itk
 {

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -19,6 +19,7 @@
 
 #include "itkSingleton.h"
 
+#include <atomic>
 
 namespace itk
 {
@@ -33,7 +34,7 @@ struct MersenneTwisterGlobals
   {};
   MersenneTwisterRandomVariateGenerator::Pointer m_StaticInstance;
   std::recursive_mutex m_StaticInstanceLock;
-  MersenneTwisterRandomVariateGenerator::IntegerType m_StaticDiffer;
+  std::atomic<MersenneTwisterRandomVariateGenerator::IntegerType> m_StaticDiffer;
 };
 
 itkGetGlobalSimpleMacro(MersenneTwisterRandomVariateGenerator, MersenneTwisterGlobals, PimplGlobals);
@@ -121,8 +122,6 @@ MersenneTwisterRandomVariateGenerator
     h2 *= UCHAR_MAX + 2U;
     h2 += p[j];
     }
-  // lock for m_StaticDiffer
-  std::lock_guard< std::recursive_mutex > mutexHolder( m_PimplGlobals->m_StaticInstanceLock );
   return ( h1 + m_PimplGlobals->m_StaticDiffer++ ) ^ h2;
 }
 
@@ -133,7 +132,6 @@ MersenneTwisterRandomVariateGenerator
   itkInitGlobalsMacro(PimplGlobals);
   IntegerType newSeed = GetInstance()->GetSeed();
   {
-    std::lock_guard< std::recursive_mutex > mutexHolder( m_PimplGlobals->m_StaticInstanceLock );
     newSeed += m_PimplGlobals->m_StaticDiffer++;
   }
   return newSeed;

--- a/Modules/Core/GPUCommon/include/itkGPUDataManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUDataManager.h
@@ -25,7 +25,6 @@
 #include "itkOpenCLUtil.h"
 #include "itkGPUContextManager.h"
 #include <mutex>
-#include <mutex>
 
 namespace itk
 {


### PR DESCRIPTION
Declared internal integer data members `m_Seed` and `m_StaticDiffer`
`atomic`, and removed three locks (`std::lock_guard<std::mutex>`) from
`MersenneTwisterRandomVariateGenerator`, to improve the performance.

For performance reasons, it is in general recommended to use atomics,
instead of mutex locking, whenever possible.