### PR TITLE
Fix shape label object obb verticies

### DIFF
--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -606,14 +606,8 @@ public:
   OrientedBoundingBoxVerticesType
   GetOrientedBoundingBoxVertices() const
   {
+    const MatrixType obbToPhysical(this->GetOrientedBoundingBoxDirection().GetTranspose());
 
-    const OrientedBoundingBoxPointType min = this->GetOrientedBoundingBoxOrigin();
-    OrientedBoundingBoxPointType       max = this->GetOrientedBoundingBoxOrigin();
-
-    for (unsigned int i = 0; i < ImageDimension; ++i)
-    {
-      max[i] += m_OrientedBoundingBoxSize[i];
-    }
 
     OrientedBoundingBoxVerticesType vertices;
 
@@ -623,18 +617,20 @@ public:
     // [maxX,minY], [maxX,maxY].
     for (unsigned int i = 0; i < OrientedBoundingBoxVerticesType::Length; ++i)
     {
-      const unsigned int msb = 1 << (ImageDimension - 1);
-      for (unsigned int j = 0; j < ImageDimension; j++)
+      constexpr unsigned int         msb = 1 << (ImageDimension - 1);
+      Vector<double, ImageDimension> offset;
+      for (unsigned int j = 0; j < ImageDimension; ++j)
       {
         if (i & msb >> j)
         {
-          vertices[i][j] = max[j];
+          offset[j] = m_OrientedBoundingBoxSize[j];
         }
         else
         {
-          vertices[i][j] = min[j];
+          offset[j] = 0;
         }
       }
+      vertices[i] = m_OrientedBoundingBoxOrigin + obbToPhysical * offset;
     }
     return vertices;
   }

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -593,13 +593,13 @@ public:
     return this->GetPrincipalAxes();
   }
 
-  /** Get an array of point verities which define the corners of the
-   * oriented bounding box.
+  /** Get an array of point vertices which define the corners of the
+   * oriented bounding box in physical space.
    *
-   * The first element in the array contains the minimum coordination
-   * values while the last contains the maximum. Use the index of the
-   * array in binary to determine min/max for the indexed vertex.
-   * For example, in 2D, binary  counting will give[0,0], [0,1],
+   * The first element in the array contains minimum coordinate values
+   * which correspond to the origin while the last contains the maximum.
+   * Use the index of the array in binary to determine min/max for the
+   * indexed vertex. For example, in 2D, binary  counting will give[0,0], [0,1],
    * [1,0], [1,1], which corresponds to [minX,minY], [minX,maxY],
    * [maxX,minY], [maxX,maxY].
    */


### PR DESCRIPTION
closes #1128
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
