### PR TITLE
BUG: GDCMIO crashes if bits allocated 16, stored 8

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -405,13 +405,17 @@ GDCMImageIO::InternalReadImageInformation()
       itkExceptionMacro("Unhandled PixelFormat: " << pixeltype);
   }
 
+  gdcm::PixelFormat::ScalarType outputpt = pixeltype.GetScalarType();
   m_RescaleIntercept = image.GetIntercept();
   m_RescaleSlope = image.GetSlope();
-  gdcm::Rescaler r;
-  r.SetIntercept(m_RescaleIntercept);
-  r.SetSlope(m_RescaleSlope);
-  r.SetPixelFormat(pixeltype);
-  gdcm::PixelFormat::ScalarType outputpt = r.ComputeInterceptSlopePixelType();
+  if (m_RescaleSlope != 1.0 || m_RescaleIntercept != 0.0)
+  {
+    gdcm::Rescaler r;
+    r.SetIntercept(m_RescaleIntercept);
+    r.SetSlope(m_RescaleSlope);
+    r.SetPixelFormat(pixeltype);
+    outputpt = r.ComputeInterceptSlopePixelType();
+  }
 
   itkAssertInDebugAndIgnoreInReleaseMacro(pixeltype <= outputpt);
 


### PR DESCRIPTION
Particular DICOM [file](https://drive.google.com/file/d/1NoxBn2c3ypCRrqeGMDAqhFhXMYLm5ofN/view?usp=sharing) crash GDCMImageIO and related applications. To reproduce drag-and-drop the file onto Slicer or ITK-Snap  window or s. test at the end of the post. It is old bug.

In fact, any 16 bits allocated/8 bits stored file will crash, such files are seldom, but not so rare, s. all _Integris_ examples (extract .Z) in [www.creatis.insa-lyon.fr/~jpr/](https://www.creatis.insa-lyon.fr/~jpr/PUBLIC/gdcm/gdcmSampleData/Philips_Medical_Images/Integris_H_3_V_11/)

The file has _Bits Allocated 16_ and _Bits Stored 8_. Crash happens because [here](https://github.com/InsightSoftwareConsortium/ITK/blob/cdca76e2a3ab7ba5f134d217a9d96e3fcac6af86/Modules/IO/GDCM/src/itkGDCMImageIO.cxx#L414) pixel type is taken from _gdcm::Rescaler_ without check of intercept and slope values ("are they different from 1 / 0?"), but [here](https://github.com/InsightSoftwareConsortium/ITK/blob/cdca76e2a3ab7ba5f134d217a9d96e3fcac6af86/Modules/IO/GDCM/src/itkGDCMImageIO.cxx#L320) re-scale is applied only if intercept and slope are different from 1 / 0.

```
#include <itkImage.h>
#include <itkImageFileReader.h>
#include <iostream>
int main(int argc, char ** argv)
{
  typedef itk::Image<unsigned short, 3> ImageTypeUS;
  typedef itk::ImageFileReader<ImageTypeUS> ReaderType;
  ReaderType::Pointer reader = ReaderType::New();
  // GDCMImageIO is assumed
  reader->SetFileName(argv[1]);
  try  {    reader->Update();  }
  catch (itk::ExceptionObject & ex)  {    return 1;  }
  ImageTypeUS::Pointer image = reader->GetOutput();
  return 0;
}
```

FYI @malaterre 