### PR TITLE
STYLE: Prepare for clang format style enforcement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -40,6 +40,7 @@ zap.pl           crlf=input
 
 # ghostflow-director GitHub automatic check for maximum repository file size
 *                     hooks-max-size=100000
+Modules/Numerics/FEM/src/dsrc2c.c hooks-max-size=260000
 Modules/ThirdParty/** hooks-max-size=300000
 Modules/ThirdParty/NIFTI/src/nifti/nifti2/nifti2_io.c hooks-max-size=400000
 Modules/ThirdParty/VNL/src/vxl/v3p/netlib/triangle.c hooks-max-size=670000

--- a/Modules/Core/Common/ITKKWStyleOverwrite.txt
+++ b/Modules/Core/Common/ITKKWStyleOverwrite.txt
@@ -31,3 +31,4 @@ itkOffset\.h SemicolonSpace Disable
 itkMultiThreaderBase.h Comments Disable
 itkSingleton\.cxx Namespace Disable
 itkExceptionObject\.h IfNDefDefine Disable
+itkConceptChecking\.h Template Disable

--- a/Modules/Core/Common/src/itkCommand.cxx
+++ b/Modules/Core/Common/src/itkCommand.cxx
@@ -23,9 +23,7 @@ namespace itk
 
   Command::~Command() = default;
 
-  CStyleCommand::CStyleCommand()
-
-  {}
+  CStyleCommand::CStyleCommand() = default;
 
   CStyleCommand::~CStyleCommand()
     {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h
@@ -94,6 +94,4 @@ private:
 };
 } // end namespace itk
 
-#endif
-
-// eof - itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h
+#endif // itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h

--- a/Modules/Filtering/FastMarching/ITKKWStyleOverwrite.txt
+++ b/Modules/Filtering/FastMarching/ITKKWStyleOverwrite.txt
@@ -6,3 +6,4 @@ test/itkFastMarchingTest.cxx Namespace Disable
 test/itkFastMarchingImageFilterRealTest2.cxx Namespace Disable
 test/itkFastMarchingImageFilterRealTest1.cxx Namespace Disable
 test/itkFastMarchingExtensionImageFilterTest.cxx Namespace Disable
+itkFastMarchingTraits\.h Template Disable

--- a/Modules/IO/RAW/include/itkRawImageIO.hxx
+++ b/Modules/IO/RAW/include/itkRawImageIO.hxx
@@ -215,9 +215,17 @@ void RawImageIO< TPixel, VImageDimension >
   {
     itkReadRawBytesAfterSwappingMacro< long >( buffer, m_ByteOrder, numberOfComponents );
   }
+  else if ( this->GetComponentType() == LONGLONG )
+  {
+    itkReadRawBytesAfterSwappingMacro< long long >( buffer, m_ByteOrder, numberOfComponents );
+  }
   else if ( this->GetComponentType() == ULONG )
   {
     itkReadRawBytesAfterSwappingMacro< unsigned long >( buffer, m_ByteOrder, numberOfComponents );
+  }
+  else if ( this->GetComponentType() == ULONGLONG )
+  {
+    itkReadRawBytesAfterSwappingMacro< unsigned long long >( buffer, m_ByteOrder, numberOfComponents );
   }
   else if ( this->GetComponentType() == FLOAT )
   {
@@ -299,9 +307,19 @@ void RawImageIO< TPixel, VImageDimension >
     {
       itkWriteRawBytesAfterSwappingMacro< long >( buffer, file, m_ByteOrder, numberOfBytes, numberOfComponents );
     }
+    else if ( this->GetComponentType() == LONGLONG )
+    {
+      itkWriteRawBytesAfterSwappingMacro< long long >(
+        buffer, file, m_ByteOrder, numberOfBytes, numberOfComponents );
+    }
     else if ( this->GetComponentType() == ULONG )
     {
       itkWriteRawBytesAfterSwappingMacro< unsigned long >(
+        buffer, file, m_ByteOrder, numberOfBytes, numberOfComponents );
+    }
+    else if ( this->GetComponentType() == ULONGLONG )
+    {
+      itkWriteRawBytesAfterSwappingMacro< unsigned long long >(
         buffer, file, m_ByteOrder, numberOfBytes, numberOfComponents );
     }
     else if ( this->GetComponentType() == FLOAT )

--- a/Modules/Numerics/Statistics/ITKKWStyleOverwrite.txt
+++ b/Modules/Numerics/Statistics/ITKKWStyleOverwrite.txt
@@ -1,2 +1,3 @@
 test/.*\.cxx Namespace Disable
+test/itkMeasurementVectorTraitsTest\.cxx Operator Disable
 itkStatisticsTypesTest\.cxx Typedefs Disable

--- a/Modules/Remote/AnalyzeObjectMapIO.remote.cmake
+++ b/Modules/Remote/AnalyzeObjectMapIO.remote.cmake
@@ -1,5 +1,5 @@
 itk_fetch_module(AnalyzeObjectMapIO
   "AnalyzeObjectMapIO plugin for ITK. From Insight Journal article with handle: https://hdl.handle.net/1926/593"
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/itkAnalyzeObjectMap.git
-  GIT_TAG 54c3e2dbf0b4259aabe6c430df75171469d7bfee
+  GIT_TAG 7388d866433896368bd3049c396b974433b22cc5
   )

--- a/Utilities/KWStyle/ITK.kws.xml
+++ b/Utilities/KWStyle/ITK.kws.xml
@@ -4,7 +4,7 @@
 <DeclarationOrder>0,1,2</DeclarationOrder>
 <Typedefs>[A-Z]</Typedefs>
 <InternalVariables>m_[A-Z]</InternalVariables>
-<SemicolonSpace>0</SemicolonSpace>
+<SemicolonSpace>1</SemicolonSpace>
 <EndOfFileNewLine>1</EndOfFileNewLine>
 <Tabs>1</Tabs>
 <Spaces>3</Spaces>

--- a/Utilities/KWStyle/ITK.kws.xml
+++ b/Utilities/KWStyle/ITK.kws.xml
@@ -13,7 +13,7 @@
 <NameOfClass>[NameOfClass],itk</NameOfClass>
 <IfNDefDefine>[NameOfClass]_[Extension]</IfNDefDefine>
 <EmptyLines>2</EmptyLines>
-<Template>[TNV]</Template>
+<Template>([TNV]|D|unsigned int|int|bool|QMatrix|B[12]|typename|class|U|R|InputImage|Arguments|Function|vecLength|Output)</Template>
 <Operator>1,1</Operator>
 <Header>Utilities/KWStyle/ITKHeader.h,false,true</Header>
 </Description>


### PR DESCRIPTION
Provide initial code changes to facilitate enforcement of an ITK style that can be uniformly applied in an automated way.

These problems appeared when enforcing a consistent style with the clang-formatting tool.  It is a first step towards providing an easier code formatting style enforcement throughout ITK.
