### PR TITLE
COMP: Update MinimalPathExtraction to remove warnings

### DIFF
--- a/Modules/Remote/MinimalPathExtraction.remote.cmake
+++ b/Modules/Remote/MinimalPathExtraction.remote.cmake
@@ -3,5 +3,5 @@ itk_fetch_module(MinimalPathExtraction
  "http://www.insight-journal.org/browse/publication/213
 "
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git
-  GIT_TAG c00dbb883a44db59004210840d6c3f9deebaf92c
+  GIT_TAG 322e9338d76b7dcfb98861c6c22e5645806821d7
   )


### PR DESCRIPTION
Update to version that removes deprecated throw decorator for functions.
The throw decorator was deprecated in C++11.

See:
[ITMInaimalPathExtraction Commit](https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/commit/322e9338d76b7dcfb98861c6c22e5645806821d7)
