### PR TITLE
BUG: Update SkullStrip module to address Doxygen configuration

### DIFF
--- a/Modules/Remote/SkullStrip.remote.cmake
+++ b/Modules/Remote/SkullStrip.remote.cmake
@@ -1,5 +1,5 @@
 itk_fetch_module(SkullStrip
   "A class to perform automatic skull-stripping for neuroimage analysis."
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSkullStrip.git
-  GIT_TAG 8054ee2d84bd3680962cda3683f18a3b321d5b6c
+  GIT_TAG 1d739d4c52d9dea336a3c8966720d451cea21b51
   )


### PR DESCRIPTION
Related to examples configuration.

Changes:

 Jon Haitz Legarreta Gorroño (2):
       ENH: Transition the example to the ITK testing framework.
       BUG: Fix wrapping.

 Matt McCormick (1):
       BUG: Use ITK_TEMPLATE_EXPORT macro for StripTsImageFilter