### PR TITLE
COMP: Provide NumericTraits<complex<T>>::ZeroValue() definition

### DIFF
--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -1080,8 +1080,8 @@ public:
   static constexpr bool IsSigned = NumericTraits< ValueType >::IsSigned;
   static constexpr bool IsInteger = false;
   static constexpr bool IsComplex = true;
-  static Self ZeroValue() { return Zero; }
-  static Self OneValue() { return One; }
+  static Self ZeroValue() { return Self(0, 0); }
+  static Self OneValue() { return Self(1, 0); }
   static constexpr unsigned int GetLength(const Self &) { return 2; }
   static constexpr unsigned int GetLength() { return 2; }
   static constexpr Self NonpositiveMin(const Self &) { return NonpositiveMin(); }


### PR DESCRIPTION
To address:

[build] ../External/ITK/Modules/Core/Common/include/itkNumericTraits.h:1083:36: warning: instantiation of variable 'itk::NumericTraits<std::__1::complex<float> >::Zero' required here, but no definition is available [-Wundefined-var-template]
[build]   static Self ZeroValue() { return Zero; }
[build]                                    ^
[build] ../External/ITK/Modules/Core/Common/include/itkNumericTraits.h:1088:48: note: in instantiation of member function 'itk::NumericTraits<std::__1::complex<float> >::ZeroValue' requested here
[build]   static Self ZeroValue(const Self &) { return ZeroValue(); }
[build]                                                ^
[build] ../External/ITK/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx:39:59: note: in instantiation of member function 'itk::NumericTraits<std::__1::complex<float> >::ZeroValue' requested here
[build]   m_DefaultPixelValue = NumericTraits< OutputPixelType >::ZeroValue(m_DefaultPixelValue);
[build]                                                           ^
[build] ../External/ITK/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h:65:15: note: in instantiation of member function 'itk::TileImageFilter<itk::Image<std::__1::complex<float>, 3>, itk::Image<std::__1::complex<float>, 4> >::TileImageFilter' requested here
[build]   itkNewMacro(Self);
[build]               ^
[build] ../Source/Utils/qikfilter.cpp:222:52: note: in instantiation of member function 'itk::TileImageFilter<itk::Image<std::__1::complex<float>, 3>, itk::Image<std::__1::complex<float>, 4> >::New' requested here
[build]     auto                             tile = TTile::New();
[build]                                                    ^
[build] ../External/ITK/Modules/Core/Common/include/itkNumericTraits.h:1062:38: note: forward declaration of template entity is here
[build]   static const Self ITKCommon_EXPORT Zero;
[build]                                      ^
[build] ../External/ITK/Modules/Core/Common/include/itkNumericTraits.h:1083:36: note: add an explicit instantiation declaration to suppress this warning if 'itk::NumericTraits<std::__1::complex<float> >::Zero' is explicitly instantiated in another translation unit
[build]   static Self ZeroValue() { return Zero; }
