### PR TITLE
BUG: Remove tiff from supported extensions for LSMImageIO

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -854,6 +854,12 @@ protected:
   void
   AddSupportedWriteExtension(const char * extension);
 
+
+  void
+  SetSupportedReadExtensions(const ArrayOfExtensionsType &);
+  void
+  SetSupportedWriteExtensions(const ArrayOfExtensionsType &);
+
   /** an implementation of ImageRegionSplitter:GetNumberOfSplits
    */
   virtual unsigned int

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -78,6 +78,18 @@ ImageIOBase::AddSupportedWriteExtension(const char * extension)
 }
 
 void
+ImageIOBase::SetSupportedReadExtensions(const ArrayOfExtensionsType & extensions)
+{
+  this->m_SupportedReadExtensions = extensions;
+}
+
+void
+ImageIOBase::SetSupportedWriteExtensions(const ArrayOfExtensionsType & extensions)
+{
+  this->m_SupportedWriteExtensions = extensions;
+}
+
+void
 ImageIOBase::Resize(const unsigned int numDimensions, const unsigned int * dimensions)
 {
   m_NumberOfDimensions = numDimensions;

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -101,9 +101,11 @@ LSMImageIO::LSMImageIO()
   m_ByteOrder = LittleEndian;
   m_FileType = Binary;
 
+  this->SetSupportedWriteExtensions(ImageIOBase::ArrayOfExtensionsType{});
   this->AddSupportedWriteExtension(".lsm");
   this->AddSupportedWriteExtension(".LSM");
 
+  this->SetSupportedReadExtensions(ImageIOBase::ArrayOfExtensionsType{});
   this->AddSupportedReadExtension(".lsm");
   this->AddSupportedReadExtension(".LSM");
 
@@ -125,19 +127,8 @@ LSMImageIO::CanReadFile(const char * filename)
     return false;
   }
 
-  bool                   extensionFound = false;
-  std::string::size_type sprPos = fname.rfind(".lsm");
-  if ((sprPos != std::string::npos) && (sprPos == fname.length() - 4))
-  {
-    extensionFound = true;
-  }
-  sprPos = fname.rfind(".LSM");
-  if ((sprPos != std::string::npos) && (sprPos == fname.length() - 4))
-  {
-    extensionFound = true;
-  }
 
-  if (!extensionFound)
+  if (!this->HasSupportedReadExtension(filename))
   {
     itkDebugMacro(<< "The filename extension is not recognized");
     return false;
@@ -209,19 +200,7 @@ LSMImageIO::CanWriteFile(const char * name)
     return false;
   }
 
-  std::string::size_type pos = filename.rfind(".lsm");
-  if ((pos != std::string::npos) && (pos == filename.length() - 4))
-  {
-    return true;
-  }
-
-  pos = filename.rfind(".LSM");
-  if ((pos != std::string::npos) && (pos == filename.length() - 4))
-  {
-    return true;
-  }
-
-  return false;
+  return this->HasSupportedWriteExtension(name);
 }
 
 void


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
