### PR TITLE
COMP: update VTKTetrahedralMeshReader to enum class

### DIFF
--- a/Modules/Registration/FEM/test/itkVTKTetrahedralMeshReader.hxx
+++ b/Modules/Registration/FEM/test/itkVTKTetrahedralMeshReader.hxx
@@ -52,7 +52,7 @@ VTKTetrahedralMeshReader<TOutputMesh>::GenerateData()
 {
   OutputMeshType * outputMesh = this->GetOutput();
 
-  outputMesh->SetCellsAllocationMethod(OutputMeshType::CellsAllocatedDynamicallyCellByCell);
+  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
 
   if (m_FileName == "")
   {


### PR DESCRIPTION
This is required to build with legacy disabled. Message was:

`m:\dashboard\itk\modules\registration\fem\test\itkVTKTetrahedralMeshReader.hxx(55): error C2039: 'CellsAllocatedDynamicallyCellByCell': is not a member of 'itk::Mesh<MeshPixelType,3,itk::DefaultStaticMeshTraits<TPixelType,3,3,float,float,TPixelType>>' [M:\Dashboard\ITK-build\Modules\Registration\FEM\test\ITKFEMRegistrationTestDriver.vcxproj]`
