### PR TITLE
BUG: Properly handle JPEGBaseline1 DICOM files

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -290,7 +290,10 @@ GDCMImageIO::Read(void * pointer)
     gdcm::ImageChangeTransferSyntax icts;
     icts.SetInput(image);
     icts.SetTransferSyntax( gdcm::TransferSyntax::ImplicitVRLittleEndian );
-    icts.Change();
+    if (!icts.Change())
+    {
+      itkExceptionMacro(<< "Failed to change to Implicit Transfer Syntax");
+    }
     image = icts.GetOutput();
   }
 
@@ -300,7 +303,10 @@ GDCMImageIO::Read(void * pointer)
     gdcm::ImageChangePlanarConfiguration icpc;
     icpc.SetInput(image);
     icpc.SetPlanarConfiguration(0);
-    icpc.Change();
+    if (!icpc.Change())
+    {
+      itkExceptionMacro(<< "Failed to change to Planar Configuration");
+    }
     image = icpc.GetOutput();
   }
 
@@ -320,7 +326,10 @@ GDCMImageIO::Read(void * pointer)
     gdcm::ImageChangePhotometricInterpretation icpi;
     icpi.SetInput(image);
     icpi.SetPhotometricInterpretation( gdcm::PhotometricInterpretation::RGB );
-    icpi.Change();
+    if (!icpi.Change())
+    {
+      itkExceptionMacro(<< "Failed to change to Photometric Interpretation");
+    }
     itkWarningMacro(<< "Converting from integer YBR to integer RGB is a lossy operation.");
     image = icpi.GetOutput();
   }


### PR DESCRIPTION
A bug was introduced in :

c074bc5aba BUG: Always convert YBR_FULL to RGB

The ImageChangePhotometricInterpretation filter is too simple and does not work
on compressed stream. Add an explicit decompression step to make sure
decompression from YBR_FULL_422 to YBR_FULL (JPEGBaseline1) happen in the
background.

Closes #1308.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [ ] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
