### PR TITLE
ENH: Adding VS2019 v142, VS2017 v140 Azure Pipelines on merge

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -13,6 +13,86 @@ pr: none
 variables:
   ExternalDataVersion: 5.0.0
 jobs:
+  - job: Windows
+    timeoutInMinutes: 0
+    cancelTimeoutInMinutes: 300
+    strategy:
+      maxParallel: 2
+      matrix:
+        v140:
+          CTEST_CMAKE_GENERATOR_TOOLSET: v140
+          CTEST_CMAKE_GENERATOR_PLATFORM: x64
+          CTEST_CONFIGURATION_TYPE: Release
+          CTEST_CMAKE_GENERATOR: "Visual Studio 15 2017"
+          imageName: 'vs2017-win2016'
+        v142:
+          CTEST_CMAKE_GENERATOR_TOOLSET: v142
+          CTEST_CMAKE_GENERATOR_PLATFORM: x64
+          CTEST_CONFIGURATION_TYPE: Release
+          CTEST_CMAKE_GENERATOR: "Visual Studio 16 2019"
+          imageName: 'windows-2019'
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 5
+
+      - script: |
+          if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
+        displayName: Checkout pull request HEAD
+
+      - script: |
+          pip3 install ninja
+          pip3 install --upgrade setuptools
+          pip3 install scikit-ci-addons
+        displayName: 'Install dependencies'
+
+      - script: |
+          git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+
+          curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
+          cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
+          cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
+        workingDirectory: $(Agent.BuildDirectory)
+        displayName: 'Download dashboard script and testing data'
+
+      - bash: |
+          cat > dashboard.cmake << EOF
+          set(CTEST_BUILD_CONFIGURATION "$(CTEST_CONFIGURATION_TYPE)")
+          set(CTEST_CMAKE_GENERATOR_TOOLSET "$(CTEST_CMAKE_GENERATOR_TOOLSET)")
+          set(CTEST_CMAKE_GENERATOR_PLATFORM "$(CTEST_CMAKE_GENERATOR_PLATFORM)")
+          set(CTEST_CMAKE_GENERATOR "$(CTEST_CMAKE_GENERATOR)")
+          set(dashboard_cache "
+            BUILD_SHARED_LIBS:BOOL=ON
+            BUILD_EXAMPLES:BOOL=OFF
+            ITK_WRAP_PYTHON:BOOL=OFF
+          ")
+          include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
+          EOF
+          cat dashboard.cmake
+        workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+        displayName: 'Configure CTest script'
+
+      - script: |
+          cmake --version
+          ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
+        displayName: 'Build and test'
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+
+      - script: |
+          ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
+        condition: succeededOrFailed()
+        displayName: 'Format CTest output in JUnit format'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
+          testRunTitle: 'CTest $(Agent.OS)'
+        condition: succeededOrFailed()
+        displayName: 'Publish test results'
+
   - job: Linux
     timeoutInMinutes: 0
     cancelTimeoutInMinutes: 300


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
