### PR TITLE
BUG: Release the Python Global Interpreter Lock (GIL) during execution

### DIFF
--- a/Wrapping/Generators/Python/PyUtils/itkPyCommand.cxx
+++ b/Wrapping/Generators/Python/PyUtils/itkPyCommand.cxx
@@ -23,86 +23,90 @@ namespace itk
 
 PyCommand::PyCommand()
 {
-    this->m_Object = nullptr;
+  this->m_Object = nullptr;
 }
+
 
 PyCommand::~PyCommand()
 {
-    if (this->m_Object)
+  if (this->m_Object)
     {
-        Py_DECREF(this->m_Object);
+    Py_DECREF(this->m_Object);
     }
-    this->m_Object = nullptr;
+  this->m_Object = nullptr;
 }
+
 
 void PyCommand::SetCommandCallable(PyObject *o)
 {
-    if (o != this->m_Object)
+  if (o != this->m_Object)
     {
-        if (this->m_Object)
-        {
-            // get rid of our reference
-            Py_DECREF(this->m_Object);
-        }
+    if (this->m_Object)
+      {
+      // get rid of our reference
+      Py_DECREF(this->m_Object);
+      }
 
-        // store the new object
-        this->m_Object = o;
+    // store the new object
+    this->m_Object = o;
 
-        if (this->m_Object)
-        {
-            // take out reference (so that the calling code doesn't
-            // have to keep a binding to the callable around)
-            Py_INCREF(this->m_Object);
-        }
+    if (this->m_Object)
+      {
+      // take out reference (so that the calling code doesn't
+      // have to keep a binding to the callable around)
+      Py_INCREF(this->m_Object);
+      }
     }
 }
 
+
 PyObject * PyCommand::GetCommandCallable()
 {
-    return this->m_Object;
+  return this->m_Object;
 }
+
 
 void PyCommand::Execute(Object *, const EventObject&)
 {
-    this->PyExecute();
+  this->PyExecute();
 }
 
 
 void PyCommand::Execute(const Object*, const EventObject&)
 {
-    this->PyExecute();
-
+  this->PyExecute();
 }
+
 
 void PyCommand::PyExecute()
 {
-    // make sure that the CommandCallable is in fact callable
-    if (!PyCallable_Check(this->m_Object))
+  // make sure that the CommandCallable is in fact callable
+  if (!PyCallable_Check(this->m_Object))
     {
-        // we throw a standard ITK exception: this makes it possible for
-        // our standard Swig exception handling logic to take this
-        // through to the invoking Python process
-        itkExceptionMacro(<<"CommandCallable is not a callable Python object, "
-                          <<"or it has not been set.");
+      // we throw a standard ITK exception: this makes it possible for
+      // our standard Swig exception handling logic to take this
+      // through to the invoking Python process
+      itkExceptionMacro(<<"CommandCallable is not a callable Python object, "
+                        <<"or it has not been set.");
     }
-    else
+  else
     {
-        PyObject *result = PyEval_CallObject(this->m_Object, (PyObject *)nullptr);
+    PyObject *result = PyEval_CallObject(this->m_Object, (PyObject *)nullptr);
 
-        if (result)
-        {
-            Py_DECREF(result);
-        }
-        else
-        {
-            // there was a Python error.  Clear the error by printing to stdout
-            PyErr_Print();
-            // make sure the invoking Python code knows there was a problem
-            // by raising an exception
-            itkExceptionMacro(<<"There was an error executing the "
-                              <<"CommandCallable.");
-        }
+    if (result)
+      {
+      Py_DECREF(result);
+      }
+    else
+      {
+      // there was a Python error.  Clear the error by printing to stdout
+      PyErr_Print();
+      // make sure the invoking Python code knows there was a problem
+      // by raising an exception
+      itkExceptionMacro(<<"There was an error executing the "
+                        <<"CommandCallable.");
+      }
     }
 }
 
-} // namespace itk
+} // end namespace itk

--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -696,7 +696,12 @@ class SwigInputGenerator(object):
         # [1:-1] is there to drop the quotes
         for lang in langs:
             headerFile.write("#ifdef SWIG%s\n" % lang)
-            headerFile.write("%%module %s%s\n" % (self.moduleName, lang.title()))
+            if lang == "PYTHON":
+                # Also, release the GIL
+                headerFile.write("%%module(threads=\"1\") %s%s\n" % (self.moduleName, lang.title()))
+                headerFile.write('%feature("nothreadallow");\n')
+            else:
+                headerFile.write("%%module %s%s\n" % (self.moduleName, lang.title()))
             headerFile.write("#endif\n")
         headerFile.write('\n')
 


### PR DESCRIPTION
Release the Python Global Interpreter Lock (GIL) so multi-threaded
Python applications, like Dask, can run in parallel while ITK does heavy
operations.

For more information, see section 32.13 Support for Multithreaded
Applications at

 http://www.swig.org/Doc4.0/Python.html#Python

Also, set `nothreadallow` as suggested in the comments
on https://github.com/swig/swig/issues/927. This avoids calls to
`PyEval_SaveThread()` and `PyEval_RestoreThread()`, which can negatively
effect performance. This change only affects module C++ code -- code
that can call Python code like ITKPyUtils does not have `threads`
enabled.