### PR TITLE
BUG: Support Numpy inputs in keywords that include "image"

### DIFF
--- a/Modules/Filtering/ImageIntensity/wrapping/test/itkImageFilterNumPyInputsTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/itkImageFilterNumPyInputsTest.py
@@ -30,3 +30,6 @@ assert(np.all(added == 3))
 added = itk.add_image_filter(Input1=array1, Input2=array2)
 assert(isinstance(added, np.ndarray))
 assert(np.all(added == 3))
+
+# support kwargs with "image" in the name
+masked = itk.mask_image_filter(array1, mask_image=array2)

--- a/Wrapping/Generators/Python/itkHelpers.py
+++ b/Wrapping/Generators/Python/itkHelpers.py
@@ -49,9 +49,10 @@ def accept_numpy_array_like(image_filter):
                 image = itk.image_view_from_array(array)
                 args_list[index] = image
 
-        potential_image_input_kwargs = ('input', 'inputimage', 'input_image', 'input1', 'input2', 'input3')
+        potential_image_input_kwargs = ('input', 'input1', 'input2', 'input3')
         for key, value in kwargs.items():
-            if key.lower() in potential_image_input_kwargs and is_arraylike(value):
+            if (key.lower() in potential_image_input_kwargs or
+                    "image" in key.lower()) and is_arraylike(value):
                 have_array_like_input = True
                 array = np.asarray(value)
                 image = itk.image_view_from_array(array)


### PR DESCRIPTION
Previously there was a whitelist on which keywords would be
automatically converted from Numpy arrays to ITK Image objects.

Now, we accept any keyword that includes the text "image" in the name.
