### PR TITLE
Fix slice image filter small size

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -260,12 +260,11 @@ SliceImageFilter< TInputImage, TOutputImage >
     {
     outputSpacing[i] = inputSpacing[i] * itk::Math::abs(m_Step[i]);
 
-    // clamp start
-    // Based on the sign of the step include 1 after the end.
+    // clamp start, inclusive start interval
     IndexValueType start = std::max( m_Start[i], inputIndex[i] - int(m_Step[i]<0));
     start = std::min( start,  static_cast<IndexValueType>(inputIndex[i] + inputSize[i]) - int(m_Step[i]<0) );
 
-    // clamp stop
+    // clamp stop as open interval
     // Based on the sign of the step include 1 after the end.
     IndexValueType stop = std::max( m_Stop[i], inputIndex[i] - int(m_Step[i]<0) );
     stop = std::min( stop,  static_cast<IndexValueType>(inputIndex[i] + inputSize[i]) - int(m_Step[i]<0));

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -275,7 +275,8 @@ SliceImageFilter< TInputImage, TOutputImage >
     if ( (m_Step[i] > 0 && stop > start) ||
          ( m_Step[i] < 0 && stop < start ) )
       {
-      outputSize[i] = (stop-start)/m_Step[i];
+      outputSize[i] = (stop-start-Math::sgn(m_Step[i]))/m_Step[i];
+      outputSize[i] += 1u;
       }
     else
       {

--- a/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
@@ -17,17 +17,17 @@
 *=========================================================================*/
 
 #include <itkSliceImageFilter.h>
-#include <gtest/gtest.h>
 
+#include "itkGTest.h"
 #include "itkPhysicalPointImageSource.h"
 #include "itkGaussianImageSource.h"
 #include "itkImageRegionConstIterator.h"
 
 // This test verifies the principle that the SliceImageFilter should
 // not change the physical location of the signal. This is done by
-// constructing an image of points, each corresponding to the phycical
+// constructing an image of points, each corresponding to the physical
 // location of the center of the voxel, then verifying that the value
-// still matches the physcial location.
+// still matches the physical location.
 
 namespace
 {
@@ -311,9 +311,30 @@ TEST(SliceImageFilterTests,Sizes)
   EXPECT_NO_THROW(filter->Update());
   EXPECT_EQ(filter->GetOutput()->GetLargestPossibleRegion().GetSize(), size) << "Check full size for negative step";
 
-  std::cout << "Filter size: " << filter->GetOutput()->GetLargestPossibleRegion() << std::endl;
-  std::cout << "Filter buffered size: " << filter->GetOutput()->GetBufferedRegion() << std::endl;
-  std::cout << "Input size: " << size << std::endl;
+  using namespace itk::GTest::TypedefsAndConstructors::Dimension3;
+
+  source->SetSize(MakeSize(19,17,11));
+
+  filter = FilterType::New();
+  filter->SetInput( source->GetOutput() );
+  filter->SetStep(2);
+  EXPECT_NO_THROW( filter->Update() ) << "Check same start and stop";
+  EXPECT_EQ( 10, filter->GetOutput()->GetLargestPossibleRegion().GetSize(0) );
+  EXPECT_EQ( 9, filter->GetOutput()->GetLargestPossibleRegion().GetSize(1) );
+  EXPECT_EQ( 6, filter->GetOutput()->GetLargestPossibleRegion().GetSize(2) );
+
+  source->SetSize(MakeSize(5,2,3));
+
+  std::cout << "CHECK" << std::endl;
+
+  filter = FilterType::New();
+  filter->SetInput( source->GetOutput() );
+  filter->SetStep(2);
+  EXPECT_NO_THROW( filter->Update() ) << "Check same start and stop";
+  EXPECT_EQ( 3, filter->GetOutput()->GetLargestPossibleRegion().GetSize(0) );
+  EXPECT_EQ( 1, filter->GetOutput()->GetLargestPossibleRegion().GetSize(1) );
+  EXPECT_EQ( 2, filter->GetOutput()->GetLargestPossibleRegion().GetSize(2) );
+
 }
 
 TEST(SliceImageFilterTests,ExceptionalCases)
@@ -361,10 +382,40 @@ TEST(SliceImageFilterTests,ExceptionalCases)
 
   filter = FilterType::New();
   filter->SetInput( source->GetOutput() );
+  filter->SetStart(1);
+  filter->SetStop(1);
+  EXPECT_NO_THROW( filter->Update() ) << "Check same start and stop";
+  EXPECT_EQ( 0u, filter->GetOutput()->GetLargestPossibleRegion().GetNumberOfPixels() );
+
+  filter = FilterType::New();
+  filter->SetInput( source->GetOutput() );
+  filter->SetStart(1);
+  filter->SetStop(1);
+  filter->SetStep(2);
+  EXPECT_NO_THROW( filter->Update() ) << "Check same start and stop";
+  EXPECT_EQ( 0u, filter->GetOutput()->GetLargestPossibleRegion().GetNumberOfPixels() );
+
+  filter = FilterType::New();
+  filter->SetInput( source->GetOutput() );
   filter->SetStart(-12);
   filter->SetStop(-10);
   filter->SetStep(-1);
   EXPECT_NO_THROW( filter->Update() ) << "Check undersized start and stop";
   EXPECT_EQ( 0u, filter->GetOutput()->GetLargestPossibleRegion().GetNumberOfPixels() );
 
+  filter = FilterType::New();
+  filter->SetInput( source->GetOutput() );
+  filter->SetStart(4);
+  filter->SetStop(4);
+  filter->SetStep(-1);
+  EXPECT_NO_THROW( filter->Update() ) << "Check same start and stop with negative step";
+  EXPECT_EQ( 0u, filter->GetOutput()->GetLargestPossibleRegion().GetNumberOfPixels() );
+
+  filter = FilterType::New();
+  filter->SetInput( source->GetOutput() );
+  filter->SetStart(4);
+  filter->SetStop(4);
+  filter->SetStep(-3);
+  EXPECT_NO_THROW( filter->Update() ) << "Check same start and stop with negative step";
+  EXPECT_EQ( 0u, filter->GetOutput()->GetLargestPossibleRegion().GetNumberOfPixels() );
 }


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
