### PR TITLE
DOC: wrong class name for PlatformMultiThreader

### DIFF
--- a/Modules/Core/Common/include/itkPlatformMultiThreader.h
+++ b/Modules/Core/Common/include/itkPlatformMultiThreader.h
@@ -34,7 +34,7 @@
 
 namespace itk
 {
-/** \class MultiThreader
+/** \class PlatformMultiThreader
  * \brief A class for performing multithreaded execution
  *
  * Multithreader is a class that provides support for multithreaded


### PR DESCRIPTION
Trying to address the mystery of missing PlatformMultiThreader from documentation.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

