### PR TITLE
BUG: Add PEP 366 __package__ support to ITKLazyModule

### DIFF
--- a/Wrapping/Generators/Python/Tests/CMakeLists.txt
+++ b/Wrapping/Generators/Python/Tests/CMakeLists.txt
@@ -17,6 +17,7 @@ itk_python_add_test(NAME PythonVerifyTTypeAPIConsistency COMMAND verifyTTypeAPIC
 itk_python_add_test(NAME PythonTypeTest COMMAND PythonTypeTest.py)
 itk_python_add_test(NAME PythonComplex COMMAND complex.py)
 itk_python_add_test(NAME PythonHelperFunctions COMMAND helpers.py)
+itk_python_add_test(NAME PythonLazyModule COMMAND lazy.py)
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
 INTERSECTION(WRAP_2 2 "${ITK_WRAP_IMAGE_DIMS}")

--- a/Wrapping/Generators/Python/Tests/lazy.py
+++ b/Wrapping/Generators/Python/Tests/lazy.py
@@ -1,0 +1,23 @@
+#==========================================================================
+#
+#   Copyright Insight Software Consortium
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+import itk
+
+# Test PEP 366 compliance of LazyITKModule
+assert(itk.__package__ == 'itk')
+from itk import ITKCommon
+assert(ITKCommon.__package__ == 'itk')

--- a/Wrapping/Generators/Python/itkLazy.py
+++ b/Wrapping/Generators/Python/itkLazy.py
@@ -35,6 +35,8 @@ class LazyITKModule(types.ModuleType):
         self.__belong_lazy_attributes = dict( (k,v[0]) for k,v in lazy_attributes.items() if len(v) > 0 )
         for k in lazy_attributes:
             setattr(self, k, not_loaded)
+        # For PEP 366
+        setattr(self, '__package__', 'itk')
 
     def __getattribute__(self, attr):
         value = types.ModuleType.__getattribute__(self, attr)


### PR DESCRIPTION
Define __package__ on ITKLazyModule as described:

  https://stackoverflow.com/questions/21233229/whats-the-purpose-of-the-package-attribute-in-python#21233334
  https://www.python.org/dev/peps/pep-0366/