### PR TITLE
STYLE: Remove deprecated support for ITK_WRAP_PYTHON_LEGACY

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -14,13 +14,6 @@ if(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND
   message(WARNING "Python executable (\"${PYTHON_VERSION_STRING}\") and library (\"${PYTHONLIBS_VERSION_STRING}\") version mismatch.")
 endif()
 
-if(NOT EXTERNAL_WRAP_ITK_PROJECT)
-  CMAKE_DEPENDENT_OPTION(ITK_WRAP_PYTHON_LEGACY "Build Legacy Python support." ON
-                         "ITK_WRAP_PYTHON" OFF)
-else()
-  set(ITK_WRAP_PYTHON_LEGACY OFF)
-endif()
-
 mark_as_advanced(PYTHON_EXECUTABLE)
 include_directories("${PYTHON_INCLUDE_DIRS}")
 
@@ -383,17 +376,6 @@ macro(itk_end_wrap_module_python)
     "${WRAPPER_LIBRARY_NAME}"
     "${ITK_WRAP_PYTHON_BINARY_DIR}/Configuration/${WRAPPER_LIBRARY_NAME}Config.py"
   )
-
-  if(ITK_WRAP_PYTHON_LEGACY)
-    # create the advanced lib module python file
-    # this file lets the final user use something like "import ITKModuleName"
-    # backwards compatibility -- to be removed
-    set(CONFIG_LIBRARY_NAME "${WRAPPER_LIBRARY_NAME}")
-    configure_file("${ITK_WRAP_PYTHON_SOURCE_DIR}/ModuleLoader.py.in"
-      "${CMAKE_CURRENT_BINARY_DIR}/${WRAPPER_LIBRARY_NAME}.py"
-      @ONLY)
-    WRAP_ITK_PYTHON_BINDINGS_INSTALL(/ "${WRAPPER_LIBRARY_NAME}" "${CMAKE_CURRENT_BINARY_DIR}/${WRAPPER_LIBRARY_NAME}.py")
-  endif()
 
   set(ITK_WRAP_PYTHON_GLOBAL_TIMESTAMP_DECLS )
   set(ITK_WRAP_PYTHON_GLOBAL_TIMESTAMP_CALLS )

--- a/Wrapping/Generators/Python/ModuleLoader.py.in
+++ b/Wrapping/Generators/Python/ModuleLoader.py.in
@@ -1,8 +1,0 @@
-import itkConfig
-import warnings
-
-warnings.warn("@CONFIG_LIBRARY_NAME@ is deprecated; Use from itk import @CONFIG_LIBRARY_NAME@' instead.")
-
-import itkBase
-itkBase.LoadModule('@CONFIG_LIBRARY_NAME@')
-del itkBase


### PR DESCRIPTION
The ITK_WRAP_PYTHON_LEGACY needed to support backwards compatibility
for python support in ITKv4.  This was intended to be removed.

ITKv5 no longer supports this backwards compatibility.