### PR TITLE
ENH: support RGB image in windowed sinc interpolation

### DIFF
--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -245,14 +245,15 @@ WindowedSincInterpolateImageFunction< TInputImage, VRadius,
 
   // Iterate over the neighborhood, taking the correct set
   // of weights in each dimension
-  double xPixelValue = 0.0;
+  using PixelType = typename NumericTraits< typename TInputImage::PixelType >::RealType;
+  PixelType xPixelValue = NumericTraits< PixelType >::ZeroValue();
   for ( unsigned int j = 0; j < m_OffsetTableSize; j++ )
     {
     // Get the offset for this neighbor
     unsigned int off = m_OffsetTable[j];
 
     // Get the intensity value at the pixel
-    double xVal = nit.GetPixel(off);
+    PixelType xVal = nit.GetPixel( off );
 
     // Multiply the intensity by each of the weights. Gotta hope
     // that the compiler will unwrap this loop and pipeline this!

--- a/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
@@ -21,6 +21,7 @@
 #include "itkWindowedSincInterpolateImageFunction.h"
 #include "itkConstantBoundaryCondition.h"
 #include "itkImageRegionIteratorWithIndex.h"
+#include "itkRGBPixel.h"
 
 namespace SincInterpolate {
 
@@ -120,6 +121,9 @@ OutputType trueValue )
   return true;
 
 }
+
+// Test instantiation with RGB pixel type
+using RGBInterpolatorType = itk::WindowedSincInterpolateImageFunction< itk::Image< itk::RGBPixel< short > >, 3 >;
 
 } // SincInterpolate namespace
 


### PR DESCRIPTION
## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

