### PR TITLE
ENH: added missing symbols to JPEG mangling header

### DIFF
--- a/Modules/ThirdParty/JPEG/src/itkjpeg/itk_jpeg_mangle.h
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg/itk_jpeg_mangle.h
@@ -182,5 +182,9 @@ nm libitkjpeg.a |grep " [TRD] " | awk '{ print "#define "$3" itk_jpeg_"$3 }'
 #define jpeg_write_tables            itk_jpeg_jpeg_write_tables
 #define jround_up                    itk_jpeg_jround_up
 #define jzero_far                    itk_jpeg_jzero_far
+#define jpeg_aritab                  itk_jpeg_jpeg_aritab
+#define jinit_arith_encoder          itk_jpeg_jinit_arith_encoder
+#define jinit_arith_decoder          itk_jpeg_jinit_arith_decoder
+#define jpeg_copy_critical_parameters itk_jpeg_jpeg_copy_critical_parameters
 
 #endif


### PR DESCRIPTION
Added 4 symbols to itk_jpeg_mangle.h

_jpeg_aritab
jinit_arith_encoder
jinit_arith_decoder
jpeg_copy_critical_parameters_


nm libitkjpeg-5.1.a | grep " [RT] " output is OK now.

Before:
```
0000000000000030 T itk_jpeg_jpeg_free_large
0000000000000010 T itk_jpeg_jpeg_free_small
0000000000000020 T itk_jpeg_jpeg_get_large
0000000000000000 T itk_jpeg_jpeg_get_small
0000000000000040 T itk_jpeg_jpeg_mem_available
0000000000000060 T itk_jpeg_jpeg_mem_init
0000000000000070 T itk_jpeg_jpeg_mem_term
0000000000000050 T itk_jpeg_jpeg_open_backing_store
0000000000000000 T itk_jpeg_jpeg_abort
00000000000000a0 T itk_jpeg_jpeg_alloc_huff_table
0000000000000080 T itk_jpeg_jpeg_alloc_quant_table
0000000000000050 T itk_jpeg_jpeg_destroy
0000000000000090 T itk_jpeg_jcopy_block_row
0000000000000030 T itk_jpeg_jcopy_sample_rows
0000000000000000 T itk_jpeg_jdiv_round_up
0000000000000420 R itk_jpeg_jpeg_natural_order
0000000000000000 R itk_jpeg_jpeg_natural_order2
0000000000000060 R itk_jpeg_jpeg_natural_order3
00000000000000e0 R itk_jpeg_jpeg_natural_order4
0000000000000160 R itk_jpeg_jpeg_natural_order5
0000000000000220 R itk_jpeg_jpeg_natural_order6
0000000000000300 R itk_jpeg_jpeg_natural_order7
0000000000000010 T itk_jpeg_jround_up
00000000000000b0 T itk_jpeg_jzero_far
00000000000001b0 T itk_jpeg_jpeg_std_error
00000000000012a0 T itk_jpeg_jinit_memory_mgr
0000000000000000 R jpeg_aritab
0000000000000120 T itk_jpeg_jpeg_abort_compress
0000000000000000 T itk_jpeg_jpeg_CreateCompress
0000000000000110 T itk_jpeg_jpeg_destroy_compress
0000000000000210 T itk_jpeg_jpeg_finish_compress
0000000000000130 T itk_jpeg_jpeg_suppress_tables
0000000000000340 T itk_jpeg_jpeg_write_marker
0000000000000420 T itk_jpeg_jpeg_write_m_byte
00000000000003d0 T itk_jpeg_jpeg_write_m_header
0000000000000430 T itk_jpeg_jpeg_write_tables
0000000000000000 T itk_jpeg_jpeg_start_compress
0000000000000150 T itk_jpeg_jpeg_write_raw_data
0000000000000090 T itk_jpeg_jpeg_write_scanlines
00000000000005e0 T itk_jpeg_jpeg_write_coefficients
0000000000000750 T jpeg_copy_critical_parameters
0000000000000000 T itk_jpeg_jpeg_add_quant_table
00000000000004e0 T itk_jpeg_jpeg_default_colorspace
0000000000000100 T itk_jpeg_jpeg_default_qtables
0000000000000190 T itk_jpeg_jpeg_quality_scaling
00000000000001f0 T itk_jpeg_jpeg_set_colorspace
0000000000000560 T itk_jpeg_jpeg_set_defaults
0000000000000150 T itk_jpeg_jpeg_set_linear_quality
00000000000001c0 T itk_jpeg_jpeg_set_quality
0000000000000a20 T itk_jpeg_jpeg_simple_progression
0000000000000250 T itk_jpeg_jpeg_mem_dest
00000000000001e0 T itk_jpeg_jpeg_stdio_dest
0000000000000000 T itk_jpeg_jinit_compress_master
00000000000012b0 T itk_jpeg_jinit_c_master_control
0000000000000e50 T itk_jpeg_jpeg_calc_jpeg_dimensions
0000000000002230 T itk_jpeg_jinit_marker_writer
0000000000000160 T itk_jpeg_jinit_c_main_controller
00000000000005a0 T itk_jpeg_jinit_c_prep_controller
0000000000000ec0 T itk_jpeg_jinit_c_coef_controller
00000000000006c0 T itk_jpeg_jinit_color_converter
0000000000000ca0 T itk_jpeg_jinit_downsampler
00000000000026e0 T itk_jpeg_jinit_huff_encoder
0000000000001610 T itk_jpeg_jinit_forward_dct
0000000000000000 T itk_jpeg_jpeg_fdct_ifast
0000000000000000 T itk_jpeg_jpeg_fdct_float
00000000000023c0 T itk_jpeg_jpeg_fdct_10x10
00000000000058f0 T itk_jpeg_jpeg_fdct_10x5
00000000000027e0 T itk_jpeg_jpeg_fdct_11x11
0000000000002d50 T itk_jpeg_jpeg_fdct_12x12
0000000000005530 T itk_jpeg_jpeg_fdct_12x6
0000000000003230 T itk_jpeg_jpeg_fdct_13x13
00000000000038d0 T itk_jpeg_jpeg_fdct_14x14
00000000000050e0 T itk_jpeg_jpeg_fdct_14x7
0000000000003e90 T itk_jpeg_jpeg_fdct_15x15
00000000000044e0 T itk_jpeg_jpeg_fdct_16x16
0000000000004bd0 T itk_jpeg_jpeg_fdct_16x8
0000000000002010 T itk_jpeg_jpeg_fdct_1x1
0000000000008e00 T itk_jpeg_jpeg_fdct_1x2
0000000000006c60 T itk_jpeg_jpeg_fdct_2x1
0000000000001f90 T itk_jpeg_jpeg_fdct_2x2
0000000000008ca0 T itk_jpeg_jpeg_fdct_2x4
0000000000001d50 T itk_jpeg_jpeg_fdct_3x3
0000000000008720 T itk_jpeg_jpeg_fdct_3x6
0000000000006ae0 T itk_jpeg_jpeg_fdct_4x2
0000000000001960 T itk_jpeg_jpeg_fdct_4x4
0000000000007cb0 T itk_jpeg_jpeg_fdct_4x8
00000000000079b0 T itk_jpeg_jpeg_fdct_5x10
0000000000001180 T itk_jpeg_jpeg_fdct_5x5
0000000000007630 T itk_jpeg_jpeg_fdct_6x12
0000000000006600 T itk_jpeg_jpeg_fdct_6x3
0000000000000620 T itk_jpeg_jpeg_fdct_6x6
00000000000071c0 T itk_jpeg_jpeg_fdct_7x14
0000000000000320 T itk_jpeg_jpeg_fdct_7x7
0000000000006ca0 T itk_jpeg_jpeg_fdct_8x16
0000000000005be0 T itk_jpeg_jpeg_fdct_8x4
0000000000002030 T itk_jpeg_jpeg_fdct_9x9
0000000000000000 T itk_jpeg_jpeg_fdct_islow
0000000000002320 T jinit_arith_encoder
0000000000000100 T itk_jpeg_jpeg_abort_decompress
0000000000000110 T itk_jpeg_jpeg_consume_input
0000000000000000 T itk_jpeg_jpeg_CreateDecompress
00000000000000f0 T itk_jpeg_jpeg_destroy_decompress
00000000000004b0 T itk_jpeg_jpeg_finish_decompress
0000000000000480 T itk_jpeg_jpeg_has_multiple_scans
0000000000000450 T itk_jpeg_jpeg_input_complete
00000000000003d0 T itk_jpeg_jpeg_read_header
0000000000000440 T itk_jpeg_jpeg_finish_output
00000000000002e0 T itk_jpeg_jpeg_read_raw_data
0000000000000230 T itk_jpeg_jpeg_read_scanlines
0000000000000140 T itk_jpeg_jpeg_start_decompress
00000000000003d0 T itk_jpeg_jpeg_start_output
0000000000000000 T itk_jpeg_jpeg_read_coefficients
0000000000000200 T itk_jpeg_jpeg_mem_src
0000000000000150 T itk_jpeg_jpeg_stdio_src
0000000000000590 T itk_jpeg_jinit_master_decompress
0000000000000250 T itk_jpeg_jpeg_calc_output_dimensions
0000000000000510 T itk_jpeg_jpeg_new_colormap
00000000000012f0 T itk_jpeg_jinit_input_controller
0000000000000d70 T itk_jpeg_jpeg_core_output_dimensions
0000000000002470 T itk_jpeg_jinit_marker_reader
0000000000002340 T itk_jpeg_jpeg_resync_to_restart
0000000000002570 T itk_jpeg_jpeg_save_markers
0000000000002650 T itk_jpeg_jpeg_set_marker_processor
0000000000002d30 T itk_jpeg_jinit_huff_decoder
0000000000000880 T itk_jpeg_jinit_d_main_controller
0000000000001290 T itk_jpeg_jinit_d_coef_controller
0000000000000300 T itk_jpeg_jinit_d_post_controller
0000000000000e80 T itk_jpeg_jinit_inverse_dct
0000000000000000 T itk_jpeg_jpeg_idct_ifast
0000000000000000 T itk_jpeg_jpeg_idct_float
0000000000002170 T itk_jpeg_jpeg_idct_10x10
0000000000005b80 T itk_jpeg_jpeg_idct_10x5
0000000000002610 T itk_jpeg_jpeg_idct_11x11
0000000000002bb0 T itk_jpeg_jpeg_idct_12x12
0000000000005790 T itk_jpeg_jpeg_idct_12x6
0000000000003120 T itk_jpeg_jpeg_idct_13x13
00000000000037b0 T itk_jpeg_jpeg_idct_14x14
0000000000005290 T itk_jpeg_jpeg_idct_14x7
0000000000003e20 T itk_jpeg_jpeg_idct_15x15
00000000000044f0 T itk_jpeg_jpeg_idct_16x16
0000000000004c70 T itk_jpeg_jpeg_idct_16x8
0000000000001d10 T itk_jpeg_jpeg_idct_1x1
0000000000008aa0 T itk_jpeg_jpeg_idct_1x2
0000000000006d30 T itk_jpeg_jpeg_idct_2x1
0000000000001c50 T itk_jpeg_jpeg_idct_2x2
00000000000088a0 T itk_jpeg_jpeg_idct_2x4
0000000000001970 T itk_jpeg_jpeg_idct_3x3
0000000000008290 T itk_jpeg_jpeg_idct_3x6
0000000000006b50 T itk_jpeg_jpeg_idct_4x2
00000000000013e0 T itk_jpeg_jpeg_idct_4x4
0000000000007f80 T itk_jpeg_jpeg_idct_4x8
0000000000007c10 T itk_jpeg_jpeg_idct_5x10
0000000000000aa0 T itk_jpeg_jpeg_idct_5x5
0000000000007820 T itk_jpeg_jpeg_idct_6x12
0000000000006510 T itk_jpeg_jpeg_idct_6x3
0000000000000820 T itk_jpeg_jpeg_idct_6x6
0000000000007320 T itk_jpeg_jpeg_idct_7x14
0000000000000490 T itk_jpeg_jpeg_idct_7x7
0000000000006d90 T itk_jpeg_jpeg_idct_8x16
0000000000005eb0 T itk_jpeg_jpeg_idct_8x4
0000000000001d50 T itk_jpeg_jpeg_idct_9x9
0000000000000000 T itk_jpeg_jpeg_idct_islow
00000000000007b0 T itk_jpeg_jinit_upsampler
0000000000000b00 T itk_jpeg_jinit_color_deconverter
0000000000000dc0 T itk_jpeg_jinit_1pass_quantizer
00000000000047a0 T itk_jpeg_jinit_2pass_quantizer
0000000000000540 T itk_jpeg_jinit_merged_upsampler
0000000000001300 T jinit_arith_decoder
```

After:
```
0000000000000030 T itk_jpeg_jpeg_free_large
0000000000000010 T itk_jpeg_jpeg_free_small
0000000000000020 T itk_jpeg_jpeg_get_large
0000000000000000 T itk_jpeg_jpeg_get_small
0000000000000040 T itk_jpeg_jpeg_mem_available
0000000000000060 T itk_jpeg_jpeg_mem_init
0000000000000070 T itk_jpeg_jpeg_mem_term
0000000000000050 T itk_jpeg_jpeg_open_backing_store
0000000000000000 T itk_jpeg_jpeg_abort
00000000000000a0 T itk_jpeg_jpeg_alloc_huff_table
0000000000000080 T itk_jpeg_jpeg_alloc_quant_table
0000000000000050 T itk_jpeg_jpeg_destroy
0000000000000090 T itk_jpeg_jcopy_block_row
0000000000000030 T itk_jpeg_jcopy_sample_rows
0000000000000000 T itk_jpeg_jdiv_round_up
0000000000000420 R itk_jpeg_jpeg_natural_order
0000000000000000 R itk_jpeg_jpeg_natural_order2
0000000000000060 R itk_jpeg_jpeg_natural_order3
00000000000000e0 R itk_jpeg_jpeg_natural_order4
0000000000000160 R itk_jpeg_jpeg_natural_order5
0000000000000220 R itk_jpeg_jpeg_natural_order6
0000000000000300 R itk_jpeg_jpeg_natural_order7
0000000000000010 T itk_jpeg_jround_up
00000000000000b0 T itk_jpeg_jzero_far
00000000000001b0 T itk_jpeg_jpeg_std_error
00000000000012a0 T itk_jpeg_jinit_memory_mgr
0000000000000000 R itk_jpeg_jpeg_aritab
0000000000000120 T itk_jpeg_jpeg_abort_compress
0000000000000000 T itk_jpeg_jpeg_CreateCompress
0000000000000110 T itk_jpeg_jpeg_destroy_compress
0000000000000210 T itk_jpeg_jpeg_finish_compress
0000000000000130 T itk_jpeg_jpeg_suppress_tables
0000000000000340 T itk_jpeg_jpeg_write_marker
0000000000000420 T itk_jpeg_jpeg_write_m_byte
00000000000003d0 T itk_jpeg_jpeg_write_m_header
0000000000000430 T itk_jpeg_jpeg_write_tables
0000000000000000 T itk_jpeg_jpeg_start_compress
0000000000000150 T itk_jpeg_jpeg_write_raw_data
0000000000000090 T itk_jpeg_jpeg_write_scanlines
0000000000000750 T itk_jpeg_jpeg_copy_critical_parameters
00000000000005e0 T itk_jpeg_jpeg_write_coefficients
0000000000000000 T itk_jpeg_jpeg_add_quant_table
00000000000004e0 T itk_jpeg_jpeg_default_colorspace
0000000000000100 T itk_jpeg_jpeg_default_qtables
0000000000000190 T itk_jpeg_jpeg_quality_scaling
00000000000001f0 T itk_jpeg_jpeg_set_colorspace
0000000000000560 T itk_jpeg_jpeg_set_defaults
0000000000000150 T itk_jpeg_jpeg_set_linear_quality
00000000000001c0 T itk_jpeg_jpeg_set_quality
0000000000000a20 T itk_jpeg_jpeg_simple_progression
0000000000000250 T itk_jpeg_jpeg_mem_dest
00000000000001e0 T itk_jpeg_jpeg_stdio_dest
0000000000000000 T itk_jpeg_jinit_compress_master
00000000000012b0 T itk_jpeg_jinit_c_master_control
0000000000000e50 T itk_jpeg_jpeg_calc_jpeg_dimensions
0000000000002230 T itk_jpeg_jinit_marker_writer
0000000000000160 T itk_jpeg_jinit_c_main_controller
00000000000005a0 T itk_jpeg_jinit_c_prep_controller
0000000000000ec0 T itk_jpeg_jinit_c_coef_controller
00000000000006c0 T itk_jpeg_jinit_color_converter
0000000000000ca0 T itk_jpeg_jinit_downsampler
00000000000026e0 T itk_jpeg_jinit_huff_encoder
0000000000001610 T itk_jpeg_jinit_forward_dct
0000000000000000 T itk_jpeg_jpeg_fdct_ifast
0000000000000000 T itk_jpeg_jpeg_fdct_float
00000000000023c0 T itk_jpeg_jpeg_fdct_10x10
00000000000058f0 T itk_jpeg_jpeg_fdct_10x5
00000000000027e0 T itk_jpeg_jpeg_fdct_11x11
0000000000002d50 T itk_jpeg_jpeg_fdct_12x12
0000000000005530 T itk_jpeg_jpeg_fdct_12x6
0000000000003230 T itk_jpeg_jpeg_fdct_13x13
00000000000038d0 T itk_jpeg_jpeg_fdct_14x14
00000000000050e0 T itk_jpeg_jpeg_fdct_14x7
0000000000003e90 T itk_jpeg_jpeg_fdct_15x15
00000000000044e0 T itk_jpeg_jpeg_fdct_16x16
0000000000004bd0 T itk_jpeg_jpeg_fdct_16x8
0000000000002010 T itk_jpeg_jpeg_fdct_1x1
0000000000008e00 T itk_jpeg_jpeg_fdct_1x2
0000000000006c60 T itk_jpeg_jpeg_fdct_2x1
0000000000001f90 T itk_jpeg_jpeg_fdct_2x2
0000000000008ca0 T itk_jpeg_jpeg_fdct_2x4
0000000000001d50 T itk_jpeg_jpeg_fdct_3x3
0000000000008720 T itk_jpeg_jpeg_fdct_3x6
0000000000006ae0 T itk_jpeg_jpeg_fdct_4x2
0000000000001960 T itk_jpeg_jpeg_fdct_4x4
0000000000007cb0 T itk_jpeg_jpeg_fdct_4x8
00000000000079b0 T itk_jpeg_jpeg_fdct_5x10
0000000000001180 T itk_jpeg_jpeg_fdct_5x5
0000000000007630 T itk_jpeg_jpeg_fdct_6x12
0000000000006600 T itk_jpeg_jpeg_fdct_6x3
0000000000000620 T itk_jpeg_jpeg_fdct_6x6
00000000000071c0 T itk_jpeg_jpeg_fdct_7x14
0000000000000320 T itk_jpeg_jpeg_fdct_7x7
0000000000006ca0 T itk_jpeg_jpeg_fdct_8x16
0000000000005be0 T itk_jpeg_jpeg_fdct_8x4
0000000000002030 T itk_jpeg_jpeg_fdct_9x9
0000000000000000 T itk_jpeg_jpeg_fdct_islow
0000000000002320 T itk_jpeg_jinit_arith_encoder
0000000000000100 T itk_jpeg_jpeg_abort_decompress
0000000000000110 T itk_jpeg_jpeg_consume_input
0000000000000000 T itk_jpeg_jpeg_CreateDecompress
00000000000000f0 T itk_jpeg_jpeg_destroy_decompress
00000000000004b0 T itk_jpeg_jpeg_finish_decompress
0000000000000480 T itk_jpeg_jpeg_has_multiple_scans
0000000000000450 T itk_jpeg_jpeg_input_complete
00000000000003d0 T itk_jpeg_jpeg_read_header
0000000000000440 T itk_jpeg_jpeg_finish_output
00000000000002e0 T itk_jpeg_jpeg_read_raw_data
0000000000000230 T itk_jpeg_jpeg_read_scanlines
0000000000000140 T itk_jpeg_jpeg_start_decompress
00000000000003d0 T itk_jpeg_jpeg_start_output
0000000000000000 T itk_jpeg_jpeg_read_coefficients
0000000000000200 T itk_jpeg_jpeg_mem_src
0000000000000150 T itk_jpeg_jpeg_stdio_src
0000000000000590 T itk_jpeg_jinit_master_decompress
0000000000000250 T itk_jpeg_jpeg_calc_output_dimensions
0000000000000510 T itk_jpeg_jpeg_new_colormap
00000000000012f0 T itk_jpeg_jinit_input_controller
0000000000000d70 T itk_jpeg_jpeg_core_output_dimensions
0000000000002470 T itk_jpeg_jinit_marker_reader
0000000000002340 T itk_jpeg_jpeg_resync_to_restart
0000000000002570 T itk_jpeg_jpeg_save_markers
0000000000002650 T itk_jpeg_jpeg_set_marker_processor
0000000000002d30 T itk_jpeg_jinit_huff_decoder
0000000000000880 T itk_jpeg_jinit_d_main_controller
0000000000001290 T itk_jpeg_jinit_d_coef_controller
0000000000000300 T itk_jpeg_jinit_d_post_controller
0000000000000e80 T itk_jpeg_jinit_inverse_dct
0000000000000000 T itk_jpeg_jpeg_idct_ifast
0000000000000000 T itk_jpeg_jpeg_idct_float
0000000000002170 T itk_jpeg_jpeg_idct_10x10
0000000000005b80 T itk_jpeg_jpeg_idct_10x5
0000000000002610 T itk_jpeg_jpeg_idct_11x11
0000000000002bb0 T itk_jpeg_jpeg_idct_12x12
0000000000005790 T itk_jpeg_jpeg_idct_12x6
0000000000003120 T itk_jpeg_jpeg_idct_13x13
00000000000037b0 T itk_jpeg_jpeg_idct_14x14
0000000000005290 T itk_jpeg_jpeg_idct_14x7
0000000000003e20 T itk_jpeg_jpeg_idct_15x15
00000000000044f0 T itk_jpeg_jpeg_idct_16x16
0000000000004c70 T itk_jpeg_jpeg_idct_16x8
0000000000001d10 T itk_jpeg_jpeg_idct_1x1
0000000000008aa0 T itk_jpeg_jpeg_idct_1x2
0000000000006d30 T itk_jpeg_jpeg_idct_2x1
0000000000001c50 T itk_jpeg_jpeg_idct_2x2
00000000000088a0 T itk_jpeg_jpeg_idct_2x4
0000000000001970 T itk_jpeg_jpeg_idct_3x3
0000000000008290 T itk_jpeg_jpeg_idct_3x6
0000000000006b50 T itk_jpeg_jpeg_idct_4x2
00000000000013e0 T itk_jpeg_jpeg_idct_4x4
0000000000007f80 T itk_jpeg_jpeg_idct_4x8
0000000000007c10 T itk_jpeg_jpeg_idct_5x10
0000000000000aa0 T itk_jpeg_jpeg_idct_5x5
0000000000007820 T itk_jpeg_jpeg_idct_6x12
0000000000006510 T itk_jpeg_jpeg_idct_6x3
0000000000000820 T itk_jpeg_jpeg_idct_6x6
0000000000007320 T itk_jpeg_jpeg_idct_7x14
0000000000000490 T itk_jpeg_jpeg_idct_7x7
0000000000006d90 T itk_jpeg_jpeg_idct_8x16
0000000000005eb0 T itk_jpeg_jpeg_idct_8x4
0000000000001d50 T itk_jpeg_jpeg_idct_9x9
0000000000000000 T itk_jpeg_jpeg_idct_islow
00000000000007b0 T itk_jpeg_jinit_upsampler
0000000000000b00 T itk_jpeg_jinit_color_deconverter
0000000000000dc0 T itk_jpeg_jinit_1pass_quantizer
00000000000047a0 T itk_jpeg_jinit_2pass_quantizer
0000000000000540 T itk_jpeg_jinit_merged_upsampler
0000000000001300 T itk_jpeg_jinit_arith_decoder
```
