### PR TITLE
COMP: fixed enum name error when legacy is OFF and ITK_USE_GPU is ON

### DIFF
--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
@@ -109,13 +109,13 @@ public:
   /** Set the state of the filter to INITIALIZED */
   void SetStateToInitialized()
   {
-    this->SetState(INITIALIZED);
+    this->SetState(FilterStateType::INITIALIZED);
   }
 
   /** Set the state of the filter to UNINITIALIZED */
   void SetStateToUninitialized()
   {
-    this->SetState(UNINITIALIZED);
+    this->SetState(FilterStateType::UNINITIALIZED);
   }
 
   /** Set/Get the state of the filter. */

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -35,7 +35,7 @@ GPUFiniteDifferenceImageFilter< TInputImage, TOutputImage, TParentImageFilter >
   this->m_NumberOfIterations = NumericTraits< unsigned int >::max();
   m_MaximumRMSError = 0.0;
   m_RMSChange = 0.0;
-  m_State = UNINITIALIZED;
+  m_State = FilterStateType::UNINITIALIZED;
   m_ManualReinitialization = false;
   this->InPlaceOff();
 }
@@ -60,7 +60,7 @@ GPUFiniteDifferenceImageFilter< TInputImage, TOutputImage, TParentImageFilter >
     itkWarningMacro("Output pixel type MUST be float or double to prevent computational errors");
     }
 
-  if ( this->GetState() == UNINITIALIZED )
+  if ( this->GetState() == FilterStateType::UNINITIALIZED )
     {
     // Allocate the output image
     //this->AllocateOutputs();


### PR DESCRIPTION
First error message: `C:\Dev\ITK-git\Modules\Core\GPUFiniteDifference\include\itkGPUFiniteDifferenceImageFilter.hxx(63,28): error C2065:  'UNINITIALIZED': undeclared identifier`.