### PR TITLE
ENH: Add script to update ITK testing macros names

### DIFF
--- a/Utilities/Maintenance/UpdateTestingMacrosNames.sh
+++ b/Utilities/Maintenance/UpdateTestingMacrosNames.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+#==========================================================================
+#
+#   Copyright Insight Software Consortium
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+
+# This script updates the testing macros names.
+#
+# The script updates the testing macros names.
+
+
+# Utility functions
+usage() {
+cat << EOF
+Usage: $0
+
+Use this script to update the testing macros names.
+
+The script updates the testing macros names.
+EOF
+}
+
+die() {
+  echo "$@" 1>&2; exit 1
+}
+
+while test $# -gt 0;
+do
+  opt="$1";
+  case "$opt" in
+    "-h"|"--help")
+      shift;
+      help=true
+      break;;
+    *)
+      break;;
+  esac
+done
+
+if test $help; then
+  usage
+  exit 1
+fi
+
+prefix='ITK_'
+
+declare -a old_strings=("EXERCISE_BASIC_OBJECT_METHODS" "TRY_EXPECT_EXCEPTION" \
+ "TRY_EXPECT_NO_EXCEPTION" "TEST_EXPECT_TRUE_STATUS_VALUE" "TEST_EXPECT_TRUE" \
+ "TEST_EXPECT_EQUAL_STATUS_VALUE" "TEST_EXPECT_EQUAL" "TEST_SET_GET" \
+ "TEST_SET_GET_VALUE" "TEST_SET_GET_NULL_VALUE" "TEST_SET_GET_BOOLEAN")
+
+# Do the replacement
+for old_str in "${old_strings[@]}"; do
+  find . -type f \( -name '*.h' -o -name '*.c' -o -name '*.cpp' \
+  -o -name '*.hxx' -o -name '*.cxx' \) \
+  -exec sed -i -e "s/\b$old_str\b/$prefix$old_str/g" {} \;
+done


### PR DESCRIPTION
Add script to update ITK testing macros names.

Motivated by PR #999.

This script should ease the task to update the testing macros names in
remote modules when used together with the [`ApplyScriptToRemotes.sh`](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/Maintenance/ApplyScriptToRemotes.sh) script.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- :no_entry_sign: Adds the License notice to new files.
- :no_entry_sign: Adds Python wrapping.
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
