### PR TITLE
PERF: Use ImageBufferRange in ImageKernelOperator GenerateCoefficients()

### DIFF
--- a/Modules/Core/Common/include/itkImageKernelOperator.hxx
+++ b/Modules/Core/Common/include/itkImageKernelOperator.hxx
@@ -20,6 +20,7 @@
 
 #include "itkImageKernelOperator.h"
 
+#include "itkImageBufferRange.h"
 #include "itkImageRegionConstIterator.h"
 
 /*
@@ -76,16 +77,9 @@ ImageKernelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
     }
   }
 
-  CoefficientVector coeff;
+  const auto imageBufferRange = Experimental::MakeImageBufferRange(m_ImageKernel.GetPointer());
 
-  ImageRegionConstIterator<ImageType> It(m_ImageKernel, m_ImageKernel->GetLargestPossibleRegion());
-
-  for (It.GoToBegin(); !It.IsAtEnd(); ++It)
-  {
-    coeff.push_back(It.Get());
-  }
-
-  return coeff;
+  return CoefficientVector(imageBufferRange.cbegin(), imageBufferRange.cend());
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>


### PR DESCRIPTION
Improved the performance of `ImageKernelOperator::GenerateCoefficients()`,
by replacing its local `ImageRegionConstIterator` variable by an
`Experimental::ImageBufferRange`.

In general, when a function iterates over an entire image buffer,
`ImageBufferRange` is significantly faster than
`ImageRegionConstIterator`.