### PR TITLE
ENH: Prefer c++11 'using' to 'typedef' for structs

### DIFF
--- a/Modules/Compatibility/Deprecated/test/itkSpawnThreadTest.cxx
+++ b/Modules/Compatibility/Deprecated/test/itkSpawnThreadTest.cxx
@@ -24,10 +24,10 @@
 #include "itksys/SystemTools.hxx"
 #include "itkMutexLock.h"
 
-typedef struct {
+using SharedThreadData = struct {
   int numberOfLoop;
   itk::MutexLock::Pointer sharedMutex;
-} SharedThreadData;
+};
 
 void* ThreadFunction(void *ptr)
 {

--- a/Modules/Core/Common/include/itkThreadSupport.h
+++ b/Modules/Core/Common/include/itkThreadSupport.h
@@ -83,11 +83,11 @@ namespace itk
   /** Platform specific Conditional Variable type alias
    */
 #if defined(ITK_USE_PTHREADS)
-  typedef struct {
+  using ConditionVariableType = struct {
   pthread_cond_t m_ConditionVariable;
-  } ConditionVariableType;
+  };
 #elif defined(ITK_USE_WIN32_THREADS)
-  typedef struct {
+  using ConditionVariableType = struct {
   int m_NumberOfWaiters;                   // number of waiting threads
   CRITICAL_SECTION m_NumberOfWaitersLock;  // Serialize access to
                                            // m_NumberOfWaiters
@@ -101,7 +101,7 @@ namespace itk
 
   int m_WasBroadcast;                      // Used as boolean. Keeps track of whether
                                            // we were broadcasting or signaling
-  } ConditionVariableType;
+  };
 #else
   using ConditionVariableType = struct { };
 #endif

--- a/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
+++ b/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
@@ -92,18 +92,18 @@ WindowsMemoryUsageObserver::~WindowsMemoryUsageObserver()
 using KPRIORITY = LONG;
 #define SystemProcessesAndThreadsInformation    5
 
-typedef struct _CLIENT_ID {
+using CLIENT_ID = struct _CLIENT_ID {
   DWORD UniqueProcess;
   DWORD UniqueThread;
-} CLIENT_ID;
+};
 
-typedef struct _UNICODE_STRING {
+using UNICODE_STRING = struct _UNICODE_STRING {
   USHORT Length;
   USHORT MaximumLength;
   PWSTR Buffer;
-} UNICODE_STRING;
+};
 
-typedef struct _VM_COUNTERS {
+using VM_COUNTERS = struct {
 #ifdef _WIN64
   // the following was inferred by painful reverse engineering
   SIZE_T PeakVirtualSize;             // not actually
@@ -130,9 +130,9 @@ typedef struct _VM_COUNTERS {
   SIZE_T PagefileUsage;
   SIZE_T PeakPagefileUsage;
 #endif
-} VM_COUNTERS;
+};
 
-typedef struct _SYSTEM_THREADS {
+using SYSTEM_THREADS = struct {
   LARGE_INTEGER KernelTime;
   LARGE_INTEGER UserTime;
   LARGE_INTEGER CreateTime;
@@ -144,9 +144,10 @@ typedef struct _SYSTEM_THREADS {
   ULONG ContextSwitchCount;
   LONG State;
   LONG WaitReason;
-} SYSTEM_THREADS, *PSYSTEM_THREADS;
+};
+using PSYSTEM_THREADS = SYSTEM_THREADS *;
 
-typedef struct _SYSTEM_PROCESSES { // Information Class 5
+using SYSTEM_PROCESSES = struct { // Information Class 5
   ULONG NextEntryDelta;
   ULONG MaximumNumberOfThreads;
   ULONG Reserved1[6];
@@ -174,7 +175,8 @@ typedef struct _SYSTEM_PROCESSES { // Information Class 5
   IO_COUNTERS IoCounters;
 #endif
   SYSTEM_THREADS Threads[1];
-} SYSTEM_PROCESSES, *PSYSTEM_PROCESSES;
+};
+using PSYSTEM_PROCESSES = SYSTEM_PROCESSES *;
 #endif
 
 MemoryUsageObserverBase::MemoryLoadType

--- a/Modules/Core/Common/test/itkTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkTimeStampTest.cxx
@@ -24,10 +24,10 @@
 // A helper struct for the test, the idea is to have one timestamp per thread.
 // To ease the writing of the test, we use  MultiThreaderBase::SingleMethodExecute
 // with an array of timestamps in the shared data
-typedef struct {
+using TimeStampTestHelper = struct {
   std::vector<itk::TimeStamp> timestamps;
   std::vector<unsigned long> counters;
-} TimeStampTestHelper;
+};
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION modified_function( void *ptr )
 {

--- a/Modules/Core/TestKernel/include/itkTestDriverInclude.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverInclude.h
@@ -73,7 +73,7 @@ std::map< std::string, int > RegressionTestBaselines(char *);
 using ComparePairType = std::pair< char *, char * >;
 
 // A structure to hold regression test parameters
-typedef struct
+using RegressionTestParameters = struct _RegressionTestParameters
 {
   std::vector< ComparePairType > compareList;
   double intensityTolerance;
@@ -82,7 +82,7 @@ typedef struct
   bool verifyInputInformation;
   double coordinateTolerance;
   double directionTolerance;
-} RegressionTestParameters;
+};
 
 RegressionTestParameters& GetRegressionTestParameters();
 
@@ -108,11 +108,11 @@ struct ProcessedOutputType
 };
 
 // A structure to hold redirect output parameters
-typedef struct
+using RedirectOutputParameters = struct _RedirectOutputParameters
 {
   bool redirect;
   std::string fileName;
-} RedirectOutputParameters;
+};
 
 RedirectOutputParameters& GetRedirectOutputParameters();
 

--- a/Modules/IO/GE/src/Ge5xHdr.h
+++ b/Modules/IO/GE/src/Ge5xHdr.h
@@ -57,7 +57,7 @@
 
 #define GE_5X_MAGIC_NUMBER       0x494d4746
 
-typedef struct GE_5x_ImgHdr {
+using Ge5xPixelHeader = struct {
   int GENESIS_IH_img_magic;
   int GENESIS_IH_img_hdr_length;
   int GENESIS_IH_img_width;
@@ -98,7 +98,7 @@ typedef struct GE_5x_ImgHdr {
   int GENESIS_IH_img_l_series;
   int GENESIS_IH_img_p_image;
   int GENESIS_IH_img_l_image;
-} Ge5xPixelHeader;
+};
 
 
 enum GE_SUITE_HDR_ENUM {

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -59,7 +59,7 @@ using Float32_t = float;
 using Float64_t = double;
 using Float96_t = long double;
 
-typedef struct {
+using zeiss_info = struct {
   UInt32_t U32MagicNumber;
   Int32_t S32StructureSize;
   Int32_t S32DimensionX;
@@ -89,7 +89,7 @@ typedef struct {
   UInt32_t u32OffsetBleachRoi;
   UInt32_t u32OffsetNextRecording;
   UInt32_t u32Reserved[TIF_CZ_LSMINFO_SIZE_RESERVED];
-} zeiss_info;
+};
 
 LSMImageIO::LSMImageIO()
 {

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
@@ -72,10 +72,10 @@ public:
 
   /** Begin is the first valid iterator position within the region.  End is ONE
       PAST the last valid iterator position in the region. */
-  typedef struct RegionStruct {
+  using RegionType = struct {
     Iterator Begin;
     Iterator End;
-  } RegionType;
+  };
 
   /** Returns an array of RegionStructs which represent contiguous
    * arrays of nodes within the narrow band. */

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -104,7 +104,7 @@ public:
   using ScanIteratorType = ConstNeighborhoodIterator<VirtualImageType>;
 
   // one ScanMemType for each thread
-  typedef struct ScanMemType {
+  using ScanMemType = struct {
     // queues used in the scanning
     // sum of the fixed value squared
     SumQueueType QsumFixed2;
@@ -127,10 +127,10 @@ public:
     FixedImagePointType     mappedFixedPoint;
     MovingImagePointType    mappedMovingPoint;
     VirtualPointType        virtualPoint;
-  } ScanMemType;
+  };
 
   // For dense scan over one image region
-  typedef struct ScanParametersType {
+  using ScanParametersType = struct {
     // const values during scanning
     ImageRegionType scanRegion;
     SizeValueType   numberOfFillZero; // for each queue
@@ -141,8 +141,7 @@ public:
     typename MovingImageType::ConstPointer  movingImage;
     typename VirtualImageType::ConstPointer virtualImage;
     RadiusType radius;
-
-  } ScanParametersType;
+  };
 
 protected:
   ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader() :


### PR DESCRIPTION
Improve consistency in the code base, and provide modern
type aliasing wiht the 'using' syntax.
