### PR TITLE
ENH: Update CI ExternalDataVersion to 5.0.1

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -11,7 +11,7 @@ trigger:
 pr: none
 
 variables:
-  ExternalDataVersion: 5.0.0
+  ExternalDataVersion: 5.0.1
 jobs:
   - job: Windows
     timeoutInMinutes: 0

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -6,7 +6,7 @@ trigger:
     - master
     - release*
 variables:
-  ExternalDataVersion: 5.0.0
+  ExternalDataVersion: 5.0.1
 jobs:
 - job: Linux
   timeoutInMinutes: 0

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -6,7 +6,7 @@ trigger:
     - master
     - release*
 variables:
-  ExternalDataVersion: 5.0.0
+  ExternalDataVersion: 5.0.1
 jobs:
 - job: Linux
   timeoutInMinutes: 0

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -6,7 +6,7 @@ trigger:
     - master
     - release*
 variables:
-  ExternalDataVersion: 5.0.0
+  ExternalDataVersion: 5.0.1
 jobs:
 - job: macOS
   timeoutInMinutes: 0

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -6,7 +6,7 @@ trigger:
     - master
     - release*
 variables:
-  ExternalDataVersion: 5.0.0
+  ExternalDataVersion: 5.0.1
 jobs:
 - job: macOS
   timeoutInMinutes: 0

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -6,7 +6,7 @@ trigger:
     - master
     - release*
 variables:
-  ExternalDataVersion: 5.0.0
+  ExternalDataVersion: 5.0.1
 jobs:
 - job: Windows
   timeoutInMinutes: 0

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -6,7 +6,7 @@ trigger:
     - master
     - release*
 variables:
-  ExternalDataVersion: 5.0.0
+  ExternalDataVersion: 5.0.1
 jobs:
 - job: Windows
   timeoutInMinutes: 0


### PR DESCRIPTION
It looks like GitHub releases is failing to serve 5.0.0 ExternalData tarballs. This may not resolve the issue, but it will not hurt.