### PR TITLE
STYLE: Replace 0 by nullptr when appropriate

### DIFF
--- a/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
+++ b/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
@@ -226,7 +226,7 @@ WindowsMemoryUsageObserver::GetMemoryUsage()
   PSYSTEM_PROCESSES sp = new SYSTEM_PROCESSES[n];
   // as we can't know how many processes are running, we loop and test a new size
   // every time.
-  while (ZwQuerySystemInformation(SystemProcessesAndThreadsInformation, sp, n * sizeof *sp, 0) ==
+  while (ZwQuerySystemInformation(SystemProcessesAndThreadsInformation, sp, n * sizeof *sp, nullptr) ==
          STATUS_INFO_LENGTH_MISMATCH)
   {
     delete[] sp;

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
@@ -51,7 +51,7 @@ PlatformMultiThreader::MultipleMethodExecute()
   }
   for (threadCount = 0; threadCount < m_NumberOfWorkUnits; ++threadCount)
   {
-    if (m_MultipleMethod[threadCount] == (ThreadFunctionType)0)
+    if (m_MultipleMethod[threadCount] == nullptr)
     {
       itkExceptionMacro(<< "No multiple method set for: " << threadCount);
       return;
@@ -73,7 +73,7 @@ PlatformMultiThreader::MultipleMethodExecute()
     m_ThreadInfoArray[threadCount].NumberOfWorkUnits = m_NumberOfWorkUnits;
 
     processId[threadCount] = (void *)_beginthreadex(
-      0, 0, m_MultipleMethod[threadCount], &m_ThreadInfoArray[threadCount], 0, (unsigned int *)&threadId);
+      nullptr, 0, m_MultipleMethod[threadCount], &m_ThreadInfoArray[threadCount], 0, (unsigned int *)&threadId);
 
     if (processId[threadCount] == nullptr)
     {
@@ -138,8 +138,8 @@ PlatformMultiThreader::SpawnThread(ThreadFunctionType f, void * UserData)
   // Using _beginthreadex on a PC
   //
   m_SpawnedThreadProcessID[id] =
-    (void *)_beginthreadex(0, 0, f, &m_SpawnedThreadInfoArray[id], 0, (unsigned int *)&threadId);
-  if (m_SpawnedThreadProcessID[id] == 0)
+    (void *)_beginthreadex(nullptr, 0, f, &m_SpawnedThreadInfoArray[id], 0, (unsigned int *)&threadId);
+  if (m_SpawnedThreadProcessID[id] == nullptr)
   {
     itkExceptionMacro("Error in thread creation !!!");
   }
@@ -177,7 +177,8 @@ PlatformMultiThreader ::SpawnDispatchSingleMethodThread(PlatformMultiThreader::W
 {
   // Using _beginthreadex on a PC
   DWORD  threadId;
-  HANDLE threadHandle = (HANDLE)_beginthreadex(0, 0, this->SingleMethodProxy, threadInfo, 0, (unsigned int *)&threadId);
+  HANDLE threadHandle =
+    (HANDLE)_beginthreadex(nullptr, 0, this->SingleMethodProxy, threadInfo, 0, (unsigned int *)&threadId);
   if (threadHandle == nullptr)
   {
     itkExceptionMacro("Error in thread creation !!!");

--- a/Modules/Core/Common/src/itkWin32OutputWindow.cxx
+++ b/Modules/Core/Common/src/itkWin32OutputWindow.cxx
@@ -30,7 +30,7 @@
 namespace itk
 {
 /** */
-HWND Win32OutputWindow::m_OutputWindow = 0;
+HWND Win32OutputWindow::m_OutputWindow = nullptr;
 
 Win32OutputWindow ::~Win32OutputWindow()
 {
@@ -100,7 +100,7 @@ Win32OutputWindow ::DisplayText(const char * text)
     /** Find the next new line in text */
     NewLinePos = strchr(text, '\n');
     /** if no new line is found then just add the text */
-    if (NewLinePos == 0)
+    if (NewLinePos == nullptr)
     {
       Win32OutputWindow::AddText(text);
     }

--- a/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
+++ b/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
@@ -75,7 +75,7 @@ IsStringEncodingValid(const std::string & str)
   // MultiByteToWideChar returns 0 if there was a problem during conversion
   // when given the MB_ERR_INVALID_CHARS flag
   const int utf16_size =
-    MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str.c_str(), static_cast<int>(str.length()), 0, 0);
+    MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str.c_str(), static_cast<int>(str.length()), nullptr, 0);
 
   return (utf16_size != 0);
 }
@@ -99,7 +99,7 @@ Utf8StringToWString(const std::string & str)
   // utf8 characters are found. An alternative would be to throw an exception
 
   // First get the size
-  const int utf16_size = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), static_cast<int>(str.length()), 0, 0);
+  const int utf16_size = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), static_cast<int>(str.length()), nullptr, 0);
 
   // Now do the conversion
   std::wstring wstr;


### PR DESCRIPTION
Fixes Visual Studio 2017 Code Analysis warnings:

> warning C26477: Use 'nullptr' rather than 0 or NULL (es.47).