### PR TITLE
BUG: Support pickling LazyITKModule with cloudpickle

### DIFF
--- a/Wrapping/Generators/Python/Tests/lazy.py
+++ b/Wrapping/Generators/Python/Tests/lazy.py
@@ -21,3 +21,11 @@ import itk
 assert(itk.__package__ == 'itk')
 from itk import ITKCommon
 assert(ITKCommon.__package__ == 'itk')
+
+# Test pickling used bash Dask
+try:
+    import cloudpickle
+    itkpickled = cloudpickle.dumps(itk)
+    cloudpickle.loads(itkpickled)
+except ImportError:
+    pass

--- a/Wrapping/Generators/Python/itkLazy.py
+++ b/Wrapping/Generators/Python/itkLazy.py
@@ -15,13 +15,17 @@
 #   limitations under the License.
 #
 #==========================================================================*/
-
-
 import types
 import itkBase
 
 not_loaded = 'not loaded'
 
+def _lazy_itk_module_reconstructor(module_name, state):
+    # Similar to copyreg._reconstructor
+    lazy_module = types.ModuleType.__new__(LazyITKModule, state)
+    types.ModuleType.__init__(lazy_module, module_name)
+
+    return lazy_module
 
 class LazyITKModule(types.ModuleType):
 
@@ -37,6 +41,8 @@ class LazyITKModule(types.ModuleType):
             setattr(self, k, not_loaded)
         # For PEP 366
         setattr(self, '__package__', 'itk')
+        setattr(self, 'lazy_attributes', lazy_attributes)
+        setattr(self, 'loaded_lazy_modules', set())
 
     def __getattribute__(self, attr):
         value = types.ModuleType.__getattribute__(self, attr)
@@ -44,7 +50,39 @@ class LazyITKModule(types.ModuleType):
             module = self.__belong_lazy_attributes[attr]
             namespace = {}
             itkBase.LoadModule(module, namespace)
+            self.loaded_lazy_modules.add(module)
             for k, v in namespace.items():
                 setattr(self, k, v)
             value = namespace[attr]
         return value
+
+    # For pickle support
+    def __reduce_ex__(self, proto):
+        state = self.__getstate__()
+        return _lazy_itk_module_reconstructor, (self.__name__, state), state
+
+    # For pickle support
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        lazy_modules = list()
+        # import ipdb; ipdb.set_trace()
+        for key in self.lazy_attributes:
+            if isinstance(state[key], LazyITKModule):
+                lazy_modules.append((key, state[key].lazy_attributes))
+            state[key] = not_loaded
+        state['lazy_modules'] = lazy_modules
+
+        return state
+
+    # For pickle support
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        for module_name, lazy_attributes in state['lazy_modules']:
+            self.__dict__.add(module_name, LazyITKModule(module_name,
+                lazy_attributes))
+
+        for module in state['loaded_lazy_modules']:
+            namespace = {}
+            itkBase.LoadModule(module, namespace)
+            for k, v in namespace.items():
+                setattr(self, k, v)


### PR DESCRIPTION
cloudpickle is used by Dask for transmitting the state of a Python
program.

Since LazyITKModule extends types.ModuleType, a few extras are required
to support its pickling.

__reduce_ex__ is re-implemented because modules using implement this
protocol, and initialization arguments are not the same as
LazyITKModule.

__getstate__ and __setstate__ are implemented to re-constitute the
LazyITKModule after it is de-serialized. Like cloudpickle's
implementation for loading dynamically created modules and imported
modules:

  https://github.com/cloudpipe/cloudpickle/blob/2db58f11991fb655e5b188d385633d63cbfd2841/cloudpickle/cloudpickle.py#L1134-L1143

We restore the LazyITKModule attributes (which can include other
LazyITKModules's, e.g. `itk.ITKCommon` (`ITKCommon` is also an
ITKLazyModule), and we reload the modules on disk with
`itkBase.Module.LoadModule`.

Addresses #1050 @jakirkham @mrocklin