### PR TITLE
Replace calls to FixedArray::Begin() and FixedArray::End()

### DIFF
--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -27,11 +27,9 @@ namespace itk
 template< typename T, unsigned int TVectorDimension >
 CovariantVector< T, TVectorDimension >
 ::CovariantVector(const ValueType & r)
+  :
+  Superclass{ r }
 {
-  for ( typename BaseArray::Iterator i = BaseArray::Begin(); i != BaseArray::End(); ++i )
-    {
-    *i = r;
-    }
 }
 
 template< typename T, unsigned int NVectorDimension >

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -29,10 +29,7 @@ template< typename TValue, unsigned int VLength >
 FixedArray< TValue, VLength >
 ::FixedArray(const ValueType & r)
 {
-  for ( Iterator i = Begin(); i != End(); ++i )
-    {
-    *i = r;
-    }
+  std::fill_n(m_InternalArray, VLength, r);
 }
 
 /**
@@ -44,13 +41,7 @@ template< typename TValue, unsigned int VLength >
 FixedArray< TValue, VLength >
 ::FixedArray(const ValueType r[VLength])
 {
-  ConstIterator input = r;
-  Iterator      i = this->Begin();
-
-  while ( i != this->End() )
-    {
-    *i++ = *input++;
-    }
+  std::copy_n(r, VLength, m_InternalArray);
 }
 
 /**
@@ -65,12 +56,7 @@ FixedArray< TValue, VLength >
 {
   if ( r != m_InternalArray )
     {
-    ConstIterator input = r;
-    Iterator      i = this->Begin();
-    while ( i != this->End() )
-      {
-      *i++ = *input++;
-      }
+    std::copy_n(r, VLength, m_InternalArray);
     }
   return *this;
 }
@@ -83,23 +69,7 @@ bool
 FixedArray< TValue, VLength >
 ::operator==(const FixedArray & r) const
 {
-  ConstIterator i = this->Begin();
-  ConstIterator j = r.Begin();
-
-  while ( i != this->End() )
-    {
-CLANG_PRAGMA_PUSH
-CLANG_SUPPRESS_Wfloat_equal
-    if ( *i != *j )
-CLANG_PRAGMA_POP
-      {
-      return false;
-      }
-    ++j;
-    ++i;
-    }
-
-  return true;
+  return std::equal(m_InternalArray, m_InternalArray + VLength, r.m_InternalArray);
 }
 
 /**
@@ -213,12 +183,7 @@ void
 FixedArray< TValue, VLength >
 ::Fill(const ValueType & value)
 {
-  Iterator i = this->Begin();
-
-  while ( i != this->End() )
-    {
-    *i++ = value;
-    }
+  std::fill_n(m_InternalArray, VLength, value);
 }
 
 /**

--- a/Modules/Core/Common/include/itkRGBPixel.hxx
+++ b/Modules/Core/Common/include/itkRGBPixel.hxx
@@ -158,7 +158,7 @@ bool
 RGBPixel< T >
 ::operator<(const Self & r) const
 {
-  return std::lexicographical_compare( this->Begin(), this->End(), r.Begin(), r.End() );
+  return std::lexicographical_compare( this->cbegin(), this->cend(), r.cbegin(), r.cend() );
 }
 
 template< typename T >

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -28,11 +28,9 @@ namespace itk
 template< typename T, unsigned int TVectorDimension >
 Vector< T, TVectorDimension >
 ::Vector(const ValueType & r)
+  :
+  Superclass{ r }
 {
-  for ( typename BaseArray::Iterator i = BaseArray::Begin(); i != BaseArray::End(); ++i )
-    {
-    *i = r;
-    }
 }
 
 template< typename T, unsigned int TVectorDimension >

--- a/Modules/Core/Common/test/itkCovariantVectorGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkCovariantVectorGeometryTest.cxx
@@ -112,7 +112,7 @@ int itkCovariantVectorGeometryTest(int, char* [] )
     std::cout << "vnl_vector_ref.begin() = va.Begin()";
     std::cout << std::endl;
     std::cout << vnlVector.begin() << " = ";
-    std::cout << va.Begin() << std::endl;
+    std::cout << va.cbegin() << std::endl;
   }
 
   // Test the const version that returns an vnl_vector
@@ -129,7 +129,7 @@ int itkCovariantVectorGeometryTest(int, char* [] )
     std::cout << "vnl_vector.begin() != vf.Begin()";
     std::cout << std::endl;
     std::cout << vnlVector2.begin() << " = ";
-    std::cout << vf.Begin() << std::endl;
+    std::cout << vf.cbegin() << std::endl;
   }
 
   // Test for CastFrom() method

--- a/Modules/Core/Common/test/itkPointGTest.cxx
+++ b/Modules/Core/Common/test/itkPointGTest.cxx
@@ -40,7 +40,7 @@ namespace
     const PointType point(stdArray);
 
     // Check that the values of all element are copied.
-    EXPECT_TRUE(std::equal(point.Begin(), point.End(), stdArray.cbegin()));
+    EXPECT_TRUE(std::equal(point.cbegin(), point.cend(), stdArray.cbegin()));
   }
 }
 

--- a/Modules/Core/Common/test/itkVectorGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGeometryTest.cxx
@@ -123,7 +123,7 @@ int itkVectorGeometryTest(int, char* [] )
     std::cout << "vnl_vector_ref.begin() = va.Begin()";
     std::cout << std::endl;
     std::cout << vnlVector.begin() << " = ";
-    std::cout << va.Begin() << std::endl;
+    std::cout << va.cbegin() << std::endl;
   }
 
   // Test the const version that returns an vnl_vector
@@ -140,7 +140,7 @@ int itkVectorGeometryTest(int, char* [] )
     std::cout << "vnl_vector.begin() != vf.Begin()";
     std::cout << std::endl;
     std::cout << vnlVector2.begin() << " = ";
-    std::cout << vf.Begin() << std::endl;
+    std::cout << vf.cbegin() << std::endl;
   }
 
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -115,8 +115,8 @@ SpatialObject< TDimension >
     PointType                  p1, p2;
     DerivativeVectorType       v1, v2;
     typename DerivativeVectorType::Iterator it = value.Begin();
-    typename DerivativeVectorType::Iterator it_v1 = v1.Begin();
-    typename DerivativeVectorType::Iterator it_v2 = v2.Begin();
+    auto it_v1 = v1.cbegin();
+    auto it_v2 = v2.cbegin();
 
     DerivativeOffsetType offsetDiv2;
     for ( unsigned short i = 0; i < TDimension; i++ )

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -314,16 +314,13 @@ Solve( OutputImageType* oImage,
   double spaceFactor = 0.;
   unsigned int axis = 0;
 
-  typename InternalNodeStructureArray::Iterator
-      n_it = iNeighbors.Begin();
-
-  while( n_it != iNeighbors.End() )
+  for(const auto& neighbor: iNeighbors)
     {
-    value = static_cast< double >( n_it->m_Value );
+    value = static_cast< double >( neighbor.m_Value );
 
     if ( oSolution >= value )
       {
-      axis = n_it->m_Axis;
+      axis = neighbor.m_Axis;
 
       // spaceFactor = \frac{1}{spacing[axis]^2}
       spaceFactor = itk::Math::sqr(1.0 / m_OutputSpacing[axis]);
@@ -347,7 +344,6 @@ Solve( OutputImageType* oImage,
       {
       break;
       }
-    ++n_it;
     }
 
   return oSolution;

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
@@ -147,8 +147,8 @@ FrequencyBandImageFilter< TImageType, TFrequencyIterator >
   else // Cut-off box taking into account max absolute scalar frequency.
     {
     vectorFrequency = freqIt.GetFrequency();
-    maxFrequency = std::abs( *std::max_element(vectorFrequency.Begin(), vectorFrequency.End()) );
-    minFrequency = std::abs( *std::min_element(vectorFrequency.Begin(), vectorFrequency.End()) );
+    maxFrequency = std::abs( *std::max_element(vectorFrequency.cbegin(), vectorFrequency.cend()) );
+    minFrequency = std::abs( *std::min_element(vectorFrequency.cbegin(), vectorFrequency.cend()) );
     scalarFrequency = std::max(maxFrequency, minFrequency);
     if ( minFrequency < maxFrequency )
       {

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -153,8 +153,8 @@ BinShrinkImageFilter<TInputImage,TOutputImage>
       factorSize[i] = this->GetShrinkFactors()[i];
       }
 
-    const size_t numSamples = std::accumulate( this->GetShrinkFactors().Begin(),
-                                               this->GetShrinkFactors().End(),
+    const size_t numSamples = std::accumulate( this->GetShrinkFactors().cbegin(),
+                                               this->GetShrinkFactors().cend(),
                                                size_t(1),
                                                std::multiplies<size_t>() );
     const double inumSamples = 1.0 / (double)numSamples;

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -454,7 +454,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>
   const unsigned int numberOfComponents = inputImage->GetNumberOfComponentsPerPixel();
   const unsigned int numberOfClusterComponents = numberOfComponents+ImageDimension;
 
-  const size_t minSuperSize = std::accumulate( m_SuperGridSize.Begin(), m_SuperGridSize.End(), size_t(1), std::multiplies<size_t>() )/4;
+  const size_t minSuperSize = std::accumulate( m_SuperGridSize.cbegin(), m_SuperGridSize.cend(), size_t(1), std::multiplies<size_t>() )/4;
 
   ConstantBoundaryCondition< TOutputImage > lbc;
   lbc.SetConstant( NumericTraits<  typename OutputImageType::PixelType >::max() );
@@ -544,7 +544,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>
   OutputPixelType nextLabel = m_Clusters.size()/numberOfClusterComponents;
   OutputPixelType prevLabel = m_Clusters.size()/numberOfClusterComponents;
 
-  const size_t minSuperSize = std::accumulate( m_SuperGridSize.Begin(), m_SuperGridSize.End(), size_t(1), std::multiplies<size_t>() )/4;
+  const size_t minSuperSize = std::accumulate( m_SuperGridSize.cbegin(), m_SuperGridSize.cend(), size_t(1), std::multiplies<size_t>() )/4;
 
   std::vector< IndexType > indexStack;
 


### PR DESCRIPTION
Four STYLE commits that replace calls to `FixedArray::Begin()` and `FixedArray::End()`:

- `Vector(value)`, `CovariantVector(value)` constructors call base class `FixedArray(value)` instead
- `FastMarching` does a range-based for-loop instead
- Const iteration calls `cbegin()` and `cend()` instead
- itkFixedArray.hxx using std::equal, and C++11 fill_n and copy_n 



