### PR TITLE
COMP: Another work around uninitialized value warnings

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -94,9 +94,7 @@ void
 InverseDisplacementFieldImageFilter< TInputImage, TOutputImage >
 ::SetOutputOrigin(const double *origin)
 {
-  OriginPointType p(origin);
-
-  this->SetOutputOrigin(p);
+  this->SetOutputOrigin( OriginPointType(origin) );
 }
 
 /**


### PR DESCRIPTION
Missing refactoring for addressing uninitialized value warnings.

In Ubuntu 18.04 with gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0, a
large number of compilation uninitialized value warning were
generated related to constructing of point and vector type from C
arrays. This patch works around these warning by performing the
operation in a single line, and remove extra conversion loops or calls
to CastFrom when a constructor suffices.
