### PR TITLE
ENH: Allow histogram matching with reference histogram

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
@@ -25,13 +25,15 @@
 namespace itk
 {
 /** \class HistogramMatchingImageFilter
- * \brief Normalize the grayscale values between two images by histogram
- * matching.
+ * \brief Normalize the grayscale values for a source image by
+ * matching the shape of the source image histogram to a
+ * reference histogram.
  *
  * HistogramMatchingImageFilter normalizes the grayscale values of a source
- * image based on the grayscale values of a reference image.
+ * image based on the grayscale values of either a reference image or a
+ * reference histogram.
  * This filter uses a histogram matching technique where the histograms of the
- * two images are matched only at a specified number of quantile values.
+ * are matched only at a specified number of quantile values.
  *
  * This filter was originally designed to normalize MR images of the same
  * MR protocol and same body part. The algorithm works best if background
@@ -39,10 +41,15 @@ namespace itk
  * A simple background exclusion method is to exclude all pixels whose
  * grayscale values are smaller than the mean grayscale value.
  * ThresholdAtMeanIntensityOn() switches on this simple background
- * exclusion method.
+ * exclusion method.  With ThresholdAtMeanIntensityOn(), The reference
+ * histogram returned from this filter will expand the first and last
+ * bin bounds to include the minimum and maximum intensity values of
+ * the entire reference image, but only intensity values greater than
+ * the mean will be used to populate the histogram.
  *
  * The source image can be set via either SetInput() or SetSourceImage().
- * The reference image can be set via SetReferenceImage().
+ * The reference object used is selected with
+ * can be set via SetReferenceImage() or SetReferenceHistogram().
  *
  * SetNumberOfHistogramLevels() sets the number of bins used when
  * creating histograms of the source and reference images.
@@ -105,16 +112,24 @@ public:
   using HistogramType = Statistics::Histogram< THistogramMeasurement >;
   using HistogramPointer = typename HistogramType::Pointer;
 
-  /** Set/Get the source image. */
-  void SetSourceImage(const InputImageType *source)
-  { this->SetInput(source); }
-  const InputImageType * GetSourceImage()
-  { return this->GetInput(); }
+  /** Set and Get the source image */
+  itkSetInputMacro(SourceImage, InputImageType);
+  itkGetInputMacro(SourceImage, InputImageType);
 
   /** Set/Get the reference image. */
-  void SetReferenceImage(const InputImageType *reference);
+  itkSetInputMacro(ReferenceImage, InputImageType);
+  itkGetInputMacro(ReferenceImage, InputImageType);
 
-  const InputImageType * GetReferenceImage();
+  /** Set the reference histogram.  The reference histogram must
+   * have the first bin minimum be the smallest intensity value for the
+   * reference image space and the last bin maximum must contain the largest
+   * intensity value for the reference image space.
+   * (Note that the ThresholdAtMeanIntensity may restrict the voxels
+   * that are used to populate the histogram to a smaller intensity range
+   * than is represented by the smallest and largest intensity values.)
+   */
+  itkSetInputMacro(ReferenceHistogram, HistogramType);
+  itkGetInputMacro(ReferenceHistogram, HistogramType);
 
   /** Set/Get the number of histogram levels used. */
   itkSetMacro(NumberOfHistogramLevels, SizeValueType);
@@ -133,14 +148,26 @@ public:
   itkGetConstMacro(ThresholdAtMeanIntensity, bool);
   itkBooleanMacro(ThresholdAtMeanIntensity);
 
-  /** This filter requires all of the input to be in the buffer. */
+  /** Set/Get if the reference histogram is regenerated from
+   * the supplied ReferenceImage (true) or supplied directly
+   * as in input argument (false).  If SetReferenceHistogram(myhistogram)
+   * is used, then GenerateReferenceHistogramFromImageOff() should almost
+   * certainly be used.  If both SetReferenceHistogram(myhistogram) and
+   * SetReferenceImage(myreferenceimage) are set, only the input object
+   * indicated by GenerateReferenceHistogramFromImage choice will be used
+   * and the other object will be ignored.
+   */
+ itkSetMacro(GenerateReferenceHistogramFromImage, bool);
+ itkGetConstMacro(GenerateReferenceHistogramFromImage, bool);
+ itkBooleanMacro(GenerateReferenceHistogramFromImage);
+
+ /** This filter requires all of the input to be in the buffer. */
   void GenerateInputRequestedRegion() override;
 
   /** Methods to get the histograms of the source, reference, and
    * output. Objects are only valid after Update() has been called
    * on this filter. */
   itkGetModifiableObjectMacro(SourceHistogram, HistogramType);
-  itkGetModifiableObjectMacro(ReferenceHistogram, HistogramType);
   itkGetModifiableObjectMacro(OutputHistogram, HistogramType);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
@@ -187,32 +214,31 @@ protected:
                          THistogramMeasurement & maxValue,
                          THistogramMeasurement & meanValue);
 
-  /** Construct a histogram from an image. */
-  void ConstructHistogram(const InputImageType *image,
-                          HistogramType *histogram, const THistogramMeasurement minValue,
-                          const THistogramMeasurement maxValue);
+ /**
+  * Construct a histogram from an image using only values in range of [minValue, maxValue].
+  * Values outside that range are ignored.
+  */
+  void
+  ConstructHistogramFromIntensityRange(const InputImageType *image,
+                          HistogramType *histogram,
+                          const THistogramMeasurement minHistogramValidValue,
+                          const THistogramMeasurement maxHistogramValidValue,
+                          const THistogramMeasurement imageTrueMinValue,
+                          const THistogramMeasurement imageTrueMaxValue
+                          );
 
 private:
   SizeValueType m_NumberOfHistogramLevels{256};
   SizeValueType m_NumberOfMatchPoints{1};
   bool          m_ThresholdAtMeanIntensity{true};
 
-  InputPixelType  m_SourceIntensityThreshold;
-  InputPixelType  m_ReferenceIntensityThreshold;
-  OutputPixelType m_OutputIntensityThreshold;
-
   THistogramMeasurement m_SourceMinValue;
   THistogramMeasurement m_SourceMaxValue;
-  THistogramMeasurement m_SourceMeanValue;
+
   THistogramMeasurement m_ReferenceMinValue;
   THistogramMeasurement m_ReferenceMaxValue;
-  THistogramMeasurement m_ReferenceMeanValue;
-  THistogramMeasurement m_OutputMinValue;
-  THistogramMeasurement m_OutputMaxValue;
-  THistogramMeasurement m_OutputMeanValue;
 
   HistogramPointer m_SourceHistogram;
-  HistogramPointer m_ReferenceHistogram;
   HistogramPointer m_OutputHistogram;
 
   using TableType = vnl_matrix< double >;
@@ -222,6 +248,7 @@ private:
   GradientArrayType m_Gradients;
   double            m_LowerGradient{0.0};
   double            m_UpperGradient{0.0};
+  bool              m_GenerateReferenceHistogramFromImage{true};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -29,24 +29,18 @@ namespace itk
 template< typename TInputImage, typename TOutputImage, typename THistogramMeasurement >
 HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
 ::HistogramMatchingImageFilter() :
-  m_SourceIntensityThreshold(NumericTraits<InputPixelType>::ZeroValue()),
-  m_ReferenceIntensityThreshold(NumericTraits<InputPixelType>::ZeroValue()),
-  m_OutputIntensityThreshold(NumericTraits<OutputPixelType>::ZeroValue()),
   m_SourceMinValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
   m_SourceMaxValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
-  m_SourceMeanValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
   m_ReferenceMinValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
   m_ReferenceMaxValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
-  m_ReferenceMeanValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
-  m_OutputMinValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
-  m_OutputMaxValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
-  m_OutputMeanValue(NumericTraits<THistogramMeasurement>::ZeroValue()),
   m_SourceHistogram(HistogramType::New()),
-  m_ReferenceHistogram(HistogramType::New()),
   m_OutputHistogram(HistogramType::New())
 
 {
-  this->SetNumberOfRequiredInputs(2);
+  this->SetNumberOfRequiredInputs(1);
+  Self::SetPrimaryInputName("SourceImage");
+  Self::AddOptionalInputName("ReferenceImage",1);
+  Self::AddOptionalInputName("ReferenceHistogram",2);
 
   m_QuantileTable.set_size(3, m_NumberOfMatchPoints + 2);
   m_QuantileTable.fill(0);
@@ -70,16 +64,10 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
   os << indent << "ThresholdAtMeanIntensity: ";
   os << m_ThresholdAtMeanIntensity << std::endl;
 
-  os << indent << "SourceIntensityThreshold: ";
-  os << m_SourceIntensityThreshold << std::endl;
-  os << indent << "ReferenceIntensityThreshold: ";
-  os << m_ReferenceIntensityThreshold << std::endl;
-  os << indent << "OutputIntensityThreshold: ";
-  os << m_ReferenceIntensityThreshold << std::endl;
   os << indent << "Source histogram: ";
   os << m_SourceHistogram.GetPointer() << std::endl;
   os << indent << "Reference histogram: ";
-  os << m_ReferenceHistogram.GetPointer() << std::endl;
+  os << this->GetReferenceHistogram() << std::endl;
   os << indent << "Output histogram: ";
   os << m_OutputHistogram.GetPointer() << std::endl;
   os << indent << "QuantileTable: " << std::endl;
@@ -90,28 +78,8 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
   os << m_LowerGradient << std::endl;
   os << indent << "UpperGradient: ";
   os << m_UpperGradient << std::endl;
-}
-
-
-template< typename TInputImage, typename TOutputImage, typename THistogramMeasurement >
-void
-HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
-::SetReferenceImage(const InputImageType *reference)
-{
-  this->ProcessObject::SetNthInput( 1,
-                                    const_cast< InputImageType * >( reference ) );
-}
-
-/*
- *
- */
-template< typename TInputImage, typename TOutputImage, typename THistogramMeasurement >
-const typename HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
-::InputImageType *
-HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
-::GetReferenceImage()
-{
-  return dynamic_cast< TInputImage * >( this->ProcessObject::GetInput(1) );
+  os << indent << "GenerateReferenceHistogramFromImage:";
+  os << m_GenerateReferenceHistogramFromImage << std::endl;
 }
 
 /*
@@ -124,15 +92,21 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
 ::GenerateInputRequestedRegion()
 {
   this->Superclass::GenerateInputRequestedRegion();
-
-  for ( unsigned int idx = 0; idx < this->GetNumberOfIndexedInputs(); ++idx )
-    {
-    if ( this->GetInput(idx) )
+  {
+    InputImageType * source_image = const_cast< InputImageType * >( this->GetSourceImage() );
+    if ( source_image )
       {
-      InputImagePointer image =
-        const_cast< InputImageType * >( this->GetInput(idx) );
-      image->SetRequestedRegionToLargestPossibleRegion();
+        source_image->SetRequestedRegionToLargestPossibleRegion();
       }
+  }
+
+  if( this->m_GenerateReferenceHistogramFromImage )
+    {
+      InputImageType * reference_image = const_cast< InputImageType * >( this->GetReferenceImage() );
+      if ( reference_image )
+        {
+          reference_image->SetRequestedRegionToLargestPossibleRegion();
+        }
     }
 }
 
@@ -142,58 +116,108 @@ void
 HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
 ::BeforeThreadedGenerateData()
 {
-  unsigned int j;
+  THistogramMeasurement sourceMeanValue;
+  THistogramMeasurement referenceMeanValue;
 
-  InputImageConstPointer source    = this->GetSourceImage();
-  InputImageConstPointer reference = this->GetReferenceImage();
+  InputPixelType  sourceIntensityThreshold;
+  InputPixelType  referenceIntensityThreshold;
 
-  this->ComputeMinMaxMean(source, m_SourceMinValue,
-                          m_SourceMaxValue, m_SourceMeanValue);
-  this->ComputeMinMaxMean(reference, m_ReferenceMinValue,
-                          m_ReferenceMaxValue, m_ReferenceMeanValue);
-
-  if ( m_ThresholdAtMeanIntensity )
+  if ( m_GenerateReferenceHistogramFromImage )
     {
-    m_SourceIntensityThreshold    = static_cast< InputPixelType >( m_SourceMeanValue );
-    m_ReferenceIntensityThreshold = static_cast< InputPixelType >( m_ReferenceMeanValue );
+    InputImageConstPointer reference = this->GetReferenceImage();
+    if( reference.IsNull() )
+    {
+      itkExceptionMacro( << "ERROR: ReferenceImage required when GenerateReferenceHistogramFromImage is true.\n")
+    }
+    this->ComputeMinMaxMean(reference, m_ReferenceMinValue,
+                            m_ReferenceMaxValue, referenceMeanValue );
+    if ( m_ThresholdAtMeanIntensity )
+      {
+        referenceIntensityThreshold = static_cast< InputPixelType >( referenceMeanValue );
+      }
+    else
+      {
+        referenceIntensityThreshold = static_cast< InputPixelType >( m_ReferenceMinValue );
+      }
+      {
+        HistogramPointer tempHistptr = HistogramType::New();
+        this->ConstructHistogramFromIntensityRange( reference,
+                                                    tempHistptr,
+                                                    referenceIntensityThreshold,
+                                                    m_ReferenceMaxValue,
+                                                    m_ReferenceMinValue,
+                                                    m_ReferenceMaxValue );
+        this->SetReferenceHistogram(tempHistptr);
+      }
     }
   else
     {
-    m_SourceIntensityThreshold    = static_cast< InputPixelType >( m_SourceMinValue );
-    m_ReferenceIntensityThreshold = static_cast< InputPixelType >( m_ReferenceMinValue );
+      const HistogramType * const referenceHistogram = this->GetReferenceHistogram();
+      if( referenceHistogram == nullptr )
+      {
+        itkExceptionMacro( << "ERROR: ReferenceHistogram required when GenerateReferenceHistogramFromImage is false.\n")
+      }
+
+      // If the reference histogram is provided, then extract summary statistics
+      // directly from the histogram.
+      const auto & allReferenceMinsByDimension = referenceHistogram->GetMins(); // Array of dimensions
+      const auto & allReferenceMinsFirstDimension = allReferenceMinsByDimension.at(0); // Mins for dimension 0
+      m_ReferenceMinValue = allReferenceMinsFirstDimension.at(0);  // First element of mins
+      const auto & allReferenceMaxsByDimension = referenceHistogram->GetMaxs(); // Array of dimensions
+      const auto & allReferenceMaxsFirstDimension = allReferenceMaxsByDimension.at(0); // Maxes for dimension 0
+      m_ReferenceMaxValue = allReferenceMaxsFirstDimension.at(allReferenceMaxsFirstDimension.size() - 1); // last element of Maxes
+
+      if ( m_ThresholdAtMeanIntensity )
+        {
+          referenceIntensityThreshold = allReferenceMinsFirstDimension.at(0);  // First element of mins array in histogram
+        }
+      else
+        {
+          referenceIntensityThreshold = static_cast< InputPixelType >( m_ReferenceMinValue );
+        }
     }
 
-  this->ConstructHistogram(source, m_SourceHistogram,
-                           m_SourceIntensityThreshold, m_SourceMaxValue);
-  this->ConstructHistogram(reference, m_ReferenceHistogram,
-                           m_ReferenceIntensityThreshold,
-                           m_ReferenceMaxValue);
+  InputImageConstPointer source    = this->GetSourceImage();
+
+  this->ComputeMinMaxMean(source, m_SourceMinValue,
+                          m_SourceMaxValue, sourceMeanValue );
+
+  if ( m_ThresholdAtMeanIntensity )
+    {
+      sourceIntensityThreshold = static_cast< InputPixelType >( sourceMeanValue );
+    }
+  else
+    {
+      sourceIntensityThreshold = static_cast< InputPixelType >( m_SourceMinValue );
+    }
+  this->ConstructHistogramFromIntensityRange(
+    source, m_SourceHistogram, sourceIntensityThreshold, m_SourceMaxValue, m_SourceMinValue, m_SourceMaxValue );
 
   // Fill in the quantile table.
   m_QuantileTable.set_size(3, m_NumberOfMatchPoints + 2);
-  m_QuantileTable[0][0] = m_SourceIntensityThreshold;
-  m_QuantileTable[1][0] = m_ReferenceIntensityThreshold;
+  m_QuantileTable[0][0] = sourceIntensityThreshold;
+  m_QuantileTable[1][0] = referenceIntensityThreshold;
 
   m_QuantileTable[0][m_NumberOfMatchPoints + 1] = m_SourceMaxValue;
   m_QuantileTable[1][m_NumberOfMatchPoints + 1] = m_ReferenceMaxValue;
 
-  double delta = 1.0 / ( double(m_NumberOfMatchPoints) + 1.0 );
-
-  for ( j = 1; j < m_NumberOfMatchPoints + 1; j++ )
+  {
+    const double delta = 1.0 / ( static_cast<double>(m_NumberOfMatchPoints) + 1.0 );
+    const HistogramType * const referenceHistogram = this->GetReferenceHistogram();
+    for ( SizeValueType j = 1; j < m_NumberOfMatchPoints + 1; j++ )
     {
-    m_QuantileTable[0][j] = m_SourceHistogram->Quantile(
-      0, double(j) * delta);
-    m_QuantileTable[1][j] = m_ReferenceHistogram->Quantile(
-      0, double(j) * delta);
+      m_QuantileTable[0][j] = m_SourceHistogram->Quantile(
+        0, static_cast<double>(j) * delta);
+      m_QuantileTable[1][j] = referenceHistogram->Quantile(
+        0, static_cast<double>(j) * delta);
     }
+  }
 
   // Fill in the gradient array.
   m_Gradients.set_size(m_NumberOfMatchPoints + 1);
-  double denominator;
-  for ( j = 0; j < m_NumberOfMatchPoints + 1; j++ )
+  for ( SizeValueType j = 0; j < m_NumberOfMatchPoints + 1; j++ )
     {
-    denominator = m_QuantileTable[0][j + 1]
-                  - m_QuantileTable[0][j];
+    const double denominator = m_QuantileTable[0][j + 1]  - m_QuantileTable[0][j];
     if ( Math::NotAlmostEquals( denominator, 0.0) )
       {
       m_Gradients[j] = m_QuantileTable[1][j + 1]
@@ -205,30 +229,30 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
       m_Gradients[j] = 0.0;
       }
     }
-
-  denominator = m_QuantileTable[0][0] - m_SourceMinValue;
-  if ( Math::NotAlmostEquals( denominator, 0.0 ) )
+  {
+    const double denominator = m_QuantileTable[0][0] - m_SourceMinValue;
+    if ( Math::NotAlmostEquals( denominator, 0.0 ) )
+      {
+        m_LowerGradient = m_QuantileTable[1][0] - m_ReferenceMinValue;
+        m_LowerGradient /= denominator;
+      }
+    else
+      {
+        m_LowerGradient = 0.0;
+      }
+  }
+  {
+    const double denominator = m_QuantileTable[0][m_NumberOfMatchPoints + 1] - m_SourceMaxValue;
+    if ( Math::NotAlmostEquals( denominator, 0.0 ) )
     {
-    m_LowerGradient = m_QuantileTable[1][0] - m_ReferenceMinValue;
-    m_LowerGradient /= denominator;
+      m_UpperGradient = m_QuantileTable[1][m_NumberOfMatchPoints + 1] - m_ReferenceMaxValue;
+      m_UpperGradient /= denominator;
     }
-  else
+    else
     {
-    m_LowerGradient = 0.0;
+      m_UpperGradient = 0.0;
     }
-
-  denominator = m_QuantileTable[0][m_NumberOfMatchPoints + 1]
-                - m_SourceMaxValue;
-  if ( Math::NotAlmostEquals( denominator, 0.0 ) )
-    {
-    m_UpperGradient = m_QuantileTable[1][m_NumberOfMatchPoints + 1]
-                      - m_ReferenceMaxValue;
-    m_UpperGradient /= denominator;
-    }
-  else
-    {
-    m_UpperGradient = 0.0;
-    }
+  }
 }
 
 
@@ -237,34 +261,38 @@ void
 HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
 ::AfterThreadedGenerateData()
 {
+  THistogramMeasurement outputMeanValue;
+  THistogramMeasurement outputMinValue;
+  THistogramMeasurement outputMaxValue;
+
+  OutputPixelType outputIntensityThreshold;
+
   OutputImagePointer output    = this->GetOutput();
 
-  this->ComputeMinMaxMean(output, m_OutputMinValue,
-                          m_OutputMaxValue, m_OutputMeanValue);
+  this->ComputeMinMaxMean(output, outputMinValue, outputMaxValue, outputMeanValue );
 
   if ( m_ThresholdAtMeanIntensity )
     {
-    m_OutputIntensityThreshold    = static_cast< OutputPixelType >( m_OutputMeanValue );
+      outputIntensityThreshold = static_cast< OutputPixelType >( outputMeanValue );
     }
   else
     {
-    m_OutputIntensityThreshold    = static_cast< OutputPixelType >( m_OutputMinValue );
+      outputIntensityThreshold = static_cast< OutputPixelType >( outputMinValue );
     }
 
-  this->ConstructHistogram(output, m_OutputHistogram,
-                           m_OutputIntensityThreshold, m_OutputMaxValue);
+  this->ConstructHistogramFromIntensityRange( output, m_OutputHistogram, outputIntensityThreshold, outputMaxValue, outputMinValue, outputMaxValue );
 
   // Fill in the quantile table.
-  m_QuantileTable[2][0] = m_OutputIntensityThreshold;
+  m_QuantileTable[2][0] = outputIntensityThreshold;
 
-  m_QuantileTable[2][m_NumberOfMatchPoints + 1] = m_OutputMaxValue;
+  m_QuantileTable[2][m_NumberOfMatchPoints + 1] = outputMaxValue;
 
-  double delta = 1.0 / ( double(m_NumberOfMatchPoints) + 1.0 );
+  const double delta = 1.0 / ( static_cast<double>(m_NumberOfMatchPoints) + 1.0 );
 
-  for ( unsigned int j = 1; j < m_NumberOfMatchPoints + 1; j++ )
+  for ( SizeValueType j = 1; j < m_NumberOfMatchPoints + 1; j++ )
     {
     m_QuantileTable[2][j] = m_OutputHistogram->Quantile(
-      0, double(j) * delta);
+      0, static_cast<double>(j) * delta);
     }
 }
 
@@ -274,10 +302,7 @@ void
 HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
 ::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
-  int          i;
-  unsigned int j;
-
-  InputImageConstPointer input  = this->GetInput();
+  InputImageConstPointer input  = this->GetSourceImage();
   OutputImagePointer     output = this->GetOutput();
 
   // Transform the source image and write to output.
@@ -287,13 +312,11 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
   InputConstIterator inIter(input, outputRegionForThread);
   OutputIterator     outIter(output, outputRegionForThread);
 
-  double srcValue, mappedValue;
-
-  for ( i = 0; !outIter.IsAtEnd(); ++inIter, ++outIter, i++ )
+  for ( SizeValueType i = 0; !outIter.IsAtEnd(); ++inIter, ++outIter, i++ )
     {
-    srcValue = static_cast< double >( inIter.Get() );
-
-    for ( j = 0; j < m_NumberOfMatchPoints + 2; j++ )
+    const double srcValue = static_cast< double >( inIter.Get() );
+    SizeValueType j = 0;
+    for ( ; j < m_NumberOfMatchPoints + 2; j++ )
       {
       if ( srcValue < m_QuantileTable[0][j] )
         {
@@ -301,6 +324,7 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
         }
       }
 
+    double  mappedValue;
     if ( j == 0 )
       {
       // Linear interpolate from min to point[0]
@@ -360,17 +384,16 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
   meanValue = static_cast< THistogramMeasurement >( sum / static_cast< double >( count ) );
 }
 
-/**
- * Construct a histogram from an image.
- */
 template< typename TInputImage, typename TOutputImage, typename THistogramMeasurement >
 void
 HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
-::ConstructHistogram(
+::ConstructHistogramFromIntensityRange(
   const InputImageType *image,
   HistogramType  *histogram,
-  const THistogramMeasurement minValue,
-  const THistogramMeasurement maxValue)
+  const THistogramMeasurement minHistogramValidValue,
+  const THistogramMeasurement maxHistogramValidValue,
+  const THistogramMeasurement imageTrueMinValue,
+  const THistogramMeasurement imageTrueMaxValue)
 {
   {
     // allocate memory for the histogram
@@ -384,11 +407,15 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
     histogram->SetMeasurementVectorSize(1);
 
     size[0] = m_NumberOfHistogramLevels;
-    lowerBound.Fill(minValue);
-    upperBound.Fill(maxValue);
+    lowerBound.Fill( minHistogramValidValue );
+    upperBound.Fill(maxHistogramValidValue);
 
-    //Initialize with equally spaced bins.
+    //Initialize with equally spaced bins withing the valid region.
     histogram->Initialize(size, lowerBound, upperBound);
+
+    //Now expand the first and last bin to represent the true reference image range
+    histogram->SetBinMin(0,0, imageTrueMinValue );
+    histogram->SetBinMax(0,m_NumberOfHistogramLevels-1,imageTrueMaxValue);
     histogram->SetToZero();
   }
 
@@ -398,7 +425,6 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
   measurement[0] = NumericTraits< MeasurementType >::ZeroValue();
 
     {
-
     // put each image pixel into the histogram
     using ConstIterator = ImageRegionConstIterator< InputImageType >;
     ConstIterator iter( image, image->GetBufferedRegion() );
@@ -406,15 +432,17 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
     iter.GoToBegin();
     while ( !iter.IsAtEnd() )
       {
-      InputPixelType value = iter.Get();
+      const InputPixelType & value = iter.Value();
 
-      if ( static_cast< double >( value ) >= minValue
-           && static_cast< double >( value ) <= maxValue )
+      if ( static_cast< double >( value ) >= minHistogramValidValue && static_cast< double >( value ) <= maxHistogramValidValue )
         {
         // add sample to histogram
         measurement[0] = value;
-        histogram->GetIndex( measurement, index );
-        histogram->IncreaseFrequencyOfIndex( index, 1 );
+        const bool is_inside_histogram = histogram->GetIndex( measurement, index );
+        if (is_inside_histogram)
+          {
+            histogram->IncreaseFrequencyOfIndex( index, 1 );
+          }
         }
       ++iter;
       }


### PR DESCRIPTION
Allow histogram matching from with either reference image or reference histogram.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
-  :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
-  :no_entry_sign: Adds the License notice to new files.
-  :no_entry_sign: Adds Python wrapping.
-  :no_entry_sign: Adds tests and baseline comparison (quantitative).
-  :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- :no_entry_sign: Adds Documentation.