### PR TITLE
BUG: Always convert YBR_FULL to RGB

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -41,6 +41,7 @@
 #include "gdcmImageHelper.h"
 #include "gdcmFileExplicitFilter.h"
 #include "gdcmImageChangeTransferSyntax.h"
+#include "gdcmImageChangePhotometricInterpretation.h"
 #include "gdcmDataSetHelper.h"
 #include "gdcmStringFilter.h"
 #include "gdcmImageApplyLookupTable.h"
@@ -300,6 +301,18 @@ GDCMImageIO::Read(void * pointer)
     ialut.Apply();
     image = ialut.GetOutput();
     len *= 3;
+  }
+  else if (pi == gdcm::PhotometricInterpretation::YBR_FULL ||
+           pi == gdcm::PhotometricInterpretation::YBR_FULL_422)
+  {
+    // ITK does not carry color space associated with an image. It is pretty
+    // much assumed that color image is expressed in RGB.
+    gdcm::ImageChangePhotometricInterpretation icpi;
+    icpi.SetInput(image);
+    icpi.SetPhotometricInterpretation( gdcm::PhotometricInterpretation::RGB );
+    icpi.Change();
+    itkWarningMacro(<< "Converting from integer YBR to integer RGB is a lossy operation.");
+    image = icpi.GetOutput();
   }
 
   if (!image.GetBuffer((char *)pointer))


### PR DESCRIPTION
itk::Image do not carry color space information. So convert from YBR_FULL to
RGB, even if it introduce a small loss. Loss is visually imperceptible, should
only impact quantitative analysis.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [ ] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
