### PR TITLE
ENH: Support NumPy array-like inputs to image filters

### DIFF
--- a/Modules/Filtering/ImageIntensity/wrapping/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/CMakeLists.txt
@@ -17,3 +17,12 @@ if(ITK_WRAP_unsigned_char AND wrap_2_index GREATER -1)
 endif()
 itk_python_expression_add_test(NAME itkSymmetricEigenAnalysisImageFilterPythonTest
   EXPRESSION "filt = itk.SymmetricEigenAnalysisImageFilter.New()")
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import numpy"
+  RESULT_VARIABLE _have_numpy_return_code
+  OUTPUT_QUIET
+  ERROR_QUIET
+  )
+if(_have_numpy_return_code EQUAL 0)
+  itk_python_add_test(NAME itkImageFilterNumPyInputsTest
+                      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkImageFilterNumPyInputsTest.py)
+endif()

--- a/Modules/Filtering/ImageIntensity/wrapping/test/itkImageFilterNumPyInputsTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/itkImageFilterNumPyInputsTest.py
@@ -1,0 +1,32 @@
+#==========================================================================
+#
+#   Copyright Insight Software Consortium
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+import itk
+import numpy as np
+itk.auto_progress(2)
+
+array1 = np.ones((4,4), dtype=np.uint8)
+array2 = 2*np.ones((4,4), dtype=np.uint8)
+
+added = itk.add_image_filter(array1, array2)
+assert(isinstance(added, np.ndarray))
+assert(np.all(added == 3))
+
+added = itk.add_image_filter(Input1=array1, Input2=array2)
+assert(isinstance(added, np.ndarray))
+assert(np.all(added == 3))

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -417,12 +417,8 @@ str = str
 
         %pythoncode %{
             def SetDirection(self, direction):
-                def is_arraylike(arr):
-                    return hasattr(arr, 'shape') and \
-                    hasattr(arr, 'dtype') and \
-                    hasattr(arr, '__array__') and \
-                    hasattr(arr, 'ndim')
-                if is_arraylike(direction):
+                import itkHelpers
+                if itkHelpers.is_arraylike(direction):
                     import itk
                     import numpy as np
 

--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -670,12 +670,12 @@ def set_inputs(new_itk_object, args=[], kargs={}):
         new_itk_object.SetInput(args[0])
         # but raise an exception if there is more than 1 argument
         if len(args) > 1:
-            raise TypeError('Object accept only 1 input.')
+            raise TypeError('Object accepts only 1 input.')
     except AttributeError:
         # There is no SetInput() method, try SetImage
         # but before, check the number of inputs
         if len(args) > 1:
-            raise TypeError('Object accept only 1 input.')
+            raise TypeError('Object accepts only 1 input.')
         methodList = ['SetImage', 'SetInputImage']
         methodName = None
         for m in methodList:

--- a/Wrapping/Generators/Python/itkHelpers.py
+++ b/Wrapping/Generators/Python/itkHelpers.py
@@ -17,8 +17,60 @@
 #==========================================================================*/
 
 import re
+import functools
 
 def camel_to_snake_case(name):
     snake = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     snake = re.sub('([a-z0-9])([A-Z])', r'\1_\2', snake)
     return snake.replace('__', '_').lower()
+
+def is_arraylike(arr):
+    return hasattr(arr, 'shape') and \
+    hasattr(arr, 'dtype') and \
+    hasattr(arr, '__array__') and \
+    hasattr(arr, 'ndim')
+
+def accept_numpy_array_like(image_filter):
+    """Decorator that allows itk.ProcessObject snake_case functions to accept
+    NumPy array-like inputs for itk.Image inputs. If a NumPy array-like is
+    passed as an input, output itk.Image's are converted to numpy.ndarray's."""
+    import numpy as np
+    import itk
+
+    @functools.wraps(image_filter)
+    def image_filter_wrapper(*args, **kwargs):
+        have_array_like_input = False
+
+        args_list = list(args)
+        for index, arg in enumerate(args):
+            if is_arraylike(arg):
+                have_array_like_input = True
+                array = np.asarray(arg)
+                image = itk.image_view_from_array(array)
+                args_list[index] = image
+
+        potential_image_input_kwargs = ('input', 'inputimage', 'input_image', 'input1', 'input2', 'input3')
+        for key, value in kwargs.items():
+            if key.lower() in potential_image_input_kwargs and is_arraylike(value):
+                have_array_like_input = True
+                array = np.asarray(value)
+                image = itk.image_view_from_array(array)
+                kwargs[key] = image
+
+        if have_array_like_input:
+            # Convert output itk.Image's to numpy.ndarray's
+            output = image_filter(*tuple(args_list), **kwargs)
+            if isinstance(output, tuple):
+                output_list = list(output)
+                for index, value in output_list:
+                    if isinstance(value, itk.Image):
+                        array = itk.array_from_image(value)
+                        output_list[index] = array
+                return tuple(output_list)
+            else:
+                if isinstance(output, itk.Image):
+                    output = itk.array_from_image(output)
+                return output
+        else:
+            return image_filter(*args, **kwargs)
+    return image_filter_wrapper

--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -531,6 +531,8 @@ class SwigInputGenerator(object):
             for processObject in processObjects:
                 snakeCase = self.camelCaseToSnakeCase(processObject)
                 self.snakeCaseProcessObjectFunctions.add(snakeCase)
+                self.outputFile.write('import itkHelpers\n')
+                self.outputFile.write('@itkHelpers.accept_numpy_array_like\n')
                 self.outputFile.write('def %s(*args, **kwargs):\n' % snakeCase)
                 self.outputFile.write('    """Procedural interface for %s"""\n' % processObject)
                 self.outputFile.write('    import itk\n')


### PR DESCRIPTION
When a NumPy array-like is passed into Python snake_case interface to
filters, the array-like arguments or standard image keyword arguments
are converted into itk.Image views, and passed to the filter. All image
outputs are converted to NumPy ndarray's if array's were used as
inputs.

Addresses #1136
