### PR TITLE
COMP: Fix loss of data ProcessObject GetNumberOfValidRequiredInputs()

### DIFF
--- a/Modules/Core/Common/include/itkStreamingImageFilter.hxx
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.hxx
@@ -120,11 +120,11 @@ StreamingImageFilter< TInputImage, TOutputImage >
   /**
    * Make sure we have the necessary inputs
    */
-  const itk::ProcessObject::DataObjectPointerArraySizeType &ninputs = this->GetNumberOfValidRequiredInputs();
+  const itk::ProcessObject::DataObjectPointerArraySizeType ninputs = this->GetNumberOfValidRequiredInputs();
   if ( ninputs < this->GetNumberOfRequiredInputs() )
     {
     itkExceptionMacro(
-      << "At least " << static_cast< unsigned int >( this->GetNumberOfRequiredInputs() )
+      << "At least " << this->GetNumberOfRequiredInputs()
       << " inputs are required but only " << ninputs << " are specified.");
     return;
     }

--- a/Modules/Core/Common/src/itkStreamingProcessObject.cxx
+++ b/Modules/Core/Common/src/itkStreamingProcessObject.cxx
@@ -134,10 +134,10 @@ void StreamingProcessObject::UpdateOutputData(DataObject *itkNotUsed(output))
   /*
    * Make sure we have the necessary inputs
    */
-  unsigned int ninputs = this->GetNumberOfValidRequiredInputs();
+  const DataObjectPointerArraySizeType ninputs = this->GetNumberOfValidRequiredInputs();
   if (ninputs < this->GetNumberOfRequiredInputs())
     {
-    itkExceptionMacro(<< "At least " << static_cast<unsigned int>( this->GetNumberOfRequiredInputs() )
+    itkExceptionMacro(<< "At least " << this->GetNumberOfRequiredInputs()
       << " inputs are required but only " << ninputs << " are specified.");
     }
 

--- a/Modules/Video/Core/src/itkTemporalProcessObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalProcessObject.cxx
@@ -352,7 +352,7 @@ TemporalProcessObject::UpdateOutputData(DataObject* itkNotUsed(output))
   try
     {
     // Make sure all required input ports full
-    DataObjectPointerArraySizeType ninputs = this->GetNumberOfValidRequiredInputs();
+    const DataObjectPointerArraySizeType ninputs = this->GetNumberOfValidRequiredInputs();
     if ( ninputs < this->GetNumberOfRequiredInputs() )
       {
       itkExceptionMacro(<< "At least " << this->GetNumberOfRequiredInputs()


### PR DESCRIPTION
Removed an implicit conversion from `DataObjectPointerArraySizeType`
(possibly 64-bits) to `unsigned int` (usually 32-bits), fixing a usually
disabled MSVC warning:

> itkStreamingProcessObject.cxx(137): warning C4267: 'initializing':
> conversion from 'size_t' to 'unsigned int', possible loss of data

Removed `static_cast<unsigned int>` from two `GetNumberOfRequiredInputs()`
calls, which caused the same possible loss of data (without a warning).

Improved consistency by declaring three similar `ninputs` variables in
the same way.