### PR TITLE
BUG: fix null deref in 'itkTreeContainerTest'. Closes #1358.

### DIFF
--- a/Modules/Core/Common/include/itkChildTreeIterator.hxx
+++ b/Modules/Core/Common/include/itkChildTreeIterator.hxx
@@ -109,6 +109,10 @@ ChildTreeIterator<TTreeType>::Next()
 {
   m_ListPosition++;
   this->m_Position = m_ParentNode->GetChild(m_ListPosition);
+  if (this->m_Position == nullptr)
+  {
+    return this->m_Root->Get(); // value irrelevant, but we have to return something
+  }
   return this->m_Position->Get();
 }
 

--- a/Modules/Core/Common/include/itkTreeIteratorBase.h
+++ b/Modules/Core/Common/include/itkTreeIteratorBase.h
@@ -200,7 +200,7 @@ public:
   void
   GoToEnd()
   {
-    m_Position = m_End;
+    m_Position = nullptr;
   }
 
   /** Is the iterator at the beginning of the tree? */
@@ -210,12 +210,11 @@ public:
     return (m_Position == m_Begin);
   }
 
-  /** Is the iterator at the end of the tree?. The iterator is at the
-   * end if it points to nullptr */
+  /** Is the iterator at the end of the tree? */
   bool
   IsAtEnd() const
   {
-    return (m_Position == m_End);
+    return (m_Position == nullptr);
   }
 
   /** Clone the iterator */
@@ -245,7 +244,6 @@ public:
     {
       m_Position = iterator.m_Position;
       m_Begin = iterator.m_Begin;
-      m_End = iterator.m_End;
       m_Root = iterator.m_Root;
       m_Tree = iterator.m_Tree;
     }
@@ -261,7 +259,6 @@ protected:
 
   mutable TreeNodeType * m_Position; // Current position of the iterator
   mutable TreeNodeType * m_Begin;
-  mutable TreeNodeType * m_End;
   const TreeNodeType *   m_Root;
   TTreeType *            m_Tree;
 

--- a/Modules/Core/Common/include/itkTreeIteratorBase.hxx
+++ b/Modules/Core/Common/include/itkTreeIteratorBase.hxx
@@ -53,7 +53,6 @@ TreeIteratorBase<TTreeType>::TreeIteratorBase(TTreeType * tree, const TreeNodeTy
   m_Position = const_cast<TreeNodeType *>(m_Root);
   m_Tree = tree;
   m_Begin = m_Position;
-  m_End = nullptr;
 }
 
 /** Constructor */
@@ -71,7 +70,6 @@ TreeIteratorBase<TTreeType>::TreeIteratorBase(const TTreeType * tree, const Tree
   m_Position = const_cast<TreeNodeType *>(m_Root);
   m_Tree = const_cast<TTreeType *>(tree);
   m_Begin = m_Position;
-  m_End = nullptr;
 }
 
 /** Return the current value of the node */


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
