### PR TITLE
COMP: remove Eigen3 shadow warnings with GCC 4.8.5

### DIFF
--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/AlignedBox.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/AlignedBox.h
@@ -143,7 +143,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF_VECTORIZABLE_FIXED_SIZE(_Scalar,_AmbientDim)
     * For 3D bounding boxes, the following names are added:
     * BottomLeftCeil, BottomRightCeil, TopLeftCeil, TopRightCeil.
     */
-  EIGEN_DEVICE_FUNC inline VectorType corner(CornerType corner) const
+  EIGEN_DEVICE_FUNC inline VectorType corner(CornerType c) const
   {
     EIGEN_STATIC_ASSERT(_AmbientDim <= 3, THIS_METHOD_IS_ONLY_FOR_VECTORS_OF_A_SPECIFIC_SIZE);
 
@@ -152,8 +152,8 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF_VECTORIZABLE_FIXED_SIZE(_Scalar,_AmbientDim)
     Index mult = 1;
     for(Index d=0; d<dim(); ++d)
     {
-      if( mult & corner ) res[d] = m_max[d];
-      else                res[d] = m_min[d];
+      if( mult & c ) res[d] = m_max[d];
+      else           res[d] = m_min[d];
       mult *= 2;
     }
     return res;

--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/AngleAxis.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/AngleAxis.h
@@ -77,7 +77,7 @@ public:
     *          represents an invalid rotation. */
   template<typename Derived>
   EIGEN_DEVICE_FUNC 
-  inline AngleAxis(const Scalar& angle, const MatrixBase<Derived>& axis) : m_axis(axis), m_angle(angle) {}
+  inline AngleAxis(const Scalar& an, const MatrixBase<Derived>& ax) : m_axis(ax), m_angle(an) {}
   /** Constructs and initialize the angle-axis rotation from a quaternion \a q.
     * This function implicitly normalizes the quaternion \a q.
     */

--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/ParametrizedLine.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/ParametrizedLine.h
@@ -55,8 +55,8 @@ public:
   /** Initializes a parametrized line of direction \a direction and origin \a origin.
     * \warning the vector direction is assumed to be normalized.
     */
-  EIGEN_DEVICE_FUNC ParametrizedLine(const VectorType& origin, const VectorType& direction)
-    : m_origin(origin), m_direction(direction) {}
+  EIGEN_DEVICE_FUNC ParametrizedLine(const VectorType& o, const VectorType& d)
+    : m_origin(o), m_direction(d) {}
 
   template <int OtherOptions>
   EIGEN_DEVICE_FUNC explicit ParametrizedLine(const Hyperplane<_Scalar, _AmbientDim, OtherOptions>& hyperplane);

--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/Quaternion.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/Quaternion.h
@@ -362,7 +362,7 @@ class Map<const Quaternion<_Scalar>, _Options >
       * \code *coeffs == {x, y, z, w} \endcode
       *
       * If the template parameter _Options is set to #Aligned, then the pointer coeffs must be aligned. */
-    EIGEN_DEVICE_FUNC explicit EIGEN_STRONG_INLINE Map(const Scalar* coeffs) : m_coeffs(coeffs) {}
+    EIGEN_DEVICE_FUNC explicit EIGEN_STRONG_INLINE Map(const Scalar* c) : m_coeffs(c) {}
 
     EIGEN_DEVICE_FUNC inline const Coefficients& coeffs() const { return m_coeffs;}
 
@@ -399,7 +399,7 @@ class Map<Quaternion<_Scalar>, _Options >
       * \code *coeffs == {x, y, z, w} \endcode
       *
       * If the template parameter _Options is set to #Aligned, then the pointer coeffs must be aligned. */
-    EIGEN_DEVICE_FUNC explicit EIGEN_STRONG_INLINE Map(Scalar* coeffs) : m_coeffs(coeffs) {}
+    EIGEN_DEVICE_FUNC explicit EIGEN_STRONG_INLINE Map(Scalar* c) : m_coeffs(c) {}
 
     EIGEN_DEVICE_FUNC inline Coefficients& coeffs() { return m_coeffs; }
     EIGEN_DEVICE_FUNC inline const Coefficients& coeffs() const { return m_coeffs; }

--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/Translation.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Geometry/Translation.h
@@ -68,7 +68,7 @@ public:
     m_coeffs.z() = sz;
   }
   /** Constructs and initialize the translation transformation from a vector of translation coefficients */
-  EIGEN_DEVICE_FUNC explicit inline Translation(const VectorType& vector) : m_coeffs(vector) {}
+  EIGEN_DEVICE_FUNC explicit inline Translation(const VectorType& v) : m_coeffs(v) {}
 
   /** \brief Retruns the x-translation by value. **/
   EIGEN_DEVICE_FUNC inline Scalar x() const { return m_coeffs.x(); }


### PR DESCRIPTION
Fixes #1254

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
