### PR TITLE
BUG: Fix possible loss of data on type conversion

### DIFF
--- a/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
@@ -121,7 +121,7 @@ public:
   }
 
   /** Get the length of the input array. */
-  static unsigned int GetLength(const Array< T > & m)
+  static std::size_t GetLength(const Array< T > & m)
   {
     return m.GetSize();
   }

--- a/Modules/Core/Common/src/itkArrayOutputSpecialization.cxx
+++ b/Modules/Core/Common/src/itkArrayOutputSpecialization.cxx
@@ -26,11 +26,11 @@ std::ostream & operator<< <double> (std::ostream & os, const Array< double > & a
 {
   NumberToString<double> convert;
   os << "[";
-  const unsigned int length = arr.size();
+  const std::size_t length = arr.size();
   if ( length >= 1 )
     {
-    const unsigned int   last   = length - 1;
-    for ( unsigned int i = 0; i < last; ++i )
+    const std::size_t last = length - 1;
+    for ( std::size_t i = 0; i < last; ++i )
       {
       os << convert(arr[i]) << ", ";
       }
@@ -45,11 +45,11 @@ std::ostream & operator<< <float> (std::ostream & os, const Array< float > & arr
 {
   NumberToString<float> convert;
   os << "[";
-  const unsigned int length = arr.size();
+  const std::size_t length = arr.size();
   if ( length >= 1 )
     {
-    const unsigned int   last   = length - 1;
-    for ( unsigned int i = 0; i < last; ++i )
+    const std::size_t last = length - 1;
+    for ( std::size_t i = 0; i < last; ++i )
       {
       os << convert(static_cast<float>(arr[i])) << ", ";
       }

--- a/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
@@ -23,7 +23,7 @@ CompositeValleyFunction
 ::CompositeValleyFunction(const MeasureArrayType & classMeans,
                           const MeasureArrayType & classSigmas)
 {
-  unsigned int length = classMeans.size();
+  const std::size_t length = classMeans.size();
 
   if ( length != classSigmas.size() )
     {
@@ -41,7 +41,7 @@ CompositeValleyFunction
     throw ex;
     }
 
-  for ( unsigned int i = 0; i < length; i++ )
+  for ( std::size_t i = 0; i < length; i++ )
     {
     this->AddNewClass(classMeans[i], classSigmas[i]);
     }

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -734,7 +734,7 @@ protected:
   unsigned int m_NumberOfCellPixelComponents{0};
 
   /** The number of independent dimensions in the point. */
-  SizeValueType m_PointDimension{3};
+  unsigned int m_PointDimension{3};
 
   /** The number of points and cells */
   SizeValueType m_NumberOfPoints;

--- a/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
+++ b/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
@@ -127,14 +127,15 @@ public:
   class CoefficientVectorSizeMismatch
   {
 public:
-    CoefficientVectorSizeMismatch(int given, int required)
-    {
-      m_Required = required;
-      m_Given = given;
-    }
+  CoefficientVectorSizeMismatch(const std::size_t given, const std::size_t required)
+    :
+    m_Required{ required },
+    m_Given{ given }
+  {
+  }
 
-    int m_Required;
-    int m_Given;
+    std::size_t m_Required;
+    std::size_t m_Given;
   };
 
   /** \brief Sets the Legendre polynomials' parameters.

--- a/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
+++ b/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
@@ -125,8 +125,8 @@ void MultivariateLegendrePolynomial
 {
   if ( coefficients.size() != m_NumberOfCoefficients )
     {
-    throw CoefficientVectorSizeMismatch(static_cast<int>( coefficients.size() ),
-                                        static_cast<int>( m_NumberOfCoefficients) );
+    throw CoefficientVectorSizeMismatch(coefficients.size(),
+                                        m_NumberOfCoefficients);
     }
 
   // copy coefficients to array of double

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -56,7 +56,7 @@ public:
   using TotalAbsoluteFrequencyType = NumericTraits< AbsoluteFrequencyType >::AccumulateType;
   using TotalRelativeFrequencyType = NumericTraits< RelativeFrequencyType >::AccumulateType;
 
-  using MeasurementVectorLength = unsigned int;
+  using MeasurementVectorLength = std::size_t;
 
   template< typename TVectorType >
   static bool IsResizable(const TVectorType &)

--- a/Modules/Video/Core/include/itkRingBuffer.hxx
+++ b/Modules/Video/Core/include/itkRingBuffer.hxx
@@ -190,7 +190,7 @@ RingBuffer< TElement >
     {
     for (size_t i = 0; i < currentSize - n; ++i)
       {
-      unsigned int tailIndex = this->GetOffsetBufferIndex(1);
+      const auto tailIndex = static_cast<SizeValueType>(this->GetOffsetBufferIndex(1));
       this->m_PointerVector.erase( this->m_PointerVector.begin() + tailIndex );
 
       // Decrement head index if necessary


### PR DESCRIPTION
Fix possible loss of data on type conversion, typically from a (possibly
64-bit) `size_t` to a 32-bit integer type, as suggested by various
occurrences of VS2017 warning C4244 and C4267 (when these warnings are
not disabled):

> video\core\include\itkRingBuffer.hxx(193): warning C4244: 'initializing': conversion from 'itk::RingBuffer<itk::DataObject>::OffsetValueType' to 'unsigned int'

> Filtering\BiasCorrection\src\itkCompositeValleyFunction.cxx(26): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int'

> Numerics\Polynomials\src\itkMultivariateLegendrePolynomial.cxx(151): warning C4267: 'argument': conversion from 'size_t' to 'int'

> Core\Common\src\itkArrayOutputSpecialization.cxx(29): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int'

> core\common\include\itkNumericTraitsArrayPixel.h(126): warning C4267: 'return': conversion from 'size_t' to 'unsigned int'

> numerics\statistics\include\itkMeasurementVectorTraits.h(308): warning C4267: 'return': conversion from 'size_t' to 'itk::Statistics::MeasurementVectorTraits::MeasurementVectorLength'

> IO\MeshBase\include\itkMeshIOBase.h(386): warning C4244: 'return': conversion from 'const itk::MeshIOBase::SizeValueType' to 'unsigned int'