### PR TITLE
STYLE: Use C++11 nullptr in itkDynamicCastInDebugMode

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1100,9 +1100,9 @@ compilers.
  * provides the GPU kernel source code as a const char*
  */
 #define itkGPUKernelClassMacro(kernel)                                                                                 \
-  /**\class kernel                                                                                                     \
-   * Workaround KWstyle bug                                                                                            \
-   * \ingroup ITKCommon                                                                                                \
+  /**\class kernel \                                                                                                                     \
+   * Workaround KWstyle bug \                                                                                                                     \
+   * \ingroup ITKCommon \                                                                                                                     \
    */                                                                                                                  \
   class kernel                                                                                                         \
   {                                                                                                                    \
@@ -1238,12 +1238,12 @@ TTarget
 itkDynamicCastInDebugMode(TSource x)
 {
 #ifndef NDEBUG
-  if (x == 0)
+  if (x == nullptr)
   {
-    return 0;
+    return nullptr;
   }
   TTarget rval = dynamic_cast<TTarget>(x);
-  if (rval == 0)
+  if (rval == nullptr)
   {
     itkGenericExceptionMacro(<< "Failed dynamic cast to " << typeid(TTarget).name()
                              << " object type = " << x->GetNameOfClass());


### PR DESCRIPTION
Fixes Visual Studio 2017 Code Analysis warnings from itkMacro.h:

> warning C26477: Use 'nullptr' rather than 0 or NULL (es.47).

Note that the formatting changes in the macro definition of
`itkGPUKernelClassMacro(kernel)` are from a post-commit hook.
These are unrelated to the fixes of those VS2017 warnings.