### PR TITLE
COMP: Address internal compiler error on MSVC 19.0.24234.1 (v140)

### DIFF
--- a/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
@@ -120,8 +120,13 @@ template< typename TInput1, typename TInput2, typename TOutput >
 class ITK_TEMPLATE_EXPORT TikhonovDeconvolutionFunctor
 {
 public:
-  TikhonovDeconvolutionFunctor() {m_RegularizationConstant = 0.0;}
+  TikhonovDeconvolutionFunctor() {}
   ~TikhonovDeconvolutionFunctor() = default;
+  TikhonovDeconvolutionFunctor( const TikhonovDeconvolutionFunctor & f)
+    : m_RegularizationConstant( f.m_RegularizationConstant )
+    , m_KernelZeroMagnitudeThreshold( f.m_KernelZeroMagnitudeThreshold )
+  {}
+
 
   bool operator!=( const TikhonovDeconvolutionFunctor & ) const
   {
@@ -167,8 +172,8 @@ public:
   }
 
 private:
-  double m_RegularizationConstant;
-  double m_KernelZeroMagnitudeThreshold;
+  double m_RegularizationConstant = 0.0;
+  double m_KernelZeroMagnitudeThreshold = 0.0;
 };
 } //namespace Functor
 

--- a/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
@@ -143,8 +143,12 @@ template< typename TPixel >
 class ITK_TEMPLATE_EXPORT WienerDeconvolutionFunctor
 {
 public:
-  WienerDeconvolutionFunctor() { m_KernelZeroMagnitudeThreshold = 0.0; }
+  WienerDeconvolutionFunctor() {}
   ~WienerDeconvolutionFunctor() = default;
+  WienerDeconvolutionFunctor( const WienerDeconvolutionFunctor & f )
+    : m_NoisePowerSpectralDensityConstant( f.m_NoisePowerSpectralDensityConstant )
+    , m_KernelZeroMagnitudeThreshold( f.m_KernelZeroMagnitudeThreshold )
+  {}
 
   bool operator!=( const WienerDeconvolutionFunctor & ) const
   {
@@ -196,8 +200,8 @@ public:
   }
 
 private:
-  double m_NoisePowerSpectralDensityConstant;
-  double m_KernelZeroMagnitudeThreshold;
+  double m_NoisePowerSpectralDensityConstant = 0.0;
+  double m_KernelZeroMagnitudeThreshold = 0.0;
 };
 } //namespace Functor
 


### PR DESCRIPTION
Work around internal compiler error with the MSVS v140 compiler
apparently related to default copy constructor used in the functor
generator filter.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
