### PR TITLE
BUG: solve memory leak when allocating png palette for writing

### DIFF
--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -714,11 +714,13 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * buffer)
   png_write_image(png_ptr, row_pointers.get());
   png_write_end(png_ptr, info_ptr);
 
-  png_destroy_write_struct(&png_ptr, &info_ptr);
   if (paletteAllocated)
   {
     // free palette memory
     png_free(png_ptr, palette);
+    palette = nullptr;
   }
+
+  png_destroy_write_struct(&png_ptr, &info_ptr);
 }
 } // end namespace itk


### PR DESCRIPTION
Allocated palette needs to be freed after writing is finished,
but before destroying the png structure
Ref #1238

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [ ] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
