### PR TITLE
BUG: operator= defined in [tube|*]SpatialObjectPoint incomplete

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -66,6 +66,7 @@ ContourSpatialObjectPoint<TPointDimension>::operator=(const ContourSpatialObject
     this->m_Id = rhs.GetId();
     this->m_PositionInObjectSpace = rhs.GetPositionInObjectSpace();
     this->m_Color = rhs.GetColor();
+    this->m_SpatialObject = rhs.GetSpatialObject();
     this->m_NormalInObjectSpace = rhs.GetNormalInObjectSpace();
     this->m_PickedPointInObjectSpace = rhs.GetPickedPointInObjectSpace();
   }

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -169,6 +169,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::operator=(const DTITubeSpatialObject
     this->SetId(rhs.GetId());
     this->SetPositionInObjectSpace(rhs.GetPositionInObjectSpace());
     this->SetColor(rhs.GetColor());
+    this->SetSpatialObject(rhs.GetSpatialObject());
 
     // Tube
     this->SetRadiusInObjectSpace(rhs.GetRadiusInObjectSpace());

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -74,6 +74,7 @@ LineSpatialObjectPoint<TPointDimension>::operator=(const LineSpatialObjectPoint 
 {
   this->m_Id = rhs.m_Id;
   this->m_Color = rhs.m_Color;
+  this->m_SpatialObject = rhs.m_SpatialObject;
   this->m_PositionInObjectSpace = rhs.m_PositionInObjectSpace;
   this->m_NormalArrayInObjectSpace = rhs.m_NormalArrayInObjectSpace;
   return *this;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -107,6 +107,12 @@ public:
     m_SpatialObject = so;
   }
 
+  SpatialObjectType *
+  GetSpatialObject() const
+  {
+    return m_SpatialObject;
+  }
+
   /** Set the position in world coordinates, using the
    *    spatialObject's objectToWorld transform, inverse */
   void

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -82,6 +82,7 @@ SpatialObjectPoint<TPointDimension>::operator=(const SpatialObjectPoint & rhs)
     this->SetId(rhs.GetId());
     this->SetPositionInObjectSpace(rhs.GetPositionInObjectSpace());
     this->SetColor(rhs.GetColor());
+    this->SetSpatialObject(rhs.GetSpatialObject());
   }
   return *this;
 }
@@ -103,6 +104,7 @@ SpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent)
     os << m_PositionInObjectSpace[i - 1] << ",";
   }
   os << m_PositionInObjectSpace[TPointDimension - 1] << std::endl;
+  os << indent << "SpatialObject: " << m_SpatialObject << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -63,6 +63,7 @@ SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObject
 {
   this->m_Id = rhs.m_Id;
   this->m_Color = rhs.m_Color;
+  this->m_SpatialObject = rhs.m_SpatialObject;
   this->m_PositionInObjectSpace = rhs.m_PositionInObjectSpace;
   this->m_NormalInObjectSpace = rhs.m_NormalInObjectSpace;
   return *this;

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -185,6 +185,7 @@ TubeSpatialObjectPoint<TPointDimension>::operator=(const TubeSpatialObjectPoint 
     this->SetId(rhs.GetId());
     this->SetPositionInObjectSpace(rhs.GetPositionInObjectSpace());
     this->SetColor(rhs.GetColor());
+    this->SetSpatialObject(rhs.GetSpatialObject());
 
     // class
     this->SetRadiusInObjectSpace(rhs.GetRadiusInObjectSpace());


### PR DESCRIPTION
The assignment operator for SpatialObjectPoint and its derived classes
that overwrite that member function were not updated to also copy
the SpatialObject pointer maintained within those classes.  That
pointer is critical to computing object to world transforms, and error
messages are given if those transforms are attempted without the
spatial object pointer of the point being set.   This commit adds
the copy of the SpatialObject pointer.
