### PR TITLE
ENH: Add Experimental::SquareImageNeighborhoodShape

### DIFF
--- a/Modules/Core/Common/include/itkImageNeighborhoodOffsets.h
+++ b/Modules/Core/Common/include/itkImageNeighborhoodOffsets.h
@@ -20,6 +20,7 @@
 #define itkImageNeighborhoodOffsets_h
 
 #include "itkRectangularImageNeighborhoodShape.h"
+#include "itkSquareImageNeighborhoodShape.h"
 #include <vector>
 
 namespace itk
@@ -46,6 +47,16 @@ GenerateRectangularImageNeighborhoodOffsets(const Size<VImageDimension> & radius
   const RectangularImageNeighborhoodShape<VImageDimension> shape(radius);
   return GenerateImageNeighborhoodOffsets(shape);
 }
+
+/** Generates the offsets for a square (or n-dimensional hypercubic) neighborhood. */
+template <unsigned VImageDimension>
+std::vector<Offset<VImageDimension>>
+GenerateSquareImageNeighborhoodOffsets(const std::size_t radius)
+{
+  const SquareImageNeighborhoodShape<VImageDimension> shape(radius);
+  return GenerateImageNeighborhoodOffsets(shape);
+}
+
 
 } // namespace Experimental
 } // namespace itk

--- a/Modules/Core/Common/include/itkSquareImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkSquareImageNeighborhoodShape.h
@@ -1,0 +1,126 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkSquareImageNeighborhoodShape_h
+#define itkSquareImageNeighborhoodShape_h
+
+#include <algorithm> // For transform.
+#include <cassert>
+
+#include "itkOffset.h"
+#include "itkSize.h"
+
+namespace itk
+{
+namespace Experimental
+{
+
+/**
+ * \class SquareImageNeighborhoodShape
+ * Square (or n-dimensional hypercubic) image-neighborhood shape.
+ * Eases creating a sequence of offsets for ShapedImageNeighborhoodRange.
+ * Can also be used for ShapedNeighborhoodIterator.
+ *
+ * The following example creates a 7 x 7 square neighborhood around
+ * pixel location [10, 20], and generates the offsets for a neighborhood range:
+ \code
+  const Index<> location = { 10, 20 };
+  const std::size_t radius = 3;
+  const SquareImageNeighborhoodShape<2> shape{ radius };
+  const std::vector<Offset<>> offsets = GenerateImageNeighborhoodOffsets(shape);
+  ShapedImageNeighborhoodRange<ImageType> neighborhoodRange{ *image, location, offsets };
+ \endcode
+ *
+ * \see ShapedNeighborhoodIterator
+ * \see ShapedImageNeighborhoodRange
+ * \ingroup ImageIterators
+ * \ingroup ITKCommon
+ */
+template <unsigned int VImageDimension>
+class SquareImageNeighborhoodShape
+{
+public:
+  static constexpr unsigned int ImageDimension = VImageDimension;
+
+  /** Constructs a square (or hypercubic) shape whose size is specified by the radius */
+  constexpr explicit SquareImageNeighborhoodShape(const std::size_t radius) ITK_NOEXCEPT
+    : m_Radius(radius)
+    , m_NumberOfOffsets(CalculateNumberOfOffsets(ImageDimension))
+  {}
+
+
+  /** Returns the number of offsets needed to represent this shape. */
+  constexpr std::size_t
+  GetNumberOfOffsets() const ITK_NOEXCEPT
+  {
+    return m_NumberOfOffsets;
+  }
+
+
+  /** Fills the specified buffer with the offsets for a neighborhood of this shape. */
+  void
+  FillOffsets(Offset<ImageDimension> * const offsets) const ITK_NOEXCEPT
+  {
+    if (m_NumberOfOffsets > 0)
+    {
+      assert(offsets != nullptr);
+      Offset<ImageDimension> offset;
+
+      offset.Fill(-static_cast<OffsetValueType>(m_Radius));
+
+      for (std::size_t i = 0; i < m_NumberOfOffsets; ++i)
+      {
+        offsets[i] = offset;
+
+        for (unsigned dimensionIndex = 0; dimensionIndex < ImageDimension; ++dimensionIndex)
+        {
+          OffsetValueType & offsetValue = offset[dimensionIndex];
+
+          ++offsetValue;
+
+          if (offsetValue <= static_cast<OffsetValueType>(m_Radius))
+          {
+            break;
+          }
+          offsetValue = -static_cast<OffsetValueType>(m_Radius);
+        }
+      }
+    }
+  }
+
+private:
+  // The radius of the neighborhood along each direction.
+  std::size_t m_Radius;
+
+  // The number of offsets needed to represent this shape.
+  std::size_t m_NumberOfOffsets;
+
+
+  // Private helper function to calculate the number of Offsets by a recursive
+  // function call. Recursion is necessary for C++11 constexpr.
+  constexpr std::size_t
+  CalculateNumberOfOffsets(const unsigned dimension) const ITK_NOEXCEPT
+  {
+    return (dimension == 0) ? 1 : (2 * m_Radius + 1) * CalculateNumberOfOffsets(dimension - 1);
+  }
+};
+
+} // namespace Experimental
+} // namespace itk
+
+#endif

--- a/Modules/Core/Common/test/itkImageNeighborhoodOffsetsGTest.cxx
+++ b/Modules/Core/Common/test/itkImageNeighborhoodOffsetsGTest.cxx
@@ -27,6 +27,10 @@
 
 #include <gtest/gtest.h>
 
+
+using itk::Experimental::GenerateRectangularImageNeighborhoodOffsets;
+using itk::Experimental::GenerateSquareImageNeighborhoodOffsets;
+
 namespace
 {
 
@@ -90,4 +94,20 @@ TEST(ImageNeighborhoodOffsets, GenerateRectangularImageNeighborhoodOffsetsForSma
   const std::vector<itk::Offset<>> offsets = itk::Experimental::GenerateRectangularImageNeighborhoodOffsets(radius);
 
   EXPECT_EQ(offsets, (std::vector<itk::Offset<>>{ { { 0, -1 } }, { { 0, 0 } }, { { 0, 1 } } }));
+}
+
+
+// Test that the generated offsets for a square neighborhood are equal to the offsets
+// generated for the equivalent rectangular shape.
+TEST(ImageNeighborhoodOffsets, OffsetsForSquareNeighborhoodEqualOffsetsForRectangularNeighborhood)
+{
+  for (std::size_t radius{}; radius <= 3; ++radius)
+  {
+    EXPECT_EQ(GenerateSquareImageNeighborhoodOffsets<1>(radius),
+              GenerateRectangularImageNeighborhoodOffsets(itk::Size<1>::Filled(radius)));
+    EXPECT_EQ(GenerateSquareImageNeighborhoodOffsets<2>(radius),
+              GenerateRectangularImageNeighborhoodOffsets(itk::Size<2>::Filled(radius)));
+    EXPECT_EQ(GenerateSquareImageNeighborhoodOffsets<3>(radius),
+              GenerateRectangularImageNeighborhoodOffsets(itk::Size<3>::Filled(radius)));
+  }
 }

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
@@ -131,8 +131,9 @@ protected:
 private:
   unsigned int m_NeighborhoodRadius{ 1 };
 
-  std::vector<Offset<ImageDimension>> m_NeighborhoodOffsets{ Experimental::GenerateRectangularImageNeighborhoodOffsets(
-    ImageSizeType::Filled(1)) };
+  std::vector<Offset<ImageDimension>> m_NeighborhoodOffsets{
+    Experimental::GenerateSquareImageNeighborhoodOffsets<ImageDimension>(1)
+  };
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -70,7 +70,7 @@ MeanImageFunction<TInputImage, TCoordRep>::SetNeighborhoodRadius(const unsigned 
 {
   if (m_NeighborhoodRadius != radius)
   {
-    m_NeighborhoodOffsets = Experimental::GenerateRectangularImageNeighborhoodOffsets(ImageSizeType::Filled(radius));
+    m_NeighborhoodOffsets = Experimental::GenerateSquareImageNeighborhoodOffsets<ImageDimension>(radius);
     m_NeighborhoodRadius = radius;
     this->Modified();
   }

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.h
@@ -121,7 +121,7 @@ public:
   void
   SetNeighborhoodRadius(unsigned int radius)
   {
-    m_NeighborhoodOffsets = Experimental::GenerateRectangularImageNeighborhoodOffsets(ImageSizeType::Filled(radius));
+    m_NeighborhoodOffsets = Experimental::GenerateSquareImageNeighborhoodOffsets<ImageDimension>(radius);
     m_NeighborhoodRadius = radius;
     m_NeighborhoodSize = m_NeighborhoodOffsets.size();
   }
@@ -138,8 +138,9 @@ private:
   unsigned int m_NeighborhoodRadius;
   unsigned int m_NeighborhoodSize;
 
-  std::vector<Offset<ImageDimension>> m_NeighborhoodOffsets{ Experimental::GenerateRectangularImageNeighborhoodOffsets(
-    ImageSizeType::Filled(1)) };
+  std::vector<Offset<ImageDimension>> m_NeighborhoodOffsets{
+    Experimental::GenerateSquareImageNeighborhoodOffsets<ImageDimension>(1)
+  };
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -155,7 +155,7 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   if (m_InitialNeighborhoodRadius > 0)
   {
     const auto neighborhoodOffsets =
-      Experimental::GenerateRectangularImageNeighborhoodOffsets(SizeType::Filled(m_InitialNeighborhoodRadius));
+      Experimental::GenerateSquareImageNeighborhoodOffsets<InputImageType::ImageDimension>(m_InitialNeighborhoodRadius);
     auto neighborhoodRange =
       Experimental::ShapedImageNeighborhoodRange<const InputImageType>(*inputImage, IndexType(), neighborhoodOffsets);
 


### PR DESCRIPTION
Added the function `GenerateSquareImageNeighborhoodOffsets(size_t radius)`
and the class `SquareImageNeighborhoodShape` to the `Experimental`
namespace, to allow specifying more explicitly and more efficiently that
the neighborhood shape should be square (or n-dimensional hypercubic).

Replaced the more general `GenerateRectangularImageNeighborhoodOffsets`
by the newly added `GenerateSquareImageNeighborhoodOffsets` in
`MeanImageFunction`, `SumOfSquaresImageFunction`, and
`ConfidenceConnectedImageFilter`