### PR TITLE
WIP: Convert GDCM image to RGB color

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -55,6 +55,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <gdcmImageChangePhotometricInterpretation.h>
 
 namespace itk
 {
@@ -301,6 +302,21 @@ GDCMImageIO::Read(void * pointer)
     image = ialut.GetOutput();
     len *= 3;
   }
+  else if (pi == gdcm::PhotometricInterpretation::YBR_FULL || pi == gdcm::PhotometricInterpretation::YBR_FULL_422 ||
+           pi == gdcm::PhotometricInterpretation::YBR_PARTIAL_420 ||
+           pi == gdcm::PhotometricInterpretation::YBR_PARTIAL_422)
+  {
+    gdcm::ImageChangePhotometricInterpretation icpi;
+    icpi.SetInput(image);
+    icpi.SetPhotometricInterpretation(gdcm::PhotometricInterpretation::RGB);
+    if (!icpi.Change())
+    {
+      itkExceptionMacro("Failure to change photometric interpretation to RGB from "
+                        << gdcm::PhotometricInterpretation::GetPIString(pi) << "!");
+    }
+    image = icpi.GetOutput();
+  }
+
 
   if (!image.GetBuffer((char *)pointer))
   {


### PR DESCRIPTION
When an ImageIO reports it's buffer as RGB it is expected to produce
and RGB image, not a color image in anther encoding format.

Co-Author: Mihail Isakov <mihail.isakov@gmail.com>

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
