### PR TITLE
ENH: Restored behaviour of depricated Analyze reader w.r.t orientation code

### DIFF
--- a/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
@@ -22,6 +22,10 @@
 #include "itkImageFileReader.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkMath.h"
+#include "itkSpatialOrientationAdapter.h"
+
+// debug
+#include <map>
 
 namespace
 {
@@ -116,6 +120,58 @@ const unsigned char LittleEndian_img[] = {
   0x00, 0x00, 0xe0, 0x42, 0x00, 0x00, 0xe0, 0x42, 0x00, 0x00, 0xe0, 0x42,
 };
 
+// Map between axis string labels and SpatialOrientation
+std::map<itk::SpatialOrientation::ValidCoordinateOrientationFlags, std::string> codeToString = {
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP, "RIP" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LIP, "LIP" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSP, "RSP" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LSP, "LSP" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIA, "RIA" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LIA, "LIA" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSA, "RSA" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LSA, "LSA" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IRP, "IRP" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ILP, "ILP" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SRP, "SRP" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SLP, "SLP" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IRA, "IRA" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ILA, "ILA" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SRA, "SRA" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SLA, "SLA" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI, "RPI" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LPI, "LPI" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI, "RAI" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LAI, "LAI" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPS, "RPS" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LPS, "LPS" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAS, "RAS" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LAS, "LAS" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PRI, "PRI" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PLI, "PLI" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ARI, "ARI" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ALI, "ALI" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PRS, "PRS" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PLS, "PLS" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ARS, "ARS" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ALS, "ALS" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IPR, "IPR" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SPR, "SPR" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IAR, "IAR" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SAR, "SAR" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IPL, "IPL" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SPL, "SPL" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IAL, "IAL" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SAL, "SAL" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIR, "PIR" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PSR, "PSR" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_AIR, "AIR" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ASR, "ASR" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIL, "PIL" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PSL, "PSL" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_AIL, "AIL" },
+  { itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ASL, "ASL" }
+};
+
 /** WriteFile
  * Write out a char array as binary
  */
@@ -167,29 +223,33 @@ ReadImage(const std::string & fileName)
 
 } // namespace
 
+
 int
-itkNiftiReadAnalyzeTest(int ac, char * av[])
+itkNiftiAnalyzeContentsAndCoordinatesTest(char *                                                   av[],
+                                          unsigned char                                            hist_orient_code,
+                                          itk::SpatialOrientation::ValidCoordinateOrientationFlags expected_code)
 {
-  if (ac < 2)
-  {
-    std::cerr << "itkNiftiReadAnalyzeTest: Missing test directory argument" << std::endl;
-    return EXIT_FAILURE;
-  }
-  //
-  // since ITK4 doesn't support writing Analyze images, we write out a
-  // 'canned' image which is in little-endian byte order.
   std::string hdrName(av[1]);
-  hdrName += "/littleEndian.hdr";
+  hdrName += "/littleEndian_";
+  hdrName += codeToString[expected_code];
+  hdrName += ".hdr";
   std::string imgName(av[1]);
-  imgName += "/littleEndian.img";
-  if (WriteFile(hdrName, LittleEndian_hdr, sizeof(LittleEndian_hdr)) != EXIT_SUCCESS)
+  imgName += "/littleEndian_";
+  imgName += codeToString[expected_code];
+  imgName += ".img";
+  // hack the header to have proper orientation code
+  unsigned char tweaked_hdr[sizeof(LittleEndian_hdr)];
+  memcpy(tweaked_hdr, LittleEndian_hdr, sizeof(LittleEndian_hdr));
+  tweaked_hdr[252] = hist_orient_code;
+
+  if (WriteFile(hdrName, tweaked_hdr, sizeof(LittleEndian_hdr)) != EXIT_SUCCESS)
   {
-    std::cerr << "itkNiftiReadAnalyzeTest: failed to write " << hdrName << std::endl;
+    std::cerr << "itkNiftiAnalyzeContentsAndCoordinatesTest: failed to write " << hdrName << std::endl;
     return EXIT_FAILURE;
   }
   if (WriteFile(imgName, LittleEndian_img, sizeof(LittleEndian_img)) != EXIT_SUCCESS)
   {
-    std::cerr << "itkNiftiReadAnalyzeTest: failed to write " << imgName << std::endl;
+    std::cerr << "itkNiftiAnalyzeContentsAndCoordinatesTest: failed to write " << imgName << std::endl;
     return EXIT_FAILURE;
   }
   //
@@ -204,8 +264,7 @@ itkNiftiReadAnalyzeTest(int ac, char * av[])
   {
     return EXIT_FAILURE;
   }
-  //
-  // compare read pixels with pixels in the array we wrote out.
+
   const auto *                             fPtr = reinterpret_cast<const float *>(LittleEndian_img);
   itk::ImageRegionConstIterator<ImageType> it(img, img->GetLargestPossibleRegion());
   it.GoToBegin();
@@ -218,9 +277,58 @@ itkNiftiReadAnalyzeTest(int ac, char * av[])
     itk::ByteSwapper<float>::SwapFromSystemToLittleEndian(&cur);
     if (itk::Math::NotExactlyEquals(it.Get(), cur))
     {
-      std::cerr << "expected pixel value " << cur << " but found " << it.Get() << std::endl;
+      std::cerr << "itkNiftiAnalyzeContentsAndCoordinatesTest: expected pixel value " << cur << " but found "
+                << it.Get() << std::endl;
       return EXIT_FAILURE;
     }
   }
+
+  itk::SpatialOrientation::ValidCoordinateOrientationFlags orientation_code =
+    itk::SpatialOrientationAdapter().FromDirectionCosines(img->GetDirection());
+  // verify the correct orientation :
+  if (orientation_code != expected_code)
+  {
+    std::cerr << "Analyze orientation " << (int)hist_orient_code << std::endl;
+    std::cerr << "expected orientation " << codeToString[expected_code] << " but found "
+              << codeToString[orientation_code] << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // TODO: check origin and spacing too
+  std::cout << "Analyze orientation " << (int)hist_orient_code << std::endl
+            << "Origin   :" << img->GetOrigin() << std::endl
+            << "Spacing  :" << img->GetSpacing() << std::endl
+            << "Code     :" << codeToString[orientation_code] << std::endl
+            << "Direction:" << img->GetDirection() << std::endl;
+
   return EXIT_SUCCESS;
+}
+
+int
+itkNiftiReadAnalyzeTest(int ac, char * av[])
+{
+  if (ac < 2)
+  {
+    std::cerr << "itkNiftiReadAnalyzeTest: Missing test directory argument" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // NOTE: according to the information from
+  // https://web.archive.org/web/20121116093304/http://wideman-one.com/gw/brain/analyze/formatdoc.htm Analyze code 5
+  // should have been PSR but it was revised in NIFTI somehow to PIL
+
+  return itkNiftiAnalyzeContentsAndCoordinatesTest(av, 0, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI) ==
+               EXIT_FAILURE ||
+             itkNiftiAnalyzeContentsAndCoordinatesTest(
+               av, 1, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP) == EXIT_FAILURE ||
+             itkNiftiAnalyzeContentsAndCoordinatesTest(
+               av, 2, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIR) == EXIT_FAILURE ||
+             itkNiftiAnalyzeContentsAndCoordinatesTest(
+               av, 3, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI) == EXIT_FAILURE ||
+             itkNiftiAnalyzeContentsAndCoordinatesTest(
+               av, 4, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSP) == EXIT_FAILURE ||
+             itkNiftiAnalyzeContentsAndCoordinatesTest(
+               av, 5, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIL) == EXIT_FAILURE
+           ? EXIT_FAILURE
+           : EXIT_SUCCESS;
 }


### PR DESCRIPTION
We noticed that after switching from old (ITK3) AnalyzeImageIO reader to
NiftiImageIO reader for Analyze files, the directions have changed
It was caused by the fact that the new NIFTI reader is ignoring
Analyze orientation code, which was breaking our tests.

Code added - more correct interpretation of Analyze header and a Unit Test
that makes sure that orientation is correctly converted to the image directions.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
