### PR TITLE
STYLE: Remove reinterpret_cast's from void to non-void pointer

### DIFF
--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -275,7 +275,7 @@ template <typename T>
 void
 ByteSwapper<T>::Swap2(void * pin)
 {
-  auto *               p = reinterpret_cast<unsigned short *>(pin);
+  auto *               p = static_cast<unsigned short *>(pin);
   const unsigned short h1 = (*p) << static_cast<short unsigned int>(8);
   const unsigned short h2 = (*p) >> static_cast<short unsigned int>(8);
   *p = h1 | h2;
@@ -286,7 +286,7 @@ template <typename T>
 void
 ByteSwapper<T>::Swap2Range(void * ptr, BufferSizeType num)
 {
-  auto * pos = reinterpret_cast<char *>(ptr);
+  auto * pos = static_cast<char *>(ptr);
   for (BufferSizeType i = 0; i < num; i++)
   {
     const char one_byte = pos[0];
@@ -338,7 +338,7 @@ void
 ByteSwapper<T>::Swap4(void * ptr)
 {
   char   one_byte;
-  auto * p = reinterpret_cast<char *>(ptr);
+  auto * p = static_cast<char *>(ptr);
 
   one_byte = p[0];
   p[0] = p[3];
@@ -354,7 +354,7 @@ template <typename T>
 void
 ByteSwapper<T>::Swap4Range(void * ptr, BufferSizeType num)
 {
-  auto * pos = reinterpret_cast<char *>(ptr);
+  auto * pos = static_cast<char *>(ptr);
 
   for (BufferSizeType i = 0; i < num; i++)
   {
@@ -417,7 +417,7 @@ void
 ByteSwapper<T>::Swap8(void * ptr)
 {
   char   one_byte;
-  auto * p = reinterpret_cast<char *>(ptr);
+  auto * p = static_cast<char *>(ptr);
 
   one_byte = p[0];
   p[0] = p[7];
@@ -441,7 +441,7 @@ template <typename T>
 void
 ByteSwapper<T>::Swap8Range(void * ptr, BufferSizeType num)
 {
-  auto * pos = reinterpret_cast<char *>(ptr);
+  auto * pos = static_cast<char *>(ptr);
 
   for (BufferSizeType i = 0; i < num; i++)
   {

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -876,7 +876,7 @@ ObjectFactoryBase ::SynchronizeObjectFactoryBase(void * objectFactoryBasePrivate
   ObjectFactoryBasePrivate * previousObjectFactoryBasePrivate;
   previousObjectFactoryBasePrivate = GetPimplGlobalsPointer();
 
-  m_PimplGlobals = reinterpret_cast<ObjectFactoryBasePrivate *>(objectFactoryBasePrivate);
+  m_PimplGlobals = static_cast<ObjectFactoryBasePrivate *>(objectFactoryBasePrivate);
   if (m_PimplGlobals && previousObjectFactoryBasePrivate)
   {
     SynchronizeList(m_PimplGlobals->m_InternalFactories, previousObjectFactoryBasePrivate->m_InternalFactories, true);

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -717,14 +717,14 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case UCHAR:
     {
       using Type = const unsigned char *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
     case CHAR:
     {
       using Type = const char *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -732,7 +732,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case USHORT:
     {
       using Type = const unsigned short *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -740,7 +740,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case SHORT:
     {
       using Type = const short *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -748,7 +748,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case UINT:
     {
       using Type = const unsigned int *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -756,7 +756,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case INT:
     {
       using Type = const int *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -764,7 +764,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case ULONG:
     {
       using Type = const unsigned long *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -772,7 +772,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case LONG:
     {
       using Type = const long *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -780,7 +780,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case ULONGLONG:
     {
       using Type = const unsigned long long *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -788,7 +788,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case LONGLONG:
     {
       using Type = const long long *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -796,7 +796,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case FLOAT:
     {
       using Type = const float *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -804,7 +804,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
     case DOUBLE:
     {
       using Type = const double *;
-      auto buf = reinterpret_cast<Type>(buffer);
+      auto buf = static_cast<Type>(buffer);
       WriteBuffer(os, buf, numComp);
     }
     break;
@@ -837,83 +837,83 @@ ImageIOBase::ReadBufferAsASCII(std::istream & is, void * buffer, IOComponentType
   {
     case UCHAR:
     {
-      auto * buf = reinterpret_cast<unsigned char *>(buffer);
+      auto * buf = static_cast<unsigned char *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
     case CHAR:
     {
-      auto * buf = reinterpret_cast<char *>(buffer);
+      auto * buf = static_cast<char *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case USHORT:
     {
-      auto * buf = reinterpret_cast<unsigned short *>(buffer);
+      auto * buf = static_cast<unsigned short *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case SHORT:
     {
-      auto * buf = reinterpret_cast<short *>(buffer);
+      auto * buf = static_cast<short *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case UINT:
     {
-      auto * buf = reinterpret_cast<unsigned int *>(buffer);
+      auto * buf = static_cast<unsigned int *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case INT:
     {
-      auto * buf = reinterpret_cast<int *>(buffer);
+      auto * buf = static_cast<int *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case ULONG:
     {
-      auto * buf = reinterpret_cast<unsigned long *>(buffer);
+      auto * buf = static_cast<unsigned long *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case LONG:
     {
-      auto * buf = reinterpret_cast<long *>(buffer);
+      auto * buf = static_cast<long *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case ULONGLONG:
     {
-      auto * buf = reinterpret_cast<unsigned long long *>(buffer);
+      auto * buf = static_cast<unsigned long long *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case LONGLONG:
     {
-      auto * buf = reinterpret_cast<long long *>(buffer);
+      auto * buf = static_cast<long long *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case FLOAT:
     {
-      auto * buf = reinterpret_cast<float *>(buffer);
+      auto * buf = static_cast<float *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;
 
     case DOUBLE:
     {
-      auto * buf = reinterpret_cast<double *>(buffer);
+      auto * buf = static_cast<double *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -180,7 +180,7 @@ LSMImageIO::ReadImageInformation()
   // information
   unsigned int tif_cz_lsminfo_size;
   void *       praw = this->TIFFImageIO::ReadRawByteFromTag(TIF_CZ_LSMINFO, tif_cz_lsminfo_size);
-  auto *       zi = reinterpret_cast<zeiss_info *>(praw);
+  auto *       zi = static_cast<zeiss_info *>(praw);
   if (praw == nullptr || tif_cz_lsminfo_size != TIF_CZ_LSMINFO_SIZE)
   {
     // no zeiss info, just use tiff spacing

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1305,31 +1305,31 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
 
     if (m_ComponentType == USHORT)
     {
-      auto * volume = reinterpret_cast<unsigned short *>(buffer);
+      auto * volume = static_cast<unsigned short *>(buffer);
       volume += pixelOffset;
       this->ReadGenericImage(volume, width, height);
     }
     else if (m_ComponentType == SHORT)
     {
-      auto * volume = reinterpret_cast<short *>(buffer);
+      auto * volume = static_cast<short *>(buffer);
       volume += pixelOffset;
       this->ReadGenericImage(volume, width, height);
     }
     else if (m_ComponentType == CHAR)
     {
-      auto * volume = reinterpret_cast<char *>(buffer);
+      auto * volume = static_cast<char *>(buffer);
       volume += pixelOffset;
       this->ReadGenericImage(volume, width, height);
     }
     else if (m_ComponentType == FLOAT)
     {
-      auto * volume = reinterpret_cast<float *>(buffer);
+      auto * volume = static_cast<float *>(buffer);
       volume += pixelOffset;
       this->ReadGenericImage(volume, width, height);
     }
     else
     {
-      auto * volume = reinterpret_cast<unsigned char *>(buffer);
+      auto * volume = static_cast<unsigned char *>(buffer);
       volume += pixelOffset;
       this->ReadGenericImage(volume, width, height);
     }

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -460,14 +460,14 @@ VTKImageIO::ReadBufferAsASCII(std::istream &              is,
     {
       case FLOAT:
       {
-        auto * buf = reinterpret_cast<float *>(buffer);
+        auto * buf = static_cast<float *>(buffer);
         ReadTensorBuffer(is, buf, numComp);
       }
       break;
 
       case DOUBLE:
       {
-        auto * buf = reinterpret_cast<double *>(buffer);
+        auto * buf = static_cast<double *>(buffer);
         ReadTensorBuffer(is, buf, numComp);
       }
       break;
@@ -784,7 +784,7 @@ VTKImageIO::WriteBufferAsASCII(std::ostream &              os,
       case FLOAT:
       {
         using Type = const float *;
-        auto buf = reinterpret_cast<Type>(buffer);
+        auto buf = static_cast<Type>(buffer);
         WriteTensorBuffer(os, buf, numComp, this->GetNumberOfComponents());
       }
       break;
@@ -792,7 +792,7 @@ VTKImageIO::WriteBufferAsASCII(std::ostream &              os,
       case DOUBLE:
       {
         using Type = const double *;
-        auto buf = reinterpret_cast<Type>(buffer);
+        auto buf = static_cast<Type>(buffer);
         WriteTensorBuffer(os, buf, numComp, this->GetNumberOfComponents());
       }
       break;

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
@@ -128,7 +128,7 @@ LBFGS2Optimizerv4::EvaluateCostCallback(void *                                  
                                         const int                                n,
                                         const LBFGS2Optimizerv4::PrecisionType   step)
 {
-  auto * optimizer = reinterpret_cast<LBFGS2Optimizerv4 *>(instance);
+  auto * optimizer = static_cast<LBFGS2Optimizerv4 *>(instance);
   return optimizer->EvaluateCost(x, g, n, step);
 }
 
@@ -166,7 +166,7 @@ LBFGS2Optimizerv4::UpdateProgressCallback(void *                                
                                           int                                      k,
                                           int                                      ls)
 {
-  auto * optimizer = reinterpret_cast<LBFGS2Optimizerv4 *>(instance);
+  auto * optimizer = static_cast<LBFGS2Optimizerv4 *>(instance);
   return optimizer->UpdateProgress(x, g, fx, xnorm, gnorm, step, n, k, ls);
 }
 


### PR DESCRIPTION
Replaced `reinterpret_cast` by `static_cast`, when converting a void to
a non-void pointer type. `static_cast` is in general less unsafe than
`reinterpret_cast`.

Fixes Visual C++ 2017 Code Analysis warning C26471: Don't use
reinterpret_cast. A cast from void* can use static_cast (type.1).