### PR TITLE
ENH: Preserving information about auto-flipped negative steps in metadata

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -24,6 +24,7 @@
 #include "itkConvertPixelBuffer.h"
 #include "itkPixelTraits.h"
 #include "itkVectorImage.h"
+#include "itkMetaDataObject.h"
 
 #include "itksys/SystemTools.hxx"
 #include <memory> // For unique_ptr
@@ -210,8 +211,16 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
       }
     }
   }
+  MetaDataDictionary & thisDic = m_ImageIO->GetMetaDataDictionary();
+  // Store original directions and spacing
+
+  EncapsulateMetaData<std::vector<double>>(
+    thisDic, "ITK_original_spacing", std::vector<double>(spacing, spacing + TOutputImage::ImageDimension));
+  EncapsulateMetaData<typename TOutputImage::DirectionType>(thisDic, "ITK_original_direction", direction);
+
   // Spacing is expected to be greater than 0
   // If negative, flip image direction along this axis.
+  // and store this information in the metadata
   for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {
     if (spacing[i] < 0)
@@ -228,8 +237,8 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
   output->SetDirection(direction); // Set the image direction cosines
 
   // Copy MetaDataDictionary from instantiated reader to output image.
-  output->SetMetaDataDictionary(m_ImageIO->GetMetaDataDictionary());
-  this->SetMetaDataDictionary(m_ImageIO->GetMetaDataDictionary());
+  output->SetMetaDataDictionary(thisDic);
+  this->SetMetaDataDictionary(thisDic);
 
   IndexType start;
   start.Fill(0);


### PR DESCRIPTION
We need information weather the image was flipped to compensate for the negative steps.
This fix can also help resolve the issues menioned in https://github.com/InsightSoftwareConsortium/ITK/commit/7501479a970694b0dd4a8c4bbf7cbcc033fe059c

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [ ] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
