### PR TITLE
COMP: MSVC AVX flag fix

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -145,7 +145,10 @@ function(check_compiler_optimization_flags c_optimization_flags_var cxx_optimiza
   if(MSVC)
       set(InstructionSetOptimizationFlags
          # https://docs.microsoft.com/en-us/cpp/build/reference/arch-x64?view=vs-2015
-         /arch:SSE /arch:SSE2 /arch:/AVX ) # /arch:/AVX2 AVX2 circa 2013
+         /arch:SSE /arch:SSE2 /arch:AVX) # AVX2 support circa 2013 hardware
+      if(MSVC_VERSION GREATER_EQUAL 1800)
+        list(APPEND InstructionSetOptimizationFlags /arch:AVX2)
+      endif()
   else()
     if (${CMAKE_C_COMPILER} MATCHES "icc.*$")
       set(USING_INTEL_ICC_COMPILER TRUE)
@@ -154,7 +157,7 @@ function(check_compiler_optimization_flags c_optimization_flags_var cxx_optimiza
       set(USING_INTEL_ICC_COMPILER TRUE)
     endif()
     if(USING_INTEL_ICC_COMPILER)
-      set(InstructionSetOptimizationFlags "" )
+      set(InstructionSetOptimizationFlags "")
     else()
       set(InstructionSetOptimizationFlags "")
     endif ()

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -145,9 +145,14 @@ function(check_compiler_optimization_flags c_optimization_flags_var cxx_optimiza
   if(MSVC)
       set(InstructionSetOptimizationFlags
          # https://docs.microsoft.com/en-us/cpp/build/reference/arch-x64?view=vs-2015
-         /arch:SSE /arch:SSE2 /arch:AVX) # AVX2 support circa 2013 hardware
+         /arch:AVX ) # AVX support circa 2013 hardware
       if(MSVC_VERSION GREATER_EQUAL 1800)
-        list(APPEND InstructionSetOptimizationFlags /arch:AVX2)
+         list(APPEND InstructionSetOptimizationFlags
+              /arch:AVX2) # AVX support circa 2013 hardware
+      endif()
+      if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
+         list(APPEND InstructionSetOptimizationFlags
+              /arch:SSE /arch:SSE2)
       endif()
   else()
     if (${CMAKE_C_COMPILER} MATCHES "icc.*$")


### PR DESCRIPTION
This is PR for AVX flag only. I have split my previous PR.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
