### PR TITLE
COMP: forgotten class for ITKV4_COMPATIBILITY in 2aae174

### DIFF
--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
@@ -126,11 +126,13 @@ public:
     spline order! */
   void SetInputImage(const TImageType *inputData) override;
 
+#if !defined( ITKV4_COMPATIBILITY )
   SizeType
   GetRadius() const override
   {
     return SizeType::Filled( m_SplineOrder + 1 );
   }
+#endif
 
 protected:
   ComplexBSplineInterpolateImageFunction();


### PR DESCRIPTION
2aae174f9e445e344cc969ea5440fc07dda4a533 has put GetRadius method inside
ITKV4_COMPATIBILITY #ifdefs, but ComplexBSplineInterpolateImageFunction
in Review module was forgotten.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.
