### PR TITLE
Python cleanup

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferPipelineTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferPipelineTest.py
@@ -15,7 +15,6 @@
 #   limitations under the License.
 #
 #==========================================================================*/
-from __future__ import print_function
 
 import sys
 try:

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -15,7 +15,7 @@
 #   limitations under the License.
 #
 #==========================================================================*/
-from __future__ import print_function
+
 import sys
 import unittest
 import datetime as dt

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyVnlTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyVnlTest.py
@@ -15,7 +15,7 @@
 #   limitations under the License.
 #
 #==========================================================================*/
-from __future__ import print_function
+
 import sys
 import unittest
 import datetime as dt

--- a/Modules/Core/Common/wrapping/test/itkDirectoryTest.py
+++ b/Modules/Core/Common/wrapping/test/itkDirectoryTest.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 itk.auto_progress(2)
 

--- a/Modules/Core/Common/wrapping/test/itkMetaDataDictionaryTest.py
+++ b/Modules/Core/Common/wrapping/test/itkMetaDataDictionaryTest.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 
 md = itk.MetaDataDictionary()

--- a/Modules/Core/SpatialObjects/wrapping/test/SpatialObjectTest.py
+++ b/Modules/Core/SpatialObjects/wrapping/test/SpatialObjectTest.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 
 itk.auto_progress(2)

--- a/Modules/Filtering/AntiAlias/wrapping/test/AntiAliasBinaryImageFilterTest.py
+++ b/Modules/Filtering/AntiAlias/wrapping/test/AntiAliasBinaryImageFilterTest.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 from sys import argv, stderr, exit
 

--- a/Modules/Filtering/FastMarching/wrapping/test/FastMarchingImageFilterTest.py
+++ b/Modules/Filtering/FastMarching/wrapping/test/FastMarchingImageFilterTest.py
@@ -35,8 +35,6 @@
 #     OUTPUTS: {FastMarchingFilterOutput3.png}
 #     ARGUMENTS:    40 90 0.5  -0.3  2.0   200 100
 
-from __future__ import print_function
-
 import itk
 from sys import argv, stderr, exit
 import os

--- a/Modules/Filtering/ImageFeature/wrapping/test/CannyEdgeDetectionImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/CannyEdgeDetectionImageFilterTest.py
@@ -16,11 +16,7 @@
 #
 #==========================================================================*/
 
-#
 #  Example on the use of the CannyEdgeDetectionImageFilter
-#
-
-from __future__ import print_function
 
 import itk
 from sys import argv, stderr, exit

--- a/Modules/Filtering/ImageGrid/wrapping/test/ResampleImageFilterTest.py
+++ b/Modules/Filtering/ImageGrid/wrapping/test/ResampleImageFilterTest.py
@@ -33,8 +33,6 @@
 #     OUTPUTS: {ResampleImageFilterOutput4.png}
 #     3
 
-from __future__ import print_function
-
 import itk
 from sys import argv, stderr, exit
 itk.auto_progress(2)

--- a/Modules/Filtering/ImageIntensity/wrapping/test/itkIntensityWindowingImageFilterTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/itkIntensityWindowingImageFilterTest.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 from sys import argv, stderr, exit
 itk.auto_progress(2)

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/FlatStructuringElementTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/FlatStructuringElementTest.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 from sys import argv, exit
 itk.auto_progress(2)

--- a/Modules/IO/GDCM/wrapping/test/ReadDicomAndReadTagTest.py
+++ b/Modules/IO/GDCM/wrapping/test/ReadDicomAndReadTagTest.py
@@ -22,8 +22,6 @@
 # - Read a tag (patient's name) directly with the GetValueFromTag() method
 # - Compare the two tags if they are the same
 
-from __future__ import print_function
-
 import itk
 import sys
 

--- a/Modules/Segmentation/LevelSets/wrapping/test/GeodesicActiveContourImageFilterTest.py
+++ b/Modules/Segmentation/LevelSets/wrapping/test/GeodesicActiveContourImageFilterTest.py
@@ -36,8 +36,6 @@
 # See the ITK Software Guide, section 9.3.3 "Geodesic Active Contours
 # Segmentation" as well as the CXX example for more comments.
 
-from __future__ import print_function
-
 import itk
 from sys import argv, stderr
 import os

--- a/Modules/Segmentation/LevelSets/wrapping/test/ThresholdSegmentationLevelSetImageFilterTest.py
+++ b/Modules/Segmentation/LevelSets/wrapping/test/ThresholdSegmentationLevelSetImageFilterTest.py
@@ -28,8 +28,6 @@
 #     OUTPUTS: {ThresholdSegmentationLevelSetImageFilterGrayMatter.png}
 #     107 69 5 180  210
 
-from __future__ import print_function
-
 import itk
 from sys import argv, stderr, exit
 import os

--- a/Wrapping/Generators/Doc/doxy2swig.py
+++ b/Wrapping/Generators/Doc/doxy2swig.py
@@ -129,10 +129,7 @@ class Doxy2SWIG:
 
     def add_text(self, value):
         """Adds text corresponding to `value` into `self.pieces`."""
-        if sys.version_info >= (3,0):
-          listTypes = (list, tuple)
-        else:
-          listTypes = (types.ListType, types.TupleType)
+        listTypes = (list, tuple)
         if type(value) in listTypes:
             self.pieces.extend(value)
         else:

--- a/Wrapping/Generators/Doc/doxy2swig.py
+++ b/Wrapping/Generators/Doc/doxy2swig.py
@@ -21,8 +21,6 @@ output will be written (the file will be clobbered).
 # Author: Prabhu Ramachandran
 # License: BSD style
 
-from __future__ import print_function
-
 from xml.dom import minidom
 import re
 import textwrap

--- a/Wrapping/Generators/Doc/itk_doxy2swig.py
+++ b/Wrapping/Generators/Doc/itk_doxy2swig.py
@@ -7,8 +7,6 @@ Usage:
 
 """
 
-from __future__ import print_function
-
 import sys
 import os
 import glob

--- a/Wrapping/Generators/Doc/itk_doxy2swig.py
+++ b/Wrapping/Generators/Doc/itk_doxy2swig.py
@@ -13,12 +13,7 @@ import sys
 import os
 import glob
 from doxy2swig import *
-if sys.version_info >= (3,0):
-    # Python 3
-    from io import StringIO
-else:
-    # Python 2
-    from cStringIO import StringIO
+from io import StringIO
 
 class itkDoxy2SWIG(Doxy2SWIG):
     def __init__(self, src, cpp_name="", swig_name=""):

--- a/Wrapping/Generators/Python/Tests/PythonTypeTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTypeTest.py
@@ -18,8 +18,6 @@
 
 # a short program to check the value returned by the GetNameOfClass() methods
 
-from __future__ import print_function
-
 import itk
 import sys
 import types

--- a/Wrapping/Generators/Python/Tests/PythonTypemapsTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTypemapsTest.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 import sys
 import gc

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -18,9 +18,6 @@
 
 # also test the import callback feature
 
-from __future__ import print_function
-
-
 def custom_callback(name, progress):
     if progress == 0:
         print("Loading %s..." % name, file=sys.stderr)

--- a/Wrapping/Generators/Python/Tests/findEmptyClasses.py
+++ b/Wrapping/Generators/Python/Tests/findEmptyClasses.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 import sys
 from itkTemplate import itkTemplate

--- a/Wrapping/Generators/Python/Tests/findSegfaults.py
+++ b/Wrapping/Generators/Python/Tests/findSegfaults.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import sys
 import commands
 import tempfile

--- a/Wrapping/Generators/Python/Tests/getNameOfClass.py
+++ b/Wrapping/Generators/Python/Tests/getNameOfClass.py
@@ -18,8 +18,6 @@
 
 # a short program to check the value returned by the GetNameOfClass() methods
 
-from __future__ import print_function
-
 import itk
 import sys
 itk.auto_progress(2)

--- a/Wrapping/Generators/Python/Tests/module2module.py
+++ b/Wrapping/Generators/Python/Tests/module2module.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 import sys
 

--- a/Wrapping/Generators/Python/Tests/returnedTypeCoverage.py
+++ b/Wrapping/Generators/Python/Tests/returnedTypeCoverage.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import itk
 import re
 import sys

--- a/Wrapping/Generators/Python/Tests/timing.py
+++ b/Wrapping/Generators/Python/Tests/timing.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import time
 
 start = time.time()

--- a/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
+++ b/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
@@ -18,8 +18,6 @@
 
 # a short program to check that ITK's API is consistent across the library.
 
-from __future__ import print_function
-
 import itk
 import sys
 import itkTemplate

--- a/Wrapping/Generators/Python/Tests/verifyTTypeAPIConsistency.py
+++ b/Wrapping/Generators/Python/Tests/verifyTTypeAPIConsistency.py
@@ -18,8 +18,6 @@
 
 # a short program to check that ITK's API is consistent across the library.
 
-from __future__ import print_function
-
 import itk
 import sys
 import itkTemplate

--- a/Wrapping/Generators/Python/Tests/wrappingCoverage.py
+++ b/Wrapping/Generators/Python/Tests/wrappingCoverage.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import sys
 import re
 import itk

--- a/Wrapping/Generators/Python/itkBase.py
+++ b/Wrapping/Generators/Python/itkBase.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import os
 import os.path
 import sys

--- a/Wrapping/Generators/Python/itkBase.py
+++ b/Wrapping/Generators/Python/itkBase.py
@@ -260,9 +260,6 @@ for d in dirs:
         data = {}
         conf = module + 'Config.py'
         path = os.path.join(d + os.sep + "Configuration", conf)
-        if sys.version_info >= (3, 0):
-            with open(path, "rb") as modulefile:
-                exec(modulefile.read(), data)
-        else:
-            execfile(path, data)
+        with open(path, "rb") as modulefile:
+            exec(modulefile.read(), data)
         module_data[module] = data

--- a/Wrapping/Generators/Python/itkBase.py
+++ b/Wrapping/Generators/Python/itkBase.py
@@ -21,11 +21,8 @@ from __future__ import print_function
 import os
 import os.path
 import sys
-if sys.version_info >= (3, 4):
-    import importlib
-    import types
-else:
-    import imp
+import importlib
+import types
 import inspect
 import itkConfig
 import itkTemplate
@@ -46,20 +43,14 @@ def LoadModule(name, namespace=None):
     This later submodule will be created if it does not already exist."""
 
     # find the module's name in sys.modules, or create a new module so named
-    if sys.version_info >= (3, 4):
-        this_module = sys.modules.setdefault(name, types.ModuleType(name))
-    else:
-        this_module = sys.modules.setdefault(name, imp.new_module(name))
+    this_module = sys.modules.setdefault(name, types.ModuleType(name))
 
     # if this library and it's template instantiations have already been loaded
     # into sys.modules, bail out after loading the defined symbols into
     # 'namespace'
     if hasattr(this_module, '__templates_loaded'):
         if namespace is not None:
-            if sys.version_info >= (3, 4):
-                swig = namespace.setdefault('swig', types.ModuleType('swig'))
-            else:
-                swig = namespace.setdefault('swig', imp.new_module('swig'))
+            swig = namespace.setdefault('swig', types.ModuleType('swig'))
             swig.__dict__.update(this_module.swig.__dict__)
 
             # don't worry about overwriting the symbols in namespace -- any
@@ -138,16 +129,10 @@ def LoadModule(name, namespace=None):
     # stomp on an existing 'swig' module, nor do we want to share 'swig'
     # modules between this_module and namespace.
 
-    if sys.version_info >= (3, 4):
-        this_module.swig = types.ModuleType('swig')
-    else:
-        this_module.swig = imp.new_module('swig')
+    this_module.swig = types.ModuleType('swig')
 
     if namespace is not None:
-        if sys.version_info >= (3, 4):
-            swig = namespace.setdefault('swig', types.ModuleType('swig'))
-        else:
-            swig = namespace.setdefault('swig', imp.new_module('swig'))
+        swig = namespace.setdefault('swig', types.ModuleType('swig'))
 
     for k, v in module.__dict__.items():
         if not k.startswith('__'):
@@ -249,19 +234,8 @@ class LibraryLoader(object):
     def load(self, name):
         self.setup()
         try:
-            if sys.version_info >= (3, 4):
-                return importlib.import_module(name)
-            else:
-                # needed in case next line raises exception, so that finally block
-                # works
-                fp = None
-                fp, pathname, description = imp.find_module(name)
-                return imp.load_module(name, fp, pathname, description)
+            return importlib.import_module(name)
         finally:
-            if sys.version_info < (3, 4):
-                # Since we may exit via an exception, close fp explicitly.
-                if fp:
-                    fp.close()
             self.cleanup()
 
     def cleanup(self):

--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -146,10 +146,7 @@ def physical_size(image_or_filter):
     """
     # required because range is overloaded in this module
     import sys
-    if sys.version_info >= (3, 0):
-      from builtins import range
-    else:
-      from __builtin__ import range
+    from builtins import range
     spacing_ = spacing(image_or_filter)
     size_ = size(image_or_filter)
     result = []

--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -16,7 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
 import re
 
 # The following line defines an ascii string used for dynamically refreshing

--- a/Wrapping/Generators/Python/itkTemplate.py
+++ b/Wrapping/Generators/Python/itkTemplate.py
@@ -361,10 +361,7 @@ class itkTemplate(object):
         modules = itkBase.lazy_attributes[name]
         for module in modules:
             # find the module's name in sys.modules, or create a new module so named
-            if sys.version_info >= (3, 4):
-                this_module = sys.modules.setdefault(module, types.ModuleType(module))
-            else:
-                this_module = sys.modules.setdefault(module, imp.new_module(module))
+            this_module = sys.modules.setdefault(module, types.ModuleType(module))
             namespace = {}
             if not hasattr(this_module, '__templates_loaded'):
                 itkBase.LoadModule(module, namespace)
@@ -381,10 +378,7 @@ class itkTemplate(object):
         def get_attrs(obj):
             if not hasattr(obj, '__dict__'):
                 return []  # slots only
-            if sys.version_info >= (3, 0):
-              dict_types = (dict, types.MappingProxyType)
-            else:
-              dict_types = (dict, types.DictProxyType)
+            dict_types = (dict, types.MappingProxyType)
             if not isinstance(obj.__dict__, dict_types):
                 raise TypeError("%s.__dict__ is not a dictionary"
                                 "" % obj.__name__)

--- a/Wrapping/Generators/Python/itkTemplate.py
+++ b/Wrapping/Generators/Python/itkTemplate.py
@@ -24,10 +24,7 @@ import re
 import sys
 import types
 import collections
-if sys.version_info >= (3, 4):
-    import importlib
-else:
-    import imp
+import importlib
 import warnings
 import itkConfig
 import itkBase

--- a/Wrapping/Generators/Python/itkTemplate.py
+++ b/Wrapping/Generators/Python/itkTemplate.py
@@ -16,8 +16,6 @@
 #
 #==========================================================================*/
 
-from __future__ import print_function
-
 import inspect
 import os
 import re

--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Import unicode literals so that StringIO works on both Python 2 and 3
-from __future__ import unicode_literals
-from __future__ import print_function
-
 import sys
 import os
 import re


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
