### PR TITLE
BUG: Fix remotes maintenance scripts

### DIFF
--- a/Utilities/Maintenance/ApplyScriptToRemotes.sh
+++ b/Utilities/Maintenance/ApplyScriptToRemotes.sh
@@ -79,7 +79,7 @@ script="$1"
 feature_branch="$2"
 commit_message="$3"
 
-if test "${script}" = "" || "${feature_branch}" = "" || "${commit_message}" = "" || $help; then
+if test "${script}" = "" || test "${feature_branch}" = "" || test "${commit_message}" = "" || $help; then
   usage
   exit 1
 fi
@@ -175,11 +175,23 @@ function apply_script_and_push_remotes() {
     git checkout -b $feature_branch origin/master
     $script
 
-    # Add the files, adding filters if necessary
-    git add -u *.txt ./*.cmake ./*.rst ./*.py ./*.yml ./*.c ./*.cxx ./*.h ./*.hxx ./*.wrap
+    # Add the files, adding filters if necessary, and redirecting stdout and
+    # stderr to /dev/null in order to avoid a too verbose output and
+    # displaying error messages if files with some given extensions are not
+    # found.
+    git add -u *.txt > /dev/null 2>&1
+    git add -u *.cmake > /dev/null 2>&1
+    git add -u *.rst > /dev/null 2>&1
+    git add -u *.py > /dev/null 2>&1
+    git add -u *.yml > /dev/null 2>&1
+    git add -u *.c > /dev/null 2>&1
+    git add -u *.cxx > /dev/null 2>&1
+    git add -u *.h > /dev/null 2>&1
+    git add -u *.hxx > /dev/null 2>&1
+    git add -u *.wrap > /dev/null 2>&1
 
     # Commit and push to the feature branch
-    git commit -m $commit_message
+    git commit -m "$commit_message"
     git push --quiet https://$username:$password@github.com/$username/$repository_basename $feature_branch
 
     cd ..
@@ -198,6 +210,6 @@ echo -e "Applying script to remotes..."
 apply_script_and_push_remotes
 echo -e "Done applying script to remotes."
 
-rm -r ../../../ITK-build
+rm -Rf ../../../ITK-build
 
 echo -e "Visit the remote repositories and open the corresponding pull requests."

--- a/Utilities/Maintenance/UpdateRequiredITKVersionInRemoteModules.sh
+++ b/Utilities/Maintenance/UpdateRequiredITKVersionInRemoteModules.sh
@@ -63,7 +63,7 @@ done
 azure_pipelines_ci_filename=$1
 python_setup_filename=$2
 
-if test "${azure_pipelines_ci_filename}" = "" || "${python_setup_filename}" = "" || $help; then
+if test "${azure_pipelines_ci_filename}" = "" || test "${python_setup_filename}" = "" || $help; then
   usage
   exit 1
 fi


### PR DESCRIPTION
Fix remotes maintenance scripts:
- Fix scripts input arguments `command not found` error adding the `test`
  command over each argument.Fixes:
  ```
  ./Utilities/Maintenance/ApplyScriptToRemotes.sh: line 82:
  UpdateTestingMacrosNames: command not found
  ./Utilities/Maintenance/ApplyScriptToRemotes.sh: line 82: ENH: Update
  ITK testing macros names: command not found
  ```

and idem for `UpdateRequiredITKVersionInRemoteModules.sh`.

Avoid the script continuing its execution if not all input parameters have
been provided.

- Fix the `git add` command failing when not finding any file extension
  that matches the filters. This was causing that even files whose
  extension matched any of those before the missing one were not being
  added. Fixes:
  ```
  fatal: pathspec './*.c' did not match any files
  fatal: pathspec './*.rst' did not match any files
  ```
  Filters are now applied individually so that if one is not
  found/fails, the rest can still be added. Also, `stdout` and `stderr`
  are redirected to `/dev/null` to avoid excessive, additional
  verbosity.

- Fix the commit message not being correctly processed: quotes within
  the script were missing (in addition to the quotes in the input
  argument so that the script considers it as a single argument).
  Fixes:
  ```
  error: pathspec 'Update' did not match any file(s) known to git.
  error: pathspec 'ITK' did not match any file(s) known to git.
  error: pathspec 'testing' did not match any file(s) known to git.
  error: pathspec 'macros' did not match any file(s) known to git.
  error: pathspec 'names' did not match any file(s) known to git.
  ```

- Fix the `ITK-build` directory not being removed for being non empty.
  Fixes:
  ```
  rm: cannot remove '../../../ITK-build': Directory not empty
  ```

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- :no_entry_sign: Adds the License notice to new files.
- :no_entry_sign: Adds Python wrapping.
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
