### PR TITLE
DOC: More clearly describe foreground/background

### DIFF
--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -80,13 +80,13 @@ BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::GenerateData()
   // create the pipeline without input and output image
   dilate->ReleaseDataFlagOn();
   dilate->SetKernel(this->GetKernel());
-  dilate->SetDilateValue(m_ForegroundValue);
+  dilate->SetForegroundValue(m_ForegroundValue); // Intensity value to dilate
   dilate->SetBackgroundValue(backgroundValue);
   dilate->SetInput(this->GetInput());
   dilate->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
 
   erode->ReleaseDataFlagOn();
-  erode->SetForegroundValue(m_ForegroundValue);
+  erode->SetForegroundValue(m_ForegroundValue); // Intensity value to erode
   erode->SetBackgroundValue(backgroundValue);
   erode->SetMarkerImage(dilate->GetOutput());
   erode->SetFullyConnected(m_FullyConnected);

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
@@ -27,10 +27,14 @@ namespace itk
 {
 /**
  * \class BinaryDilateImageFilter
- * \brief Fast binary dilation
+ * \brief Fast binary dilation of a single intensity value in the image.
  *
  * BinaryDilateImageFilter is a binary dilation
- * morphologic operation. This implementation is based on the papers:
+ * morphologic operation on the foreground of an image. Only the value designated
+ * by the single "DilateValue" is considered as foreground, and all other values
+ * are considered background.
+ *
+ * This implementation is based on the papers:
  *
  * L.Vincent "Morphological transformations of binary images with
  * arbitrary structuring elements", and

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
@@ -31,8 +31,23 @@ namespace itk
  *
  * BinaryDilateImageFilter is a binary dilation
  * morphologic operation on the foreground of an image. Only the value designated
- * by the single "DilateValue" is considered as foreground, and all other values
- * are considered background.
+ * by the intensity value "SetForegroundValue()" (alias as SetDilateValue()) is considered
+ * as foreground, and other intensity values are considered background.
+ *
+ * Gray scale images can be processed as binary images by selecting a
+ * "ForegroundValue" (alias "DilateValue").  Pixel values matching the dilate value are
+ * considered the "foreground" and all other pixels are
+ * "background". This is useful in processing segmented images where
+ * all pixels in segment #1 have value 1 and pixels in segment #2 have
+ * value 2, etc. A particular "segment number" can be processed.
+ * ForegroundValue defaults to the maximum possible value of the
+ * PixelType.
+ *
+ * The structuring element is assumed to be composed of binary values
+ * (zero or one). Only elements of the structuring element having
+ * values > 0 are candidates for affecting the center pixel.  A
+ * reasonable choice of structuring element is
+ * itk::BinaryBallStructuringElement.
  *
  * This implementation is based on the papers:
  *
@@ -43,21 +58,6 @@ namespace itk
  * morphological transformations with 3d structuring elements
  * for arbitrary size and shape". IEEE Transactions on Image
  * Processing. Vol. 9. No. 3. 2000. pp. 283-286.
- *
- * Gray scale images can be processed as binary images by selecting a
- * "DilateValue".  Pixel values matching the dilate value are
- * considered the "foreground" and all other pixels are
- * "background". This is useful in processing segmented images where
- * all pixels in segment #1 have value 1 and pixels in segment #2 have
- * value 2, etc. A particular "segment number" can be processed.
- * DilateValue defaults to the maximum possible value of the
- * PixelType.
- *
- * The structuring element is assumed to be composed of binary values
- * (zero or one). Only elements of the structuring element having
- * values > 0 are candidates for affecting the center pixel.  A
- * reasonable choice of structuring element is
- * itk::BinaryBallStructuringElement.
  *
  * \sa ImageToImageFilter BinaryErodeImageFilter BinaryMorphologyImageFilter
  * \ingroup ITKBinaryMathematicalMorphology
@@ -113,8 +113,8 @@ public:
   using InputSizeType = typename InputImageType::SizeType;
 
   /** Set the value in the image to consider as "foreground". Defaults to
-   * maximum value of PixelType. This is an alias to the
-   * ForegroundValue in the superclass. */
+   * maximum value of PixelType. This is a function alias to the
+   * SetForegroundValue in the superclass. */
   void
   SetDilateValue(const InputPixelType & value)
   {
@@ -122,8 +122,8 @@ public:
   }
 
   /** Get the value in the image considered as "foreground". Defaults to
-   * maximum value of PixelType. This is an alias to the
-   * ForegroundValue in the superclass. */
+   * maximum value of PixelType. This is a function alias to the
+   * GetForegroundValue in the superclass. */
   InputPixelType
   GetDilateValue() const
   {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
@@ -27,10 +27,14 @@ namespace itk
 {
 /**
  * \class BinaryErodeImageFilter
- * \brief Fast binary erosion
+ * \brief Fast binary erosion of a single intensity value in the image.
  *
  * BinaryErodeImageFilter is a binary erosion
- * morphologic operation. This implementation is based on the papers:
+ * morphologic operation on the foreground of an image. Only the value designated
+ * by the single "DilateValue" is considered as foreground, and all other values
+ * are considered background.
+ *
+ * This implementation is based on the papers:
  *
  * L.Vincent "Morphological transformations of binary images with
  * arbitrary structuring elements", and

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
@@ -31,8 +31,24 @@ namespace itk
  *
  * BinaryErodeImageFilter is a binary erosion
  * morphologic operation on the foreground of an image. Only the value designated
- * by the single "DilateValue" is considered as foreground, and all other values
- * are considered background.
+ * by the intensity value "SetForegroundValue()" (alias as SetErodeValue()) is considered
+ * as foreground, and other intensity values are considered background.
+ *
+ * Gray scale images can be processed as binary images by selecting a
+ * "ForegroundValue" (alias "ErodeValue").  Pixel values matching the erode value are
+ * considered the "foreground" and all other pixels are
+ * "background". This is useful in processing segmented images where
+ * all pixels in segment #1 have value 1 and pixels in segment #2 have
+ * value 2, etc. A particular "segment number" can be processed.
+ * ForegroundValue defaults to the maximum possible value of the
+ * PixelType. The eroded pixels will receive the BackgroundValue
+ * (defaults to NumericTraits::NonpositiveMin() ).
+ *
+ * The structuring element is assumed to be composed of binary values
+ * (zero or one). Only elements of the structuring element having
+ * values > 0 are candidates for affecting the center pixel.  A
+ * reasonable choice of structuring element is
+ * itk::BinaryBallStructuringElement.
  *
  * This implementation is based on the papers:
  *
@@ -44,28 +60,13 @@ namespace itk
  * for arbitrary size and shape". IEEE Transactions on Image
  * Processing. Vol. 9. No. 3. 2000. pp. 283-286.
  *
- * Gray scale images can be processed as binary images by selecting a
- * "ErodeValue".  Pixel values matching the erode value are
- * considered the "foreground" and all other pixels are
- * "background". This is useful in processing segmented images where
- * all pixels in segment #1 have value 1 and pixels in segment #2 have
- * value 2, etc. A particular "segment number" can be processed.
- * ErodeValue defaults to the maximum possible value of the
- * PixelType. The eroded pixels will receive the BackgroundValue
- * (defaults to 0).
- *
- * The structuring element is assumed to be composed of binary values
- * (zero or one). Only elements of the structuring element having
- * values > 0 are candidates for affecting the center pixel.  A
- * reasonable choice of structuring element is
- * itk::BinaryBallStructuringElement.
  *
  * \sa ImageToImageFilter BinaryDilateImageFilter BinaryMorphologyImageFilter
  * \ingroup ITKBinaryMathematicalMorphology
  *
  * \sphinx
  * \sphinxexample{Filtering/BinaryMathematicalMorphology/ErodeABinaryImage,Erode A Binary Image}
- * \endsphin
+ * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 class ITK_TEMPLATE_EXPORT BinaryErodeImageFilter
@@ -115,7 +116,7 @@ public:
 
   /** Set the value in the image to consider as "foreground". Defaults to
    * maximum value of PixelType. This is an alias to the
-   * ForegroundValue in the superclass. */
+   * SetForegroundValue in the superclass. */
   void
   SetErodeValue(const InputPixelType & value)
   {
@@ -124,7 +125,7 @@ public:
 
   /** Get the value in the image considered as "foreground". Defaults to
    * maximum value of PixelType. This is an alias to the
-   * ForegroundValue in the superclass. */
+   * GetForegroundValue in the superclass. */
   InputPixelType
   GetErodeValue() const
   {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -73,12 +73,12 @@ BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Gener
   // create the pipeline without input and output image
   dilate->ReleaseDataFlagOn();
   dilate->SetKernel(this->GetKernel());
-  dilate->SetDilateValue(m_ForegroundValue);
+  dilate->SetForegroundValue(m_ForegroundValue); // Intensity value to dilate
 
   erode->SetKernel(this->GetKernel());
   erode->ReleaseDataFlagOn();
-  erode->SetErodeValue(m_ForegroundValue);
-  erode->SetBackgroundValue(backgroundValue);
+  erode->SetForegroundValue(m_ForegroundValue); // Intensity value to erode
+  erode->SetBackgroundValue(backgroundValue);   // Replacement value for eroded voxel
   erode->SetInput(dilate->GetOutput());
 
   // now we have 2 cases:

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
@@ -60,9 +60,9 @@ BinaryMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Gener
   dilate->ReleaseDataFlagOn();
   erode->SetKernel(this->GetKernel());
   erode->ReleaseDataFlagOn();
-  dilate->SetDilateValue(m_ForegroundValue);
-  erode->SetErodeValue(m_ForegroundValue);
-  erode->SetBackgroundValue(m_BackgroundValue);
+  dilate->SetForegroundValue(m_ForegroundValue); // Intensity value to dilate
+  erode->SetForegroundValue(m_ForegroundValue);  // Intensity value to erode
+  erode->SetBackgroundValue(m_BackgroundValue);  // Replacement value for eroded voxels
 
   /** set up the minipipeline */
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -59,8 +59,8 @@ BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::GenerateData()
   /** set up erosion and dilation methods */
   typename BinaryErodeImageFilter<InputImageType, OutputImageType, TKernel>::Pointer erode =
     BinaryErodeImageFilter<InputImageType, OutputImageType, TKernel>::New();
-  erode->SetErodeValue(m_ForegroundValue);
-  erode->SetBackgroundValue(m_BackgroundValue);
+  erode->SetForegroundValue(m_ForegroundValue); // Intensity value to erode
+  erode->SetBackgroundValue(m_BackgroundValue); // Replacement value of eroded voxels
   erode->SetKernel(this->GetKernel());
   erode->SetInput(this->GetInput());
   erode->ReleaseDataFlagOn();


### PR DESCRIPTION
The generalalization of "binary" as '0' and 'not zero'
is not used in the "Binary[Dilate|Erode]ImageFilter.

Images with values of 0 or 1 require an explicit setting
of the DilateValue or ErodeValue to 1 in order to
designate 1 as the foreground value to be dilated/eroded.

Expand the documentation to more forcefully convey this
important consideration.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
