### PR TITLE
DOC: Only warn when Module_NeuralNetworks is selected

### DIFF
--- a/Modules/Remote/NeuralNetworks.remote.cmake
+++ b/Modules/Remote/NeuralNetworks.remote.cmake
@@ -13,7 +13,7 @@ network implementations due to performance issues."
   GIT_TAG c293e56699d6d102dcde567baf1cf5b704819c17
   )
 
-  if(NOT ITK_LEGACY_SILENT)
+  if(NOT ITK_LEGACY_SILENT AND Module_NeuralNetworks)
     message(WARNING "NeuralNetworks remote module is deprecated.
     Development of this module has ended, and it will be removed
     in future ITK versions.")


### PR DESCRIPTION
The warning should not be issued if the module is not requested.
