### PR TITLE
BUG: Re-implement is_static_castable to be compatible with gcc 8

### DIFF
--- a/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
+++ b/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
@@ -215,15 +215,10 @@ struct Not : NotC<TF::Value>
  *
  * Identifies if "static_cast<TToType>(TFromType)" can be done.
  */
-template <typename TFromType, typename TToType, typename TNoDeclType = TToType>
-struct is_static_castable : std::false_type
-{};
-/// \cond SPECIALIZATION_IMPLEMENTATION
 template <typename TFromType, typename TToType>
-struct is_static_castable<TFromType, TToType, decltype(static_cast<TToType>(std::declval<TFromType>()))>
-  : std::true_type
-{};
-/// \endcond
+using is_static_castable = std::integral_constant<bool,
+                                                  std::is_constructible<TToType, TFromType>::value ||
+                                                    std::is_convertible<TFromType, TToType>::value>;
 } // namespace mpl
 
 


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

Fixes #1130.

This new version might not be strictly equivalent to the old one but I could not find a counter example. I am, of course, open to suggestions.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

<!-- **Thanks for contributing to ITK!** -->
