### PR TITLE
ENH: Added code to detect non-uniform sampling in ImageSeriesReader

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.h
@@ -207,6 +207,8 @@ protected:
 
   bool m_UseStreaming{ true };
 
+  bool m_SpacingDefined{ false };
+
 private:
   using ReaderType = ImageFileReader<TOutputImage>;
 

--- a/Modules/IO/ImageBase/test/CMakeLists.txt
+++ b/Modules/IO/ImageBase/test/CMakeLists.txt
@@ -28,6 +28,7 @@ itkImageIODirection2DTest.cxx
 itkImageIODirection3DTest.cxx
 itkImageIOFileNameExtensionsTests.cxx
 itkImageSeriesReaderDimensionsTest.cxx
+itkImageSeriesReaderSamplingTest.cxx
 itkImageSeriesReaderVectorTest.cxx
 itkImageSeriesWriterTest.cxx
 itkIOPluginTest.cxx
@@ -277,6 +278,17 @@ itk_add_test(NAME itkImageSeriesReaderDimensionsTest1
               DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0077.dcm})
 
 set_property(TEST itkImageSeriesReaderDimensionsTest1 APPEND PROPERTY DEPENDS ITK_Data)
+
+itk_add_test(NAME itkImageSeriesReaderSamplingTest1
+      COMMAND ITKIOImageBaseTestDriver itkImageSeriesReaderSamplingTest
+              DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0075.dcm}
+              DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0076.dcm}
+              DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0076.dcm} # duplicated slice test to emulate non-uniform sampling
+              DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0077.dcm})
+
+set_property(TEST itkImageSeriesReaderDimensionsTest1 APPEND PROPERTY DEPENDS ITK_Data)
+# TODO: add a test with a missing slice, for that we need to have example with one more slice
+
 
 itk_add_test(NAME itkImageFileReaderPositiveSpacingTest
       COMMAND ITKIOImageBaseTestDriver itkImageFileReaderPositiveSpacingTest

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
@@ -1,0 +1,83 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImageSeriesReader.h"
+
+int
+itkImageSeriesReaderSamplingTest(int ac, char * av[])
+{
+
+  if (ac < 3)
+  {
+    std::cerr << "usage: itkIOTests itkImageSeriesReaderSamplingTest inputFileName(s)" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+
+  using Image3DType = itk::Image<short, 3>;
+  using Reader3DType = itk::ImageSeriesReader<Image3DType>;
+
+  Reader3DType::FileNamesContainer fnames;
+  for (int i = 1; i < ac; ++i)
+  {
+    std::cout << av[i] << std::endl;
+    fnames.push_back(av[i]);
+  }
+
+  std::cout << "testing reading a series of 2D images to 3D with extra slices" << std::endl;
+  try
+  {
+    Reader3DType::Pointer reader = Reader3DType::New();
+    reader->SetFileNames(fnames);
+    reader->Update();
+    bool globalNonUniformSampling = false;
+    if (itk::ExposeMetaData<bool>(
+          reader->GetOutput()->GetMetaDataDictionary(), "ITK_non_uniform_sampling", globalNonUniformSampling) &&
+        globalNonUniformSampling)
+    {
+      std::cout << "output ITK_non_uniform_sampling detected " << std::endl;
+    }
+    else
+    {
+      std::cout << "output ITK_non_uniform_sampling not found" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    // iterate over all slices to detect offending slice
+    for (auto d : *reader->GetMetaDataDictionaryArray())
+    {
+      itk::MetaDataDictionary theMetadata = *d;
+      bool                    nonUniformSampling = false;
+      if (itk::ExposeMetaData<bool>(theMetadata, "ITK_non_uniform_sampling", nonUniformSampling) && nonUniformSampling)
+      {
+        std::cout << "slice ITK_non_uniform_sampling detected" << std::endl;
+      }
+      else
+      {
+        std::cout << "slice ITK_non_uniform_sampling not detected" << std::endl;
+      }
+    }
+  }
+  catch (itk::ExceptionObject & ex)
+  {
+    std::cout << ex;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
A simple change to the ImageSeriesReader to verify spacing between consecutive images, addresses InsightSoftwareConsortium/ITK#441 , can be used to diagnose missing dicom slices. 

CC: @seanm 

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
