### PR TITLE
DOC: Adding migration guide for "vector" filters

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -422,6 +422,33 @@ primary output, as it was a shallow copy of the primary
 input. Additionally, minor API changes have occoured related to the
 decorated output methods to conform to ITK conventions.
 
+Consolidated Vector Filter
+--------------------------
+
+In ITK 5.0 many "vector" specialized filters and functions are
+deprecated. These filters commonly contain a "Vector" prefix to the
+regular filter. "Vector" may refer to an `itk::Image` of
+`itk::Vector` pixel types and/or  an `itk::VectorImage`. Support for
+"vector" images is being consolidated into the regular filters without
+the "Vector" prefix. The follow depricated classes need to be replaced
+as follows:
+
+* `VectorCentralDifferenceImageFunction` -> `CentralDifferenceImageFunction`
+* `VectorExpandImageFilter` -> `ExpandImageFilter`
+* `VectorCastImageFilter` -> `CastImageFilter`
+* `VectorResampleImageFilter` -> `ResampleImageFilter`
+
+Additionally, the following change should be considered:
+
+* `WarpImageFilter` -> `ResampleImageFilter`
+* `WarpVectorImageFilter` -> `ResampleImageFilter`
+
+[This update to the ITK
+Examples](https://github.com/InsightSoftwareConsortium/ITK/commit/b8dbc939ecb086b0e60faf4710657596553f643f)
+is illustrative on how to use the `ResampleImageFilter` is place of a
+warp filter. Note these warp filters are being considered filters for
+deprecation in the future.
+
 
 Python changes
 --------------


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
