### PR TITLE
COMP: compile the test with legacy disabled

### DIFF
--- a/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
@@ -73,7 +73,9 @@ itkGDCMImageIONoCrashTest(int ac, char * av[])
   std::cout << "SeriesInstanceUID: " << gdcmImageIO->GetSeriesInstanceUID() << std::endl;
   std::cout << "FrameOfReferenceInstanceUID: " << gdcmImageIO->GetFrameOfReferenceInstanceUID() << std::endl;
   std::cout << "KeepOriginalUID: " << gdcmImageIO->GetKeepOriginalUID() << std::endl;
+#ifndef ITK_LEGACY_REMOVE
   std::cout << "LoadSequences: " << gdcmImageIO->GetLoadSequences() << std::endl;
+#endif
   std::cout << "LoadPrivateTags: " << gdcmImageIO->GetLoadPrivateTags() << std::endl;
   std::cout << "CompressionType: " << gdcmImageIO->GetCompressionType() << std::endl;
 


### PR DESCRIPTION
This should have been part of 71c90c83de8631e655144ad9eb6a462bcf059f56.
