### PR TITLE
ENH: Improve diagnostic warnings for ResampleImage misuse

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -175,6 +175,11 @@ public:
   /** Typedef the reference image type to be the ImageBase of the OutputImageType */
   using ReferenceImageBaseType = ImageBase<ImageDimension>;
 
+  /* See superclass for doxygen. This method adds the additional check
+   * that the output space is set */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   /** Get/Set the coordinate transformation.
    * Set the coordinate transform to use for resampling.  Note that this must
    * be in physical coordinates and it is the output-to-input transform, NOT
@@ -242,9 +247,10 @@ public:
 
   /** Set a reference image to use to define the output information.
    *  By default, output information is specified through the
-   *  SetOutputSpacing, Origin, and Direction methods.  Alternatively,
-   *  this method can be used to specify an image from which to
-   *  copy the information. UseReferenceImageOn must be set to utilize the
+   *  SetOutputSpacing, SetOutputOrigin, and SetOutputDirection or
+   *  SetOutputParametersFromImage methods.
+   *  Alternatively, this method can be used to specify an image from which to
+   *  copy the pixel information. UseReferenceImageOn must be set to utilize the
    *  reference image. */
   itkSetInputMacro(ReferenceImage, ReferenceImageBaseType);
 

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -74,6 +74,23 @@ template <typename TInputImage,
           typename TInterpolatorPrecisionType,
           typename TTransformPrecisionType>
 void
+ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
+  VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+  const ReferenceImageBaseType * const referenceImage = this->GetReferenceImage();
+  if (this->m_Size[0] == 0 && referenceImage && !m_UseReferenceImage)
+  {
+    itkExceptionMacro("Output image size is zero in all dimensions.  Consider using SetUseReferenceImageOn()."
+                      "to define the resample output from the ReferenceImage.");
+  }
+}
+
+template <typename TInputImage,
+          typename TOutputImage,
+          typename TInterpolatorPrecisionType,
+          typename TTransformPrecisionType>
+void
 ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::SetOutputSpacing(
   const double * spacing)
 {
@@ -575,7 +592,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   // Get pointers to the input and output
   OutputImageType * outputPtr = this->GetOutput();
 
-  const ReferenceImageBaseType * referenceImage = this->GetReferenceImage();
+  const ReferenceImageBaseType * const referenceImage = this->GetReferenceImage();
 
   // Set the size of the output region
   if (m_UseReferenceImage && referenceImage)


### PR DESCRIPTION
Using a "ReferenceImage" for the ResampleImageFilter is a two step
process requiring both 'SetReferenceImage(im)' and 'UseReferenceImageOn()'.

Failing to use both calls silently generates a resampled image of size
zero in all dimensions.
