### PR TITLE
ENH: Prefer explicit casting over implicit casting for vxl

### DIFF
--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -61,6 +61,9 @@ public:
    *  setting for memory management.                          */
   Array(const Array &);
 
+  /** Construct from a VnlVectorType */
+  explicit Array(const VnlVectorType &);
+
   /** Constructor with size. Size can only be changed by assignment */
   explicit Array(SizeValueType dimension);
 

--- a/Modules/Core/Common/include/itkArray.hxx
+++ b/Modules/Core/Common/include/itkArray.hxx
@@ -41,6 +41,15 @@ Array<TValue>::Array(const Self & rhs)
   m_LetArrayManageMemory(true)
 {}
 
+template <typename TValue>
+Array<TValue>::Array(const VnlVectorType & rhs)
+  : vnl_vector<TValue>(rhs)
+  ,
+  // The vnl vector copy constructor creates new memory
+  // no matter the setting of let array manage memory of rhs
+  m_LetArrayManageMemory(true)
+{}
+
 /** Constructor with size */
 template <typename TValue>
 Array<TValue>::Array(SizeValueType dimension)

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -211,7 +211,7 @@ ImageSink<TInputImage>::VerifyInputInformation() ITKv5_CONST
 
       if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
           !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||
-          !inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
+          !inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(inputPtrN->GetDirection().GetVnlMatrix().as_ref(),
                                                                       this->m_DirectionTolerance))
       {
         std::ostringstream originString, spacingString, directionString;
@@ -231,8 +231,8 @@ ImageSink<TInputImage>::VerifyInputInformation() ITKv5_CONST
                         << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
           spacingString << "\tTolerance: " << coordinateTol << std::endl;
         }
-        if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
-                                                                        this->m_DirectionTolerance))
+        if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
+              inputPtrN->GetDirection().GetVnlMatrix().as_ref(), this->m_DirectionTolerance))
         {
           directionString.setf(std::ios::scientific);
           directionString.precision(7);

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -187,7 +187,7 @@ ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CO
 
       if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
           !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||
-          !inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
+          !inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(inputPtrN->GetDirection().GetVnlMatrix().as_ref(),
                                                                       this->m_DirectionTolerance))
       {
         std::ostringstream originString, spacingString, directionString;
@@ -207,8 +207,8 @@ ImageToImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CO
                         << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
           spacingString << "\tTolerance: " << coordinateTol << std::endl;
         }
-        if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(inputPtrN->GetDirection().GetVnlMatrix(),
-                                                                        this->m_DirectionTolerance))
+        if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
+              inputPtrN->GetDirection().GetVnlMatrix().as_ref(), this->m_DirectionTolerance))
         {
           directionString.setf(std::ios::scientific);
           directionString.precision(7);

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -263,15 +263,14 @@ public:
     {
       itkGenericExceptionMacro(<< "Singular matrix. Determinant is 0.");
     }
-    vnl_matrix<T> temp = vnl_matrix_inverse<T>(m_Matrix);
-    return temp;
+    return vnl_matrix_fixed<T, NColumns, NRows>{ vnl_matrix_inverse<T>(m_Matrix.as_ref()) };
   }
 
   /** Return the transposed matrix. */
   inline vnl_matrix_fixed<T, NColumns, NRows>
   GetTranspose() const
   {
-    return m_Matrix.transpose();
+    return vnl_matrix_fixed<T, NColumns, NRows>{ m_Matrix.transpose().as_matrix() };
   }
 
   /** Default constructor. */

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.h
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.h
@@ -203,8 +203,7 @@ public:
   inline vnl_matrix<T>
   GetInverse() const
   {
-    vnl_matrix<T> temp = vnl_matrix_inverse<T>(m_Matrix);
-    return temp;
+    return static_cast<vnl_matrix<T>>(vnl_matrix_inverse<T>(m_Matrix));
   }
 
   /** Return the transposed matrix. */

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -93,14 +93,11 @@ Rigid2DTransform<TParametersValueType>::ComputeMatrixParameters()
 {
   // Extract the orthogonal part of the matrix
   //
-  vnl_matrix<TParametersValueType> p(2, 2);
-  p = this->GetMatrix().GetVnlMatrix();
-  vnl_svd<TParametersValueType>    svd(p);
-  vnl_matrix<TParametersValueType> r(2, 2);
-  r = svd.U() * svd.V().transpose();
+  MatrixType                       p{ this->GetMatrix().GetVnlMatrix() };
+  vnl_svd<TParametersValueType>    svd{ (p.GetVnlMatrix()).as_ref() };
+  vnl_matrix<TParametersValueType> r{ svd.U() * svd.V().transpose() };
 
   m_Angle = std::acos(r[0][0]);
-
   if (r[1][0] < 0.0)
   {
     m_Angle = -m_Angle;

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -258,7 +258,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
           ++(*gradientItContainer[i]);
         }
 
-        vnl_svd<double> pseudoInverseSolver(m_TensorBasis);
+        vnl_svd<double> pseudoInverseSolver{ m_TensorBasis.as_matrix() };
         if (m_NumberOfGradientDirections > 6)
         {
           D = pseudoInverseSolver.solve(m_BMatrix * B);
@@ -371,7 +371,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
           }
         }
 
-        vnl_svd<double> pseudoInverseSolver(m_TensorBasis);
+        vnl_svd<double> pseudoInverseSolver{ m_TensorBasis.as_matrix() };
         if (m_NumberOfGradientDirections > 6)
         {
           D = pseudoInverseSolver.solve(m_BMatrix * B);

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -197,7 +197,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverseJacobia
   if (useSVD)
   {
     this->ComputeJacobianWithRespectToPositionInternal(index, jacobian, false);
-    vnl_svd<typename JacobianPositionType::element_type> svd(jacobian);
+    vnl_svd<typename JacobianPositionType::element_type> svd{ jacobian.as_ref() };
     for (unsigned int i = 0; i < jacobian.rows(); i++)
     {
       for (unsigned int j = 0; j < jacobian.cols(); j++)
@@ -431,7 +431,8 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::VerifyFixedParame
       originString << "InverseDisplacementField Spacing: " << inverseFieldSpacing
                    << ", DisplacementField Spacing: " << fieldSpacing << std::endl;
     }
-    if (!inverseFieldDirection.GetVnlMatrix().as_ref().is_equal(fieldDirection.GetVnlMatrix(), directionTolerance))
+    if (!inverseFieldDirection.GetVnlMatrix().as_ref().is_equal(fieldDirection.GetVnlMatrix().as_ref(),
+                                                                directionTolerance))
     {
       unequalDirections = true;
       originString << "InverseDisplacementField Direction: " << inverseFieldDirection

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -276,7 +276,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
           }
 
           // Compute tensor product of gradI with itself
-          const vnl_matrix<SpacePrecisionType> tnspose = gradI.GetTranspose();
+          const vnl_matrix<SpacePrecisionType> tnspose{ gradI.GetTranspose().as_matrix() };
           StructureTensorType                  product(gradI * tnspose);
           tensor += product;
         }

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -383,7 +383,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::GenerateInputReq
     this->m_DefFieldSameInformation =
       (outputPtr->GetOrigin().GetVnlVector().is_equal(fieldPtr->GetOrigin().GetVnlVector(), coordinateTol)) &&
       (outputPtr->GetSpacing().GetVnlVector().is_equal(fieldPtr->GetSpacing().GetVnlVector(), coordinateTol)) &&
-      (outputPtr->GetDirection().GetVnlMatrix().as_ref().is_equal(fieldPtr->GetDirection().GetVnlMatrix(),
+      (outputPtr->GetDirection().GetVnlMatrix().as_ref().is_equal(fieldPtr->GetDirection().GetVnlMatrix().as_ref(),
                                                                   this->GetDirectionTolerance()));
 
     if (this->m_DefFieldSameInformation)

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -171,8 +171,8 @@ ImageMomentsCalculator<TImage>::Compute()
   }
 
   // Compute principal moments and axes
-  vnl_symmetric_eigensystem<double> eigen(m_Cm.GetVnlMatrix());
-  vnl_diag_matrix<double>           pm = eigen.D;
+  vnl_symmetric_eigensystem<double> eigen{ m_Cm.GetVnlMatrix().as_matrix() };
+  vnl_diag_matrix<double>           pm{ eigen.D };
   for (unsigned int i = 0; i < ImageDimension; i++)
   {
     m_Pm[i] = pm(i) * m_M0;
@@ -181,8 +181,8 @@ ImageMomentsCalculator<TImage>::Compute()
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  vnl_real_eigensystem                  eigenrot(m_Pa.GetVnlMatrix());
-  vnl_diag_matrix<std::complex<double>> eigenval = eigenrot.D;
+  vnl_real_eigensystem                  eigenrot{ m_Pa.GetVnlMatrix().as_matrix() };
+  vnl_diag_matrix<std::complex<double>> eigenval{ eigenrot.D };
   std::complex<double>                  det(1.0, 0.0);
 
   for (unsigned int i = 0; i < ImageDimension; i++)

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -320,7 +320,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
 
   // Compute principal moments and axes
   VectorType                        principalMoments;
-  vnl_symmetric_eigensystem<double> eigen(centralMoments.GetVnlMatrix());
+  vnl_symmetric_eigensystem<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
   vnl_diag_matrix<double>           pm = eigen.D;
   for (unsigned int i = 0; i < ImageDimension; i++)
   {
@@ -330,8 +330,8 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  vnl_real_eigensystem                  eigenrot(principalAxes.GetVnlMatrix());
-  vnl_diag_matrix<std::complex<double>> eigenval = eigenrot.D;
+  vnl_real_eigensystem                  eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
+  vnl_diag_matrix<std::complex<double>> eigenval{ eigenrot.D };
   std::complex<double>                  det(1.0, 0.0);
 
   for (unsigned int i = 0; i < ImageDimension; i++)
@@ -787,7 +787,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputeOrientedBoundingBox(LabelObject
 
   const ImageType * output = this->GetOutput();
 
-  VNLMatrixType principalAxesBasisMatrix = labelObject->GetPrincipalAxes().GetVnlMatrix();
+  VNLMatrixType principalAxesBasisMatrix{ labelObject->GetPrincipalAxes().GetVnlMatrix().as_matrix() };
 
   const typename LabelObjectType::CentroidType centroid = labelObject->GetCentroid();
   const unsigned int                           numLines = labelObject->GetNumberOfLines();

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -221,8 +221,8 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
     }
 
     // Compute principal moments and axes
-    vnl_symmetric_eigensystem<double> eigen(centralMoments.GetVnlMatrix());
-    vnl_diag_matrix<double>           pm = eigen.D;
+    vnl_symmetric_eigensystem<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
+    vnl_diag_matrix<double>           pm{ eigen.D };
     for (unsigned int i = 0; i < ImageDimension; i++)
     {
       //    principalMoments[i] = 4 * std::sqrt( pm(i,i) );
@@ -232,8 +232,8 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
 
     // Add a final reflection if needed for a proper rotation,
     // by multiplying the last row by the determinant
-    vnl_real_eigensystem                  eigenrot(principalAxes.GetVnlMatrix());
-    vnl_diag_matrix<std::complex<double>> eigenval = eigenrot.D;
+    vnl_real_eigensystem                  eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
+    vnl_diag_matrix<std::complex<double>> eigenval{ eigenrot.D };
     std::complex<double>                  det(1.0, 0.0);
 
     for (unsigned int i = 0; i < ImageDimension; i++)

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -151,16 +151,15 @@ public:
 
     m_Rank = svd.rank();
 
-    VNLVectorType y = m_B.as_vector() - m_A * iP.GetVnlVector();
+    const auto y{ m_B.as_vector() - m_A * iP.GetVnlVector() };
 
     VNLVectorType displacement = svd.solve(y);
-    PointType     oP;
 
+    PointType oP;
     for (unsigned int dim = 0; dim < PointDimension; dim++)
     {
       oP[dim] = iP[dim] + displacement[dim];
     }
-
     return oP;
   }
 

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -969,7 +969,8 @@ MINCImageIO::WriteImageInformation()
     origin[i] = this->GetOrigin(i);
   }
 
-  vnl_matrix<double> inverseDirectionCosines = vnl_matrix_inverse<double>(dircosmatrix);
+  const vnl_matrix<double> inverseDirectionCosines{ static_cast<vnl_matrix<double>>(
+    vnl_matrix_inverse<double>(dircosmatrix)) };
   origin *= inverseDirectionCosines; // transform to minc convention
 
   for (unsigned int i = 0; i < nDims; i++)

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -541,7 +541,8 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
 
   if (!this->GetVirtualOrigin().GetVnlVector().is_equal(field->GetOrigin().GetVnlVector(), coordinateTol) ||
       !this->GetVirtualSpacing().GetVnlVector().is_equal(field->GetSpacing().GetVnlVector(), coordinateTol) ||
-      !this->GetVirtualDirection().GetVnlMatrix().as_ref().is_equal(field->GetDirection().GetVnlMatrix(), directionTol))
+      !this->GetVirtualDirection().GetVnlMatrix().as_ref().is_equal(field->GetDirection().GetVnlMatrix().as_ref(),
+                                                                    directionTol))
   {
     std::ostringstream originString, spacingString, directionString;
     originString << "Virtual Origin: " << this->GetVirtualOrigin()

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -397,17 +397,18 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::ComputeHessianAnd
   }
   else
   {
-    vnl_matrix<TInternalComputationValueType> hessianInverse =
-      vnl_matrix_inverse<TInternalComputationValueType>(newHessian);
     DerivativeType gradient(numLocalPara);
-    DerivativeType newtonStep(numLocalPara);
     for (SizeValueType p = 0; p < numLocalPara; p++)
     {
       gradient[p] = this->m_Gradient[offset + p];
     }
-    // gradient is already negated
-    newtonStep = hessianInverse * gradient;
 
+    const vnl_matrix<TInternalComputationValueType> hessianInverse{
+      static_cast<vnl_matrix<TInternalComputationValueType>>(
+        vnl_matrix_inverse<TInternalComputationValueType>(newHessian))
+    };
+    // gradient is already negated
+    const DerivativeType newtonStep{ hessianInverse * gradient };
     for (SizeValueType p = 0; p < numLocalPara; p++)
     {
       this->m_NewtonStep[offset + p] = newtonStep[p];

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -105,7 +105,7 @@ LevelSetFunction<TImageType>::ComputeMinimalCurvature(const NeighborhoodType & i
   }
 
   // Eigensystem
-  vnl_symmetric_eigensystem<ScalarValueType> eig(Curve);
+  vnl_symmetric_eigensystem<ScalarValueType> eig{ Curve.as_matrix() };
 
   mincurve = itk::Math::abs(eig.get_eigenvalue(ImageDimension - 1));
   for (i = 0; i < ImageDimension; i++)


### PR DESCRIPTION
vxl implicitly casts between various storage types (i.e.
from vnl_vector_fixed to vnl_vector), and many algorithms
are only written to accept vnl_[vector|matrix]<T> types.

Best practice guidelines recommend that single argument constructors
and type cast operations be made `explicit` to avoid
surprising implicit conversions.  Making vxl conform to this
best practice requires explicitly requesting the most
appropriate typecast.

Additionally, reviewing and modifying to future proof
to take advantage of move constructor/assignment by
prefering initialization to assignment.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
