### PR TITLE
fixed composite transform writing to MINC .xfm

### DIFF
--- a/Modules/IO/TransformMINC/itk-module.cmake
+++ b/Modules/IO/TransformMINC/itk-module.cmake
@@ -13,6 +13,8 @@ itk_module(ITKIOTransformMINC
   TEST_DEPENDS
     ITKTestKernel
     ITKDisplacementField
+    ITKMINC
+    ITKIOMINC
   FACTORY_NAMES
     TransformIO::MINC
   DESCRIPTION

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -118,7 +118,7 @@ MINCTransformIOTemplate<TParametersValueType>::ReadOneTransform(VIO_General_tran
     }
     case CONCATENATED_TRANSFORM:
     {
-      for (int i = 0; i < get_n_concated_transforms(xfm); ++i)
+      for (int i = get_n_concated_transforms(xfm) - 1; i >= 0; --i)
       {
         this->ReadOneTransform(get_nth_general_transform(xfm, i));
       }
@@ -324,9 +324,9 @@ MINCTransformIOTemplate<TParametersValueType>::Write()
     this->WriteOneTransform(count, (*it).GetPointer(), xfm, xfm_file_base.c_str(), serial);
   }
 
-  VIO_General_transform transform = xfm[0];
+  VIO_General_transform transform = xfm[xfm.size() - 1];
 
-  for (size_t i = 1; i < xfm.size(); ++i)
+  for (int i = xfm.size() - 2; i >= 0; --i)
   {
     VIO_General_transform concated;
     concat_general_transforms(&transform, &xfm[i], &concated);

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -19,18 +19,20 @@
 #include <iostream>
 #include <fstream>
 #include "itkMINCTransformIOFactory.h"
+#include "itkMINCImageIOFactory.h"
 #include "itkTransformFileWriter.h"
 #include "itkTransformFileReader.h"
 #include "itkAffineTransform.h"
 #include "itkTransformFactory.h"
 #include "itksys/SystemTools.hxx"
 #include "itkDisplacementFieldTransform.h"
+#include "itkCompositeTransform.h"
 #include "itkIOTestHelper.h"
 #include "itkMath.h"
 
-
 static constexpr int point_counter = 1000;
-
+using TransformFileReader = itk::TransformFileReaderTemplate<double>;
+using TransformFileWriter = itk::TransformFileWriterTemplate<double>;
 
 template <typename T>
 void
@@ -81,11 +83,11 @@ check_linear(const char * linear_transform)
 
   affine->Scale(4.0);
 
-  itk::TransformFileWriter::Pointer writer;
-  itk::TransformFileReader::Pointer reader;
+  TransformFileWriter::Pointer writer;
+  TransformFileReader::Pointer reader;
 
-  reader = itk::TransformFileReader::New();
-  writer = itk::TransformFileWriter::New();
+  reader = TransformFileReader::New();
+  writer = TransformFileWriter::New();
   writer->AddTransform(affine);
 
   writer->SetFileName(linear_transform);
@@ -110,7 +112,7 @@ check_linear(const char * linear_transform)
 
   try
   {
-    itk::TransformFileReader::TransformListType list = *reader->GetTransformList();
+    TransformFileReader::TransformListType list = *reader->GetTransformList();
 
     if (list.front()->GetTransformTypeAsString() != "AffineTransform_double_3_3")
     {
@@ -212,11 +214,11 @@ check_nonlinear_double(const char * nonlinear_transform)
 
   disp->Print(std::cout);
 
-  itk::TransformFileWriter::Pointer nlwriter;
-  itk::TransformFileReader::Pointer nlreader;
+  TransformFileWriter::Pointer nlwriter;
+  TransformFileReader::Pointer nlreader;
 
-  nlreader = itk::TransformFileReader::New();
-  nlwriter = itk::TransformFileWriter::New();
+  nlreader = TransformFileReader::New();
+  nlwriter = TransformFileWriter::New();
   nlwriter->AddTransform(disp);
   nlwriter->SetFileName(nonlinear_transform);
   nlreader->SetFileName(nonlinear_transform);
@@ -252,7 +254,7 @@ check_nonlinear_double(const char * nonlinear_transform)
   std::cout << "[PASSED]" << std::endl;
 
   std::cout << "Comparing of non linear transform (double) : " << std::endl;
-  itk::TransformFileReader::TransformListType list = *nlreader->GetTransformList();
+  TransformFileReader::TransformListType list = *nlreader->GetTransformList();
   std::cout << "Read :" << list.size() << " transformations" << std::endl;
 
   if (list.front()->GetTransformTypeAsString() != "DisplacementFieldTransform_double_3_3")
@@ -449,14 +451,14 @@ secondTest()
   os << "0 0.5 0.866025447845459 0;" << std::endl;
   fb.close();
 
-  itk::TransformFileReader::Pointer reader;
-  reader = itk::TransformFileReader::New();
+  TransformFileReader::Pointer reader;
+  reader = TransformFileReader::New();
   reader->SetFileName("Rotation.xfm");
 
   reader->Update();
 
-  const itk::TransformFileReader::TransformListType * list = reader->GetTransformList();
-  auto                                                lit = list->begin();
+  const TransformFileReader::TransformListType * list = reader->GetTransformList();
+  auto                                           lit = list->begin();
   while (lit != list->end())
   {
     (*lit)->Print(std::cout);
@@ -465,9 +467,270 @@ secondTest()
   return EXIT_SUCCESS;
 }
 
+
+static int
+check_composite(const char * transform_file)
+{
+  using AffineTransformType = itk::AffineTransform<double, 3>;
+  using CompositeTransformType = itk::CompositeTransform<double, 3>;
+
+  const double tolerance = 1e-5;
+
+  AffineTransformType::Pointer    affine1 = AffineTransformType::New();
+  AffineTransformType::Pointer    affine2 = AffineTransformType::New();
+  CompositeTransformType::Pointer compositeTransform = CompositeTransformType::New();
+
+  itk::ObjectFactoryBase::RegisterFactory(itk::MINCTransformIOFactory::New());
+
+  // Set it's parameters
+  AffineTransformType::OutputVectorType rot_axis;
+  rot_axis[0] = 0.0;
+  rot_axis[1] = 1.0;
+  rot_axis[2] = 0.0;
+  // Set it's parameters
+  affine1->Rotate3D(rot_axis, itk::Math::pi / 6);
+
+  AffineTransformType::OutputVectorType offset;
+
+  offset[0] = 0.0;
+  offset[1] = 0.0;
+  offset[2] = 10.0;
+
+  affine2->Translate(offset);
+
+  compositeTransform->AddTransform(affine1);
+  compositeTransform->AddTransform(affine2);
+
+
+  TransformFileWriter::Pointer writer;
+  TransformFileReader::Pointer reader;
+
+  reader = TransformFileReader::New();
+  writer = TransformFileWriter::New();
+  writer->AddTransform(compositeTransform);
+
+  writer->SetFileName(transform_file);
+  reader->SetFileName(transform_file);
+
+  compositeTransform->Print(std::cout);
+  try
+  {
+    writer->Update();
+    std::cout << std::endl;
+    std::cout << "Testing read : " << std::endl;
+    reader->Update();
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << "Error while saving the transforms" << std::endl;
+    std::cerr << excp << std::endl;
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  try
+  {
+    TransformFileReader::TransformListType list = *reader->GetTransformList();
+
+    // MINC XFM internally collapeses two concatenated linear transforms into one
+    if (list.front()->GetTransformTypeAsString() != "AffineTransform_double_3_3")
+    {
+      std::cerr << "Read back transform of type:" << list.front()->GetTransformTypeAsString() << std::endl;
+      return EXIT_FAILURE;
+    }
+    AffineTransformType::Pointer affine_xfm = static_cast<AffineTransformType *>(list.front().GetPointer());
+
+    std::cout << "Read transform : " << std::endl;
+    affine_xfm->Print(std::cout);
+
+    vnl_random randgen(12345678);
+
+    AffineTransformType::InputPointType pnt, pnt2;
+
+    std::cout << "Testing that transformations are the same ..." << std::endl;
+    for (int i = 0; i < point_counter; i++)
+    {
+      AffineTransformType::OutputPointType v1;
+      AffineTransformType::OutputPointType v2;
+
+      RandomPoint<double>(randgen, pnt, 100);
+      pnt2 = pnt;
+      v1 = compositeTransform->TransformPoint(pnt);
+      v2 = affine_xfm->TransformPoint(pnt2);
+
+      if ((v1 - v2).GetSquaredNorm() > tolerance)
+      {
+        std::cerr << "Original Pixel (" << v1 << ") doesn't match read-in Pixel (" << v2 << " ) "
+                  << " in " << compositeTransform << " at " << pnt << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+    std::cout << " Done !" << std::endl;
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << "Error while reading the transforms" << std::endl;
+    std::cerr << excp << std::endl;
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}
+
+static int
+check_composite2(const char * transform_file, const char * transform_grid_file)
+{
+  const double tolerance = 1e-5;
+
+  std::filebuf fb;
+  fb.open(transform_file, std::ios::out);
+  std::ostream os(&fb);
+  std::cout << "Testing reading of composite transform" << std::endl << std::endl << std::endl << std::endl;
+  // create concatenation of two transforms:
+  // nonlinear grid with shift by 1
+  // rotation by 45 deg
+  os << "MNI Transform File" << std::endl;
+  os << std::endl;
+  os << "Transform_Type = Grid_Transform;" << std::endl;
+  os << "Displacement_Volume = " << transform_grid_file << ";" << std::endl;
+  os << "Transform_Type = Linear;" << std::endl;
+
+  os << "Linear_Transform =" << std::endl;
+  os << " 0.70710676908493 -0.70710676908493 0 0" << std::endl;
+  os << " 0.70710676908493 0.70710676908493 0 0" << std::endl;
+  os << " 0 0 1 0;" << std::endl;
+
+  fb.close();
+
+  try
+  {
+    // generate field
+    using DisplacementFieldTransform = itk::DisplacementFieldTransform<double, 3>;
+    using DisplacementFieldType = DisplacementFieldTransform::DisplacementFieldType;
+
+    DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+
+    // create zero displacement field
+    DisplacementFieldType::SizeType  imageSize3D = { { 10, 10, 10 } };
+    DisplacementFieldType::IndexType startIndex3D = { { 0, 0, 0 } };
+
+    double                            spacing[] = { 2.0, 2.0, 2.0 };
+    double                            origin[] = { -10.0, -10.0, -10.0 };
+    DisplacementFieldType::RegionType region;
+
+    region.SetSize(imageSize3D);
+    region.SetIndex(startIndex3D);
+
+    field->SetLargestPossibleRegion(region);
+    field->SetBufferedRegion(region);
+    field->SetRequestedRegion(region);
+
+    field->SetSpacing(spacing);
+    field->SetOrigin(origin);
+    field->Allocate();
+
+    DisplacementFieldType::PixelType displacement;
+    displacement.Fill(0.0);
+    displacement[0] = 1.0;
+    field->FillBuffer(displacement);
+
+    using MincWriterType = itk::ImageFileWriter<DisplacementFieldType>;
+
+    typename MincWriterType::Pointer writer = MincWriterType::New();
+    // expecting .mnc here
+    writer->SetFileName(transform_grid_file);
+
+    writer->SetInput(field);
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << "Error while writing the deformation field" << std::endl;
+    std::cerr << excp << std::endl;
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+
+  try
+  {
+    TransformFileReader::Pointer reader;
+    using CompositeTransformType = itk::CompositeTransform<double, 3>;
+
+    reader = TransformFileReader::New();
+    reader->SetFileName(transform_file);
+    reader->Update();
+
+    const TransformFileReader::TransformListType * list = reader->GetTransformList();
+
+    if (list->size() != 2)
+    {
+      std::cerr << "Unexpected number of transforms:" << list->size() << std::endl;
+      std::cerr << "Expected:2" << std::endl;
+      std::cout << "[FAILED]" << std::endl;
+      return EXIT_FAILURE;
+    }
+    std::cout << "Reading back transforms : " << list->size() << std::endl << std::endl;
+
+    using CompositeTransformType = itk::CompositeTransform<double, 3>;
+    using TransformType = itk::Transform<double, 3>;
+
+    CompositeTransformType::Pointer _xfm = CompositeTransformType::New();
+    for (auto it = list->begin(); it != list->end(); ++it)
+    {
+      (*it)->Print(std::cout);
+      std::cout << std::endl;
+      _xfm->AddTransform(static_cast<TransformType *>((*it).GetPointer()));
+    }
+    std::cout << std::endl;
+    std::cout << std::endl;
+    std::cout << std::endl;
+
+    _xfm->Print(std::cout);
+
+    std::cout << "Testing that transformations is expected ..." << std::endl;
+
+    CompositeTransformType::InputPointType  pnt;
+    CompositeTransformType::OutputPointType v, v2;
+
+    pnt[0] = 1.0;
+    pnt[1] = pnt[2] = 0.0;
+    // expected transform: shift by 1 , rotate by 45 deg
+    v2[0] = v[1] = sqrt(2);
+    v2[2] = 0.0;
+
+    v = _xfm->TransformPoint(pnt);
+
+    std::cout << "In:" << pnt << " Out:" << v << std::endl;
+    if ((v - v2).GetSquaredNorm() > tolerance)
+    {
+      std::cerr << "Expected coordinates (" << v << ") doesn't match read-in coordinates (" << v2 << " ) "
+                << " in " << _xfm << " at " << pnt << std::endl;
+      return EXIT_FAILURE;
+    }
+
+
+    std::cout << " Done !" << std::endl;
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << "Error while reading the transforms" << std::endl;
+    std::cerr << excp << std::endl;
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}
+
+
 int
 itkIOTransformMINCTest(int argc, char * argv[])
 {
+  itk::ObjectFactoryBase::RegisterFactory(itk::MINCImageIOFactory::New(),
+                                          itk::ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT);
+
   if (argc > 1)
   {
     itksys::SystemTools::ChangeDirectory(argv[1]);
@@ -479,6 +742,10 @@ itkIOTransformMINCTest(int argc, char * argv[])
   int result2 = check_nonlinear_double("itkIOTransformMINCTestTransformNonLinear.xfm");
   int result3 = check_nonlinear_float("itkIOTransformMINCTestTransformNonLinear_float.xfm");
   int result4 = secondTest();
+  int result5 = check_composite("itkIOTransformMINCTestTransformComposite.xfm");
+  int result6 = check_composite2("itkIOTransformMINCTestTransformComposite2.xfm",
+                                 "itkIOTransformMINCTestTransformComposite2_grid_0.mnc");
 
-  return !(result1 == EXIT_SUCCESS && result2 == EXIT_SUCCESS && result3 == EXIT_SUCCESS && result4 == EXIT_SUCCESS);
+  return !(result1 == EXIT_SUCCESS && result2 == EXIT_SUCCESS && result3 == EXIT_SUCCESS && result4 == EXIT_SUCCESS &&
+           result5 == EXIT_SUCCESS && result6 == EXIT_SUCCESS);
 }


### PR DESCRIPTION
BUG: fixed composite transform writing to MINC .xfm

I noticed that composite transform and MINC transform API actually have different order of representing concatenated transformations. 

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
