### PR TITLE
BUG: Remove VectorExpandImageFilter wrapping

### DIFF
--- a/Modules/Filtering/ImageIntensity/wrapping/itkVectorExpandImageFilter.wrap
+++ b/Modules/Filtering/ImageIntensity/wrapping/itkVectorExpandImageFilter.wrap
@@ -1,3 +1,0 @@
-itk_wrap_class("itk::VectorExpandImageFilter" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_VECTOR_REAL}" 2)
-itk_end_wrap_class()


### PR DESCRIPTION
This class has been deprecated in favor of ExpandImageFilter.