### PR TITLE
BUG: Wrap WindowedSincInterpolateImageFunction SmartPointer

### DIFF
--- a/Modules/Core/ImageFunction/wrapping/itkWindowedSincInterpolateImageFunction.wrap
+++ b/Modules/Core/ImageFunction/wrapping/itkWindowedSincInterpolateImageFunction.wrap
@@ -11,7 +11,7 @@ foreach(function ${window_functions})
   itk_end_wrap_class()
 endforeach()
 
-itk_wrap_class("itk::WindowedSincInterpolateImageFunction")
+itk_wrap_class("itk::WindowedSincInterpolateImageFunction" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${WRAP_ITK_SCALAR})
       foreach(r ${radii}) # radius

--- a/Modules/Filtering/ImageGrid/wrapping/test/ResampleImageFilterTest.py
+++ b/Modules/Filtering/ImageGrid/wrapping/test/ResampleImageFilterTest.py
@@ -121,3 +121,16 @@ filter.SetDefaultPixelValue(100)
 
 if(exampleAction == 2):
     writer.Update()
+
+
+# Make sure we can instantiate with a windowed sinc interpolator
+ImageType = itk.Image[itk.F,3]
+
+resample = itk.ResampleImageFilter[ImageType,ImageType].New()
+interpolator = itk.WindowedSincInterpolateImageFunction[ImageType,3,itk.HammingWindowFunction[3,]].New()
+resample.SetInterpolator(interpolator)
+
+image = ImageType.New()
+resample = itk.ResampleImageFilter.New(image)
+interpolator = itk.WindowedSincInterpolateImageFunction.New(image)
+resample.SetInterpolator(interpolator)


### PR DESCRIPTION
Required to pass an instance to ResampleImageFilter.

Closes #1100 