### PR TITLE
PERF: Use IndexRange in BSplineInterpolationWeightFunction constructor

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -22,7 +22,7 @@
 #include "itkImage.h"
 #include "itkMatrix.h"
 #include "itkMath.h"
-#include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkIndexRange.h"
 
 namespace itk
 {
@@ -40,24 +40,17 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::BS
   // Initialize offset to index lookup table
   m_OffsetToIndexTable.set_size(m_NumberOfWeights, SpaceDimension);
 
-  using CharImageType = Image<char, SpaceDimension>;
-  typename CharImageType::Pointer tempImage = CharImageType::New();
-  tempImage->SetRegions(m_SupportSize);
-  tempImage->Allocate(true); // initialize buffer to zero
-
-  using IteratorType = ImageRegionConstIteratorWithIndex<CharImageType>;
-  IteratorType iterator(tempImage, tempImage->GetBufferedRegion());
   unsigned int counter = 0;
 
-  while (!iterator.IsAtEnd())
+  for (const IndexType index : Experimental::ZeroBasedIndexRange<VSpaceDimension>(m_SupportSize))
   {
     for (unsigned int j = 0; j < SpaceDimension; j++)
     {
-      m_OffsetToIndexTable[counter][j] = iterator.GetIndex()[j];
+      m_OffsetToIndexTable[counter][j] = index[j];
     }
     ++counter;
-    ++iterator;
   }
+
 
   // Initialize the interpolation kernel
   m_Kernel = KernelType::New();

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkBSplineInterpolationWeightFunction.h"
+#include "itkImageRegionConstIteratorWithIndex.h"
 
 // Test template instantiation for TCoordRep = float and VSplineOrder = 1.
 // Note that this particular template instantiation would take forever to


### PR DESCRIPTION
The constructor of `BSplineInterpolationWeightFunction` originally
created a `tempImage`, just for `ImageRegionConstIteratorWithIndex` to
iterate over an index space of size `m_SupportSize`.

This commit replaces this use of `ImageRegionConstIteratorWithIndex` by
`ZeroBasedIndexRange`, which efficiently iterates over a zero-based
index space, without the need for a `tempImage`.