### PR TITLE
STYLE: Add ITK prefix to testing macros in release branch

### DIFF
--- a/Modules/Core/TestKernel/include/itkTestingMacros.h
+++ b/Modules/Core/TestKernel/include/itkTestingMacros.h
@@ -32,6 +32,20 @@ namespace itk
 // end namespace itk - this is here for documentation purposes
 }
 
+// e39284b354a047a8f7931bc9d541f193480ad1b3 introduced ITK_ prefix
+// so define the new names for the benefit of the new code
+// which is compiled with ITK_FUTURE_LEGACY_REMOVE enabled.
+#define ITK_EXERCISE_BASIC_OBJECT_METHODS EXERCISE_BASIC_OBJECT_METHODS
+#define ITK_TRY_EXPECT_EXCEPTION TRY_EXPECT_EXCEPTION
+#define ITK_TRY_EXPECT_NO_EXCEPTION TRY_EXPECT_NO_EXCEPTION
+#define ITK_TEST_EXPECT_TRUE_STATUS_VALUE TEST_EXPECT_TRUE_STATUS_VALUE
+#define ITK_TEST_EXPECT_TRUE TEST_EXPECT_TRUE
+#define ITK_TEST_EXPECT_EQUAL_STATUS_VALUE TEST_EXPECT_EQUAL_STATUS_VALUE
+#define ITK_TEST_EXPECT_EQUAL TEST_EXPECT_EQUAL
+#define ITK_TEST_SET_GET TEST_SET_GET
+#define ITK_TEST_SET_GET_VALUE TEST_SET_GET_VALUE
+#define ITK_TEST_SET_GET_NULL_VALUE TEST_SET_GET_NULL_VALUE
+#define ITK_TEST_SET_GET_BOOLEAN TEST_SET_GET_BOOLEAN
 
 // object's Class must be specified to build on sun studio
 #define EXERCISE_BASIC_OBJECT_METHODS( object, Class, SuperClass )        \


### PR DESCRIPTION
This is going into the release branch, which will turn into 5.0.1. I encountered the need for this while updating ITKMontage to use `ITK_` prefix on testing macros. I compile that with all legacies disabled.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

