### PR TITLE
STYLE: Use image->TransformPhysicalPointToIndex(point), returning index

### DIFF
--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.hxx
@@ -107,8 +107,6 @@ WarpMeshFilter< TInputMesh, TOutputMesh, TDisplacementField >
 
   using InputPointType = typename InputMeshType::PointType;
   using OutputPointType = typename OutputMeshType::PointType;
-  using IndexType = typename DisplacementFieldType::IndexType;
-  IndexType index;
 
   OutputPointType displacedPoint;
 
@@ -119,7 +117,7 @@ WarpMeshFilter< TInputMesh, TOutputMesh, TDisplacementField >
   while ( inputPoint != inPoints->End() )
     {
     const InputPointType & originalPoint = inputPoint.Value();
-    fieldPtr->TransformPhysicalPointToIndex(originalPoint, index);
+    const auto index = fieldPtr->TransformPhysicalPointToIndex(originalPoint);
     displacement = fieldPtr->GetPixel(index);
 
     for ( unsigned int i = 0; i < Dimension; i++ )

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -151,7 +151,7 @@ SpatialObjectToImageStatisticsCalculator< TInputImage, TInputSpatialObject,
         maskImage->TransformIndexToPhysicalPoint( ind, pnt );
         tPnt = maskSpatialObject->GetObjectToWorldTransform()
           ->TransformPoint( pnt );
-        m_Image->TransformPhysicalPointToIndex( tPnt, ind );
+        ind = m_Image->TransformPhysicalPointToIndex(tPnt);
         mv[0] = m_Image->GetPixel(ind);
         m_Sum += static_cast< AccumulateType >( mv[0] );
         for ( unsigned int i = 1; i < Self::SampleDimension; i++ )
@@ -176,16 +176,14 @@ SpatialObjectToImageStatisticsCalculator< TInputImage, TInputSpatialObject,
 
     Point< double, Self::ObjectDimension > ptMin;
     Point< double, Self::ObjectDimension > ptMax;
-    IndexType indMin;
-    IndexType indMax;
     SizeType size;
     for ( unsigned int i = 0; i < Self::ObjectDimension; i++ )
       {
       ptMin[i] = bounds[i * 2];
       ptMax[i] = bounds[i * 2 + 1];
       }
-    m_Image->TransformPhysicalPointToIndex( ptMin, indMin );
-    m_Image->TransformPhysicalPointToIndex( ptMax, indMax );
+    auto indMin = m_Image->TransformPhysicalPointToIndex(ptMin);
+    auto indMax = m_Image->TransformPhysicalPointToIndex(ptMax);
     IndexType imageIndex = m_Image->GetLargestPossibleRegion().GetIndex();
     SizeType imageSize = m_Image->GetLargestPossibleRegion().GetSize();
     for ( unsigned int i = 0; i < Self::ObjectDimension; i++ )

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -156,9 +156,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>
 ::ComputeJacobianWithRespectToPosition( const InputPointType & point,
                                         JacobianPositionType & jacobian ) const
 {
-  IndexType idx;
-
-  this->m_DisplacementField->TransformPhysicalPointToIndex( point, idx );
+  const auto idx = m_DisplacementField->TransformPhysicalPointToIndex(point);
   this->ComputeJacobianWithRespectToPosition( idx, jacobian );
 }
 
@@ -177,8 +175,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>
 ::ComputeInverseJacobianWithRespectToPosition( const InputPointType & point,
                                         InverseJacobianPositionType & jacobian ) const
 {
-  IndexType idx;
-  this->m_DisplacementField->TransformPhysicalPointToIndex(point, idx);
+  const auto idx = m_DisplacementField->TransformPhysicalPointToIndex(point);
   this->ComputeJacobianWithRespectToPositionInternal( idx, jacobian, true );
 }
 
@@ -190,9 +187,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>
   JacobianPositionType & jacobian,
   bool useSVD ) const
 {
-  IndexType idx;
-
-  this->m_DisplacementField->TransformPhysicalPointToIndex( point, idx );
+  const auto idx = m_DisplacementField->TransformPhysicalPointToIndex(point);
   this->GetInverseJacobianOfForwardFieldWithRespectToPosition( idx, jacobian,
                                                                useSVD );
 }

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -135,7 +135,7 @@ ShrinkImageFilter< TInputImage, TOutputImage >
   // We wish to perform the following mapping of outputIndex to
   // inputIndex on all points in our region
   outputPtr->TransformIndexToPhysicalPoint(outputIndex, tempPoint);
-  inputPtr->TransformPhysicalPointToIndex(tempPoint, inputIndex);
+  inputIndex = inputPtr->TransformPhysicalPointToIndex(tempPoint);
 
   // Given that the size is scaled by a constant factor eq:
   // inputIndex = outputIndex * factorSize
@@ -217,7 +217,7 @@ ShrinkImageFilter< TInputImage, TOutputImage >
   // We wish to perform the following mapping of outputIndex to
   // inputIndex on all points in our region
   outputPtr->TransformIndexToPhysicalPoint(outputIndex, tempPoint);
-  inputPtr->TransformPhysicalPointToIndex(tempPoint, inputIndex);
+  inputIndex = inputPtr->TransformPhysicalPointToIndex(tempPoint);
 
   // Given that the size is scaled by a constant factor eq:
   // inputIndex = outputIndex * factorSize

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -115,13 +115,12 @@ void PolylineMask2DImageFilter< TInputImage, TPolyline, TOutputImage >
   VertexType     endVertex;
   VertexType     pstartVertex;
   VertexType     tmpVertex;
-  ImageIndexType tmpIndex;
 
 /* Check if the polyline coordinates are within the input image */
   while ( piter != container->End() )
     {
     tmpVertex     = piter.Value();
-    outputImagePtr->TransformPhysicalPointToIndex(tmpVertex, tmpIndex);
+    const auto tmpIndex = outputImagePtr->TransformPhysicalPointToIndex(tmpVertex);
     if ( !outputImagePtr->GetBufferedRegion().IsInside(tmpIndex) )
       {
       itkExceptionMacro(<< "Polyline vertex is out of bounds (Vertex,Index): "
@@ -150,8 +149,6 @@ void PolylineMask2DImageFilter< TInputImage, TPolyline, TOutputImage >
   tmpVertex = pstartVertex;
   ++piter;
 
-  ImageIndexType startImageIndex;
-  ImageIndexType endImageIndex;
   ImageIndexType tmpImageIndex;
   tmpImageIndex.Fill(0);
 
@@ -166,8 +163,8 @@ void PolylineMask2DImageFilter< TInputImage, TPolyline, TOutputImage >
     startVertex    = tmpVertex;
     endVertex      = piter.Value();
 
-    outputImagePtr->TransformPhysicalPointToIndex(startVertex, startImageIndex);
-    outputImagePtr->TransformPhysicalPointToIndex(endVertex, endImageIndex);
+    const auto startImageIndex = outputImagePtr->TransformPhysicalPointToIndex(startVertex);
+    const auto endImageIndex = outputImagePtr->TransformPhysicalPointToIndex(endVertex);
 
     //itkDebugMacro(<<"Projection image (index,physical
     // coordinate):"<<startImageIndex<<","<<startVertex<<std::endl);
@@ -213,8 +210,8 @@ void PolylineMask2DImageFilter< TInputImage, TPolyline, TOutputImage >
   startVertex    = tmpVertex;
   endVertex      = pstartVertex;
 
-  outputImagePtr->TransformPhysicalPointToIndex(startVertex, startImageIndex);
-  outputImagePtr->TransformPhysicalPointToIndex(endVertex, endImageIndex);
+  const auto startImageIndex = outputImagePtr->TransformPhysicalPointToIndex(startVertex);
+  const auto endImageIndex = outputImagePtr->TransformPhysicalPointToIndex(endVertex);
 
   if ( endImageIndex[1] > startImageIndex[1] )
     {

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -501,7 +501,7 @@ void PolylineMaskImageFilter< TInputImage, TPolyline, TVector, TOutputImage >
     {
     outputImagePtr->TransformIndexToPhysicalPoint(outputIt.GetIndex(), inputPoint);
     outputPoint = this->TransformProjectPoint(inputPoint);
-    projectionImagePtr->TransformPhysicalPointToIndex(outputPoint, projectionImageIndex);
+    projectionImageIndex = projectionImagePtr->TransformPhysicalPointToIndex(outputPoint);
 
     if ( !projectionImagePtr->GetBufferedRegion().IsInside(projectionImageIndex) )
       {

--- a/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.hxx
@@ -52,7 +52,7 @@ AttributePositionLabelMapFilter<TImage, TAttributeAccessor, VPhysicalPosition>
       {
       point[i] = position[i];
       }
-    this->GetOutput()->TransformPhysicalPointToIndex( point, idx );
+    idx = this->GetOutput()->TransformPhysicalPointToIndex( point );
     }
   else
     {

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -282,8 +282,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
 {
   if( ! this->m_VirtualImage.IsNull() )
     {
-    VirtualIndexType index;
-    this->m_VirtualImage->TransformPhysicalPointToIndex( point, index );
+    const auto index = m_VirtualImage->TransformPhysicalPointToIndex(point);
     return this->GetVirtualRegion().IsInside( index );
     }
 

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -250,10 +250,8 @@ BlockMatchingImageFilter< TFixedImage, TMovingImage, TFeatures, TDisplacements, 
   for ( SizeValueType idx = first, last = first + count; idx < last; idx++ )
     {
     FeaturePointsPhysicalCoordinates originalLocation = featurePoints->GetPoint( idx );
-    ImageIndexType fixedIndex;
-    fixedImage->TransformPhysicalPointToIndex(    originalLocation, fixedIndex );
-    ImageIndexType movingIndex;
-    movingImage->TransformPhysicalPointToIndex( originalLocation, movingIndex );
+    const auto fixedIndex = fixedImage->TransformPhysicalPointToIndex(originalLocation);
+    const auto movingIndex = movingImage->TransformPhysicalPointToIndex(originalLocation);
 
     // the block is selected for a minimum similarity metric
     SimilaritiesValue  similarity = NumericTraits< SimilaritiesValue >::ZeroValue();

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -53,12 +53,11 @@ ImageToImageMetricv4GetValueAndDerivativeThreader< ThreadedIndexedContainerParti
   using ElementIdentifierType = typename TImageToImageMetricv4::VirtualPointSetType::MeshTraits::PointIdentifier;
   const ElementIdentifierType begin = indexSubRange[0];
   const ElementIdentifierType end   = indexSubRange[1];
-  VirtualIndexType virtualIndex;
   typename VirtualImageType::ConstPointer virtualImage = this->m_Associate->GetVirtualImage();
   for( ElementIdentifierType i = begin; i <= end; ++i )
     {
     const VirtualPointType & virtualPoint = virtualSampledPointSet->GetPoint( i );
-    virtualImage->TransformPhysicalPointToIndex( virtualPoint, virtualIndex );
+    const auto virtualIndex = virtualImage->TransformPhysicalPointToIndex( virtualPoint );
     this->ProcessVirtualPoint( virtualIndex, virtualPoint, threadId );
     }
   //Finalize per thread actions

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -96,8 +96,8 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase< TDomainPartitioner, 
     {
     JointPDFPointType jointPDFpoint;
     this->m_Associate->ComputeJointPDFPoint( fixedImageValue, movingImageValue, jointPDFpoint );
-    JointPDFIndexType jointPDFIndex;
-    this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->TransformPhysicalPointToIndex( jointPDFpoint, jointPDFIndex );
+    const auto jointPDFIndex =
+      m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->TransformPhysicalPointToIndex( jointPDFpoint );
     if( this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetBufferedRegion().IsInside( jointPDFIndex ) )
       {
       typename JointHistogramType::PixelType jointHistogramPixel;


### PR DESCRIPTION
Replaced `image->TransformPhysicalPointToIndex(point, index)` calls by
`image->TransformPhysicalPointToIndex(point)`, which returns the index.

The `TransformPhysicalPointToIndex(point)` overload was introduced with
ITK 5.0.0. It is slightly faster than the original overload, as it does
not figure out whether or not the point is inside the image. However,
this commit is mostly intended to increase code readability.