### PR TITLE
ENH: Download clang-format 8.0.1 executable

### DIFF
--- a/CMake/ITKClangFormatConfig.cmake.in
+++ b/CMake/ITKClangFormatConfig.cmake.in
@@ -1,0 +1,17 @@
+set(ITK_SOURCE_DIR "@ITK_SOURCE_DIR@")
+set(CMAKE_SOURCE_DIR "@CMAKE_SOURCE_DIR@")
+set(CLANG_FORMAT_EXECUTABLE "@CLANG_FORMAT_EXECUTABLE@")
+
+set(WORKING_DIR "")
+if(ITK_SOURCE_DIR)
+  set(WORKING_DIR "${ITK_SOURCE_DIR}")
+else()
+  set(WORKING_DIR "${CMAKE_SOURCE_DIR}")
+endif()
+
+find_package(Git)
+if(GIT_FOUND AND EXISTS "${WORKING_DIR}/.git/config")
+  execute_process(COMMAND ${GIT_EXECUTABLE} config clangFormat.binary
+    "${CLANG_FORMAT_EXECUTABLE}"
+    WORKING_DIRECTORY ${WORKING_DIR})
+endif()

--- a/CMake/ITKModuleClangFormat.cmake
+++ b/CMake/ITKModuleClangFormat.cmake
@@ -1,0 +1,15 @@
+# Download and configure clang-format for style uniformity during development.
+#
+# This code helps download a version of clang-format binaries consistent with
+# ITK's clang-format configuration. Git configuration is added during
+# development to help automatically apply the formatting.
+#
+# Globally, the ITK/.clang-format file provides the base style configuration.
+# For more information on ITK coding style, see the ITK Coding Style Guide in
+# the ITK Software Guide.
+option(ITK_USE_CLANG_FORMAT "Enable the use of clang-format for coding style formatting." ${BUILD_TESTING})
+mark_as_advanced(ITK_USE_CLANG_FORMAT)
+
+if(BUILD_TESTING AND ITK_USE_CLANG_FORMAT AND NOT CMAKE_CROSSCOMPILING)
+  include(${ITK_CMAKE_DIR}/../Utilities/ClangFormat/DownloadClangFormat.cmake)
+endif()

--- a/CMake/ITKModuleMacros.cmake
+++ b/CMake/ITKModuleMacros.cmake
@@ -6,6 +6,7 @@ include(${_ITKModuleMacros_DIR}/ITKModuleAPI.cmake)
 include(${_ITKModuleMacros_DIR}/ITKModuleDoxygen.cmake)
 include(${_ITKModuleMacros_DIR}/ITKModuleHeaderTest.cmake)
 include(${_ITKModuleMacros_DIR}/ITKModuleKWStyleTest.cmake)
+include(${_ITKModuleMacros_DIR}/ITKModuleClangFormat.cmake)
 include(${_ITKModuleMacros_DIR}/CppcheckTargets.cmake)
 include(${_ITKModuleMacros_DIR}/ITKModuleCPPCheckTest.cmake)
 

--- a/Utilities/ClangFormat/DownloadClangFormat.cmake
+++ b/Utilities/ClangFormat/DownloadClangFormat.cmake
@@ -1,0 +1,50 @@
+include(ExternalProject)
+
+if(WIN32)
+  set(exe .exe)
+endif()
+set(CLANG_FORMAT_EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ClangFormat-prefix/src/ClangFormat/clang-format${exe})
+configure_file("${ITK_CMAKE_DIR}/ITKClangFormatConfig.cmake.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/ITKClangFormatConfig.cmake" @ONLY)
+
+set(_clang_format_hash )
+set(_clang_format_url )
+if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set(_clang_format_hash
+    b14de32036c48f6c62998e2ebab509e71a0ae71464acb4616484e3a6eb941e1d9fac38559f5d27ea0cbbb512d590279ffb3015fae17779229e1090c2763ebcf3)
+  set(_clang_format_url "https://data.kitware.com/api/v1/file/hashsum/sha512/${_clang_format_hash}/download")
+elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" AND (NOT CMAKE_HOST_SYSTEM_VERSION VERSION_LESS "13.0.0"))
+  set(_clang_format_hash
+    97460f9eef556a27592ccd99d8fc894554e5b3196326df4e33bfcdecfcb7eda2b5c7488008abc4dd923d607f2cb47d61567b1da99df60f31f719195118c117a9)
+  set(_clang_format_url "https://data.kitware.com/api/v1/file/hashsum/sha512/${_clang_format_hash}/download")
+elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
+  set(_clang_format_hash
+    e96dd15938fd9b1c57028a519189f138397774eb6b66971d114300d2a80248adda9f74b192985a3c91c7de52c4dbe21800bc6b3cc8201c4985fc39ecfc64fdbe)
+  set(_clang_format_url "https://data.kitware.com/api/v1/file/hashsum/sha512/${_clang_format_hash}/download")
+else()
+  # If desired, a compatible clang-format can be provided manually with
+  #   `git config clangFormat.binary /path/to/clang-format`.
+endif()
+
+# XXX Implementation of the itk_download_attempt_check macro copied from the
+#     ITK main CMakeLists.txt. This allows external modules to use the logic
+#     which is not defined when building against an ITK build tree.
+#     Equivalent to "itk_download_attempt_check(ClangFormat)".
+if(ITK_FORBID_DOWNLOADS)
+  message(SEND_ERROR "Attempted to download ClangFormat when ITK_FORBID_DOWNLOADS is ON")
+endif()
+if(NOT TARGET ClangFormat AND _clang_format_hash)
+  ExternalProject_add(ClangFormat
+    URL ${_clang_format_url}
+    URL_HASH SHA512=${_clang_format_hash}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    LOG_DOWNLOAD 1
+    LOG_UPDATE 0
+    LOG_CONFIGURE 0
+    LOG_BUILD 0
+    LOG_TEST 0
+    LOG_INSTALL 0
+    INSTALL_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/ITKClangFormatConfig.cmake
+    )
+endif()


### PR DESCRIPTION
A clang-format executable for all major platforms is downloaded with
development builds with a version compatible with ITK's clang-format
configuration, currently 8.0.1. Git is configured with the executable's
path.

In the future, this will help automatically apply ITK's Coding Style
Guidelines in Git hooks and aliases.
