### PR TITLE
BUG: Fix IndexRange for itk::Size that has both zero's and non-zero's

### DIFF
--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -430,11 +430,25 @@ private:
   static IndexType
   CalculateMaxIndex(const MinIndexType & minIndex, const SizeType & size)
   {
+    const bool sizeHasZeroValue = [&size] {
+      for (const auto sizeValue : size)
+      {
+        if (sizeValue == 0)
+        {
+          return true;
+        }
+      }
+      return false;
+    }();
+
+    // Treat any size that has a zero value equally.
+    const SizeType normalizedSize = sizeHasZeroValue ? SizeType{ { 0 } } : size;
+
     IndexType index;
 
     for (unsigned i = 0; i < VDimension; ++i)
     {
-      index[i] = minIndex[i] + static_cast<IndexValueType>(size[i]) - 1;
+      index[i] = minIndex[i] + static_cast<IndexValueType>(normalizedSize[i]) - 1;
     }
 
     return index;

--- a/Modules/Core/Common/test/itkIndexRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexRangeGTest.cxx
@@ -104,6 +104,36 @@ ExpectRangeIsEmptyWhenRegionSizeIsZero()
   EXPECT_TRUE(ImageRegionIndexRange<VDimension>{ zeroSizedImageRegion }.empty());
 }
 
+
+template <typename TRange>
+void
+ExpectRangeBeginIsEnd(const TRange & range)
+{
+  EXPECT_EQ(range.cbegin(), range.cend());
+}
+
+
+template <unsigned VDimension>
+void
+ExpectRangeBeginIsEndWhenSizeHasZeroValue()
+{
+  const itk::Index<VDimension> randomIndex = GenerateRandomIndex<VDimension>();
+
+  for (unsigned i{}; i < VDimension; ++i)
+  {
+    auto size = itk::Size<VDimension>::Filled(2);
+
+    size[i] = 0;
+
+    ExpectRangeBeginIsEnd(ZeroBasedIndexRange<VDimension>{ size });
+    ExpectRangeBeginIsEnd(ImageRegionIndexRange<VDimension>{ size });
+
+    // Now do the test for an arbitrary (random) region index:
+    const itk::ImageRegion<VDimension> imageRegion{ randomIndex, size };
+
+    ExpectRangeBeginIsEnd(ImageRegionIndexRange<VDimension>{ imageRegion });
+  }
+}
 } // namespace
 
 
@@ -293,4 +323,13 @@ TEST(IndexRange, IsEmptyWhenRegionSizeIsZero)
   ExpectRangeIsEmptyWhenRegionSizeIsZero<1>();
   ExpectRangeIsEmptyWhenRegionSizeIsZero<2>();
   ExpectRangeIsEmptyWhenRegionSizeIsZero<3>();
+}
+
+
+// Tests that the begin is equal to the end, for a range constructed with an itk::Size
+// that has a size value of zero.
+TEST(IndexRange, BeginIsEndWhenSizeHasZeroValue)
+{
+  ExpectRangeBeginIsEndWhenSizeHasZeroValue<2>();
+  ExpectRangeBeginIsEndWhenSizeHasZeroValue<3>();
 }


### PR DESCRIPTION
`IndexRange` did behave incorrectly when it would be constructed with an
`itk::Size` that has one or more zero values _and_ a non-zero value at
its last position, for example `Size<3>{{0, 0, 8}}`. Specifically, in
that case the iterators returned by `IndexRange::begin()` and
`IndexRange::end()` were different, while they should compare equal.
This bug caused Valgrind defects, issue #1397, reported by Bradley
@blowekamp

The bug affects both `IndexRange` specializations,
`ImageRegionIndexRange` and `ZeroBasedIndexRange`.

This bug fix ensures that a `itk::Size` that has one or more zero values
is treated the same way as a `itk::Size` that has _only_ zero values.

Fixes issue #1397 Valgrind Defects related to the MedianImageFilter