### PR TITLE
WIP: STYLE: Move ITK5 ranges, shapes, policies out of Experimental namespace

### DIFF
--- a/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
@@ -38,8 +38,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /**
  * \class ConnectedImageNeighborhoodShape
@@ -299,7 +297,15 @@ GenerateConnectedImageNeighborhoodShapeOffsets() ITK_NOEXCEPT
   return offsets;
 }
 
+
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::ConnectedImageNeighborhoodShape;
+using ::itk::GenerateConnectedImageNeighborhoodShapeOffsets;
 } // namespace Experimental
+#endif // ITK_LEGACY_REMOVE
+
 } // namespace itk
 
 #undef ITK_X_ASSERT

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -334,7 +334,7 @@ public:
   }
 
   /** Activates a whole range of offsets, for example, an std::vector<OffsetType>,
-   * which could be from Experimental::GenerateImageNeighborhoodOffsets(shape). */
+   * which could be from GenerateImageNeighborhoodOffsets(shape). */
   template <typename TOffsets>
   void
   ActivateOffsets(const TOffsets & offsets)

--- a/Modules/Core/Common/include/itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h
@@ -25,8 +25,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /**
  * \class ConstantBoundaryImageNeighborhoodPixelAccessPolicy
@@ -148,7 +146,14 @@ public:
   }
 };
 
-} // namespace Experimental
+
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy;
+}
+#endif // ITK_LEGACY_REMOVE
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -34,8 +34,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /**
  * \class ImageBufferRange
@@ -686,7 +684,14 @@ MakeImageBufferRange(TImage * const image)
   }
 }
 
-} // namespace Experimental
-} // namespace itk
 
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::ImageBufferRange;
+using ::itk::MakeImageBufferRange;
+} // namespace Experimental
+#endif // ITK_LEGACY_REMOVE
+
+} // namespace itk
 #endif

--- a/Modules/Core/Common/include/itkImageNeighborhoodOffsets.h
+++ b/Modules/Core/Common/include/itkImageNeighborhoodOffsets.h
@@ -24,8 +24,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /** Generates the offsets for a neighborhood of the specified shape. */
 template <typename TImageNeighborhoodShape>
@@ -47,7 +45,14 @@ GenerateRectangularImageNeighborhoodOffsets(const Size<VImageDimension> & radius
   return GenerateImageNeighborhoodOffsets(shape);
 }
 
-} // namespace Experimental
-} // namespace itk
 
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::GenerateImageNeighborhoodOffsets;
+using ::itk::GenerateRectangularImageNeighborhoodOffsets;
+} // namespace Experimental
+#endif // ITK_LEGACY_REMOVE
+
+} // namespace itk
 #endif

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -33,8 +33,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /**
  * \class ImageRegionRange
@@ -463,7 +461,14 @@ public:
   ~ImageRegionRange() = default;
 };
 
-} // namespace Experimental
+
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::ImageRegionRange;
+}
+#endif // ITK_LEGACY_REMOVE
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -30,8 +30,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /**
   * \class IndexRange
@@ -455,7 +453,16 @@ using ImageRegionIndexRange = IndexRange<VDimension, false>;
 template <unsigned VDimension>
 using ZeroBasedIndexRange = IndexRange<VDimension, true>;
 
+
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::IndexRange;
+using ::itk::ImageRegionIndexRange;
+using ::itk::ZeroBasedIndexRange;
 } // namespace Experimental
+#endif // ITK_LEGACY_REMOVE
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkRectangularImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkRectangularImageNeighborhoodShape.h
@@ -27,8 +27,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /**
  * \class RectangularImageNeighborhoodShape
@@ -124,7 +122,14 @@ private:
   }
 };
 
-} // namespace Experimental
+
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::RectangularImageNeighborhoodShape;
+}
+#endif // ITK_LEGACY_REMOVE
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -32,8 +32,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /**
  * \class ShapedImageNeighborhoodRange
@@ -809,7 +807,13 @@ public:
 };
 
 
-} // namespace Experimental
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::ShapedImageNeighborhoodRange;
+}
+#endif // ITK_LEGACY_REMOVE
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkZeroFluxNeumannImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannImageNeighborhoodPixelAccessPolicy.h
@@ -25,8 +25,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 
 /**
  * \class ZeroFluxNeumannImageNeighborhoodPixelAccessPolicy
@@ -128,7 +126,14 @@ public:
   }
 };
 
-} // namespace Experimental
+
+#if !defined(ITK_LEGACY_REMOVE)
+namespace Experimental // For ITK 5.0 legacy support
+{
+using ::itk::ZeroFluxNeumannImageNeighborhoodPixelAccessPolicy;
+}
+#endif // ITK_LEGACY_REMOVE
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
+++ b/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
@@ -41,7 +41,7 @@ template <unsigned int VImageDimension,
 void
 Assert_GetNumberOfOffsets_returns_expected_number()
 {
-  using ShapeType = itk::Experimental::ConnectedImageNeighborhoodShape<VImageDimension>;
+  using ShapeType = itk::ConnectedImageNeighborhoodShape<VImageDimension>;
 
   // Test GetNumberOfOffsets() on a 'constexpr shape', at compile-time:
   constexpr ShapeType constexprShape(VMaximumCityblockDistance, VIncludeCenterPixel);
@@ -80,7 +80,7 @@ void
 Assert_GenerateImageNeighborhoodOffsets_returns_expected_offsets_excluding_center_pixel(
   const std::vector<itk::Offset<VImageDimension>> & expectedOffsets)
 {
-  using ShapeType = itk::Experimental::ConnectedImageNeighborhoodShape<VImageDimension>;
+  using ShapeType = itk::ConnectedImageNeighborhoodShape<VImageDimension>;
 
   const bool      includeCenterPixel = false;
   const ShapeType shape{ VMaximumCityblockDistance, includeCenterPixel };
@@ -93,7 +93,7 @@ template <unsigned int VImageDimension>
 void
 Assert_The_middle_offset_is_all_zero_when_center_pixel_is_included()
 {
-  using ShapeType = itk::Experimental::ConnectedImageNeighborhoodShape<VImageDimension>;
+  using ShapeType = itk::ConnectedImageNeighborhoodShape<VImageDimension>;
   using OffsetType = itk::Offset<VImageDimension>;
 
   const bool       includeCenterPixel = true;
@@ -119,7 +119,7 @@ template <unsigned int VImageDimension>
 void
 Assert_Offsets_are_unique_and_colexicographically_ordered()
 {
-  using ShapeType = itk::Experimental::ConnectedImageNeighborhoodShape<VImageDimension>;
+  using ShapeType = itk::ConnectedImageNeighborhoodShape<VImageDimension>;
   using OffsetType = itk::Offset<VImageDimension>;
 
   for (unsigned int maximumCityblockDistance = 0; maximumCityblockDistance < VImageDimension;
@@ -292,8 +292,7 @@ TEST(ConnectedImageNeighborhoodShape, SupportsConstShapedNeighborhoodIterator)
   constexpr bool        includeCenterPixel = false;
 
   shapedNeighborhoodIterator.ActivateOffsets(
-    itk::Experimental::
-      GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, cityBlockDistance, includeCenterPixel>());
+    itk::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, cityBlockDistance, includeCenterPixel>());
 
   ASSERT_EQ(shapedNeighborhoodIterator.GetActiveIndexList(), activeIndexList);
 }

--- a/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
@@ -29,13 +29,13 @@
 #include <gtest/gtest.h>
 
 // Test template instantiations for various template arguments:
-template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 1>>;
-template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 2>>;
-template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 3>>;
-template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 4>>;
-template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const itk::Image<short>>;
-template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::VectorImage<short>>;
-template class itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const itk::VectorImage<short>>;
+template class itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 1>>;
+template class itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 2>>;
+template class itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 3>>;
+template class itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::Image<short, 4>>;
+template class itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const itk::Image<short>>;
+template class itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<itk::VectorImage<short>>;
+template class itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const itk::VectorImage<short>>;
 
 namespace
 {
@@ -78,9 +78,8 @@ TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsZeroOutsideImageB
 {
   using PixelType = int;
   using ImageType = itk::Image<PixelType>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<
-    ImageType,
-    itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<ImageType>>;
+  using RangeType =
+    itk::ShapedImageNeighborhoodRange<ImageType, itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<ImageType>>;
 
   enum
   {
@@ -93,7 +92,7 @@ TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsZeroOutsideImageB
   const ImageType::IndexType                                locationOutsideImage{ { -1, -1 } };
   const itk::Size<ImageType::ImageDimension>                radius = { {} };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   const RangeType range{ *image, locationOutsideImage, offsets };
 
   for (const PixelType pixel : range)
@@ -109,9 +108,8 @@ TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsSpecifiedConstant
 {
   using PixelType = int;
   using ImageType = itk::Image<PixelType>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<
-    ImageType,
-    itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<ImageType>>;
+  using RangeType =
+    itk::ShapedImageNeighborhoodRange<ImageType, itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<ImageType>>;
 
   enum
   {
@@ -124,7 +122,7 @@ TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsSpecifiedConstant
   const ImageType::IndexType                                locationOutsideImage{ { -1, -1 } };
   const itk::Size<ImageType::ImageDimension>                radius = { {} };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   const auto numberOfExpectedNeighbors = offsets.size();
 
   for (PixelType constantValue = -1; constantValue <= 2; ++constantValue)
@@ -154,9 +152,9 @@ TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsSameValuesAsConst
 {
   using PixelType = int;
   using ImageType = itk::Image<PixelType>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<
-    ImageType,
-    itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const ImageType>>;
+  using RangeType =
+    itk::ShapedImageNeighborhoodRange<ImageType,
+                                      itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<const ImageType>>;
 
   enum
   {
@@ -168,7 +166,7 @@ TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsSameValuesAsConst
   const ImageType::IndexType                                location{ {} };
   const itk::Size<ImageType::ImageDimension>                radius = { { 1, 2 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
 
   for (PixelType constantValue = -1; constantValue <= 2; ++constantValue)
   {

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -30,17 +30,17 @@
 #include <type_traits> // For std::is_reference.
 
 // Test template instantiations for various ImageDimension values, and const Image:
-template class itk::Experimental::ImageBufferRange<itk::Image<short, 1>>;
-template class itk::Experimental::ImageBufferRange<itk::Image<short, 2>>;
-template class itk::Experimental::ImageBufferRange<itk::Image<short, 3>>;
-template class itk::Experimental::ImageBufferRange<itk::Image<short, 4>>;
-template class itk::Experimental::ImageBufferRange<const itk::Image<short>>;
-template class itk::Experimental::ImageBufferRange<itk::VectorImage<short>>;
-template class itk::Experimental::ImageBufferRange<const itk::VectorImage<short, 4>>;
+template class itk::ImageBufferRange<itk::Image<short, 1>>;
+template class itk::ImageBufferRange<itk::Image<short, 2>>;
+template class itk::ImageBufferRange<itk::Image<short, 3>>;
+template class itk::ImageBufferRange<itk::Image<short, 4>>;
+template class itk::ImageBufferRange<const itk::Image<short>>;
+template class itk::ImageBufferRange<itk::VectorImage<short>>;
+template class itk::ImageBufferRange<const itk::VectorImage<short, 4>>;
 
-using itk::Experimental::ImageBufferRange;
-using itk::Experimental::MakeImageBufferRange;
-using itk::Experimental::RangeGTestUtilities;
+using itk::ImageBufferRange;
+using itk::MakeImageBufferRange;
+using itk::RangeGTestUtilities;
 
 
 namespace

--- a/Modules/Core/Common/test/itkImageNeighborhoodOffsetsGTest.cxx
+++ b/Modules/Core/Common/test/itkImageNeighborhoodOffsetsGTest.cxx
@@ -60,7 +60,7 @@ TEST(ImageNeighborhoodOffsets, GenerateImageNeighborhoodOffsetsReturnsEmptyVecto
 {
   constexpr unsigned int                            ImageDimension = 2;
   const EmptyImageNeighborhoodShape<ImageDimension> shape = {};
-  const std::vector<itk::Offset<>> offsets = itk::Experimental::GenerateImageNeighborhoodOffsets(shape);
+  const std::vector<itk::Offset<>>                  offsets = itk::GenerateImageNeighborhoodOffsets(shape);
 
   EXPECT_EQ(offsets, std::vector<itk::Offset<>>());
 }
@@ -69,7 +69,7 @@ TEST(ImageNeighborhoodOffsets, GenerateImageNeighborhoodOffsetsReturnsEmptyVecto
 TEST(ImageNeighborhoodOffsets, GenerateRectangularImageNeighborhoodOffsetsReturnsOneOffsetForDefaultRadius)
 {
   const itk::Size<>                radius = { {} };
-  const std::vector<itk::Offset<>> offsets = itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+  const std::vector<itk::Offset<>> offsets = itk::GenerateRectangularImageNeighborhoodOffsets(radius);
 
   EXPECT_EQ(offsets, std::vector<itk::Offset<>>(1));
 }
@@ -78,7 +78,7 @@ TEST(ImageNeighborhoodOffsets, GenerateRectangularImageNeighborhoodOffsetsReturn
 TEST(ImageNeighborhoodOffsets, GenerateRectangularImageNeighborhoodOffsetsForSmallestHorizontalNeigborhood)
 {
   const itk::Size<>                radius = { { 1, 0 } };
-  const std::vector<itk::Offset<>> offsets = itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+  const std::vector<itk::Offset<>> offsets = itk::GenerateRectangularImageNeighborhoodOffsets(radius);
 
   EXPECT_EQ(offsets, (std::vector<itk::Offset<>>{ { { -1, 0 } }, { { 0, 0 } }, { { 1, 0 } } }));
 }
@@ -87,7 +87,7 @@ TEST(ImageNeighborhoodOffsets, GenerateRectangularImageNeighborhoodOffsetsForSma
 TEST(ImageNeighborhoodOffsets, GenerateRectangularImageNeighborhoodOffsetsForSmallestVerticalNeigborhood)
 {
   const itk::Size<>                radius = { { 0, 1 } };
-  const std::vector<itk::Offset<>> offsets = itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+  const std::vector<itk::Offset<>> offsets = itk::GenerateRectangularImageNeighborhoodOffsets(radius);
 
   EXPECT_EQ(offsets, (std::vector<itk::Offset<>>{ { { 0, -1 } }, { { 0, 0 } }, { { 0, 1 } } }));
 }

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -33,17 +33,17 @@
 #include <type_traits> // For std::is_reference.
 
 // Test template instantiations for various ImageDimension values, and const Image:
-template class itk::Experimental::ImageRegionRange<itk::Image<short, 1>>;
-template class itk::Experimental::ImageRegionRange<itk::Image<short, 2>>;
-template class itk::Experimental::ImageRegionRange<itk::Image<short, 3>>;
-template class itk::Experimental::ImageRegionRange<itk::Image<short, 4>>;
-template class itk::Experimental::ImageRegionRange<const itk::Image<short>>;
-template class itk::Experimental::ImageRegionRange<itk::VectorImage<short>>;
-template class itk::Experimental::ImageRegionRange<const itk::VectorImage<short>>;
-template class itk::Experimental::ImageRegionRange<itk::Image<itk::RGBPixel<std::uint8_t>>>;
-template class itk::Experimental::ImageRegionRange<itk::Image<itk::Vector<long, 11>>>;
+template class itk::ImageRegionRange<itk::Image<short, 1>>;
+template class itk::ImageRegionRange<itk::Image<short, 2>>;
+template class itk::ImageRegionRange<itk::Image<short, 3>>;
+template class itk::ImageRegionRange<itk::Image<short, 4>>;
+template class itk::ImageRegionRange<const itk::Image<short>>;
+template class itk::ImageRegionRange<itk::VectorImage<short>>;
+template class itk::ImageRegionRange<const itk::VectorImage<short>>;
+template class itk::ImageRegionRange<itk::Image<itk::RGBPixel<std::uint8_t>>>;
+template class itk::ImageRegionRange<itk::Image<itk::Vector<long, 11>>>;
 
-using itk::Experimental::ImageRegionRange;
+using itk::ImageRegionRange;
 
 
 namespace
@@ -108,8 +108,8 @@ typename TImage::Pointer
 CreateImageFilledWithSequenceOfNaturalNumbers(const unsigned sizeX, const unsigned sizeY)
 {
   using PixelType = typename TImage::PixelType;
-  const auto                                        image = CreateImage<TImage>(sizeX, sizeY);
-  const itk::Experimental::ImageBufferRange<TImage> imageBufferRange{ *image };
+  const auto                          image = CreateImage<TImage>(sizeX, sizeY);
+  const itk::ImageBufferRange<TImage> imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
   return image;
 }
@@ -599,7 +599,7 @@ TEST(ImageRegionRange, IteratesForwardOverSamePixelsAsImageRegionIterator)
   const auto image = ImageType::New();
   image->SetRegions(RegionType{ IndexType{ { -1, -2 } }, SizeType{ { 9, 11 } } });
   image->Allocate();
-  const itk::Experimental::ImageBufferRange<ImageType> imageBufferRange{ *image };
+  const itk::ImageBufferRange<ImageType> imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
 
   Expect_ImageRegionRange_iterates_forward_over_same_pixels_as_ImageRegionIterator(
@@ -619,7 +619,7 @@ TEST(ImageRegionRange, IteratesBackwardOverSamePixelsAsImageRegionIterator)
   const auto image = ImageType::New();
   image->SetRegions(RegionType{ IndexType{ { -1, -2 } }, SizeType{ { 9, 11 } } });
   image->Allocate();
-  const itk::Experimental::ImageBufferRange<ImageType> imageBufferRange{ *image };
+  const itk::ImageBufferRange<ImageType> imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
 
   Expect_ImageRegionRange_iterates_backward_over_same_pixels_as_ImageRegionIterator(

--- a/Modules/Core/Common/test/itkIndexRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexRangeGTest.cxx
@@ -24,16 +24,16 @@
 #include <gtest/gtest.h>
 
 // Test template instantiations for various template arguments:
-template class itk::Experimental::IndexRange<1, true>;
-template class itk::Experimental::IndexRange<1, false>;
-template class itk::Experimental::IndexRange<2, true>;
-template class itk::Experimental::IndexRange<2, false>;
+template class itk::IndexRange<1, true>;
+template class itk::IndexRange<1, false>;
+template class itk::IndexRange<2, true>;
+template class itk::IndexRange<2, false>;
 
 
-using itk::Experimental::IndexRange;
-using itk::Experimental::ImageRegionIndexRange;
-using itk::Experimental::ZeroBasedIndexRange;
-using itk::Experimental::RangeGTestUtilities;
+using itk::IndexRange;
+using itk::ImageRegionIndexRange;
+using itk::ZeroBasedIndexRange;
+using itk::RangeGTestUtilities;
 
 
 static_assert(sizeof(ZeroBasedIndexRange<3>) < sizeof(ImageRegionIndexRange<3>),

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -26,8 +26,6 @@
 
 namespace itk
 {
-namespace Experimental
-{
 // Utilities for GoogleTest unit tests of iterator ranges.
 // Note: This class is only for internal (testing) purposes.
 // It is not part of the public API of ITK.
@@ -115,7 +113,6 @@ private:
   }
 };
 
-} // end namespace Experimental
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -34,16 +34,16 @@
 #include <numeric> // For std::inner_product
 
 // Test template instantiations for various ImageDimenion values, and const Image:
-template class itk::Experimental::ShapedImageNeighborhoodRange<itk::Image<short, 1>>;
-template class itk::Experimental::ShapedImageNeighborhoodRange<itk::Image<short, 2>>;
-template class itk::Experimental::ShapedImageNeighborhoodRange<itk::Image<short, 3>>;
-template class itk::Experimental::ShapedImageNeighborhoodRange<itk::Image<short, 4>>;
-template class itk::Experimental::ShapedImageNeighborhoodRange<const itk::Image<short>>;
-template class itk::Experimental::ShapedImageNeighborhoodRange<itk::VectorImage<short>>;
-template class itk::Experimental::ShapedImageNeighborhoodRange<const itk::VectorImage<short>>;
+template class itk::ShapedImageNeighborhoodRange<itk::Image<short, 1>>;
+template class itk::ShapedImageNeighborhoodRange<itk::Image<short, 2>>;
+template class itk::ShapedImageNeighborhoodRange<itk::Image<short, 3>>;
+template class itk::ShapedImageNeighborhoodRange<itk::Image<short, 4>>;
+template class itk::ShapedImageNeighborhoodRange<const itk::Image<short>>;
+template class itk::ShapedImageNeighborhoodRange<itk::VectorImage<short>>;
+template class itk::ShapedImageNeighborhoodRange<const itk::VectorImage<short>>;
 
-using itk::Experimental::ShapedImageNeighborhoodRange;
-using itk::Experimental::RangeGTestUtilities;
+using itk::ShapedImageNeighborhoodRange;
+using itk::RangeGTestUtilities;
 
 namespace
 {
@@ -168,7 +168,7 @@ ExpectRangeIsNotEmptyForNonEmptyImageAndShapeOffsetContainer()
   // Then create a non-empty vector of shape offsets:
   const itk::Size<TImage::ImageDimension>                radius{ { 1 } };
   const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
 
   // Sanity check: the container of shape offset is expected to be non-empty.
   EXPECT_FALSE(shapeOffsets.empty());
@@ -186,7 +186,7 @@ ExpectCopyConstructedRangeHasSameIteratorsAsOriginal()
   const auto                                             image = CreateSmallImage<TImage>();
   const itk::Size<TImage::ImageDimension>                radius{ { 1 } };
   const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   const typename TImage::IndexType           location{ {} };
   const ShapedImageNeighborhoodRange<TImage> originalRange{ *image, location, shapeOffsets };
 
@@ -201,7 +201,7 @@ ExpectCopyAssignedRangeHasSameIteratorsAsOriginal()
   const auto                                             image = CreateSmallImage<TImage>();
   const itk::Size<TImage::ImageDimension>                radius{ { 1 } };
   const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   const typename TImage::IndexType           location{ {} };
   const ShapedImageNeighborhoodRange<TImage> originalRange{ *image, location, shapeOffsets };
 
@@ -216,7 +216,7 @@ ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove()
   const auto                                             image = CreateSmallImage<TImage>();
   const itk::Size<TImage::ImageDimension>                radius{ { 1 } };
   const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   const typename TImage::IndexType location{ {} };
 
   RangeGTestUtilities::ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove(
@@ -231,7 +231,7 @@ ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove()
   const auto                                             image = CreateSmallImage<TImage>();
   const itk::Size<TImage::ImageDimension>                radius{ { 1 } };
   const std::vector<itk::Offset<TImage::ImageDimension>> shapeOffsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   const typename TImage::IndexType location{ {} };
 
   RangeGTestUtilities::ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove(
@@ -252,13 +252,13 @@ TEST(ShapedImageNeighborhoodRange, EquivalentBeginOrEndIteratorsCompareEqual)
   const itk::Size<ImageType::ImageDimension>                radius{ {} };
   const ImageType::IndexType                                location{ {} };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
-  const itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::iterator       begin = range.begin();
-  const itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::iterator       end = range.end();
-  const itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::const_iterator cbegin = range.cbegin();
-  const itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::const_iterator cend = range.cend();
+  const itk::ShapedImageNeighborhoodRange<ImageType>::iterator       begin = range.begin();
+  const itk::ShapedImageNeighborhoodRange<ImageType>::iterator       end = range.end();
+  const itk::ShapedImageNeighborhoodRange<ImageType>::const_iterator cbegin = range.cbegin();
+  const itk::ShapedImageNeighborhoodRange<ImageType>::const_iterator cend = range.cend();
 
   // An iterator object compares equal to itself:
   EXPECT_EQ(begin, begin);
@@ -290,8 +290,8 @@ TEST(ShapedImageNeighborhoodRange, BeginAndEndDoNotCompareEqual)
   const itk::Size<ImageType::ImageDimension>                radius{ {} };
   const ImageType::IndexType                                location{ {} };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
   EXPECT_FALSE(range.begin() == range.end());
   EXPECT_NE(range.begin(), range.end());
@@ -308,15 +308,14 @@ TEST(ShapedImageNeighborhoodRange, IteratorConvertsToConstIterator)
   const itk::Size<ImageType::ImageDimension>                radius{ {} };
   const ImageType::IndexType                                location{ {} };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
-  const itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::iterator       begin = range.begin();
-  const itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::const_iterator const_begin_from_begin = begin;
+  const itk::ShapedImageNeighborhoodRange<ImageType>::iterator       begin = range.begin();
+  const itk::ShapedImageNeighborhoodRange<ImageType>::const_iterator const_begin_from_begin = begin;
   EXPECT_EQ(const_begin_from_begin, begin);
 
-  const itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::const_iterator const_begin_from_range_begin =
-    range.begin();
+  const itk::ShapedImageNeighborhoodRange<ImageType>::const_iterator const_begin_from_range_begin = range.begin();
   EXPECT_EQ(const_begin_from_range_begin, range.begin());
 }
 
@@ -337,8 +336,8 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdVectorConstructor)
   const ImageType::IndexType                                location{ {} };
   const itk::Size<ImageType::ImageDimension>                radius = { { 0, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
   // Easily store all pixels of the ShapedImageNeighborhoodRange in an std::vector:
   const std::vector<PixelType> stdVector(range.begin(), range.end());
@@ -363,8 +362,8 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdReverseCopy)
   const ImageType::IndexType                                location{ {} };
   const itk::Size<ImageType::ImageDimension>                radius = { { 0, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
   const unsigned numberOfNeighborhoodPixels = 3;
 
@@ -405,8 +404,8 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdInnerProduct)
   const ImageType::IndexType                                location{ {} };
   const itk::Size<ImageType::ImageDimension>                radius = { { 0, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
   const double innerProduct = std::inner_product(range.begin(), range.end(), range.begin(), 0.0);
 
@@ -430,8 +429,8 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdForEach)
   const ImageType::IndexType                                location{ {} };
   const itk::Size<ImageType::ImageDimension>                radius = { { 0, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
   std::for_each(range.begin(), range.end(), [](const PixelType pixel) { EXPECT_TRUE(pixel > 0); });
 }
@@ -443,7 +442,7 @@ TEST(ShapedImageNeighborhoodRange, CanBeUsedAsExpressionOfRangeBasedForLoop)
 {
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<ImageType>;
 
   enum
   {
@@ -455,7 +454,7 @@ TEST(ShapedImageNeighborhoodRange, CanBeUsedAsExpressionOfRangeBasedForLoop)
   const ImageType::IndexType                                location{ {} };
   const itk::Size<ImageType::ImageDimension>                radius = { { 0, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   RangeType range{ *image, location, offsets };
 
   for (const PixelType pixel : range)
@@ -498,16 +497,16 @@ TEST(ShapedImageNeighborhoodRange, DistanceBetweenIteratorsCanBeObtainedBySubtra
   const ImageType::IndexType                                location{ {} };
   const itk::Size<ImageType::ImageDimension>                radius = { { 2, 3 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::iterator it1 = range.begin();
+  itk::ShapedImageNeighborhoodRange<ImageType>::iterator it1 = range.begin();
 
   const std::size_t numberOfNeighborhoodPixels = range.size();
 
   for (std::size_t i1 = 0; i1 < numberOfNeighborhoodPixels; ++i1, ++it1)
   {
-    itk::Experimental::ShapedImageNeighborhoodRange<ImageType>::iterator it2 = it1;
+    itk::ShapedImageNeighborhoodRange<ImageType>::iterator it2 = it1;
 
     for (std::size_t i2 = 0; i2 < numberOfNeighborhoodPixels; ++i2, ++it2)
     {
@@ -534,8 +533,8 @@ TEST(ShapedImageNeighborhoodRange, IteratorRetrievesSamePixelValuesAsConstNeighb
   const ImageType::IndexType                                testLocations[] = { { {} }, { { 0, 1 } }, { { 1, 0 } } };
   const itk::Size<ImageType::ImageDimension>                radius = { { 2, 3 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<const ImageType> range{ *image, initialLocation, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<const ImageType> range{ *image, initialLocation, offsets };
   itk::ConstNeighborhoodIterator<ImageType> constNeighborhoodIterator(radius, image, image->GetRequestedRegion());
 
   for (const auto & location : testLocations)
@@ -566,12 +565,12 @@ TEST(ShapedImageNeighborhoodRange, IteratorReferenceActsLikeARealReference)
     sizeY = 11
   };
   const auto image = CreateImageFilledWithSequenceOfNaturalNumbers<ImageType>(sizeX, sizeY);
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<ImageType>;
 
   const ImageType::IndexType                                location = { { 1, 0 } };
   const itk::Size<ImageType::ImageDimension>                radius = { { 1, 0 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   RangeType           range{ *image, location, offsets };
   RangeType::iterator it = range.begin();
 
@@ -632,9 +631,9 @@ TEST(ShapedImageNeighborhoodRange, SupportsVectorImage)
   const ImageType::IndexType                                location = { { 0, 1 } };
   const itk::Size<ImageType::ImageDimension>                radius = { { 0, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
 
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<ImageType>;
   RangeType range{ *image, location, offsets };
 
   for (PixelType pixelValue : range)
@@ -669,8 +668,8 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdSort)
   const ImageType::IndexType                                location{ { 1, 1 } };
   const itk::Size<ImageType::ImageDimension>                radius = { { 1, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
   // Initial order: (1, 2, 3, ..., 9).
   const std::vector<PixelType> initiallyOrderedPixels(range.cbegin(), range.cend());
@@ -704,8 +703,8 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdNthElement)
   const ImageType::IndexType                                location{ { 1, 1 } };
   const itk::Size<ImageType::ImageDimension>                radius = { { 1, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
-  itk::Experimental::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
+  itk::ShapedImageNeighborhoodRange<ImageType> range{ *image, location, offsets };
 
   std::reverse(range.begin(), range.end());
 
@@ -728,7 +727,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsCanBePassedToStdNthElement)
 
 TEST(ShapedImageNeighborhoodRange, IteratorIsDefaultConstructible)
 {
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<itk::Image<int>>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<itk::Image<int>>;
 
   RangeType::iterator defaultConstructedIterator;
 
@@ -748,7 +747,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsSupportRandomAccess)
 {
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<ImageType>;
   enum
   {
     sizeX = 3,
@@ -759,7 +758,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorsSupportRandomAccess)
   const ImageType::IndexType                                location{ { 1, 1 } };
   const itk::Size<ImageType::ImageDimension>                radius = { { 1, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   RangeType range{ *image, location, offsets };
 
   // Testing expressions from Table 111 "Random access iterator requirements
@@ -878,7 +877,7 @@ TEST(ShapedImageNeighborhoodRange, SupportsSubscript)
 {
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<ImageType>;
 
   enum
   {
@@ -890,7 +889,7 @@ TEST(ShapedImageNeighborhoodRange, SupportsSubscript)
   const ImageType::IndexType                                location{ { 1, 1 } };
   const itk::Size<ImageType::ImageDimension>                radius = { { 1, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   RangeType range{ *image, location, offsets };
 
   const std::size_t numberOfNeighbors = range.size();
@@ -910,7 +909,7 @@ TEST(ShapedImageNeighborhoodRange, ProvidesReverseIterators)
 {
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<ImageType>;
   enum
   {
     sizeX = 9,
@@ -921,7 +920,7 @@ TEST(ShapedImageNeighborhoodRange, ProvidesReverseIterators)
   const ImageType::IndexType                                location{ {} };
   const itk::Size<ImageType::ImageDimension>                radius = { { 0, 1 } };
   const std::vector<itk::Offset<ImageType::ImageDimension>> offsets =
-    itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+    itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   RangeType range{ *image, location, offsets };
 
   const unsigned numberOfNeighborhoodPixels = 3;
@@ -958,7 +957,7 @@ TEST(ShapedImageNeighborhoodRange, ProvidesReverseIterators)
 TEST(ShapedImageNeighborhoodRange, ConstructorSupportsRValueShapeOffsets)
 {
   using ImageType = itk::Image<unsigned char>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<ImageType>;
   using OffsetType = ImageType::OffsetType;
 
   const auto                 image = CreateImage<ImageType>(1, 2);
@@ -977,12 +976,12 @@ TEST(ShapedImageNeighborhoodRange, SupportsArbitraryBufferedRegionIndex)
   using ImageType = itk::Image<int>;
 
   // Do zero-padding for neighborhood pixels outside the image:
-  using PolicyType = itk::Experimental::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<ImageType>;
-  using RangeType = itk::Experimental::ShapedImageNeighborhoodRange<ImageType, PolicyType>;
+  using PolicyType = itk::ConstantBoundaryImageNeighborhoodPixelAccessPolicy<ImageType>;
+  using RangeType = itk::ShapedImageNeighborhoodRange<ImageType, PolicyType>;
 
   // A minimal radius, and trivial shape offsets (n = 1), just for the test.
   const itk::Size<ImageType::ImageDimension> radius = { { 0 } };
-  const auto offsets = itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
+  const auto                                 offsets = itk::GenerateRectangularImageNeighborhoodOffsets(radius);
 
   const ImageType::IndexType zeroIndex{ { 0 } };
   const ImageType::IndexType arbitraryIndex{ { 10, -1 } };

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -165,7 +165,7 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussianKernel()
       size.Fill(0);
       size[direction] = static_cast<SizeValueType>(m_Sigma[direction] * m_Extent[direction]);
       dogNeighborhood.SetRadius(size);
-      m_ImageNeighborhoodOffsets[direction] = Experimental::GenerateRectangularImageNeighborhoodOffsets(size);
+      m_ImageNeighborhoodOffsets[direction] = GenerateRectangularImageNeighborhoodOffsets(size);
 
       typename GaussianDerivativeSpatialFunctionType::ArrayType s;
       s[0] = m_Sigma[direction];
@@ -210,7 +210,7 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const Ind
 
     const OperatorNeighborhoodType & operatorNeighborhood = m_OperatorArray[direction];
 
-    const Experimental::ShapedImageNeighborhoodRange<const InputImageType> neighborhoodRange(
+    const ShapedImageNeighborhoodRange<const InputImageType> neighborhoodRange(
       *image, index, m_ImageNeighborhoodOffsets[direction]);
     assert(neighborhoodRange.size() == operatorNeighborhood.Size());
 

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -65,8 +65,7 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
   image->SetOrigin(origin);
   image->SetSpacing(spacing);
 
-  using itk::Experimental::ZeroBasedIndexRange;
-  for (const auto index : ZeroBasedIndexRange<ImageType::ImageDimension>(size))
+  for (const auto index : itk::ZeroBasedIndexRange<ImageType::ImageDimension>(size))
   {
     image->SetPixel(index, index[0] + index[1]);
   }

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -167,7 +167,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBoxInIndexSpace() c
   const ImageType & image = *imagePointer;
 
   const auto HasForegroundPixels = [&image](const RegionType & region) {
-    for (const PixelType pixelValue : Experimental::ImageRegionRange<const ImageType>{ image, region })
+    for (const PixelType pixelValue : ImageRegionRange<const ImageType>{ image, region })
     {
       constexpr auto zeroValue = NumericTraits<PixelType>::ZeroValue();
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -91,7 +91,7 @@ Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the
   // Initialize all pixels to zero.
   image->Allocate(true);
 
-  const itk::Experimental::ImageRegionIndexRange<VImageDimension> indexRange{ imageRegion };
+  const itk::ImageRegionIndexRange<VImageDimension> indexRange{ imageRegion };
 
   // Expected size: the "region size" of a single pixel (1x1, in 2D, 1x1x1 in 3D).
   const itk::Size<VImageDimension> expectedSize = [] {
@@ -125,7 +125,7 @@ Expect_AxisAlignedBoundingBoxRegion_equals_image_region_when_only_a_single_pixel
   // Set all pixels to non-zero.
   image->FillBuffer(1);
 
-  const itk::Experimental::ImageBufferRange<ImageType> imageRange{ *image };
+  const itk::ImageBufferRange<ImageType> imageRange{ *image };
 
   for (auto && pixel : imageRange)
   {

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -86,9 +86,6 @@ CLANG_SUPPRESS_Wfloat_equal
   template <typename TInputImage, typename TMaskImage, typename TOutputImage>
   void N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::GenerateData()
   {
-    using itk::Experimental::ImageBufferRange;
-    using itk::Experimental::MakeImageBufferRange;
-
     this->AllocateOutputs();
 
     const InputImageType * inputImage = this->GetInput();
@@ -263,9 +260,6 @@ CLANG_SUPPRESS_Wfloat_equal
   void N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::SharpenImage(
     const RealImageType * unsharpenedImage, RealImageType * sharpenedImage) const
   {
-    using itk::Experimental::ImageBufferRange;
-    using itk::Experimental::MakeImageBufferRange;
-
     const auto          maskImageBufferRange = MakeImageBufferRange(this->GetMaskImage());
     const auto          confidenceImageBufferRange = MakeImageBufferRange(this->GetConfidenceImage());
     const MaskPixelType maskLabel = this->GetMaskLabel();
@@ -482,8 +476,6 @@ CLANG_SUPPRESS_Wfloat_equal
   N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::UpdateBiasFieldEstimate(
     RealImageType * fieldEstimate, const std::size_t numberOfIncludedPixels)
   {
-    using itk::Experimental::MakeImageBufferRange;
-
     // Temporarily set the direction cosine to identity since the B-spline
     // approximation algorithm works in parametric space and not physical
     // space.
@@ -652,7 +644,6 @@ CLANG_SUPPRESS_Wfloat_equal
   N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::CalculateConvergenceMeasurement(
     const RealImageType * fieldEstimate1, const RealImageType * fieldEstimate2) const
   {
-    using itk::Experimental::MakeImageBufferRange;
     using SubtracterType = SubtractImageFilter<RealImageType, RealImageType, RealImageType>;
     typename SubtracterType::Pointer subtracter = SubtracterType::New();
     subtracter->SetInput1(fieldEstimate1);

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
@@ -143,7 +143,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, T
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&im_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   // iterate on the layer to be scanned
   auto nodeIt = layerPlus1.begin();
@@ -207,7 +207,7 @@ BinaryImageToLevelSetImageAdaptor<TInput,
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&im_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   typename LevelSetLabelObjectType::ConstIndexIterator lineIt(labelObject);
   lineIt.GoToBegin();
@@ -271,7 +271,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, T
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&im_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   auto nodeIt = layer0.begin();
   auto nodeEnd = layer0.end();
@@ -411,7 +411,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, ShiSparseLevelSetImage<TInput::ImageDi
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&im_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   typename LevelSetLabelObjectType::ConstIndexIterator lineIt(labelObject);
   lineIt.GoToBegin();
@@ -554,7 +554,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, MalcolmSparseLevelSetImage<TInput::Ima
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&im_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   typename LevelSetLabelObjectType::ConstIndexIterator lineIt(labelObject);
   lineIt.GoToBegin();
@@ -615,7 +615,7 @@ BinaryImageToLevelSetImageAdaptor<TInput, MalcolmSparseLevelSetImage<TInput::Ima
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&sp_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   auto nodeIt = list_0.begin();
   auto nodeEnd = list_0.end();

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
@@ -176,7 +176,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::EvolveWithUnPhasedP
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&sp_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   TermContainerPointer termContainer = this->m_EquationContainer->GetEquation(this->m_CurrentLevelSetId);
 
@@ -266,7 +266,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::EvolveWithPhasedPro
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&sp_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   TermContainerPointer termContainer = this->m_EquationContainer->GetEquation(this->m_CurrentLevelSetId);
 
@@ -361,7 +361,7 @@ UpdateMalcolmSparseLevelSet<VDimension, TEquationContainer>::CompactLayersToSing
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&sp_nbc);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   auto nodeIt = listZero.begin();
   auto nodeEnd = listZero.end();

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
@@ -72,7 +72,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::Update()
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   // Step 2.1.1
   this->UpdateLayerPlusOne();
@@ -192,7 +192,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::UpdateLayerPlusOne()
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   LevelSetLayerType insertListIn;
   LevelSetLayerType insertListOut;
@@ -292,7 +292,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::UpdateLayerMinusOne()
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   LevelSetLayerType insertListIn;
   LevelSetLayerType insertListOut;
@@ -389,7 +389,7 @@ UpdateShiSparseLevelSet<VDimension, TEquationContainer>::Con(const LevelSetInput
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
   neighIt.SetLocation(idx);
 
   const LevelSetOutputType oppositeStatus =

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
@@ -111,7 +111,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   const LevelSetLayerType & layerMinus2 = this->m_InputLevelSet->GetLayer(LevelSetType::MinusTwoLayer());
 
@@ -202,7 +202,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   LevelSetInputType inputIndex;
   while (nodeIt != nodeEnd)
@@ -364,7 +364,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   LevelSetLayerType & outputlayerMinus1 = this->m_OutputLevelSet->GetLayer(LevelSetType::MinusOneLayer());
 
@@ -470,7 +470,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   TermContainerPointer termContainer = this->m_EquationContainer->GetEquation(this->m_CurrentLevelSetId);
 
@@ -576,7 +576,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   TermContainerPointer termContainer = this->m_EquationContainer->GetEquation(this->m_CurrentLevelSetId);
 
@@ -681,7 +681,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   TermContainerPointer termContainer = this->m_EquationContainer->GetEquation(this->m_CurrentLevelSetId);
 
@@ -809,7 +809,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   TermContainerPointer termContainer = this->m_EquationContainer->GetEquation(this->m_CurrentLevelSetId);
 
@@ -867,7 +867,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   NeighborhoodIteratorType neighIt(radius, this->m_InternalImage, this->m_InternalImage->GetLargestPossibleRegion());
 
   neighIt.OverrideBoundaryCondition(&spNBC);
-  neighIt.ActivateOffsets(Experimental::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
+  neighIt.ActivateOffsets(GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, 1, false>());
 
   TermContainerPointer termContainer = this->m_EquationContainer->GetEquation(this->m_CurrentLevelSetId);
 


### PR DESCRIPTION
Moved the iterator ranges, image neighborhood shapes, and pixel access
policies, introduced with ITK 5, out of the `Experimental` namespace.
