### PR TITLE
COMP: ImageRegionRangeGTest issue #1147 Unused function template warning

### DIFF
--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -184,6 +184,8 @@ namespace
     EXPECT_EQ(rangeIterator, range.begin());
   }
 
+
+#ifdef NDEBUG
   template <typename TImage>
   void Check_Range_constructor_throws_ExceptionObject_when_iteration_region_is_outside_of_buffered_region(
     TImage& image,
@@ -203,7 +205,7 @@ namespace
       EXPECT_TRUE(std::strstr(description, "outside of buffered region") != nullptr);
     }
   }
-
+#endif
 
 }  // namespace
 


### PR DESCRIPTION
@dzenanz reported the following compile warning from
Mac10.13-AppleClang-dbg-x86_64-static as issue #1147:

> itkImageRegionRangeGTest.cxx:188:8: warning: unused function template
> 'Check_Range_constructor_throws_...' [-Wunused-template]

This warning occurs only with debug builds. It is fixed by surrounding
the definition of the function template by `#ifdef NDEBUG` ... `#endif`.

Closes #1147.