### PR TITLE
ENH: update PhaseSymmetry remote module

### DIFF
--- a/Modules/Remote/PhaseSymmetry.remote.cmake
+++ b/Modules/Remote/PhaseSymmetry.remote.cmake
@@ -11,5 +11,5 @@ http://hdl.handle.net/10380/3330
 http://www.insight-journal.org/browse/publication/846
 "
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKPhaseSymmetry.git
-  GIT_TAG 91041964bb798b16c1caa5cfef0d91f32ada8332
+  GIT_TAG 26e6fbf0823413b956e3ec93f4e6faac076fe37c
   )


### PR DESCRIPTION
* BUG: maintain image direction in internal filters. Closes #23.
* ENH: use ITKImageIO and ITKTransformIO in examples' CMakeLists.txt
* COMP: build with legacy disabled
* ENH: allow finding ITK via configuration file