### PR TITLE
COMP: fixing a couple of VNL related linking errors

### DIFF
--- a/Modules/Core/Common/test/itkPointGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkPointGeometryTest.cxx
@@ -98,7 +98,7 @@ itkPointGeometryTest(int, char *[])
   std::cout << "Squared Euclidean distance between pc and pb = ";
   std::cout << distance2 << std::endl;
 
-  vnl_vector_ref<ValueType> vnlVector = pa.GetVnlVector();
+  auto vnlVector = pa.GetVnlVector();
   std::cout << "vnl_vector = ";
   {
     for (unsigned int i = 0; i < N; i++)


### PR DESCRIPTION
These two errors are getting fixed. Ref #1431.

In project ITKCommon1TestDriver, file C:\Dev\ITK-2019\Modules\Core\Common\test\itkPointGeometryTest.obj, line 1: Error LNK2019: unresolved external symbol "public: __cdecl vnl_vector_ref<double>::vnl_vector_ref<double>(unsigned int,double *)" (??0?$vnl_vector_ref@N@@QEAA@IPEAN@Z) referenced in function "public: class vnl_vector_ref<double> __cdecl itk::Point<double,3>::GetVnlVector(void)" (?GetVnlVector@?$Point@N$02@itk@@QEAA?AV?$vnl_vector_ref@N@@XZ)

In project ITKCommon1TestDriver, file C:\Dev\ITK-2019\Modules\Core\Common\test\itkPointGeometryTest.obj, line 1: Error LNK2019: unresolved external symbol "public: __cdecl vnl_vector_ref<double>::~vnl_vector_ref<double>(void)" (??1?$vnl_vector_ref@N@@QEAA@XZ) referenced in function "int __cdecl itkPointGeometryTest(int,char * * const)" (?itkPointGeometryTest@@YAHHQEAPEAD@Z)