### PR TITLE
ENH: back-porting #1165 to support Visual Studio 2019

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/gdcmIPPSorter.cxx
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/gdcmIPPSorter.cxx
@@ -48,7 +48,7 @@ struct dircos_key {
 };
 
 struct dircos_comp {
-  bool operator()( dircos_key const & lhs, dircos_key const & rhs ) {
+  bool operator()( dircos_key const & lhs, dircos_key const & rhs ) const {
     const double *iop1 = lhs.dircos;
     const double *iop2 = rhs.dircos;
     return std::lexicographical_compare(iop1, iop1+6,

--- a/Modules/ThirdParty/VNL/src/vxl/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/CMakeLists.txt
@@ -117,7 +117,11 @@ set( CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} ${VXL_EXTRA_CMAKE_EXE_
 set( CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${VXL_EXTRA_CMAKE_MODULE_LINKER_FLAGS}" )
 set( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${VXL_EXTRA_CMAKE_SHARED_LINKER_FLAGS}" )
 
-
+if(MSVC_VERSION GREATER_EQUAL 1920)
+# Force synchronous writes of .pdb files for building VXL on MSVC 1920-1929
+# https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-201
+  add_compile_options( "/FS" )
+endif()
 #-------------------------------------------------------------------
 #-- BUILD CONFIG OPTIONS
 


### PR DESCRIPTION
On my computer, this patch is not required to build with VS2019. Should we still consider merging it?