### PR TITLE
DOC: Purge outdated media wiki WikiExamples

### DIFF
--- a/Documentation/Maintenance/Release.md
+++ b/Documentation/Maintenance/Release.md
@@ -179,7 +179,7 @@ The following must be ensured before tagging the ITK repository:
     * For bugfix releases, this is done before the tag. For feature releases,
     this is done after the final tag.
   * Make sure **all new remote modules are built in by the Doxygen build**.
-  * **Update** the `WikiExamples` and `SphinxExamples` remote modules.
+  * **Update** the `SphinxExamples` remote modules.
 
 ### Increment the version number
 
@@ -664,23 +664,6 @@ Generate the `.tar.gz` and `.zip` tarballs:
    git archive --format=tar --prefix=${prefix}/ --output=${prefix}.tar ${tag}
    gzip -9  ${prefix}.tar
    git archive --format=zip -9 --prefix=${prefix}/ --output=${prefix}.zip ${tag}
-```
-
-Update ITK Wiki Examples
-------------------------
-
-Update the CMake minimum version in the example files if necessary.
-
-Download the latest examples from the [ITK wiki examples] (i.e. `git pull`
-on the `ITKWikiExamples` repository), and run:
-
-```sh
-   wget -O ITKWikiExamples-master.zip https://github.com/InsightSoftwareConsortium/ITKWikiExamples/archive/master.zip
-   unzip ITKWikiExamples-master.zip
-   mv ITKWikiExamples-master InsightWikiExamples-${version}
-   zip -r InsightWikiExamples-${version}.zip InsightWikiExamples-${version}
-   tar cvf InsightWikiExamples-${version}.tar InsightWikiExamples-${version}
-   gzip -9 InsightWikiExamples-${version}.tar
 ```
 
 Upload the release artifacts to GitHub

--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.h
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup   ITKVtkGlue
  *
  * \sphinx
- * \sphinxexample{Remote/WikiExamples/DisplayITKImage,Display ITK Image}
+ * \sphinxexample{Remote/SphinxExamples/DisplayITKImage,Display ITK Image}
  * \sphinxexample{IO/itkVtkImageConvertDICOM,Uses a custom user matrix to align the image with DICOM physical space}
  * \endsphinx
  */

--- a/Modules/Remote/WikiExamples.remote.cmake
+++ b/Modules/Remote/WikiExamples.remote.cmake
@@ -1,8 +1,0 @@
-#
-# ITK WikiExamples
-#
-itk_fetch_module(WikiExamples
-  "A collection of examples that illustrate how to use ITK."
-  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKWikiExamples.git
-  GIT_TAG 07f0e1622ca3eeed8b9c5b9665b066b785af86e8
-  )

--- a/Utilities/Doxygen/GenerateExamplesDox.cmake
+++ b/Utilities/Doxygen/GenerateExamplesDox.cmake
@@ -16,36 +16,7 @@ file( GLOB_RECURSE examples_list_fullpath
   "${PROJECT_SOURCE_DIR}/Examples/*.py"
   "${PROJECT_SOURCE_DIR}/Examples/*.java"
 )
-file( GLOB_RECURSE wiki_examples_list_fullpath
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Conversions/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Curves/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Developer/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/DICOM/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/EdgesAndGradients/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Functions/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/ImageProcessing/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Images/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/ImageSegmentation/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Inspection/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Instructions/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/IO/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Iterators/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Math/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Meshes/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Metrics/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Morphology/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Operators/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/PointSet/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Registration/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Segmentation/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/SimpleOperations/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Smoothing/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/SpatialObjects/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/SpectralAnalysis/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Statistics/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/VectorImages/*.cxx"
-  "${PROJECT_SOURCE_DIR}/Modules/Remote/WikiExamples/Visualization/*.cxx"
-)
+
 file( GLOB_RECURSE sphinx_examples_list_fullpath
   "${PROJECT_SOURCE_DIR}/Modules/Remote/SphinxExamples/src/*.cxx"
   "${PROJECT_SOURCE_DIR}/Modules/Remote/SphinxExamples/src/*.py"
@@ -59,7 +30,7 @@ foreach( _example ${examples_list_fullpath} )
   list( APPEND examples_list ${example_relative} )
 endforeach()
 string( LENGTH "${PROJECT_SOURCE_DIR}/Modules/Remote/" root_length )
-foreach( _example ${wiki_examples_list_fullpath} ${sphinx_examples_list_fullpath} )
+foreach( _example ${sphinx_examples_list_fullpath} )
   string( SUBSTRING ${_example} ${root_length} -1 example_relative )
   list( APPEND examples_list ${example_relative} )
 endforeach()


### PR DESCRIPTION
The WikiExamples have been migrated to ITKExamples
for easier maintenance, and consistent documentation.
