### PR TITLE
PERF: Use ShapedImageNeighborhoodRange in MeanImageFunction

### DIFF
--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
@@ -19,7 +19,11 @@
 #define itkMeanImageFunction_h
 
 #include "itkImageFunction.h"
+#include "itkImageNeighborhoodOffsets.h"
 #include "itkNumericTraits.h"
+#include "itkOffset.h"
+
+#include <vector>
 
 namespace itk
 {
@@ -65,6 +69,9 @@ public:
   /** InputImageType type alias support */
   using InputImageType = TInputImage;
 
+  /** InputPixel type alias support */
+  using typename Superclass::InputPixelType;
+
   /** OutputType typdef support. */
   using OutputType = typename Superclass::OutputType;
 
@@ -76,6 +83,9 @@ public:
 
   /** Point type alias support */
   using PointType = typename Superclass::PointType;
+
+  /** Size type of the underlying image. */
+  using ImageSizeType = typename InputImageType::SizeType;
 
   /** Dimension of the underlying image. */
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
@@ -108,7 +118,8 @@ public:
 
   /** Get/Set the radius of the neighborhood over which the
       statistics are evaluated */
-  itkSetMacro(NeighborhoodRadius, unsigned int);
+  void
+  SetNeighborhoodRadius(unsigned int);
   itkGetConstReferenceMacro(NeighborhoodRadius, unsigned int);
 
 protected:
@@ -119,6 +130,9 @@ protected:
 
 private:
   unsigned int m_NeighborhoodRadius{ 1 };
+
+  std::vector<Offset<ImageDimension>> m_NeighborhoodOffsets{ Experimental::GenerateRectangularImageNeighborhoodOffsets(
+    ImageSizeType::Filled(1)) };
 };
 } // end namespace itk
 


### PR DESCRIPTION
Improved the performance of `MeanImageFunction::EvaluateAtIndex`
by replacing its local `itk::ConstNeighborhoodIterator` variable by
an `Experimental::ShapedImageNeighborhoodRange` variable.

Similar to a previous commit:
"PERF: Use ShapedImageNeighborhoodRange in SumOfSquaresImageFunction"
SHA-1 e3fd64de1408c79c50fb17e3f046e1d5d98a89c6