### PR TITLE
ENH: ImageIO check format support in two phases

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -663,6 +663,14 @@ public:
     this->SetComponentType(ImageIOBase::LONG);
   }
 
+  /** Check fileName as an extensions contained in the supported
+   * extension list. If ignoreCase is true, the case of the characters
+   * is ignored. */
+  virtual bool
+  HasSupportedReadExtension(const char * fileName, bool ignoreCase = true);
+  virtual bool
+  HasSupportedWriteExtension(const char * fileName, bool ignoreCase = true);
+
 protected:
   ImageIOBase();
   ~ImageIOBase() override;
@@ -671,15 +679,6 @@ protected:
 
   virtual const ImageRegionSplitterBase *
   GetImageRegionSplitter() const;
-
-  /** Check fileName as an extensions contained in the supported
-   * extension list. If ignoreCase is true, the case of the characters
-   * is ignored.
-   */
-  virtual bool
-  HasSupportedReadExtension(const char * fileName, bool ignoreCase = true);
-  virtual bool
-  HasSupportedWriteExtension(const char * fileName, bool ignoreCase = true);
 
   /** Used internally to keep track of the type of the pixel. */
   IOPixelType m_PixelType{ SCALAR };

--- a/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
@@ -19,49 +19,99 @@
 #include "itkImageIOFactory.h"
 
 #include <mutex>
-
+#include <vector>
 
 namespace itk
 {
 
 namespace
 {
-std::mutex createImageIOLock;
+std::vector<ImageIOBase::Pointer>
+GetAllImageIOInstances()
+{
+  static std::mutex           createImageIOLock;
+  std::lock_guard<std::mutex> mutexHolder(createImageIOLock);
+
+  const auto                        allInstances = ObjectFactoryBase::CreateAllInstance("itkImageIOBase");
+  std::vector<ImageIOBase::Pointer> result;
+  result.reserve(allInstances.size());
+  for (auto & possibleImageIO : allInstances)
+  {
+    auto * io = dynamic_cast<ImageIOBase *>(possibleImageIO.GetPointer());
+    if (io)
+    {
+      result.emplace_back(io);
+    }
+    else
+    {
+      std::cerr << "Error ImageIO factory did not return an ImageIOBase: " << possibleImageIO->GetNameOfClass() << '\n';
+    }
+  }
+  return result;
 }
+} // namespace
 
 ImageIOBase::Pointer
 ImageIOFactory::CreateImageIO(const char * path, FileModeType mode)
 {
-  std::list<ImageIOBase::Pointer> possibleImageIO;
-
-  std::lock_guard<std::mutex> mutexHolder(createImageIOLock);
-
-  for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkImageIOBase"))
+  if (mode != FileModeType::ReadMode && mode != FileModeType::WriteMode)
   {
-    auto * io = dynamic_cast<ImageIOBase *>(allobject.GetPointer());
-    if (io)
-    {
-      possibleImageIO.emplace_back(io);
-    }
-    else
-    {
-      std::cerr << "Error ImageIO factory did not return an ImageIOBase: " << allobject->GetNameOfClass() << std::endl;
-    }
+    return nullptr;
   }
-  for (auto & k : possibleImageIO)
+
+  auto       imageIOInstances = GetAllImageIOInstances();
+  const bool ignoreCase = true;
+  // check instances that support file extension
+  for (auto & imageIO : imageIOInstances)
   {
     if (mode == FileModeType::ReadMode)
     {
-      if (k->CanReadFile(path))
+      if (imageIO->HasSupportedReadExtension(path, ignoreCase))
       {
-        return k;
+        if (imageIO->CanReadFile(path))
+        {
+          return imageIO;
+        }
+        else
+        {
+          imageIO = nullptr; // don't check it again
+        }
       }
     }
-    else if (mode == FileModeType::WriteMode)
+    else
     {
-      if (k->CanWriteFile(path))
+      if (imageIO->HasSupportedWriteExtension(path, ignoreCase))
       {
-        return k;
+        if (imageIO->CanWriteFile(path))
+        {
+          return imageIO;
+        }
+        else
+        {
+          imageIO = nullptr;
+        }
+      }
+    }
+  }
+
+  for (auto & imageIO : imageIOInstances)
+  {
+    if (!imageIO)
+    {
+      continue;
+    }
+    if (mode == FileModeType::ReadMode)
+    {
+      if (imageIO->CanReadFile(path))
+      {
+        return imageIO;
+      }
+    }
+    else
+    {
+      if (imageIO->CanWriteFile(path))
+      {
+        return imageIO;
       }
     }
   }


### PR DESCRIPTION
Closes #1410. HasSupportedReadExtension/HasSupportedWriteExtension in ImageIOBase are now public.
