### PR TITLE
DOC: Improve the documentation clarity for NormalizeImage.

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
@@ -33,8 +33,12 @@ namespace itk
  * StatisticsImageFilter to compute the mean and variance of the input
  * and then applies ShiftScaleImageFilter to shift and scale the pixels.
  *
- * NB: since this filter normalizes the data to lie within -1 to 1,
- * integral types will produce an image that DOES NOT HAVE a unit variance.
+ * NB: since this filter normalizes the data such that the mean is at 0, and
+ * \f$-\sigma\f$ to \f$+\sigma\f$ is mapped to -1.0 to 1.0,
+ * output image integral types will produce an image that DOES NOT HAVE
+ * a unit variance due to 68% of the intensity values being mapped to the
+ * real number range of -1.0 to 1.0 and then cast to the output
+ * integral value.
  *
  * \sa NormalizeToConstantImageFilter
  *


### PR DESCRIPTION
Expand upon the existing caveats to clarify the intended
output values of the image.
