### PR TITLE
BUG: Do not require PyBUF_WRITABLE in GetArrayViewFromImage

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -92,7 +92,7 @@ PyBuffer<TImage>
   size_t                      pixelSize     = sizeof(ComponentType);
   size_t                      len           = 1;
 
-  if(PyObject_GetBuffer(arr, &pyBuffer, PyBUF_WRITABLE | PyBUF_ND | PyBUF_ANY_CONTIGUOUS ) == -1)
+  if(PyObject_GetBuffer(arr, &pyBuffer, PyBUF_ND | PyBUF_ANY_CONTIGUOUS ) == -1)
     {
     PyErr_SetString( PyExc_RuntimeError, "Cannot get an instance of NumPy array." );
     PyBuffer_Release(&pyBuffer);

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -201,5 +201,14 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         index[1] = 1
         assert(image.GetPixel(index) == 3)
 
+    def test_NumPyBridge_ImageFromBuffer(self):
+        "Create an image with image_from_array with a non-writeable input"
+
+        data = 'hello world '
+        array = np.frombuffer(data, dtype=np.uint8)
+        array = array.reshape((2, 6))
+        image = itk.image_from_array(array)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
GetArrayFromImage was refactored so the buffer is first passed to this
GetArrayViewFromImage.  In this case, it does not need to be writable.
Remove the restriction to retain used in GetArrayViewFromImage.

See also:

  https://github.com/numpy/numpy/pull/11739