### PR TITLE
BUG: Regression in PolygonSpatialObject::IsInsideInObjectSpace #1082

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -258,7 +258,7 @@ PolygonSpatialObject< TDimension >
 
         if( node1 != node2 )
           {
-          if ( ( node1[Y] <= y && node2[Y] > y )
+          if ( ( node1[Y] < y && node2[Y] >= y )
                || ( node2[Y] < y && node1[Y] >= y ) )
             {
             if ( node1[X] + ( ( y - node1[Y] ) / ( node2[Y] - node1[Y] ) )


### PR DESCRIPTION
Closes #1082.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

