### PR TITLE
PERF: Use ImageBufferRange in Testing::StretchIntensityImageFilter

### DIFF
--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -29,6 +29,7 @@
 #define itkTestingStretchIntensityImageFilter_hxx
 
 #include "itkTestingStretchIntensityImageFilter.h"
+#include "itkImageBufferRange.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkMath.h"
@@ -61,15 +62,11 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateDa
   }
 
   const TInputImage * inputImage = this->GetInput();
-
-  ImageRegionConstIteratorWithIndex<TInputImage> it(inputImage, inputImage->GetBufferedRegion());
-
   m_InputMaximum = NumericTraits<InputPixelType>::NonpositiveMin();
   m_InputMinimum = NumericTraits<InputPixelType>::max();
 
-  while (!it.IsAtEnd())
+  for (const InputPixelType value : Experimental::MakeImageBufferRange(inputImage))
   {
-    const InputPixelType value = it.Get();
     if (value > m_InputMaximum)
     {
       m_InputMaximum = value;
@@ -78,7 +75,6 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateDa
     {
       m_InputMinimum = value;
     }
-    ++it;
   }
 
   if (itk::Math::abs(m_InputMaximum - m_InputMinimum) > itk::Math::abs(NumericTraits<InputPixelType>::epsilon()))


### PR DESCRIPTION
Improved the performance of `Testing::StretchIntensityImageFilter`
member function `BeforeThreadedGenerateData()` by replacing its local
`ImageRegionConstIteratorWithIndex` variable by an
`Experimental::ImageBufferRange`.

In general, when a function iterates over an entire image buffer,
`ImageBufferRange` is significantly faster than
`ImageRegionConstIteratorWithIndex`.