### PR TITLE
Run clang-format on pre-commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -45,7 +45,7 @@ zap.pl           crlf=input
 # ghostflow-director GitHub automatic check for maximum repository file size
 *                     hooks-max-size=100000
 Modules/Numerics/FEM/src/dsrc2c.c hooks-max-size=260000
-Modules/ThirdParty/** hooks-max-size=300000
+Modules/ThirdParty/** hooks-max-size=300000 hooks.style=
 Modules/ThirdParty/NIFTI/src/nifti/nifti2/nifti2_io.c hooks-max-size=400000
 Modules/ThirdParty/VNL/src/vxl/v3p/netlib/triangle.c hooks-max-size=670000
 Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx hooks-max-size=120000

--- a/CMake/ITKModuleClangFormat.cmake
+++ b/CMake/ITKModuleClangFormat.cmake
@@ -10,6 +10,6 @@
 option(ITK_USE_CLANG_FORMAT "Enable the use of clang-format for coding style formatting." ${BUILD_TESTING})
 mark_as_advanced(ITK_USE_CLANG_FORMAT)
 
-if(BUILD_TESTING AND ITK_USE_CLANG_FORMAT AND NOT CMAKE_CROSSCOMPILING)
+if(BUILD_TESTING AND ITK_USE_CLANG_FORMAT AND NOT CMAKE_CROSSCOMPILING AND NOT ITK_FORBID_DOWNLOADS)
   include(${ITK_CMAKE_DIR}/../Utilities/ClangFormat/DownloadClangFormat.cmake)
 endif()

--- a/Utilities/Hooks/pre-commit-style.bash
+++ b/Utilities/Hooks/pre-commit-style.bash
@@ -147,14 +147,37 @@ run_KWStyle() {
 #-----------------------------------------------------------------------------
 # clangformat.
 check_for_clangformat() {
+  clangformat_required_version=8.0.1
+  system_tools="
+    clang-format-$clangformat_required_version
+    clang-format
+"
+  for tool in $system_tools; do
+    if type -p "$tool" >/dev/null; then
+      system_clang_format="$tool"
+      break
+    fi
+  done
   clangformat_path=$(git config clangFormat.binary) ||
-  clangformat_path=$(which clang-format) ||
+  clangformat_path=$(type -p "$system_clang_format" >/dev/null) ||
   die "clang-format executable was not found.
 
-Please install clang-format version 8.0 or set the executable location with
+Please install clang-format version $clangformat_required_version or set the executable location with
 
   git config clangFormat.binary /path/to/clang-format
-  "
+"
+  if ! "$clangformat_path" --version | grep "clang-format version $clangformat_required_version" >/dev/null 2>/dev/null; then
+    die "clang-format version $clangformat_required_version is required (exactly)
+
+Set the path the clang-format $clangformat_required_version executable with
+
+  git config clangFormat.binary /path/to/clang-format
+
+or disable the clang-format pre-commit hook with
+
+  git config hooks.clangformat false
+"
+  fi
 }
 
 run_clang_format_check_attr()

--- a/Utilities/Hooks/pre-commit-style.bash
+++ b/Utilities/Hooks/pre-commit-style.bash
@@ -154,13 +154,13 @@ run_KWStyle() {
 #-----------------------------------------------------------------------------
 # clangformat.
 check_for_clangformat() {
-  clangformat_path=$(git config hooks.clangformat.path) ||
-  clangformat_path=$(which clangformat) ||
-  die "clangformat executable was not found.
+  clangformat_path=$(git config clangFormat.binary) ||
+  clangformat_path=$(which clang-format) ||
+  die "clang-format executable was not found.
 
 Please install clang-format version 8.0 or set the executable location with
 
-  git config hooks.clangformat.path /path/to/clang-format
+  git config clangFormat.binary /path/to/clang-format
   "
 }
 

--- a/Utilities/Hooks/pre-commit-style.bash
+++ b/Utilities/Hooks/pre-commit-style.bash
@@ -140,6 +140,7 @@ run_KWStyle_on_file() {
 Line numbers in the errors shown refer to the file:
 ${1}.kws"
   fi
+  return 0
 }
 
 run_KWStyle() {
@@ -239,6 +240,13 @@ run_clangformat_on_file() {
 }
 
 run_clangformat() {
+  $do_KWStyle && check_for_KWStyle
+  if test $?; then
+    have_KWStyle=true
+  else
+    have_KWStyle=false
+  fi
+
   merge_tool=$(get_merge_tool "$merge_tool") || die "Merge tool not configured.
 
 Set the merge tool with
@@ -254,13 +262,6 @@ For more information, see
   while read MERGED; do
     run_clangformat_on_file "$MERGED" || return
   done # end for changed files
-
-  $do_KWStyle && check_for_KWStyle
-  if test $?; then
-    have_KWStyle=false
-  else
-    have_KWStyle=true
-  fi
 }
 
 # Do not run during merge commits for now.

--- a/Utilities/SetupForDevelopment.sh
+++ b/Utilities/SetupForDevelopment.sh
@@ -51,6 +51,10 @@ messages for interaction with Gerrit. Also, removing the "gerrit" and "stage" re
           git remote remove stage
 fi
 
+# Style hook configuration
+git config hooks.KWStyle.conf "Utilities/KWStyle/ITK.kws.xml"
+git config hooks.KWStyle.overwriteRulesConf "Utilities/KWStyle/ITKOverwrite.txt"
+
 # Make sure we are inside the repository.
 cd "$(echo "$0"|sed 's/[^/]*$//')"/..
 
@@ -103,5 +107,5 @@ echo -e "Git version $git_version is OK.\n"
 
 
 # Record the version of this setup so Hooks/pre-commit can check it.
-SetupForDevelopment_VERSION=6
+SetupForDevelopment_VERSION=7
 git config hooks.SetupForDevelopment ${SetupForDevelopment_VERSION}


### PR DESCRIPTION
Automatically run `clang-format` on changed, non-third-party C++ files at pre-commit time, and allow the developer to review and test the style changes with the standard `git mergetool` configuration (see `git help mergetool`).

This should be merged after #1191 since most of the files in the repository currently have many changes when clang-format is executed.