### PR TITLE
BUG: integer division by zero is undefined behaviour, no point in tes…

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -547,19 +547,14 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin|Linux")
     itkFloatingPointExceptionsTest FPOverFlow)
   itk_add_test(NAME itkFloatingPointExceptionsTest4 COMMAND ITKCommon1TestDriver
     itkFloatingPointExceptionsTest FPUnderFlow)
-  itk_add_test(NAME itkFloatingPointExceptionsTest5 COMMAND ITKCommon1TestDriver
-    itkFloatingPointExceptionsTest IntDivByZero)
 
   set_tests_properties(
     itkFloatingPointExceptionsTest1
     itkFloatingPointExceptionsTest2
     itkFloatingPointExceptionsTest3
     itkFloatingPointExceptionsTest4
-    itkFloatingPointExceptionsTest5
     PROPERTIES WILL_FAIL TRUE
     )
-
-  itk_memcheck_ignore(itkFloatingPointExceptionsTest5)
 
 endif()
 

--- a/Modules/Core/Common/test/itkFloatingPointExceptionsExtern.cxx
+++ b/Modules/Core/Common/test/itkFloatingPointExceptionsExtern.cxx
@@ -19,4 +19,3 @@
 
 extern const double itkFloatingPointExceptionsTest_double_zero = 0.0;
 extern const double itkFloatingPointExceptionsTest_double_max = DBL_MAX;
-extern const int    itkFloatingPointExceptionsTest_int_zero = 0;

--- a/Modules/Core/Common/test/itkFloatingPointExceptionsTest.cxx
+++ b/Modules/Core/Common/test/itkFloatingPointExceptionsTest.cxx
@@ -23,7 +23,6 @@
 // compilation time errors for divide by zero and overflow
 extern const double itkFloatingPointExceptionsTest_double_zero;
 extern const double itkFloatingPointExceptionsTest_double_max;
-extern const int    itkFloatingPointExceptionsTest_int_zero;
 
 
 int
@@ -40,7 +39,6 @@ itkFloatingPointExceptionsTest(int argc, char * argv[])
   double double_zero = itkFloatingPointExceptionsTest_double_zero;
   double double_max = itkFloatingPointExceptionsTest_double_max;
   double test1 = itkFloatingPointExceptionsTest_double_zero;
-  int    int_zero = itkFloatingPointExceptionsTest_int_zero;
 
   std::string testName(argv[1]);
   if (testName == "DivByZero")
@@ -126,25 +124,5 @@ itkFloatingPointExceptionsTest(int argc, char * argv[])
     }
   }
 
-  if (testName == "IntDivByZero")
-  {
-    std::cout << "Testing integer divide by zero" << std::endl;
-    std::cout.flush();
-    try
-    {
-      int s = 1 / int_zero;
-      //
-      // should never reach here
-      std::cout << "Integer divide by zero Exception not caught"
-                << " result is " << s << std::endl;
-      error_return++;
-    }
-    catch (itk::ExceptionObject & e)
-    {
-      std::cout << "Integer divide by zero  exception caught" << std::endl;
-      std::cout << e;
-      std::cout.flush();
-    }
-  }
   return error_return;
 }


### PR DESCRIPTION
…ting it

Integer division by zero is undefined behaviour per the C++ standard.
As such, it's not guaranteed to throw an exception, so testing for that is not sensible.

This fixes the test crashing under UBSan, which detects such undefined division.