### PR TITLE
COMP: fix warning about missing override in CastImageFilter

### DIFF
--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
@@ -125,7 +125,7 @@ public:
 
 protected:
   CastImageFilter();
-  virtual ~CastImageFilter() = default;
+  ~CastImageFilter() override = default;
 
   void GenerateOutputInformation() override;
 


### PR DESCRIPTION
```text
/Users/builder/externalModules/Filtering/ImageFilterBase/include/itkCastImageFilter.h:128:11: warning: '~CastImageFilter' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
  virtual ~CastImageFilter() = default;
          ^
```
This was introduced in 75d98250d5c87c274c87c9a33c1f442c4addab86.
