### PR TITLE
Fix image sink override warning

### DIFF
--- a/Modules/Core/Common/include/itkImageSink.h
+++ b/Modules/Core/Common/include/itkImageSink.h
@@ -137,7 +137,7 @@ public:
 
 protected:
   ImageSink();
-  ~ImageSink() = default;
+  ~ImageSink() override = default;
 
   void PrintSelf(std::ostream & os, Indent indent) const override;
 


### PR DESCRIPTION
Fixing warning:
```
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkImageSink.h:140:3: warning: '~ImageSink' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
  ~ImageSink() = default;
  ^
```

This patch should be merged into the release and master branches.