### PR TITLE
BUG: Address buffer overflow with deprecated GDCM1 interface

### DIFF
--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -183,52 +183,52 @@ public:
    * Instead user are encourage to use directly the GetValueFromTag function
    */
   void
-  GetPatientName(char * name);
+  GetPatientName(char * name, size_t len = 512);
 
   void
-  GetPatientID(char * id);
+  GetPatientID(char * id, size_t len = 512);
 
   void
-  GetPatientSex(char * sex);
+  GetPatientSex(char * sex, size_t len = 512);
 
   void
-  GetPatientAge(char * age);
+  GetPatientAge(char * age, size_t len = 512);
 
   void
-  GetStudyID(char * id);
+  GetStudyID(char * id, size_t len = 512);
 
   void
-  GetPatientDOB(char * dob);
+  GetPatientDOB(char * dob, size_t len = 512);
 
   void
-  GetStudyDescription(char * desc);
+  GetStudyDescription(char * desc, size_t len = 512);
 
   void
-  GetBodyPart(char * part);
+  GetBodyPart(char * part, size_t len = 512);
 
   void
-  GetNumberOfSeriesInStudy(char * series);
+  GetNumberOfSeriesInStudy(char * series, size_t len = 512);
 
   void
-  GetNumberOfStudyRelatedSeries(char * series);
+  GetNumberOfStudyRelatedSeries(char * series, size_t len = 512);
 
   void
-  GetStudyDate(char * date);
+  GetStudyDate(char * date, size_t len = 512);
 
   void
-  GetModality(char * modality);
+  GetModality(char * modality, size_t len = 512);
 
   void
-  GetManufacturer(char * manu);
+  GetManufacturer(char * manu, size_t len = 512);
 
   void
-  GetInstitution(char * ins);
+  GetInstitution(char * ins, size_t len = 512);
 
   void
-  GetModel(char * model);
+  GetModel(char * model, size_t len = 512);
 
   void
-  GetScanOptions(char * options);
+  GetScanOptions(char * options, size_t len = 512);
 #endif
 
   /** More general method to retrieve an arbitrary DICOM value based

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -693,22 +693,22 @@ GDCMImageIO::InternalReadImageInformation()
 #if defined(ITKIO_DEPRECATED_GDCM1_API)
   // Now is a good time to fill in the class member:
   char name[512];
-  this->GetPatientName(name);
-  this->GetPatientID(name);
-  this->GetPatientSex(name);
-  this->GetPatientAge(name);
-  this->GetStudyID(name);
-  this->GetPatientDOB(name);
-  this->GetStudyDescription(name);
-  this->GetBodyPart(name);
-  this->GetNumberOfSeriesInStudy(name);
-  this->GetNumberOfStudyRelatedSeries(name);
-  this->GetStudyDate(name);
-  this->GetModality(name);
-  this->GetManufacturer(name);
-  this->GetInstitution(name);
-  this->GetModel(name);
-  this->GetScanOptions(name);
+  this->GetPatientName(name, 512);
+  this->GetPatientID(name, 512);
+  this->GetPatientSex(name, 512);
+  this->GetPatientAge(name, 512);
+  this->GetStudyID(name, 512);
+  this->GetPatientDOB(name, 512);
+  this->GetStudyDescription(name, 512);
+  this->GetBodyPart(name, 512);
+  this->GetNumberOfSeriesInStudy(name, 512);
+  this->GetNumberOfStudyRelatedSeries(name, 512);
+  this->GetStudyDate(name, 512);
+  this->GetModality(name, 512);
+  this->GetManufacturer(name, 512);
+  this->GetInstitution(name, 512);
+  this->GetModel(name, 512);
+  this->GetScanOptions(name, 512);
 #endif
 }
 
@@ -1301,147 +1301,163 @@ GDCMImageIO::Write(const void * buffer)
 // Convenience methods to query patient and scanner information. These
 // methods are here for compatibility with the DICOMImageIO2 class.
 void
-GDCMImageIO::GetPatientName(char * name)
+GDCMImageIO::GetPatientName(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0010|0010", m_PatientName);
-  strcpy(name, m_PatientName.c_str());
+  strncpy(name, m_PatientName.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetPatientID(char * name)
+GDCMImageIO::GetPatientID(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0010|0020", m_PatientID);
-  strcpy(name, m_PatientID.c_str());
+  strncpy(name, m_PatientID.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetPatientSex(char * name)
+GDCMImageIO::GetPatientSex(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0010|0040", m_PatientSex);
-  strcpy(name, m_PatientSex.c_str());
+  strncpy(name, m_PatientSex.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetPatientAge(char * name)
+GDCMImageIO::GetPatientAge(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0010|1010", m_PatientAge);
-  strcpy(name, m_PatientAge.c_str());
+  strncpy(name, m_PatientAge.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetStudyID(char * name)
+GDCMImageIO::GetStudyID(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0020|0010", m_StudyID);
-  strcpy(name, m_StudyID.c_str());
+  strncpy(name, m_StudyID.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetPatientDOB(char * name)
+GDCMImageIO::GetPatientDOB(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0010|0030", m_PatientDOB);
-  strcpy(name, m_PatientDOB.c_str());
+  strncpy(name, m_PatientDOB.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetStudyDescription(char * name)
+GDCMImageIO::GetStudyDescription(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0008|1030", m_StudyDescription);
-  strcpy(name, m_StudyDescription.c_str());
+  strncpy(name, m_StudyDescription.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetBodyPart(char * name)
+GDCMImageIO::GetBodyPart(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0018|0015", m_BodyPart);
-  strcpy(name, m_BodyPart.c_str());
+  strncpy(name, m_BodyPart.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetNumberOfSeriesInStudy(char * name)
+GDCMImageIO::GetNumberOfSeriesInStudy(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0020|1000", m_NumberOfSeriesInStudy);
-  strcpy(name, m_NumberOfSeriesInStudy.c_str());
+  strncpy(name, m_NumberOfSeriesInStudy.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetNumberOfStudyRelatedSeries(char * name)
+GDCMImageIO::GetNumberOfStudyRelatedSeries(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0020|1206", m_NumberOfStudyRelatedSeries);
-  strcpy(name, m_NumberOfStudyRelatedSeries.c_str());
+  strncpy(name, m_NumberOfStudyRelatedSeries.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetStudyDate(char * name)
+GDCMImageIO::GetStudyDate(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0008|0020", m_StudyDate);
-  strcpy(name, m_StudyDate.c_str());
+  strncpy(name, m_StudyDate.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetModality(char * name)
+GDCMImageIO::GetModality(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0008|0060", m_Modality);
-  strcpy(name, m_Modality.c_str());
+  strncpy(name, m_Modality.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetManufacturer(char * name)
+GDCMImageIO::GetManufacturer(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0008|0070", m_Manufacturer);
-  strcpy(name, m_Manufacturer.c_str());
+  strncpy(name, m_Manufacturer.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetInstitution(char * name)
+GDCMImageIO::GetInstitution(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0008|0080", m_Institution);
-  strcpy(name, m_Institution.c_str());
+  strncpy(name, m_Institution.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetModel(char * name)
+GDCMImageIO::GetModel(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0008|1090", m_Model);
-  strcpy(name, m_Model.c_str());
+  strncpy(name, m_Model.c_str(), len);
+  name[len - 1] = '\0';
 }
 
 void
-GDCMImageIO::GetScanOptions(char * name)
+GDCMImageIO::GetScanOptions(char * name, size_t len)
 {
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
   ExposeMetaData<std::string>(dict, "0018|0022", m_ScanOptions);
-  strcpy(name, m_ScanOptions.c_str());
+  strncpy(name, m_ScanOptions.c_str(), len);
+  name[len - 1] = '\0';
 }
 #endif
 


### PR DESCRIPTION
Add string buffer length argument to methods using C strings for
output.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
