### PR TITLE
COMP: Properly conditionalize _snprintf hack to only old MS compilers

### DIFF
--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -27,7 +27,7 @@
  * loops iterating too many times.  This turns off optimization to
  * allow the tests to pass.
  */
-#if _MSC_VER == 1900
+#if defined(_MSC_VER) && (_MSC_VER == 1900)
 #  pragma optimize("", off)
 #endif
 

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -29,10 +29,6 @@
 #include "vnl/algo/vnl_determinant.h"
 #include <cstdio>
 
-#if defined(_MSC_VER)
-#  define snprintf _snprintf
-#endif // _MSC_VER
-
 namespace itk
 {
 //---------------------------------------------------------

--- a/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
@@ -27,10 +27,6 @@ NumericSeriesFileNames ::NumericSeriesFileNames()
   : m_SeriesFormat("%d")
 {}
 
-#if defined(_MSC_VER)
-#  define snprintf _snprintf
-#endif // _MSC_VER
-
 const std::vector<std::string> &
 NumericSeriesFileNames ::GetFileNames()
 {

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -271,7 +271,7 @@ CORDirCosines()
  * loops iterating too many times.  This turns off optimization to
  * allow the tests to pass.
  */
-#if _MSC_VER == 1900
+#if defined(_MSC_VER) && (_MSC_VER == 1900)
 #  pragma optimize("", off)
 #endif
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -23,7 +23,7 @@
  * loops iterating too many times.  This turns off optimization to
  * allow the tests to pass.
  */
-#if _MSC_VER == 1900
+#if defined(_MSC_VER) && (_MSC_VER == 1900)
 #  pragma optimize("", off)
 #endif
 

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -180,14 +180,11 @@ PNGImageIO::Read(void * buffer)
     itkExceptionMacro("File is not png type " << this->GetFileName());
   }
 
-  //  VS 7.1 has problems with setjmp/longjmp in C++ code
-#if !defined(MSC_VER) || _MSC_VER != 1310
   if (wrapSetjmp(png_ptr))
   {
     png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
     itkExceptionMacro("File is not png type " << this->GetFileName());
   }
-#endif
 
   png_init_io(png_ptr, fp);
   png_set_sig_bytes(png_ptr, 8);
@@ -574,15 +571,12 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * buffer)
 
   png_init_io(png_ptr, fp);
 
-//  VS 7.1 has problems with setjmp/longjmp in C++ code
-#if !defined(_MSC_VER) || _MSC_VER != 1310
   png_set_error_fn(png_ptr, (png_voidp) nullptr, itkPNGWriteErrorFunction, itkPNGWriteWarningFunction);
   if (wrapSetjmp(png_ptr))
   {
     itkExceptionMacro("Error while writing Slice to file: " << this->GetFileName() << std::endl
                                                             << "Reason: " << itksys::SystemTools::GetLastSystemError());
   }
-#endif
 
   int          colorType;
   unsigned int numComp = this->GetNumberOfComponents();


### PR DESCRIPTION
For github issue #1115.