### PR TITLE
BUG: sign memory probe to detect freed memory

### DIFF
--- a/Modules/Core/Common/include/itkMemoryProbe.h
+++ b/Modules/Core/Common/include/itkMemoryProbe.h
@@ -36,14 +36,14 @@ namespace itk
  *
  * \ingroup ITKCommon
  */
-class ITKCommon_EXPORT MemoryProbe : public ResourceProbe<SizeValueType, double>
+class ITKCommon_EXPORT MemoryProbe : public ResourceProbe<OffsetValueType, double>
 {
 public:
   MemoryProbe();
   ~MemoryProbe() override;
 
   /** Type for measuring memory. */
-  using MemoryLoadType = SizeValueType;
+  using MemoryLoadType = OffsetValueType;
 
   /** Type for measuring the average memory. */
   using MeanMemoryLoadType = double;

--- a/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
@@ -55,7 +55,7 @@ itkMemoryProbesCollecterBaseTest(int, char *[])
   Sleep(5000);
   mcollecter.Stop("Update");
   probe.Stop();
-  size_t total = probe.GetTotal();
+  itk::MemoryProbe::MemoryLoadType total = probe.GetTotal();
   std::cout << " Total Value " << probe.GetTotal() << std::endl;
   if (total == 0)
   {
@@ -65,7 +65,17 @@ itkMemoryProbesCollecterBaseTest(int, char *[])
     return EXIT_SUCCESS;
   }
   mcollecter.Report();
+  probe.Start();
   delete[] buf;
+  Sleep(5000);
+  probe.Stop();
+  if ( total != 0 && total < probe.GetTotal() )
+  {
+    std::cerr << "Freeing memory should result in less memory but it is "
+              << probe.GetTotal() << probe.GetUnit()
+              << " instead of " << total << probe.GetUnit() << std::endl;
+    return EXIT_FAILURE;
+  }
 
 
   ITK_TRY_EXPECT_EXCEPTION(mcollecter.GetProbe("IDoNotExist"));


### PR DESCRIPTION
I have modified the memory probe test to illustrate the problem. The test fails without the proposed modification of itkMemoryProbe.h. This problem had actually been reported a long time ago in Jira by @cyrilmory but I don't know if we have access to the former bug tracker...
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
