### PR TITLE
STYLE: Prevent double initialization

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -162,7 +162,7 @@ public:
   m_OrderEigenValues(OrderByValue) {}
 
   SymmetricEigenAnalysis(const unsigned int dimension):
-  m_UseEigenLibrary(false),
+
   m_Dimension(dimension),
   m_Order(dimension),
   m_OrderEigenValues(OrderByValue) {}


### PR DESCRIPTION
m_UseEigenLibrary is initialized in place to false,
and does not need an initializer in the constructor.