### PR TITLE
WIP: ENH: GDCMIO writer compression JpegLS, RLE, lossy Jpeg

### DIFF
--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -164,6 +164,26 @@ public:
   itkGetConstMacro(LoadPrivateTags, bool);
   itkBooleanMacro(LoadPrivateTags);
 
+  /** Convert input Y'CbCr to RGB, enabled by default.
+   */
+  itkSetMacro(ReadYBRtoRGB, bool);
+  itkGetConstMacro(ReadYBRtoRGB, bool);
+  itkBooleanMacro(ReadYBRtoRGB);
+
+  /** Convert RGB to Y'CbCr before compression, disabled by default.
+   * RLE compression is supported, other are allowed, except lossy JPEG.
+   * Photo-metric interpretation will be YBR_FULL.
+   *
+   * "It is unusual to use an RGB color space for RLE compression,
+   * since no advantage is taken of correlation between the red, green
+   * and blue components (e.g., of luminance), and poor compression is
+   * achieved (note however that the conversion from RGB to YBR_FULL
+   * is itself lossy." DICOM PS3.5 2019d Section 8.2.2
+   */
+  itkSetMacro(WriteRGBtoYBR, bool);
+  itkGetConstMacro(WriteRGBtoYBR, bool);
+  itkBooleanMacro(WriteRGBtoYBR);
+
 #if defined(ITKIO_DEPRECATED_GDCM1_API)
   /** Convenience methods to query patient information and scanner
    * information. These methods are here for compatibility with the
@@ -323,7 +343,8 @@ public:
     JPEG = 0,
     JPEG2000,
     JPEGLS,
-    RLE
+    RLE,
+    LOSSYJPEG
   };
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
@@ -332,6 +353,7 @@ public:
   static constexpr TCompressionType JPEG2000 = TCompressionType::JPEG2000;
   static constexpr TCompressionType JPEGLS = TCompressionType::JPEGLS;
   static constexpr TCompressionType RLE = TCompressionType::RLE;
+  static constexpr TCompressionType LOSSYJPEG = TCompressionType::LOSSYJPEG;
 #endif
 
   itkSetEnumMacro(CompressionType, TCompressionType);
@@ -360,6 +382,10 @@ protected:
   bool m_KeepOriginalUID;
 
   bool m_LoadPrivateTags;
+
+  bool m_ReadYBRtoRGB;
+
+  bool m_WriteRGBtoYBR;
 
 private:
 #if defined(ITKIO_DEPRECATED_GDCM1_API)

--- a/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
@@ -107,6 +107,12 @@ itkGDCMImageIOTest2(int argc, char * argv[])
   output_j2k += "-j2k.dcm";
   std::string output_jpll = output;
   output_jpll += "-jpll.dcm";
+  std::string output_jpegls = output;
+  output_jpegls += "-jpegls.dcm";
+  std::string output_rle = output;
+  output_rle += "-rle.dcm";
+  std::string output_jpls = output;
+  output_jpls += "-jpls.dcm";
   std::string output_raw = output;
   output_raw += "-raw.dcm";
 
@@ -135,6 +141,48 @@ itkGDCMImageIOTest2(int argc, char * argv[])
   // Save as JPEG Lossless
   dicomIO->SetCompressionType(itk::GDCMImageIO::TCompressionType::JPEG);
   writer->SetFileName(output_jpll.c_str());
+  try
+  {
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & e)
+  {
+    std::cerr << "exception in file writer " << std::endl;
+    std::cerr << e << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Save as JPEGLS Lossless
+  dicomIO->SetCompressionType(itk::GDCMImageIO::TCompressionType::JPEGLS);
+  writer->SetFileName(output_jpegls.c_str());
+  try
+  {
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & e)
+  {
+    std::cerr << "exception in file writer " << std::endl;
+    std::cerr << e << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Save as RLE
+  dicomIO->SetCompressionType(itk::GDCMImageIO::TCompressionType::RLE);
+  writer->SetFileName(output_rle.c_str());
+  try
+  {
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & e)
+  {
+    std::cerr << "exception in file writer " << std::endl;
+    std::cerr << e << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Save as lossy JPEG
+  dicomIO->SetCompressionType(itk::GDCMImageIO::TCompressionType::LOSSYJPEG);
+  writer->SetFileName(output_jpls.c_str());
   try
   {
     writer->Update();


### PR DESCRIPTION
New writer compression

- Lossy Jpeg
- Jpeg-LS
- RLE (optionally _YBR_FULL_)



**Edit**:
s. compression, RLE _RGB_ vs. RLE _YBR_FULL_

```
Raw        3146730 B (1024 x 1024 RGB char)
RLE RGB    2320614 B (100%)
Jpeg       1707380 B
RLE YBR    1681038 B (72.44%)
Jpeg2000   1107454 B
Jpeg-LS     746946 B
lossy Jpeg  558156 B
```

**Edit**:
Tests for all compressors. Everything is [here](https://drive.google.com/drive/folders/1pYuCEsTI9gEQ2dGQaORpuiRjof6wd6gO?usp=sharing).

```
#include <itkImage.h>
#include <itkImageFileReader.h>
#include <itkImageFileWriter.h>
#include <itkGDCMImageIO.h>
#include <iostream>
#include <string>
typedef itk::Image<itk::RGBPixel<unsigned char>, 3> RGBImageType;
typedef itk::ImageFileReader<RGBImageType> RGBImageReaderType;
typedef itk::ImageFileWriter<RGBImageType> RGBImageWriterType;
int main(int argc, char ** argv)
{
  if (argc < 2)
  {
    std::cout << "File name is required" << std::endl;
    return 0;
  }
  std::vector<std::string> compressors;
  compressors.push_back("JPEG");
  compressors.push_back("JPEG2000");
  compressors.push_back("JPEGLS");
  compressors.push_back("RLE");
  compressors.push_back("LOSSYJPEG");
  for (size_t x = 0; x < 5; x++)  // 'x < 2' for current master branch
  {
    RGBImageReaderType::Pointer reader = RGBImageReaderType::New();
    try
    {
      reader->SetFileName(argv[1]);
      reader->Update();
    }
    catch (itk::ExceptionObject & ex)
    {
      std::cout << ex.GetDescription() << std::endl;
      return 1;
    }
    const std::string f = compressors.at(x) + std::string(".dcm");
    RGBImageWriterType::Pointer writer = RGBImageWriterType::New();
    itk::GDCMImageIO::Pointer imageIO = itk::GDCMImageIO::New();
#if 1
    imageIO->SetCompressionType(static_cast<itk::GDCMImageIO::TCompressionType>(x));
#else
    // or
    imageIO->SetCompressor(compressors.at(x).c_str()); 
#endif
    if (x == 3) imageIO->SetWriteRGBtoYBR(true); // create RLE / YBR_FULL, opt.
    writer->SetImageIO(imageIO);
    writer->SetUseCompression(true); // Important to set here, not in imageIO, AFAIK
    writer->SetFileName(f.c_str());
    try
    {
      writer->SetInput(reader->GetOutput());
      writer->Update();
    }
    catch (itk::ExceptionObject & ex)
    {
      std::cout << ex.GetDescription() << std::endl;
      return 1;
    }
  }
  return 0;
}
```