### PR TITLE
DOC: invocation of AddWork uses -> as instance is always a pointer

### DIFF
--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -76,7 +76,9 @@ public:
    *
    * This method returns an std::future, and calling get()
    * will block until the result is ready. Example usage:
-   * auto result = pool.AddWork([](int param) { return param; }, 7);
+\code
+auto result = pool->AddWork([](int param) { return param; }, 7);
+\endcode
    * std::cout << result.get() << std::endl; */
   template< class Function, class... Arguments >
   auto


### PR DESCRIPTION
## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.
