### PR TITLE
STYLE: Replace std::copy(input, input + n, output) by C++11 std::copy_n

### DIFF
--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -192,7 +192,7 @@ GaussianDerivativeOperator< TPixel, VDimension, TAllocator >
   // Make symmetric
   size_t s = coeff.size() - 1;
   coeff.insert(coeff.begin(), s, 0);
-  std::copy( coeff.rbegin(), coeff.rbegin() + s, coeff.begin() );
+  std::copy_n( coeff.rbegin(), s, coeff.begin() );
 
   return coeff;
 }

--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
@@ -49,9 +49,7 @@ ImageConstIteratorWithIndex< TImage >
   m_EndIndex          = it.m_EndIndex;
   m_Region            = it.m_Region;
 
-  std::copy(it.m_OffsetTable,
-            it.m_OffsetTable+ImageDimension + 1,
-            m_OffsetTable);
+  std::copy_n(it.m_OffsetTable, ImageDimension + 1, m_OffsetTable);
 
   m_Position    = it.m_Position;
   m_Begin       = it.m_Begin;
@@ -86,9 +84,7 @@ ImageConstIteratorWithIndex< TImage >
                            "Region " << m_Region << " is outside of buffered region " << bufferedRegion );
     }
 
-  std::copy(m_Image->GetOffsetTable(),
-            m_Image->GetOffsetTable()+ImageDimension + 1 ,
-            m_OffsetTable);
+  std::copy_n(m_Image->GetOffsetTable(), ImageDimension + 1, m_OffsetTable);
 
   // Compute the start position
   OffsetValueType offs =  m_Image->ComputeOffset(m_BeginIndex);
@@ -134,9 +130,7 @@ ImageConstIteratorWithIndex< TImage >
     m_PositionIndex     = it.m_PositionIndex;
     m_Region            = it.m_Region;
 
-    std::copy(it.m_OffsetTable,
-              it.m_OffsetTable+ImageDimension + 1,
-              m_OffsetTable);
+    std::copy_n(it.m_OffsetTable, ImageDimension + 1, m_OffsetTable);
 
     m_Position    = it.m_Position;
     m_Begin       = it.m_Begin;

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
@@ -46,9 +46,7 @@ ImageConstIteratorWithOnlyIndex< TImage >
   m_EndIndex          = it.m_EndIndex;
   m_Region            = it.m_Region;
 
-  std::copy(it.m_OffsetTable,
-            it.m_OffsetTable+ImageDimension + 1,
-            m_OffsetTable);
+  std::copy_n(it.m_OffsetTable, ImageDimension + 1, m_OffsetTable);
 
   m_Remaining   = it.m_Remaining;
 }
@@ -66,9 +64,7 @@ ImageConstIteratorWithOnlyIndex< TImage >
   m_PositionIndex     = m_BeginIndex;
   m_Region            = region;
 
-  std::copy(m_Image->GetOffsetTable(),
-            m_Image->GetOffsetTable()+ImageDimension + 1,
-            m_OffsetTable);
+  std::copy_n(m_Image->GetOffsetTable(), ImageDimension + 1, m_OffsetTable);
 
   // Compute the end offset
   m_Remaining = false;
@@ -102,9 +98,7 @@ ImageConstIteratorWithOnlyIndex< TImage >
     m_PositionIndex     = it.m_PositionIndex;
     m_Region            = it.m_Region;
 
-    std::copy(it.m_OffsetTable,
-              it.m_OffsetTable+ImageDimension + 1,
-              m_OffsetTable);
+    std::copy_n(it.m_OffsetTable, ImageDimension + 1, m_OffsetTable);
 
     m_Remaining   = it.m_Remaining;
     }

--- a/Modules/Core/Common/include/itkImportImageContainer.hxx
+++ b/Modules/Core/Common/include/itkImportImageContainer.hxx
@@ -29,6 +29,7 @@
 #define itkImportImageContainer_hxx
 
 #include "itkImportImageContainer.h"
+#include <algorithm> // For copy_n.
 
 namespace itk
 {
@@ -67,9 +68,7 @@ ImportImageContainer< TElementIdentifier, TElement >
       {
       TElement *temp = this->AllocateElements(size, UseDefaultConstructor);
       // only copy the portion of the data used in the old buffer
-      std::copy(m_ImportPointer,
-                m_ImportPointer+m_Size,
-                temp);
+      std::copy_n(m_ImportPointer, m_Size, temp);
 
       DeallocateManagedMemory();
 
@@ -110,9 +109,7 @@ ImportImageContainer< TElementIdentifier, TElement >
       {
       const TElementIdentifier size = m_Size;
       TElement *               temp = this->AllocateElements(size, false);
-      std::copy(m_ImportPointer,
-                m_ImportPointer+m_Size,
-                temp);
+      std::copy_n(m_ImportPointer, m_Size, temp);
 
       DeallocateManagedMemory();
 

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -220,9 +220,7 @@ public:
    * \sa GetIndex() */
   void SetIndex(const IndexValueType val[VDimension])
   {
-    std::copy(val,
-              val + VDimension,
-              m_InternalArray);
+    std::copy_n(val, VDimension, m_InternalArray);
   }
 
   /** Sets the value of one of the elements.

--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -198,9 +198,7 @@ public:
   void SetRadius(const SizeValueType *rad)
   {
     SizeType s;
-    std::copy(rad,
-              rad+VDimension,
-              s.m_InternalArray);
+    std::copy_n(rad, VDimension, s.m_InternalArray);
     this->SetRadius(s);
   }
 

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -112,9 +112,7 @@ Neighborhood< TPixel, VDimension, TContainer >
   m_DataBuffer ( other.m_DataBuffer ),
   m_OffsetTable( other.m_OffsetTable )
 {
-  std::copy(other.m_StrideTable,
-            other.m_StrideTable+VDimension,
-            m_StrideTable);
+  std::copy_n(other.m_StrideTable, VDimension, m_StrideTable);
 }
 
 template< typename TPixel, unsigned int VDimension, typename TContainer >

--- a/Modules/Core/Common/include/itkNeighborhoodAllocator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAllocator.h
@@ -78,7 +78,7 @@ public:
     m_ElementCount(other.m_ElementCount),
     m_Data(new TPixel[other.m_ElementCount])
   {
-    std::copy(other.m_Data, other.m_Data + m_ElementCount, m_Data);
+    std::copy_n(other.m_Data, m_ElementCount, m_Data);
   }
 
 
@@ -99,7 +99,7 @@ public:
     if(this != &other)
       {
       this->set_size(other.m_ElementCount);
-      std::copy(other.m_Data, other.m_Data + m_ElementCount, m_Data);
+      std::copy_n(other.m_Data, m_ElementCount, m_Data);
     }
     return *this;
   }

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -176,9 +176,7 @@ public:
    * \sa GetOffset() */
   void SetOffset(const OffsetValueType val[VDimension])
   {
-    std::copy(val,
-              val + VDimension,
-              m_InternalArray);
+    std::copy_n(val, VDimension, m_InternalArray);
   }
 
   /** Sets the value of one of the elements.

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -20,6 +20,7 @@
 
 #include "itkIntTypes.h"
 #include "itkMacro.h"
+#include <algorithm> // For copy_n.
 #include <type_traits>
 #include <memory>
 
@@ -165,9 +166,7 @@ public:
    *  \sa GetSize */
   void SetSize(const SizeValueType val[VDimension])
   {
-    std::copy(val,
-              val + VDimension,
-              m_InternalArray);
+    std::copy_n(val, VDimension, m_InternalArray);
   }
 
   /** Sets the value of one of the elements.

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -266,7 +266,7 @@ public:
         itkAssertInDebugAndIgnoreInReleaseMacro(newBuffer);
         const std::size_t nb = std::min(newSize, oldSize);
         itkAssertInDebugAndIgnoreInReleaseMacro(nb == 0 || (nb > 0  && oldBuffer != nullptr));
-        std::copy(oldBuffer, oldBuffer+nb, newBuffer);
+        std::copy_n(oldBuffer, nb, newBuffer);
         }
     };
 

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -79,7 +79,7 @@ VariableLengthVector< TValue >
     m_Data = this->AllocateElements(m_NumElements);
     itkAssertInDebugAndIgnoreInReleaseMacro(m_Data != nullptr);
     itkAssertInDebugAndIgnoreInReleaseMacro(v.m_Data != nullptr);
-    std::copy(&v.m_Data[0], &v.m_Data[m_NumElements], &this->m_Data[0]);
+    std::copy_n(&v.m_Data[0], m_NumElements, &this->m_Data[0]);
     }
   else
     {
@@ -198,9 +198,7 @@ void VariableLengthVector< TValue >
       itkAssertInDebugAndIgnoreInReleaseMacro(temp);
       itkAssertInDebugAndIgnoreInReleaseMacro(m_NumElements == 0 || (m_NumElements>0 && m_Data != nullptr));
       // only copy the portion of the data used in the old buffer
-      std::copy(m_Data,
-                m_Data+m_NumElements,
-                temp);
+      std::copy_n(m_Data, m_NumElements, temp);
       if ( m_LetArrayManageMemory )
         {
         delete[] m_Data;
@@ -380,7 +378,7 @@ VariableLengthVector< TValue >
   itkAssertInDebugAndIgnoreInReleaseMacro(v.m_Data     != nullptr);
   itkAssertInDebugAndIgnoreInReleaseMacro(this->m_Data != nullptr);
 
-  std::copy(&v.m_Data[0], &v.m_Data[N], &this->m_Data[0]);
+  std::copy_n(&v.m_Data[0], N, &this->m_Data[0]);
 
   return *this;
 }

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -411,9 +411,7 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>
         images[j]->GetBufferPointer();
 
       ParametersValueType *dataPointer = this->m_InternalParametersBuffer.data_block();
-      std::copy(baseImagePointer,
-                baseImagePointer+numberOfPixels,
-                dataPointer);
+      std::copy_n(baseImagePointer, numberOfPixels, dataPointer);
       }
     this->SetParameters( this->m_InternalParametersBuffer );
     }

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -500,9 +500,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>
     const ParametersValueType * const baseImagePointer = images[j]->GetBufferPointer();
 
     ParametersValueType *dataPointer = this->m_InternalParametersBuffer.data_block();
-    std::copy(baseImagePointer,
-              baseImagePointer+numberOfPixels,
-              dataPointer + j * numberOfPixels);
+    std::copy_n(baseImagePointer, numberOfPixels, dataPointer + j * numberOfPixels);
 
     this->m_CoefficientImages[j]->CopyInformation( images[j] );
     this->m_CoefficientImages[j]->SetRegions( images[j]->GetLargestPossibleRegion() );

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -753,9 +753,9 @@ CompositeTransform<TParametersValueType, NDimensions>
       it--;
       const ParametersType & subParameters = (*it)->GetParameters();
       /* use vnl_vector data_block() to get data ptr */
-      std::copy(subParameters.data_block(),
-                subParameters.data_block()+subParameters.Size(),
-                &(this->m_Parameters.data_block() )[offset]);
+      std::copy_n(subParameters.data_block(),
+                  subParameters.Size(),
+                  &(this->m_Parameters.data_block() )[offset]);
       offset += subParameters.Size();
 
       }
@@ -850,9 +850,9 @@ CompositeTransform<TParametersValueType, NDimensions>
     it--;
     const FixedParametersType & subFixedParameters = (*it)->GetFixedParameters();
     /* use vnl_vector data_block() to get data ptr */
-    std::copy(subFixedParameters.data_block(),
-              subFixedParameters.data_block()+subFixedParameters.Size(),
-              &(this->m_FixedParameters.data_block() )[offset]);
+    std::copy_n(subFixedParameters.data_block(),
+                subFixedParameters.Size(),
+                &(this->m_FixedParameters.data_block() )[offset]);
     offset += subFixedParameters.Size();
     }
   while( it != transforms.begin() );

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -96,9 +96,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>
     {
     const ParametersType & subParameters = (*it)->GetParameters();
     /* use vnl_vector data_block() to get data ptr */
-    std::copy(subParameters.data_block(),
-              subParameters.data_block()+subParameters.Size(),
-              &(this->m_Parameters.data_block() )[offset]);
+    std::copy_n(subParameters.data_block(),
+                subParameters.Size(),
+                &(this->m_Parameters.data_block() )[offset]);
     offset += subParameters.Size();
     ++it;
     }
@@ -171,9 +171,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>
     {
     const FixedParametersType & subFixedParameters = (*it)->GetFixedParameters();
     /* use vnl_vector data_block() to get data ptr */
-    std::copy(subFixedParameters.data_block(),
-              subFixedParameters.data_block()+subFixedParameters.Size(),
-              &(this->m_FixedParameters.data_block() )[offset]);
+    std::copy_n(subFixedParameters.data_block(),
+                subFixedParameters.Size(),
+                &(this->m_FixedParameters.data_block() )[offset]);
     offset += subFixedParameters.Size();
     ++it;
     }

--- a/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -105,9 +105,9 @@ FFTWHalfHermitianToRealInverseFFTImageFilter< TInputImage, TOutputImage >
     // complex<double> and double[2] types are compatible memory layouts.
     // The reinterpret_cast is used here to
     // make the "C" fftw libary compatible with the c++ complex<double>.
-    std::copy( inputPtr->GetBufferPointer(),
-               inputPtr->GetBufferPointer()+totalInputSize,
-               reinterpret_cast< typename InputImageType::PixelType * > (in) );
+    std::copy_n( inputPtr->GetBufferPointer(),
+                 totalInputSize,
+                 reinterpret_cast< typename InputImageType::PixelType * > (in) );
     }
   FFTWProxyType::Execute( plan );
 

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1401,7 +1401,7 @@ void TIFFImageIO::PutGrayscale( TType *to, TType * from,
 {
   for( unsigned int y = ysize; y-- > 0;)
     {
-    std::copy(from, from + xsize, to);
+    std::copy_n(from, xsize, to);
     to += xsize;
     to += toskew;
     from += xsize;
@@ -1421,7 +1421,7 @@ void TIFFImageIO::PutRGB_( TType *to, TType * from,
 
   for( unsigned int y = ysize; y-- > 0;)
     {
-    std::copy(from, from + linesize, to);
+    std::copy_n(from, linesize, to);
 
     to += linesize;
     to += toskew;

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -353,9 +353,9 @@ BayesianClassifierImageFilter< TInputVectorImage, TLabelsType,
   while ( !itrLabelsImage.IsAtEnd() )
     {
     posteriorsPixel = itrPosteriorsImage.Get();
-    std::copy(posteriorsPixel.GetDataPointer(),
-              posteriorsPixel.GetDataPointer()+posteriorsPixel.Size(),
-              posteriorsVector.begin() );
+    std::copy_n(posteriorsPixel.GetDataPointer(),
+                posteriorsPixel.Size(),
+                posteriorsVector.begin() );
     itrLabelsImage.Set( static_cast< TLabelsType >(
                           decisionRule->Evaluate( posteriorsVector ) ) );
     ++itrLabelsImage;


### PR DESCRIPTION
Replaced each call of the form `std::copy(input, input + n, output)` by
the equivalent C++11 `std::copy_n(input, n, output)` call. Added missing
`#include <algorithm>` directives.

Does simplify the code, and might in some cases improve the performance,
especially when the original code did two function calls to retrieve the
input iterator, as in `std::copy(f(), f() + n, output)`.