### PR TITLE
STYLE: Move #include "itk_H5Cpp.h" from itkHDF5TransformIO.h to cxx file

### DIFF
--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
@@ -23,7 +23,6 @@
 #include "itkTransformIOBase.h"
 #include <memory>
 #include <string>
-#include "itk_H5Cpp.h"
 
 // Avoids KWStyle error from forward declaration below.
 namespace itk
@@ -33,7 +32,8 @@ namespace itk
 namespace H5
 {
 class H5File;
-}
+class PredType;
+} // namespace H5
 
 namespace itk
 {

--- a/Modules/IO/TransformHDF5/itk-module.cmake
+++ b/Modules/IO/TransformHDF5/itk-module.cmake
@@ -9,7 +9,6 @@ itk_module(ITKIOTransformHDF5
     ITKHDF5
   TEST_DEPENDS
     ITKTestKernel
-    ITKHDF5
   FACTORY_NAMES
     TransformIO::HDF5
   DESCRIPTION

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -18,6 +18,7 @@
 
 #define ITK_TEMPLATE_EXPLICIT_HDF5TransformIO
 #include "itkHDF5TransformIO.h"
+#include "itk_H5Cpp.h"
 #include "itksys/SystemTools.hxx"
 #include "itksys/SystemInformation.hxx"
 #include "itkCompositeTransform.h"


### PR DESCRIPTION
Forward-declared `H5::PredType`, and moved the `#include "itk_H5Cpp.h"`
from itkHDF5TransformIO.h to the corresponding cxx file.

Removed `ITKHDF5` from its itk_module `TEST_DEPENDS`, as suggested by
Bradley @blowekamp

Could reduce compilation time and header file dependencies.