### PR TITLE
STYLE: C++ Rule of Zero for Neighborhood Operators, support nothrow move

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -59,6 +59,9 @@ namespace itk
  * annulus to be bright or dark.
  * 4) call \c CreateOperator()
  *
+ * \note AnnulusOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \sa NeighborhoodOperator
  * \sa Neighborhood
  *
@@ -79,26 +82,6 @@ public:
   using SpacingType = Vector<double, TDimension>;
 
   itkTypeMacro(AnnulusOperator, NeighborhoodOperator);
-
-  AnnulusOperator()
-    : NeighborhoodOperator<TPixel, TDimension, TAllocator>()
-    , m_InteriorValue(NumericTraits<PixelType>::ZeroValue())
-    , m_AnnulusValue(NumericTraits<PixelType>::OneValue())
-    , m_ExteriorValue(NumericTraits<PixelType>::ZeroValue())
-    , m_Spacing(1.0)
-  {}
-
-  AnnulusOperator(const Self & other)
-    : NeighborhoodOperator<TPixel, TDimension, TAllocator>(other)
-    , m_InnerRadius(other.m_InnerRadius)
-    , m_Thickness(other.m_Thickness)
-    , m_Normalize(other.m_Normalize)
-    , m_BrightCenter(other.m_BrightCenter)
-    , m_InteriorValue(other.m_InteriorValue)
-    , m_AnnulusValue(other.m_AnnulusValue)
-    , m_ExteriorValue(other.m_ExteriorValue)
-    , m_Spacing(other.m_Spacing)
-  {}
 
   /** This function is called to create the operator.  The radius of
    * the operator is determine automatically.  */
@@ -226,25 +209,6 @@ public:
     return m_ExteriorValue;
   }
 
-  /** Assignment operator */
-  Self &
-  operator=(const Self & other)
-  {
-    if (this != &other)
-    {
-      Superclass::operator=(other);
-      m_InnerRadius = other.m_InnerRadius;
-      m_Thickness = other.m_Thickness;
-      m_Spacing = other.m_Spacing;
-      m_InteriorValue = other.m_InteriorValue;
-      m_AnnulusValue = other.m_AnnulusValue;
-      m_ExteriorValue = other.m_ExteriorValue;
-      m_Normalize = other.m_Normalize;
-      m_BrightCenter = other.m_BrightCenter;
-    }
-    return *this;
-  }
-
   /** Prints some debugging information */
   void
   PrintSelf(std::ostream & os, Indent i) const override
@@ -275,10 +239,10 @@ private:
   double      m_Thickness{ 1.0 };
   bool        m_Normalize{ false };
   bool        m_BrightCenter{ false };
-  PixelType   m_InteriorValue;
-  PixelType   m_AnnulusValue;
-  PixelType   m_ExteriorValue;
-  SpacingType m_Spacing;
+  PixelType   m_InteriorValue{ NumericTraits<PixelType>::ZeroValue() };
+  PixelType   m_AnnulusValue{ NumericTraits<PixelType>::OneValue() };
+  PixelType   m_ExteriorValue{ NumericTraits<PixelType>::ZeroValue() };
+  SpacingType m_Spacing{ 1.0 };
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -50,6 +50,9 @@ namespace itk
          0    0   0
    \endcode
  *
+ * \note DerivativeOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \sa NeighborhoodOperator
  * \sa Neighborhood
  * \sa ForwardDifferenceOperator
@@ -72,28 +75,6 @@ public:
 
   using PixelType = typename Superclass::PixelType;
   using PixelRealType = typename Superclass::PixelRealType;
-
-  /** Constructor. */
-  DerivativeOperator() {}
-
-  /** Copy constructor. */
-  DerivativeOperator(const Self & other)
-    : NeighborhoodOperator<TPixel, VDimension, TAllocator>(other)
-  {
-    m_Order = other.m_Order;
-  }
-
-  /** Assignment operator */
-  Self &
-  operator=(const Self & other)
-  {
-    if (this != &other)
-    {
-      Superclass::operator=(other);
-      m_Order = other.m_Order;
-    }
-    return *this;
-  }
 
   /** Sets the order of the derivative. */
   void

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.h
@@ -33,6 +33,9 @@ namespace itk
  * NeighborhoodOperator that should be applied to a Neighborhood using the
  * inner product.
  *
+ * \note ForwardDifferenceOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \ingroup Operators
  * \ingroup ITKCommon
  *
@@ -49,22 +52,6 @@ public:
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
   using PixelType = typename Superclass::PixelType;
-
-  /** Constructor. */
-  ForwardDifferenceOperator() = default;
-
-  /** Copy constructor */
-  ForwardDifferenceOperator(const Self & other)
-    : NeighborhoodOperator<TPixel, VDimension, TAllocator>(other)
-  {}
-
-  /** Assignment operator */
-  Self &
-  operator=(const Self & other)
-  {
-    Superclass::operator=(other);
-    return *this;
-  }
 
 protected:
   /** Necessary to work around VC++ compiler bug. */

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -62,6 +62,9 @@ namespace itk
  * This implementation is derived from the Insight Journal paper:
  * https://hdl.handle.net/1926/1290
  *
+ * \note GaussianDerivativeOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \sa GaussianOperator
  * \sa NeighborhoodOperator
  * \sa NeighborhoodIterator
@@ -85,17 +88,6 @@ public:
   /** Neighborhood operator types. */
   using GaussianOperatorType = GaussianOperator<TPixel, VDimension, TAllocator>;
   using DerivativeOperatorType = DerivativeOperator<TPixel, VDimension, TAllocator>;
-
-  /** Constructor. */
-  GaussianDerivativeOperator() = default;
-
-  /** Copy constructor */
-  GaussianDerivativeOperator(const Self & other);
-
-  /** Assignment operator */
-  Self &
-  operator=(const Self & other);
-
 
   /** Set/Get the flag for calculating scale-space normalized
    * derivatives.

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -28,34 +28,6 @@ namespace itk
 {
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GaussianDerivativeOperator(const Self & other)
-  : NeighborhoodOperator<TPixel, VDimension, TAllocator>(other)
-  , m_NormalizeAcrossScale(other.m_NormalizeAcrossScale)
-  , m_Variance(other.m_Variance)
-  , m_MaximumError(other.m_MaximumError)
-  , m_MaximumKernelWidth(other.m_MaximumKernelWidth)
-  , m_Order(other.m_Order)
-  , m_Spacing(other.m_Spacing)
-{}
-
-template <typename TPixel, unsigned int VDimension, typename TAllocator>
-GaussianDerivativeOperator<TPixel, VDimension, TAllocator> &
-GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::operator=(const Self & other)
-{
-  if (this != &other)
-  {
-    Superclass::operator=(other);
-    m_NormalizeAcrossScale = other.m_NormalizeAcrossScale;
-    m_Spacing = other.m_Spacing;
-    m_Order = other.m_Order;
-    m_Variance = other.m_Variance;
-    m_MaximumError = other.m_MaximumError;
-    m_MaximumKernelWidth = other.m_MaximumKernelWidth;
-  }
-  return *this;
-}
-
-template <typename TPixel, unsigned int VDimension, typename TAllocator>
 typename GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::CoefficientVector
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
 {

--- a/Modules/Core/Common/include/itkGaussianOperator.h
+++ b/Modules/Core/Common/include/itkGaussianOperator.h
@@ -51,6 +51,9 @@ namespace itk
  * Primal Sketch.  Dissertation. Royal Institute of Technology, Stockholm,
  * Sweden. May 1991.).
  *
+ * \note GaussianOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \sa NeighborhoodOperator
  * \sa NeighborhoodIterator
  * \sa Neighborhood
@@ -71,32 +74,6 @@ public:
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
   itkTypeMacro(GaussianOperator, NeighborhoodOperator);
-
-  /** Constructor. */
-  GaussianOperator() {}
-
-  /** Copy constructor */
-  GaussianOperator(const Self & other)
-    : NeighborhoodOperator<TPixel, VDimension, TAllocator>(other)
-  {
-    m_Variance = other.m_Variance;
-    m_MaximumError = other.m_MaximumError;
-    m_MaximumKernelWidth = other.m_MaximumKernelWidth;
-  }
-
-  /** Assignment operator */
-  Self &
-  operator=(const Self & other)
-  {
-    if (this != &other)
-    {
-      Superclass::operator=(other);
-      m_Variance = other.m_Variance;
-      m_MaximumError = other.m_MaximumError;
-      m_MaximumKernelWidth = other.m_MaximumKernelWidth;
-    }
-    return *this;
-  }
 
   /** Sets the desired variance of the Gaussian kernel. */
   void

--- a/Modules/Core/Common/include/itkImageKernelOperator.h
+++ b/Modules/Core/Common/include/itkImageKernelOperator.h
@@ -36,6 +36,9 @@ namespace itk
  * http://www.insight-journal.org/browse/publication/208
  *
  *
+ * \note ImageKernelOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \sa NeighborhoodOperator
  * \sa NeighborhoodIterator
  * \sa Neighborhood
@@ -56,22 +59,6 @@ public:
   using CoefficientVector = typename Superclass::CoefficientVector;
 
   itkTypeMacro(ImageKernelOperator, NeighborhoodOperator);
-
-  /** Constructor. */
-  ImageKernelOperator() = default;
-
-  /** Copy constructor */
-  ImageKernelOperator(const Self & orig)
-    : Neighborhood<TPixel, VDimension, TAllocator>(orig)
-  {}
-
-  /** Assignment operator. */
-  Self &
-  operator=(const Self & orig)
-  {
-    Superclass::operator=(orig);
-    return *this;
-  }
 
   /** Set the image kernel. Only images with odd size in all
    * dimensions are allowed. If an image with an even size is passed

--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -50,6 +50,10 @@ namespace itk
  *  of doubles that is of length VDimension (the dimensionality of the image).
  *  Make sure to use 1/pixel_spacing to properly scale derivatives.
  *
+ * \note LaplacianOperator does not have any user-declared "special member function"
+ * for copy, move, or destruction, following the C++ Rule of Zero: the compiler will
+ * generate them if necessary.
+ *
  * \sa NeighborhoodOperator
  * \sa Neighborhood
  * \ingroup Operators
@@ -81,27 +85,9 @@ public:
     }
   }
 
-  /** Copy constructor   */
-  LaplacianOperator(const Self & other)
-    : NeighborhoodOperator<TPixel, VDimension, TAllocator>(other)
-  {
-    for (unsigned i = 0; i < VDimension; ++i)
-    {
-      m_DerivativeScalings[i] = other.m_DerivativeScalings[i];
-    }
-  }
-
   /** This function is called to create the operator  */
   void
   CreateOperator();
-
-  /** Assignment operator   */
-  Self &
-  operator=(const Self & other)
-  {
-    Superclass::operator=(other);
-    return *this;
-  }
 
   /** Prints some debugging information   */
   void

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.h
@@ -58,6 +58,9 @@ namespace itk
  * a scalar result.  This process effects convolution when applied to
  * successive neighborhoods across a region of interest in an image.
  *
+ * \note NeighborhoodOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \ingroup Operators
  * \ingroup ITKCommon
  *
@@ -83,25 +86,6 @@ public:
 
   /** Slice iterator type alias support */
   using SliceIteratorType = SliceIterator<TPixel, Self>;
-
-  /** Constructor. */
-  NeighborhoodOperator() { m_Direction = 0; }
-
-  /** Copy constructor */
-  NeighborhoodOperator(const Self & orig)
-    : Neighborhood<TPixel, VDimension, TAllocator>(orig)
-  {
-    m_Direction = orig.m_Direction;
-  }
-
-  /** Assignment operator. */
-  Self &
-  operator=(const Self & orig)
-  {
-    Superclass::operator=(orig);
-    m_Direction = orig.m_Direction;
-    return *this;
-  }
 
   /** Sets the dimensional direction of a directional operator. */
   void
@@ -192,7 +176,7 @@ protected:
 
 private:
   /** Direction (dimension number) of the derivative. */
-  unsigned long m_Direction;
+  unsigned long m_Direction{ 0 };
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -79,6 +79,9 @@ namespace itk
  * The \c x kernel is just rotated as required to obtain the kernel in the
  * \c y and \c z directions.
  *
+ * \note SobelOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \sa NeighborhoodOperator
  * \sa Neighborhood
  * \sa ForwardDifferenceOperator
@@ -101,11 +104,6 @@ public:
 
   itkTypeMacro(SobelOperator, NeighborhoodOperator);
 
-  SobelOperator() = default;
-  SobelOperator(const Self & other)
-    : NeighborhoodOperator<TPixel, VDimension, TAllocator>(other)
-  {}
-
   /** Creates the operator with length only in the specified direction.  For
    * the Sobel operator, this
    * The radius of the operator will be 0 except along the axis on which
@@ -122,15 +120,7 @@ public:
    * operator is defined by the subclass implementation of the Fill method.
    * \sa CreateDirectional \sa Fill */
   // virtual void CreateToRadius(const unsigned long);
-  /**
-   * Assignment operator
-   */
-  Self &
-  operator=(const Self & other)
-  {
-    Superclass::operator=(other);
-    return *this;
-  }
+
 
   /**
    * Prints some debugging information

--- a/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
@@ -16,14 +16,54 @@
  *
  *=========================================================================*/
 
+#include "itkAnnulusOperator.h"
+#include "itkBackwardDifferenceOperator.h"
 #include "itkDerivativeOperator.h"
 #include "itkForwardDifferenceOperator.h"
-#include "itkBackwardDifferenceOperator.h"
+#include "itkGaussianDerivativeOperator.h"
 #include "itkGaussianOperator.h"
+#include "itkImageKernelOperator.h"
 #include "itkLaplacianOperator.h"
+#include "itkNeighborhoodOperator.h"
 #include "itkSobelOperator.h"
+
+#include <type_traits> // For is_default_constructible, is_copy_constructible, etc.
+
 namespace
 {
+template <typename T>
+constexpr bool
+IsDefaultConstructibleCopyableNoThrowMovableAndDestructible()
+{
+  return std::is_default_constructible<T>::value && std::is_copy_constructible<T>::value &&
+         std::is_copy_assignable<T>::value && std::is_nothrow_move_constructible<T>::value &&
+         std::is_nothrow_move_assignable<T>::value && std::is_nothrow_destructible<T>::value;
+}
+
+static_assert(std::is_copy_assignable<itk::NeighborhoodOperator<int, 3>>::value,
+              "NeighborhoodOperator should be copy-assignable.");
+static_assert(std::is_nothrow_move_assignable<itk::NeighborhoodOperator<int, 3>>::value,
+              "NeighborhoodOperator should be noexcept move-assignable.");
+
+static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::AnnulusOperator<int>>(),
+              "AnnulusOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::DerivativeOperator<int>>(),
+              "DerivativeOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+static_assert(
+  IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::ForwardDifferenceOperator<int>>(),
+  "ForwardDifferenceOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+static_assert(
+  IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::GaussianDerivativeOperator<int>>(),
+  "GaussianDerivativeOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::GaussianOperator<int>>(),
+              "GaussianOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::ImageKernelOperator<int>>(),
+              "ImageKernelOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::LaplacianOperator<int>>(),
+              "LaplacianOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::SobelOperator<int>>(),
+              "SobelOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+
 void
 println(const char * c)
 {


### PR DESCRIPTION
Adjusted `NeighborhoodOperator` and eight derived classes according to
the C++ Rule of Zero for special member functions, by removing
used-declared default-constructors, copy-constructors, and assignment
operators.

Implicitly fixed an old bug in the assignment of `LaplacianOperator`, as
it previously did not copy its `m_DerivativeScalings` data member.

This commit effectively makes move-construction and move-assignment of
those classes "noexcept", as is checked in newly added static
assertions, in itkNeighborhoodOperatorTest. It could also improves the
performance of a "move" of such a type of object.