### PR TITLE
BUG: Don't use InsertElement which modifies MTime

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -348,8 +348,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>
       this->m_OutputPointData->Begin();
     while( ItIn != this->m_InputPointData->End() )
       {
-      this->m_InputPointData->InsertElement(
-        ItIn.Index(), ItIn.Value() - ItOut.Value() );
+      this->m_InputPointData->CastToSTLContainer()[ItIn.Index()] = ItIn.Value() - ItOut.Value();
 
       if( this->GetDebug() )
         {
@@ -1101,6 +1100,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>
   typename PointDataImageType::IndexType startPhiIndex =
     this->m_PhiLattice->GetLargestPossibleRegion().GetIndex();
 
+  this->m_OutputPointData->CastToSTLContainer().resize(this->m_InputPointData->Size());
   typename PointDataContainerType::ConstIterator ItIn =
     this->m_InputPointData->Begin();
   while( ItIn != this->m_InputPointData->End() )
@@ -1146,8 +1146,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>
         break;
         }
       }
-    this->m_OutputPointData->InsertElement( ItIn.Index(),
-      collapsedPhiLattices[0]->GetPixel( startPhiIndex ) );
+    this->m_OutputPointData->CastToSTLContainer()[ItIn.Index()] = collapsedPhiLattices[0]->GetPixel(startPhiIndex);
     ++ItIn;
     }
 }


### PR DESCRIPTION
Use the VectorContainer's STL interface to avoid causing MTime to be
called too many time. This has reported to overflow the global time
stamp with it's a 32-bit integer.
SimpleITK/SimpleITK#750
closes ITK/ITK#1352

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
