### PR TITLE
COMP: avoid integer type conversion and use static_cast for necessary…

### DIFF
--- a/Modules/IO/TIFF/include/itkTIFFImageIO.h
+++ b/Modules/IO/TIFF/include/itkTIFFImageIO.h
@@ -223,7 +223,7 @@ protected:
   GetFormat();
 
   void
-  GetColor(unsigned int index, unsigned short * red, unsigned short * green, unsigned short * blue);
+  GetColor(uint64_t index, uint16_t * red, uint16_t * green, uint16_t * blue);
 
   // Check that tag t can be found
   bool
@@ -249,7 +249,7 @@ protected:
 
 private:
   void
-  AllocateTiffPalette(int bps);
+  AllocateTiffPalette(uint16_t bps);
 
   void
   ReadCurrentPage(void * out, size_t pixelOffset);
@@ -303,11 +303,11 @@ private:
                    unsigned int toskew,
                    unsigned int fromskew);
 
-  unsigned short * m_ColorRed;
-  unsigned short * m_ColorGreen;
-  unsigned short * m_ColorBlue;
-  int              m_TotalColors{ -1 };
-  unsigned int     m_ImageFormat{ TIFFImageIO::NOFORMAT };
+  uint16_t *   m_ColorRed;
+  uint16_t *   m_ColorGreen;
+  uint16_t *   m_ColorBlue;
+  uint64_t     m_TotalColors{ 0 };
+  unsigned int m_ImageFormat{ TIFFImageIO::NOFORMAT };
 };
 } // end namespace itk
 


### PR DESCRIPTION
- use static_cast insted of old style cast
- use variable type that avoid integer conversion
- use directly native libTiff types when possible
- makes sure no overflow happens when counting the number of colors in the palette

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [] :no_entry_sign: Adds the License notice to new files.
- [] :no_entry_sign: Adds Python wrapping.
- [] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
