### PR TITLE
ENH: Add ImageRegionRange<TImage> to itk::Experimental namespace

### DIFF
--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -1,0 +1,482 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+#ifndef itkImageRegionRange_h
+#define itkImageRegionRange_h
+
+#include <algorithm> // For any_of and copy_n.
+#include <cassert>
+#include <cstddef> // For ptrdiff_t.
+#include <iterator> // For bidirectional_iterator_tag.
+#include <functional> // For multiplies.
+#include <numeric> // For accumulate.
+#include <type_traits> // For conditional and is_const.
+
+#include "itkImageHelper.h"
+#include "itkImageRegion.h"
+#include "itkImageBufferRange.h"
+
+namespace itk
+{
+namespace Experimental
+{
+
+/**
+ * \class ImageRegionRange
+ * Modern C++11 range to iterate over the pixels of an image region.
+ * Designed to conform to Standard C++ Iterator requirements,
+ * so that it can be used in range-based for loop, and passed to
+ * Standard C++ algorithms.
+ *
+ * The following example adds 42 to each pixel, using a range-based for loop:
+   \code
+   ImageRegionRange<ImageType> range{ *image, imageRegion };
+
+   for (auto&& pixel : range)
+   {
+     pixel = pixel + 42;
+   }
+   \endcode
+ *
+ * The following example prints the values of the pixels:
+   \code
+   for (const auto pixel : range)
+   {
+     std::cout << pixel << std::endl;
+   }
+   \endcode
+ *
+ * \author Niels Dekker, LKEB, Leiden University Medical Center
+ *
+ * \see ImageRegionIterator
+ * \see ImageRegionIndexRange
+ * \see ImageBufferRange
+ * \see ShapedImageNeighborhoodRange
+ * \ingroup ImageIterators
+ * \ingroup ITKCommon
+ */
+template<typename TImage>
+class ImageRegionRange final
+{
+private:
+  using Self = ImageRegionRange;
+  using ImageDimensionType = typename TImage::ImageDimensionType;
+  using PixelType = typename TImage::PixelType;
+
+  static constexpr bool IsImageTypeConst = std::is_const<TImage>::value;
+  static constexpr ImageDimensionType ImageDimension = TImage::ImageDimension;
+
+  using BufferIteratorType = typename ImageBufferRange<TImage>::iterator;
+  using RegionType = typename TImage::RegionType;
+  using SizeType = typename TImage::SizeType;
+  using OffsetType = typename TImage::OffsetType;
+  using OffsetTableType = Offset<ImageDimension + 1>;
+  using IndexType = typename RegionType::IndexType;
+
+
+  /**
+   * \class QualifiedIterator
+   * Iterator class that is either 'const' or non-const qualified.
+   * A non-const qualified instantiation of this template allows the pixel that
+   * it points to, to be modified. A const qualified instantiation does not.
+   *
+   * \note The definition of this class is private. Please use its type alias
+   * ImageRegionRange::iterator, or ImageRegionRange::const_iterator!
+   * \see ImageRegionRange
+   * \ingroup ImageIterators
+   * \ingroup ITKCommon
+   */
+  template <bool VIsConst>
+  class QualifiedIterator final
+  {
+  private:
+    // Const and non-const iterators are friends, in order to implement the
+    // constructor that allow conversion from non-const to const iterator.
+    friend class QualifiedIterator<!VIsConst>;
+
+    // ImageRegionRange is a friend, as it should be the only one that can
+    // directly use the private constructor of the iterator.
+    friend class ImageRegionRange;
+
+    // Use either a const or a non-const qualified image buffer iterator.
+    using QualifiedBufferIteratorType = typename std::conditional<VIsConst,
+      typename ImageBufferRange<TImage>::const_iterator,
+      typename ImageBufferRange<TImage>::iterator>::type;
+
+    // QualifiedIterator data members (strictly private):
+
+    // Iterator to the current pixel.
+    QualifiedBufferIteratorType m_BufferIterator{};
+
+    // A copy of the offset table of the image.
+    OffsetTableType m_OffsetTable{ {} };
+
+    // N-Dimensional offset relative to the index of the iteration region.
+    OffsetType m_IterationOffset{ {} };
+
+    // Size of the iteration region.
+    SizeType m_IterationRegionSize{ {} };
+
+    // Private constructor, used to create the begin and the end iterator of a range.
+    // Only used by its friend class ImageRegionRange.
+    QualifiedIterator(
+      const QualifiedBufferIteratorType& bufferIterator,
+      const OffsetTableType& offsetTable,
+      const OffsetType& iterationOffset,
+      const SizeType& regionSize) ITK_NOEXCEPT
+      :
+    m_BufferIterator(bufferIterator),
+      // Note: Use parentheses instead of curly braces to initialize data members,
+      // to avoid AppleClang 6.0.0.6000056 compilation error, "no viable conversion..."
+      m_OffsetTable(offsetTable),
+      m_IterationOffset(iterationOffset),
+      m_IterationRegionSize(regionSize)
+    {
+    }
+
+    template <std::size_t VIndex>
+    void Increment(std::true_type) ITK_NOEXCEPT
+    {
+      static_assert(VIndex < (ImageDimension - 1),
+        "For a larger index value, the other overload should be picked");
+
+      m_BufferIterator += m_OffsetTable[VIndex];
+
+      if (static_cast<SizeValueType>(++m_IterationOffset[VIndex]) >= m_IterationRegionSize[VIndex])
+      {
+        m_IterationOffset[VIndex] = 0;
+        m_BufferIterator -= m_OffsetTable[VIndex] * m_IterationRegionSize[VIndex];
+        this->Increment<VIndex + 1>(std::integral_constant < bool, (VIndex + 1) < (ImageDimension - 1) > {});
+      }
+    }
+
+    template <std::size_t VIndex>
+    void Increment(std::false_type) ITK_NOEXCEPT
+    {
+      static_assert(VIndex == (ImageDimension - 1),
+        "For a smaller index value, the other overload should be picked");
+
+      ++m_IterationOffset[VIndex];
+      m_BufferIterator += m_OffsetTable[VIndex];
+    }
+
+
+    template <std::size_t VIndex>
+    void Decrement(std::true_type) ITK_NOEXCEPT
+    {
+      static_assert(VIndex < (ImageDimension - 1),
+        "For a larger index value, the other overload should be picked");
+
+      m_BufferIterator -= m_OffsetTable[VIndex];
+
+      if (--m_IterationOffset[VIndex] < 0)
+      {
+        m_IterationOffset[VIndex] = m_IterationRegionSize[VIndex] - 1;
+        m_BufferIterator += m_OffsetTable[VIndex] * m_IterationRegionSize[VIndex];
+        this->Decrement<VIndex + 1>(std::integral_constant < bool, (VIndex + 1) < (ImageDimension - 1) > {});
+      }
+    }
+
+    template <std::size_t VIndex>
+    void Decrement(std::false_type) ITK_NOEXCEPT
+    {
+      static_assert(VIndex == (ImageDimension - 1),
+        "For a smaller index value, the other overload should be picked");
+
+      --m_IterationOffset[VIndex];
+      m_BufferIterator -= m_OffsetTable[VIndex];
+    }
+
+
+  public:
+    // Types conforming the iterator requirements of the C++ standard library:
+    using difference_type = std::ptrdiff_t;
+    using value_type = typename std::iterator_traits<QualifiedBufferIteratorType>::value_type;
+    using reference = typename std::iterator_traits<QualifiedBufferIteratorType>::reference;
+    using pointer = typename std::iterator_traits<QualifiedBufferIteratorType>::pointer;
+    using iterator_category = std::bidirectional_iterator_tag;
+
+    /** Default-constructor, as required for any C++11 Forward Iterator. Offers
+     * the guarantee added to the C++14 Standard: "value-initialized iterators
+     * may be compared and shall compare equal to other value-initialized
+     * iterators of the same type."
+     */
+    QualifiedIterator() = default;
+
+    /** Constructor that allows implicit conversion from non-const to const
+     * iterator. Also serves as copy-constructor of a non-const iterator.  */
+    QualifiedIterator(const QualifiedIterator<false>& arg) ITK_NOEXCEPT
+      :
+    m_BufferIterator(arg.m_BufferIterator),
+      // Note: Use parentheses instead of curly braces to initialize data members,
+      // to avoid AppleClang 6.0.0.6000056 compilation error, "no viable conversion..."
+      m_OffsetTable(arg.m_OffsetTable),
+      m_IterationOffset(arg.m_IterationOffset),
+      m_IterationRegionSize(arg.m_IterationRegionSize)
+    {
+    }
+
+
+    /**  Returns a reference to the current pixel. */
+    reference operator*() const ITK_NOEXCEPT
+    {
+      return *m_BufferIterator;
+    }
+
+    /** Prefix increment ('++it'). */
+    QualifiedIterator& operator++() ITK_NOEXCEPT
+    {
+      this->Increment<0>(std::integral_constant<bool, (ImageDimension > 1)>{});
+      return *this;
+    }
+
+
+    /** Postfix increment ('it++').
+     * \note Usually prefix increment ('++it') is preferable. */
+    QualifiedIterator operator++(int) ITK_NOEXCEPT
+    {
+      auto result = *this;
+      ++(*this);
+      return result;
+    }
+
+
+    /** Prefix decrement ('--it'). */
+    QualifiedIterator& operator--() ITK_NOEXCEPT
+    {
+      this->Decrement<0>(std::integral_constant<bool, (ImageDimension > 1)>{});
+      return *this;
+    }
+
+
+    /** Postfix increment ('it--').
+     * \note  Usually prefix increment ('--it') is preferable. */
+    QualifiedIterator operator--(int) ITK_NOEXCEPT
+    {
+      auto result = *this;
+      --(*this);
+      return result;
+    }
+
+
+    /** Returns (it1 == it2) for iterators it1 and it2. Note that these iterators
+     * should be from the same range. This operator does not support comparing iterators
+     * from different ranges. */
+    friend bool operator==(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      return lhs.m_BufferIterator == rhs.m_BufferIterator;
+    }
+
+
+    /** Returns (it1 != it2) for iterators it1 and it2. */
+    friend bool operator!=(const QualifiedIterator& lhs, const QualifiedIterator& rhs) ITK_NOEXCEPT
+    {
+      // Implemented just like the corresponding std::rel_ops operator.
+      return !(lhs == rhs);
+    }
+
+
+    /** Explicitly-defaulted assignment operator. */
+    QualifiedIterator& operator=(const QualifiedIterator&) ITK_NOEXCEPT = default;
+
+
+    /** Explicitly-defaulted destructor. */
+    ~QualifiedIterator() = default;
+  };
+
+  // Inspired by, and originally copied from ImageBase::FastComputeOffset(ind)).
+  static OffsetValueType ComputeOffset(
+    const OffsetTableType& offsetTable,
+    const IndexType & bufferedRegionIndex,
+    const IndexType& index)
+  {
+    OffsetValueType offsetValue = 0;
+    ImageHelper<ImageDimension, ImageDimension>::ComputeOffset(
+      bufferedRegionIndex,
+      index,
+      offsetTable.data(),
+      offsetValue);
+    return offsetValue;
+  }
+
+  // ImageRegionRange data members (strictly private):
+
+  BufferIteratorType m_BufferBegin{};
+
+  IndexType m_BufferedRegionIndex{ {} };
+
+  IndexType m_IterationRegionIndex{ {} };
+
+  SizeType m_IterationRegionSize{ {} };
+
+  // A copy of the offset table of the image.
+  OffsetTableType m_OffsetTable{ {} };
+
+public:
+  using const_iterator = QualifiedIterator<true>;
+  using iterator = QualifiedIterator<IsImageTypeConst>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+
+  /** Constructs an empty range
+   */
+  ImageRegionRange() ITK_NOEXCEPT = default;
+
+
+  /** Constructs an object, representing the range of pixels of the specified
+  * region, within the specified image.
+   */
+  explicit ImageRegionRange(TImage& image, const RegionType& iterationRegion)
+    :
+    m_BufferBegin{ std::begin(ImageBufferRange<TImage>{ image }) },
+    // Note: Use parentheses instead of curly braces to initialize data members,
+    // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."
+    m_BufferedRegionIndex(image.TImage::GetBufferedRegion().GetIndex()),
+    m_IterationRegionIndex(iterationRegion.GetIndex()),
+    m_IterationRegionSize(iterationRegion.GetSize())
+  {
+    const OffsetValueType* const offsetTable = image.GetOffsetTable();
+    assert(offsetTable != nullptr);
+
+    if (iterationRegion.GetNumberOfPixels() > 0) // If region is non-empty
+    {
+      // Check if the iteration region is within the buffered region, similar
+      // to checks in ImageConstIteratorWithIndex(const TImage*, const RegionType&)
+      // and ImageConstIterator::SetRegion(const RegionType&).
+
+      const auto& bufferedRegion = image.GetBufferedRegion();
+
+      itkAssertOrThrowMacro((bufferedRegion.IsInside(iterationRegion)),
+        "Iteration region " << iterationRegion <<
+        " is outside of buffered region " << bufferedRegion);
+    }
+
+    std::copy_n(offsetTable, ImageDimension + 1, m_OffsetTable.data());
+  }
+
+
+  /** Constructs a range of the pixels of the requested region of an image.
+   */
+  explicit ImageRegionRange(TImage& image)
+    :
+    ImageRegionRange(image, image.GetRequestedRegion())
+  {
+  }
+
+
+  /** Returns an iterator to the first pixel. */
+  iterator begin() const ITK_NOEXCEPT
+  {
+    return iterator
+    {
+      m_BufferBegin + Self::ComputeOffset(m_OffsetTable, m_BufferedRegionIndex, m_IterationRegionIndex),
+      m_OffsetTable,
+      OffsetType(),
+      m_IterationRegionSize
+    };
+  }
+
+  /** Returns an 'end iterator' for this range. */
+  iterator end() const ITK_NOEXCEPT
+  {
+    auto endRegionIndex = m_IterationRegionIndex;
+    endRegionIndex.back() += m_IterationRegionSize.back();
+
+    OffsetType iterationOffset{};
+    *(iterationOffset.rbegin()) = m_IterationRegionSize.back();
+
+    return iterator
+    {
+      m_BufferBegin + Self::ComputeOffset(m_OffsetTable, m_BufferedRegionIndex, endRegionIndex),
+      m_OffsetTable,
+      iterationOffset,
+      m_IterationRegionSize
+    };
+  }
+
+  /** Returns a const iterator to the first pixel.
+   * Provides only read-only access to the pixel data. */
+  const_iterator cbegin() const ITK_NOEXCEPT
+  {
+    return this->begin();
+  }
+
+  /** Returns a const 'end iterator' for this range. */
+  const_iterator cend() const ITK_NOEXCEPT
+  {
+    return this->end();
+  }
+
+  /** Returns a reverse 'begin iterator' for this range. */
+  reverse_iterator rbegin() const ITK_NOEXCEPT
+  {
+    return reverse_iterator{ this->end() };
+  }
+
+  /** Returns a reverse 'end iterator' for this range. */
+  reverse_iterator rend() const ITK_NOEXCEPT
+  {
+    return reverse_iterator{ this->begin() };
+  }
+
+  /** Returns a const reverse 'begin iterator' for this range. */
+  const_reverse_iterator crbegin() const ITK_NOEXCEPT
+  {
+    return this->rbegin();
+  }
+
+  /** Returns a const reverse 'end iterator' for this range. */
+  const_reverse_iterator crend() const ITK_NOEXCEPT
+  {
+    return this->rend();
+  }
+
+
+  /** Returns the size of the range, that is the number of pixels in the region. */
+  std::size_t size() const ITK_NOEXCEPT
+  {
+    return std::accumulate(
+      m_IterationRegionSize.begin(),
+      m_IterationRegionSize.end(),
+      std::size_t{1},
+      std::multiplies<std::size_t>{});
+  }
+
+
+  /** Tells whether the range is empty. */
+  bool empty() const ITK_NOEXCEPT
+  {
+    return std::any_of(
+      m_IterationRegionSize.begin(),
+      m_IterationRegionSize.end(),
+      [](const SizeValueType sizeValue)
+    {
+      return sizeValue == 0;
+    });
+  }
+
+
+  /** Explicitly-defaulted destructor. */
+  ~ImageRegionRange() = default;
+};
+
+} // namespace Experimental
+} // namespace itk
+
+#endif

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -617,6 +617,7 @@ set(ITKCommonGTests
       itkImageNeighborhoodOffsetsGTest.cxx
       itkImageBaseGTest.cxx
       itkImageBufferRangeGTest.cxx
+      itkImageRegionRangeGTest.cxx
       itkIndexRangeGTest.cxx
       itkMersenneTwisterRandomVariateGeneratorGTest.cxx
       itkPointGTest.cxx

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -1,0 +1,601 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+ // First include the header file to be tested:
+#include "itkImageRegionRange.h"
+
+#include "itkImage.h"
+#include "itkImageBufferRange.h"
+#include "itkImageRegionIterator.h"
+#include "itkMacro.h" // For itkNotUsed.
+#include "itkRGBPixel.h"
+#include "itkRangeGTestUtilities.h"
+#include "itkVectorImage.h"
+
+#include <gtest/gtest.h>
+#include <algorithm>  // For std::reverse_copy, std::equal, etc.
+#include <numeric>  // For std::inner_product
+#include <type_traits>  // For std::is_reference.
+
+// Test template instantiations for various ImageDimension values, and const Image:
+template class itk::Experimental::ImageRegionRange<itk::Image<short, 1>>;
+template class itk::Experimental::ImageRegionRange<itk::Image<short, 2>>;
+template class itk::Experimental::ImageRegionRange<itk::Image<short, 3>>;
+template class itk::Experimental::ImageRegionRange<itk::Image<short, 4>>;
+template class itk::Experimental::ImageRegionRange<const itk::Image<short>>;
+template class itk::Experimental::ImageRegionRange<itk::VectorImage<short>>;
+template class itk::Experimental::ImageRegionRange<const itk::VectorImage<short>>;
+template class itk::Experimental::ImageRegionRange<itk::Image<itk::RGBPixel<std::uint8_t>>>;
+template class itk::Experimental::ImageRegionRange<itk::Image<itk::Vector<long, 11>>>;
+
+using itk::Experimental::ImageRegionRange;
+
+
+namespace
+{
+  // Tells whether or not ImageRegionRange<TImage>::iterator::operator*() returns a reference.
+  // (If it does not return a reference, it actually returns a proxy to the pixel.)
+  template <typename TImage>
+  constexpr bool DoesImageRegionRangeIteratorDereferenceOperatorReturnReference()
+  {
+    using IteratorType = typename ImageRegionRange<TImage>::iterator;
+
+    return std::is_reference<decltype(*std::declval<IteratorType>())>::value;
+  }
+
+
+  static_assert(DoesImageRegionRangeIteratorDereferenceOperatorReturnReference<itk::Image<int>>(),
+    "ImageRegionRange::iterator::operator*() should return a reference for an itk::Image.");
+  static_assert(DoesImageRegionRangeIteratorDereferenceOperatorReturnReference<const itk::Image<int>>(),
+    "ImageRegionRange::iterator::operator*() should return a reference for a 'const' itk::Image.");
+  static_assert(!DoesImageRegionRangeIteratorDereferenceOperatorReturnReference<itk::VectorImage<int>>(),
+    "ImageRegionRange::iterator::operator*() should not return a reference for an itk::VectorImage.");
+  static_assert(!DoesImageRegionRangeIteratorDereferenceOperatorReturnReference<const itk::VectorImage<int>>(),
+    "ImageRegionRange::iterator::operator*() should not return a reference for a 'const' itk::VectorImage.");
+
+
+  template<typename TImage>
+  typename TImage::Pointer CreateImage(const unsigned sizeX, const unsigned sizeY)
+  {
+    const auto image = TImage::New();
+    const typename TImage::SizeType imageSize = { { sizeX , sizeY } };
+    image->SetRegions(imageSize);
+    image->Allocate();
+    return image;
+  }
+
+
+  // Creates a test image, filled with a sequence of natural numbers, 1, 2, 3, ..., N.
+  template<typename TImage>
+  typename TImage::Pointer CreateImageFilledWithSequenceOfNaturalNumbers(const unsigned sizeX, const unsigned sizeY)
+  {
+    using PixelType = typename TImage::PixelType;
+    const auto image = CreateImage<TImage>(sizeX, sizeY);
+    const itk::Experimental::ImageBufferRange<TImage> imageBufferRange{ *image };
+    std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
+    return image;
+  }
+
+
+  template< typename TPixel, unsigned VImageDimension >
+  void SetVectorLengthIfImageIsVectorImage(
+    itk::VectorImage<TPixel, VImageDimension>& image,
+    const unsigned vectorLength)
+  {
+    image.SetVectorLength(vectorLength);
+  }
+
+
+  template< typename TPixel, unsigned VImageDimension >
+  void SetVectorLengthIfImageIsVectorImage(
+    itk::Image<TPixel, VImageDimension>& itkNotUsed(image),
+    const unsigned itkNotUsed(vectorLength))
+  {
+    // Do not set the VectorLength. The specified image is not a VectorImage.
+  }
+
+
+  template <typename TRange>
+  void ExpectBeginIsEndWhenRangeIsDefaultConstructed()
+  {
+    TRange defaultConstructedRange;
+    EXPECT_EQ(defaultConstructedRange.begin(), defaultConstructedRange.end());
+  }
+
+
+  template <typename TRange>
+  void ExpectRangeIsEmptyWhenDefaultConstructed()
+  {
+    TRange defaultConstructedRange;
+    EXPECT_TRUE(defaultConstructedRange.empty());
+  }
+
+
+  template <typename TImage>
+  void ExpectRangeIsNotEmptyForNonEmptyImage()
+  {
+    // First create a non-empty image:
+    const auto image = TImage::New();
+    typename TImage::SizeType imageSize;
+    imageSize.Fill(1);
+    image->SetRegions(imageSize);
+    SetVectorLengthIfImageIsVectorImage(*image, 1);
+    image->Allocate();
+
+    EXPECT_FALSE((ImageRegionRange<TImage>{ *image }.empty()));
+  }
+
+
+  template <typename TImage>
+  void Expect_ImageRegionRange_iterates_forward_over_same_pixels_as_ImageRegionIterator(
+    TImage& image,
+    const itk::ImageRegion<TImage::ImageDimension>& iterationRegion)
+  {
+    using PixelType = typename TImage::PixelType;
+
+    itk::ImageRegionIterator<TImage> imageRegionIterator{ &image, iterationRegion };
+    ImageRegionRange<TImage> range{ image, iterationRegion };
+
+    ASSERT_TRUE(imageRegionIterator.IsAtBegin());
+
+    for (const PixelType pixel : range)
+    {
+      ASSERT_FALSE(imageRegionIterator.IsAtEnd());
+      EXPECT_EQ(pixel, imageRegionIterator.Get());
+      ++imageRegionIterator;
+    }
+    EXPECT_TRUE(imageRegionIterator.IsAtEnd());
+  }
+
+  template <typename TImage>
+  void Expect_ImageRegionRange_iterates_backward_over_same_pixels_as_ImageRegionIterator(
+    TImage& image,
+    const itk::ImageRegion<TImage::ImageDimension>& iterationRegion)
+  {
+    itk::ImageRegionIterator<TImage> imageRegionIterator{ &image, iterationRegion };
+    ImageRegionRange<TImage> range{ image, iterationRegion };
+
+    auto rangeIterator = range.cend();
+    imageRegionIterator.GoToEnd();
+
+    while (!imageRegionIterator.IsAtBegin())
+    {
+      ASSERT_NE(rangeIterator, range.begin());
+      --imageRegionIterator;
+      --rangeIterator;
+      EXPECT_EQ(*rangeIterator, imageRegionIterator.Get());
+    };
+
+    EXPECT_EQ(rangeIterator, range.begin());
+  }
+
+  template <typename TImage>
+  void Check_Range_constructor_throws_ExceptionObject_when_iteration_region_is_outside_of_buffered_region(
+    TImage& image,
+    const typename TImage::RegionType& region)
+  {
+    try
+    {
+      const ImageRegionRange<TImage> range{ image, region };
+
+      // The test fails when the construction of this range does not trigger an exception.
+      GTEST_FAIL();
+    }
+    catch (const itk::ExceptionObject& exceptionObject)
+    {
+      const char* const description = exceptionObject.GetDescription();
+      ASSERT_NE(description, nullptr);
+      EXPECT_TRUE(std::strstr(description, "outside of buffered region") != nullptr);
+    }
+  }
+
+
+}  // namespace
+
+
+// Tests that a begin iterator compares equal to another begin iterator of the
+// same range. Also does this test for end iterators.
+TEST(ImageRegionRange, EquivalentBeginOrEndIteratorsCompareEqual)
+{
+  using ImageType = itk::Image<int>;
+  using RangeType = ImageRegionRange<ImageType>;
+
+  const auto image = CreateImage<ImageType>(2, 3);
+
+  const RangeType range{*image};
+
+  const RangeType::iterator begin = range.begin();
+  const RangeType::iterator end = range.end();
+  const RangeType::const_iterator cbegin = range.cbegin();
+  const RangeType::const_iterator cend = range.cend();
+
+  // An iterator object compares equal to itself:
+  EXPECT_EQ(begin, begin);
+  EXPECT_EQ(end, end);
+  EXPECT_EQ(cbegin, cbegin);
+  EXPECT_EQ(cend, cend);
+
+  // Multiple calls of the same function yield equivalent objects:
+  EXPECT_EQ(range.begin(), range.begin());
+  EXPECT_EQ(range.end(), range.end());
+  EXPECT_EQ(range.cbegin(), range.cbegin());
+  EXPECT_EQ(range.cend(), range.cend());
+
+  // Corresponding const_iterator and non-const iterator compare equal:
+  EXPECT_EQ(begin, cbegin);
+  EXPECT_EQ(end, cend);
+  EXPECT_EQ(cbegin, begin);
+  EXPECT_EQ(cend, end);
+}
+
+
+TEST(ImageRegionRange, BeginAndEndOfNonEmptyImageRegionAreNotEqual)
+{
+  using ImageType = itk::Image<int>;
+
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  const auto image = CreateImage<ImageType>(2, 3);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  ImageRegionRange<ImageType> range{ *image, region };
+
+  EXPECT_FALSE(range.begin() == range.end());
+  EXPECT_NE(range.begin(), range.end());
+}
+
+
+// Tests that an iterator converts (implicitly) to a const_iterator.
+TEST(ImageRegionRange, IteratorConvertsToConstIterator)
+{
+  using ImageType = itk::Image<int>;
+  using RangeType = ImageRegionRange<ImageType>;
+
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  const auto image = CreateImage<ImageType>(2, 3);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  RangeType range{ *image, region };
+
+  const RangeType::iterator begin = range.begin();
+  const RangeType::const_iterator const_begin_from_begin = begin;
+  EXPECT_EQ(const_begin_from_begin, begin);
+
+  const RangeType::const_iterator const_begin_from_range_begin = range.begin();
+  EXPECT_EQ(const_begin_from_range_begin, range.begin());
+}
+
+
+// Tests that the iterators of an ImageRegionRange can be used as first and
+// second argument of an std::vector constructor.
+TEST(ImageRegionRange, IteratorsCanBePassedToStdVectorConstructor)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  ImageRegionRange<ImageType> range{ *image, region };
+
+  // Easily store all pixels of the ImageRegionRange in an std::vector:
+  const std::vector<PixelType> stdVector(range.begin(), range.end());
+  EXPECT_EQ(stdVector, std::vector<PixelType>(range.cbegin(), range.cend()));
+  EXPECT_TRUE(std::equal(stdVector.begin(), stdVector.end(), range.cbegin()));
+}
+
+
+// Tests that the iterators can be used as first and
+// second argument of std::reverse (which requires bidirectional iterators).
+TEST(ImageRegionRange, IteratorsCanBePassedToStdReverseCopy)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  ImageRegionRange<ImageType> range{ *image, region };
+
+  const unsigned numberOfPixels = sizeX * sizeY;
+
+  const std::vector<PixelType> stdVector(range.begin(), range.end());
+  std::vector<PixelType> reversedStdVector1(numberOfPixels);
+  std::vector<PixelType> reversedStdVector2(numberOfPixels);
+  std::vector<PixelType> reversedStdVector3(numberOfPixels);
+
+  // Checks bidirectionality of the ImageRegionRange iterators!
+  std::reverse_copy(stdVector.cbegin(), stdVector.cend(), reversedStdVector1.begin());
+  std::reverse_copy(range.begin(), range.end(), reversedStdVector2.begin());
+  std::reverse_copy(range.cbegin(), range.cend(), reversedStdVector3.begin());
+
+  // Sanity check
+  EXPECT_NE(reversedStdVector1, stdVector);
+  EXPECT_NE(reversedStdVector2, stdVector);
+  EXPECT_NE(reversedStdVector3, stdVector);
+
+  // The real tests:
+  EXPECT_EQ(reversedStdVector1, reversedStdVector2);
+  EXPECT_EQ(reversedStdVector1, reversedStdVector3);
+}
+
+
+// Tests that the iterators can be used as first and
+// second argument of std::inner_product.
+TEST(ImageRegionRange, IteratorsCanBePassedToStdInnerProduct)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  enum { sizeX = 2, sizeY = 2 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  ImageRegionRange<ImageType> range{ *image, region };
+
+  const double innerProduct = std::inner_product(range.begin(), range.end(), range.begin(), 0.0);
+
+  EXPECT_EQ(innerProduct, 30);
+}
+
+
+// Tests that the iterators can be used as first and
+// second argument of std::for_each.
+TEST(ImageRegionRange, IteratorsCanBePassedToStdForEach)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  ImageRegionRange<ImageType> range{ *image, region };
+
+  std::for_each(range.begin(), range.end(), [](const PixelType pixel)
+  {
+    EXPECT_TRUE(pixel > 0);
+  });
+}
+
+
+// Tests that an ImageRegionRange can be used as the "range expression" of a
+// C++11 range-based for loop.
+TEST(ImageRegionRange, CanBeUsedAsExpressionOfRangeBasedForLoop)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  using RangeType = ImageRegionRange<ImageType>;
+
+  enum { sizeX = 2, sizeY = 3 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  RangeType range{ *image, region };
+
+  for (const PixelType pixel : range)
+  {
+    EXPECT_NE(pixel, 42);
+  }
+
+  for (auto&& pixel : range)
+  {
+    pixel = 42;
+  }
+
+  for (const PixelType pixel : range)
+  {
+    EXPECT_EQ(pixel, 42);
+  }
+}
+
+
+// Tests that ImageRegionRange<VectorImage<T>> is supported well.
+TEST(ImageRegionRange, SupportsVectorImage)
+{
+  using ImageType = itk::VectorImage<unsigned char>;
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  using PixelType = ImageType::PixelType;
+  enum { vectorLength = 2, sizeX = 2, sizeY = 2, sizeZ = 2 };
+  const auto image = ImageType::New();
+  const typename ImageType::SizeType imageSize = { { sizeX , sizeY, sizeZ } };
+  image->SetRegions(imageSize);
+  image->SetVectorLength(vectorLength);
+  image->Allocate(true);
+  PixelType fillPixelValue(vectorLength);
+  fillPixelValue.Fill(42);
+  image->FillBuffer(fillPixelValue);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  using RangeType = ImageRegionRange<ImageType>;
+  RangeType range{ *image, region };
+
+  for (PixelType pixelValue : range)
+  {
+    EXPECT_EQ(pixelValue, fillPixelValue);
+  }
+
+  PixelType otherPixelValue(vectorLength);
+  otherPixelValue.Fill(1);
+  image->SetPixel({ {} }, otherPixelValue);
+
+  RangeType::const_iterator it = range.begin();
+  const PixelType firstPixelValueFromRange = *it;
+  EXPECT_EQ(firstPixelValueFromRange, otherPixelValue);
+  ++it;
+  const PixelType secondPixelValueFromRange = *it;
+  EXPECT_EQ(secondPixelValueFromRange, fillPixelValue);
+}
+
+
+TEST(ImageRegionRange, IteratorIsDefaultConstructible)
+{
+  using RangeType = ImageRegionRange<itk::Image<int>>;
+
+  RangeType::iterator defaultConstructedIterator{};
+
+  // Test that a default-constructed iterator behaves according to C++ proposal
+  // N3644, "Null Forward Iterators" by Alan Talbot, which is accepted with
+  // C++14: "value-initialized iterators may be compared and shall compare
+  // equal to other value-initialized iterators of the same type."
+  // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3644.pdf
+
+  EXPECT_TRUE(defaultConstructedIterator == defaultConstructedIterator);
+  EXPECT_FALSE(defaultConstructedIterator != defaultConstructedIterator);
+  EXPECT_EQ(defaultConstructedIterator, RangeType::iterator{});
+}
+
+
+TEST(ImageRegionRange, ProvidesReverseIterators)
+{
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType>;
+  constexpr auto ImageDimension = ImageType::ImageDimension;
+  using RangeType = ImageRegionRange<ImageType>;
+  enum { sizeX = 9, sizeY = 11 };
+  const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
+  const itk::ImageRegion<ImageDimension> region{ itk::Size<ImageDimension>::Filled(2) };
+
+  RangeType range{ *image, region };
+
+  const unsigned numberOfPixels = sizeX * sizeY;
+
+  const std::vector<PixelType> stdVector(range.begin(), range.end());
+  std::vector<PixelType> reversedStdVector1(numberOfPixels);
+  std::vector<PixelType> reversedStdVector2(numberOfPixels);
+  std::vector<PixelType> reversedStdVector3(numberOfPixels);
+
+  std::reverse_copy(stdVector.cbegin(), stdVector.cend(), reversedStdVector1.begin());
+
+  const RangeType::const_reverse_iterator crbegin = range.crbegin();
+  const RangeType::const_reverse_iterator crend = range.crend();
+  const RangeType::reverse_iterator rbegin = range.rbegin();
+  const RangeType::reverse_iterator rend = range.rend();
+
+  EXPECT_EQ(crbegin, rbegin);
+  EXPECT_EQ(crend, rend);
+
+  std::copy(crbegin, crend, reversedStdVector2.begin());
+  std::copy(rbegin, rend, reversedStdVector3.begin());
+
+  // Sanity check
+  EXPECT_NE(reversedStdVector1, stdVector);
+  EXPECT_NE(reversedStdVector2, stdVector);
+  EXPECT_NE(reversedStdVector3, stdVector);
+
+  // The real tests:
+  EXPECT_EQ(reversedStdVector1, reversedStdVector2);
+  EXPECT_EQ(reversedStdVector1, reversedStdVector3);
+}
+
+
+// Tests that begin() == end() for a default-constructed range.
+TEST(ImageRegionRange, BeginIsEndWhenDefaultConstructed)
+{
+  ExpectBeginIsEndWhenRangeIsDefaultConstructed<ImageRegionRange<itk::Image<int>>>();
+  ExpectBeginIsEndWhenRangeIsDefaultConstructed<ImageRegionRange<itk::VectorImage<int>>>();
+}
+
+
+// Tests empty() for a default-constructed range.
+TEST(ImageRegionRange, IsEmptyWhenDefaultConstructed)
+{
+  ExpectRangeIsEmptyWhenDefaultConstructed<ImageRegionRange<itk::Image<int>>>();
+  ExpectRangeIsEmptyWhenDefaultConstructed<ImageRegionRange<itk::VectorImage<int>>>();
+}
+
+
+// Tests that range.empty() returns false for a non-empty image.
+TEST(ImageRegionRange, IsNotEmptyWhenImageIsNonEmpty)
+{
+  ExpectRangeIsNotEmptyForNonEmptyImage<itk::Image<int>>();
+  ExpectRangeIsNotEmptyForNonEmptyImage<itk::VectorImage<int>>();
+}
+
+
+TEST(ImageRegionRange, IteratesForwardOverSamePixelsAsImageRegionIterator)
+{
+  using ImageType = itk::Image<unsigned char>;
+
+  using PixelType = ImageType::PixelType ;
+  using IndexType = ImageType::IndexType;
+  using SizeType = ImageType::SizeType;
+  using RegionType = ImageType::RegionType;
+
+  const auto image = ImageType::New();
+  image->SetRegions(RegionType{ IndexType{ {-1, -2}},  SizeType{ { 9 , 11 } } });
+  image->Allocate();
+  const itk::Experimental::ImageBufferRange<ImageType> imageBufferRange{ *image };
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
+
+  Expect_ImageRegionRange_iterates_forward_over_same_pixels_as_ImageRegionIterator(
+    *image, RegionType{ IndexType{{1, 2}}, SizeType{{3, 4}} });
+}
+
+
+TEST(ImageRegionRange, IteratesBackwardOverSamePixelsAsImageRegionIterator)
+{
+  using ImageType = itk::Image<unsigned char>;
+
+  using PixelType = ImageType::PixelType;
+  using IndexType = ImageType::IndexType;
+  using SizeType = ImageType::SizeType;
+  using RegionType = ImageType::RegionType;
+
+  const auto image = ImageType::New();
+  image->SetRegions(RegionType{ IndexType{ {-1, -2}},  SizeType{ { 9 , 11 } } });
+  image->Allocate();
+  const itk::Experimental::ImageBufferRange<ImageType> imageBufferRange{ *image };
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
+
+  Expect_ImageRegionRange_iterates_backward_over_same_pixels_as_ImageRegionIterator(
+    *image, RegionType{ IndexType{{1, 2}}, SizeType{{3, 4}} });
+}
+
+
+// Tests that a range constructor throws an itk::ExceptionObject when the
+// iteration region is not entirely within the buffered region.
+TEST(ImageRegionRange, ThrowsInReleaseWhenIterationRegionIsOutsideBufferedRegion)
+{
+#ifdef NDEBUG
+  // NDEBUG suggests that we are in Release mode.
+
+  using ImageType = itk::Image<unsigned char>;
+
+  using IndexType = ImageType::IndexType;
+  using SizeType = ImageType::SizeType;
+  using RegionType = ImageType::RegionType;
+
+  const auto image = ImageType::New();
+
+  const IndexType imageIndex{ {-1, -2} };
+  const SizeType imageSize{ {3 , 4} };
+
+  image->SetRegions(RegionType{ imageIndex, imageSize});
+  image->Allocate(true);
+
+  Check_Range_constructor_throws_ExceptionObject_when_iteration_region_is_outside_of_buffered_region(
+    *image, RegionType{ imageIndex, imageSize + SizeType::Filled(1) });
+
+  Check_Range_constructor_throws_ExceptionObject_when_iteration_region_is_outside_of_buffered_region(
+    *image, RegionType{ imageIndex - SizeType::Filled(1), imageSize });
+
+#endif
+}

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -20,8 +20,7 @@
 
 #include "itkMath.h"
 #include "itkImageMaskSpatialObject.h"
-#include "itkImageRegionConstIterator.h"
-#include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkImageRegionRange.h"
 
 #include <cstdint> // For uintmax_t.
 
@@ -181,11 +180,11 @@ ImageMaskSpatialObject< TDimension, TPixel >
 
   const auto HasForegroundPixels = [&image](const RegionType& region)
   {
-    for (ImageRegionConstIterator<ImageType> it{ &image, region }; !it.IsAtEnd(); ++it)
+    for (const PixelType pixelValue: Experimental::ImageRegionRange<const ImageType>{ image, region })
     {
       constexpr auto zeroValue = NumericTraits<PixelType>::ZeroValue();
 
-      if (it.Get() != zeroValue)
+      if (pixelValue != zeroValue)
       {
         return true;
       }


### PR DESCRIPTION
Added `ImageRegionRange<TImage>` to the `itk::Experimental` namespace,
supporting modern C++ iteration (bidirectional) over a range of pixels
of an image region.

Replaced the classic `ImageRegionConstIterator<ImageType>` by
`ImageRegionRange<const ImageType>`, when doing bounding box computation
in `ImageMaskSpatialObject`. A performance improvement of 5 % or more
was observed.