### PR TITLE
ENH: Adding support for writing aux_file in Nifti.

### DIFF
--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1341,7 +1341,6 @@ mat44_transpose(const mat44 & in)
 void
 NiftiImageIO ::WriteImageInformation()
 {
-  //  MetaDataDictionary &thisDic=this->GetMetaDataDictionary();
   //
   //
   // First of all we need to not go any further if there's
@@ -1656,6 +1655,20 @@ NiftiImageIO ::WriteImageInformation()
   this->m_NiftiImage->scl_inter = static_cast<float>(m_RescaleIntercept);
   // TODO: Note both arguments are the same, no need to distinguish between them.
   this->SetNIfTIOrientationFromImageIO(this->GetNumberOfDimensions(), this->GetNumberOfDimensions());
+
+  MetaDataDictionary & thisDic = this->GetMetaDataDictionary();
+  std::string          temp;
+  if (itk::ExposeMetaData<std::string>(thisDic, "aux_file", temp))
+  {
+    if (temp.length() > 23)
+    {
+      itkExceptionMacro(<< "aux_file too long, Nifti limit is 23 characters");
+    }
+    else
+    {
+      strcpy(this->m_NiftiImage->aux_file, temp.c_str());
+    }
+  }
 }
 
 namespace

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -175,10 +175,11 @@ MakeNiftiImage()
     img->SetOrigin(og);
   }
   {
-    // Set the qform and sfrom codes for the MetaDataDictionary.
+    // Set the qform, sfrom and aux_file values for the MetaDataDictionary.
     itk::MetaDataDictionary & thisDic = img->GetMetaDataDictionary();
     itk::EncapsulateMetaData<std::string>(thisDic, "qform_code_name", "NIFTI_XFORM_SCANNER_ANAT");
     itk::EncapsulateMetaData<std::string>(thisDic, "sform_code_name", "NIFTI_XFORM_UNKNOWN");
+    itk::EncapsulateMetaData<std::string>(thisDic, "aux_file", "aux_info.txt");
   }
 
   try
@@ -220,6 +221,13 @@ MakeNiftiImage()
     {
       std::cerr << "ERROR: sform code not recovered from file properly:  'NIFTI_XFORM_UNKNOWN' != '" << sform_temp
                 << "'" << std::endl;
+      return EXIT_FAILURE;
+    }
+    std::string auxfile_temp = "";
+    if (!itk::ExposeMetaData<std::string>(thisDic, "aux_file", auxfile_temp) || auxfile_temp != "aux_info.txt")
+    {
+      std::cerr << "ERROR: aux_file not recovered from file properly:  'aux_info.txt' != '" << auxfile_temp << "'"
+                << std::endl;
       return EXIT_FAILURE;
     }
   }


### PR DESCRIPTION
The NiftiImageIO only read the aux_file meta-data and did not support
writing it. Now it does.