### PR TITLE
COMP: Fixed itkWarningMacro and itkDebugMacro to confirm to PRE10-C

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -388,6 +388,7 @@ OutputWindowDisplayDebugText(const char *);
 #  define itkDebugStatement(x)
 #else
 #  define itkDebugMacro(x)                                                                                             \
+    do                                                                                                                 \
     {                                                                                                                  \
       if (this->GetDebug() && ::itk::Object::GetGlobalWarningDisplay())                                                \
       {                                                                                                                \
@@ -396,7 +397,7 @@ OutputWindowDisplayDebugText(const char *);
                << this->GetNameOfClass() << " (" << this << "): " x << "\n\n";                                         \
         ::itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());                                                     \
       }                                                                                                                \
-    }
+    } while (0)
 
 // The itkDebugStatement is to be used to protect code that is only
 // used in the itkDebugMacro
@@ -407,6 +408,7 @@ OutputWindowDisplayDebugText(const char *);
  * but not necessarily fatal.) Example usage looks like:
  * itkWarningMacro(<< "this is warning info" << this->SomeVariable); */
 #define itkWarningMacro(x)                                                                                             \
+  do                                                                                                                   \
   {                                                                                                                    \
     if (::itk::Object::GetGlobalWarningDisplay())                                                                      \
     {                                                                                                                  \
@@ -415,7 +417,7 @@ OutputWindowDisplayDebugText(const char *);
              << this->GetNameOfClass() << " (" << this << "): " x << "\n\n";                                           \
       ::itk::OutputWindowDisplayWarningText(itkmsg.str().c_str());                                                     \
     }                                                                                                                  \
-  }
+  } while (0)
 
 // The itkDebugStatement is to be used ot protect code that is only
 // used in the itkDebugMacro

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -204,9 +204,9 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
 
     ImageRegionConstIteratorWithIndex<InputFieldType> It(inputField, inputField->GetBufferedRegion());
 
-    itkDebugMacro("Extracting points from input displacement field.")
+    itkDebugMacro("Extracting points from input displacement field.");
 
-      for (It.GoToBegin(); !It.IsAtEnd(); ++It)
+    for (It.GoToBegin(); !It.IsAtEnd(); ++It)
     {
       typename DisplacementFieldType::IndexType index = It.GetIndex();
 

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -439,7 +439,7 @@ ImageSeriesReader<TOutputImage>::GetMetaDataDictionaryArray() const
   if (this->m_OutputInformationMTime > this->m_MetaDataDictionaryArrayMTime)
   {
     itkWarningMacro("The MetaDataDictionaryArray is not up to date. This is no longer updated in the "
-                    "UpdateOutputInformation method but in GenerateData.")
+                    "UpdateOutputInformation method but in GenerateData.");
   }
   return &m_MetaDataDictionaryArray;
 }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1249,7 +1249,8 @@ TIFFImageIO::ReadTIFFTags()
         case TIFF_UNDEFINED:
         default:
           itkWarningMacro(<< field_name << " has unsupported data type (" << itkTIFFFieldDataType(field)
-                          << ") for meta-data dictionary.") break;
+                          << ") for meta-data dictionary.");
+          break;
       }
     }
     catch (...)

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
@@ -277,8 +277,8 @@ LBFGS2Optimizerv4::GetStopConditionDescription() const
 void
 LBFGS2Optimizerv4 ::SetScales(const ScalesType &)
 {
-  itkWarningMacro(<< "LBFGS optimizer does not support scaling. All scales are set to one.")
-    m_Scales.SetSize(this->m_Metric->GetNumberOfLocalParameters());
+  itkWarningMacro(<< "LBFGS optimizer does not support scaling. All scales are set to one.");
+  m_Scales.SetSize(this->m_Metric->GetNumberOfLocalParameters());
   m_Scales.Fill(NumericTraits<ScalesType::ValueType>::OneValue());
   this->m_ScalesAreIdentity = true;
 }
@@ -286,8 +286,8 @@ LBFGS2Optimizerv4 ::SetScales(const ScalesType &)
 void
 LBFGS2Optimizerv4 ::SetWeights(const ScalesType)
 {
-  itkWarningMacro(<< "LBFGS optimizer does not support weights. All weights are set to one.")
-    m_Weights.SetSize(this->m_Metric->GetNumberOfLocalParameters());
+  itkWarningMacro(<< "LBFGS optimizer does not support weights. All weights are set to one.");
+  m_Weights.SetSize(this->m_Metric->GetNumberOfLocalParameters());
   m_Weights.Fill(NumericTraits<ScalesType::ValueType>::OneValue());
   this->m_WeightsAreIdentity = true;
 }

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -95,8 +95,8 @@ LBFGSBOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
 void
 LBFGSBOptimizerv4 ::SetScales(const ScalesType &)
 {
-  itkWarningMacro(<< "LBFGSB optimizer does not support scaling. All scales are set to one.")
-    m_Scales.SetSize(this->m_Metric->GetNumberOfLocalParameters());
+  itkWarningMacro(<< "LBFGSB optimizer does not support scaling. All scales are set to one.");
+  m_Scales.SetSize(this->m_Metric->GetNumberOfLocalParameters());
   m_Scales.Fill(NumericTraits<ScalesType::ValueType>::OneValue());
   this->m_ScalesAreIdentity = true;
 }

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -129,12 +129,12 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::BeforeThreadedGenera
 
     shrunkImage = shrinker->GetOutput();
   }
-  itkDebugMacro("Shinking Completed")
+  itkDebugMacro("Shinking Completed");
 
-    const typename InputImageType::RegionType region = inputImage->GetBufferedRegion();
-  const unsigned int                          numberOfComponents = inputImage->GetNumberOfComponentsPerPixel();
-  const unsigned int                          numberOfClusterComponents = numberOfComponents + ImageDimension;
-  const size_t                                numberOfClusters = shrunkImage->GetBufferedRegion().GetNumberOfPixels();
+  const typename InputImageType::RegionType region = inputImage->GetBufferedRegion();
+  const unsigned int                        numberOfComponents = inputImage->GetNumberOfComponentsPerPixel();
+  const unsigned int                        numberOfClusterComponents = numberOfComponents + ImageDimension;
+  const size_t                              numberOfClusters = shrunkImage->GetBufferedRegion().GetNumberOfPixels();
 
 
   // allocate array of scalars


### PR DESCRIPTION
See: https://wiki.sei.cmu.edu/confluence/display/c/PRE10-C.+Wrap+multistatement+macros+in+a+do-while+loop

Apparently some formatting got updated by KWStyle,clangformat on commit. 

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [ ] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
