### PR TITLE
ENH: update remote modules to comply with new enum class style

### DIFF
--- a/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
+++ b/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
@@ -20,5 +20,5 @@ itk_fetch_module(AnisotropicDiffusionLBR
     http://insight-journal.org/browse/publication/953
   "
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKAnisotropicDiffusionLBR.git
-  GIT_TAG 4d77257093139a6399c243370e0cc4301b26b54f
+  GIT_TAG 8a51cc37cb3be19121702d3ea2194f0233bd923c
   )

--- a/Modules/Remote/BSplineGradient.remote.cmake
+++ b/Modules/Remote/BSplineGradient.remote.cmake
@@ -1,5 +1,5 @@
 itk_fetch_module(BSplineGradient
   "Approximate an image's gradient from a b-spline fit to its intensity."
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBSplineGradient.git
-  GIT_TAG 3ff6549ae4cb9dad7a13453cecf1bb7edc55d1fb
+  GIT_TAG 881795e057570e9957acaeed7c5de3d19cdb6022
 )

--- a/Modules/Remote/BioCell.remote.cmake
+++ b/Modules/Remote/BioCell.remote.cmake
@@ -4,5 +4,5 @@ It has classes to represent cells' shape, color, and growth state.
 It also has classes to represent a cell genome,
 whose expression is modeled by differential equations."
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBioCell.git
-  GIT_TAG 6dd1b454f64a17a60d88d58a84d895014714b181
+  GIT_TAG 8be5ca909129e96b399df802cd477f4450de7ba2
   )

--- a/Modules/Remote/GenericLabelInterpolator.remote.cmake
+++ b/Modules/Remote/GenericLabelInterpolator.remote.cmake
@@ -1,5 +1,5 @@
 itk_fetch_module(GenericLabelInterpolator
   "A generic interpolator for multi-label images."
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKGenericLabelInterpolator.git
-  GIT_TAG 187ab99b7d42718c99e5017f0acd3900d7469bd1
+  GIT_TAG a75f39880fcbe8974edb78eed02e2578e919f50e
   )

--- a/Modules/Remote/Montage.remote.cmake
+++ b/Modules/Remote/Montage.remote.cmake
@@ -2,5 +2,5 @@
 itk_fetch_module(Montage
 "Reconstruction of 3D volumetric dataset from a collection of 2D slices"
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMontage.git
-  GIT_TAG d48b400cea8d96f1db51829f0d3a6596e4da2c78
+  GIT_TAG 9bbe940b7c79031f75cbac952ba0c11413605fe5
   )

--- a/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
+++ b/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
@@ -14,5 +14,5 @@ IEEE Trans Biomed Eng. 2008 Aug;55(8):2022-38. doi: 10.1109/TBME.2008.921158.
 This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKMorphologicalContourInterpolation.git
-  GIT_TAG 8e3c0d3794a65e10000da68495ea84771f663016
+  GIT_TAG f356b10884c8b2183cd17ff4c2c90cd6f7e6e844
   )

--- a/Modules/Remote/RLEImage.remote.cmake
+++ b/Modules/Remote/RLEImage.remote.cmake
@@ -9,5 +9,5 @@ http://hdl.handle.net/10380/3562
 This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKRLEImage.git
-  GIT_TAG d187a261ce3f53608ef49c2d42e4ce3d1e9ca678
+  GIT_TAG af24e0a367d4466d6cdc066d7b030ac598ed62ae
   )

--- a/Modules/Remote/SphinxExamples.remote.cmake
+++ b/Modules/Remote/SphinxExamples.remote.cmake
@@ -2,5 +2,5 @@
 itk_fetch_module(SphinxExamples
   "This module builds the examples found at https://itk.org/ITKExamples/"
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKExamples.git
-  GIT_TAG 721e4dffaed71ef07a250044cc697d8b7576712a
+  GIT_TAG 1ca5187b3e7b43af0401c4497c60f69dfdf6075f
   )

--- a/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
+++ b/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
@@ -7,5 +7,5 @@ See the following Insight Journal's publication:
   http://www.insight-journal.org/browse/publication/831
   https://hdl.handle.net/10380/3307"
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/itkSubdivisionQuadEdgeMeshFilter
-  GIT_TAG b6f4c590c570ce05068c8def330784a798c1dd75
+  GIT_TAG b9214cc50744446881d12b53c737fbff4e41565c
   )

--- a/Modules/Remote/TextureFeatures.remote.cmake
+++ b/Modules/Remote/TextureFeatures.remote.cmake
@@ -13,5 +13,5 @@ For more information, see:
   http://insight-journal.org/browse/publication/985
 "
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTextureFeatures.git
-  GIT_TAG f2fbb8f0a78b81238029501c891173d2f57d9d64
+  GIT_TAG 7643fb34ced0b40ad7eb0f2a28d56a3a2941cc0f
   )

--- a/Modules/Remote/TotalVariation.remote.cmake
+++ b/Modules/Remote/TotalVariation.remote.cmake
@@ -7,5 +7,5 @@ Please refer to the documentation upstream for a detailed description:
 https://github.com/albarji/proxTV
 "
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
-  GIT_TAG 01a499f935de526b13d4d6af8dc183c0543f6da2
+  GIT_TAG 85d019eb79a89a9b1cf9bb897f290a3cfcaafeee
 )


### PR DESCRIPTION
There are probably some other changes in some of the remotes. I didn't check whether all the modules have the new changes.