### PR TITLE
ENH: add IsPositive() and friends to RGB's and RGBA's NumericTraits

### DIFF
--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -142,6 +142,34 @@ public:
     return OneValue();
   }
 
+  /** Is a given value positive? */
+  static bool
+  IsPositive(Self val)
+  {
+    return NumericTraits<typename Self::LuminanceType>::IsPositive(val.GetLuminance());
+  }
+
+  /** Is a given value nonpositive? */
+  static bool
+  IsNonpositive(Self val)
+  {
+    return NumericTraits<typename Self::LuminanceType>::IsNonpositive(val.GetLuminance());
+  }
+
+  /** Is a given value negative? */
+  static bool
+  IsNegative(Self val)
+  {
+    return NumericTraits<typename Self::LuminanceType>::IsNegative(val.GetLuminance());
+  }
+
+  /** Is a given value nonnegative? */
+  static bool
+  IsNonnegative(Self val)
+  {
+    return NumericTraits<typename Self::LuminanceType>::IsNonnegative(val.GetLuminance());
+  }
+
   static constexpr bool IsSigned = NumericTraits<ValueType>::IsSigned;
   static constexpr bool IsInteger = NumericTraits<ValueType>::IsInteger;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -142,6 +142,34 @@ public:
     return OneValue();
   }
 
+  /** Is a given value positive? */
+  static bool
+  IsPositive(Self val)
+  {
+    return NumericTraits<typename Self::LuminanceType>::IsPositive(val.GetLuminance());
+  }
+
+  /** Is a given value nonpositive? */
+  static bool
+  IsNonpositive(Self val)
+  {
+    return NumericTraits<typename Self::LuminanceType>::IsNonpositive(val.GetLuminance());
+  }
+
+  /** Is a given value negative? */
+  static bool
+  IsNegative(Self val)
+  {
+    return NumericTraits<typename Self::LuminanceType>::IsNegative(val.GetLuminance());
+  }
+
+  /** Is a given value nonnegative? */
+  static bool
+  IsNonnegative(Self val)
+  {
+    return NumericTraits<typename Self::LuminanceType>::IsNonnegative(val.GetLuminance());
+  }
+
   static constexpr bool IsSigned = NumericTraits<ValueType>::IsSigned;
   static constexpr bool IsInteger = NumericTraits<ValueType>::IsInteger;
   static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
