### PR TITLE
Update vnl 11 21 19

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix_ref.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix_ref.h
@@ -50,7 +50,7 @@ class VNL_EXPORT vnl_matrix_ref : public vnl_matrix<T>
   { }
 
   //vnl_matrix base class is not no_except, so derived class can not be either
-  vnl_matrix_ref(vnl_matrix_ref<T> && rhs) = default;
+  vnl_matrix_ref(vnl_matrix_ref<T> &&) = default;
 
   ~vnl_matrix_ref() = default;
 

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
@@ -454,7 +454,7 @@ class VNL_EXPORT vnl_vector
     , data{ extdata }
     , m_LetArrayManageMemory{ manage_own_memory }
   {  }
-  
+
 //#if !VXL_LEGACY_FUTURE_REMOVE
   /*
    * This function is a work around for transitioning to data members

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.hxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.hxx
@@ -105,7 +105,9 @@ vnl_vector<T>::vnl_vector (size_t len, size_t n, T const values[])
 {
   vnl_vector_alloc_blah(len);
   // If user specified values, initialize first n elements with values
-  const size_t copy_num{std::min(len,n) };
+  // n.b Assignment is used over universal initialization to avoid a
+  // gcc 4.8.5 ICE.
+  const size_t copy_num = std::min(len,n);
   std::copy(values, values + copy_num, data);
 }
 

--- a/Modules/ThirdParty/VNL/src/vxl/vcl/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/vcl/CMakeLists.txt
@@ -88,8 +88,8 @@ write_compiler_detection_header(
 # Install platform-specific compiler detection files
 #
 if("${VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")
-  set(_compilers_destination vcl/compilers)
-  set(_compiler_detection_destination vcl)
+  set(_compilers_destination ${VXL_INSTALL_INCLUDE_DIR}/vcl/compilers)
+  set(_compiler_detection_destination ${VXL_INSTALL_INCLUDE_DIR}/vcl)
 else()
   set(_compilers_destination ${VXL_INSTALL_INCLUDE_DIR}/compilers)
   set(_compiler_detection_destination ${VXL_INSTALL_INCLUDE_DIR})


### PR DESCRIPTION
closes #1430
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
