### PR TITLE
ENH: Add static member function itk::Index::Filled(IndexValueType)

### DIFF
--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -465,6 +465,18 @@ public:
     return &m_InternalArray[0];
   }
 
+
+  /** Returns an Index object, filled with the specified value for each element.
+   */
+  static Self
+  Filled(const IndexValueType value)
+  {
+    Self result;
+    result.Fill(value);
+    return result;
+  }
+
+
 private:
   void
   ExceptionThrowingBoundsCheck(size_type pos) const

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -613,6 +613,7 @@ set(ITKCommonGTests
       itkImageBaseGTest.cxx
       itkImageBufferRangeGTest.cxx
       itkImageRegionRangeGTest.cxx
+      itkIndexGTest.cxx
       itkIndexRangeGTest.cxx
       itkMersenneTwisterRandomVariateGeneratorGTest.cxx
       itkNeighborhoodAllocatorGTest.cxx

--- a/Modules/Core/Common/test/itkIndexGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexGTest.cxx
@@ -1,0 +1,58 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkIndex.h"
+#include <gtest/gtest.h>
+#include <limits>
+
+namespace
+{
+template <unsigned VDimension>
+void
+Expect_Filled_returns_Index_with_specified_value_for_each_element()
+{
+  using itk::IndexValueType;
+  using IndexType = itk::Index<VDimension>;
+
+  // Tests that all elements from IndexType::Filled(indexValue) get the specified value.
+  const auto Expect_Filled_with_value = [](const IndexValueType indexValue) {
+    for (const auto filledIndexValue : IndexType::Filled(indexValue))
+    {
+      EXPECT_EQ(filledIndexValue, indexValue);
+    }
+  };
+
+  // Test for indexValue 0, 1, 2, and its maximum.
+  for (IndexValueType indexValue = 0; indexValue <= 2; ++indexValue)
+  {
+    Expect_Filled_with_value(indexValue);
+  }
+  Expect_Filled_with_value(std::numeric_limits<IndexValueType>::max());
+}
+} // namespace
+
+
+// Tests that itk::Index::Filled(value) returns an itk::Index with the
+// specified value for each element.
+TEST(Index, FilledReturnsIndexWithSpecifiedValueForEachElement)
+{
+  // Test for 1-D and 3-D.
+  Expect_Filled_returns_Index_with_specified_value_for_each_element<1>();
+  Expect_Filled_returns_Index_with_specified_value_for_each_element<3>();
+}


### PR DESCRIPTION
Added static `itk::Index` member function `Filled(value)`,
analogue to `FixedArray::Filled(value)` and `Size::Filled(value)`.

This convenience function should ease initializing a data member or a
local variable of type `itk::Index<N>` with the proper content.

Follow-up to 8d915a0fb1cb4d9c5adb6abd9c243c77e800cbf6, 2019-04-12:
"ENH: Add static member function Size<VDimension>::Filled(SizeValueType)"