### PR TITLE
OpenCV update

### DIFF
--- a/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
+++ b/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
@@ -109,7 +109,7 @@ OpenCVVideoIO::SetReadFromFile()
 {
   if (!this->m_ReaderOpen && !this->m_WriterOpen)
   {
-    this->m_ReadType = ReadFromFile;
+    this->m_ReadType = ReadType::ReadFromFile;
   }
   else
   {
@@ -122,7 +122,7 @@ OpenCVVideoIO::SetReadFromCamera()
 {
   if (!this->m_ReaderOpen && !this->m_WriterOpen)
   {
-    this->m_ReadType = ReadFromCamera;
+    this->m_ReadType = ReadType::ReadFromCamera;
   }
   else
   {
@@ -199,7 +199,7 @@ OpenCVVideoIO::ReadImageInformation()
   IplImage *  tempImage;
 
   // Open capture from a file
-  if (this->m_ReadType == ReadFromFile)
+  if (this->m_ReadType == ReadType::ReadFromFile)
   {
 
     // Make sure file can be read
@@ -246,7 +246,7 @@ OpenCVVideoIO::ReadImageInformation()
   }
 
   // Open capture from a camera
-  else if (this->m_ReadType == ReadFromCamera)
+  else if (this->m_ReadType == ReadType::ReadFromCamera)
   {
 
     // Open the camera capture
@@ -558,7 +558,7 @@ OpenCVVideoIO::OpenReader()
   }
 
   // If neither reader nor writer is currently open, open the reader
-  if (this->m_ReadType == ReadFromFile)
+  if (this->m_ReadType == ReadType::ReadFromFile)
   {
     this->m_Capture = cvCaptureFromFile(this->GetFileName());
     if (this->m_Capture != nullptr)
@@ -570,7 +570,7 @@ OpenCVVideoIO::OpenReader()
       itkExceptionMacro("Video failed to open");
     }
   }
-  else if (this->m_ReadType == ReadFromCamera)
+  else if (this->m_ReadType == ReadType::ReadFromCamera)
   {
     this->m_Capture = cvCaptureFromCAM(this->m_CameraIndex);
     if (this->m_Capture != nullptr)
@@ -622,7 +622,7 @@ OpenCVVideoIO::ResetMembers()
   this->m_LastIFrame = 0;
 
   // Default to reading from a file
-  this->m_ReadType = ReadFromFile;
+  this->m_ReadType = ReadType::ReadFromFile;
   this->m_CameraIndex = 0;
 
   // Members from ImageIOBase

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
@@ -24,11 +24,15 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkOpenCVVideoIOFactory.h"
 
-#if defined(CV_VERSION_EPOCH)
+#if defined(CV_VERSION_EPOCH) // OpenCV 2.4.x
 #  include "highgui.h"
-#else
-#  include "opencv2/imgcodecs.hpp"           // cv::imread
-#  include "opencv2/imgcodecs/imgcodecs_c.h" // CV_LOAD_IMAGE_COLOR
+#else                              // OpenCV >= 3.x
+#  include "opencv2/imgcodecs.hpp" // cv::imread
+#  if (CV_VERSION_MAJOR == 3)
+#    include "opencv2/imgcodecs/imgcodecs_c.h"        // CV_LOAD_IMAGE_COLOR
+#  else                                               // OpenCV 4.x and later
+#    include "opencv2/imgcodecs/legacy/constants_c.h" // CV_LOAD_IMAGE_COLOR
+#  endif
 #endif
 
 

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -23,14 +23,16 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkOpenCVVideoIOFactory.h"
 
-#if defined(CV_VERSION_EPOCH)
-// OpenCV 2.4.x
+#if defined(CV_VERSION_EPOCH) // OpenCV 2.4.x
 #  include "highgui.h"
-#else
-// OpenCV 3.x
-#  include "opencv2/imgcodecs.hpp"           // cv::imread
-#  include "opencv2/imgcodecs/imgcodecs_c.h" // CV_LOAD_IMAGE_COLOR
-#  include "opencv2/imgproc/types_c.h"       // CV_RGB2BGR
+#else                                  // OpenCV >= 3.x
+#  include "opencv2/imgcodecs.hpp"     // cv::imread
+#  include "opencv2/imgproc/types_c.h" // CV_RGB2BGR
+#  if (CV_VERSION_MAJOR == 3)
+#    include "opencv2/imgcodecs/imgcodecs_c.h"        // CV_LOAD_IMAGE_COLOR
+#  else                                               // OpenCV 4.x and later
+#    include "opencv2/imgcodecs/legacy/constants_c.h" // CV_LOAD_IMAGE_COLOR
+#  endif
 #endif
 
 //-----------------------------------------------------------------------------

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOFactoryTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOFactoryTest.cxx
@@ -58,7 +58,8 @@ test_OpenCVVideoIOFactory(char * input, char * output, SizeValueType cameraNumbe
   // Create the VideoIOBase for reading from a file
   //////
   std::cout << "Trying to create IO for reading from file..." << std::endl;
-  itk::VideoIOBase::Pointer ioReadFile = itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::ReadFileMode, input);
+  itk::VideoIOBase::Pointer ioReadFile =
+    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::ReadFileMode, input);
   if (!ioReadFile)
   {
     std::cerr << "Did not create valid VideoIO for reading from file " << std::endl;
@@ -81,7 +82,7 @@ test_OpenCVVideoIOFactory(char * input, char * output, SizeValueType cameraNumbe
     std::stringstream ss;
     ss << cameraNumber;
     itk::VideoIOBase::Pointer ioReadCamera =
-      itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::ReadCameraMode, ss.str().c_str());
+      itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::ReadCameraMode, ss.str().c_str());
     if (!ioReadCamera)
     {
       std::cerr << "Did not create valid VideoIO for reading from camera" << std::endl;
@@ -93,7 +94,8 @@ test_OpenCVVideoIOFactory(char * input, char * output, SizeValueType cameraNumbe
   // Create the VideoIOBase for writing to a file
   //////
   std::cout << "Trying to create IO for writing to file..." << std::endl;
-  itk::VideoIOBase::Pointer ioWrite = itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::WriteMode, output);
+  itk::VideoIOBase::Pointer ioWrite =
+    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::WriteMode, output);
   if (!ioWrite)
   {
     std::cerr << "Did not create valid VideoIO for writing " << std::endl;


### PR DESCRIPTION
Ref #806.

This makes some progress, but tests still run into two compile errors of type: `error C2039: 'cvLoadImage': is not a member of 'cv'`. It looks like they removed `cvLoadImage` from OpenCV 4.

It would be good if someone more familiar with OpenCV could take over this PR.