### PR TITLE
BUG: ITKFixedPointInverseDisplacementField wrapping test config update

### DIFF
--- a/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
+++ b/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
@@ -1,5 +1,5 @@
 itk_fetch_module(FixedPointInverseDisplacementField
   "Computes the inverse of a displacement field."
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKFixedPointInverseDisplacementField.git
-  GIT_TAG 66f94a4ff6a8fbe5ac8501983f4492bf2c228bd6
+  GIT_TAG 0906a379e360381d8babc05d851aabd0b3ea8b16
   )


### PR DESCRIPTION
Adds:

 matt.mccormick@kitware.com (1):
        STYLE: Move Python test to wrapping/test/CMakeLists.txt

This will improve the nightly Doxygen builds.