### PR TITLE
ENH: ImageBase Transform-Vector single argument overloads more generic

### DIFF
--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -605,11 +605,11 @@ public:
    * the image acquisition device. Returns the resulting gradient.
    * \sa Image
    */
-  template< typename TCoordRep >
-  FixedArray< TCoordRep, VImageDimension > TransformLocalVectorToPhysicalVector(
-    const FixedArray< TCoordRep, VImageDimension > & inputGradient) const
+  template< typename TVector >
+  TVector TransformLocalVectorToPhysicalVector(
+    const TVector & inputGradient) const
   {
-    FixedArray< TCoordRep, VImageDimension > outputGradient;
+    TVector outputGradient;
     TransformLocalVectorToPhysicalVector(inputGradient, outputGradient);
     return outputGradient;
   }
@@ -654,11 +654,11 @@ public:
    * parallel to the image grid. Returns the result.
    *
    */
-  template< typename TCoordRep >
-  FixedArray< TCoordRep, VImageDimension > TransformPhysicalVectorToLocalVector(
-    const FixedArray< TCoordRep, VImageDimension > & inputGradient) const
+  template< typename TVector >
+  TVector TransformPhysicalVectorToLocalVector(
+    const TVector & inputGradient) const
   {
-    FixedArray< TCoordRep, VImageDimension > outputGradient;
+    TVector outputGradient;
     TransformPhysicalVectorToLocalVector(inputGradient, outputGradient);
     return outputGradient;
   }

--- a/Modules/Core/Common/test/itkImageBaseGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBaseGTest.cxx
@@ -18,7 +18,10 @@
 
  // First include the header file to be tested:
 #include "itkImageBase.h"
+
+#include "itkCovariantVector.h"
 #include "itkImage.h"
+#include "itkVector.h"
 
 #include <gtest/gtest.h>
 #include <type_traits> // For is_same.
@@ -51,6 +54,8 @@ namespace
 
     using FloatArrayType = itk::FixedArray<float, ImageDimension>;
     using DoubleArrayType = itk::FixedArray<double, ImageDimension>;
+    using VectorType = itk::Vector<double, ImageDimension>;
+    using CovariantVectorType = itk::CovariantVector<double, ImageDimension>;
 
     const ImageBaseType& imageBase = *image;
 
@@ -83,7 +88,7 @@ namespace
 
     // The two member functions TransformLocalVectorToPhysicalVector and
     // TransformPhysicalVectorToLocalVector are expected to return an
-    // array of the same type as their first function argument.
+    // array or vector of the same type as their first function argument.
     Expect_same_type_and_equal_value(
       imageBase.TransformLocalVectorToPhysicalVector(FloatArrayType()),
       FloatArrayType());
@@ -91,11 +96,23 @@ namespace
       imageBase.TransformLocalVectorToPhysicalVector(DoubleArrayType()),
       DoubleArrayType());
     Expect_same_type_and_equal_value(
+      imageBase.TransformLocalVectorToPhysicalVector(VectorType()),
+      VectorType());
+    Expect_same_type_and_equal_value(
+      imageBase.TransformLocalVectorToPhysicalVector(CovariantVectorType()),
+      CovariantVectorType());
+    Expect_same_type_and_equal_value(
       imageBase.TransformPhysicalVectorToLocalVector(FloatArrayType()),
       FloatArrayType());
     Expect_same_type_and_equal_value(
       imageBase.TransformPhysicalVectorToLocalVector(DoubleArrayType()),
       DoubleArrayType());
+    Expect_same_type_and_equal_value(
+      imageBase.TransformPhysicalVectorToLocalVector(VectorType()),
+      VectorType());
+    Expect_same_type_and_equal_value(
+      imageBase.TransformPhysicalVectorToLocalVector(CovariantVectorType()),
+      CovariantVectorType());
   }
 
 } // end namespace

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -829,9 +829,7 @@ BSplineInterpolateImageFunction< TImageType, TCoordRep, TCoefficientType >
 
   if ( this->m_UseImageDirection )
     {
-    CovariantVectorType orientedDerivative;
-    this->GetInputImage()->TransformLocalVectorToPhysicalVector(derivativeValue, orientedDerivative);
-    derivativeValue = orientedDerivative;
+    derivativeValue = this->GetInputImage()->TransformLocalVectorToPhysicalVector(derivativeValue);
     }
 
 }
@@ -894,9 +892,7 @@ BSplineInterpolateImageFunction< TImageType, TCoordRep, TCoefficientType >
 
   if ( this->m_UseImageDirection )
     {
-    CovariantVectorType orientedDerivative;
-    inputImage->TransformLocalVectorToPhysicalVector(derivativeValue, orientedDerivative);
-    return orientedDerivative;
+    return inputImage->TransformLocalVectorToPhysicalVector(derivativeValue);
     }
 
   return ( derivativeValue );

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -240,8 +240,8 @@ CentralDifferenceImageFunction< TInputImage, TCoordRep, TOutputType >
 
     if ( this->m_UseImageDirection )
       {
-      ScalarDerivativeType componentDerivativeOut;
-      inputImage->TransformLocalVectorToPhysicalVector(componentDerivative, componentDerivativeOut);
+      const auto componentDerivativeOut =
+        inputImage->TransformLocalVectorToPhysicalVector(componentDerivative);
       for ( unsigned int dim = 0; dim < MaxDims; dim++ )
         {
         OutputConvertType::SetNthComponent( nc * MaxDims + dim, derivative, componentDerivativeOut[dim] );
@@ -337,9 +337,7 @@ CentralDifferenceImageFunction< TInputImage, TCoordRep, TOutputType >
   // direction, we need to reorient into index-space if the user desires.
   if ( ! this->m_UseImageDirection )
     {
-    OutputType derivative;
-    inputImage->TransformPhysicalVectorToLocalVector( orientedDerivative, derivative );
-    orientedDerivative = derivative;
+    orientedDerivative = inputImage->TransformPhysicalVectorToLocalVector(orientedDerivative);
     }
 }
 
@@ -568,7 +566,6 @@ CentralDifferenceImageFunction< TInputImage, TCoordRep, TOutputType >
   for ( unsigned int nc = 0; nc < numberComponents; nc++)
     {
     ScalarDerivativeType componentDerivative;
-    ScalarDerivativeType componentDerivativeOut;
 
     for ( unsigned int dim = 0; dim < MaxDims; dim++ )
       {
@@ -596,7 +593,8 @@ CentralDifferenceImageFunction< TInputImage, TCoordRep, TOutputType >
 
     if ( this->m_UseImageDirection )
       {
-      inputImage->TransformLocalVectorToPhysicalVector(componentDerivative, componentDerivativeOut);
+      const auto componentDerivativeOut =
+        inputImage->TransformLocalVectorToPhysicalVector(componentDerivative);
       for ( unsigned int dim = 0; dim < MaxDims; dim++ )
         {
         OutputConvertType::SetNthComponent( nc * MaxDims + dim, derivative, componentDerivativeOut[dim] );

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -287,21 +287,17 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>
 
       OutputVectorType tempPix;
 
-      OutputVectorType rpix;
       tempPix = m_DisplacementField->GetPixel( difIndex[row][1] );
-      m_DisplacementField->TransformLocalVectorToPhysicalVector( tempPix, rpix );
+      const auto rpix = m_DisplacementField->TransformLocalVectorToPhysicalVector(tempPix);
 
-      OutputVectorType lpix;
       tempPix = m_DisplacementField->GetPixel( difIndex[row][0] );
-      m_DisplacementField->TransformLocalVectorToPhysicalVector( tempPix, lpix );
+      const auto lpix = m_DisplacementField->TransformLocalVectorToPhysicalVector(tempPix);
 
-      OutputVectorType rrpix;
       tempPix = m_DisplacementField->GetPixel( ddrindex );
-      m_DisplacementField->TransformLocalVectorToPhysicalVector( tempPix, rrpix );
+      const auto rrpix = m_DisplacementField->TransformLocalVectorToPhysicalVector(tempPix);
 
-      OutputVectorType llpix;
       tempPix = m_DisplacementField->GetPixel( ddlindex );
-      m_DisplacementField->TransformLocalVectorToPhysicalVector( tempPix, llpix );
+      const auto llpix = m_DisplacementField->TransformLocalVectorToPhysicalVector(tempPix);
 
 
       // 4th order centered difference

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -876,8 +876,8 @@ ShapeLabelMapFilter< TImage, TLabelImage >
         }
       }
 
-    Vector<double, ImageDimension> physicalOffset;
-    output->TransformLocalVectorToPhysicalVector(spacingAxis, physicalOffset);
+    const auto physicalOffset =
+      output->TransformLocalVectorToPhysicalVector(spacingAxis);
     VNLVectorType  paOffset = principalAxesBasisMatrix*physicalOffset.GetVnlVector();
 
     for ( unsigned int i = 0; i < ImageDimension; ++i )

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -389,9 +389,8 @@ ESMDemonsRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
     itkExceptionMacro(<< "Unknown gradient type");
     }
 
-  CovariantVectorType usedGradientTimes2;
-  this->GetFixedImage()->TransformLocalVectorToPhysicalVector(
-    usedOrientFreeGradientTimes2, usedGradientTimes2);
+  const auto usedGradientTimes2 =
+    this->GetFixedImage()->TransformLocalVectorToPhysicalVector(usedOrientFreeGradientTimes2);
 
   /**
    * Compute Update.


### PR DESCRIPTION
The `ImageBase` overloads of `TransformLocalVectorToPhysicalVector` and
`TransformPhysicalVectorToLocalVector` with a single argument
(inputGradient), introduced with ITK 5.0.0, always transformed a
`FixedArray` to another `FixedArray`. This appeared to limit the
usefulness of these overloads, as they would not transform an
`itk::Vector` to another `itk::Vector`, or an `itk::CovariantVector` to
another `itk::CovariantVector`.

The first commit, 4d9dc8f6357673e87ff35ce147a10b6964ffdef5, removes this limitation. It adds support for `Vector` and
`CovariantVector` transformations, by making the overloads more generic:
their return type `TVector` will now be deduced from their argument type.

The second commit, f5bb85e3edd653d3f2c4bc26b825c816cbef757f actually uses the new single argument overloads
in those places in ITK where they could improve code readibility.