### PR TITLE
BUG: Flawed logic for itkExceptionObject.h guards

### DIFF
--- a/Modules/Core/Common/ITKKWStyleOverwrite.txt
+++ b/Modules/Core/Common/ITKKWStyleOverwrite.txt
@@ -30,3 +30,4 @@ itkSize\.h SemicolonSpace Disable
 itkOffset\.h SemicolonSpace Disable
 itkMultiThreaderBase.h Comments Disable
 itkSingleton\.cxx Namespace Disable
+itkExceptionObject\.h IfNDefDefine Disable

--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -15,12 +15,9 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkMacro_h
-#error "Do not include itkExceptionObject.h directly,  include itkMacro.h instead."
-#else // itkMacro_h
-
 #ifndef itkExceptionObject_h
-#define itkExceptionObject_h
+#error "Do not include itkExceptionObject.h directly,  include itkMacro.h instead."
+#else // itkExceptionObject_h
 
 #include <string>
 #include <stdexcept>
@@ -307,5 +304,3 @@ public:
 } // end namespace itk
 
 #endif //itkExceptionObject_h
-
-#endif //itkMacro_h

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1330,7 +1330,9 @@ class kernel                                \
 #define ITKv5_CONST const
 #endif
 
+#define itkExceptionObject_h
 #include "itkExceptionObject.h"
+#undef itkExceptionObject_h
 
 /** itkDynamicCastInDebugMode
   * Use static_cast in Release builds, and dynamic_cast in Debug

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -19,7 +19,6 @@
 #define itkPolygonSpatialObject_hxx
 
 #include "itkPolygonSpatialObject.h"
-#include "itkExceptionObject.h"
 #include "itkMath.h"
 
 namespace itk

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -21,7 +21,6 @@
 // Disable warning for lengthy symbol names in this file only
 
 #include "itkCovariantVector.h"
-#include "itkExceptionObject.h"
 #include <list>
 #include "itkSpatialObjectProperty.h"
 #include "itkProcessObject.h"

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkPatchBasedDenoisingBaseImageFilter_hxx
 
 #include "itkPatchBasedDenoisingBaseImageFilter.h"
-#include "itkExceptionObject.h"
 #include "itkEventObject.h"
 
 namespace itk

--- a/Modules/IO/ImageBase/include/itkImageFileReaderException.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReaderException.h
@@ -20,7 +20,6 @@
 #include "ITKIOImageBaseExport.h"
 
 #include "itkMacro.h"
-#include "itkExceptionObject.h"
 
 namespace itk
 {

--- a/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
@@ -20,7 +20,6 @@
 #include "ITKIOMeshBaseExport.h"
 
 #include "itkMacro.h"
-#include "itkExceptionObject.h"
 
 namespace itk
 {

--- a/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
@@ -20,7 +20,6 @@
 #include "ITKIOMeshBaseExport.h"
 
 #include "itkMacro.h"
-#include "itkExceptionObject.h"
 
 namespace itk
 {

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -19,7 +19,6 @@
 #define itkConformalFlatteningMeshFilter_hxx
 
 #include "itkConformalFlatteningMeshFilter.h"
-#include "itkExceptionObject.h"
 
 #include "itkMath.h"
 

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
@@ -20,7 +20,6 @@
 
 #include "itkMultiphaseFiniteDifferenceImageFilter.h"
 #include "itkImageRegionConstIterator.h"
-#include "itkExceptionObject.h"
 #include "itkEventObject.h"
 
 namespace itk

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #include "itkVoxBoCUBImageIO.h"
 #include "itkIOCommon.h"
-#include "itkExceptionObject.h"
 #include "itkMetaDataObject.h"
 #include "itkByteSwapper.h"
 #include "itksys/SystemTools.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.h
+++ b/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.h
@@ -20,7 +20,6 @@
 #define itkFEMObjectSpatialObject_h
 
 #include "itkFEMObject.h"
-#include "itkExceptionObject.h"
 #include "itkSpatialObject.h"
 
 namespace itk

--- a/Modules/Numerics/FEM/test/itkFEMGenerateMeshTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMGenerateMeshTest.cxx
@@ -19,7 +19,6 @@
 #include "itkFEMGenerateMesh.h"
 #include "itkFEMElement2DC0LinearQuadrilateralStrain.h"
 #include "itkFEMMaterialLinearElasticity.h"
-#include "itkExceptionObject.h"
 #include "itkFEMElement3DC0LinearHexahedronStrain.h"
 
 //

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -21,7 +21,6 @@
 #include "itkRegistrationParameterScalesFromJacobian.h"
 
 #include "itkSize.h"
-#include "itkExceptionObject.h"
 #include "itkImageRegistrationMethodImageSource.h"
 #include "itkVectorImageToImageMetricTraitsv4.h"
 #include "itkTestingMacros.h"

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
@@ -22,7 +22,6 @@
 #include "itkRegistrationParameterScalesFromJacobian.h"
 
 #include "itkSize.h"
-#include "itkExceptionObject.h"
 #include "itkImageRegistrationMethodImageSource.h"
 #include "itkMath.h"
 #include "itkTestingMacros.h"

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -19,7 +19,6 @@
 #define itkESMDemonsRegistrationFunction_hxx
 
 #include "itkESMDemonsRegistrationFunction.h"
-#include "itkExceptionObject.h"
 #include "itkMath.h"
 
 namespace itk

--- a/Modules/Video/IO/include/itkVideoIOBase.h
+++ b/Modules/Video/IO/include/itkVideoIOBase.h
@@ -19,7 +19,6 @@
 #define itkVideoIOBase_h
 
 #include "itkImageIOBase.h"
-#include "itkExceptionObject.h"
 #include "ITKVideoIOExport.h"
 #include "vnl/vnl_vector.h"
 


### PR DESCRIPTION
The desire is that itkExceptionObject.h can only be included from
itkMacro.h, but the conditional logic allowed itkExceptionObject.h to be
included as long as itkMacro.h was included first.

Additionally the KWSys enforced style was violated because
itkExceptionObject_h was not defined at the top of the
itkExceptionObject.h file.
