### PR TITLE
ENH: Add check expected input in HistogramMatchingImageFilter

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
@@ -208,6 +208,8 @@ protected:
    */
   void VerifyInputInformation() ITKv5_CONST override {}
 
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Compute min, max and mean of an image. */
   void ComputeMinMaxMean(const InputImageType *image,
                          THistogramMeasurement & minValue,

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -114,6 +114,30 @@ HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
 template< typename TInputImage, typename TOutputImage, typename THistogramMeasurement >
 void
 HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
+::VerifyPreconditions() ITKv5_CONST
+{
+  Superclass::VerifyPreconditions();
+
+  if ( m_GenerateReferenceHistogramFromImage )
+  {
+    if (  this->GetReferenceImage() == nullptr )
+    {
+      itkExceptionMacro( << "ReferenceImage required when GenerateReferenceHistogramFromImage is true." )
+    }
+  }
+  else
+  {
+    if ( this->GetReferenceHistogram() == nullptr )
+    {
+      itkExceptionMacro( << "ReferenceHistogram required when GenerateReferenceHistogramFromImage is false." )
+    }
+  }
+}
+
+
+template< typename TInputImage, typename TOutputImage, typename THistogramMeasurement >
+void
+HistogramMatchingImageFilter< TInputImage, TOutputImage, THistogramMeasurement >
 ::BeforeThreadedGenerateData()
 {
   THistogramMeasurement sourceMeanValue;


### PR DESCRIPTION
Overload the VerifyPrecondition method to check the filters inputs are
set as required before pipeline execution.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
