### PR TITLE
Fix multithreaded point set to point set metric thread safety issue

### DIFF
--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
@@ -255,7 +255,6 @@ private:
   /** the points container which will be actually used for storing
    * measurement vectors */
   VectorContainerConstPointer  m_VectorContainer;
-
 };  // end of class VectorContainerToListSampleAdaptor
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.h
@@ -82,6 +82,11 @@ protected:
   EuclideanDistancePointSetToPointSetMetricv4() = default;
   ~EuclideanDistancePointSetToPointSetMetricv4() override = default;
 
+  bool RequiresFixedPointsLocator() const override
+    {
+    return false;
+    }
+
   /** PrintSelf function */
   void PrintSelf( std::ostream & os, Indent indent ) const override;
 };

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
@@ -114,6 +114,11 @@ protected:
   ExpectationBasedPointSetToPointSetMetricv4();
   ~ExpectationBasedPointSetToPointSetMetricv4() override = default;
 
+  bool RequiresFixedPointsLocator() const override
+    {
+    return false;
+    }
+
   /** PrintSelf function */
   void PrintSelf( std::ostream & os, Indent indent ) const override;
 

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
@@ -224,6 +224,16 @@ protected:
 
   void PrintSelf( std::ostream& os, Indent indent ) const override;
 
+  bool RequiresFixedPointsLocator() const override
+    {
+    return false;
+    }
+
+  bool RequiresMovingPointsLocator() const override
+    {
+    return false;
+    }
+
 private:
   DensityFunctionPointer                   m_MovingDensityFunction;
 

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -412,6 +412,15 @@ protected:
     return Superclass::POINT_SET_METRIC;
     }
 
+  virtual bool RequiresMovingPointsLocator() const
+    {
+    return true;
+    };
+
+  virtual bool RequiresFixedPointsLocator() const
+    {
+    return true;
+    };
 
 private:
   mutable bool m_MovingTransformPointLocatorsNeedInitialization;
@@ -427,6 +436,12 @@ private:
 
   mutable ModifiedTimeType m_MovingTransformedPointSetTime;
   mutable ModifiedTimeType m_FixedTransformedPointSetTime;
+
+  //Create ranges over the point set for multithreaded computation of value and derivatives
+  using PointIdentifierPair = std::pair<PointIdentifier, PointIdentifier>;
+  using PointIdentifierRanges = std::vector<PointIdentifierPair>;
+  const PointIdentifierRanges  CreateRanges() const;
+
 };
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.hxx
@@ -161,43 +161,65 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
 {
   this->InitializeForIteration();
 
-  CompensatedSummation< MeasureType > value;
 
-  PointsConstIterator It = this->m_FixedTransformedPointSet->GetPoints()->Begin();
   // Virtual point set will be the same size as fixed point set as long as it's
   // generated from the fixed point set.
   if( this->m_VirtualTransformedPointSet->GetNumberOfPoints() != this->m_FixedTransformedPointSet->GetNumberOfPoints() )
     {
     itkExceptionMacro("Expected FixedTransformedPointSet to be the same size as VirtualTransformedPointSet.");
     }
-  PointsConstIterator virtualIt = this->m_VirtualTransformedPointSet->GetPoints()->Begin();
+  /*
+   * Split pointset in nWorkUnit ranges and sum individually
+   * This splitting is required in order to avoid having the threads
+   * repeatedly write to same location causing false sharing
+   */
+  //Use STL container to make sure no unesecarry checks are performed
+  using FixedTransformedVectorContainer = typename FixedPointsContainer::STLContainerType;
+  using VirtualPointsContainer = typename VirtualPointSetType::PointsContainer;
+  using VirtualVectorContainer =  typename VirtualPointsContainer::STLContainerType;
+  const VirtualVectorContainer &virtualTransformedPointSet =
+    this->m_VirtualTransformedPointSet->GetPoints()->CastToSTLConstContainer();
+  const FixedTransformedVectorContainer &fixedTransformedPointSet =
+    this->m_FixedTransformedPointSet->GetPoints()->CastToSTLConstContainer();
 
-  while( It != this->m_FixedTransformedPointSet->GetPoints()->End() )
+  PointIdentifierRanges ranges = this->CreateRanges();
+  std::vector< CompensatedSummation< MeasureType > > threadValues( ranges.size() );
+  std::function< void(unsigned int) > sumNeighborhoodValues =
+      [ this, &threadValues, &ranges, &virtualTransformedPointSet, &fixedTransformedPointSet]
+      (unsigned int rangeIndex)
     {
-    /* Verify the virtual point is in the virtual domain.
-     * If user hasn't defined a virtual space, and the active transform is not
-     * a displacement field transform type, then this will always return true. */
-    if( ! this->IsInsideVirtualDomain( virtualIt.Value() ) )
-      {
-      ++It;
-      ++virtualIt;
-      continue;
-      }
-
+    CompensatedSummation< MeasureType > threadValue = 0;
     PixelType pixel;
     NumericTraits<PixelType>::SetLength( pixel, 1 );
-    if( this->m_UsePointSetData )
+
+
+    for( PointIdentifier index=ranges[rangeIndex].first; index < ranges[rangeIndex].second; index++)
       {
-      bool doesPointDataExist = this->m_FixedPointSet->GetPointData( It.Index(), &pixel );
-      if( ! doesPointDataExist )
+      if( this->IsInsideVirtualDomain( virtualTransformedPointSet[index] ) )
         {
-        itkExceptionMacro( "The corresponding data for point " << It.Value() << " (pointId = " << It.Index() << ") does not exist." );
+        if( this->m_UsePointSetData )
+          {
+          bool doesPointDataExist = this->m_FixedPointSet->GetPointData( index, &pixel );
+          if( ! doesPointDataExist )
+            {
+            itkExceptionMacro( "The corresponding data for point (pointId = " << index << ") does not exist." );
+            }
+          }
+        threadValue += this->GetLocalNeighborhoodValue( fixedTransformedPointSet[index], pixel );
         }
       }
+      threadValues[rangeIndex] = threadValue;
+    };
 
-    value += this->GetLocalNeighborhoodValue( It.Value(), pixel );
-    ++virtualIt;
-    ++It;
+  //Sum per thread
+  MultiThreaderBase::New()->ParallelizeArray( (PointIdentifier) 0,
+                          (PointIdentifier) ranges.size(),
+                           sumNeighborhoodValues, nullptr );
+  //Join sums
+  CompensatedSummation<MeasureType> value = 0;
+  for(unsigned int i=0; i < threadValues.size(); i++)
+    {
+    value += threadValues[i];
     }
 
   DerivativeType derivative;
@@ -235,6 +257,13 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
 {
   this->InitializeForIteration();
 
+  // Virtual point set will be the same size as fixed point set as long as it's
+  // generated from the fixed point set.
+  if( this->m_VirtualTransformedPointSet->GetNumberOfPoints() != this->m_FixedTransformedPointSet->GetNumberOfPoints() )
+    {
+    itkExceptionMacro( "Expected FixedTransformedPointSet to be the same size as VirtualTransformedPointSet." );
+    }
+
   derivative.SetSize( this->GetNumberOfParameters() );
   if( ! this->GetStoreDerivativeAsSparseFieldForLocalSupportTransforms() )
     {
@@ -242,119 +271,153 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
     }
   derivative.Fill( NumericTraits<DerivativeValueType>::ZeroValue() );
 
-  CompensatedSummation<MeasureType> value;
-  MovingTransformJacobianType  jacobian( MovingPointDimension, this->GetNumberOfLocalParameters() );
-  MovingTransformJacobianType  jacobianCache;
+  /*
+   * Split pointset in nWorkUnits ranges and sum individually
+   * This splitting is required in order to avoid having the threads
+   * repeatedly write to same location causing false sharing
+   */
+  //Use STL container to make sure no unesecarry checks are performed
+  using FixedTransformedVectorContainer = typename FixedPointsContainer::STLContainerType;
+  using VirtualPointsContainer = typename VirtualPointSetType::PointsContainer;
+  using VirtualVectorContainer =  typename VirtualPointsContainer::STLContainerType;
+  const VirtualVectorContainer &virtualTransformedPointSet =
+    this->m_VirtualTransformedPointSet->GetPoints()->CastToSTLConstContainer();
+  const FixedTransformedVectorContainer &fixedTransformedPointSet =
+    this->m_FixedTransformedPointSet->GetPoints()->CastToSTLConstContainer();
 
-  DerivativeType localTransformDerivative( this->GetNumberOfLocalParameters() );
-  localTransformDerivative.Fill( NumericTraits<DerivativeValueType>::ZeroValue() );
-
-  // Virtual point set will be the same size as fixed point set as long as it's
-  // generated from the fixed point set.
-  if( this->m_VirtualTransformedPointSet->GetNumberOfPoints() != this->m_FixedTransformedPointSet->GetNumberOfPoints() )
+  PointIdentifierRanges ranges = this->CreateRanges();
+  std::vector< CompensatedSummation< MeasureType > > threadValues( ranges.size() );
+  using CompensatedDerivative = typename std::vector< CompensatedSummation<ParametersValueType> >;
+  std::vector< CompensatedDerivative > threadDerivatives( ranges.size() );
+  std::function< void(unsigned int) > sumNeighborhoodValues =
+      [ this, &derivative, &threadDerivatives, &threadValues, &ranges, &calculateValue,
+        &virtualTransformedPointSet, &fixedTransformedPointSet]
+      (unsigned int rangeIndex)
     {
-    itkExceptionMacro( "Expected FixedTransformedPointSet to be the same size as VirtualTransformedPointSet." );
-    }
-  PointsConstIterator virtualIt = this->m_VirtualTransformedPointSet->GetPoints()->Begin();
-  PointsConstIterator It = this->m_FixedTransformedPointSet->GetPoints()->Begin();
-  PointsConstIterator end = this->m_FixedTransformedPointSet->GetPoints()->End();
+    MovingTransformJacobianType  jacobian( MovingPointDimension, this->GetNumberOfLocalParameters() );
+    MovingTransformJacobianType  jacobianCache;
 
-  while( It != end )
-    {
-    MeasureType pointValue = NumericTraits<MeasureType>::ZeroValue();
-    LocalDerivativeType pointDerivative;
+    DerivativeType threadLocalTransformDerivative( this->GetNumberOfLocalParameters() );
+    threadLocalTransformDerivative.Fill( NumericTraits<DerivativeValueType>::ZeroValue() );
 
-    /* Verify the virtual point is in the virtual domain.
-     * If user hasn't defined a virtual space, and the active transform is not
-     * a displacement field transform type, then this will always return true. */
-    if( ! this->IsInsideVirtualDomain( virtualIt.Value() ) )
-      {
-      ++It;
-      ++virtualIt;
-      continue;
-      }
+    CompensatedDerivative threadDerivativeSum( this->GetNumberOfLocalParameters() );
 
+    CompensatedSummation< MeasureType > threadValue;
     PixelType pixel;
     NumericTraits<PixelType>::SetLength( pixel, 1 );
-    if( this->m_UsePointSetData )
+    for( PointIdentifier index=ranges[rangeIndex].first; index < ranges[rangeIndex].second; index++)
       {
-      bool doesPointDataExist = this->m_FixedPointSet->GetPointData( It.Index(), &pixel );
-      if( ! doesPointDataExist )
+      MeasureType pointValue = NumericTraits<MeasureType>::ZeroValue();
+      LocalDerivativeType pointDerivative;
+
+      /* Verify the virtual point is in the virtual domain.
+       * If user hasn't defined a virtual space, and the active transform is not
+       * a displacement field transform type, then this will always return true. */
+      if( ! this->IsInsideVirtualDomain( virtualTransformedPointSet[index] ) )
         {
-        itkExceptionMacro( "The corresponding data for point " << It.Value() << " (pointId = " << It.Index() << ") does not exist." );
+        continue;
         }
-      }
 
-    if( calculateValue )
-      {
-      this->GetLocalNeighborhoodValueAndDerivative( It.Value(), pointValue, pointDerivative, pixel );
-      value += pointValue;
-      }
-    else
-      {
-      pointDerivative = this->GetLocalNeighborhoodDerivative( It.Value(), pixel );
-      }
-
-    // Map into parameter space
-    if( this->HasLocalSupport() || this->m_CalculateValueAndDerivativeInTangentSpace )
-      {
-      // Reset to zero since we're not accumulating in the local-support case.
-      localTransformDerivative.Fill( NumericTraits<DerivativeValueType>::ZeroValue() );
-      }
-
-    if( this->m_CalculateValueAndDerivativeInTangentSpace )
-      {
-      jacobian.Fill( 0.0 );
-      for( DimensionType d = 0; d < MovingPointDimension; d++ )
+      if( this->m_UsePointSetData )
         {
-        jacobian(d, d) = 1.0;
+        bool doesPointDataExist = this->m_FixedPointSet->GetPointData( index, &pixel );
+        if( ! doesPointDataExist )
+          {
+          itkExceptionMacro( "The corresponding data for point with id " << index << " does not exist." );
+          }
         }
-      }
-    else
-      {
-      this->GetMovingTransform()->
-        ComputeJacobianWithRespectToParametersCachedTemporaries( virtualIt.Value(),
-                                                                 jacobian,
-                                                                 jacobianCache );
-      }
 
-    for( NumberOfParametersType par = 0; par < this->GetNumberOfLocalParameters(); par++ )
-      {
-      for( DimensionType d = 0; d < PointDimension; ++d )
+      if( calculateValue )
         {
-        localTransformDerivative[par] += jacobian(d, par) * pointDerivative[d];
-        }
-      }
-
-    // For local-support transforms, store the per-point result
-    if( this->HasLocalSupport() || this->m_CalculateValueAndDerivativeInTangentSpace )
-      {
-      if( this->GetStoreDerivativeAsSparseFieldForLocalSupportTransforms() )
-        {
-        this->StorePointDerivative( virtualIt.Value(), localTransformDerivative, derivative );
+        this->GetLocalNeighborhoodValueAndDerivative( fixedTransformedPointSet[index], pointValue, pointDerivative, pixel );
+        threadValue += pointValue;
         }
       else
         {
-        for( NumberOfParametersType par = 0; par < this->GetNumberOfLocalParameters(); par++ )
+        pointDerivative = this->GetLocalNeighborhoodDerivative( fixedTransformedPointSet[index], pixel );
+        }
+
+      // Map into parameter space
+      threadLocalTransformDerivative.Fill( NumericTraits<DerivativeValueType>::ZeroValue() );
+
+      if( this->m_CalculateValueAndDerivativeInTangentSpace )
+        {
+        for( DimensionType d = 0; d < PointDimension; ++d )
           {
-          derivative[this->GetNumberOfLocalParameters() * It.Index() + par] = localTransformDerivative[par];
+          threadLocalTransformDerivative[d] += pointDerivative[d];
           }
         }
+      else
+        {
+        this->GetMovingTransform()->
+          ComputeJacobianWithRespectToParametersCachedTemporaries( virtualTransformedPointSet[index],
+                                                                   jacobian,
+                                                                   jacobianCache );
+
+        for( NumberOfParametersType par = 0; par < this->GetNumberOfLocalParameters(); par++ )
+          {
+          for( DimensionType d = 0; d < PointDimension; ++d )
+            {
+            threadLocalTransformDerivative[par] += jacobian(d, par) * pointDerivative[d];
+            }
+          }
+        }
+      // For local-support transforms, store the per-point result
+      if( this->HasLocalSupport() || this->m_CalculateValueAndDerivativeInTangentSpace )
+        {
+        if( this->GetStoreDerivativeAsSparseFieldForLocalSupportTransforms() )
+          {
+          this->StorePointDerivative( virtualTransformedPointSet[index], threadLocalTransformDerivative, derivative );
+          }
+        else
+          {
+          for( NumberOfParametersType par = 0; par < this->GetNumberOfLocalParameters(); par++ )
+            {
+            derivative[this->GetNumberOfLocalParameters() * index + par] = threadLocalTransformDerivative[par];
+            }
+          }
+        }
+      for( NumberOfParametersType par = 0; par < this->GetNumberOfLocalParameters(); par++ )
+        {
+        threadDerivativeSum[par] += threadLocalTransformDerivative[par];
+        }
       }
+      threadValues[rangeIndex] = threadValue;
+      threadDerivatives[rangeIndex] = threadDerivativeSum;
+    };
 
-    ++It;
-    ++virtualIt;
+  //Sum per thread
+  MultiThreaderBase::New()->ParallelizeArray( (PointIdentifier) 0,
+                          (PointIdentifier) ranges.size(),
+                           sumNeighborhoodValues, nullptr );
+
+  //Sum thread results
+  CompensatedSummation<MeasureType> value = 0;
+  for(unsigned int i=0; i < threadValues.size(); i++)
+    {
+    value += threadValues[i];
     }
-
   MeasureType valueSum = value.GetSum();
+
   if( this->VerifyNumberOfValidPoints( valueSum, derivative ) )
     {
     // For global-support transforms, average the accumulated derivative result
     if( ! this->HasLocalSupport() && ! this->m_CalculateValueAndDerivativeInTangentSpace )
       {
-      derivative = localTransformDerivative / static_cast<DerivativeValueType>( this->m_NumberOfValidPoints );
+      CompensatedDerivative localTransformDerivative( this->GetNumberOfLocalParameters() );
+      for(unsigned int i=0; i< threadDerivatives.size(); i++)
+        {
+        for( NumberOfParametersType par = 0; par < this->GetNumberOfLocalParameters(); par++ )
+          {
+          localTransformDerivative[par] += threadDerivatives[i][par];
+          }
+        }
+      for( NumberOfParametersType par = 0; par < this->GetNumberOfLocalParameters(); par++ )
+        {
+         derivative[par] = localTransformDerivative[par].GetSum()
+                                  / static_cast<DerivativeValueType>( this->m_NumberOfValidPoints );
+         }
       }
-
     valueSum /= static_cast<MeasureType>( this->m_NumberOfValidPoints );
     }
   calculatedValue = valueSum;
@@ -428,7 +491,11 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
 {
   // Transform the moving point set with the moving transform.
   // We calculate the value and derivatives in the moving space.
-  if( ( this->GetMTime() > this->m_MovingTransformedPointSetTime ) || ( this->m_MovingTransform->GetMTime() > this->GetMTime() ) || !this->m_MovingTransformedPointSet )
+  bool update = !this->m_MovingTransformedPointSet;
+  update = update || this->m_MovingTransformedPointSetTime < this->GetMTime();
+  update = update || ( this->m_CalculateValueAndDerivativeInTangentSpace &&
+              ( this->m_MovingTransform->GetMTime() > this->m_MovingTransformedPointSetTime ) );
+  if( update )
     {
     this->m_MovingTransformPointLocatorsNeedInitialization = true;
     this->m_MovingTransformedPointSet = MovingTransformedPointSetType::New();
@@ -440,7 +507,7 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
     typename MovingPointsContainer::ConstIterator It = this->m_MovingPointSet->GetPoints()->Begin();
     while( It != this->m_MovingPointSet->GetPoints()->End() )
       {
-      if( this->m_CalculateValueAndDerivativeInTangentSpace == true )
+      if( this->m_CalculateValueAndDerivativeInTangentSpace )
         {
         PointType point = inverseTransform->TransformPoint( It.Value() );
         this->m_MovingTransformedPointSet->SetPoint( It.Index(), point );
@@ -453,6 +520,13 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
       ++It;
       }
     this->m_MovingTransformedPointSetTime = this->GetMTime();
+    if(!this->m_CalculateValueAndDerivativeInTangentSpace)
+      {
+      this->m_MovingTransformedPointSetTime = std::max( this->m_MovingTransformedPointSetTime,
+                                                        this->m_MovingTransform->GetMTime() );
+      }
+
+
     }
 }
 
@@ -462,11 +536,14 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
 ::TransformFixedAndCreateVirtualPointSet() const
 {
   // Transform the fixed point set through the virtual domain, and into the moving domain
-  if( ( this->GetMTime() > this->m_FixedTransformedPointSetTime )
-      || ( this->m_FixedTransform->GetMTime() > this->GetMTime() )
-      || ! this->m_FixedTransformedPointSet
-      || ! this->m_VirtualTransformedPointSet
-      || ( this->m_MovingTransform->GetMTime() > this->GetMTime() ) )
+  bool update =  ! this->m_FixedTransformedPointSet || ! this->m_VirtualTransformedPointSet;
+  update = update || this->m_FixedTransformedPointSetTime < this->GetMTime();
+  update = update || ( this->m_CalculateValueAndDerivativeInTangentSpace &&
+                       ( this->m_FixedTransform->GetMTime() > this->m_FixedTransformedPointSetTime ) );
+  update = update || ( !this->m_CalculateValueAndDerivativeInTangentSpace &&
+                       ( ( this->m_FixedTransform->GetMTime() > this->m_FixedTransformedPointSetTime) ||
+                         ( this->m_MovingTransform->GetMTime() > this->m_FixedTransformedPointSetTime)   ) );
+  if( update )
     {
     this->m_FixedTransformPointLocatorsNeedInitialization = true;
     this->m_FixedTransformedPointSet = FixedTransformedPointSetType::New();
@@ -474,12 +551,13 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
     this->m_VirtualTransformedPointSet = VirtualPointSetType::New();
     this->m_VirtualTransformedPointSet->Initialize();
 
-    typename FixedTransformType::InverseTransformBasePointer inverseTransform = this->m_FixedTransform->GetInverseTransform();
+    using InverseTransformBasePointer  = typename FixedTransformType::InverseTransformBasePointer;
+    InverseTransformBasePointer inverseTransform = this->m_FixedTransform->GetInverseTransform();
 
     typename FixedPointsContainer::ConstIterator It = this->m_FixedPointSet->GetPoints()->Begin();
     while( It != this->m_FixedPointSet->GetPoints()->End() )
       {
-      if( this->m_CalculateValueAndDerivativeInTangentSpace == true )
+      if( this->m_CalculateValueAndDerivativeInTangentSpace )
         {
         // txf into virtual space
         PointType point = inverseTransform->TransformPoint( It.Value() );
@@ -497,7 +575,14 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
         }
       ++It;
       }
-    this->m_FixedTransformedPointSetTime = this->GetMTime();
+      this->m_FixedTransformedPointSetTime = std::max( this->GetMTime(),
+                                                       this->m_FixedTransform->GetMTime());
+      if(!this->m_CalculateValueAndDerivativeInTangentSpace)
+        {
+        this->m_FixedTransformedPointSetTime = std::max( this->m_FixedTransformedPointSetTime,
+                                                         this->m_MovingTransform->GetMTime() );
+        }
+
     }
 }
 
@@ -516,13 +601,14 @@ void
 PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>
 ::InitializePointsLocators() const
 {
-  if( this->m_FixedTransformPointLocatorsNeedInitialization )
+  if( this->RequiresFixedPointsLocator() &&
+      this->m_FixedTransformPointLocatorsNeedInitialization )
     {
     if( !this->m_FixedTransformedPointSet )
       {
       itkExceptionMacro( "The fixed transformed point set does not exist." );
       }
-    if( ! this->m_FixedTransformedPointsLocator )
+    if( !this->m_FixedTransformedPointsLocator )
       {
       this->m_FixedTransformedPointsLocator = PointsLocatorType::New();
       }
@@ -530,13 +616,14 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
     this->m_FixedTransformedPointsLocator->Initialize();
     }
 
-  if( this->m_MovingTransformPointLocatorsNeedInitialization )
+  if( this->RequiresMovingPointsLocator() &&
+      this->m_MovingTransformPointLocatorsNeedInitialization )
     {
     if( !this->m_MovingTransformedPointSet )
       {
       itkExceptionMacro( "The moving transformed point set does not exist." );
       }
-    if( ! this->m_MovingTransformedPointsLocator )
+    if( !this->m_MovingTransformedPointsLocator )
       {
       this->m_MovingTransformedPointsLocator = PointsLocatorType::New();
       }
@@ -544,6 +631,33 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
     this->m_MovingTransformedPointsLocator->Initialize();
     }
 }
+
+template<typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
+const
+typename PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>
+::PointIdentifierRanges
+PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>
+::CreateRanges() const
+{
+  PointIdentifier nPoints = this->m_FixedTransformedPointSet->GetNumberOfPoints();
+  PointIdentifier nWorkUnits = MultiThreaderBase::New()->GetNumberOfWorkUnits();
+  if(nWorkUnits > nPoints || MultiThreaderBase::New()->GetMaximumNumberOfThreads() <= 1)
+    {
+    nWorkUnits = 1;
+    }
+  PointIdentifier startRange = 0;
+  PointIdentifierRanges ranges;
+  for(PointIdentifier p=1; p < nWorkUnits; ++p)
+    {
+    PointIdentifier endRange = (p * nPoints) / (double) nWorkUnits;
+    ranges.push_back( PointIdentifierPair(startRange, endRange) );
+    startRange = endRange;
+    }
+  ranges.push_back( PointIdentifierPair(startRange, nPoints) );
+
+  return ranges;
+}
+
 
 /** PrintSelf */
 template<typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
