### PR TITLE
COMP: Improve default building of ITK with MSVC 1920-2929 version

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -217,6 +217,12 @@ macro(check_compiler_platform_flags)
          if(MSVC_VERSION GREATER 1310)
            set(ITK_REQUIRED_CXX_FLAGS "${ITK_REQUIRED_CXX_FLAGS} /bigobj")
          endif()
+         # Force synchronous writes for building ITK on MSVC 1920-1929
+         # https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-201
+         if(MSVC_VERSION GREATER_EQUAL 1920)
+           set(ITK_REQUIRED_C_FLAGS "${ITK_REQUIRED_CXX_FLAGS} /FS")
+           set(ITK_REQUIRED_CXX_FLAGS "${ITK_REQUIRED_CXX_FLAGS} /FS")
+         endif()
        endif()
   endif()
 


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-2019

and discussions:

https://discourse.itk.org/t/has-anyone-tried-to-build-visual-studio-c-2019/1561

## PR Checklist
- :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- :no_entry_sign: Adds the License notice to new files.
- :no_entry_sign: Adds Python wrapping.
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- :no_entry_sign: Adds Documentation.

