### PR TITLE
BUG: Wrong component type for non supported tiff with USHORT palette

### DIFF
--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -456,10 +456,12 @@ TIFFImageIO::ReadImageInformation()
       this->SetPixelType(RGBA);
   }
 
-  if ((this->GetFormat() == TIFFImageIO::PALETTE_GRAYSCALE || this->GetFormat() == TIFFImageIO::PALETTE_RGB) &&
-      m_TotalColors > 0 && this->GetExpandRGBPalette())
+  bool isPalette =
+    (this->GetFormat() == TIFFImageIO::PALETTE_GRAYSCALE || this->GetFormat() == TIFFImageIO::PALETTE_RGB) &&
+    m_TotalColors > 0;
+  bool isPaletteShortType = false;
+  if (isPalette)
   {
-    m_ComponentType = UCHAR;
     // detect if palette appears to be 8-bit or 16-bit
     for (unsigned int cc = 0; cc < 256; ++cc)
     {
@@ -467,15 +469,16 @@ TIFFImageIO::ReadImageInformation()
       this->GetColor(cc, &red, &green, &blue);
       if (red > 255 || green > 255 || blue > 255)
       {
-        m_ComponentType = USHORT;
+        isPaletteShortType = true;
         break;
       }
     }
   }
-  if (!m_IsReadAsScalarPlusPalette)
+
+  if (isPalette && this->GetExpandRGBPalette())
   {
-    // make sure the palette is empty
-    m_ColorPalette.resize(0);
+    // put the component type the same as the palette type
+    m_ComponentType = (isPaletteShortType) ? USHORT : UCHAR;
   }
 
 
@@ -496,17 +499,30 @@ TIFFImageIO::ReadImageInformation()
       itkExceptionMacro("Unable to read tiff file: " << emsg);
     }
 
-    itkDebugMacro(<< "Using TIFFReadRGBAImage");
 
-    this->SetNumberOfComponents(4);
-    this->SetPixelType(RGBA);
-    m_ComponentType = UCHAR;
-
-    if (m_IsReadAsScalarPlusPalette)
+    if (!m_IsReadAsScalarPlusPalette)
     {
-      itkWarningMacro(<< "Could not read this palette image as scalar+Palette because of its TIFF format");
-      m_IsReadAsScalarPlusPalette = false;
+      itkDebugMacro(<< "Using TIFFReadRGBAImage");
+      this->SetNumberOfComponents(4);
+      this->SetPixelType(RGBA);
+      m_ComponentType = UCHAR;
     }
+    else
+    {
+      itkDebugMacro(<< "Using TIFFReadRGBImage");
+      itkWarningMacro(<< "Could not read this palette image as scalar+Palette because of its TIFF format");
+      // can't read as scalar+palette so reset type to RGB
+      m_IsReadAsScalarPlusPalette = false;
+      this->SetNumberOfComponents(3);
+      this->SetPixelType(RGB); // RGBA is not valid for palette, so cannot be
+      m_ComponentType = (isPaletteShortType) ? USHORT : UCHAR;
+    }
+  }
+
+  if (!m_IsReadAsScalarPlusPalette)
+  {
+    // make sure the palette is empty
+    m_ColorPalette.resize(0);
   }
 }
 


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [] :no_entry_sign: Adds the License notice to new files.
- [] :no_entry_sign: Adds Python wrapping.
- [] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
