### PR TITLE
ENH: Update SphinxExamples to lastest master branch

### DIFF
--- a/Modules/Remote/SphinxExamples.remote.cmake
+++ b/Modules/Remote/SphinxExamples.remote.cmake
@@ -2,5 +2,5 @@
 itk_fetch_module(SphinxExamples
   "This module builds the examples found at https://itk.org/ITKExamples/"
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKExamples.git
-  GIT_TAG 3966234dc803b269a8acad2dcdc8ef9ffbda4940
+  GIT_TAG abaac79d3380b23a6cd38ac772c91302463ed3c3
   )


### PR DESCRIPTION
This updates the support for ITKv5.0.0, update python to 3.6 support,
updates submodules to working hashes, updates documentation warnings,
uses https vs http for websites that support it, and updates http addresses
that are are permanently redirected.
