### PR TITLE
STYLE: For a const image, iterator and const_iterator should be the same

### DIFF
--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -637,7 +637,7 @@ private:
 
 public:
   using const_iterator = QualifiedIterator<true>;
-  using iterator = QualifiedIterator<false>;
+  using iterator = QualifiedIterator<IsImageTypeConst>;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -70,6 +70,26 @@ static_assert(!DoesImageRegionRangeIteratorDereferenceOperatorReturnReference<co
               "ImageRegionRange::iterator::operator*() should not return a reference for a 'const' itk::VectorImage.");
 
 
+// Tells whether or not ImageRegionRange<TImage>::iterator is the same type
+// as ImageRegionRange<TImage>::const_iterator.
+template <typename TImage>
+constexpr bool
+IsIteratorTypeTheSameAsConstIteratorType()
+{
+  using RangeType = ImageRegionRange<TImage>;
+
+  return std::is_same<typename RangeType::iterator, typename RangeType::const_iterator>::value;
+}
+
+
+static_assert(!IsIteratorTypeTheSameAsConstIteratorType<itk::Image<int>>() &&
+                !IsIteratorTypeTheSameAsConstIteratorType<itk::VectorImage<int>>(),
+              "For a non-const image, non-const iterator and const_iterator should be different types!");
+static_assert(IsIteratorTypeTheSameAsConstIteratorType<const itk::Image<int>>() &&
+                IsIteratorTypeTheSameAsConstIteratorType<const itk::VectorImage<int>>(),
+              "For a const image, non-const iterator and const_iterator should be the same type!");
+
+
 template <typename TImage>
 typename TImage::Pointer
 CreateImage(const unsigned sizeX, const unsigned sizeY)

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -59,6 +59,26 @@ CreateImage(const unsigned sizeX, const unsigned sizeY)
 }
 
 
+// Tells whether or not ShapedImageNeighborhoodRange<TImage>::iterator is the same type
+// as ShapedImageNeighborhoodRange<TImage>::const_iterator.
+template <typename TImage>
+constexpr bool
+IsIteratorTypeTheSameAsConstIteratorType()
+{
+  using RangeType = ShapedImageNeighborhoodRange<TImage>;
+
+  return std::is_same<typename RangeType::iterator, typename RangeType::const_iterator>::value;
+}
+
+
+static_assert(!IsIteratorTypeTheSameAsConstIteratorType<itk::Image<int>>() &&
+                !IsIteratorTypeTheSameAsConstIteratorType<itk::VectorImage<int>>(),
+              "For a non-const image, non-const iterator and const_iterator should be different types!");
+static_assert(IsIteratorTypeTheSameAsConstIteratorType<const itk::Image<int>>() &&
+                IsIteratorTypeTheSameAsConstIteratorType<const itk::VectorImage<int>>(),
+              "For a const image, non-const iterator and const_iterator should be the same type!");
+
+
 // Creates a test image, filled with a sequence of natural numbers, 1, 2, 3, ..., N.
 template <typename TImage>
 typename TImage::Pointer


### PR DESCRIPTION
Ensured that `RangeType::iterator` and `RangeType::const_iterator` are
the same type, when the range is declared to iterate over a `const`
image:

 - Added compile-time tests to `ImageRegionRange` and
   `ShapedImageNeighborhoodRange`
 - Adjusting `ShapedImageNeighborhoodRange::iterator` accordingly.

Note that `ImageBufferRange` was already OK.

This commit aims to improve consistency between ITK image range types.