### PR TITLE
BUG: All exceptions must be derived from python's BaseException class

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -97,8 +97,8 @@
         assert ndarr.ndim in ( 2, 3, 4 ), \
             "Only arrays of 2, 3 or 4 dimensions are supported."
         if( not ndarr.flags['C_CONTIGUOUS'] and not ndarr.flags['F_CONTIGUOUS'] ):
-            raise "Array memory is not contiguous. Try converting your array with " \
-                  + "`ascontiguousarray()` or `copy()` or use `GetImageFromArray()`"
+            raise ValueError("Array memory is not contiguous. Try converting your array with "
+                  + "`ascontiguousarray()` or `copy()` or use `GetImageFromArray()`")
 
         if ( ndarr.ndim == 3 and is_vector ) or (ndarr.ndim == 4):
             if( ndarr.flags['C_CONTIGUOUS'] ):

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -209,6 +209,23 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         array = array.reshape((2, 6))
         image = itk.image_from_array(array)
 
+    def test_non_contiguous_array(self):
+        "Check that a non-contiguous array raises the appropriate error"
+
+        data = np.random.random((10, 10, 10))
+        data = data[..., 0]   # slicing the array makes it non-contiguous
+        assert not data.flags['C_CONTIGUOUS']
+        assert not data.flags['F_CONTIGUOUS']
+        try:
+            itk.image_from_array(data)
+        except ValueError as e:
+            assert str(e) == ("Array memory is not contiguous. "
+                              "Try converting your array with "
+                              "`ascontiguousarray()` or `copy()` "
+                              "or use `GetImageFromArray()`")
+        else:
+            assert False
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
If a non-continuous array is passed in, the error is not constructed properly.  It is recommended that Python errors should not just say `raise "my error message here"` but instead  `raise MyExceptionClass("my error message here")`.

I found this while investigating an error in the itk-jupyter-widgets library, detailed here: https://github.com/InsightSoftwareConsortium/itk-jupyter-widgets/issues/156. Here is the relevant part of the error traceback:
```python-traceback
~/anaconda3/envs/viz/lib/python3.7/site-packages/itk/Configuration/../itkPyBufferPython.py in GetImageViewFromArray(ndarr, is_vector)
   4044             "Only arrays of 2, 3 or 4 dimensions are supported."
   4045         if( not ndarr.flags['C_CONTIGUOUS'] and not ndarr.flags['F_CONTIGUOUS'] ):
-> 4046             raise "Array memory is not contiguous. Try converting your array with " \
   4047                   + "`ascontiguousarray()` or `copy()` or use `GetImageFromArray()`"
   4048 

TypeError: exceptions must derive from BaseException
```

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] [~~Makes breaking changes~~](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ] [~~Makes design changes~~](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] ~~Adds the License notice to new files.~~
- [ ] ~~Adds Python wrapping.~~
- [X] Adds tests and baseline comparison (quantitative).
- [X] [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] ~~Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)~~
- [ ] ~~Adds Documentation.~~

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
