### PR TITLE
ENH: wrap IterationReporter

### DIFF
--- a/Modules/Core/Common/wrapping/ITKCommonBase.wrap
+++ b/Modules/Core/Common/wrapping/ITKCommonBase.wrap
@@ -54,6 +54,7 @@ itk_wrap_simple_class("itk::TimeProbe")
 # TODO: enable pointer support, once fixed the protected New() method.
 itk_wrap_simple_class("itk::MetaDataObjectBase" POINTER)
 itk_wrap_simple_class("itk::ProgressReporter")
+itk_wrap_simple_class("itk::IterationReporter")
 itk_wrap_simple_class("itk::MultiThreaderBase" POINTER)
 itk_wrap_simple_class("itk::PoolMultiThreader" POINTER)
 if(ITK_USE_TBB)


### PR DESCRIPTION
As far as I understand, [`IterationReporter`](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Core/Common/include/itkIterationReporter.h) is not yet wrapped, thus is unusable from Python. This contribution should fix this.

[We are currently trying to implement iteration reporting in RTK](https://github.com/SimonRit/RTK/pull/266), and this missing wrapping prevents us from testing our code from Python.

As this is my first contribution to ITK ever, I hope I did everything alright!

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ] [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] Adds the License notice to new files.
- [X] Adds Python wrapping.
- [ ] Adds tests and baseline comparison (quantitative).
- [ ] [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
