### PR TITLE
DOC: Moved wiki pages to sphinx examples

### DIFF
--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.h
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.h
@@ -37,10 +37,10 @@ namespace itk
  *
  * \ingroup   ITKVtkGlue
  *
- * \wiki
- * \wikiexample{IO/ImageToVTKImageFilter,Display an ITK image}
- * \wikiexample{IO/itkVtkImageConvertDICOM,Uses a custom user matrix to align the image with DICOM physical space}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Remote/WikiExamples/DisplayITKImage,Display ITK Image}
+ * \sphinxexample{IO/itkVtkImageConvertDICOM,Uses a custom user matrix to align the image with DICOM physical space}
+ * \endsphinx
  */
 template <typename TInputImage >
 class ITK_TEMPLATE_EXPORT ImageToVTKImageFilter : public ProcessObject

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.h
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.h
@@ -42,6 +42,9 @@ namespace itk
  *  output.
  *
  * \ingroup ITKVtkGlue
+ * \sphinx
+ * \sphinxexample{Bridge/VtkGlue/VTKImageToITKImage,VTK Image To ITK Image}
+ * \endsphinx
  */
 template <typename TOutputImage >
 class ITK_TEMPLATE_EXPORT VTKImageToImageFilter : public VTKImageImport< TOutputImage >

--- a/Modules/Compatibility/Deprecated/include/itkVectorResampleImageFilter.h
+++ b/Modules/Compatibility/Deprecated/include/itkVectorResampleImageFilter.h
@@ -54,9 +54,11 @@ namespace itk
  * \ingroup GeometricTransform
  * \ingroup ITKDeprecated
  *
- * \wiki
- * \wikiexample{VectorImages/VectorResampleImageFilter,Translate a vector image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Compatibility/Deprecated/ResampleRGBImage,Resample RGB Image}
+ * \sphinxexample{Core/Transform/TranslateAVectorImage,Translate A Vector Image}
+ * \sphinxexample{Compatibility/Deprecated/ResampleITK::VectorImage,Resample A Vector Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType = double >
 class ITK_TEMPLATE_EXPORT VectorResampleImageFilter:

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -61,9 +61,6 @@ namespace itk
  * \ingroup ImageObjects
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Utilities/BoundingBox,Bounding box}
- * \endwiki
  */
 template<
   typename TPointIdentifier = IdentifierType,

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -42,9 +42,9 @@ namespace itk
  * \sa Neighborhood \sa ImageIterator \sa NeighborhoodIterator
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ConstNeighborhoodIterator,Iterate over a region of an image with a neighborhood (without write access)}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateWithNeighborhoodWithoutAccess,Iterate Region In Image With Neighborhood Without Write Access}
+ * \endsphinx
  */
 template< typename TImage,  typename TBoundaryCondition =
             ZeroFluxNeumannBoundaryCondition< TImage > >

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.h
@@ -59,9 +59,9 @@ template <typename TValue> class VariableLengthVector;
  * \ingroup ImageObjects
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ConstantBoundaryCondition,Make out of bounds pixels return a constant value}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/OutOfBoundsPixelsReturnConstValue,Make Out Of Bounds Pixels Return Constant Value}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage = TInputImage >
 class ITK_TEMPLATE_EXPORT ConstantBoundaryCondition:

--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -58,9 +58,9 @@ namespace itk
  * \ingroup Operators
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Operators/DerivativeOperator,Create a derivative kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateDerivativeKernel,Create Derivative Kernel}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VDimension = 2,
           typename TAllocator = NeighborhoodAllocator< TPixel > >

--- a/Modules/Core/Common/include/itkExtractImageFilter.h
+++ b/Modules/Core/Common/include/itkExtractImageFilter.h
@@ -81,9 +81,9 @@ namespace itk
  * \ingroup GeometricTransform
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{ImageProcessing/ExtractImageFilter,Crop an image by specifying the region to keep}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CropImageBySpecifyingRegion,Crop Image By Specifying Region}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Core/Common/include/itkFileOutputWindow.h
+++ b/Modules/Core/Common/include/itkFileOutputWindow.h
@@ -33,6 +33,10 @@ namespace itk
  * \ingroup OSSystemObjects
  *
  * \ingroup ITKCommon
+ *
+ * \sphinx
+ * \sphinxexample{Core/Common/DirectWarningToFile,Direct Warning To File}
+ * \endsphinx
  */
 
 class ITKCommon_EXPORT FileOutputWindow:public OutputWindow

--- a/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalIterator.h
@@ -29,6 +29,10 @@ namespace itk
  * \ingroup ImageIterators
  *
  * \ingroup ITKCommon
+ *
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateImageStartingAtSeed,Iterate Image Starting At Seed}
+ * \endsphinx
  */
 template< typename TImage, typename TFunction >
 class FloodFilledImageFunctionConditionalIterator:public FloodFilledImageFunctionConditionalConstIterator<

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.h
@@ -36,9 +36,9 @@ namespace itk
  * \ingroup Operators
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Operators/ForwardDifferenceOperator,Create a forward difference kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateForwardDifferenceKernel,Create Forward Difference Kernel}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VDimension = 2,
           typename TAllocator = NeighborhoodAllocator< TPixel > >

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -70,9 +70,9 @@ namespace itk
  * \ingroup Operators
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Operators/GaussianDerivativeOperator,Create a Gaussian derivative kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateGaussianDerivativeKernel,Create Gaussian Derivative Kernel}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VDimension = 2,
           typename TAllocator = NeighborhoodAllocator< TPixel > >

--- a/Modules/Core/Common/include/itkGaussianOperator.h
+++ b/Modules/Core/Common/include/itkGaussianOperator.h
@@ -58,9 +58,9 @@ namespace itk
  * \ingroup Operators
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Operators/GaussianOperator,Create a Gaussian kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateGaussianKernel,Create Gaussian Kernel}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VDimension = 2,
           typename TAllocator = NeighborhoodAllocator< TPixel > >

--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -69,6 +69,17 @@ namespace itk
  *
  * \sphinx
  * \sphinxexample{Core/Common/SetPixelValueInOneImage,Set Pixel Value In One Image}
+ * \sphinxexample{Core/Common/GetImageSize,Get Image Size}
+ * \sphinxexample{Core/Common/SortITKIndex,Sort ITK Index}
+ * \sphinxexample{Core/Common/ReturnObjectFromFunction,Return Object From Function}
+ * \sphinxexample{Core/Common/CreateAnotherInstanceOfAnImage,Create Another Instance Of An Image}
+ * \sphinxexample{Core/Common/PassImageToFunction,Pass Image To Function}
+ * \sphinxexample{Core/Common/DeepCopyImage,Deep Copy Image}
+ * \sphinxexample{Core/Common/ThrowException,Throw Exception}
+ * \sphinxexample{Core/Common/GetOrSetMemberVariableOfITKClass,Get Or Set Member Variable Of ITK Class}
+ * \sphinxexample{Core/Common/MiniPipeline,Mini Pipeline}
+ * \sphinxexample{Core/Common/CheckIfModuleIsPresent,Check If Module Is Present}
+ * \sphinxexample{Core/Common/DisplayImage,Display Image}
  * \endsphinx
  */
 template< typename TPixel, unsigned int VImageDimension = 2 >

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
@@ -108,9 +108,9 @@ namespace itk
  *
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ImageRandomConstIteratorWithIndex,Randomly select pixels from a region of an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/RandomSelectOfPixelsFromRegion,Random Selection Of Pixels From Region}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ImageRandomConstIteratorWithIndex:public ImageConstIteratorWithIndex< TImage >

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -206,10 +206,10 @@ public:
  *
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ImageRandomNonRepeatingConstIteratorWithIndex,Randomly select pixels from a region of an image without replacement}
- * \wikiexample{Utilities/RandomPermutation,Permute a sequence of indices}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/RandomSelectPixelFromRegionWithoutReplacee,Random Select Pixel From Region Without Replacing}
+ * \sphinxexample{Core/Common/PermuteSequenceOfIndices,Permute Sequence Of Indices}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ImageRandomNonRepeatingConstIteratorWithIndex:public ImageConstIteratorWithIndex< TImage >

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
@@ -69,6 +69,10 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  *
  * \ingroup ITKCommon
+ *
+ * \sphinx
+ * \sphinxexample{Core/Common/AddNoiseToBinaryImage,Add Noise To Binary Image}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ImageRandomNonRepeatingIteratorWithIndex:public ImageRandomNonRepeatingConstIteratorWithIndex< TImage >

--- a/Modules/Core/Common/include/itkImageRegionConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIterator.h
@@ -99,9 +99,9 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ImageRegionConstIterator,Iterate over a region of an image (without write access)}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateRegionWithoutWriteAccess,Iterate Region In Image Without Write Access}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ImageRegionConstIterator:public ImageConstIterator< TImage >

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
@@ -119,9 +119,9 @@ namespace itk
  * \ingroup ITKCommon
  *
  *
- * \wiki
- * \wikiexample{Iterators/ImageRegionConstIteratorWithIndex,Iterate over a region of an image with efficient access to the current index (without write access)}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess,Iterate Region In Image With Access To Index Without Write Access}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ImageRegionConstIteratorWithIndex:public ImageConstIteratorWithIndex< TImage >

--- a/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h
@@ -123,9 +123,9 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ImageRegionExclusionConstIteratorWithIndex,Iterator over an image skipping a specified region}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateOverSpecificRegion,Iterate Over Image While Skipping Specific Region}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ImageRegionExclusionConstIteratorWithIndex:

--- a/Modules/Core/Common/include/itkImageRegionIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionIterator.h
@@ -70,9 +70,9 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ImageRegionIterator,Iterate over a region of an image (with write access)}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateRegionWithWriteAccess,Iterate Region In Image With Write Access}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ImageRegionIterator:public ImageRegionConstIterator< TImage >

--- a/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
@@ -63,9 +63,9 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/ImageRegionIteratorWithIndex,Iterate over a region of an image with efficient access to the current index (with write access)}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateRegionWithAccessToIndexWithWriteAccess,Iterate Region In Image With Access To Current Index With Write Access}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ImageRegionIteratorWithIndex:public ImageRegionConstIteratorWithIndex< TImage >

--- a/Modules/Core/Common/include/itkImageSource.h
+++ b/Modules/Core/Common/include/itkImageSource.h
@@ -59,9 +59,9 @@ namespace itk
  * \ingroup DataSources
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Developer/ImageSource,Produce an image programmatically.}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/ProduceImageProgrammatically,Produce Image Programmatically}
+ * \endsphinx
  */
 template< typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ImageSource

--- a/Modules/Core/Common/include/itkImageToImageFilter.h
+++ b/Modules/Core/Common/include/itkImageToImageFilter.h
@@ -94,14 +94,15 @@ namespace itk
  * \ingroup ImageFilters
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Developer/ImageFilter,Filter an image}
- * \wikiexample{Developer/ImageFilterMultipleInputs,Write a filter with multiple inputs of the same type.}
- * \wikiexample{Developer/ImageFilterMultipleInputsDifferentType,Write a filter with multiple inputs of different types.}
- * \wikiexample{Developer/ImageFilterMultipleOutputs,Write a filter with multiple outputs of the same type.}
- * \wikiexample{Developer/OilPaintingImageFilter,Multi-threaded oil painting image filter}
- * \wikiexample{Developer/ImageFilterMultipleOutputsDifferentType,Write a filter with multiple outputs of different types.}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/FilterImage,Filter Image}
+ * \sphinxexample{Core/Common/MultipleInputsOfSameType,Multiple Inputs Of Same Type}
+ * \sphinxexample{Core/Common/MultipleInputsOfDifferentType,Multiple Inputs Of Different Type}
+ * \sphinxexample{Core/Common/MultipleOutputsOfSameType,Multiple Outputs Of Same Type}
+ * \sphinxexample{Core/Common/MultThreadOilPainting,Mult-thread Oil Painting}
+ * \sphinxexample{Core/Common/MultipleOutputsOfDifferentType,Multiple Outputs Of Different Type}
+ * \sphinxexample{Core/Common/FilterImageUsingMultipleThreads,Filter Image Using Multiple Threads}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ImageToImageFilter:public ImageSource< TOutputImage >,

--- a/Modules/Core/Common/include/itkImportImageFilter.h
+++ b/Modules/Core/Common/include/itkImportImageFilter.h
@@ -35,9 +35,9 @@ namespace itk
  * \ingroup IOFilters
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{IO/ImportImageFilter,Convert a C-style array to an itkImage}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/ConvertArrayToImage,Convert Array To Image}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VImageDimension = 2 >
 class ITK_TEMPLATE_EXPORT ImportImageFilter:

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.h
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.h
@@ -67,6 +67,11 @@ namespace itk
  *
  * \ingroup ImageFilters
  * \ingroup ITKCommon
+ *
+ * \sphinx
+ * \sphinxexample{Core/Common/FilterImageWithoutCopying,Filter Image Without Copying Its Data}
+ * \sphinxexample{Core/Common/InPlaceFilterOfImage,In Place Filter Of Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage = TInputImage >
 class ITK_TEMPLATE_EXPORT InPlaceImageFilter:public ImageToImageFilter< TInputImage, TOutputImage >

--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -55,9 +55,9 @@ namespace itk
  * \ingroup Operators
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Operators/LaplacianOperator,Create a Laplacian kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateLaplacianKernel,Create Laplacian Kernel}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VDimension = 2,
           typename TAllocator = NeighborhoodAllocator< TPixel > >

--- a/Modules/Core/Common/include/itkLightObject.h
+++ b/Modules/Core/Common/include/itkLightObject.h
@@ -51,6 +51,10 @@ namespace itk
  * \ingroup ITKSystemObjects
  * \ingroup DataRepresentation
  * \ingroup ITKCommon
+ *
+ * \sphinx
+ * \sphinx{Core/Common/GetNameOfClass, Get Name Of Class}
+ * \endsphinx
  */
 class ITKCommon_EXPORT LightObject
 {

--- a/Modules/Core/Common/include/itkLineConstIterator.h
+++ b/Modules/Core/Common/include/itkLineConstIterator.h
@@ -48,9 +48,9 @@ namespace itk
  *
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/LineConstIterator,Iterate over a line through an image without write access}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateLineThroughImageWithoutWriteAccess,Iterate Line Through Image Without Write Access}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT LineConstIterator

--- a/Modules/Core/Common/include/itkLineIterator.h
+++ b/Modules/Core/Common/include/itkLineIterator.h
@@ -48,9 +48,9 @@ namespace itk
  * \sa LineConstIterator
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/LineIterator,Iterate over a line through an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateLineThroughImage,Iterate Line Through Image}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT LineIterator:public LineConstIterator< TImage >

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -40,9 +40,10 @@ namespace itk
  * \ingroup DataRepresentation
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Math/Matrix,Matrix}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/Matrix,Matrix}
+ * \sphinxexample{Core/Common/MatrixInverse, Matrix Inverse}
+ * \endsphinx
  */
 
 template< typename T, unsigned int NRows = 3, unsigned int NColumns = 3 >

--- a/Modules/Core/Common/include/itkMetaDataDictionary.h
+++ b/Modules/Core/Common/include/itkMetaDataDictionary.h
@@ -46,6 +46,9 @@ namespace itk
  * modified.
  *
  * \ingroup ITKCommon
+ * \sphinx
+ * \sphinxexample{Core/Common/StoreNonPixelDataInImage,Store Non-Pixel Data In Image}
+ * \endsphinx
  */
 class ITKCommon_EXPORT MetaDataDictionary
 {

--- a/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.h
+++ b/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.h
@@ -35,10 +35,10 @@ namespace itk
  * \ingroup Operators
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{ImageProcessing/MinimumMaximumImageCalculator,Find the minimum and maximum value (and the position of the value) in an image}
- * \wikiexample{Developer/OilPaintingImageFilter,Multi-threaded oil painting image filter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/FindMaxAndMinInImage,Find Max And Min In Image}
+ * \sphinxexample{Developer/OilPaintingImageFilter,Multi-threaded oil painting image filter}
+ * \endsphinx
  */
 template< typename TInputImage >
 class ITK_TEMPLATE_EXPORT MinimumMaximumImageCalculator:public Object

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -202,10 +202,10 @@ std::cout << *iterator[c]              << std::endl;
  * \ingroup Operators
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Iterators/NeighborhoodIterator,Iterate over a region of an image with a neighborhood (with write access)}
- * \wikiexample{VectorImages/NeighborhoodIterator,NeighborhoodIterator on a VectorImage}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/IterateRegionWithNeighborhood,Iterate Region In Image With Neighborhood}
+ * \sphinxexample{VectorImages/NeighborhoodIterator,Neighborhood Iterator On Vector Image}
+ * \endsphinx
  */
 template< typename TImage, typename TBoundaryCondition =
             ZeroFluxNeumannBoundaryCondition< TImage > >

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.h
@@ -60,6 +60,10 @@ namespace itk
  *
  * \ingroup Operators
  * \ingroup ITKCommon
+ *
+ * \sphinx
+ * \sphinxexample{Core/Common/DemonstrateAllOperators,Demonstrate All Operators}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VDimension,
           typename TAllocator = NeighborhoodAllocator< TPixel > >

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -50,9 +50,9 @@ namespace itk
  *
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{SimpleOperations/Transparency,Make part of an image transparent}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/CommonTransparency,Make Part Of An Image Transparent}
+ * \endsphinx
  */
 
 template< typename TComponent = unsigned short >

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -87,9 +87,9 @@ namespace itk
  * \ingroup Operators
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{Operators/SobelOperator,Create the Sobel kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CreateSobelKernel,Create Sobel Kernel}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VDimension = 2,
           typename TAllocator = NeighborhoodAllocator< TPixel > >

--- a/Modules/Core/Common/include/itkUnaryFunctorImageFilter.h
+++ b/Modules/Core/Common/include/itkUnaryFunctorImageFilter.h
@@ -42,9 +42,9 @@ namespace itk
  * \ingroup   IntensityImageFilters     MultiThreaded
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{ImageProcessing/UnaryFunctorImageFilter,Apply a custom operation to each pixel in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{ImageProcessing/UnaryFunctorImageFilter,Apply Custom Operation To Each Pixel In Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage, typename TFunction >
 class ITK_TEMPLATE_EXPORT UnaryFunctorImageFilter:public InPlaceImageFilter< TInputImage, TOutputImage >

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -81,9 +81,9 @@ struct VariableLengthVectorExpression;
  * \ingroup DataRepresentation
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{SimpleOperations/VariableLengthVector,Variable length vector}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/VariableLengthVector,Variable Length Vector}
+ * \endsphinx
  *
  * \invariant If \c m_LetArrayManageMemory is true, \c m_Data is deletable
  * (whether it's null or pointing to something with no elements. i.e. \c

--- a/Modules/Core/Common/include/itkVectorImage.h
+++ b/Modules/Core/Common/include/itkVectorImage.h
@@ -71,11 +71,11 @@ namespace itk
  * \ingroup ImageObjects
  * \ingroup ITKCommon
  *
- * \wiki
- * \wikiexample{IO/ReadVectorImage,Read an image file with an unknown number of components}
- * \wikiexample{VectorImages/VectorImage,Create a vector image}
- * \wikiexample{VectorImages/NeighborhoodIterator,NeighborhoodIterator on a VectorImage}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Common/CastVectorImageToAnotherType,Cast Vector Image To Another Type}
+ * \sphinxexample{Core/Common/CreateVectorImage,Create Vector Image}
+ * \sphinxexample{VectorImages/NeighborhoodIterator,Neighborhood Iterator On Vector Image}
+ * \endsphinx
  */
 template< typename TPixel, unsigned int VImageDimension = 3 >
 class ITK_TEMPLATE_EXPORT VectorImage:

--- a/Modules/Core/ImageAdaptors/include/itkAddPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAddPixelAccessor.h
@@ -35,9 +35,9 @@ namespace Accessor
  * \ingroup ImageAdaptors
  * \ingroup ITKImageAdaptors
  *
- * \wiki
- * \wikiexample{ImageProcessing/AddPixelAccessor,Add a constant to every pixel without duplicating the image in memory (an accessor)}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage,Add Constant To Every Pixel Without Duplicating Memory}
+ * \endsphinx
  */
 
 template< typename TPixel >

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -47,9 +47,9 @@ template <typename TPixelType, unsigned int VImageDimension > class VectorImage;
  *
  * \ingroup ITKImageAdaptors
  *
- * \wiki
- * \wikiexample{ImageProcessing/ImageAdaptorExtractVectorComponent,Present an image by first performing an operation}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/ImageAdaptors/PresentImageAfterOperation,Present Image After Operation}
+ * \endsphinx
  */
 template< typename TImage, typename TAccessor >
 class ITK_TEMPLATE_EXPORT ImageAdaptor:public ImageBase< TImage::ImageDimension >

--- a/Modules/Core/ImageAdaptors/include/itkNthElementImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementImageAdaptor.h
@@ -35,10 +35,10 @@ namespace itk
  * \ingroup ImageAdaptors
  * \ingroup ITKImageAdaptors
  *
- * \wiki
- * \wikiexample{ImageProcessing/NthElementImageAdaptor,Extract a component/channel of an itkImage with pixels with multiple components}
- * \wikiexample{ImageProcessing/ProcessingNthImageElement,Process the nth component/element/channel of a vector image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents,Extract Channel Of Image With Multiple Components}
+ * \sphinxexample{Core/ImageAdaptors/ProcessNthComponentOfVectorImage,Process Nth Component Of Vector Image}
+ * \endsphinx
  */
 
 // Create a helper class to help the SunPro CC compiler

--- a/Modules/Core/ImageAdaptors/include/itkRGBToVectorImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkRGBToVectorImageAdaptor.h
@@ -30,10 +30,6 @@ namespace itk
  * \ingroup ImageAdaptors
  *
  * \ingroup ITKImageAdaptors
- *
- * \wiki
- * \wikiexample{Conversions/RGBToVectorImageAdaptor,Present an image of RGBPixel pixels as an image of vectors}
- * \endwiki
  */
 template< typename TImage >
 class RGBToVectorImageAdaptor:public

--- a/Modules/Core/ImageAdaptors/include/itkVectorImageToImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkVectorImageToImageAdaptor.h
@@ -134,9 +134,9 @@ private:
  *
  * \ingroup ITKImageAdaptors
  *
- * \wiki
- * \wikiexample{VectorImages/VectorImageToImageAdaptor,View a component of a vector image as if it were a scalar image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage,View Component Vector Image As Scalar Image}
+ * \endsphinx
  */
 template< typename TPixelType, unsigned int Dimension >
 class VectorImageToImageAdaptor:public

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -77,9 +77,6 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  *
- * \wiki
- * \wikiexample{ImageProcessing/Upsampling,Upsampling an image}
- * \endwiki
  */
 template<
   typename TImageType,

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.h
@@ -34,10 +34,9 @@ namespace itk
  * \sa ImageFunction
  * \ingroup ITKImageFunction
  *
- * \wiki
- * \wikiexample{Functions/GaussianBlurImageFunction,GaussianBlurImageFunction}
- * \wikiexample{Functions/GaussianBlurImageFunctionFilter,GaussianBlurImageFunctionFilter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/ImageFunction/GaussianBlueImageFunction,GaussianBlurImageFunction}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutput = double >
 class ITK_TEMPLATE_EXPORT GaussianBlurImageFunction:

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.h
@@ -58,6 +58,10 @@ namespace itk
  * \author Nick Tustison
  *
  * \ingroup ITKImageFunction
+ *
+ * \sphinx
+ * \sphinxexample{Core/ImageFunction/ResampleSegmentedImage,Resample Segmented Image}
+ * \endsphinx
  */
 
 template <typename TInputImage, typename TCoordRep = double,

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -41,9 +41,9 @@ namespace itk
  * \ingroup ImageFunctions ImageInterpolators
  * \ingroup ITKImageFunction
  *
- * \wiki
- * \wikiexample{ImageProcessing/LinearInterpolateImageFunction,Linearly interpolate a position in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/ImageFunction/LinearlyInterpolatePositionInImage,Linearly Interpolate Position In Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TCoordRep = double >
 class ITK_TEMPLATE_EXPORT LinearInterpolateImageFunction:

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
@@ -39,9 +39,9 @@ namespace itk
  * \ingroup ImageFunctions
  * \ingroup ITKImageFunction
  *
- * \wiki
- * \wikiexample{Functions/MedianImageFunction,Compute the median of an image at a pixels (in a regular neighborhood)}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/ImageFunction/ComputeMedianOfImageAtPixel,Compute Median Of Image At Pixel}
+ * \endsphinx
  */
 template< typename TInputImage, typename TCoordRep = float >
 class ITK_TEMPLATE_EXPORT MedianImageFunction:

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.h
@@ -33,9 +33,9 @@ namespace itk
  * \sa ImageFunction
  * \ingroup ITKImageFunction
  *
- * \wiki
- * \wikiexample{Functions/NeighborhoodOperatorImageFunction,Multiply a kernel with an image at a particular location}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/ImageFunction/MultiplyKernelWithAnImageAtLocation,Multiply Kernel With An Image At Location}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutput >
 class ITK_TEMPLATE_EXPORT NeighborhoodOperatorImageFunction:

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -99,6 +99,12 @@ namespace itk
  *
  * \ingroup MeshObjects
  * \ingroup ITKMesh
+ *
+ * \sphinx
+ * \sphinxexample{Core/Mesh/AddPointsAndEdges,Add Points And Edges}
+ * \sphinxexample{Core/Mesh/ConvertMeshToUnstructeredGrid,Convert Mesh To Unstructered Grid}
+ * \sphinxexample{Core/Mesh/WorkingWithPointAndCellData,Working With Point And Cell Data}
+ * \endsphinx
  */
 template<
   typename TPixelType,

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
@@ -44,6 +44,10 @@ namespace itk
  * "Evaluation of new algorithms for the interactive measurement of
  * surface area and volume", Med Phys 21(6) 1994.).
  * \ingroup ITKMesh
+ *
+ * \sphinx
+ * \sphinxexample{Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh,Calculate Area And Volume Of Simplex Mesh}
+ * \endsphinx
  */
 
 template< typename TInputMesh >

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.h
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.h
@@ -37,6 +37,10 @@ namespace itk
  * \ingroup ITKMesh
  *
  * \sa MeshFileWriter
+ *
+ * \sphinx
+ * \sphinxexample{Core/Mesh/WorkingWithPointAndCellData,Write Mesh To VTP}
+ * \endsphinx
  */
 template< typename TInputMesh >
 class ITK_TEMPLATE_EXPORT VTKPolyDataWriter:public Object

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
@@ -40,9 +40,9 @@ namespace itk
  *
  * \ingroup ITKSpatialObjects
  *
- * \wiki
- * \wikiexample{SpatialObjects/BlobSpatialObject,Blob}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/SpatialObjects/Blob,Blob}
+ * \endsphinx
  */
 template< unsigned int TDimension = 3 >
 class ITK_TEMPLATE_EXPORT BlobSpatialObject:

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -34,6 +34,10 @@ namespace itk
  *
  * \sa SpatialObjectPoint
  * \ingroup ITKSpatialObjects
+ *
+ * \sphinx
+ * \sphinxexample{Core/SpatialObjects/{{ContourSpatialObject,Contour Spacial Object}
+ * \endsphinx
  */
 
 template< unsigned int TDimension = 3 >

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -28,9 +28,9 @@ namespace itk
  *
  * \ingroup ITKSpatialObjects
  *
- * \wiki
- * \wikiexample{SpatialObjects/EllipseSpatialObject,Ellipse}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/SpatialObjects/Ellipse,Ellipse}
+ * \endsphinx
  */
 
 template< unsigned int TDimension = 3 >

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
@@ -34,9 +34,6 @@ namespace itk
  * \sa LineSpatialObjectPoint
  * \ingroup ITKSpatialObjects
  *
- * \wiki
- * \wikiexample{SpatialObjects/LineSpatialObject,Line spatial object}
- * \endwiki
  */
 
 template< unsigned int TDimension = 3 >

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -33,9 +33,9 @@ namespace itk
  * A LineSpatialObjectPoint has NDimension-1 normals.
  * \ingroup ITKSpatialObjects
  *
- * \wiki
- * \wikiexample{SpatialObjects/LineSpatialObject,Line spatial object}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/SpatialObjects/LineSpacialObject,Line Spatial Object}
+ * \endsphinx
  */
 
 template< unsigned int TPointDimension = 3 >

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
@@ -32,9 +32,9 @@ namespace itk
  *  Spatial object.
  * \ingroup ITKSpatialObjects
  *
- * \wiki
- * \wikiexample{SpatialObjects/SpatialObjectToImageFilter,Convert a spatial object to an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/SpatialObjects/ConvertSpacialObjectToImage,Convert Spacial Object To Image}
+ * \endsphinx
  */
 template< typename TInputSpatialObject, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT SpatialObjectToImageFilter:public ImageSource< TOutputImage >

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
@@ -80,9 +80,9 @@ r = std::sqrt(x^2 + y^2 + z^2)
  *
  * \ingroup ITKTransform
  *
- * \wiki
- * \wikiexample{Utilities/AzimuthElevationToCartesianTransform,Cartesian to AzimuthElevation and vice-versa}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Transform/CartesianToAzimuthElevation,Cartesian To Azimuth Elevation}
+ * \endsphinx
  */
 template<typename TParametersValueType=double,
          unsigned int NDimensions = 3>

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -105,9 +105,9 @@ outputPoint = transform->TransformPoint( inputPoint );
  *
  * \sa BSplineTransform
  *
- * \wiki
- * \wikiexample{Registration/ImageRegistrationMethodBSpline,A global registration of two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Registration/ImageRegistrationMethodBSpline,Global Registration Of Two Images (BSpline)}
+ * \endsphinx
  */
 template<typename TParametersValueType=double,
           unsigned int NDimensions = 3,

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -98,8 +98,6 @@ namespace itk
  * the space dimension and the spline order.
  *
  * \ingroup ITKTransform
- * \wikiexample{Registration/ImageRegistrationMethodBSpline,
- *   A global registration of two images}
  */
 template<typename TParametersValueType=double,
           unsigned int NDimensions = 3,

--- a/Modules/Core/Transform/include/itkScaleTransform.h
+++ b/Modules/Core/Transform/include/itkScaleTransform.h
@@ -33,9 +33,9 @@ namespace itk
  *
  * \ingroup ITKTransform
  *
- * \wiki
- * \wikiexample{ImageProcessing/ScaleTransform,Scale an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Transform/ScaleAnImage,Scale An Image}
+ * \endsphinx
  */
 template<typename TParametersValueType=float,
           unsigned int NDimensions=3>

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -33,11 +33,11 @@ namespace itk
  *
  * \ingroup ITKTransform
  *
- * \wiki
- * \wikiexample{SimpleOperations/TranslationTransform,Translate an image}
- * \wikiexample{Registration/ImageRegistrationMethod,A basic global registration of two images}
- * \wikiexample{Registration/MutualInformation,Mutual Information}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Core/Transform/TranslateAVectorImage,Translate Vector Image}
+ * \sphinxexample{Registration/Common/GlobalRegistrationOfTwoImages,Global Registration Of Two Images}
+ * \sphinxexample{Registration/Common/MutualInformation,Mutual Information}
+ * \endsphinx
  */
 template<typename TParametersValueType=double,
            unsigned int NDimensions = 3>

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
@@ -58,6 +58,10 @@ namespace itk
  * \ingroup ImageEnhancement
  *
  * \ingroup ITKAnisotropicSmoothing
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2,Smooth Image While Preserving Edges (Curvature)}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class VectorCurvatureAnisotropicDiffusionImageFilter:

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
@@ -53,9 +53,9 @@ namespace itk
  * \ingroup ImageEnhancement
  * \ingroup ITKAnisotropicSmoothing
  *
- * \wiki
- * \wikiexample{Smoothing/VectorGradientAnisotropicDiffusionImageFilter,Smooth an image while preserving edges}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges,Smooth Image While Preserving Edges}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class VectorGradientAnisotropicDiffusionImageFilter:

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
@@ -49,6 +49,10 @@ namespace itk
  * \sa MorphologyImageFilter, GrayscaleDilateImageFilter, GrayscaleErodeImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKBinaryMathematicalMorphology
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/BinaryMathematicalMorphology/ClosingBinaryImage,Closing Binary Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage, typename TKernel >

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.h
@@ -49,6 +49,10 @@ namespace itk
  * \sa MorphologyImageFilter, GrayscaleDilateImageFilter, GrayscaleErodeImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKBinaryMathematicalMorphology
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/BinaryMathematicalMorphology/OpeningBinaryImage,Opening A Binary Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage, typename TKernel >

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.h
@@ -48,6 +48,10 @@ namespace itk
  * \sa BinaryThinningImageFilter
  * \ingroup ImageEnhancement MathematicalMorphologyImageFilters
  * \ingroup ITKBinaryMathematicalMorphology
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/BinaryMathematicalMorphology/PruneBinaryImage,Prune Binary Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.h
@@ -52,9 +52,9 @@ namespace itk
  * \ingroup ImageEnhancement MathematicalMorphologyImageFilters
  * \ingroup ITKBinaryMathematicalMorphology
  *
- * \wiki
- * \wikiexample{ImageProcessing/BinaryThinningImageFilter,Skeletonize/thin an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/BinaryMathematicalMorphology/ThinImage,Thin Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/Colormap/include/itkCustomColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkCustomColormapFunction.h
@@ -40,6 +40,11 @@ namespace Function
  * https://hdl.handle.net/1926/1452
  *
  * \ingroup ITKColormap
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/Colormap/CreateACustomColorMap, Create A Custom Color Map}
+ * \sphinxexample{Filtering/Colormap/ApplyAColorMapToAnImage,Apply A Color Map To An Image}
+ * \endsphinx
  */
 template< typename TScalar, typename TRGBPixel >
 class ITK_TEMPLATE_EXPORT CustomColormapFunction:

--- a/Modules/Filtering/Colormap/include/itkJetColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkJetColormapFunction.h
@@ -40,6 +40,10 @@ namespace Function
  * https://hdl.handle.net/1926/1452
  *
  * \ingroup ITKColormap
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/Colormap/MapScalarsIntoJetColormap,Map Scalars Into Jet Colormap}
+ * \endsphinx
  */
 template< typename TScalar, typename TRGBPixel >
 class ITK_TEMPLATE_EXPORT JetColormapFunction:

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
@@ -70,6 +70,7 @@ namespace itk
  * \ingroup ITKColormap
  *
  * \sphinx
+ * \sphinxexample{Filtering/Colormap/CreateACustomColorMap, Create A Custom Color Map}
  * \sphinxexample{Filtering/Colormap/ApplyAColorMapToAnImage,Apply A Color Map To An Image}
  * \endsphinx
  */

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.h
@@ -57,9 +57,9 @@ namespace itk
  * \author James C. Gee
  * \ingroup ITKConvolution
  *
- * \wiki
- * \wikiexample{ImageProcessing/ConvolutionImageFilter,Convolve an image with a kernel}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Convolution/ConvolveImageWithKernel,Convolve Image With Kernel}
+ * \endsphinx
  */
 template< typename TInputImage, typename TKernelImage = TInputImage, typename TOutputImage = TInputImage >
 class ITK_TEMPLATE_EXPORT ConvolutionImageFilter :

--- a/Modules/Filtering/Convolution/include/itkFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkFFTNormalizedCorrelationImageFilter.h
@@ -92,6 +92,10 @@ namespace itk
  *
  * \author: Dirk Padfield, GE Global Research, padfield\@research.ge.com
  * \ingroup ITKConvolution
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/Convolution/NormalizedCorrelationUsingFFT,Normalized Correlation Using FFT}
+ * \endsphinx
  */
 
 template <typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -133,6 +133,10 @@ namespace itk
  *
  * \author: Dirk Padfield, GE Global Research, padfield\@research.ge.com
  * \ingroup ITKConvolution
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages,Normalized Correlation Using FFT With Mask Images For Input Images}
+ * \endsphinx
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage=TInputImage >

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.h
@@ -42,9 +42,11 @@ namespace itk
  * \sa NeighborhoodIterator
  * \ingroup ITKConvolution
  *
- * \wiki
- * \wikiexample{Images/NormalizedCorrelationImageFilter,Normalized correlation}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Convolution/NormalizedCorrelation,Normalized Correlation}
+ * \sphinxexample{Filtering/Convolution/NormalizedCorrelationOfMaskedImage,Normalized Correlation Of Masked Image}
+ * \sphinxexmaple{Filtering/Convolution/ColorNormalizedCorrelation,Color Normalized Operation}
+ * \endsphinx
  */
 template< typename TInputImage, typename TMaskImage, typename TOutputImage, typename TOperatorValueType =
             typename TOutputImage::PixelType >

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.h
@@ -71,6 +71,10 @@ namespace itk
  * \ingroup MultiThreaded
  *
  * \ingroup ITKCurvatureFlow
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow,Binary Min And Max Curvature Flow Of Binary Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT BinaryMinMaxCurvatureFlowImageFilter:

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.h
@@ -85,6 +85,11 @@ namespace itk
   *  TInputImage and TOutputImage must have the same dimension.
   *  TOutputImage's pixel type must be a real number type.
   * \ingroup ITKCurvatureFlow
+  *
+  * \sphinx
+  * \sphinxexample{Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow,Smooth Image Using Curvature Flow}
+  * \sphinxexample{Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow,Smooth RGB Image Using Curvature Flow}
+  * \endsphinx
   */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT CurvatureFlowImageFilter:

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.h
@@ -72,6 +72,11 @@ namespace itk
  * \ingroup MultiThreaded
  *
  * \ingroup ITKCurvatureFlow
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow,Smooth Image Using Min Max Curvature Flow}
+ * \sphinxexample{Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow,SmoothRGBImageUsingMinMaxCurvatureFlow}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT MinMaxCurvatureFlowImageFilter:

--- a/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.h
@@ -66,9 +66,9 @@ namespace itk
  * \author Zach Pincus
  * \ingroup ITKDistanceMap
  *
- * \wiki
- * \wikiexample{ImageProcessing/ApproximateSignedDistanceMapImageFilter, Compute a distance map from objects in a binary image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/DistanceMap/ApproxDistanceMapOfBinary, Approximate Distance Map Of Binary Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
@@ -61,9 +61,9 @@ ected
  * \ingroup MultiThreaded
  * \ingroup ITKDistanceMap
  *
- * \wiki
- * \wikiexample{Curves/ContourMeanDistanceImageFilter,Compute the mean distance between all points of two curves}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves,Mean Distance Between All Points On Two Curves}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 >
 class ITK_TEMPLATE_EXPORT ContourMeanDistanceImageFilter:

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -82,6 +82,10 @@ namespace itk
  * \ingroup ImageFeatureExtraction
  *
  * \ingroup ITKDistanceMap
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/DistanceMap/SignedDistanceMapOfBinary,Signed Distance Map Of Binary Image}
+ * \endsphinx
  */
 
 template< typename TInputImage,

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
@@ -57,6 +57,10 @@ namespace itk
  *
  * \ingroup ImageFeatureExtraction
  * \ingroup ITKDistanceMap
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/DistanceMap/MaurerDistanceMapOfBinary,Maurer Distance Map Of Binary Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT SignedMaurerDistanceMapImageFilter:

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
@@ -51,6 +51,10 @@ namespace itk
  *
  * \sa InverseFFTImageFilter, FFTComplexToComplexImageFilter
  * \ingroup ITKFFT
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/FFT/ComputeForwardFFT,Compute Forward FFT}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage=Image< std::complex<typename TInputImage::PixelType>, TInputImage::ImageDimension> >
 class ITK_TEMPLATE_EXPORT ForwardFFTImageFilter:

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
@@ -39,6 +39,10 @@ namespace itk
  *
  * \sa ForwardFFTImageFilter, InverseFFTImageFilter
  * \ingroup ITKFFT
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/FFT/ComputeInverseFFTOfImage,Compute Inverse FFT Of Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage=Image< typename TInputImage::PixelType::value_type, TInputImage::ImageDimension> >
 class ITK_TEMPLATE_EXPORT InverseFFTImageFilter:

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
@@ -37,10 +37,6 @@ namespace itk
  * \sa ForwardFFTImageFilter
  * \ingroup ITKFFT
  *
- * \wiki
- * \wikiexample{SpectralAnalysis/VnlForwardFFTImageFilter,Compute the FFT of an image}
- * \wikiexample{SpectralAnalysis/CrossCorrelationInFourierDomain,Compute the cross-correlation of two images in the Fourier domain}
- * \endwiki
  */
 template< typename TInputImage, typename TOutputImage=Image< std::complex<typename TInputImage::PixelType>, TInputImage::ImageDimension> >
 class ITK_TEMPLATE_EXPORT VnlForwardFFTImageFilter:

--- a/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
@@ -38,9 +38,7 @@ namespace itk
  * \sa InverseFFTImageFilter
  * \ingroup ITKFFT
  *
- * \wiki
- * \wikiexample{SpectralAnalysis/CrossCorrelationInFourierDomain,Compute the cross-correlation of two images in the Fourier domain}
- * \endwiki
+ *
  */
 template< typename TInputImage, typename TOutputImage=Image< typename TInputImage::PixelType::value_type, TInputImage::ImageDimension> >
 class ITK_TEMPLATE_EXPORT VnlInverseFFTImageFilter:

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.h
@@ -41,6 +41,10 @@ namespace itk
  * itk::RecursiveGaussianImageFilter.
  *
  * \ingroup ITKGPUSmoothing
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter,Smooth Image With Discrete Gaussian Filter}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
@@ -47,9 +47,9 @@ namespace itk
  * \ingroup IntensityImageFilters MultiThreaded
  * \ingroup ITKImageCompare
  *
- * \wiki
- * \wikiexample{ImageProcessing/AbsoluteValueDifferenceImageFilter,Compute the absolute value of the difference of corresponding pixels in two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageCompare/AbsValueOfTwoImages,Absolute Value Of Difference Between Two Images}
+ * \endsphinx
  */
 namespace Functor
 {

--- a/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
@@ -46,9 +46,9 @@ namespace itk
  * \ingroup IntensityImageFilters MultiThreaded
  * \ingroup ITKImageCompare
  *
- * \wiki
- * \wikiexample{ImageProcessing/SquaredDifferenceImageFilter,Compute the squared difference of corresponding pixels in two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageCompare/SquaredDifferenceOfTwoImages,Squared Difference Of Two Images}
+ * \endsphinx
  */
 namespace Functor
 {

--- a/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.h
@@ -47,11 +47,11 @@ namespace itk
  * \sa VectorIndexSelectionCastImageFilter
  * \ingroup ITKImageCompose
  *
- * \wiki
- * \wikiexample{VectorImages/ImageToVectorImageFilter,Create a vector image from a collection of scalar images}
- * \wikiexample{ImageProcessing/Compose3DCovariantVectorImageFilter,Compose a vector image (with 3 components) from three scalar images}
- * \wikiexample{SpectralAnalysis/RealAndImaginaryToComplexImageFilter,Convert a real image and an imaginary image to a complex image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageCompose/CreateVectorImageFromScalarImages,Create Vector Image From Scalar Images}
+ * \sphinxexample{Filtering/ImageCompose/ComposeVectorFromThreeScalarImages,Compose Vector From Three Scalar Images}
+ * \sphinxexample{Filtering/ImageCompose/ConvertRealAndImaginaryToComplexImage,Convert Real And Imaginary Images To Complex Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage=VectorImage<typename TInputImage::PixelType, TInputImage::ImageDimension> >

--- a/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
@@ -193,9 +193,9 @@ struct MakeJoin {
  * \ingroup IntensityImageFilters  MultiThreaded
  * \ingroup ITKImageCompose
  *
- * \wiki
- * \wikiexample{VectorImages/JoinImageFilter,Join images\, stacking their components}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageCompose/JoinImages,Join Images}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 >
 class JoinImageFilter:

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.h
@@ -66,9 +66,9 @@ namespace itk
  * \todo Support vector images
  * \ingroup ITKImageFeature
  *
- * \wiki
- * \wikiexample{Smoothing/BilateralImageFilter,Bilateral filter an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFeature/BilateralFilterAnImage,Bilateral Filter An Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
@@ -40,9 +40,10 @@ namespace itk
  * \ingroup ImageFeatureExtraction
  * \ingroup ITKImageFeature
  *
- * \wiki
- * \wikiexample{EdgesAndGradients/DerivativeImageFilter,Compute the derivative of an image in a particular direction}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFeature/DerivativeImage,Apply A Filter Only To A Specified Region Of An Image}
+ * \sphinxexample{Filtering/ImageFeature/RequesterRegion, Apply A Filter Only To A Specified Region Of An Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT DerivativeImageFilter:

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
@@ -55,9 +55,7 @@ namespace itk
  *
  * \ingroup ITKImageFeature
  *
- * \wiki
- * \wikiexample{Conversions/HoughTransform2DLinesImageFilter,HoughTransform2DLinesImageFilter}
- * \endwiki
+ *
  */
 
 template< typename TInputPixelType, typename TOutputPixelType >

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
@@ -45,9 +45,9 @@ namespace itk
  * \ingroup ImageFeatureExtraction
  * \ingroup ITKImageFeature
  *
- * \wiki
- * \wikiexample{ImageProcessing/LaplacianSharpeningImageFilter,Sharpen an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFeature/SharpenImage,Sharpen Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT LaplacianSharpeningImageFilter:

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.h
@@ -37,7 +37,9 @@ namespace itk
 * background value.
 *
 * The neighborhood "radius" is set thanks to the radius params.
-*
+* \sphinx
+* \sphinxexample{Filtering/ImageFeature/ExtractContoursFromImage,Extract Contours From Image}
+* \endsphinx
 * \sa Image
 * \sa Neighborhood
 * \sa NeighborhoodOperator

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.h
@@ -65,6 +65,10 @@ namespace itk
  * \sa ZeroCrossingImageFilter
  * \ingroup ImageFeatureExtraction
  * \ingroup ITKImageFeature
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor,Zero-crossing Based Edge Decor}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ZeroCrossingBasedEdgeDetectionImageFilter:

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
@@ -55,9 +55,9 @@ namespace itk
  *  \ingroup ImageFeatureExtraction
  * \ingroup ITKImageFeature
  *
- * \wiki
- * \wikiexample{ImageProcessing/ZeroCrossingImageFilter,Find zero crossings in a signed image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFeature/FindZeroCrossings,Find Zero Crossings In Signed Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ZeroCrossingImageFilter:

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.h
@@ -43,10 +43,10 @@ namespace itk
  * \ingroup MultiThreaded
  * \ingroup ITKImageFilterBase
  *
- * \wiki
- * \wikiexample{ImageProcessing/BinaryFunctorImageFilter,Apply a predefined operation to corresponding pixels in two images}
- * \wikiexample{ImageProcessing/BinaryFunctorImageFilterCustom,Apply a custom operation to corresponding pixels in two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages,Predefined Operation To Corresponding Pixels In Two Images}
+ * \sphinxexample{Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages,Custom Operation To Corresponding Pixels In Two Images}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2,
           typename TOutputImage, typename TFunction    >

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
@@ -43,9 +43,9 @@ namespace itk
  * \sa NeighborhoodIterator
  * \ingroup ITKImageFilterBase
  *
- * \wiki
- * \wikiexample{Images/MaskNeighborhoodOperatorImageFilter,Apply a kernel to every pixel in an image that is non-zero in a mask}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage,Apply Kernel To Every Pixel In Non-Zero Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TMaskImage, typename TOutputImage, typename TOperatorValueType =
             typename TOutputImage::PixelType >

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.h
@@ -43,9 +43,9 @@ namespace itk
  * \sa NeighborhoodIterator
  * \ingroup ITKImageFilterBase
  *
- * \wiki
- * \wikiexample{Images/NeighborhoodOperatorImageFilter,Apply a kernel to every pixel in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFilterBase/ApplyKernelToEveryPixel,Apply Kernel To Every Pixel}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage, typename TOperatorValueType = typename TOutputImage::PixelType >
 class ITK_TEMPLATE_EXPORT NeighborhoodOperatorImageFilter:

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
@@ -43,9 +43,9 @@ namespace itk
  * \ingroup IntensityImageFilters
  * \ingroup ITKImageFilterBase
  *
- * \wiki
- * \wikiexample{Statistics/NoiseImageFilter,Compute the local noise in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFilterBase/ComputerLocalNoise,Compute Local Noise In Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT NoiseImageFilter:

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.h
@@ -49,9 +49,9 @@ namespace itk {
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKImageFusion
  *
- * \wiki
- * \wikiexample{Segmentation/LabelMapContourOverlayImageFilter,Color the boundaries of labeled regions in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFusion/ColorBoundariesOfRegions,Color Boundaries Of Labeled Regions}
+ * \endsphinx
  */
 template<typename TLabelMap, typename TFeatureImage, typename TOutputImage=Image< RGBPixel< typename TFeatureImage::PixelType >, TFeatureImage::ImageDimension > >
 class ITK_TEMPLATE_EXPORT LabelMapContourOverlayImageFilter :

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapOverlayImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapOverlayImageFilter.h
@@ -47,6 +47,10 @@ namespace itk {
  * \sa LabelMapToRGBImageFilter, LabelMapToBinaryImageFilter, LabelMapToLabelImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKImageFusion
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFusion/ColorLabeledRegions,Color Labeled Regions In Image}
+ * \endsphinx
 */
 template<typename TLabelMap, typename TFeatureImage, typename TOutputImage=Image< RGBPixel< typename TFeatureImage::PixelType >, TFeatureImage::ImageDimension > >
 class ITK_TEMPLATE_EXPORT LabelMapOverlayImageFilter :

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.h
@@ -47,9 +47,9 @@ namespace itk
  *
  * \ingroup ITKImageFusion
  *
- * \wiki
- * \wikiexample{ImageProcessing/LabelOverlayImageFilter,Overlay a LabelMap on an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageFusion/OverlayLabelMapOnImage,Overlay Label Map On Image}
+ * \endsphinx
  */
 template< typename  TInputImage, typename TLabelImage, typename  TOutputImage >
 class ITK_TEMPLATE_EXPORT LabelOverlayImageFilter:

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -50,6 +50,11 @@ template <typename TPixelType, unsigned int VImageDimension > class VectorImage;
  *
  * \ingroup GradientFilters
  * \ingroup ITKImageGradient
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGradient/GradientOfVectorImage,Gradient Of Vector Image}
+ * \sphinxexample{Filtering/ImageGradient/ComputeAndDisplayGradient,Compute And Display Gradient Of Image}
+ * \sphinxend
  */
 template< typename TInputImage,
           typename TOperatorValueType = float,

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -46,6 +46,7 @@ namespace itk
  *
  * \sphinx
  * \sphinxexample{Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput,Apply GradientRecursiveGaussianImageFilter on Image with Vector type}
+ * \sphinxexample{Filtering/ImageGradient/ImplementationOfSnakes,Implementation Of Snakes}
  * \endsphimx
  */
 template< typename TInputImage,

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
@@ -123,6 +123,10 @@ namespace itk
  * with Confidence Values", Proceedings of the MIAR conference, August 2006.
  *
  * \ingroup ITKImageGrid
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/FitSplineIntoPointSet,}
+ * \endsphinx
  */
 
 template< typename TInputPointSet, typename TOutputImage >

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
@@ -35,9 +35,9 @@ namespace itk
  * \ingroup GeometricTransform
  * \ingroup ITKImageGrid
  *
- * \wiki
- * \wikiexample{ImageProcessing/CropImageFilter,Crop an image by specifying the region to throw away}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/CropImageBySpecifyingRegion2,Crop Image By Specifying Region}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT CropImageFilter:

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
@@ -42,6 +42,7 @@ namespace itk
  *
  * \sphinx
  * \sphinxexample{Filtering/ImageGrid/PasteImageIntoAnotherOne,Paste Image Into Another One}
+ * \sphinxexample{Filtering/ImageGrid/RunImageFilterOnRegionOfImage,Run Image Filter On Region Of Image}
  * \endsphinx
  */
 template< typename TInputImage, typename TSourceImage = TInputImage, typename TOutputImage = TInputImage >

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.h
@@ -59,9 +59,9 @@ namespace itk
  * \ingroup GeometricTransform Streamed
  * \ingroup ITKImageGrid
  *
- * \wiki
- * \wikiexample{Images/ShrinkImageFilter,Shrink an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/ShrinkImage,Shrink Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ShrinkImageFilter:

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
@@ -41,11 +41,10 @@ namespace itk
  * specifying a layout of 1,1,0.
  * \ingroup ITKImageGrid
  *
- * \wiki
- * \wikiexample{ImageProcessing/TileImageFilter,Tile multiple images into another image}
- * \wikiexample{ImageProcessing/TileImageFilter_CreateVolume,Stack multiple 2D images into a 3D image}
- * \wikiexample{ImageProcessing/TileImageFilter_SideBySide,Tile multiple images side by side}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/Stack2DImagesInto3DImage,Stack 2D Images Into 3D Image}
+ * \sphinxexample{Filtering/ImageGrid/TileImagesSideBySide,Tile Images Side By Side}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/ImageGrid/include/itkWrapPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWrapPadImageFilter.h
@@ -45,9 +45,9 @@ namespace itk
  * \sa MirrorPadImageFilter, ConstantPadImageFilter
  * \ingroup ITKImageGrid
  *
- * \wiki
- * \wikiexample{Images/WrapPadImageFilter,Pad an image by wrapping}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageGrid/PadImageByWrapping,Pad Image By Wrapping}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT WrapPadImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
@@ -61,9 +61,9 @@ public:
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/AbsImageFilter,Compute the absolute value of an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/AbsValueOfImage,Absolute Value Of Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class AbsImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAddImageFilter.h
@@ -70,10 +70,10 @@ namespace itk
  * \ingroup IntensityImageFilters  MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/AddImageFilter,Add two images together}
- * \wikiexample{ImageProcessing/AddConstantToImageFilter,Add a constant to every pixel in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/AddTwoImages,Add Two Images Together}
+ * \sphinxexample{Filtering/ImageIntensity/AddConstantToEveryPixel,Add Constant To Every Pixel}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1 >
 class ITK_TEMPLATE_EXPORT AddImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkAndImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAndImageFilter.h
@@ -46,9 +46,9 @@ namespace itk
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/AndImageFilter,Binary AND two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/BinaryANDTwoImages,Binary AND Two Images}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1 >
 class AndImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
@@ -130,9 +130,9 @@ Clamp< TInput, TOutput >
  * \sa UnaryFunctorImageFilter
  * \sa CastImageFilter
  *
- * \wiki
- * \wikiexample{ImageProcessing/ClampImageFilter,Cast an image from one type to another but clamp to the output value range}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput,Cast Image To Another Type But Clamp To Output Range}
+ * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT ClampImageFilter :

--- a/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
@@ -39,9 +39,9 @@ namespace itk
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/DivideImageFilter,Pixel-wise division of two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/PixelDivisionOfTwoImages,Pixel Division Of Two Images}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT DivideImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
@@ -33,6 +33,9 @@ namespace itk
  * number of dimensions, and the output to be of a scalar image type.
  *
  * \ingroup ITKImageIntensity
+ * \sphinx
+ * \sphinxexample{,}
+ * \endsphinx
  */
 namespace Functor
 {

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.h
@@ -111,9 +111,9 @@ private:
  *
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/IntensityWindowingImageFilter,IntensityWindowingImageFilter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/IntensityWindowing,Intensity Windowing}
+ * \endsphinx
  *
  * \sa RescaleIntensityImageFilter
  */

--- a/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.h
@@ -81,9 +81,9 @@ private:
  *
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/InvertIntensityImageFilter,Invert an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/InvertImage,Invert Image}
+ * \endsphinx
  */
 template< typename  TInputImage, typename  TOutputImage = TInputImage >
 class ITK_TEMPLATE_EXPORT InvertIntensityImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -138,9 +138,9 @@ private:
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/MaskImageFilter,Apply a mask to an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/MaskImage,Mask Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage >
 class MaskImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -124,9 +124,9 @@ private:
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/MaskNegatedImageFilter,Apply the inverse of a mask to an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/InverseOfMaskToImage,Inverse Of Mask To Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage >
 class MaskNegatedImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
@@ -73,9 +73,9 @@ public:
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/MaximumImageFilter,Pixel wise compare two input images and set the output pixel to their max}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/SetOutputPixelToMax,Compare Two Images And Set Output Pixel To Max}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1 >
 class MaximumImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
@@ -64,9 +64,9 @@ public:
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/MinimumImageFilter,Pixel wise compare two input images and set the output pixel to their min}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/SetOutputPixelToMin,Compare Two Images And Set Output Pixel To Min}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1 >
 class MinimumImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
@@ -45,9 +45,9 @@ namespace itk
  * \ingroup MathematicalImageFilters
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/NormalizeImageFilter,Normalize an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/NormalizeImage,Normalize Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT NormalizeImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.h
@@ -47,9 +47,9 @@ namespace itk {
  * \ingroup MathematicalImageFilters
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/NormalizeToConstantImageFilter,Scale all pixels so that their sum is a specified constant}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/ScalePixelSumToConstant,Scale All Pixel's Sum To Constant}
+ * \endsphinx
  */
 template<typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT NormalizeToConstantImageFilter :

--- a/Modules/Filtering/ImageIntensity/include/itkOrImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkOrImageFilter.h
@@ -47,9 +47,9 @@ namespace itk
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/OrImageFilter,Binary OR two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/BinaryORTwoImages,Binary OR Two Images}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1 >
 class OrImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
@@ -28,9 +28,9 @@ namespace itk
  * \ingroup IntensityImageFilters  MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/SquareImageFilter,Square every pixel in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/SquareEveryPixel,Square Every Pixel}
+ * \endsphinx
  */
 
 namespace Functor

--- a/Modules/Filtering/ImageIntensity/include/itkSubtractImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSubtractImageFilter.h
@@ -58,10 +58,10 @@ namespace itk
  * \ingroup IntensityImageFilters MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/SubtractImageFilter,Subtract two images}
- * \wikiexample{ImageProcessing/SubtractConstantFromImageFilter,Subtract a constant from every pixel in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/SubtractTwoImages,Subtract Two Images}
+ * \sphinxexample{Filtering/ImageIntensity/SubtractConstantFromEveryPixel,Subtract Constant From Every Pixel}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1 >
 class SubtractImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkVectorIndexSelectionCastImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorIndexSelectionCastImageFilter.h
@@ -76,9 +76,9 @@ private:
 *
 * \sa ComposeImageFilter
  *
- * \wiki
- * \wikiexample{VectorImages/VectorIndexSelectionCastImageFilter,Extract a component/channel of a vector image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/ExtractComponentOfVectorImage,Extract Component Of Vector Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
@@ -36,9 +36,9 @@ namespace itk
  * \ingroup IntensityImageFilters  MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{VectorImages/VectorMagnitudeImageFilter,Compute the magnitude of each pixel in a vector image to produce a magnitude image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/ComputerMagInVectorImageToMakeMagImage,Computer Magnitude In Vector Image To Make Magnitude Image}
+ * \endsphinx
  */
 
 namespace Functor

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.h
@@ -85,9 +85,9 @@ private:
  *
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{Images/VectorRescaleIntensityImageFilter,Apply a transformation to the magnitude of vector valued image pixels}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/TransformVectorValuedImagePixels,Transform Magnitude Of Vector Valued Image Pixels}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage = TInputImage >
 class ITK_TEMPLATE_EXPORT VectorRescaleIntensityImageFilter:

--- a/Modules/Filtering/ImageIntensity/include/itkXorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkXorImageFilter.h
@@ -47,9 +47,9 @@ namespace itk
  * \ingroup MultiThreaded
  * \ingroup ITKImageIntensity
  *
- * \wiki
- * \wikiexample{ImageProcessing/XorImageFilter,Binary XOR (exclusive OR) two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageIntensity/BinaryXORTwoImages,Binary XOR Two Images}
+ * \endsphinx
  */
 template< typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1 >
 class XorImageFilter:

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.h
@@ -43,10 +43,10 @@ namespace itk
  * \sa LabelContourImageFilter BinaryErodeImageFilter SimpleContourExtractorImageFilter
  * \ingroup ITKImageLabel
  *
- * \wiki
- * \wikiexample{EdgesAndGradients/BinaryContourImageFilter,Extract the boundaries of connected regions in a binary image}
- * \wikiexample{EdgesAndGradients/BinaryBoundaries,Extract the inner and outer boundaries of blobs in a binary image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage,Extract Boundaries Of Connected Regions In Binary Image}
+ * \sphinxexample{Filtering/ImageLabel/ExtractBoundariesOfBlobsInBinaryImage,Extract Inner And Outer Boundaries Of Blobs In Binary Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.h
@@ -45,9 +45,9 @@ namespace itk
  *
  * \ingroup ITKImageLabel
  *
- * \wiki
- * \wikiexample{ImageSegmentation/LabelContourImageFilter,Label the contours of connected components}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageLabel/LabelContoursOfConnectComponent,Label Contours Of Connect Components}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -67,9 +67,9 @@ namespace itk
  * \ingroup ImageFeatureExtraction
  * \ingroup ITKImageStatistics
  *
- * \wiki
- * \wikiexample{Segmentation/EstimatePCAModel,Compute a PCA shape model from a training sample}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageStatistics/ComputePCAShapeFromSample,Compute PCA Shape From Training Sample}
+ * \endsphinx
  */
 
 template< typename TInputImage,

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -53,9 +53,9 @@ namespace itk
  * \ingroup MathematicalStatisticsImageFilters
  * \ingroup ITKImageStatistics
  *
- * \wiki
- * \wikiexample{ImageProcessing/LabelStatisticsImageFilter,Get statistical properties of labeled regions in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageStatistics/StatisticalPropertiesOfRegions,Statistical Properties Of Labeled Regions}
+ * \endsphinx
  */
 template< typename TInputImage, typename TLabelImage >
 class ITK_TEMPLATE_EXPORT LabelStatisticsImageFilter:

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
@@ -47,9 +47,9 @@ namespace itk
  * \ingroup MathematicalStatisticsImageFilters
  * \ingroup ITKImageStatistics
  *
- * \wiki
- * \wikiexample{Statistics/StatisticsImageFilter,Compute min\, max\, variance and mean of an Image.}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage,Compute Min, Max, Variance And Mean Of Image}
+ * \endsphinx
  */
 template< typename TInputImage >
 class ITK_TEMPLATE_EXPORT StatisticsImageFilter:

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.h
@@ -46,9 +46,9 @@ namespace itk
  * \sa ConnectedComponentImageFilter, LabelImageToLabelMapFilter, LabelMap, LabelObject
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageProcessing/BinaryImageToLabelMapFilter,Label binary regions in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/LabelBinaryRegionsInImage,Label Binary Regions In Image}
+ * \endsphinx
  */
 
 template< typename TInputImage,

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.h
@@ -53,9 +53,9 @@ namespace itk
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageProcessing/BinaryImageToShapeLabelMapFilter,Label binary regions in an image and get their properties}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/LabelBinaryRegionsAndGetProperties,Label Binary Regions And Get Properties}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage =
             LabelMap< ShapeLabelObject< SizeValueType, TInputImage::ImageDimension > > >

--- a/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
@@ -47,9 +47,9 @@ namespace itk
  * \ingroup IntensityImageFilters  MultiThreaded
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageProcessing/BinaryNotImageFilter,Invert an image using the Binary Not operation}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/InvertImageUsingBinaryNot,Invert Image Using Binary Not Operation}
+ * \endsphinx
  */
 namespace Functor {
 

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.h
@@ -41,6 +41,10 @@ namespace itk
  * \sa StatisticsLabelObject, LabelStatisticsOpeningImageFilter, BinaryStatisticsOpeningImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKLabelMap
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific,Keep Binary Regions That Meet Specific Properties}
+ * \endsphinx
  */
 template< typename TInputImage, typename TFeatureImage >
 class ITK_TEMPLATE_EXPORT BinaryStatisticsOpeningImageFilter:

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.h
@@ -40,9 +40,9 @@ namespace itk
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageSegmentation/LabelImageToLabelMapFilter,Convert an itk::Image consisting of labeled regions to a LabelMap}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/ConvertImageToLabelMap,Convert itk::Image With Labels To Label Map}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage =
             LabelMap< LabelObject< typename TInputImage::PixelType,

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.h
@@ -40,9 +40,10 @@ namespace itk
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageSegmentation/LabelImageToShapeLabelMapFilter,Convert an itk::Image consisting of labeled regions to a ShapeLabelMap}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/ShapeAttributesForBinaryImage,Shape Attributes For Binary Image}
+ * \sphinxexample{Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap,Convert Image With Labeled Regions To ShapeLabelMap}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage =
             LabelMap< ShapeLabelObject< typename TInputImage::PixelType,

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.h
@@ -62,9 +62,9 @@ namespace itk
  * \ingroup LabeledImageObject
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageProcessing/ManuallyRemovingLabels,Remove labels from a LabelMap}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/RemoveLabelsFromLabelMa,Remove Labels From Label Map}
+ * \endsphinx
  */
 template< typename TLabelObject >
 class ITK_TEMPLATE_EXPORT LabelMap:public ImageBase< TLabelObject::ImageDimension >

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
@@ -38,9 +38,9 @@ namespace itk
  * \ingroup LabeledImageFilters
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageProcessing/LabelMapToLabelImageFilter,Convert a LabelMap to a normal image with different values representing each region}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/ConvertLabelMapToImage,Convert Label Map To Normal Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT LabelMapToLabelImageFilter:

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.h
@@ -43,9 +43,9 @@ namespace itk
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageProcessing/LabelShapeKeepNObjectsImageFilter,Keep only regions that rank above a certain level of a particular property}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/KeepRegionsAboveLevel,Keep Regions Above Certain Level}
+ * \endsphinx
  */
 template< typename TInputImage >
 class ITK_TEMPLATE_EXPORT LabelShapeKeepNObjectsImageFilter:

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h
@@ -48,6 +48,10 @@ namespace itk
  * \sa ShapeLabelObject, RelabelComponentImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKLabelMap
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/MergeLabelMaps,Merge LabelMaps}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT MergeLabelMapFilter:

--- a/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.h
@@ -41,9 +41,9 @@ namespace itk
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKLabelMap
  *
- * \wiki
- * \wikiexample{ImageProcessing/ShapeOpeningLabelMapFilter,Keep only regions that meet a specified threshold of a specified property}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/LabelMap/KeepRegionsThatMeetSpecific,Keep Regions That Meet Specific Properties}
+ * \endsphinx
  */
 template< typename TImage >
 class ITK_TEMPLATE_EXPORT ShapeOpeningLabelMapFilter:

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
@@ -77,12 +77,12 @@ namespace itk
  *
  * \ingroup ITKMathematicalMorphology
  *
- * \wiki
- * \wikiexample{Morphology/FlatStructuringElement,Erode a binary image using a flat (box) structuring element}
- * \endwiki
- * \wiki
- * \wikiexample{Morphology/FlatStructuringElementRadiusIsParametric,Generate structuring elements with accurate area}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct,Erode Binary Image Using Flat Structure Element}
+ * \endsphinx
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea,Generate Structuring Elements With Accurate Area}
+ * \endsphinx
  */
 
 template< unsigned int VDimension >

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
@@ -46,9 +46,9 @@ namespace itk
  * \ingroup MathematicalMorphologyImageFilters
  * \ingroup ITKMathematicalMorphology
  *
- * \wiki
- * \wikiexample{ImageProcessing/RegionalMaximaImageFilter,RegionalMaximaImageFilter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/RegionalMaximal,Regional Maximal}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT RegionalMaximaImageFilter:

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
@@ -44,9 +44,9 @@ namespace itk
  * \ingroup MathematicalMorphologyImageFilters
  * \ingroup ITKMathematicalMorphology
  *
- * \wiki
- * \wikiexample{ImageProcessing/RegionalMinimaImageFilter,RegionalMinimaImageFilter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/RegionalMinimal,Regional Minimal}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT RegionalMinimaImageFilter:

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h
@@ -51,9 +51,9 @@ namespace itk
  * \ingroup MathematicalMorphologyImageFilters
  * \ingroup ITKITKMathematicalMorphology
  *
- * \wiki
- * \wikiexample{ImageProcessing/ValuedRegionalMaximaImageFilter,ValuedRegionalMaximaImageFilter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/ValuedRegionalMaximaImage,Valued Regional Maxima Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ValuedRegionalMaximaImageFilter:

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMinimaImageFilter.h
@@ -47,9 +47,9 @@ namespace itk
  * \ingroup MathematicalMorphologyImageFilters
  * \ingroup ITKMathematicalMorphology
  *
- * \wiki
- * \wikiexample{ImageProcessing/ValuedRegionalMinimaImageFilter,ValuedRegionalMinimaImageFilter}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/MathematicalMorphology/ValuedRegionalMinimalImage,Valued Regional Minimal Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ValuedRegionalMinimaImageFilter:

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -88,9 +88,9 @@ namespace itk
  *
  * \ingroup ITKPath
  *
- * \wiki
- * \wikiexample{Segmentation/ContourExtractor2DImageFilter,Extract contours from an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Path/ExtractContoursFromImage,Extract Contours From Image}
+ * \endsphinx
  */
 
 template< typename TInputImage >

--- a/Modules/Filtering/Path/include/itkPolyLineParametricPath.h
+++ b/Modules/Filtering/Path/include/itkPolyLineParametricPath.h
@@ -48,9 +48,9 @@ namespace itk
  * \ingroup PathObjects
  * \ingroup ITKPath
  *
- * \wiki
- * \wikiexample{Curves/PolyLineParametricPath,A data structure for a piece-wise linear curve}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Path/DataStructureForPieceWiseLinearCurve,Data Structure For Piece-Wise Linear Curve}
+ * \endsphinx
  */
 template< unsigned int VDimension >
 class ITK_TEMPLATE_EXPORT PolyLineParametricPath:public

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
@@ -54,9 +54,9 @@ namespace itk
  * \see DiscreteGaussianImageFilter
  * \ingroup ITKSmoothing
  *
- * \wiki
- * \wikiexample{EdgesAndGradients/RecursiveGaussianImageFilter,Find higher derivatives of an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Filtering/Smoothing/FindHigherDerivativesOfImage,Find Higher Derivatives Of Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage = TInputImage >
 class ITK_TEMPLATE_EXPORT RecursiveGaussianImageFilter:

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
@@ -43,9 +43,6 @@ namespace itk
  * \ingroup SingleThreaded
  * \ingroup ITKSmoothing
  *
- * \wiki
- * \wikiexample{Smoothing/SmoothingRecursiveGaussianImageFilter,Gaussian smoothing that works with image adaptors}
- * \endwiki
  */
 
 template< typename TInputImage,

--- a/Modules/Filtering/Thresholding/include/itkLiThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkLiThresholdImageFilter.h
@@ -46,6 +46,10 @@ namespace itk
  *
  * \ingroup Multithreaded
  * \ingroup ITKThresholding
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/Thresholding/DemonstrateThresholdAlgorithms,Demonstrate Available Threshold Algorithms}
+ * \endsphinx
  */
 
 template<typename TInputImage, typename TOutputImage, typename TMaskImage=TOutputImage>

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -41,14 +41,14 @@ namespace itk
  * https://hdl.handle.net/10380/3279  or
  * http://www.insight-journal.org/browse/publication/811
  *
- * \wiki
- * \wikiexample{Segmentation/OtsuThresholdImageFilter,Separate foreground and background using Otsu's method}
- * \endwiki
- *
  * \sa HistogramThresholdImageFilter
  *
  * \ingroup Multithreaded
  * \ingroup ITKThresholding
+ *
+ * \sphinx
+ * \sphinxexample{Filtering/Thresholding/SeparateGroundUsingOtsu,Separate Foreround And Background Using Otsu Method}
+ * \endsphinx
  */
 
 template<typename TInputImage, typename TOutputImage, typename TMaskImage=TOutputImage>

--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -73,9 +73,10 @@ namespace itk
  *
  * \ingroup ITKIOGDCM
  *
- * \wiki
- * \wikiexample{DICOM/ResampleDICOM,Resample a DICOM series}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{IO/GDCM/ResamleDICOMSeries,Resample DICOM Series}
+ * \sphinxexample{IO/GDCM/ReadDICOMSeriesAndWrite3DImage,Read DICOM Series and Write 3D Image}
+ * \endsphinx
  */
 class InternalHeader;
 class ITKIOGDCM_EXPORT GDCMImageIO:public ImageIOBase

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
@@ -37,6 +37,10 @@ namespace itk
  * DefaultConvertPixelTraits.
  *
  * \ingroup ITKIOImageBase
+ *
+ * \sphinx
+ * \sphinxexample{IO/ImageBase/ConvertImageToAnotherType, Convert Image To Another Type}
+ * \endsphinx
  */
 template<
   typename InputPixelType,

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
@@ -77,6 +77,10 @@ public:
  *
  * \ingroup IOFilters
  * \ingroup ITKIOImageBase
+ *
+ * \sphinx
+ * \sphinxexample{IO/ImageBase/Creade3DFromSeriesOf2D,Creade 3D Volume From Series Of 2D Images}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ImageSeriesWriter:public ProcessObject

--- a/Modules/IO/TransformBase/include/itkTransformFileReader.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileReader.h
@@ -29,9 +29,9 @@ namespace itk
    * \brief TODO
    * \ingroup ITKIOTransformBase
    *
-   * \wiki
-   * \wikiexample{IO/TransformFileReader,Read a transform from a file}
-   * \endwiki
+   * \sphinx
+   * \sphinxexample{IO/TransformBase/ReadTransformFromFile,Read Transform From File}
+   * \endsphinx
    */
 template<typename TParametersValueType>
 class ITK_TEMPLATE_EXPORT TransformFileReaderTemplate: public LightProcessObject

--- a/Modules/IO/TransformBase/include/itkTransformFileWriter.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileWriter.h
@@ -31,9 +31,9 @@ namespace itk
    * \brief TODO
    * \ingroup ITKIOTransformBase
    *
-   * \wiki
-   * \wikiexample{IO/TransformFileWriter,Write a transform to a file}
-   * \endwiki
+   * \sphinx
+   * \sphinxexample{IO/TransformBase/WriteTransformToFile,Write Transform From File}
+   * \endsphinx
    */
 template<typename TParametersValueType>
 class ITKIOTransformBase_TEMPLATE_EXPORT TransformFileWriterTemplate:public LightProcessObject

--- a/Modules/IO/TransformFactory/include/itkTransformFactory.h
+++ b/Modules/IO/TransformFactory/include/itkTransformFactory.h
@@ -35,6 +35,10 @@ namespace itk
 /** \class TransformFactory
  * \brief Create instances of Transforms
  * \ingroup ITKTransformFactory
+ *
+ * /sphinx
+ * /sphinxexample{IO/TransformFactory/RegisterTransformWithTransformFactory,Register Transform With Transform Factory}
+ * /endsphinx
  */
 
 template< typename T >

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -69,9 +69,9 @@ namespace itk
  *
  * \ingroup ITKReview
  *
- * \wiki
- * \wikiexample{ImageProcessing/LabelGeometryImageFilter,Get geometric properties of labeled regions in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Nonunit/Review/GeometricPropertiesOfRegion,Geometric Properties Of Labeled Region}
+ * \endsphinx
  */
 template< typename TLabelImage, typename TIntensityImage = TLabelImage >
 class ITK_TEMPLATE_EXPORT LabelGeometryImageFilter:

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.h
@@ -54,10 +54,6 @@ namespace itk
  *      https://hdl.handle.net/1926/1533
  *
  * \ingroup ITKReview
- *
- * \wiki
- * \wikiexample{Segmentation/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation,Single-phase Chan And Vese Dense Field Level Set Segmentation}
- * \endwiki
  */
 template< typename TInputImage, typename TFeatureImage, typename TOutputImage,
           typename TFunction = ScalarChanAndVeseLevelSetFunction< TInputImage, TFeatureImage >,

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.h
@@ -64,11 +64,11 @@ namespace itk
  *
  * \ingroup ITKReview
  *
- * \wiki
- * \wikiexample{Segmentation/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation,Multiphase Chan And Vese Sparse Field Level Set Segmentation}
- * \wikiexample{Segmentation/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation,Single-phase Chan And Vese Sparse Field Level Set Segmentation}
- * \wikiexample{Segmentation/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation,Single-phase Chan And Vese Dense Field Level Set Segmentation}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation,Multiphase Chan And Vese Sparse Field Level Set Segmentation}
+ * \sphinxexample{Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation,Single-phase Chan And Vese Sparse Field Level Set Segmentation}
+ * \sphinxexample{Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation2,Single-phase Chan And Vese Dense Field Level Set Segmentation}
+ * \endsphinx
  */
 template< typename TInputImage,
           typename TFeatureImage,

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.h
@@ -55,10 +55,11 @@ namespace itk
  *
  * \ingroup ITKReview
  *
- * \wiki
- * \wikiexample{Segmentation/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation,Multiphase Chan And Vese Sparse Field Level Set Segmentation}
- * \wikiexample{Segmentation/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation,Single-phase Chan And Vese Sparse Field Level Set Segmentation}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation,Multiphase Chan And Vese Sparse Field Level Set Segmentation}
+ * \sphinxexample{Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation,Single-phase Chan And Vese Sparse Field Level Set Segmentation}
+ * \sphinxexample{Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation2,Single-phase Chan And Vese Dense Field Level Set Segmentation}
+ * \endsphinx
  */
 template< typename TInputImage, typename TFeatureImage, typename TOutputImage,
           typename TFunction = ScalarChanAndVeseLevelSetFunction< TInputImage, TFeatureImage >,

--- a/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
@@ -58,6 +58,10 @@ namespace itk
  *
  * \ingroup Numerics Optimizers
  * \ingroup ITKOptimizers
+ *
+ * \sphinx
+ * \sphinxexample{Numerics/Optimizers/AmoebaOptimizer, Amoeba Optimization}
+ * \endsphinx
  */
 class ITKOptimizers_EXPORT AmoebaOptimizer:
   public SingleValuedNonLinearVnlOptimizer

--- a/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
@@ -75,6 +75,10 @@ namespace itk
  *
  * \ingroup Numerics Optimizers
  * \ingroup ITKOptimizers
+ *
+ * \sphinx
+ * \sphinxexample{Numerics/Optimizers/ExhaustiveOptimizer,Exhaustive Optimizer}
+ * \endsphinx
  */
 class ITKOptimizers_EXPORT ExhaustiveOptimizer:
   public SingleValuedNonLinearOptimizer

--- a/Modules/Numerics/Optimizers/include/itkLevenbergMarquardtOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLevenbergMarquardtOptimizer.h
@@ -29,6 +29,10 @@ namespace itk
  *
  * \ingroup Numerics Optimizers
  * \ingroup ITKOptimizers
+ *
+ * \sphinx
+ * \sphinxexample{Numerics/Optimizers/LevenbergMarquardtOptimization, Levenberg-Marquardt Optimiztion}
+ * \endsphinx
  */
 class ITKOptimizers_EXPORT LevenbergMarquardtOptimizer:
   public MultipleValuedNonLinearVnlOptimizer

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
@@ -52,9 +52,11 @@ namespace Statistics
  * \sa MixtureModelComponentBase, GaussianMixtureModelComponent
  * \ingroup ITKStatistics
  *
- * \wiki
- * \wikiexample{Statistics/ExpectationMaximizationMixtureModelEstimator_2D,2D Gaussian Mixture Model Expectation Maximization}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/2DGaussianMixtureModelExpectMax,2D Gaussian Mixture Model Expectation Maximum}
+ * \sphinxexample{Numerics/Statistics/DistributionOfPixelsUsingGMM,Distribution Of Pixels Using GMM EM}
+ * \sphinxexample{Numerics/Statistics/DistributeSamplingUsingGMM,Distribute Sampling Using GMM EM}
+ * \endsphinx
  */
 
 template< typename TSample >

--- a/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
@@ -54,9 +54,9 @@ namespace Statistics
  * can be obtained from http://commonfund.nih.gov/bioinformatics.
  * \ingroup ITKStatistics
  *
- * \wiki
- * \wikiexample{Statistics/GaussianDistribution,Create a Gaussian distribution}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/CreateGaussianDistribution,Create Gaussian Distribution}
+ * \endsphinx
  */
 class ITKStatistics_EXPORT GaussianDistribution:
   public ProbabilityDistribution

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
@@ -45,9 +45,9 @@ namespace Statistics
  * \sa Sample, ListSample
  * \ingroup ITKStatistics
  *
- * \wiki
- * \wikiexample{Statistics/ImageToListSampleAdaptor,Create a list of samples from an image without duplicating the data}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication,Create List Of Samples From Image Without Duplication}
+ * \endsphinx
  */
 
 template< typename TImage >

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
@@ -67,10 +67,6 @@ namespace Statistics
  * \sa ImageKmeansModelEstimator
  * \sa WeightedCentroidKdTreeGenerator, KdTree
  * \ingroup ITKStatistics
- *
- * \wiki
- * \wikiexample{Statistics/KdTreeBasedKmeansEstimator,Compute kmeans clusters}
- * \endwiki
  */
 
 template< typename TKdTree >

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.h
@@ -61,9 +61,9 @@ namespace Statistics
  * WeightedCentroidKdTreeGenerator
  * \ingroup ITKStatistics
  *
- * \wiki
- * \wikiexample{Statistics/KdTree,Spatial search}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/SpatialSearch,Spatial Search}
+ * \endsphinx
  */
 
 template< typename TSample >

--- a/Modules/Numerics/Statistics/include/itkListSample.h
+++ b/Modules/Numerics/Statistics/include/itkListSample.h
@@ -42,9 +42,9 @@ namespace Statistics
  * \sa Sample, Histogram
  * \ingroup ITKStatistics
  *
- * \wiki
- * \wikiexample{Statistics/ListSample,Create a list of sample measurements}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/CreateListOfSampleMeasurements,Create List Of Sample Measurements}
+ * \endsphinx
  */
 
 template< typename TMeasurementVector >

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.h
@@ -35,6 +35,10 @@ namespace Statistics
  * added to the computed histogram.
  *
  * \ingroup ITKStatistics
+ *
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/ComputeHistogramOfMaskedRegion,Compute Histogram Of Masked Region In Image}
+ * \endsphinx
  */
 
 template< typename TImage, typename TMaskImage >

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.h
@@ -47,9 +47,9 @@ namespace Statistics
  *
  * \ingroup ITKStatistics
  *
- * \wiki
- * \wikiexample{Statistics/MembershipSample,Create a list of samples with associated class IDs}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/CreateListOfSamplesWithIDs,Create List Of Samples With Associated ID's}
+ * \endsphinx
  */
 
 template< typename TSample >

--- a/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.h
@@ -46,9 +46,9 @@ namespace Statistics
  *
  * \ingroup ITKStatistics
  *
- * \wiki
- * \wikiexample{Statistics/SampleToHistogramFilter,Create a histogram from a list of sample measurements}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/CreateHistogramFromListOfMeasurements,Create Histogram From List Of Measurements}
+ * \endsphinx
  */
 
 template< typename TSample, typename THistogram >

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
@@ -99,6 +99,10 @@ namespace Statistics
  *
  * Author: Zachary Pincus
  * \ingroup ITKStatistics
+ *
+ * \sphinx
+ * \sphinxexample{Numerics/Statistics/ComputeTextureFeatures,Compute Texture Features}
+ * \endsphinx
  */
 
 template< typename TImageType,

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
@@ -62,6 +62,10 @@ namespace itk
  * \sa MaskFeaturePointSelectionFilter
  *
  * \ingroup ITKRegistrationCommon
+ *
+ * \sphinx
+ * \sphinxexample{Registration/Common/MatchFeaturePoints,Match Feature Points}
+ * \endsphinx
  */
 
 template<

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.h
@@ -60,11 +60,11 @@ namespace itk
  * \ingroup RegistrationFilters
  * \ingroup ITKRegistrationCommon
  *
- * \wiki
- * \wikiexample{Registration/ImageRegistrationMethod,A basic global registration of two images}
- * \wikiexample{Registration/ImageRegistrationMethodAffine,A global registration of two images}
- * \wikiexample{Registration/ImageRegistrationMethodBSpline,A global registration of two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Registration/Common/GlobalRegistrationOfTwoImages,Global Registration Of Two Images}
+ * \sphinxexample{Core/Transform/GlobalRegistrationTwoImagesAffine,Global Registration Two Images (Affine)}
+ * \sphinxexample{Core/Transform/GlobalRegistrationTwoImagesBSpline,Global Registration Of Two Images (BSpline)}
+ * \endsphinx
  */
 template< typename TFixedImage, typename TMovingImage >
 class ITK_TEMPLATE_EXPORT ImageRegistrationMethod:public ProcessObject

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
@@ -78,9 +78,9 @@ namespace itk
  *
  * \ingroup ITKRegistrationCommon
  *
- * \wiki
- * \wikiexample{Registration/LandmarkBasedTransformInitializer,Rigidly register one image to another using manually specified landmarks}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Registration/Common/RegisterImageToAnotherUsingLandmarks,Register Image To Another Using Landmarks}
+ * \endsphinx
  */
 template< typename TTransform,
           typename TFixedImage = itk::ImageBase<TTransform::InputSpaceDimension > ,

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -107,6 +107,10 @@ namespace itk
  *
  * \ingroup RegistrationMetrics
  * \ingroup ITKRegistrationCommon
+ *
+ * \sphinx
+ * \sphinxexample{Registration/Common/WatchRegistration,Watch Registration}
+ * \endsphinx
  */
 template <typename TFixedImage, typename TMovingImage>
 class ITK_TEMPLATE_EXPORT MattesMutualInformationImageToImageMetric:

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.h
@@ -31,9 +31,9 @@ namespace itk
  * \brief TODO
  * \ingroup ITKRegistrationCommon
  *
- * \wiki
- * \wikiexample{Metrics/MeanSquaresImageToImageMetric,Compute the mean squares metric between two images}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Registration/Common/ComputeMeanSquareBetweenTwoImages,Compute Mean Squares Metric Between Two Images}
+ * \endsphinx
  */
 template< typename TFixedImage, typename TMovingImage >
 class ITK_TEMPLATE_EXPORT MeanSquaresImageToImageMetric:

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
@@ -85,10 +85,10 @@ namespace itk
  * \ingroup RegistrationMetrics
  * \ingroup ITKRegistrationCommon
  *
- * \wiki
- * \wikiexample{Registration/MutualInformation,Mutual Information}
- * \wikiexample{Registration/MutualInformationAffine,Mutual Information Affine}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Registration/Common/MutualInformation,Mutual Information}
+ * \sphinxexample{Core/Transform/MutualInformationAffine,Mutual Information Affine}
+ * \endsphinx
  */
 template< typename TFixedImage, typename TMovingImage >
 class ITK_TEMPLATE_EXPORT MutualInformationImageToImageMetric:

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.h
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.h
@@ -56,9 +56,9 @@ namespace itk
  * \ingroup PyramidImageFilter MultiThreaded Streamed
  * \ingroup ITKRegistrationCommon
  *
- * \wiki
- * \wikiexample{ImageProcessing/RecursiveMultiResolutionPyramidImageFilter,Construct a multiresolution pyramid from an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Registration/Common/MultiresolutionPyramidFromImage,Multiresolution Pyramid From Image}
+ * \endsphinx
  */
 template<
   typename TInputImage,

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
@@ -122,9 +122,9 @@ namespace itk
  * \ingroup ClassificationFilters
  * \ingroup ITKClassifiers
  *
- * \wiki
- * \wikiexample{Statistics/ImageKmeansModelEstimator,Compute kmeans clusters of pixels in an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Segmentation/Classifiers/KMeansClusterOfPixelsInImage,K Means Cluster Of Pixels In Image}
+ * \endsphinx
  */
 template< typename TInputImage,
           typename TMembershipFunction >

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
@@ -55,9 +55,10 @@ namespace itk
  * \ingroup ClassificationFilters
  * \ingroup ITKClassifiers
  *
- * \wiki
- * \wikiexample{Statistics/ScalarImageKmeansImageFilter,Cluster the pixels in a greyscale image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Segmentation/Classifiers/ClusterPixelsInGrayscaleImage,Cluster Pixels In Grayscale Image}
+ * \sphinxexample{Segmentation/Classifiers/KMeansClustering,K-Means Clustering}
+ * \endsphinx
  */
 template< typename TInputImage,
           typename TOutputImage = Image< unsigned char, TInputImage::ImageDimension > >

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
@@ -48,9 +48,10 @@ namespace itk
  * \ingroup SingleThreaded
  * \ingroup ITKConnectedComponents
  *
- * \wiki
- * \wikiexample{ImageProcessing/ConnectedComponentImageFilter,Label connected components in a binary image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage,Label Connect Components In Binary Image}
+ * \sphinxexample{Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage,Extra Largest Connect Component From Binary Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage, typename TMaskImage = TInputImage >

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
@@ -72,9 +72,9 @@ namespace itk
  * \ingroup SingleThreaded
  * \ingroup ITKConnectedComponents
  *
- * \wiki
- * \wikiexample{ImageProcessing/RelabelComponentImageFilter,Assign contiguous labels to connected regions of an image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions,Assign Contiguous Labels To Connected Regions In An Image}
+ * \endsphinx
  */
 
 template< typename TInputImage, typename TOutputImage >

--- a/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
@@ -42,9 +42,9 @@ namespace itk
  *         Uses ConnectedComponentFunctorImageFilter.
  * \ingroup ITKConnectedComponents
  *
- * \wiki
- * \wikiexample{ImageProcessing/ScalarConnectedComponentImageFilter,Label connected components in a grayscale image}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage,Label Connect Components In Grayscale Image}
+ * \endsphinx
  */
 
 namespace Functor

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.h
@@ -75,6 +75,10 @@ namespace itk
  *
  * \ingroup RegionGrowingSegmentation
  * \ingroup ITKKLMRegionGrowing
+ *
+ * \sphinx
+ * \sphinxexample{Segmentation/KLMRegionGrowing/BasicRegionGrowing,Basic Region Growing}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT RegionGrowImageFilter:

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.h
@@ -55,9 +55,9 @@ namespace itk
  * \ingroup RegionGrowingSegmentation
  * \ingroup ITKRegionGrowing
  *
- * \wiki
- * \wikiexample{ImageSegmentation/ConfidenceConnectedImageFilter,Segment pixels with similar statistics using connectivity}
- * \endwiki
+ * \sphinx
+ * \sphinxexample{Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats,SegmentPixelsWithSimilarStats}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ConfidenceConnectedImageFilter:

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.h
@@ -32,6 +32,9 @@ namespace itk
  *
  * \ingroup RegionGrowingSegmentation
  * \ingroup ITKRegionGrowing
+ * \sphinx
+ * \sphinxexample{Segmentation/RegionGrowing/ConnectedComponentsInImage,Connected Components In Image}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT ConnectedThresholdImageFilter:

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -42,6 +42,10 @@ namespace itk
  *
  * \ingroup MeshObjects
  * \ingroup ITKVoronoi
+ *
+ * \sphinx
+ * \sphinexample{Segmentation/Voronoi/VoronoiDiagram,Voronoi Diagram}
+ * \endsphinx
  */
 template< typename TCoordType >
 class ITK_TEMPLATE_EXPORT VoronoiDiagram2D:

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -41,6 +41,10 @@ namespace itk
  * and the resulting vertices.
  *
  * \ingroup ITKVoronoi
+ *
+ * \sphinx
+ * \sphinxexample{Segmentation/Voronoi/VoronoiDiagram,Voronoi Diagram}
+ * \endsphinx
  */
 template< typename TCoordType >
 class ITK_TEMPLATE_EXPORT VoronoiDiagram2DGenerator:

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
@@ -47,6 +47,10 @@ namespace itk
  * \sa WatershedImageFilter, MorphologicalWatershedFromMarkersImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
  * \ingroup ITKWatersheds
+ *
+ * \sphinx
+ * \sphinexample{Segmentation/Watersheds/MorphologicalWatershedSegmentation,Morphological Watershed Segmentation}
+ * \endsphinx
  */
 template< typename TInputImage, typename TOutputImage >
 class ITK_TEMPLATE_EXPORT MorphologicalWatershedImageFilter:


### PR DESCRIPTION
  -Moved wiki 2DGaussianMixtureModelExpectMax examples to sphinx
  -Moved wiki AbsValueOfImage example to sphinx
  -Moved wiki AbsValueOfTwoImages example to sphinx
  -Moved wiki AddConstantToEveryPixel example to sphinx
  -Moved wiki AddConstantToPixelsWithoutDuplicatingImage example to sphinx
  -Moved wiki AddNoiseToBinaryImage examples to sphinx
  -Moved wiki AddPointsAndEdges examples to sphinx
  -Moved wiki AddTwoImages example to sphinx
  -Moved wiki AmoebaOptimization example
  -Moved wiki ApplyKernelToEveryPixel example to sphinx
  -Moved wiki ApplyKernelToEveryPixelInNonZeroImage example to sphinx
  -Moved wiki ApproxDistanceMapOfBinary example to sphinx
  -Moved wiki AssignContiguousLabelsToConnectedRegions examples to sphinx
  -Moved wiki BasicRegionGrowing examples to sphinx
  -Moved wiki BilateralFilterAnImage examples to sphinx
  -Moved wiki BinaryANDTwoImages example to sphinx
  -Moved wiki BinaryMinMaxCurvatureFlow examples to sphinx
  -Moved wiki BinaryORTwoImages example to sphinx
  -Moved wiki BinaryXORTwoImages example to sphinx
  -Moved wiki Blob examples to sphinx
  -Moved wiki CalculateAreaAndVolumeOfSimplexMesh examples to sphinx
  -Moved wiki CartesianToAzimuthElevation examples to sphinx
  -Moved wiki CastImageToAnotherTypeButClampToOutput example to sphinx
  -Moved wiki CastVectorImageToAnotherType example to sphinx
  -Moved wiki CheckIfModuleIsPresent examples to sphinx
  -Moved wiki ClosingBinaryImage examples to sphinx
  -Moved wiki ClusterPixelsInGrayscaleImage examples to sphinx
  -Moved wiki ColorBoundariesOfRegions example to sphinx
  -Moved wiki ColorLabeledRegions example to sphinx
  -Moved wiki ColorNormalizedCorrelation examples to sphinx
  -Moved wiki ComposeVectorFromThreeScalarImages example to sphinx
  -Moved wiki ComputeAndDisplayGradient examples to sphinx
  -Moved wiki ComputeHistogramOfMaskedRegion examples to sphinx
  -Moved wiki ComputeInverseFFTOfImage examples to sphinx
  -Moved wiki ComputeMeanSquareBetweenTwoImages examples to sphinx
  -Moved wiki ComputeMinMaxVarianceMeanOfImage examples to sphinx
  -Moved wiki ComputePCAShapeFromSample examples to sphinx
  -Moved wiki ComputeTextureFeatures examples to sphinx
  -Moved wiki ComputerLocalNoise examples to sphinx
  -Moved wiki ComputerMagInVectorImageToMakeMagImage example to sphinx
  -Moved wiki ConnectedComponentsInImage examples to sphinx
  -Moved wiki ContourSpatialObject examples to sphinx
  -Moved wiki ConvertArrayToImage example
  -Moved wiki ConvertImageToAnotherType example
  -Moved wiki ConvertImageWithLabelsToShapeLabelMap example to sphinx
  -Moved wiki ConvertLabelMapToImage example to sphinx
  -Moved wiki ConvertMeshToUnstructeredGrid examples to sphinx
  -Moved wiki ConvertRealAndImaginaryToComplexImage examples to sphinx
  -Moved wiki ConvertSpacialObjectToImage examples to sphinx
  -Moved wiki ConvolveImageWithKernel example to sphinx
  -Moved wiki Creade3DFromSeriesOf2D examples to sphinx
  -Moved wiki CreateAnotherInstanceOfAnImage examples to sphinx
  -Moved wiki CreateDerivativeKernel examples to sphinx
  -Moved wiki CreateForwardDifferenceKernel examples to sphinx
  -Moved wiki CreateGaussianDerivativeKernel examples to sphinx
  -Moved wiki CreateGaussianDistribution examples to sphinx
  -Moved wiki CreateGaussianKernel examples to sphinx
  -Moved wiki CreateHistogramFromListOfMeasurements examples to sphinx
  -Moved wiki CreateLaplacianKernel examples to sphinx
  -Moved wiki CreateListOfSampleMeasurements examples to sphinx
  -Moved wiki CreateListOfSamplesFromImage examples to sphinx
  -Moved wiki CreateListOfSamplesWithIDs examples to sphinx
  -Moved wiki CreateSobelKernel examples to sphinx
  -Moved wiki CreateVectorImage example to sphinx
  -Moved wiki CreateVectorImageFromScalarImages example to sphinx
  -Moved wiki CropImageBySpecifyingRegion example to sphinx
  -Moved wiki CropImageBySpecifyingRegion2 example to sphinx
  -Moved wiki CustomColormapFilter example
  -Moved wiki CustomOperationToEachPixelInImage example to sphinx
  -Moved wiki DataStructureForPieceWiseLinearCurve examples to sphinx
  -Moved wiki DeepCopyImage examples to sphinx
  -Moved wiki DemonstrateAllOperators examples to sphinx
  -Moved wiki DemonstrateThresholdAlgorithms examples to sphinx
  -Moved wiki DirectWarningToFile examples to sphinx
  -Moved wiki DisplayITKImage examples to sphinx
  -Moved wiki DisplayImage examples to sphinx
  -Moved wiki DistributeSamplingUsingGMM examples to sphinx
  -Moved wiki DistributionOfPixelsUsingGMM examples to sphinx
  -Moved wiki Ellipse examples to sphinx
  -Moved wiki ErodeBinaryImageUsingFlatStruct examples to sphinx
  -Moved wiki ExhaustiveOptimizer examples to sphinx
  -Moved wiki ExtraLargestConnectComponent examples to sphinx
  -Moved wiki ExtractBoundariesOfBlobsInBinaryImage examples to sphinx
  -Moved wiki ExtractBoundariesOfConnectedRegions examples to sphinx
  -Moved wiki ExtractChannelOfImageWithMultipleComponents example to sphinx
  -Moved wiki ExtractComponentOfVectorImage example to sphinx
  -Moved wiki ExtractContoursFromImage examples to sphinx
  -Moved wiki FilterImage examples to sphinx
  -Moved wiki FilterImageUsingMultipleThreads examples to sphinx
  -Moved wiki FilterImageWithoutCopying examples to sphinx
  -Moved wiki FindHigherDerivativesOfImage examples to sphinx
  -Moved wiki FindMaxAndMinInImage example to sphinx
  -Moved wiki FindZeroCrossings example to sphinx
  -Moved wiki ForwardFFT examples to sphinx
  -Moved wiki GDCMImageIO examples
  -Moved wiki GaussianBlurImageFunction example
  -Moved wiki GenerateStructureElementsWithAccurateArea examples to sphinx
  -Moved wiki GeometricPropertiesOfRegion example to sphinx
  -Moved wiki GetImageSize example
  -Moved wiki GlobalRegistrationOfTwoImages examples to sphinx
  -Moved wiki GlobalRegistrationTwoImagesAffine examples to sphinx
  -Moved wiki GlobalRegistrationTwoImagesBSpline examples to sphinx
  -Moved wiki GradientOfVectorImage examples to sphinx
  -Moved wiki ImplementationOfSnakes examples to sphinx
  -Moved wiki InPlaceFilterOfImage examples to sphinx
  -Moved wiki IntensityWindowing example to sphinx
  -Moved wiki InverseOfMaskToImage example to sphinx
  -Moved wiki InvertImage example to sphinx
  -Moved wiki InvertImageUsingBinaryNot example to sphinx
  -Moved wiki IterateImageStartingAtSeed examples to sphinx
  -Moved wiki IterateLineThroughImage example to sphinx
  -Moved wiki IterateLineThroughImageWithoutWriteAccess example to sphinx
  -Moved wiki IterateOverSpecificRegion example to sphinx
  -Moved wiki IterateRegionWithAccessToIndex examples to sphinx
  -Moved wiki IterateRegionWithNeighborhood example to sphinx
  -Moved wiki IterateRegionWithWriteAccess example to sphinx
  -Moved wiki IterateRegionWithoutWriteAccess example to sphinx
  -Moved wiki IterateWithNeighborhoodWithoutAccess example to sphinx
  -Moved wiki JoinImages example to sphinx
  -Moved wiki KMeansClusterOfPixelsInImage examples to sphinx
  -Moved wiki KMeansClustering examples to sphinx
  -Moved wiki KeepBinaryRegionsThatMeetSpecific example to sphinx
  -Moved wiki KeepRegionsAboveLevel example to sphinx
  -Moved wiki KeepRegionsThatMeetSpecific example
  -Moved wiki LabelBinaryRegionsAndGetProperties example to sphinx
  -Moved wiki LabelBinaryRegionsInImage example to sphinx
  -Moved wiki LabelConnectComponentsInBinaryImage examples to sphinx
  -Moved wiki LabelConnectComponentsInGrayscaleImage examples to sphinx
  -Moved wiki LabelContoursOfConnectComponent examples to sphinx
  -Moved wiki LevenbergMarquardtOptimization example
  -Moved wiki LightObject example
  -Moved wiki LineSpacialObject examples to sphinx
  -Moved wiki LinearlyInterpolatePositionInImage example to sphinx
  -Moved wiki MapScalarsIntoJetColormap examples to sphinx
  -Moved wiki MaskImage example to sphinx
  -Moved wiki MatchFeaturePoints examples to sphinx
  -Moved wiki Matrix example
  -Moved wiki MatrixInverse example
  -Moved wiki MaurerDistanceMapOfBinary example to sphinx
  -Moved wiki MeanDistanceBetweenAllPointsOnTwoCurves examples to sphinx
  -Moved wiki MedianImageFunction example
  -Moved wiki MergeLabelMaps example to sphinx
  -Moved wiki MiniPipeline examples to sphinx
  -Moved wiki MorphologicalWatershedSegmentation examples to sphinx
  -Moved wiki MultThreadOilPainting examples to sphinx
  -Moved wiki Multiphase.. examples to sphinx
  -Moved wiki MultipleInputsOfDifferentType examples to sphinx
  -Moved wiki MultipleInputsOfSameType examples to sphinx
  -Moved wiki MultipleOutputsOfDifferentType examples to sphinx
  -Moved wiki MultipleOutputsOfSameType examples to sphinx
  -Moved wiki MultiplyKernelWithAnImageAtLocation example
  -Moved wiki MultiresolutionPyramidFromImage example to sphinx
  -Moved wiki MutualInformation examples to sphinx
  -Moved wiki MutualInformationAffine examples to sphinx
  -Moved wiki NeighborhoodIteratorOnVectorImage example to sphinx
  -Moved wiki NormalizeImage example to sphinx
  -Moved wiki NormalizedCorrelation example to sphinx
  -Moved wiki NormalizedCorrelationOfMaskedImage example to sphinx
  -Moved wiki NormalizedCorrelationUsingFFT example to sphinx
  -Moved wiki NormalizedCorrelationUsingFFTWithMaskImages example to sphinx
  -Moved wiki OpeningBinaryImage examples to sphinx
  -Moved wiki OutOfBoundsPixelsReturnConstValue example to sphinx
  -Moved wiki OverlayLabelMapOnImage example to sphinx
  -Moved wiki OverlayLabelMapOnTopOfAnImage example to sphinx
  -Moved wiki PadImageByWrapping example to sphinx
  -Moved wiki PassImageToFunction examples to sphinx
  -Moved wiki PermuteSequenceOfIndices examples to sphinx
  -Moved wiki PixelDivisionOfTwoImages example to sphinx
  -Moved wiki PresentImageAfterOperation example to sphinx
  -Moved wiki ProcessNthComponentOfVectorImage example to sphinx
  -Moved wiki ProduceImageProgrammatically examples to sphinx
  -Moved wiki PruneBinaryImage examples to sphinx
  -Moved wiki RandomSelectOfPixelsFromRegion example to sphinx
  -Moved wiki ReadTransformFromFile example
  -Moved wiki RegionalMaximal example to sphinx
  -Moved wiki RegionalMinimal example to sphinx
  -Moved wiki RegisterImageToAnotherUsingLandmarks examples to sphinx
  -Moved wiki RegisterTransformWithTransformFactory example
  -Moved wiki RemoveLabelsFromLabelMap example
  -Moved wiki RequestRegion and DerivativeImage example
  -Moved wiki ResampleITK::VectorImage examples to sphinx
  -Moved wiki ResampleRGBImage example to sphinx
  -Moved wiki ResampleSegmentedImage example to sphinx
  -Moved wiki ReturnObjectFromFunction examples to sphinx
  -Moved wiki RunImageFilterOnRegionOfImage example to sphinx
  -Moved wiki ScalarToRGBColormapImageFilter example
  -Moved wiki ScaleImage example
  -Moved wiki ScalePixelSumToConstant example to sphinx
  -Moved wiki SegmentPixelsWithSimilarStats examples to sphinx
  -Moved wiki SeparateGroundUsingOtsu examples to sphinx
  -Moved wiki SetOutputPixelToMax example to sphinx
  -Moved wiki SetOutputPixelToMin example to sphinx
  -Moved wiki ShapeAttributesForBinaryImage example to sphinx
  -Moved wiki SharpenImage example to sphinx
  -Moved wiki ShrinkImage example to sphinx
  -Moved wiki SignedDistanceMapOfBinary example to sphinx
  -Moved wiki Single.. examples to sphinx
  -Moved wiki Singlephase.. examples to sphinx
  -Moved wiki SmoothImageUsingCurvatureFlow examples to sphinx
  -Moved wiki SmoothImageUsingMinMaxCurvatureFlow examples to sphinx
  -Moved wiki SmoothImageWhilePreservingEdges examples to sphinx
  -Moved wiki SmoothImageWhilePreservingEdges2 examples to sphinx
  -Moved wiki SmoothImageWithDiscreteGaussianFilter examples to sphinx
  -Moved wiki SmoothRGBImageUsingCurvatureFlow examples to sphinx
  -Moved wiki SmoothRGBImageUsingMinMaxCurvatureFlow examples to sphinx
  -Moved wiki SortITKIndex examples to sphinx
  -Moved wiki SpatialSearch examples to sphinx
  -Moved wiki SquareEveryPixel example to sphinx
  -Moved wiki SquaredDifferenceOfTwoImages example to sphinx
  -Moved wiki Stack2DImagesInto3DImage example to sphinx
  -Moved wiki StatisticalPropertiesOfRegion example to sphinx
  -Moved wiki StoreNonPixelDataInImage examples to sphinx
  -Moved wiki SubtractConstantFromEveryPixel example to sphinx
  -Moved wiki SubtractTwoImages example to sphinx
  -Moved wiki ThinImage example to sphinx
  -Moved wiki ThrowException examples to sphinx
  -Moved wiki TileImagesSideBySide example to sphinx
  -Moved wiki TransformVectorValuedImagePixels example to sphinx
  -Moved wiki TranslateAVectorImage example to sphinx
  -Moved wiki Transparency example
  -Moved wiki VTKImageToITKImage examples to sphinx
  -Moved wiki ValuedRegionalMaximaImage example to sphinx
  -Moved wiki ValuedRegionalMinimalImage example to sphinx
  -Moved wiki VariableLengthVector example
  -Moved wiki ViewComponentVectorImageAsScaleImage example to sphinx
  -Moved wiki VoronoiDiagram examples to sphinx
  -Moved wiki WatchRegistration examples to sphinx
  -Moved wiki WorkingWithPointAndCellData examples to sphinx
  -Moved wiki WriteTransformToFile example
  -Moved wiki ZeroCrossingBasedEdgeDecor examples to sphinx

Co-Authored By: Mathew J. Seng <mathewseng@gmail.com>

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- :no_entry_sign: Adds the License notice to new files.
- :no_entry_sign: Adds Python wrapping.
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
-  :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] Adds Documentation.
