### PR TITLE
PERF: Use ShapedImageNeighborhoodRange in MedianImageFunction

### DIFF
--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
@@ -19,7 +19,9 @@
 #define itkMedianImageFunction_h
 
 #include "itkImageFunction.h"
+#include "itkImageNeighborhoodOffsets.h"
 #include "itkNumericTraits.h"
+#include "itkOffset.h"
 
 namespace itk
 {
@@ -79,6 +81,9 @@ public:
   /** Point type alias support */
   using PointType = typename Superclass::PointType;
 
+  /** Size type of the underlying image. */
+  using ImageSizeType = typename InputImageType::SizeType;
+
   /** Dimension of the underlying image. */
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
@@ -107,7 +112,8 @@ public:
 
   /** Get/Set the radius of the neighborhood over which the
       statistics are evaluated */
-  itkSetMacro(NeighborhoodRadius, unsigned int);
+  void
+  SetNeighborhoodRadius(unsigned int);
   itkGetConstReferenceMacro(NeighborhoodRadius, unsigned int);
 
 protected:
@@ -118,6 +124,9 @@ protected:
 
 private:
   unsigned int m_NeighborhoodRadius{ 1 };
+
+  std::vector<Offset<ImageDimension>> m_NeighborhoodOffsets{ Experimental::GenerateRectangularImageNeighborhoodOffsets(
+    ImageSizeType::Filled(1)) };
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
@@ -19,7 +19,8 @@
 #define itkMedianImageFunction_hxx
 
 #include "itkMedianImageFunction.h"
-#include "itkConstNeighborhoodIterator.h"
+#include "itkImage.h"
+#include "itkShapedImageNeighborhoodRange.h"
 
 #include <vector>
 #include <algorithm>
@@ -32,6 +33,19 @@ namespace itk
 template <typename TInputImage, typename TCoordRep>
 MedianImageFunction<TInputImage, TCoordRep>::MedianImageFunction()
 {}
+
+
+template <typename TInputImage, typename TCoordRep>
+void
+MedianImageFunction<TInputImage, TCoordRep>::SetNeighborhoodRadius(const unsigned int radius)
+{
+  if (m_NeighborhoodRadius != radius)
+  {
+    m_NeighborhoodOffsets = Experimental::GenerateRectangularImageNeighborhoodOffsets(ImageSizeType::Filled(radius));
+    m_NeighborhoodRadius = radius;
+    this->Modified();
+  }
+}
 
 
 /**
@@ -52,9 +66,9 @@ template <typename TInputImage, typename TCoordRep>
 typename MedianImageFunction<TInputImage, TCoordRep>::OutputType
 MedianImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
 {
-  unsigned int i;
+  const InputImageType * const image = this->GetInputImage();
 
-  if (!this->GetInputImage())
+  if (image == nullptr)
   {
     return (NumericTraits<OutputType>::max());
   }
@@ -64,29 +78,14 @@ MedianImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & i
     return (NumericTraits<OutputType>::max());
   }
 
-  // Create an N-d neighborhood kernel, using a zeroflux boundary condition
-  typename InputImageType::SizeType kernelSize;
-  kernelSize.Fill(m_NeighborhoodRadius);
-
-  ConstNeighborhoodIterator<InputImageType> it(
-    kernelSize, this->GetInputImage(), this->GetInputImage()->GetBufferedRegion());
-
-  // Set the iterator at the desired location
-  it.SetLocation(index);
+  const Experimental::ShapedImageNeighborhoodRange<const InputImageType> neighborhoodRange(
+    *image, index, m_NeighborhoodOffsets);
 
   // We have to copy the pixels so we can run std::nth_element.
-  std::vector<InputPixelType>                    pixels;
-  typename std::vector<InputPixelType>::iterator medianIterator;
-
-  // Walk the neighborhood
-  for (i = 0; i < it.Size(); ++i)
-  {
-    pixels.push_back(it.GetPixel(i));
-  }
+  std::vector<InputPixelType> pixels(neighborhoodRange.cbegin(), neighborhoodRange.cend());
 
   // Get the median value
-  unsigned int medianPosition = it.Size() / 2;
-  medianIterator = pixels.begin() + medianPosition;
+  const auto medianIterator = pixels.begin() + (pixels.size() / 2);
   std::nth_element(pixels.begin(), medianIterator, pixels.end());
 
   return (*medianIterator);


### PR DESCRIPTION
Improved the performance of `MedianImageFunction::EvaluateAtIndex`
by replacing its local `itk::ConstNeighborhoodIterator` variable by
an `Experimental::ShapedImageNeighborhoodRange` variable.

Analog to recent commits on other `ImageFunction` templates:
- "PERF: Use ShapedImageNeighborhoodRange in MeanImageFunction"
  SHA-1 7e6a391160df7551cb9f3da416d3ac3d3f02e441
- "PERF: Use ShapedImageNeighborhoodRange in SumOfSquaresImageFunction"
  SHA-1 e3fd64de1408c79c50fb17e3f046e1d5d98a89c6