### PR TITLE
BUG: Update IsotropicWavelets module for Doxygen build

### DIFF
--- a/Modules/Remote/IsotropicWavelets.remote.cmake
+++ b/Modules/Remote/IsotropicWavelets.remote.cmake
@@ -9,5 +9,5 @@ Cerdan, P.H. \"Steerable Isotropic Wavelets for Multiscale and Phase Analysis\".
 "
   # Upstream repository was transfered from phcerdan to InsightSoftwareConsortium
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKIsotropicWavelets.git
-  GIT_TAG e76bc678cbcbdb70e479008772ac6451c2cf038b
+  GIT_TAG 8f79edab90e4f80b883f6abbaeb120cdbc01da5a
 )


### PR DESCRIPTION
To address the Doxygen CMake configuration error on the location of the
Python tests.

Changes:

   Matt McCormick (3):
     COMP: Wrap GaussianImageSource for StructureTensor
     BUG: Move Python tests to wrapping/test/CMakeLists.txt
     ENH: Build against ITK 5.0.1 and bump Python package version
