### PR TITLE
COMP: Range-based for-loops on BoundaryFaces should use reference

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
@@ -62,7 +62,7 @@ MeanImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   // Process each of the boundary faces. These are N-d regions which border
   // the edge of the buffer.
-  for (const auto boundaryFace : calculatorResult.GetBoundaryFaces())
+  for (const auto & boundaryFace : calculatorResult.GetBoundaryFaces())
   {
     GenerateDataInSubregion<ZeroFluxNeumannImageNeighborhoodPixelAccessPolicy<InputImageType>>(
       *input, *output, boundaryFace, neighborhoodOffsets.get(), neighborhoodSize);

--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
@@ -84,7 +84,7 @@ MedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   // Process each of the boundary faces.  These are N-d regions which border
   // the edge of the buffer.
-  for (const auto boundaryFace : calculatorResult.GetBoundaryFaces())
+  for (const auto & boundaryFace : calculatorResult.GetBoundaryFaces())
   {
     auto neighborhoodRange =
       ShapedImageNeighborhoodRange<const InputImageType>(*input, Index<InputImageDimension>(), neighborhoodOffsets);


### PR DESCRIPTION
Fixes a warning from Mac10.14-AppleClang-dbg-ASanUBSan, reported by
Dženan Zukić @dzenanz:

> warning: loop variable 'boundaryFace' of type 'const itk::ImageRegion<3>'
> creates a copy from type 'const itk::ImageRegion<3>' [-Wrange-loop-analysis]