### PR TITLE
COMP: Fix GTest gcc4.6, Mac10.10 error VNumberOfExpectedPixels deduction

### DIFF
--- a/Modules/Filtering/Smoothing/test/itkMeanImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMeanImageFilterGTest.cxx
@@ -23,6 +23,7 @@
 #include "itkImageBufferRange.h"
 
 #include <numeric> // For iota.
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -71,22 +72,24 @@ CreateImageFilledWithSequenceOfNaturalNumbers(const typename TImage::RegionType 
 }
 
 
-template <typename TImage, std::size_t VNumberOfExpectedPixels>
+template <typename TImage>
 void
 Expect_output_has_specified_pixel_values_when_input_has_sequence_of_natural_numbers(
-  const typename TImage::RegionType & imageRegion,
-  const typename TImage::PixelType (&expectedPixelValues)[VNumberOfExpectedPixels])
+  const typename TImage::RegionType &             imageRegion,
+  const std::vector<typename TImage::PixelType> & expectedPixelValues)
 {
+  using PixelType = typename TImage::PixelType;
+
   const auto inputImage = CreateImageFilledWithSequenceOfNaturalNumbers<TImage>(imageRegion);
   const auto filter = itk::MeanImageFilter<TImage, TImage>::New();
   filter->SetInput(inputImage);
   filter->Update();
 
-  const TImage * const outputImage = filter->GetOutput();
-  const auto           outputImageBufferRange = itk::Experimental::MakeImageBufferRange(outputImage);
+  const TImage * const         outputImage = filter->GetOutput();
+  const auto                   outputImageBufferRange = itk::Experimental::MakeImageBufferRange(outputImage);
+  const std::vector<PixelType> outputPixelValues(outputImageBufferRange.cbegin(), outputImageBufferRange.cend());
 
-  ASSERT_EQ(outputImageBufferRange.size(), VNumberOfExpectedPixels);
-  EXPECT_TRUE(std::equal(outputImageBufferRange.cbegin(), outputImageBufferRange.cend(), expectedPixelValues));
+  EXPECT_EQ(outputPixelValues, expectedPixelValues);
 }
 
 } // namespace

--- a/Modules/Filtering/Smoothing/test/itkMedianImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMedianImageFilterGTest.cxx
@@ -23,6 +23,7 @@
 #include "itkImageBufferRange.h"
 
 #include <numeric> // For iota.
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -71,22 +72,24 @@ CreateImageFilledWithSequenceOfNaturalNumbers(const typename TImage::RegionType 
 }
 
 
-template <typename TImage, std::size_t VNumberOfExpectedPixels>
+template <typename TImage>
 void
 Expect_output_has_specified_pixel_values_when_input_has_sequence_of_natural_numbers(
-  const typename TImage::RegionType & imageRegion,
-  const typename TImage::PixelType (&expectedPixelValues)[VNumberOfExpectedPixels])
+  const typename TImage::RegionType &             imageRegion,
+  const std::vector<typename TImage::PixelType> & expectedPixelValues)
 {
+  using PixelType = typename TImage::PixelType;
+
   const auto inputImage = CreateImageFilledWithSequenceOfNaturalNumbers<TImage>(imageRegion);
   const auto filter = itk::MedianImageFilter<TImage, TImage>::New();
   filter->SetInput(inputImage);
   filter->Update();
 
-  const TImage * const outputImage = filter->GetOutput();
-  const auto           outputImageBufferRange = itk::Experimental::MakeImageBufferRange(outputImage);
+  const TImage * const         outputImage = filter->GetOutput();
+  const auto                   outputImageBufferRange = itk::Experimental::MakeImageBufferRange(outputImage);
+  const std::vector<PixelType> outputPixelValues(outputImageBufferRange.cbegin(), outputImageBufferRange.cend());
 
-  ASSERT_EQ(outputImageBufferRange.size(), VNumberOfExpectedPixels);
-  EXPECT_TRUE(std::equal(outputImageBufferRange.cbegin(), outputImageBufferRange.cend(), expectedPixelValues));
+  EXPECT_EQ(outputPixelValues, expectedPixelValues);
 }
 
 } // namespace


### PR DESCRIPTION
Works around compilation errors (presumably because of compiler bugs) in
itkMeanImageFilterGTest and itkMedianImageFilterGTest, as two compilers
failed to deduce the size of an array that is passed by reference, from
an initializer-list argument.

Ubuntu-gcc4.6-Release:

> note: template argument deduction/substitution failed:
> note: couldn't deduce template parameter 'VNumberOfExpectedPixels'

Mac10.10-AppleClang-dbg-x86_64-static

> note: candidate template ignored: couldn't infer template argument 'VNumberOfExpectedPixels'

The fix consists of using `std::vector` instead. Which has another
advantage (compared to using a reference to a C-style array), that it
can be passed directly to the GoogleTest `EXPECT_EQ` macro.

Reported by Dženan Zukić (@dzenanz)