### PR TITLE
PERF: Use ShapedImageNeighborhoodRange in MedianImageFilter

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
@@ -19,12 +19,13 @@
 #define itkMedianImageFilter_hxx
 #include "itkMedianImageFilter.h"
 
-#include "itkConstNeighborhoodIterator.h"
-#include "itkNeighborhoodInnerProduct.h"
-#include "itkImageRegionIterator.h"
+#include "itkBufferedImageNeighborhoodPixelAccessPolicy.h"
+#include "itkImageNeighborhoodOffsets.h"
+#include "itkImageRegionRange.h"
+#include "itkIndexRange.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkOffset.h"
-#include "itkProgressReporter.h"
+#include "itkShapedImageNeighborhoodRange.h"
 
 #include <vector>
 #include <algorithm>
@@ -46,46 +47,56 @@ MedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   typename OutputImageType::Pointer     output = this->GetOutput();
   typename InputImageType::ConstPointer input = this->GetInput();
 
-  // Find the data-set boundary "faces"
-  NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        bC;
-  typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType faceList =
-    bC(input, outputRegionForThread, this->GetRadius());
+  const auto radius = this->GetRadius();
+
+  // Find the data-set boundary "faces" and the center non-boundary subregion.
+  const auto calculatorResult =
+    NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::Compute(*input, outputRegionForThread, radius);
+
+  using namespace Experimental;
+  const auto neighborhoodOffsets = GenerateRectangularImageNeighborhoodOffsets<InputImageDimension>(radius);
+  const auto neighborhoodSize = neighborhoodOffsets.size();
 
   // All of our neighborhoods have an odd number of pixels, so there is
-  // always a median index (if there where an even number of pixels
-  // in the neighborhood we have to average the middle two values).
+  // always a median.
+  std::vector<InputPixelType> pixels(neighborhoodSize);
+  const auto                  medianIterator = pixels.begin() + (neighborhoodSize / 2);
 
-  ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;
-  std::vector<InputPixelType>                      pixels;
+  const auto nonBoundaryRegion = calculatorResult.GetNonBoundaryRegion();
+
+  if (nonBoundaryRegion.GetSize() != InputSizeType())
+  {
+    // Process the non-boundary subregion, using a faster pixel access policy without boundary extrapolation.
+    auto neighborhoodRange =
+      ShapedImageNeighborhoodRange<const InputImageType, BufferedImageNeighborhoodPixelAccessPolicy<InputImageType>>(
+        *input, Index<InputImageDimension>(), neighborhoodOffsets);
+    auto outputIterator = ImageRegionRange<OutputImageType>(*output, nonBoundaryRegion).begin();
+
+    for (const auto & index : ImageRegionIndexRange<InputImageDimension>(nonBoundaryRegion))
+    {
+      neighborhoodRange.SetLocation(index);
+      std::copy_n(neighborhoodRange.cbegin(), neighborhoodSize, pixels.begin());
+      std::nth_element(pixels.begin(), medianIterator, pixels.end());
+      *outputIterator = *medianIterator;
+      ++outputIterator;
+    }
+  }
+
   // Process each of the boundary faces.  These are N-d regions which border
   // the edge of the buffer.
-  for (auto fit = faceList.begin(); fit != faceList.end(); ++fit)
+  for (const auto boundaryFace : calculatorResult.GetBoundaryFaces())
   {
-    ImageRegionIterator<OutputImageType> it = ImageRegionIterator<OutputImageType>(output, *fit);
+    auto neighborhoodRange =
+      ShapedImageNeighborhoodRange<const InputImageType>(*input, Index<InputImageDimension>(), neighborhoodOffsets);
+    auto outputIterator = ImageRegionRange<OutputImageType>(*output, boundaryFace).begin();
 
-    ConstNeighborhoodIterator<InputImageType> bit =
-      ConstNeighborhoodIterator<InputImageType>(this->GetRadius(), input, *fit);
-    bit.OverrideBoundaryCondition(&nbc);
-    bit.GoToBegin();
-    const unsigned int neighborhoodSize = bit.Size();
-    const unsigned int medianPosition = neighborhoodSize / 2;
-    while (!bit.IsAtEnd())
+    for (const auto & index : ImageRegionIndexRange<InputImageDimension>(boundaryFace))
     {
-      // collect all the pixels in the neighborhood, note that we use
-      // GetPixel on the NeighborhoodIterator to honor the boundary conditions
-      pixels.resize(neighborhoodSize);
-      for (unsigned int i = 0; i < neighborhoodSize; ++i)
-      {
-        pixels[i] = (bit.GetPixel(i));
-      }
-
-      // get the median value
-      const typename std::vector<InputPixelType>::iterator medianIterator = pixels.begin() + medianPosition;
+      neighborhoodRange.SetLocation(index);
+      std::copy_n(neighborhoodRange.cbegin(), neighborhoodSize, pixels.begin());
       std::nth_element(pixels.begin(), medianIterator, pixels.end());
-      it.Set(static_cast<typename OutputImageType::PixelType>(*medianIterator));
-
-      ++bit;
-      ++it;
+      *outputIterator = *medianIterator;
+      ++outputIterator;
     }
   }
 }


### PR DESCRIPTION
Improved the performance of `MedianImageFilter::Update`
by replacing its local `itk::ConstNeighborhoodIterator` variable by
`Experimental::ShapedImageNeighborhoodRange` variables, using
`BufferedImageNeighborhoodPixelAccessPolicy` for the non-boundary
(center) subregion.

~25% reduction of the run-time duration was observed on a
`filter->Update()` call, using VS2017, processing a 256x256x256 image.
For a 1024x1024x16 image, the performance improvement appeared even higher.