### PR TITLE
ENH: Separate boundary/non-boundary regions ImageBoundaryFacesCalculator

### DIFF
--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.h
@@ -69,6 +69,55 @@ struct ImageBoundaryFacesCalculator
   using FaceListType = std::list<RegionType>;
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;
 
+  /** \class Result
+   *
+   * Represents the result of ImageBoundaryFacesCalculator::Compute
+   *
+   * \ingroup ITKCommon
+   */
+  class Result
+  {
+  public:
+    /** Returns the center (non-boundary) region. */
+    RegionType
+    GetNonBoundaryRegion() const
+    {
+      return m_NonBoundaryRegion;
+    }
+
+    /** Returns the boundary faces (the regions at the boundary of the image). */
+    const FaceListType &
+    GetBoundaryFaces() const
+    {
+      return m_BoundaryFaces;
+    }
+
+    /** Tells whether Result objects `lhs` and `rhs` are equal. */
+    friend bool
+    operator==(const Result & lhs, const Result & rhs)
+    {
+      return (lhs.m_NonBoundaryRegion == rhs.m_NonBoundaryRegion) && (lhs.m_BoundaryFaces == rhs.m_BoundaryFaces);
+    }
+
+    /** Tells whether Result objects `lhs` and `rhs` are unequal. */
+    friend bool
+    operator!=(const Result & lhs, const Result & rhs)
+    {
+      return !(lhs == rhs);
+    }
+
+  private:
+    friend struct ImageBoundaryFacesCalculator;
+
+    RegionType   m_NonBoundaryRegion;
+    FaceListType m_BoundaryFaces;
+  };
+
+  /** Splits the specified region into a non-boundary region and a list of
+   * boundary faces, and returns the result. */
+  static Result
+  Compute(const TImage &, RegionType, RadiusType);
+
   FaceListType
   operator()(const TImage *, RegionType, RadiusType);
 };


### PR DESCRIPTION
`NeighborhoodAlgorithm::ImageBoundaryFacesCalculator::operator()` places
the non-boundary region (at the center) in a list together with all the
boundary regions (the faces) that it has found. It appears clearer to
keep the non-boundary region and the boundary regions separate.

This commit adds a `Compute(image, region, radius)` member function
and a result type `Result` to `ImageBoundaryFacesCalculator`, which
keep them separate.

It replaces the old `operator()` call by a call to the new `Compute`, in
`MeanImageFilter`, to shorten the code and improve readability.

`operator()` is now implemented by calling `Execute`. `operator()` still
returns the list that has all regions together, as it did before.