### PR TITLE
STYLE: Remove redundant code from operator<< for enum's, using lambda's

### DIFF
--- a/Modules/Core/Common/src/itkExtractImageFilter.cxx
+++ b/Modules/Core/Common/src/itkExtractImageFilter.cxx
@@ -23,24 +23,20 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const ExtractImageFilterCollapseStrategy value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
-      s = "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN";
-      break;
-    case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
-      s = "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY";
-      break;
-    case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
-      s = "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX";
-      break;
-    case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
-      s = "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS";
-      break;
-    default:
-      s = "INVALID VALUE FOR ExtractImageFilterCollapseStrategy";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
+        return "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN";
+      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
+        return "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY";
+      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
+        return "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX";
+      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
+        return "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS";
+      default:
+        return "INVALID VALUE FOR ExtractImageFilterCollapseStrategy";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/Common/src/itkFrustumSpatialFunction.cxx
+++ b/Modules/Core/Common/src/itkFrustumSpatialFunction.cxx
@@ -22,18 +22,16 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const RotationPlaneType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case RotationPlaneType::RotateInXZPlane:
-      s = "FrustumSpatialFunction< VDimension, TInput >::FrustumRotationPlaneType::RotateInXZPlane";
-      break;
-    case RotationPlaneType::RotateInYZPlane:
-      s = "FrustumSpatialFunction< VDimension, TInput >::FrustumRotationPlaneType::RotateInYZPlane";
-      break;
-    default:
-      s = "INVALID VALUE FOR RotationPlaneType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case RotationPlaneType::RotateInXZPlane:
+        return "FrustumSpatialFunction< VDimension, TInput >::FrustumRotationPlaneType::RotateInXZPlane";
+      case RotationPlaneType::RotateInYZPlane:
+        return "FrustumSpatialFunction< VDimension, TInput >::FrustumRotationPlaneType::RotateInYZPlane";
+      default:
+        return "INVALID VALUE FOR RotationPlaneType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/Common/src/itkLoggerBase.cxx
+++ b/Modules/Core/Common/src/itkLoggerBase.cxx
@@ -105,33 +105,26 @@ LoggerBase::PrintSelf(std::ostream & os, Indent indent) const
 std::ostream &
 operator<<(std::ostream & out, const LoggerBase::PriorityLevelType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case LoggerBase::PriorityLevelType::MUSTFLUSH:
-      s = "LoggerBase::PriorityLevelType::MUSTFLUSH";
-      break;
-    case LoggerBase::PriorityLevelType::FATAL:
-      s = "LoggerBase::PriorityLevelType::FATAL";
-      break;
-    case LoggerBase::PriorityLevelType::CRITICAL:
-      s = "LoggerBase::PriorityLevelType::CRITICAL";
-      break;
-    case LoggerBase::PriorityLevelType::WARNING:
-      s = "LoggerBase::PriorityLevelType::WARNING";
-      break;
-    case LoggerBase::PriorityLevelType::INFO:
-      s = "LoggerBase::PriorityLevelType::INFO";
-      break;
-    case LoggerBase::PriorityLevelType::DEBUG:
-      s = "LoggerBase::PriorityLevelType::DEBUG";
-      break;
-    case LoggerBase::PriorityLevelType::NOTSET:
-      s = "LoggerBase::PriorityLevelType::NOTSET";
-      break;
-    default:
-      s = "INVALID VALUE FOR LoggerBase::PriorityLevelType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case LoggerBase::PriorityLevelType::MUSTFLUSH:
+        return "LoggerBase::PriorityLevelType::MUSTFLUSH";
+      case LoggerBase::PriorityLevelType::FATAL:
+        return "LoggerBase::PriorityLevelType::FATAL";
+      case LoggerBase::PriorityLevelType::CRITICAL:
+        return "LoggerBase::PriorityLevelType::CRITICAL";
+      case LoggerBase::PriorityLevelType::WARNING:
+        return "LoggerBase::PriorityLevelType::WARNING";
+      case LoggerBase::PriorityLevelType::INFO:
+        return "LoggerBase::PriorityLevelType::INFO";
+      case LoggerBase::PriorityLevelType::DEBUG:
+        return "LoggerBase::PriorityLevelType::DEBUG";
+      case LoggerBase::PriorityLevelType::NOTSET:
+        return "LoggerBase::PriorityLevelType::NOTSET";
+      default:
+        return "INVALID VALUE FOR LoggerBase::PriorityLevelType";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Core/Common/src/itkLogggerThreadWrapper.cxx
+++ b/Modules/Core/Common/src/itkLogggerThreadWrapper.cxx
@@ -22,24 +22,20 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const LoggerThreadWrapperOperationType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case LoggerThreadWrapperOperationType::SET_PRIORITY_LEVEL:
-      s = "LoggerThreadWrapperOperationType::SET_PRIORITY_LEVEL";
-      break;
-    case LoggerThreadWrapperOperationType::SET_LEVEL_FOR_FLUSHING:
-      s = "LoggerThreadWrapperOperationType::SET_LEVEL_FOR_FLUSHING";
-      break;
-    case LoggerThreadWrapperOperationType::ADD_LOG_OUTPUT:
-      s = "LoggerThreadWrapperOperationType::ADD_LOG_OUTPUT";
-      break;
-    case LoggerThreadWrapperOperationType::WRITE:
-      s = "LoggerThreadWrapperOperationType::WRITE";
-      break;
-    default:
-      s = "INVALID VALUE FOR LoggerThreadWrapperOperationType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case LoggerThreadWrapperOperationType::SET_PRIORITY_LEVEL:
+        return "LoggerThreadWrapperOperationType::SET_PRIORITY_LEVEL";
+      case LoggerThreadWrapperOperationType::SET_LEVEL_FOR_FLUSHING:
+        return "LoggerThreadWrapperOperationType::SET_LEVEL_FOR_FLUSHING";
+      case LoggerThreadWrapperOperationType::ADD_LOG_OUTPUT:
+        return "LoggerThreadWrapperOperationType::ADD_LOG_OUTPUT";
+      case LoggerThreadWrapperOperationType::WRITE:
+        return "LoggerThreadWrapperOperationType::WRITE";
+      default:
+        return "INVALID VALUE FOR LoggerThreadWrapperOperationType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -967,21 +967,18 @@ ObjectFactoryBasePrivate * ObjectFactoryBase::m_PimplGlobals;
 std::ostream &
 operator<<(std::ostream & out, const ObjectFactoryBase::InsertionPositionType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT:
-      s = "ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT";
-      break;
-    case ObjectFactoryBase::InsertionPositionType::INSERT_AT_BACK:
-      s = "ObjectFactoryBase::InsertionPositionType::INSERT_AT_BACK";
-      break;
-    case ObjectFactoryBase::InsertionPositionType::INSERT_AT_POSITION:
-      s = "ObjectFactoryBase::InsertionPositionType::INSERT_AT_POSITION";
-      break;
-    default:
-      s = "INVALID VALUE FOR ObjectFactoryBase::InsertionPositionType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT:
+        return "ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT";
+      case ObjectFactoryBase::InsertionPositionType::INSERT_AT_BACK:
+        return "ObjectFactoryBase::InsertionPositionType::INSERT_AT_BACK";
+      case ObjectFactoryBase::InsertionPositionType::INSERT_AT_POSITION:
+        return "ObjectFactoryBase::InsertionPositionType::INSERT_AT_POSITION";
+      default:
+        return "INVALID VALUE FOR ObjectFactoryBase::InsertionPositionType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/Common/src/itkObjectStore.cxx
+++ b/Modules/Core/Common/src/itkObjectStore.cxx
@@ -23,18 +23,16 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const StrategyForGrowthType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case StrategyForGrowthType::LINEAR_GROWTH:
-      s = "StrategyForGrowthType::LINEAR_GROWTH";
-      break;
-    case StrategyForGrowthType::EXPONENTIAL_GROWTH:
-      s = "StrategyForGrowthType::EXPONENTIAL_GROWTH";
-      break;
-    default:
-      s = "INVALID VALUE FOR ObjectStore<TObjectType>::GrowthStrategyType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case StrategyForGrowthType::LINEAR_GROWTH:
+        return "StrategyForGrowthType::LINEAR_GROWTH";
+      case StrategyForGrowthType::EXPONENTIAL_GROWTH:
+        return "StrategyForGrowthType::EXPONENTIAL_GROWTH";
+      default:
+        return "INVALID VALUE FOR ObjectStore<TObjectType>::GrowthStrategyType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/Common/src/itkSymmetricEigenAnalysis.cxx
+++ b/Modules/Core/Common/src/itkSymmetricEigenAnalysis.cxx
@@ -22,21 +22,18 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const OrderType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case OrderType::OrderByValue:
-      s = "OrderType::OrderByValue";
-      break;
-    case OrderType::OrderByMagnitude:
-      s = "OrderType::OrderByMagnitude";
-      break;
-    case OrderType::DoNotOrder:
-      s = "OrderType::DoNotOrder";
-      break;
-    default:
-      s = "INVALID VALUE FOR OrderType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case OrderType::OrderByValue:
+        return "OrderType::OrderByValue";
+      case OrderType::OrderByMagnitude:
+        return "OrderType::OrderByMagnitude";
+      case OrderType::DoNotOrder:
+        return "OrderType::DoNotOrder";
+      default:
+        return "INVALID VALUE FOR OrderType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/Common/src/itkTreeIteratorBase.cxx
+++ b/Modules/Core/Common/src/itkTreeIteratorBase.cxx
@@ -23,36 +23,28 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const TreeIteratorBaseNodeType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case TreeIteratorBaseNodeType::UNDEFIND:
-      s = "TreeIteratorBaseNodeType::UNDEFIND";
-      break;
-    case TreeIteratorBaseNodeType::PREORDER:
-      s = "TreeIteratorBaseNodeType::PREORDER";
-      break;
-    case TreeIteratorBaseNodeType::INORDER:
-      s = "TreeIteratorBaseNodeType::INORDER";
-      break;
-    case TreeIteratorBaseNodeType::POSTORDER:
-      s = "TreeIteratorBaseNodeType::POSTORDER";
-      break;
-    case TreeIteratorBaseNodeType::LEVELORDER:
-      s = "TreeIteratorBaseNodeType::LEVELORDER";
-      break;
-    case TreeIteratorBaseNodeType::CHILD:
-      s = "TreeIteratorBaseNodeType::CHILD";
-      break;
-    case TreeIteratorBaseNodeType::ROOT:
-      s = "TreeIteratorBaseNodeType::ROOT";
-      break;
-    case TreeIteratorBaseNodeType::LEAF:
-      s = "TreeIteratorBaseNodeType::LEAF";
-      break;
-    default:
-      s = "INVALID VALUE FOR TreeIteratorBaseNodeType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case TreeIteratorBaseNodeType::UNDEFIND:
+        return "TreeIteratorBaseNodeType::UNDEFIND";
+      case TreeIteratorBaseNodeType::PREORDER:
+        return "TreeIteratorBaseNodeType::PREORDER";
+      case TreeIteratorBaseNodeType::INORDER:
+        return "TreeIteratorBaseNodeType::INORDER";
+      case TreeIteratorBaseNodeType::POSTORDER:
+        return "TreeIteratorBaseNodeType::POSTORDER";
+      case TreeIteratorBaseNodeType::LEVELORDER:
+        return "TreeIteratorBaseNodeType::LEVELORDER";
+      case TreeIteratorBaseNodeType::CHILD:
+        return "TreeIteratorBaseNodeType::CHILD";
+      case TreeIteratorBaseNodeType::ROOT:
+        return "TreeIteratorBaseNodeType::ROOT";
+      case TreeIteratorBaseNodeType::LEAF:
+        return "TreeIteratorBaseNodeType::LEAF";
+      default:
+        return "INVALID VALUE FOR TreeIteratorBaseNodeType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/GPUFiniteDifference/src/itkGPUFiniteDifferenceFilterTypeEnum.cxx
+++ b/Modules/Core/GPUFiniteDifference/src/itkGPUFiniteDifferenceFilterTypeEnum.cxx
@@ -22,18 +22,17 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const GPUFiniteDifferenceFilterTypeEnum value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case GPUFiniteDifferenceFilterTypeEnum::UNINITIALIZED:
-      s = "GPUFiniteDifferenceImageFilter<TInputImage,TOutputImage,TParentImageFilter>::FilterStateType::UNINITIALIZED";
-      break;
-    case GPUFiniteDifferenceFilterTypeEnum::INITIALIZED:
-      s = "GPUFiniteDifferenceFilterTypeEnum::INITIALIZED";
-      break;
-    default:
-      s = "INVALID VALUE FOR GPUFiniteDifferenceFilterTypeEnum";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case GPUFiniteDifferenceFilterTypeEnum::UNINITIALIZED:
+        return "GPUFiniteDifferenceImageFilter<TInputImage,TOutputImage,TParentImageFilter>::FilterStateType::"
+               "UNINITIALIZED";
+      case GPUFiniteDifferenceFilterTypeEnum::INITIALIZED:
+        return "GPUFiniteDifferenceFilterTypeEnum::INITIALIZED";
+      default:
+        return "INVALID VALUE FOR GPUFiniteDifferenceFilterTypeEnum";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/Mesh/src/itkMesh.cxx
+++ b/Modules/Core/Mesh/src/itkMesh.cxx
@@ -23,24 +23,20 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const MeshClassCellsAllocationMethodType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case MeshClassCellsAllocationMethodType::CellsAllocationMethodUndefined:
-      s = "MeshClassCellsAllocationMethodType::CellsAllocationMethodUndefined";
-      break;
-    case MeshClassCellsAllocationMethodType::CellsAllocatedAsStaticArray:
-      s = "MeshClassCellsAllocationMethodType::CellsAllocatedAsStaticArray";
-      break;
-    case MeshClassCellsAllocationMethodType::CellsAllocatedAsADynamicArray:
-      s = "MeshClassCellsAllocationMethodType::CellsAllocatedAsADynamicArray";
-      break;
-    case MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell:
-      s = "MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell";
-      break;
-    default:
-      s = "INVALID VALUE FOR MeshClassCellsAllocationMethodType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case MeshClassCellsAllocationMethodType::CellsAllocationMethodUndefined:
+        return "MeshClassCellsAllocationMethodType::CellsAllocationMethodUndefined";
+      case MeshClassCellsAllocationMethodType::CellsAllocatedAsStaticArray:
+        return "MeshClassCellsAllocationMethodType::CellsAllocatedAsStaticArray";
+      case MeshClassCellsAllocationMethodType::CellsAllocatedAsADynamicArray:
+        return "MeshClassCellsAllocationMethodType::CellsAllocatedAsADynamicArray";
+      case MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell:
+        return "MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell";
+      default:
+        return "INVALID VALUE FOR MeshClassCellsAllocationMethodType";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Core/SpatialObjects/src/itkDTITubeSpatialObjectPoint.cxx
+++ b/Modules/Core/SpatialObjects/src/itkDTITubeSpatialObjectPoint.cxx
@@ -23,21 +23,18 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const DTITubeSpatialObjectPointFieldEnumType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case DTITubeSpatialObjectPointFieldEnumType::FA:
-      s = "DTITubeSpatialObjectPointFieldEnumType::FA";
-      break;
-    case DTITubeSpatialObjectPointFieldEnumType::ADC:
-      s = "DTITubeSpatialObjectPointFieldEnumType::ADC";
-      break;
-    case DTITubeSpatialObjectPointFieldEnumType::GA:
-      s = "DTITubeSpatialObjectPointFieldEnumType::GA";
-      break;
-    default:
-      s = "INVALID VALUE FOR DTITubeSpatialObjectPointFieldEnumType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case DTITubeSpatialObjectPointFieldEnumType::FA:
+        return "DTITubeSpatialObjectPointFieldEnumType::FA";
+      case DTITubeSpatialObjectPointFieldEnumType::ADC:
+        return "DTITubeSpatialObjectPointFieldEnumType::ADC";
+      case DTITubeSpatialObjectPointFieldEnumType::GA:
+        return "DTITubeSpatialObjectPointFieldEnumType::GA";
+      default:
+        return "INVALID VALUE FOR DTITubeSpatialObjectPointFieldEnumType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Core/TestKernel/src/itkTestingExtractSliceImageFilter.cxx
+++ b/Modules/Core/TestKernel/src/itkTestingExtractSliceImageFilter.cxx
@@ -25,25 +25,21 @@ namespace Testing
 std::ostream &
 operator<<(std::ostream & out, const TestExtractSliceImageFilterCollapseStrategy value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
-      s = "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN";
-      break;
-    case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
-      s = "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY";
-      break;
-    case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
-      s = "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX";
-      break;
-    case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
-      s = "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS";
-      break;
-    default:
-      s = "INVALID VALUE FOR TestExtractSliceImageFilterCollapseStrategy";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
+        return "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN";
+      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
+        return "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY";
+      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
+        return "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX";
+      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
+        return "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS";
+      default:
+        return "INVALID VALUE FOR TestExtractSliceImageFilterCollapseStrategy";
+    }
+  }();
 }
 } // end namespace Testing
 } // end namespace itk

--- a/Modules/Core/Transform/src/itkTransformBase.cxx
+++ b/Modules/Core/Transform/src/itkTransformBase.cxx
@@ -25,61 +25,49 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const typename TransformBaseTemplate<double>::TransformCategoryType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case TransformBaseTemplate<double>::TransformCategoryType::UnknownTransformCategory:
-      s = "TransformBaseTemplate<double>::TransformCategoryType::UnknownTransformCategory";
-      break;
-    case TransformBaseTemplate<double>::TransformCategoryType::Linear:
-      s = "TransformBaseTemplate<double>::TransformCategoryType::Linear";
-      break;
-    case TransformBaseTemplate<double>::TransformCategoryType::BSpline:
-      s = "TransformBaseTemplate<double>::TransformCategoryType::BSpline";
-      break;
-    case TransformBaseTemplate<double>::TransformCategoryType::Spline:
-      s = "TransformBaseTemplate<double>::TransformCategoryType::Spline";
-      break;
-    case TransformBaseTemplate<double>::TransformCategoryType::DisplacementField:
-      s = "TransformBaseTemplate<double>::TransformCategoryType::DisplacementField";
-      break;
-    case TransformBaseTemplate<double>::TransformCategoryType::VelocityField:
-      s = "TransformBaseTemplate<double>::TransformCategoryType::VelocityField";
-      break;
-    default:
-      s = "INVALID VALUE FOR TransformBaseTemplate<double>::TransformCategoryType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case TransformBaseTemplate<double>::TransformCategoryType::UnknownTransformCategory:
+        return "TransformBaseTemplate<double>::TransformCategoryType::UnknownTransformCategory";
+      case TransformBaseTemplate<double>::TransformCategoryType::Linear:
+        return "TransformBaseTemplate<double>::TransformCategoryType::Linear";
+      case TransformBaseTemplate<double>::TransformCategoryType::BSpline:
+        return "TransformBaseTemplate<double>::TransformCategoryType::BSpline";
+      case TransformBaseTemplate<double>::TransformCategoryType::Spline:
+        return "TransformBaseTemplate<double>::TransformCategoryType::Spline";
+      case TransformBaseTemplate<double>::TransformCategoryType::DisplacementField:
+        return "TransformBaseTemplate<double>::TransformCategoryType::DisplacementField";
+      case TransformBaseTemplate<double>::TransformCategoryType::VelocityField:
+        return "TransformBaseTemplate<double>::TransformCategoryType::VelocityField";
+      default:
+        return "INVALID VALUE FOR TransformBaseTemplate<double>::TransformCategoryType";
+    }
+  }();
 }
 /** Print enum values */
 std::ostream &
 operator<<(std::ostream & out, const typename TransformBaseTemplate<float>::TransformCategoryType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case TransformBaseTemplate<float>::TransformCategoryType::UnknownTransformCategory:
-      s = "TransformBaseTemplate<float>::TransformCategoryType::UnknownTransformCategory";
-      break;
-    case TransformBaseTemplate<float>::TransformCategoryType::Linear:
-      s = "TransformBaseTemplate<float>::TransformCategoryType::Linear";
-      break;
-    case TransformBaseTemplate<float>::TransformCategoryType::BSpline:
-      s = "TransformBaseTemplate<float>::TransformCategoryType::BSpline";
-      break;
-    case TransformBaseTemplate<float>::TransformCategoryType::Spline:
-      s = "TransformBaseTemplate<float>::TransformCategoryType::Spline";
-      break;
-    case TransformBaseTemplate<float>::TransformCategoryType::DisplacementField:
-      s = "TransformBaseTemplate<float>::TransformCategoryType::DisplacementField";
-      break;
-    case TransformBaseTemplate<float>::TransformCategoryType::VelocityField:
-      s = "TransformBaseTemplate<float>::TransformCategoryType::VelocityField";
-      break;
-    default:
-      s = "INVALID VALUE FOR TransformBaseTemplate<float>::TransformCategoryType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case TransformBaseTemplate<float>::TransformCategoryType::UnknownTransformCategory:
+        return "TransformBaseTemplate<float>::TransformCategoryType::UnknownTransformCategory";
+      case TransformBaseTemplate<float>::TransformCategoryType::Linear:
+        return "TransformBaseTemplate<float>::TransformCategoryType::Linear";
+      case TransformBaseTemplate<float>::TransformCategoryType::BSpline:
+        return "TransformBaseTemplate<float>::TransformCategoryType::BSpline";
+      case TransformBaseTemplate<float>::TransformCategoryType::Spline:
+        return "TransformBaseTemplate<float>::TransformCategoryType::Spline";
+      case TransformBaseTemplate<float>::TransformCategoryType::DisplacementField:
+        return "TransformBaseTemplate<float>::TransformCategoryType::DisplacementField";
+      case TransformBaseTemplate<float>::TransformCategoryType::VelocityField:
+        return "TransformBaseTemplate<float>::TransformCategoryType::VelocityField";
+      default:
+        return "INVALID VALUE FOR TransformBaseTemplate<float>::TransformCategoryType";
+    }
+  }();
 }
 
 ITK_GCC_PRAGMA_DIAG_PUSH()

--- a/Modules/Filtering/Colormap/src/itkScalarToRGBColormapImageFilter.cxx
+++ b/Modules/Filtering/Colormap/src/itkScalarToRGBColormapImageFilter.cxx
@@ -23,54 +23,40 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const RGBColormapFilterEnumType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case RGBColormapFilterEnumType::Red:
-      s = "RGBColormapFilterEnumType::Red";
-      break;
-    case RGBColormapFilterEnumType::Green:
-      s = "RGBColormapFilterEnumType::Green";
-      break;
-    case RGBColormapFilterEnumType::Blue:
-      s = "RGBColormapFilterEnumType::Blue";
-      break;
-    case RGBColormapFilterEnumType::Grey:
-      s = "RGBColormapFilterEnumType::Grey";
-      break;
-    case RGBColormapFilterEnumType::Hot:
-      s = "RGBColormapFilterEnumType::Hot";
-      break;
-    case RGBColormapFilterEnumType::Cool:
-      s = "RGBColormapFilterEnumType::Cool";
-      break;
-    case RGBColormapFilterEnumType::Spring:
-      s = "RGBColormapFilterEnumType";
-      break;
-    case RGBColormapFilterEnumType::Summer:
-      s = "RGBColormapFilterEnumType::Summer";
-      break;
-    case RGBColormapFilterEnumType::Autumn:
-      s = "RGBColormapFilterEnumType::Autumn";
-      break;
-    case RGBColormapFilterEnumType::Winter:
-      s = "RGBColormapFilterEnumType::Winter";
-      break;
-    case RGBColormapFilterEnumType::Copper:
-      s = "RGBColormapFilterEnumType::Copper";
-      break;
-    case RGBColormapFilterEnumType::Jet:
-      s = "RGBColormapFilterEnumType::Jet";
-      break;
-    case RGBColormapFilterEnumType::HSV:
-      s = "RGBColormapFilterEnumType::HSV";
-      break;
-    case RGBColormapFilterEnumType::OverUnder:
-      s = "RGBColormapFilterEnumType::OverUnder";
-      break;
-    default:
-      s = "INVALID VALUE FOR RGBColormapFilterEnumType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case RGBColormapFilterEnumType::Red:
+        return "RGBColormapFilterEnumType::Red";
+      case RGBColormapFilterEnumType::Green:
+        return "RGBColormapFilterEnumType::Green";
+      case RGBColormapFilterEnumType::Blue:
+        return "RGBColormapFilterEnumType::Blue";
+      case RGBColormapFilterEnumType::Grey:
+        return "RGBColormapFilterEnumType::Grey";
+      case RGBColormapFilterEnumType::Hot:
+        return "RGBColormapFilterEnumType::Hot";
+      case RGBColormapFilterEnumType::Cool:
+        return "RGBColormapFilterEnumType::Cool";
+      case RGBColormapFilterEnumType::Spring:
+        return "RGBColormapFilterEnumType";
+      case RGBColormapFilterEnumType::Summer:
+        return "RGBColormapFilterEnumType::Summer";
+      case RGBColormapFilterEnumType::Autumn:
+        return "RGBColormapFilterEnumType::Autumn";
+      case RGBColormapFilterEnumType::Winter:
+        return "RGBColormapFilterEnumType::Winter";
+      case RGBColormapFilterEnumType::Copper:
+        return "RGBColormapFilterEnumType::Copper";
+      case RGBColormapFilterEnumType::Jet:
+        return "RGBColormapFilterEnumType::Jet";
+      case RGBColormapFilterEnumType::HSV:
+        return "RGBColormapFilterEnumType::HSV";
+      case RGBColormapFilterEnumType::OverUnder:
+        return "RGBColormapFilterEnumType::OverUnder";
+      default:
+        return "INVALID VALUE FOR RGBColormapFilterEnumType";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Filtering/Convolution/src/itkConvolutionImageFilterBase.cxx
+++ b/Modules/Filtering/Convolution/src/itkConvolutionImageFilterBase.cxx
@@ -23,18 +23,16 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const ConvolutionImageFilterOutputRegionType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case ConvolutionImageFilterOutputRegionType::SAME:
-      s = "ConvolutionImageFilterOutputRegionType::SAME";
-      break;
-    case ConvolutionImageFilterOutputRegionType::VALID:
-      s = "ConvolutionImageFilterOutputRegionType::VALID";
-      break;
-    default:
-      s = "INVALID VALUE FOR ConvolutionImageFilterOutputRegionType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case ConvolutionImageFilterOutputRegionType::SAME:
+        return "ConvolutionImageFilterOutputRegionType::SAME";
+      case ConvolutionImageFilterOutputRegionType::VALID:
+        return "ConvolutionImageFilterOutputRegionType::VALID";
+      default:
+        return "INVALID VALUE FOR ConvolutionImageFilterOutputRegionType";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Filtering/Denoising/src/itkPatchBasedDenoisingBaseImageFilter.cxx
+++ b/Modules/Filtering/Denoising/src/itkPatchBasedDenoisingBaseImageFilter.cxx
@@ -23,59 +23,51 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const NoiseType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case NoiseType::NOMODEL:
-      s = "NoiseType::NOMODEL";
-      break;
-    case NoiseType::GAUSSIAN:
-      s = "NoiseType::GAUSSIAN";
-      break;
-    case NoiseType::RICIAN:
-      s = "NoiseType::RICIAN";
-      break;
-    case NoiseType::POISSON:
-      s = "NoiseType::POISSON";
-      break;
-    default:
-      s = "INVALID VALUE FOR NoiseType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case NoiseType::NOMODEL:
+        return "NoiseType::NOMODEL";
+      case NoiseType::GAUSSIAN:
+        return "NoiseType::GAUSSIAN";
+      case NoiseType::RICIAN:
+        return "NoiseType::RICIAN";
+      case NoiseType::POISSON:
+        return "NoiseType::POISSON";
+      default:
+        return "INVALID VALUE FOR NoiseType";
+    }
+  }();
 }
 
 std::ostream &
 operator<<(std::ostream & out, const SpaceType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case SpaceType::EUCLIDEAN:
-      s = "SpaceType::EUCLIDEAN";
-      break;
-    case SpaceType::RIEMANNIAN:
-      s = "SpaceType::RIEMANNIAN";
-      break;
-    default:
-      s = "INVALID VALUE FOR SpaceType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case SpaceType::EUCLIDEAN:
+        return "SpaceType::EUCLIDEAN";
+      case SpaceType::RIEMANNIAN:
+        return "SpaceType::RIEMANNIAN";
+      default:
+        return "INVALID VALUE FOR SpaceType";
+    }
+  }();
 }
 std::ostream &
 operator<<(std::ostream & out, const StateTypeOfFilter value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case StateTypeOfFilter::UNINITIALIZED:
-      s = "StateTypeOfFilter::UNINITIALIZED";
-      break;
-    case StateTypeOfFilter::INITIALIZED:
-      s = "StateTypeOfFilter::INITIALIZED";
-      break;
-    default:
-      s = "INVALID VALUE FOR StateTypeOfFilter";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case StateTypeOfFilter::UNINITIALIZED:
+        return "StateTypeOfFilter::UNINITIALIZED";
+      case StateTypeOfFilter::INITIALIZED:
+        return "StateTypeOfFilter::INITIALIZED";
+      default:
+        return "INVALID VALUE FOR StateTypeOfFilter";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Filtering/DiffusionTensorImage/src/itkDiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/src/itkDiffusionTensor3DReconstructionImageFilter.cxx
@@ -22,21 +22,18 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const GradientEnumeration value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case GradientEnumeration::GradientIsInASingleImage:
-      s = "GradientEnumeration::GradientIsInASingleImage";
-      break;
-    case GradientEnumeration::GradientIsInManyImages:
-      s = "GradientEnumeration::GradientIsInManyImages";
-      break;
-    case GradientEnumeration::Else:
-      s = "GradientEnumeration::Else";
-      break;
-    default:
-      s = "INVALID VALUE FOR GradientEnumeration";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case GradientEnumeration::GradientIsInASingleImage:
+        return "GradientEnumeration::GradientIsInASingleImage";
+      case GradientEnumeration::GradientIsInManyImages:
+        return "GradientEnumeration::GradientIsInManyImages";
+      case GradientEnumeration::Else:
+        return "GradientEnumeration::Else";
+      default:
+        return "INVALID VALUE FOR GradientEnumeration";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageIntensity/src/itkSymmetricEigenAnalysisImageFilter.cxx
+++ b/Modules/Filtering/ImageIntensity/src/itkSymmetricEigenAnalysisImageFilter.cxx
@@ -25,22 +25,19 @@ namespace Functor
 std::ostream &
 operator<<(std::ostream & out, const OrderTypeOfEigenValue value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case OrderTypeOfEigenValue::OrderByValue:
-      s = "OrderTypeOfEigenValue::OrderByValue";
-      break;
-    case OrderTypeOfEigenValue::OrderByMagnitude:
-      s = "OrderTypeOfEigenValue::OrderByMagnitude";
-      break;
-    case OrderTypeOfEigenValue::DoNotOrder:
-      s = "OrderTypeOfEigenValue::DoNotOrder";
-      break;
-    default:
-      s = "INVALID VALUE FOR OrderTypeOfEigenValue";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case OrderTypeOfEigenValue::OrderByValue:
+        return "OrderTypeOfEigenValue::OrderByValue";
+      case OrderTypeOfEigenValue::OrderByMagnitude:
+        return "OrderTypeOfEigenValue::OrderByMagnitude";
+      case OrderTypeOfEigenValue::DoNotOrder:
+        return "OrderTypeOfEigenValue::DoNotOrder";
+      default:
+        return "INVALID VALUE FOR OrderTypeOfEigenValue";
+    }
+  }();
 }
-} // end namespace Functor
+} // namespace Functor
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/src/itkMergeLabelMapFilter.cxx
+++ b/Modules/Filtering/LabelMap/src/itkMergeLabelMapFilter.cxx
@@ -23,24 +23,20 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const ChoiceMethod value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case ChoiceMethod::KEEP:
-      s = "ChoiceMethod::KEEP";
-      break;
-    case ChoiceMethod::AGGREGATE:
-      s = "ChoiceMethod::AGGREGATE";
-      break;
-    case ChoiceMethod::PACK:
-      s = "ChoiceMethod::PACK";
-      break;
-    case ChoiceMethod::STRICT:
-      s = "ChoiceMethod::STRICT";
-      break;
-    default:
-      s = "INVALID VALUE FOR ChoiceMethod";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case ChoiceMethod::KEEP:
+        return "ChoiceMethod::KEEP";
+      case ChoiceMethod::AGGREGATE:
+        return "ChoiceMethod::AGGREGATE";
+      case ChoiceMethod::PACK:
+        return "ChoiceMethod::PACK";
+      case ChoiceMethod::STRICT:
+        return "ChoiceMethod::STRICT";
+      default:
+        return "INVALID VALUE FOR ChoiceMethod";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Filtering/Smoothing/src/itkRecursiveGaussianImageFilter.cxx
+++ b/Modules/Filtering/Smoothing/src/itkRecursiveGaussianImageFilter.cxx
@@ -23,21 +23,18 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const EnumGaussianOrderType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case EnumGaussianOrderType::ZeroOrder:
-      s = "EnumType::ZeroOrder";
-      break;
-    case EnumGaussianOrderType::FirstOrder:
-      s = "EnumType::FirstOrder";
-      break;
-    case EnumGaussianOrderType::SecondOrder:
-      s = "EnumType::SecondOrder";
-      break;
-    default:
-      s = "INVALID VALUE FOR EnumType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case EnumGaussianOrderType::ZeroOrder:
+        return "EnumType::ZeroOrder";
+      case EnumGaussianOrderType::FirstOrder:
+        return "EnumType::FirstOrder";
+      case EnumGaussianOrderType::SecondOrder:
+        return "EnumType::SecondOrder";
+      default:
+        return "INVALID VALUE FOR EnumType";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1517,24 +1517,20 @@ GDCMImageIO::PrintSelf(std::ostream & os, Indent indent) const
 std::ostream &
 operator<<(std::ostream & out, const GDCMImageIO::TCompressionType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case GDCMImageIO::TCompressionType::JPEG:
-      s = "GDCMImageIO::TCompressionType::JPEG";
-      break;
-    case GDCMImageIO::TCompressionType::JPEG2000:
-      s = "GDCMImageIO::TCompressionType::JPEG2000";
-      break;
-    case GDCMImageIO::TCompressionType::JPEGLS:
-      s = "GDCMImageIO::TCompressionType::JPEGLS";
-      break;
-    case GDCMImageIO::TCompressionType::RLE:
-      s = "GDCMImageIO::TCompressionType::RLE";
-      break;
-    default:
-      s = "INVALID VALUE FOR GDCMImageIO::TCompressionType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case GDCMImageIO::TCompressionType::JPEG:
+        return "GDCMImageIO::TCompressionType::JPEG";
+      case GDCMImageIO::TCompressionType::JPEG2000:
+        return "GDCMImageIO::TCompressionType::JPEG2000";
+      case GDCMImageIO::TCompressionType::JPEGLS:
+        return "GDCMImageIO::TCompressionType::JPEGLS";
+      case GDCMImageIO::TCompressionType::RLE:
+        return "GDCMImageIO::TCompressionType::RLE";
+      default:
+        return "INVALID VALUE FOR GDCMImageIO::TCompressionType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
@@ -72,18 +72,16 @@ ImageIOFactory::CreateImageIO(const char * path, FileModeType mode)
 std::ostream &
 operator<<(std::ostream & out, const ImageIOFactory::FileModeType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case ImageIOFactory::FileModeType::ReadMode:
-      s = "ImageIOFactory::FileModeType::ReadMode";
-      break;
-    case ImageIOFactory::FileModeType::WriteMode:
-      s = "ImageIOFactory::FileModeType::WriteMode";
-      break;
-    default:
-      s = "INVALID VALUE FOR ImageIOFactory::FileModeType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case ImageIOFactory::FileModeType::ReadMode:
+        return "ImageIOFactory::FileModeType::ReadMode";
+      case ImageIOFactory::FileModeType::WriteMode:
+        return "ImageIOFactory::FileModeType::WriteMode";
+      default:
+        return "INVALID VALUE FOR ImageIOFactory::FileModeType";
+    }
+  }();
 }
 } // end namespace itk

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -1133,25 +1133,21 @@ JPEG2000ImageIO ::CanStreamWrite()
 std::ostream &
 operator<<(std::ostream & out, const JPEG2000ImageIOInternal::DFMFormatType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case JPEG2000ImageIOInternal::DFMFormatType::PXM_DFMT:
-      s = "JPEG2000ImageIOInternal::DFMFormatType::PXM_DFMT";
-      break;
-    case JPEG2000ImageIOInternal::DFMFormatType::PGX_DFMT:
-      s = "JPEG2000ImageIOInternal::DFMFormatType::PGX_DFMT";
-      break;
-    case JPEG2000ImageIOInternal::DFMFormatType::BMP_DFMT:
-      s = "JPEG2000ImageIOInternal::DFMFormatType::BMP_DFMT";
-      break;
-    case JPEG2000ImageIOInternal::DFMFormatType::YUV_DFMT:
-      s = "JPEG2000ImageIOInternal::DFMFormatType::YUV_DFMT";
-      break;
-    default:
-      s = "INVALID VALUE FOR JPEG2000ImageIOInternal::DFMFormatType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case JPEG2000ImageIOInternal::DFMFormatType::PXM_DFMT:
+        return "JPEG2000ImageIOInternal::DFMFormatType::PXM_DFMT";
+      case JPEG2000ImageIOInternal::DFMFormatType::PGX_DFMT:
+        return "JPEG2000ImageIOInternal::DFMFormatType::PGX_DFMT";
+      case JPEG2000ImageIOInternal::DFMFormatType::BMP_DFMT:
+        return "JPEG2000ImageIOInternal::DFMFormatType::BMP_DFMT";
+      case JPEG2000ImageIOInternal::DFMFormatType::YUV_DFMT:
+        return "JPEG2000ImageIOInternal::DFMFormatType::YUV_DFMT";
+      default:
+        return "INVALID VALUE FOR JPEG2000ImageIOInternal::DFMFormatType";
+    }
+  }();
 }
 
 // Define how to print enumeration

--- a/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
@@ -70,19 +70,17 @@ MeshIOFactory ::CreateMeshIO(const char * path, FileModeType mode)
 std::ostream &
 operator<<(std::ostream & out, const MeshIOFactory::FileModeType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case MeshIOFactory::FileModeType::ReadMode:
-      s = "MeshIOFactory::FileModeType::ReadMode";
-      break;
-    case MeshIOFactory::FileModeType::WriteMode:
-      s = "MeshIOFactory::FileModeType::WriteMode";
-      break;
-    default:
-      s = "INVALID VALUE FOR MeshIOFactory::FileModeType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case MeshIOFactory::FileModeType::ReadMode:
+        return "MeshIOFactory::FileModeType::ReadMode";
+      case MeshIOFactory::FileModeType::WriteMode:
+        return "MeshIOFactory::FileModeType::WriteMode";
+      default:
+        return "INVALID VALUE FOR MeshIOFactory::FileModeType";
+    }
+  }();
 }
 
 } // end namespace itk

--- a/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
@@ -65,19 +65,17 @@ TransformIOFactoryTemplate<TParametersValueType>::CreateTransformIO(const char *
 std::ostream &
 operator<<(std::ostream & out, const TransformIOFactoryFileModeType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case TransformIOFactoryFileModeType::ReadMode:
-      s = "TransformIOFactoryFileModeType::ReadMode";
-      break;
-    case TransformIOFactoryFileModeType::WriteMode:
-      s = "TransformIOFactoryFileModeType::WriteMode";
-      break;
-    default:
-      s = "INVALID VALUE FOR TransformIOFactoryFileModeType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case TransformIOFactoryFileModeType::ReadMode:
+        return "TransformIOFactoryFileModeType::ReadMode";
+      case TransformIOFactoryFileModeType::WriteMode:
+        return "TransformIOFactoryFileModeType::WriteMode";
+      default:
+        return "INVALID VALUE FOR TransformIOFactoryFileModeType";
+    }
+  }();
 }
 
 ITK_GCC_PRAGMA_DIAG_PUSH()

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -189,19 +189,17 @@ GradientDescentOptimizer ::AdvanceOneStep()
 std::ostream &
 operator<<(std::ostream & out, const GradientDescentOptimizer::StopConditionType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case GradientDescentOptimizer::StopConditionType::MaximumNumberOfIterations:
-      s = "GradientDescentOptimizer::StopConditionType::MaximumNumberOfIterations";
-      break;
-    case GradientDescentOptimizer::StopConditionType::MetricError:
-      s = "GradientDescentOptimizer::StopConditionType::MetricError";
-      break;
-    default:
-      s = "INVALID VALUE FOR GradientDescentOptimizer::StopConditionType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case GradientDescentOptimizer::StopConditionType::MaximumNumberOfIterations:
+        return "GradientDescentOptimizer::StopConditionType::MaximumNumberOfIterations";
+      case GradientDescentOptimizer::StopConditionType::MetricError:
+        return "GradientDescentOptimizer::StopConditionType::MetricError";
+      default:
+        return "INVALID VALUE FOR GradientDescentOptimizer::StopConditionType";
+    }
+  }();
 }
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -276,31 +276,25 @@ RegularStepGradientDescentBaseOptimizer ::PrintSelf(std::ostream & os, Indent in
 std::ostream &
 operator<<(std::ostream & out, const RegularStepGradientDescentBaseOptimizer::StopConditionType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case RegularStepGradientDescentBaseOptimizer::StopConditionType::GradientMagnitudeTolerance:
-      s = "RegularStepGradientDescentBaseOptimizer::StopConditionType::GradientMagnitudeTolerance";
-      break;
-    case RegularStepGradientDescentBaseOptimizer::StopConditionType::StepTooSmall:
-      s = "RegularStepGradientDescentBaseOptimizer::StopConditionType::StepTooSmall";
-      break;
-    case RegularStepGradientDescentBaseOptimizer::StopConditionType::ImageNotAvailable:
-      s = "RegularStepGradientDescentBaseOptimizer::StopConditionType::ImageNotAvailable";
-      break;
-    case RegularStepGradientDescentBaseOptimizer::StopConditionType::CostFunctionError:
-      s = "RegularStepGradientDescentBaseOptimizer::StopConditionType::CostFunctionError";
-      break;
-    case RegularStepGradientDescentBaseOptimizer::StopConditionType::MaximumNumberOfIterations:
-      s = "RegularStepGradientDescentBaseOptimizer::StopConditionType::MaximumNumberOfIterations";
-      break;
-    case RegularStepGradientDescentBaseOptimizer::StopConditionType::Unknown:
-      s = "RegularStepGradientDescentBaseOptimizer::StopConditionType::Unknown";
-      break;
-    default:
-      s = "INVALID VALUE FOR ";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case RegularStepGradientDescentBaseOptimizer::StopConditionType::GradientMagnitudeTolerance:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::GradientMagnitudeTolerance";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionType::StepTooSmall:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::StepTooSmall";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionType::ImageNotAvailable:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::ImageNotAvailable";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionType::CostFunctionError:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::CostFunctionError";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionType::MaximumNumberOfIterations:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::MaximumNumberOfIterations";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionType::Unknown:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::Unknown";
+      default:
+        return "INVALID VALUE FOR ";
+    }
+  }();
 }
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -492,25 +492,21 @@ SPSAOptimizer::GetStopConditionDescription() const
 std::ostream &
 operator<<(std::ostream & out, const SPSAOptimizer::StopConditionType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case SPSAOptimizer::StopConditionType::Unknown:
-      s = "SPSAOptimizer::StopConditionType::Unknown";
-      break;
-    case SPSAOptimizer::StopConditionType::MaximumNumberOfIterations:
-      s = "SPSAOptimizer::StopConditionType::MaximumNumberOfIterations";
-      break;
-    case SPSAOptimizer::StopConditionType::BelowTolerance:
-      s = "SPSAOptimizer::StopConditionType::BelowTolerance";
-      break;
-    case SPSAOptimizer::StopConditionType::MetricError:
-      s = "SPSAOptimizer::StopConditionType::MetricError";
-      break;
-    default:
-      s = "INVALID VALUE FOR SPSAOptimizer::StopConditionType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case SPSAOptimizer::StopConditionType::Unknown:
+        return "SPSAOptimizer::StopConditionType::Unknown";
+      case SPSAOptimizer::StopConditionType::MaximumNumberOfIterations:
+        return "SPSAOptimizer::StopConditionType::MaximumNumberOfIterations";
+      case SPSAOptimizer::StopConditionType::BelowTolerance:
+        return "SPSAOptimizer::StopConditionType::BelowTolerance";
+      case SPSAOptimizer::StopConditionType::MetricError:
+        return "SPSAOptimizer::StopConditionType::MetricError";
+      default:
+        return "INVALID VALUE FOR SPSAOptimizer::StopConditionType";
+    }
+  }();
 }
 
 } // end namespace itk

--- a/Modules/Numerics/Optimizersv4/src/itkMultiStartOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkMultiStartOptimizerv4.cxx
@@ -23,30 +23,24 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const StopType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case StopType::MAXIMUM_NUMBER_OF_ITERATIONS:
-      s = "StopType::MAXIMUM_NUMBER_OF_ITERATIONS";
-      break;
-    case StopType::COSTFUNCTION_ERROR:
-      s = "StopType::COSTFUNCTION_ERROR";
-      break;
-    case StopType::UPDATE_PARAMETERS_ERROR:
-      s = "StopType::UPDATE_PARAMETERS_ERROR";
-      break;
-    case StopType::STEP_TOO_SMALL:
-      s = "StopType::STEP_TOO_SMALL";
-      break;
-    case StopType::CONVERGENCE_CHECKER_PASSED:
-      s = "StopType::CONVERGENCE_CHECKER_PASSED";
-      break;
-    case StopType::OTHER_ERROR:
-      s = "StopType::OTHER_ERROR";
-      break;
-    default:
-      s = "INVALID VALUE FOR StopType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case StopType::MAXIMUM_NUMBER_OF_ITERATIONS:
+        return "StopType::MAXIMUM_NUMBER_OF_ITERATIONS";
+      case StopType::COSTFUNCTION_ERROR:
+        return "StopType::COSTFUNCTION_ERROR";
+      case StopType::UPDATE_PARAMETERS_ERROR:
+        return "StopType::UPDATE_PARAMETERS_ERROR";
+      case StopType::STEP_TOO_SMALL:
+        return "StopType::STEP_TOO_SMALL";
+      case StopType::CONVERGENCE_CHECKER_PASSED:
+        return "StopType::CONVERGENCE_CHECKER_PASSED";
+      case StopType::OTHER_ERROR:
+        return "StopType::OTHER_ERROR";
+      default:
+        return "INVALID VALUE FOR StopType";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectMetricBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectMetricBase.cxx
@@ -23,49 +23,41 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const SourceTypeOfGradient value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case SourceTypeOfGradient::GRADIENT_SOURCE_FIXED:
-      s = "SourceTypeOfGradient::GRADIENT_SOURCE_FIXED";
-      break;
-    case SourceTypeOfGradient::GRADIENT_SOURCE_MOVING:
-      s = "SourceTypeOfGradient::GRADIENT_SOURCE_MOVING";
-      break;
-    case SourceTypeOfGradient::GRADIENT_SOURCE_BOTH:
-      s = "SourceTypeOfGradient::GRADIENT_SOURCE_BOTH";
-      break;
-    default:
-      s = "INVALID VALUE FOR SourceTypeOfGradient";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case SourceTypeOfGradient::GRADIENT_SOURCE_FIXED:
+        return "SourceTypeOfGradient::GRADIENT_SOURCE_FIXED";
+      case SourceTypeOfGradient::GRADIENT_SOURCE_MOVING:
+        return "SourceTypeOfGradient::GRADIENT_SOURCE_MOVING";
+      case SourceTypeOfGradient::GRADIENT_SOURCE_BOTH:
+        return "SourceTypeOfGradient::GRADIENT_SOURCE_BOTH";
+      default:
+        return "INVALID VALUE FOR SourceTypeOfGradient";
+    }
+  }();
 }
 
 /** Define how to print enumerations */
 std::ostream &
 operator<<(std::ostream & out, const CategoryTypeForMetric value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case CategoryTypeForMetric::UNKNOWN_METRIC:
-      s = "CategoryTypeForMetric::UNKNOWN_METRIC";
-      break;
-    case CategoryTypeForMetric::OBJECT_METRIC:
-      s = "CategoryTypeForMetric::OBJECT_METRIC";
-      break;
-    case CategoryTypeForMetric::IMAGE_METRIC:
-      s = "CategoryTypeForMetric::IMAGE_METRIC";
-      break;
-    case CategoryTypeForMetric::POINT_SET_METRIC:
-      s = "CategoryTypeForMetric::POINT_SET_METRIC";
-      break;
-    case CategoryTypeForMetric::MULTI_METRIC:
-      s = "CategoryTypeForMetric::MULTI_METRIC";
-      break;
-    default:
-      s = "INVALID VALUE FOR CategoryTypeForMetric";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case CategoryTypeForMetric::UNKNOWN_METRIC:
+        return "CategoryTypeForMetric::UNKNOWN_METRIC";
+      case CategoryTypeForMetric::OBJECT_METRIC:
+        return "CategoryTypeForMetric::OBJECT_METRIC";
+      case CategoryTypeForMetric::IMAGE_METRIC:
+        return "CategoryTypeForMetric::IMAGE_METRIC";
+      case CategoryTypeForMetric::POINT_SET_METRIC:
+        return "CategoryTypeForMetric::POINT_SET_METRIC";
+      case CategoryTypeForMetric::MULTI_METRIC:
+        return "CategoryTypeForMetric::MULTI_METRIC";
+      default:
+        return "INVALID VALUE FOR CategoryTypeForMetric";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Numerics/Optimizersv4/src/itkRegistrationParameterScalesEstimator.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkRegistrationParameterScalesEstimator.cxx
@@ -23,27 +23,22 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const StrategyTypeForSampling value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case StrategyTypeForSampling::FullDomainSampling:
-      s = "StrategyTypeForSampling::FullDomainSampling";
-      break;
-    case StrategyTypeForSampling::CornerSampling:
-      s = "StrategyTypeForSampling::CornerSampling";
-      break;
-    case StrategyTypeForSampling::RandomSampling:
-      s = "StrategyTypeForSampling::RandomSampling";
-      break;
-    case StrategyTypeForSampling::CentralRegionSampling:
-      s = "StrategyTypeForSampling::CentralRegionSampling";
-      break;
-    case StrategyTypeForSampling::VirtualDomainPointSetSampling:
-      s = "StrategyTypeForSampling::VirtualDomainPointSetSampling";
-      break;
-    default:
-      s = "INVALID VALUE FOR StrategyTypeForSampling";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case StrategyTypeForSampling::FullDomainSampling:
+        return "StrategyTypeForSampling::FullDomainSampling";
+      case StrategyTypeForSampling::CornerSampling:
+        return "StrategyTypeForSampling::CornerSampling";
+      case StrategyTypeForSampling::RandomSampling:
+        return "StrategyTypeForSampling::RandomSampling";
+      case StrategyTypeForSampling::CentralRegionSampling:
+        return "StrategyTypeForSampling::CentralRegionSampling";
+      case StrategyTypeForSampling::VirtualDomainPointSetSampling:
+        return "StrategyTypeForSampling::VirtualDomainPointSetSampling";
+      default:
+        return "INVALID VALUE FOR StrategyTypeForSampling";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/src/itkMRFImageFilter.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/src/itkMRFImageFilter.cxx
@@ -22,18 +22,16 @@ namespace itk
 std::ostream &
 operator<<(std::ostream & out, const MRFStopType value)
 {
-  const char * s = nullptr;
-  switch (value)
-  {
-    case MRFStopType::MaximumNumberOfIterations:
-      s = "MRFStopType::MaximumNumberOfIterations";
-      break;
-    case MRFStopType::ErrorTolerance:
-      s = "MRFStopType::ErrorTolerance";
-      break;
-    default:
-      s = "MRFStopType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case MRFStopType::MaximumNumberOfIterations:
+        return "MRFStopType::MaximumNumberOfIterations";
+      case MRFStopType::ErrorTolerance:
+        return "MRFStopType::ErrorTolerance";
+      default:
+        return "MRFStopType";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Video/IO/src/itkVideoIOBase.cxx
+++ b/Modules/Video/IO/src/itkVideoIOBase.cxx
@@ -44,18 +44,16 @@ VideoIOBase::PrintSelf(std::ostream & os, Indent indent) const
 std::ostream &
 operator<<(std::ostream & out, const VideoIOBase::ReadType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case VideoIOBase::ReadType::ReadFromFile:
-      s = "VideoIOBase::ReadType::ReadFromFile";
-      break;
-    case VideoIOBase::ReadType::ReadFromCamera:
-      s = "VideoIOBase::ReadType::ReadFromCamera";
-      break;
-    default:
-      s = "INVALID VALUE FOR VideoIOBase::ReadType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case VideoIOBase::ReadType::ReadFromFile:
+        return "VideoIOBase::ReadType::ReadFromFile";
+      case VideoIOBase::ReadType::ReadFromCamera:
+        return "VideoIOBase::ReadType::ReadFromCamera";
+      default:
+        return "INVALID VALUE FOR VideoIOBase::ReadType";
+    }
+  }();
 }
 } // namespace itk

--- a/Modules/Video/IO/src/itkVideoIOFactory.cxx
+++ b/Modules/Video/IO/src/itkVideoIOFactory.cxx
@@ -83,21 +83,18 @@ VideoIOFactory::CreateVideoIO(IOModeType mode, const char * arg)
 std::ostream &
 operator<<(std::ostream & out, const VideoIOFactory::IOModeType value)
 {
-  const char * s = 0;
-  switch (value)
-  {
-    case VideoIOFactory::IOModeType::ReadFileMode:
-      s = "VideoIOFactory::IOModeType::ReadFileMode";
-      break;
-    case VideoIOFactory::IOModeType::ReadCameraMode:
-      s = "VideoIOFactory::IOModeType::ReadCameraMode";
-      break;
-    case VideoIOFactory::IOModeType::WriteMode:
-      s = "VideoIOFactory::IOModeType::WriteMode";
-      break;
-    default:
-      s = "INVALID VALUE FOR VideoIOFactory::IOModeType";
-  }
-  return out << s;
+  return out << [value] {
+    switch (value)
+    {
+      case VideoIOFactory::IOModeType::ReadFileMode:
+        return "VideoIOFactory::IOModeType::ReadFileMode";
+      case VideoIOFactory::IOModeType::ReadCameraMode:
+        return "VideoIOFactory::IOModeType::ReadCameraMode";
+      case VideoIOFactory::IOModeType::WriteMode:
+        return "VideoIOFactory::IOModeType::WriteMode";
+      default:
+        return "INVALID VALUE FOR VideoIOFactory::IOModeType";
+    }
+  }();
 }
 } // end namespace itk


### PR DESCRIPTION
This commit removed a significant amount of redundant lines of code from
the implementation of `operator<<(out, value)` for `enum` value types,
using C++11 lambda's. It removed local `s` variables, that appeared
unnecessary.

Thereby, it fixes many Visual Studio 2017 Code Analysis warnings,
regarding `const char * s = 0`, which said:

> warning C26477: Use 'nullptr' rather than 0 or NULL (es.47).

A minimal fix of this warning, `const char * s = nullptr`, would still
be risky, as `out << s` might crash when `s` is a `nullptr`.