### PR TITLE
BUG: Ensure strict weak ordering in HessianToObjectnessMeasure's sort

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -142,11 +142,11 @@ private:
   // functor used to sort the eigenvalues are to be sorted
   // |e1|<=|e2|<=...<=|eN|
   //
-  // Returns ( abs(a) <= abs(b) )
-  struct AbsLessEqualCompare {
+  // Returns ( abs(a) < abs(b) )
+  struct AbsLessCompare {
     bool operator()(EigenValueType a, EigenValueType b)
     {
-      return itk::Math::abs(a) <= itk::Math::abs(b);
+      return itk::Math::abs(a) < itk::Math::abs(b);
     }
   };
 

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -78,7 +78,7 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
     // Sort the eigenvalues by magnitude but retain their sign.
     // The eigenvalues are to be sorted |e1|<=|e2|<=...<=|eN|
     EigenValueArrayType sortedEigenValues = eigenValues;
-    std::sort( sortedEigenValues.Begin(), sortedEigenValues.End(), AbsLessEqualCompare() );
+    std::sort( sortedEigenValues.Begin(), sortedEigenValues.End(), AbsLessCompare() );
 
     // Check whether eigenvalues have the right sign
     bool signConstraintsSatisfied = true;


### PR DESCRIPTION
This is a squash and rebase of #994.
