### PR TITLE
STYLE: Add const to SetStartingShrinkFactors parameter

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
@@ -442,7 +442,7 @@ public:
    * clamped to a minimum value of 1. */
   void SetStartingShrinkFactors(unsigned int factor);
 
-  void SetStartingShrinkFactors(unsigned int *factors);
+  void SetStartingShrinkFactors(const unsigned int *factors);
 
   /** Get the starting shrink factors. */
   const unsigned int * GetStartingShrinkFactors() const;

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -266,20 +266,15 @@ void
 MRIBiasFieldCorrectionFilter< TInputImage, TOutputImage, TMaskImage >
 ::SetStartingShrinkFactors(unsigned int factor)
 {
-  unsigned int array[ImageDimension];
-
-  for ( unsigned int dim = 0; dim < ImageDimension; ++dim )
-    {
-    array[dim] = factor;
-    }
-
-  this->SetStartingShrinkFactors(array);
+  const auto fixedArray =
+    FixedArray<unsigned int, ImageDimension>::Filled(factor);
+  this->SetStartingShrinkFactors(fixedArray.GetDataPointer());
 }
 
 template< typename TInputImage, typename TOutputImage, typename TMaskImage >
 void
 MRIBiasFieldCorrectionFilter< TInputImage, TOutputImage, TMaskImage >
-::SetStartingShrinkFactors(unsigned int *factors)
+::SetStartingShrinkFactors(const unsigned int *factors)
 {
   for ( unsigned int dim = 0; dim < ImageDimension; ++dim )
     {

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
@@ -169,7 +169,7 @@ public:
    * clamped to a minimum value of 1. */
   virtual void SetStartingShrinkFactors(unsigned int factor);
 
-  virtual void SetStartingShrinkFactors(unsigned int *factors);
+  virtual void SetStartingShrinkFactors(const unsigned int *factors);
 
   /** Get the starting shrink factors */
   const unsigned int * GetStartingShrinkFactors() const;

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -110,14 +110,9 @@ MultiResolutionPyramidImageFilter< TInputImage, TOutputImage >
 ::SetStartingShrinkFactors(
   unsigned int factor)
 {
-  unsigned int array[ImageDimension];
-
-  for ( unsigned int dim = 0; dim < ImageDimension; ++dim )
-    {
-    array[dim] = factor;
-    }
-
-  this->SetStartingShrinkFactors(array);
+  const auto fixedArray =
+    FixedArray<unsigned int, ImageDimension>::Filled(factor);
+  this->SetStartingShrinkFactors(fixedArray.GetDataPointer());
 }
 
 /**
@@ -127,7 +122,7 @@ template< typename TInputImage, typename TOutputImage >
 void
 MultiResolutionPyramidImageFilter< TInputImage, TOutputImage >
 ::SetStartingShrinkFactors(
-  unsigned int *factors)
+  const unsigned int *factors)
 {
   for ( unsigned int dim = 0; dim < ImageDimension; ++dim )
     {


### PR DESCRIPTION
Declared the `factors` parameter of `SetStartingShrinkFactors` as
pointer-to-const for both `MultiResolutionPyramidImageFilter` and
`MRIBiasFieldCorrectionFilter`, as these member functions do not
modify their argument.

Adjusted the "single factor overloads" of these member functions, to
make use of the improved const-correctness.