### PR TITLE
Respect do not wait for threads

### DIFF
--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -32,11 +32,11 @@ namespace itk
 
 struct ThreadPoolGlobals
 {
-  ThreadPoolGlobals():m_DoNotWaitForThreads(false){};
+  ThreadPoolGlobals() = default;
   // To lock on the internal variables.
   std::mutex m_Mutex;
   ThreadPool::Pointer m_ThreadPoolInstance;
-  bool m_DoNotWaitForThreads;
+  bool m_WaitForThreads = true;
 };
 
 itkGetGlobalSimpleMacro(ThreadPool, ThreadPoolGlobals, PimplGlobals);
@@ -79,7 +79,7 @@ ThreadPool
 ::GetDoNotWaitForThreads()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  return m_PimplGlobals->m_DoNotWaitForThreads;
+  return !m_PimplGlobals->m_WaitForThreads;
 }
 
 void
@@ -87,7 +87,7 @@ ThreadPool
 ::SetDoNotWaitForThreads(bool doNotWaitForThreads)
 {
   itkInitGlobalsMacro(PimplGlobals);
-  m_PimplGlobals->m_DoNotWaitForThreads = doNotWaitForThreads;
+  m_PimplGlobals->m_WaitForThreads = !doNotWaitForThreads;
 }
 
 ThreadPool
@@ -142,7 +142,7 @@ ThreadPool
   //explicitly terminated by a call to the ExitProcess function".
   waitForThreads = false;
 #else
-  if(m_PimplGlobals->m_DoNotWaitForThreads)
+  if ( !m_PimplGlobals->m_WaitForThreads )
     {
     waitForThreads = false;
     }

--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -36,7 +36,17 @@ struct ThreadPoolGlobals
   // To lock on the internal variables.
   std::mutex m_Mutex;
   ThreadPool::Pointer m_ThreadPoolInstance;
+#if defined( _WIN32 ) && defined( ITKCommon_EXPORTS )
+  // ThreadPool's destructor is called during DllMain's DLL_PROCESS_DETACH.
+  // Because ITKCommon-5.X.dll is usually being detached due to process termination,
+  // lpvReserved is non-NULL meaning that "all threads in the process
+  // except the current thread either have exited already or have been
+  // explicitly terminated by a call to the ExitProcess function".
+  // Therefore we must not wait for the condition_variable.
+  bool m_WaitForThreads = false;
+#else // In a static library, we have to wait.
   bool m_WaitForThreads = true;
+#endif
 };
 
 itkGetGlobalSimpleMacro(ThreadPool, ThreadPoolGlobals, PimplGlobals);
@@ -133,35 +143,21 @@ ThreadPool
 ThreadPool
 ::~ThreadPool()
 {
-  bool waitForThreads = !m_Threads.empty();
-#if defined(_WIN32) && defined(ITKCommon_EXPORTS)
-  //This destructor is called during DllMain's DLL_PROCESS_DETACH.
-  //Because ITKCommon-4.X.dll is usually being detached due to process termination,
-  //lpvReserved is non-NULL meaning that "all threads in the process
-  //except the current thread either have exited already or have been
-  //explicitly terminated by a call to the ExitProcess function".
-  waitForThreads = false;
-#else
-  if ( !m_PimplGlobals->m_WaitForThreads )
     {
-    waitForThreads = false;
-    }
-#endif
-  {
     std::unique_lock< std::mutex > mutexHolder( m_PimplGlobals->m_Mutex );
 
     this->m_Stopping = true;
     }
 
-  if (waitForThreads)
+  if ( m_PimplGlobals->m_WaitForThreads && !m_Threads.empty() )
     {
     m_Condition.notify_all();
     }
 
   // Even if the threads have already been terminated,
   // we should join() the std::thread variables.
-  // Otherwise some sanity check in debug mode makes a problem.
-  for (ThreadIdType i = 0; i < m_Threads.size(); i++)
+  // Otherwise some sanity check in debug mode complains.
+  for ( ThreadIdType i = 0; i < m_Threads.size(); i++ )
     {
     m_Threads[i].join();
     }


### PR DESCRIPTION
Closes #1038. @DeswingBE, please check whether this fixes your problem.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

