### PR TITLE
STYLE: MeanImageFilter use vector<Offset>, range-based-for on IndexRange

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.h
@@ -22,6 +22,8 @@
 #include "itkImage.h"
 #include "itkNumericTraits.h"
 
+#include <vector>
+
 namespace itk
 {
 /** \class MeanImageFilter
@@ -106,11 +108,10 @@ protected:
 private:
   template <typename TPixelAccessPolicy>
   static void
-  GenerateDataInSubregion(const TInputImage &                       inputImage,
-                          TOutputImage &                            outputImage,
-                          const ImageRegion<InputImageDimension> &  imageRegion,
-                          const Offset<InputImageDimension> * const neighborhoodOffsets,
-                          const std::size_t                         neighborhoodSize);
+  GenerateDataInSubregion(const TInputImage &                              inputImage,
+                          TOutputImage &                                   outputImage,
+                          const ImageRegion<InputImageDimension> &         imageRegion,
+                          const std::vector<Offset<InputImageDimension>> & neighborhoodOffsets);
 };
 } // end namespace itk
 


### PR DESCRIPTION
Replaced `std::unique_ptr<Offset>[]>` by `std::vector<Offset>`, storing
the rectangular neighborhood shape offsets of the filter.

Replaced old-style `for` by C++11 range-based for-loop on
`ImageRegionIndexRange`.

Removed unnecessary local `ImageRegionRange` variable.

This commit aims to improve code readability, while it does not seem to
make the filter any slower. Actually, the filter seems slightly faster
than before (as observed with VS2017 Release).