### PR TITLE
ENH: Deprecate Neuralnetwork module

### DIFF
--- a/Modules/Remote/NeuralNetworks.remote.cmake
+++ b/Modules/Remote/NeuralNetworks.remote.cmake
@@ -1,7 +1,21 @@
+if(NOT ITK_LEGACY_REMOVE)
+
 itk_fetch_module(NeuralNetworks
-"This remote module contains classes and support classes
+"This deprecated remote module contains classes and support classes
 for the calculation of artificial neural networks.
-This can be used, for instance, for image classification."
+
+This can be used, for instance, for image classification.
+
+This historical set of features is likely not appropriate for modern neural
+network implementations due to performance issues."
+
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKNeuralNetworks.git
-  GIT_TAG 602d7d09a9234d6d90dff4052a83a0143043008b
+  GIT_TAG c293e56699d6d102dcde567baf1cf5b704819c17
   )
+
+  if(NOT ITK_LEGACY_SILENT)
+    message(WARNING "NeuralNetworks remote module is deprecated.
+    Development of this module has ended, and it will be removed
+    in future ITK versions.")
+  endif()
+endif()


### PR DESCRIPTION
Explicitly specify that these methods are outdated.

Provide an explicit disclaimer that this historical set of features
is likely not appropriate for modern neural network implementations
due to performance issues.  The note is intended to assist with avoiding
confusion by users looking for modern machine learning approaches with
ITK.
