### PR TITLE
ENH: MultiResolutionPDEDeformableRegistration supports more Registrat…

### DIFF
--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -78,6 +78,7 @@ namespace itk
  * \ingroup ITKPDEDeformableRegistration
  */
 template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType = float,
+          typename TRegistrationType = PDEDeformableRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >,
           typename TDefaultRegistrationType = DemonsRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >,
           typename TFloatImageType = Image< TRealType, TFixedImage::ImageDimension > >
 class ITK_TEMPLATE_EXPORT MultiResolutionPDEDeformableRegistration:
@@ -121,7 +122,7 @@ public:
   using FloatImageType = TFloatImageType;
 
   /** The internal registration type. */
-  using RegistrationType = TDefaultRegistrationType;
+  using RegistrationType = TRegistrationType;
   using RegistrationPointer = typename RegistrationType::Pointer;
 
   /** The default registration type. */

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -77,29 +77,30 @@ namespace itk
  * \ingroup DeformableImageRegistration
  * \ingroup ITKPDEDeformableRegistration
  */
-template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType = float,
-          typename TRegistrationType = PDEDeformableRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >,
-          typename TDefaultRegistrationType = DemonsRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >,
-          typename TFloatImageType = Image< TRealType, TFixedImage::ImageDimension > >
-class ITK_TEMPLATE_EXPORT MultiResolutionPDEDeformableRegistration:
-  public ImageToImageFilter< TDisplacementField, TDisplacementField >
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType = float,
+          typename TRegistrationType = PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>,
+          typename TDefaultRegistrationType = DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>,
+          typename TFloatImageType = Image<TRealType, TFixedImage::ImageDimension>>
+class ITK_TEMPLATE_EXPORT MultiResolutionPDEDeformableRegistration
+  : public ImageToImageFilter<TDisplacementField, TDisplacementField>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(MultiResolutionPDEDeformableRegistration);
 
   /** Standard class type aliases */
   using Self = MultiResolutionPDEDeformableRegistration;
-  using Superclass =
-      ImageToImageFilter< TDisplacementField, TDisplacementField >;
-  using Pointer = SmartPointer< Self >;
-  using ConstPointer = SmartPointer< const Self >;
+  using Superclass = ImageToImageFilter<TDisplacementField, TDisplacementField>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiResolutionPDEDeformableRegistration,
-               ImageToImageFilter);
+  itkTypeMacro(MultiResolutionPDEDeformableRegistration, ImageToImageFilter);
 
   /** Fixed image type. */
   using FixedImageType = TFixedImage;
@@ -292,7 +293,7 @@ private:
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "itkMultiResolutionPDEDeformableRegistration.hxx"
+#  include "itkMultiResolutionPDEDeformableRegistration.hxx"
 #endif
 
 #endif

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -77,13 +77,14 @@ namespace itk
  * \ingroup DeformableImageRegistration
  * \ingroup ITKPDEDeformableRegistration
  */
-template <typename TFixedImage,
-          typename TMovingImage,
-          typename TDisplacementField,
-          typename TRealType = float,
-          typename TRegistrationType = PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>,
-          typename TDefaultRegistrationType = DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>,
-          typename TFloatImageType = Image<TRealType, TFixedImage::ImageDimension>>
+template <
+  typename TFixedImage,
+  typename TMovingImage,
+  typename TDisplacementField,
+  typename TRealType = float,
+  typename TFloatImageType = Image<TRealType, TFixedImage::ImageDimension>,
+  typename TRegistrationType = PDEDeformableRegistrationFilter<TFloatImageType, TFloatImageType, TDisplacementField>,
+  typename TDefaultRegistrationType = DemonsRegistrationFilter<TFloatImageType, TFloatImageType, TDisplacementField>>
 class ITK_TEMPLATE_EXPORT MultiResolutionPDEDeformableRegistration
   : public ImageToImageFilter<TDisplacementField, TDisplacementField>
 {

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -77,24 +77,28 @@ namespace itk
  * \ingroup DeformableImageRegistration
  * \ingroup ITKPDEDeformableRegistration
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType = float>
-class ITK_TEMPLATE_EXPORT MultiResolutionPDEDeformableRegistration
-  : public ImageToImageFilter<TDisplacementField, TDisplacementField>
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType = float,
+          typename TDefaultRegistrationType = DemonsRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >,
+          typename TFloatImageType = Image< TRealType, TFixedImage::ImageDimension > >
+class ITK_TEMPLATE_EXPORT MultiResolutionPDEDeformableRegistration:
+  public ImageToImageFilter< TDisplacementField, TDisplacementField >
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(MultiResolutionPDEDeformableRegistration);
 
   /** Standard class type aliases */
   using Self = MultiResolutionPDEDeformableRegistration;
-  using Superclass = ImageToImageFilter<TDisplacementField, TDisplacementField>;
-  using Pointer = SmartPointer<Self>;
-  using ConstPointer = SmartPointer<const Self>;
+  using Superclass =
+      ImageToImageFilter< TDisplacementField, TDisplacementField >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiResolutionPDEDeformableRegistration, ImageToImageFilter);
+  itkTypeMacro(MultiResolutionPDEDeformableRegistration,
+               ImageToImageFilter);
 
   /** Fixed image type. */
   using FixedImageType = TFixedImage;
@@ -114,14 +118,14 @@ public:
   static constexpr unsigned int ImageDimension = FixedImageType::ImageDimension;
 
   /** Internal float image type. */
-  using FloatImageType = Image<TRealType, Self::ImageDimension>;
+  using FloatImageType = TFloatImageType;
 
   /** The internal registration type. */
-  using RegistrationType = PDEDeformableRegistrationFilter<FloatImageType, FloatImageType, DisplacementFieldType>;
+  using RegistrationType = TDefaultRegistrationType;
   using RegistrationPointer = typename RegistrationType::Pointer;
 
   /** The default registration type. */
-  using DefaultRegistrationType = DemonsRegistrationFilter<FloatImageType, FloatImageType, DisplacementFieldType>;
+  using DefaultRegistrationType = TDefaultRegistrationType;
 
   /** The fixed multi-resolution image pyramid type. */
   using FixedImagePyramidType = MultiResolutionPyramidImageFilter<FixedImageType, FloatImageType>;
@@ -287,7 +291,7 @@ private:
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkMultiResolutionPDEDeformableRegistration.hxx"
+#include "itkMultiResolutionPDEDeformableRegistration.hxx"
 #endif
 
 #endif

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -29,9 +29,20 @@ namespace itk
 /**
  * Default constructor
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
-  MultiResolutionPDEDeformableRegistration()
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::MultiResolutionPDEDeformableRegistration()
 {
   this->SetNumberOfRequiredInputs(2);
   // Primary input is optional in this filter
@@ -63,10 +74,21 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Set the moving image image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::SetMovingImage(
-  const MovingImageType * ptr)
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::SetMovingImage(const MovingImageType * ptr)
 {
   this->ProcessObject::SetNthInput(2, const_cast<MovingImageType *>(ptr));
 }
@@ -74,11 +96,27 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Get the moving image image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
-const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
-  MovingImageType *
-  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::GetMovingImage()
-    const
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
+const typename MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                                        TMovingImage,
+                                                        TDisplacementField,
+                                                        TRealType,
+                                                        TRegistrationType,
+                                                        TDefaultRegistrationType,
+                                                        TFloatImageType>::MovingImageType *
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::GetMovingImage() const
 {
   return dynamic_cast<const MovingImageType *>(this->ProcessObject::GetInput(2));
 }
@@ -86,10 +124,21 @@ const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImag
 /*
  * Set the fixed image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::SetFixedImage(
-  const FixedImageType * ptr)
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::SetFixedImage(const FixedImageType * ptr)
 {
   this->ProcessObject::SetNthInput(1, const_cast<FixedImageType *>(ptr));
 }
@@ -97,11 +146,27 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Get the fixed image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
-const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
-  FixedImageType *
-  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::GetFixedImage()
-    const
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
+const typename MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                                        TMovingImage,
+                                                        TDisplacementField,
+                                                        TRealType,
+                                                        TRegistrationType,
+                                                        TDefaultRegistrationType,
+                                                        TFloatImageType>::FixedImageType *
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::GetFixedImage() const
 {
   return dynamic_cast<const FixedImageType *>(this->ProcessObject::GetInput(1));
 }
@@ -109,10 +174,21 @@ const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImag
 /*
  *
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 std::vector<SmartPointer<DataObject>>::size_type
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
-  GetNumberOfValidRequiredInputs() const
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::GetNumberOfValidRequiredInputs() const
 {
   typename std::vector<SmartPointer<DataObject>>::size_type num = 0;
 
@@ -132,10 +208,21 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /**
  * Set the number of multi-resolution levels
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::SetNumberOfLevels(
-  unsigned int num)
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::SetNumberOfLevels(unsigned int num)
 {
   if (m_NumberOfLevels != num)
   {
@@ -157,11 +244,21 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /**
  * Standard PrintSelf method.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::PrintSelf(
-  std::ostream & os,
-  Indent         indent) const
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
@@ -202,9 +299,21 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
  * registrator and field_expander.
  *
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::GenerateData()
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::GenerateData()
 {
   // Check for nullptr images and pointers
   MovingImageConstPointer movingImage = this->GetMovingImage();
@@ -409,17 +518,41 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   m_RegistrationFilter->GetOutput()->ReleaseData();
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::StopRegistration()
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::StopRegistration()
 {
   m_RegistrationFilter->StopRegistration();
   m_StopRegistrationFlag = true;
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 bool
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::Halt()
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::Halt()
 {
   // Halt the registration after the user-specified number of levels
   if (m_NumberOfLevels != 0)
@@ -441,10 +574,21 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
-  GenerateOutputInformation()
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::GenerateOutputInformation()
 {
   typename DataObject::Pointer output;
 
@@ -469,10 +613,21 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
-  GenerateInputRequestedRegion()
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::GenerateInputRequestedRegion()
 {
   // call the superclass's implementation
   Superclass::GenerateInputRequestedRegion();
@@ -501,10 +656,21 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType,
+          typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
-  EnlargeOutputRequestedRegion(DataObject * ptr)
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TRegistrationType,
+                                         TDefaultRegistrationType,
+                                         TFloatImageType>::EnlargeOutputRequestedRegion(DataObject * ptr)
 {
   // call the superclass's implementation
   Superclass::EnlargeOutputRequestedRegion(ptr);

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -29,8 +29,8 @@ namespace itk
 /**
  * Default constructor
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
   MultiResolutionPDEDeformableRegistration()
 {
   this->SetNumberOfRequiredInputs(2);
@@ -63,9 +63,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Set the moving image image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::SetMovingImage(
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::SetMovingImage(
   const MovingImageType * ptr)
 {
   this->ProcessObject::SetNthInput(2, const_cast<MovingImageType *>(ptr));
@@ -74,10 +74,10 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Get the moving image image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
-const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
   MovingImageType *
-  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::GetMovingImage()
+  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::GetMovingImage()
     const
 {
   return dynamic_cast<const MovingImageType *>(this->ProcessObject::GetInput(2));
@@ -86,9 +86,9 @@ const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImag
 /*
  * Set the fixed image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::SetFixedImage(
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::SetFixedImage(
   const FixedImageType * ptr)
 {
   this->ProcessObject::SetNthInput(1, const_cast<FixedImageType *>(ptr));
@@ -97,10 +97,10 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Get the fixed image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
-const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
   FixedImageType *
-  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::GetFixedImage()
+  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::GetFixedImage()
     const
 {
   return dynamic_cast<const FixedImageType *>(this->ProcessObject::GetInput(1));
@@ -109,9 +109,9 @@ const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImag
 /*
  *
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 std::vector<SmartPointer<DataObject>>::size_type
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
   GetNumberOfValidRequiredInputs() const
 {
   typename std::vector<SmartPointer<DataObject>>::size_type num = 0;
@@ -132,9 +132,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /**
  * Set the number of multi-resolution levels
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::SetNumberOfLevels(
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::SetNumberOfLevels(
   unsigned int num)
 {
   if (m_NumberOfLevels != num)
@@ -157,9 +157,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /**
  * Standard PrintSelf method.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::PrintSelf(
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::PrintSelf(
   std::ostream & os,
   Indent         indent) const
 {
@@ -202,9 +202,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
  * registrator and field_expander.
  *
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::GenerateData()
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::GenerateData()
 {
   // Check for nullptr images and pointers
   MovingImageConstPointer movingImage = this->GetMovingImage();
@@ -409,17 +409,17 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   m_RegistrationFilter->GetOutput()->ReleaseData();
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::StopRegistration()
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::StopRegistration()
 {
   m_RegistrationFilter->StopRegistration();
   m_StopRegistrationFlag = true;
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 bool
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::Halt()
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::Halt()
 {
   // Halt the registration after the user-specified number of levels
   if (m_NumberOfLevels != 0)
@@ -441,9 +441,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
   GenerateOutputInformation()
 {
   typename DataObject::Pointer output;
@@ -469,9 +469,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
   GenerateInputRequestedRegion()
 {
   // call the superclass's implementation
@@ -501,9 +501,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType>::
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
   EnlargeOutputRequestedRegion(DataObject * ptr)
 {
   // call the superclass's implementation

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -33,16 +33,16 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::MultiResolutionPDEDeformableRegistration()
+                                         TDefaultRegistrationType>::MultiResolutionPDEDeformableRegistration()
 {
   this->SetNumberOfRequiredInputs(2);
   // Primary input is optional in this filter
@@ -78,17 +78,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::SetMovingImage(const MovingImageType * ptr)
+                                         TDefaultRegistrationType>::SetMovingImage(const MovingImageType * ptr)
 {
   this->ProcessObject::SetNthInput(2, const_cast<MovingImageType *>(ptr));
 }
@@ -100,23 +100,23 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 const typename MultiResolutionPDEDeformableRegistration<TFixedImage,
                                                         TMovingImage,
                                                         TDisplacementField,
                                                         TRealType,
+                                                        TFloatImageType,
                                                         TRegistrationType,
-                                                        TDefaultRegistrationType,
-                                                        TFloatImageType>::MovingImageType *
+                                                        TDefaultRegistrationType>::MovingImageType *
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::GetMovingImage() const
+                                         TDefaultRegistrationType>::GetMovingImage() const
 {
   return dynamic_cast<const MovingImageType *>(this->ProcessObject::GetInput(2));
 }
@@ -128,17 +128,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::SetFixedImage(const FixedImageType * ptr)
+                                         TDefaultRegistrationType>::SetFixedImage(const FixedImageType * ptr)
 {
   this->ProcessObject::SetNthInput(1, const_cast<FixedImageType *>(ptr));
 }
@@ -150,23 +150,23 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 const typename MultiResolutionPDEDeformableRegistration<TFixedImage,
                                                         TMovingImage,
                                                         TDisplacementField,
                                                         TRealType,
+                                                        TFloatImageType,
                                                         TRegistrationType,
-                                                        TDefaultRegistrationType,
-                                                        TFloatImageType>::FixedImageType *
+                                                        TDefaultRegistrationType>::FixedImageType *
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::GetFixedImage() const
+                                         TDefaultRegistrationType>::GetFixedImage() const
 {
   return dynamic_cast<const FixedImageType *>(this->ProcessObject::GetInput(1));
 }
@@ -178,17 +178,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 std::vector<SmartPointer<DataObject>>::size_type
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::GetNumberOfValidRequiredInputs() const
+                                         TDefaultRegistrationType>::GetNumberOfValidRequiredInputs() const
 {
   typename std::vector<SmartPointer<DataObject>>::size_type num = 0;
 
@@ -212,17 +212,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::SetNumberOfLevels(unsigned int num)
+                                         TDefaultRegistrationType>::SetNumberOfLevels(unsigned int num)
 {
   if (m_NumberOfLevels != num)
   {
@@ -248,17 +248,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::PrintSelf(std::ostream & os, Indent indent) const
+                                         TDefaultRegistrationType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
@@ -303,17 +303,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::GenerateData()
+                                         TDefaultRegistrationType>::GenerateData()
 {
   // Check for nullptr images and pointers
   MovingImageConstPointer movingImage = this->GetMovingImage();
@@ -522,17 +522,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::StopRegistration()
+                                         TDefaultRegistrationType>::StopRegistration()
 {
   m_RegistrationFilter->StopRegistration();
   m_StopRegistrationFlag = true;
@@ -542,17 +542,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 bool
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::Halt()
+                                         TDefaultRegistrationType>::Halt()
 {
   // Halt the registration after the user-specified number of levels
   if (m_NumberOfLevels != 0)
@@ -578,17 +578,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::GenerateOutputInformation()
+                                         TDefaultRegistrationType>::GenerateOutputInformation()
 {
   typename DataObject::Pointer output;
 
@@ -617,17 +617,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::GenerateInputRequestedRegion()
+                                         TDefaultRegistrationType>::GenerateInputRequestedRegion()
 {
   // call the superclass's implementation
   Superclass::GenerateInputRequestedRegion();
@@ -660,17 +660,17 @@ template <typename TFixedImage,
           typename TMovingImage,
           typename TDisplacementField,
           typename TRealType,
+          typename TFloatImageType,
           typename TRegistrationType,
-          typename TDefaultRegistrationType,
-          typename TFloatImageType>
+          typename TDefaultRegistrationType>
 void
 MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TMovingImage,
                                          TDisplacementField,
                                          TRealType,
+                                         TFloatImageType,
                                          TRegistrationType,
-                                         TDefaultRegistrationType,
-                                         TFloatImageType>::EnlargeOutputRequestedRegion(DataObject * ptr)
+                                         TDefaultRegistrationType>::EnlargeOutputRequestedRegion(DataObject * ptr)
 {
   // call the superclass's implementation
   Superclass::EnlargeOutputRequestedRegion(ptr);

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -29,8 +29,8 @@ namespace itk
 /**
  * Default constructor
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
   MultiResolutionPDEDeformableRegistration()
 {
   this->SetNumberOfRequiredInputs(2);
@@ -63,9 +63,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Set the moving image image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::SetMovingImage(
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::SetMovingImage(
   const MovingImageType * ptr)
 {
   this->ProcessObject::SetNthInput(2, const_cast<MovingImageType *>(ptr));
@@ -74,10 +74,10 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Get the moving image image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
-const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
   MovingImageType *
-  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::GetMovingImage()
+  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::GetMovingImage()
     const
 {
   return dynamic_cast<const MovingImageType *>(this->ProcessObject::GetInput(2));
@@ -86,9 +86,9 @@ const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImag
 /*
  * Set the fixed image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::SetFixedImage(
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::SetFixedImage(
   const FixedImageType * ptr)
 {
   this->ProcessObject::SetNthInput(1, const_cast<FixedImageType *>(ptr));
@@ -97,10 +97,10 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /*
  * Get the fixed image.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
-const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
+const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
   FixedImageType *
-  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::GetFixedImage()
+  MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::GetFixedImage()
     const
 {
   return dynamic_cast<const FixedImageType *>(this->ProcessObject::GetInput(1));
@@ -109,9 +109,9 @@ const typename MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImag
 /*
  *
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 std::vector<SmartPointer<DataObject>>::size_type
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
   GetNumberOfValidRequiredInputs() const
 {
   typename std::vector<SmartPointer<DataObject>>::size_type num = 0;
@@ -132,9 +132,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /**
  * Set the number of multi-resolution levels
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::SetNumberOfLevels(
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::SetNumberOfLevels(
   unsigned int num)
 {
   if (m_NumberOfLevels != num)
@@ -157,9 +157,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
 /**
  * Standard PrintSelf method.
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::PrintSelf(
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::PrintSelf(
   std::ostream & os,
   Indent         indent) const
 {
@@ -202,9 +202,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
  * registrator and field_expander.
  *
  */
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::GenerateData()
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::GenerateData()
 {
   // Check for nullptr images and pointers
   MovingImageConstPointer movingImage = this->GetMovingImage();
@@ -409,17 +409,17 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   m_RegistrationFilter->GetOutput()->ReleaseData();
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::StopRegistration()
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::StopRegistration()
 {
   m_RegistrationFilter->StopRegistration();
   m_StopRegistrationFlag = true;
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 bool
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::Halt()
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::Halt()
 {
   // Halt the registration after the user-specified number of levels
   if (m_NumberOfLevels != 0)
@@ -441,9 +441,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
   GenerateOutputInformation()
 {
   typename DataObject::Pointer output;
@@ -469,9 +469,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
   GenerateInputRequestedRegion()
 {
   // call the superclass's implementation
@@ -501,9 +501,9 @@ MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacemen
   }
 }
 
-template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TDefaultRegistrationType, typename TFloatImageType>
+template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType, typename TRegistrationType, typename TDefaultRegistrationType, typename TFloatImageType>
 void
-MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TDefaultRegistrationType, TFloatImageType>::
+MultiResolutionPDEDeformableRegistration<TFixedImage, TMovingImage, TDisplacementField, TRealType, TRegistrationType, TDefaultRegistrationType, TFloatImageType>::
   EnlargeOutputRequestedRegion(DataObject * ptr)
 {
   // call the superclass's implementation


### PR DESCRIPTION
…ionFilter

By making RegistrationType a template parameter, more RegistrationFilters can be accepted
(e.g. GPUDemonsRegistrationFilter)

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
