### PR TITLE
BUG: Workaround for segfault in itkStatisticsAlgorithmTest (v140)

### DIFF
--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest.cxx
@@ -20,11 +20,6 @@
 #include "itkStatisticsAlgorithm.h"
 #include "itkTestingMacros.h"
 
-// Problem has been solved in _MSC_FULL_VER == 191125508
-#if (NDEBUG && (_MSC_FULL_VER == 190024215 || _MSC_FULL_VER == 191025017))
-#  pragma optimize("g", off) // disable global optimizations
-#endif
-
 int
 itkStatisticsAlgorithmTest(int, char *[])
 {
@@ -91,14 +86,7 @@ itkStatisticsAlgorithmTest(int, char *[])
     }
   }
 
-#if defined(_MSC_VER) && (_MSC_VER == 1900)
-  // test failure occurs on Azure Pipelines testing infrastructure (SEGFAULT)
-  // https://dev.azure.com/itkrobotbatch/ITK.Coverage/_build/latest?definitionId=3&branchName=master
-  // but I cannot reproduce it locally, and therefore cannot fix it
-  // so exit the test prematurely on v140 toolset to avoid the crash
-  return EXIT_SUCCESS;
-#endif
-
+  constSample = sample;
   // Now testing the real algorithm
   ITK_TRY_EXPECT_NO_EXCEPTION(
     itk::Statistics::Algorithm::FindSampleBound(constSample, constSample->Begin(), constSample->End(), lower, upper));


### PR DESCRIPTION
Fixes the issue for VS2015 but I don't have _MSC_FULL_VER 191025017 #1287