### PR TITLE
DOC: Moved wiki examples to sphinx examples part2

### DIFF
--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
@@ -37,9 +37,9 @@ namespace itk
  *
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Operators/BackwardDifferenceOperator,Create a backward difference kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateABackwardDifferenceOperator,Create A Backward Difference Operator}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int TDimension = 2,
           typename TAllocator = NeighborhoodAllocator< TPixel > >

--- a/Modules/Core/Common/include/itkCommand.h
+++ b/Modules/Core/Common/include/itkCommand.h
@@ -35,9 +35,9 @@ namespace itk
  * \ingroup ITKSystemObjects
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Utilities/ObserveEvent,Observe an event}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/ObserveAnEvent,Observe An Event}
+ * \endsphinx
  */
 
 // The superclass that all commands should be subclasses of

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -44,9 +44,9 @@ namespace itk
  * \ingroup DataRepresentation
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Utilities/FixedArray,C-style array}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateAFixedArray,Create A Fixed Array}
+ * \endsphinx
  */
 template< typename TValue, unsigned int VLength = 3 >
 class ITK_TEMPLATE_EXPORT FixedArray

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -117,9 +117,9 @@ namespace Statistics
  * \ingroup Common
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Utilities/MersenneTwisterRandomVariateGenerator,Random number generator}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/MersenneTwisterRandomNumberGenerator,Mersenne Twister Random Number Generator}
+ * \endsphinx
  */
 
 struct MersenneTwisterGlobals;

--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -53,9 +53,9 @@ class ITK_FORWARD_EXPORT Command;
  * \ingroup DataRepresentation
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Utilities/CreateAnother,Copy a filter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateAnother,Copy Another}
+ * \endsphinx
  */
 class ITKCommon_EXPORT Object:public LightObject
 {

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -142,10 +142,10 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ShapedNeighborhoodIterator_Manual,Iterate over a region of an image with a shaped neighborhood}
- * \wikiexample{Iterators/ShapedNeighborhoodIterator,Iterate over a region of an image with a shaped neighborhood}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator,Iterate Over A Region With A Shaped Neighborhood Iterator Manually}
+ * \sphinxexample{Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator,Iterate Over A Region With A Shaped Neighborhood Iterator}
+ * \endsphinx
  */
 template< typename TImage,
           typename TBoundaryCondition = ZeroFluxNeumannBoundaryCondition< TImage >

--- a/Modules/Core/Common/include/itkSimpleFilterWatcher.h
+++ b/Modules/Core/Common/include/itkSimpleFilterWatcher.h
@@ -60,9 +60,9 @@ namespace itk
  *
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Utilities/SimpleFilterWatcher,Monitor a filter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/WatchAFilter,Watch A filter}
+ * \endsphinx
  */
 class ITKCommon_EXPORT SimpleFilterWatcher
 {

--- a/Modules/Core/Common/include/itkTimeProbe.h
+++ b/Modules/Core/Common/include/itkTimeProbe.h
@@ -37,9 +37,9 @@ namespace itk
  *
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Utilities/TimeProbe,Time probe}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/ComputeTimeBetweenPoints,Compute Time Between Points}
+ * \endsphinx
  */
 class ITKCommon_EXPORT TimeProbe:public
   ResourceProbe< RealTimeClock::TimeStampType, RealTimeClock::TimeStampType >

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -40,9 +40,9 @@ namespace itk
  * \ingroup DataRepresentation
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Utilities/VectorContainer,Vector container}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateOnAVectorContainer,Iterate On A Vector Container}
+ * \endsphinx
  */
 template<
   typename TElementIdentifier,

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.h
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.h
@@ -99,9 +99,9 @@ namespace itk
  *
  * \ingroup ITKAntiAlias
  *
- * \wiki
- * \wikiexample{Smoothing/AntiAliasBinaryImageFilter,Anti alias a binary image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction,Smooth Binary Image Before Surface Extraction}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT AntiAliasBinaryImageFilter:

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
@@ -58,9 +58,9 @@ namespace itk
  * \sa ImageToImageFilter BinaryErodeImageFilter BinaryMorphologyImageFilter
  * \ingroup ITKBinaryMathematicalMorphology
  *
- * \wiki
- * \wikiexample{Morphology/BinaryDilateImageFilter,Dilate a binary image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/BinaryMathematicalMorphology/DilateABinaryImage,Dilate A Binary Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage, typename TKernel >
 class ITK_TEMPLATE_EXPORT BinaryDilateImageFilter:

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
@@ -59,9 +59,9 @@ namespace itk
  * \sa ImageToImageFilter BinaryDilateImageFilter BinaryMorphologyImageFilter
  * \ingroup ITKBinaryMathematicalMorphology
  *
- * \wiki
- * \wikiexample{Morphology/BinaryErodeImageFilter,Erode a binary image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/BinaryMathematicalMorphology/ErodeABinaryImage,Erode A Binary Image}
+ * \endsphin
  */
 template< typename TInputImage, typename TOutputImage, typename TKernel >
 class ITK_TEMPLATE_EXPORT BinaryErodeImageFilter:

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
@@ -69,9 +69,9 @@ namespace itk
  * \ingroup   IntensityImageFilters     MultiThreaded
  * \ingroup ITKColormap
  *
- * \wiki
- * \wikiexample{SimpleOperations/ScalarToRGBColormapImageFilter,Apply a color map to an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Colormap/ApplyAColorMapToAnImage,Apply A Color Map To An Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ScalarToRGBColormapImageFilter:

--- a/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.h
@@ -37,9 +37,9 @@ namespace itk
  * \ingroup IntensityImageFilters  MultiThreaded
  * \ingroup ITKImageCompare
  *
- * \wiki
- * \wikiexample{Inspection/CheckerBoardImageFilter,Combine two images by alternating blocks of a checkerboard pattern}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern,Combine Two Images With Checker Board Pattern}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT CheckerBoardImageFilter:

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.h
@@ -35,9 +35,9 @@ namespace itk
  * \ingroup MultiThreaded
  * \ingroup ITKImageFeature
  *
- * \wiki
- * \wikiexample{EdgesAndGradients/LaplacianRecursiveGaussianImageFilter,Compute the Laplacian of Gaussian (LoG) of an image}
- * \endwiki
+ * \spihnx
+ * \sphinxexample{Filtering/ImageFeature/ComputeLaplacian,Compute Laplacian}
+ * \endsphinx
  */
 template< typename TInputImage,
           typename TOutputImage = TInputImage >

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
@@ -41,9 +41,9 @@ namespace itk
  *
  * \ingroup ITKImageFeature
  *
- * \wiki
- * \wikiexample{EdgesAndGradients/SobelEdgeDetectionImageFilter,SobelEdgeDetectionImageFilter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFeature/SobelEdgeDetectionImageFilter,Sobel Edge Detection Image Filter}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
@@ -92,9 +92,9 @@ public:
  * \sa ExtractImageFilter
  * \ingroup ITKImageFilterBase
  *
- * \wiki
- * \wikiexample{ImageProcessing/CastImageFilter,Cast an image from one type to another}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFilterBase/CastAnImageToAnotherType,Cast An Image To Another Type}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT CastImageFilter:

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
@@ -33,9 +33,9 @@ namespace itk
  * \sa NeighborhoodIterator
  * \ingroup ITKImageGradient
  *
- * \wiki
- * \wikiexample{EdgesAndGradients/GradientMagnitudeImageFilter,Compute the gradient magnitude image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGradient/ComputeGradientMagnitude,Compute Gradient Magnitude Of Grayscale Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT GradientMagnitudeImageFilter:

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
@@ -38,9 +38,9 @@ namespace itk
  * \ingroup SingleThreaded
  * \ingroup ITKImageGradient
  *
- * \wiki
- * \wikiexample{EdgesAndGradients/GradientMagnitudeRecursiveGaussianImageFilter,Find the gradient magnitude of the image first smoothed with a Gaussian kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGradient/ComputeGradientMagnitude,Compute Gradient Magnitude Of Grayscale Image}
+ * \endsphinx
  */
 // NOTE that the typename macro has to be used here in lieu
 // of "typename" because VC++ doesn't like the typename keyword

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -44,9 +44,9 @@ namespace itk
  * \ingroup SingleThreaded
  * \ingroup ITKImageGradient
  *
- * \wiki
- * \wikiexample{EdgesAndGradients/GradientRecursiveGaussianImageFilter,Compute the gradient of an image by convolution with the first derivative of a Gaussian}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput,Apply GradientRecursiveGaussianImageFilter on Image with Vector type}
+ * \endsphimx
  */
 template< typename TInputImage,
           typename TOutputImage = Image< CovariantVector<

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
@@ -40,9 +40,9 @@ namespace itk
  * \ingroup GeometricTransform
  * \ingroup ITKImageGrid
  *
- * \wiki
- * \wikiexample{ImageProcessing/PasteImageFilter,Paste a part of one image into another image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/PasteImageIntoAnotherOne,Paste Image Into Another One}
+ * \endsphinx
  */
 template< typename TInputImage, typename TSourceImage = TInputImage, typename TOutputImage = TInputImage >
 class ITK_TEMPLATE_EXPORT PasteImageFilter:

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.h
@@ -43,9 +43,9 @@ namespace itk
  * \ingroup Streamed
  * \ingroup ITKImageGrid
  *
- * \wiki
- * \wikiexample{ImageProcessing/PermuteAxesImageFilter,Switch the axes of an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/PermuteAxesOfAnImage,Permute Axes Of An Image}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT PermuteAxesImageFilter:

--- a/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.h
@@ -45,9 +45,9 @@ namespace itk
  * \ingroup GeometricTransform
  * \ingroup ITKImageGrid
  *
- * \wiki
- * \wikiexample{ImageProcessing/RegionOfInterestImageFilter,Extract a portion of an image (region of interest)}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/ExtractRegionOfInterestInOneImage,Extract Region Of Interest In One Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT RegionOfInterestImageFilter:

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -76,9 +76,9 @@ namespace itk
  * \ingroup GeometricTransform MultiThreaded Streamed
  * \ingroup ITKImageGrid
  *
- * \wiki
- * \wikiexample{Registration/WarpImageFilter,Warp one image to another using manually specified landmarks}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/WarpAnImageUsingADeformationField,Warp An Image Using A Deformation Field}
+ * \endsphinx
  */
 template<
   typename TInputImage,

--- a/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
@@ -77,9 +77,9 @@ public:
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{Math/Trig/Atan2ImageFilter,Compute the arctangent of each pixel.}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/ApplyAtanImageFilter,Apply Atan Image Filter}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2, typename TOutputImage >
 class Atan2ImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
@@ -128,9 +128,9 @@ private:
  *
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/RescaleIntensityImageFilter,Rescale the intensity values of an image to a specified range}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/RescaleAnImage,Rescale An Image}
+ * \endsphinx
  */
 template< typename  TInputImage, typename  TOutputImage = TInputImage >
 class ITK_TEMPLATE_EXPORT RescaleIntensityImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkSigmoidImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSigmoidImageFilter.h
@@ -40,9 +40,9 @@ namespace itk
  *
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/SigmoidImageFilter,Pass image pixels through a sigmoid function}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/ComputeSigmoid,Compute Sigmoid}
+ * \endsphinx
  */
 
 namespace Functor

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
@@ -63,9 +63,9 @@ namespace itk
  * \ingroup ImageEnhancement
  * \ingroup ITKImageStatistics
  *
- * \wiki
- * \wikiexample{NeedDemo/ImageProcessing/AdaptiveHistogramEqualizationImageFilter,Adaptive histogram equalization}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter,Adaptive Histogram Equalization Image Filter}
+ * \endsphinx
  */
 template< typename TImageType , typename TKernel = Neighborhood<bool, TImageType::ImageDimension> >
 class ITK_TEMPLATE_EXPORT AdaptiveHistogramEqualizationImageFilter:

--- a/Modules/Filtering/MathematicalMorphology/include/itkBinaryBallStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBinaryBallStructuringElement.h
@@ -53,9 +53,9 @@ namespace itk
  * \ingroup ImageIterators
  * \ingroup ITKMathematicalMorphology
  *
- * \wiki
- * \wikiexample{Morphology/BinaryBallStructuringElement,An elliptical structuring element}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement,Create A Binary Ball Structuring Element}
+ * \endsphinx
  */
 
 template< typename TPixel, unsigned int VDimension = 2,

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.h
@@ -44,9 +44,9 @@ namespace itk
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKMathematicalMorphology
  *
- * \wiki
- * \wikiexample{Morphology/GrayscaleDilateImageFilter,Dilate a grayscale image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/DilateAGrayscaleImage,Dilate A Grayscale Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage, typename TKernel >

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.h
@@ -44,9 +44,9 @@ namespace itk
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKMathematicalMorphology
  *
- * \wiki
- * \wikiexample{Morphology/GrayscaleErodeImageFilter,Erode a grayscale image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/ErodeAGrayscaleImage,Erode A Grayscale Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage, typename TKernel >

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.h
@@ -63,6 +63,10 @@ namespace itk
  * (and of course it requires that the output have some itk::Vector for point
  * data and cell data.
  * \ingroup ITKQuadEdgeMeshFiltering
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh,Compute Normals Of A Mesh}
+ * \endsphinx
  */
 template< typename TInputMesh, typename TOutputMesh >
 class ITK_TEMPLATE_EXPORT NormalQuadEdgeMeshFilter:

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
@@ -48,9 +48,9 @@ namespace itk {
  *
  * \ingroup ITKQuadEdgeMeshFiltering
  *
- * \wiki
- * \wikiexample{Meshes/QuadEdgeMeshParameterizationFilter,Planar parameterization of a mesh}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh,Compute Planar Parameterization Of A Mesh}
+ * \endsphinx
  */
 template< typename TInputMesh, typename TOutputMesh, typename TSolverTraits >
 class ITK_TEMPLATE_EXPORT ParameterizationQuadEdgeMeshFilter:

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.h
@@ -35,9 +35,9 @@ namespace itk
  * \ingroup ImageEnhancement
  * \ingroup ITKSmoothing
  *
- * \wiki
- * \wikiexample{Smoothing/BinomialBlurImageFilter,Blur an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Smoothing/BlurringAnImageUsingABinomialKernel,Blurring An Image Using A Binomial Kernel}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT BinomialBlurImageFilter:

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
@@ -53,9 +53,9 @@ namespace itk
  * \ingroup ImageFeatureExtraction
  * \ingroup ITKSmoothing
  *
- * \wiki
- * \wikiexample{Smoothing/DiscreteGaussianImageFilter,Smooth an image with a discrete Gaussian filter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Smoothing/SmoothWithRecursiveGaussian,Computes the smoothing with Gaussian kernel}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.h
@@ -43,10 +43,10 @@ namespace itk
  * \ingroup IntensityImageFilters
  * \ingroup ITKSmoothing
  *
- * \wiki
- * \wikiexample{Smoothing/MedianImageFilter,Median filter an image}
- * \wikiexample{Smoothing/RGBMedianImageFilter,Median filter an RGB image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Smoothing/ApplyMedianFilter,Median Filter Of An Image}
+ * \sphihnxexample{Filtering/Smoothing/MedianFilteringOfAnRGBImage,Median Filter Of An RGB Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT MedianImageFilter:

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
@@ -56,9 +56,9 @@ namespace itk
  * \ingroup IntensityImageFilters  MultiThreaded
  * \ingroup ITKThresholding
  *
- * \wiki
- * \wikiexample{ImageProcessing/BinaryThresholdImageFilter,Threshold an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Thresholding/ThresholdAnImageUsingBinary,Threshold An Image Using Binary Thresholding}
+ * \endsphinx
  */
 namespace Functor
 {

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
@@ -50,6 +50,10 @@ namespace itk
  * \sa ThresholdLabelerImageFilter
  * \ingroup IntensityImageFilters  MultiThreaded
  * \ingroup ITKThresholding
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/Thresholding/ThresholdAnImageUsingOtsu,Threshold An Image Using Otsu}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.h
@@ -62,9 +62,9 @@ namespace itk
  * \ingroup IntensityImageFilters MultiThreaded
  * \ingroup ITKThresholding
  *
- * \wiki
- * \wikiexample{ImageProcessing/ThresholdImageFilter,Threshold an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Thresholding/ThresholdAnImage,Threshold An Image}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ThresholdImageFilter:public InPlaceImageFilter< TImage, TImage >

--- a/Modules/IO/ImageBase/include/itkNumericSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkNumericSeriesFileNames.h
@@ -47,9 +47,9 @@ namespace itk
  *
  * \ingroup ITKIOImageBase
  *
- * \wiki
- * \wikiexample{Utilities/NumericSeriesFileNames,Create a list of file names}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{IO/ImageBase/CreateAListOfFileNames,Create A List Of File Names}
+ * \endsphinx
  */
 class ITKIOImageBase_EXPORT NumericSeriesFileNames:public Object
 {

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.h
@@ -67,6 +67,11 @@ namespace itk
  * \ingroup ITKIOMeshBase
  *
  * \author Wanlin Zhu. Uviversity of New South Wales, Australia.
+ *
+ * \sphinx
+ * \sphinxexample{IO/Mesh/WriteMesh,Write Mesh}
+ * \sphinxexample{IO/Mesh/ReadMesh,Read Mesh}
+ * \endsphinx
  */
 
 template< typename TOutputMesh,

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -67,9 +67,9 @@ namespace Statistics
  * \sa Sample, DenseFrequencyContainer, SparseFrequencyContainer, VariableDimensionHistogram
  * \ingroup ITKStatistics
  *
- * \wiki
- * \wikiexample{Statistics/Histogram,Compute a histogram from measurements.}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/HistogramCreationAndBinAccess,Histogram Creation And Bin Access}
+ * \endsphinx
  */
 
 template< typename TMeasurement = float,

--- a/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
@@ -140,6 +140,10 @@ namespace itk
  *
  * \ingroup WatershedSegmentation
  * \ingroup ITKWatersheds
+ *
+ * \sphinx
+ * \sphinxexample{Segmentation/Watersheds/SegmentWithWatershedImageFilter,Watershed Image Filter}
+ * \endsphinx
  */
 template< typename TInputImage >
 class ITK_TEMPLATE_EXPORT WatershedImageFilter:


### PR DESCRIPTION
Link to Sphinx based documentation instead of
outdated media wiki documentation
 - Moved wiki AdaptiveHistogramEqualizationImageFilter example
 - Moved wiki AntiAliasBinaryImageFilter example
 - Moved wiki Atan2ImageFilter example
 - Moved wiki BackwardDifferenceOperator example
 - Moved wiki BinaryBallStructuringElement example
 - Moved wiki BinaryDilateImageFilter examples
 - Moved wiki BinaryErodeImageFilter examples
 - Moved wiki BinomialBlurImageFilter example
 - Moved wiki CastImageFilter example
 - Moved wiki CheckerBoardImageFilter example
 - Moved wiki CreateAnother example
 - Moved wiki FixedArray example
 - Moved wiki GradientMagnitudeImageFilter example
 - Moved wiki GradientMagnitudeRecursiveGaussianImageFilter example
 - Moved wiki GradientRecursiveGaussianImageFilter example
 - Moved wiki GrayscaleDilateImageFilter example
 - Moved wiki GrayscaleErodeImageFilter example
 - Moved wiki Histogram example
 - Moved wiki LaplacianRecursiveGaussianImageFilter example
 - Moved wiki MedianImageFilter examples
 - Moved wiki MersenneTwisterRandomVariateGenerator example
 - Moved wiki NumericSeriesFileNames example
 - Moved wiki ObserveEvent example
 - Moved wiki OtsuMultipleThresholdsImageFilter example
 - Moved wiki PasteImageFilter example
 - Moved wiki PermuteAxesImageFilter example
 - Moved wiki QuadEdgeMeshNormalFilter example
 - Moved wiki QuadEdgeMeshParameterizationFilter example
 - Moved wiki ReadWrite example
 - Moved wiki RegionOfInterestImageFilter example
 - Moved wiki RescaleIntensityImageFilter example
 - Moved wiki ScalarToRGBColormapImageFilter example
 - Moved wiki ShapedNeighborhoodIterator example
 - Moved wiki SigmoidImageFilter example
 - Moved wiki SimpleFilterWatcher example
 - Moved wiki SmoothingRecursiveGaussianImageFilter example
 - Moved wiki SobelEdgeDetectionImageFilter example
 - Moved wiki ThresholdImageFilter example
 - Moved wiki TimeProbe example
 - Moved wiki VectorContainer example
 - Moved wiki WarpImageFilter example
 - Moved wiki WatershedImageFilter example

Co-authored-by: Mathew J. Seng <mathewseng@gmail.com>

## PR Checklist
- [X] Adds Documentation.
