### PR TITLE
hessianToObjectness strict weak ordering

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -146,7 +146,7 @@ private:
   struct AbsLessEqualCompare {
     bool operator()(EigenValueType a, EigenValueType b)
     {
-      return itk::Math::abs(a) <= itk::Math::abs(b);
+      return itk::Math::abs(a) < itk::Math::abs(b);
     }
   };
 

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -149,6 +149,13 @@ private:
       return itk::Math::abs(a) < itk::Math::abs(b);
     }
   };
+  
+  struct AbsLessEqualCompare {
+    bool operator()(EigenValueType a, EigenValueType b)
+    {
+      return itk::Math::abs(a) <= itk::Math::abs(b);
+    }
+  };
 
   double       m_Alpha{0.5};
   double       m_Beta{0.5};

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -140,10 +140,10 @@ protected:
 
 private:
   // functor used to sort the eigenvalues are to be sorted
-  // |e1|<=|e2|<=...<=|eN|
+  // |e1|<|e2|<...<|eN|
   //
-  // Returns ( abs(a) <= abs(b) )
-  struct AbsLessEqualCompare {
+  // Returns ( abs(a) < abs(b) )
+  struct AbsLessCompare {
     bool operator()(EigenValueType a, EigenValueType b)
     {
       return itk::Math::abs(a) < itk::Math::abs(b);

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -76,9 +76,9 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
     eigenCalculator.ComputeEigenValues(it.Get(), eigenValues);
 
     // Sort the eigenvalues by magnitude but retain their sign.
-    // The eigenvalues are to be sorted |e1|<=|e2|<=...<=|eN|
+    // The eigenvalues are to be sorted |e1|<|e2|<...<|eN|
     EigenValueArrayType sortedEigenValues = eigenValues;
-    std::sort( sortedEigenValues.Begin(), sortedEigenValues.End(), AbsLessEqualCompare() );
+    std::sort( sortedEigenValues.Begin(), sortedEigenValues.End(), AbsLessCompare() );
 
     // Check whether eigenvalues have the right sign
     bool signConstraintsSatisfied = true;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
if two eigen value is equal it will return true and cause error "invalid operator<".
Because strict weak ordering of sort.
So i think it should be modified to "return itk::Math::abs(a) '<' itk::Math::abs(b);"