### PR TITLE
Spatial object meta io spacing

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
@@ -66,7 +66,7 @@ MetaBlobConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
 
     for (unsigned int ii = 0; ii < NDimensions; ii++)
     {
-      point[ii] = (*it2)->m_X[ii];
+      point[ii] = (*it2)->m_X[ii] * Blob->ElementSpacing(ii);
     }
 
     pnt.SetPositionInObjectSpace(point);

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
@@ -71,12 +71,12 @@ MetaContourConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 
     for (unsigned int i = 0; i < NDimensions; i++)
     {
-      point[i] = (*itCP)->m_X[i];
+      point[i] = (*itCP)->m_X[i] * contourMO->ElementSpacing(i);
     }
 
     for (unsigned int i = 0; i < NDimensions; i++)
     {
-      pickedPoint[i] = (*itCP)->m_XPicked[i];
+      pickedPoint[i] = (*itCP)->m_XPicked[i] * contourMO->ElementSpacing(i);
     }
 
     for (unsigned int i = 0; i < NDimensions; i++)

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -71,7 +71,7 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 
     for (unsigned int ii = 0; ii < NDimensions; ii++)
     {
-      point[ii] = (*it2)->m_X[ii];
+      point[ii] = (*it2)->m_X[ii] * tube->ElementSpacing(ii);
     }
 
     // Get the fields from the metaIO
@@ -106,7 +106,7 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
     // This attribute is optional
     if (Math::NotExactlyEquals((*it2)->GetField("r"), -1))
     {
-      pnt.SetRadiusInObjectSpace((*it2)->GetField("r"));
+      pnt.SetRadiusInObjectSpace((*it2)->GetField("r") * tube->ElementSpacing(0));
     }
 
     char vnd[] = "v1x";

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
@@ -64,7 +64,7 @@ MetaLandmarkConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTy
 
     for (unsigned int ii = 0; ii < NDimensions; ii++)
     {
-      point[ii] = (*it2)->m_X[ii];
+      point[ii] = (*it2)->m_X[ii] * landmarkMO->ElementSpacing(ii);
     }
 
     pnt.SetPositionInObjectSpace(point);

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
@@ -65,7 +65,7 @@ MetaLineConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
 
     for (unsigned int ii = 0; ii < NDimensions; ii++)
     {
-      point[ii] = (*it2)->m_X[ii];
+      point[ii] = (*it2)->m_X[ii] * lineMO->ElementSpacing(ii);
     }
 
     pnt.SetPositionInObjectSpace(point);

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -69,7 +69,7 @@ MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectToSpatialObjec
     typename MeshType::PointType pt;
     for (unsigned int i = 0; i < NDimensions; i++)
     {
-      pt[i] = ((*it_points)->m_X)[i];
+      pt[i] = ((*it_points)->m_X)[i] * _mesh->ElementSpacing(i);
     }
     mesh->SetPoint((*it_points)->m_Id, pt);
     it_points++;

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
@@ -64,7 +64,7 @@ MetaSurfaceConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 
     for (unsigned int ii = 0; ii < NDimensions; ii++)
     {
-      point[ii] = (*it2)->m_X[ii];
+      point[ii] = (*it2)->m_X[ii] * surfaceMO->ElementSpacing(ii);
     }
 
     for (unsigned int ii = 0; ii < NDimensions; ii++)

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
@@ -62,8 +62,13 @@ MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
   {
     TubePointType pnt;
 
-    pnt.SetPositionInObjectSpace((*it2)->m_X);
-    pnt.SetRadiusInObjectSpace((*it2)->m_R);
+    TubePointType::PointType pos;
+    for (unsigned int d = 0; d < NDimensions; ++d)
+    {
+      pos[d] = (*it2)->m_X[d] * tubeMO->ElementSpacing(d);
+    }
+    pnt.SetPositionInObjectSpace(pos);
+    pnt.SetRadiusInObjectSpace((*it2)->m_R * tubeMO->ElementSpacing(0));
 
     for (unsigned int i = 0; i < NDimensions; i++)
     {

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
@@ -62,7 +62,7 @@ MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
   {
     TubePointType pnt;
 
-    TubePointType::PointType pos;
+    typename TubePointType::PointType pos;
     for (unsigned int d = 0; d < NDimensions; ++d)
     {
       pos[d] = (*it2)->m_X[d] * tubeMO->ElementSpacing(d);

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
@@ -73,7 +73,7 @@ MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObject
   {
     VesselTubePointType pnt;
 
-    VesselTubePointType::PointType pos;
+    typename VesselTubePointType::PointType pos;
     for (unsigned int d = 0; d < NDimensions; ++d)
     {
       pos[d] = (*it2)->m_X[d] * vesselTubeMO->ElementSpacing(d);

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
@@ -69,12 +69,6 @@ MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObject
   itk::CovariantVector<double, NDimensions> v;
   itk::Vector<double, NDimensions>          t;
 
-  for (unsigned int d = 0; d < NDimensions; ++d)
-  {
-    std::cout << vesselTubeMO->ElementSpacing(d) << ", ";
-  }
-  std::cout << std::endl;
-
   for (unsigned int identifier = 0; identifier < vesselTubeMO->GetPoints().size(); identifier++)
   {
     VesselTubePointType pnt;

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
@@ -69,12 +69,23 @@ MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObject
   itk::CovariantVector<double, NDimensions> v;
   itk::Vector<double, NDimensions>          t;
 
+  for (unsigned int d = 0; d < NDimensions; ++d)
+  {
+    std::cout << vesselTubeMO->ElementSpacing(d) << ", ";
+  }
+  std::cout << std::endl;
+
   for (unsigned int identifier = 0; identifier < vesselTubeMO->GetPoints().size(); identifier++)
   {
     VesselTubePointType pnt;
 
-    pnt.SetPositionInObjectSpace((*it2)->m_X);
-    pnt.SetRadiusInObjectSpace((*it2)->m_R);
+    VesselTubePointType::PointType pos;
+    for (unsigned int d = 0; d < NDimensions; ++d)
+    {
+      pos[d] = (*it2)->m_X[d] * vesselTubeMO->ElementSpacing(d);
+    }
+    pnt.SetPositionInObjectSpace(pos);
+    pnt.SetRadiusInObjectSpace((*it2)->m_R * vesselTubeMO->ElementSpacing(0));
     pnt.SetMedialness((*it2)->m_Medialness);
     pnt.SetRidgeness((*it2)->m_Ridgeness);
     pnt.SetBranchness((*it2)->m_Branchness);


### PR DESCRIPTION
MetaIO allowed points to be written in scaled space - where that
space was related to physical space via ElementSpacing scale vector.
That pseudo-index space didn't preserve orientation or origin,
so it is of limited use.

With ITKv5, SpatialObjects no longer maintain a notion of index space.
Points exist in "object" space or "World" space.  Points are written
in object space.  So, the flawed/limited notation of ElementSpacing of
MetaIO should be considered on reading, but not used on writing.

This fixes reading (conversion) of MetaIO objects to spatialobjects to preserve
ElementSpacing on read and keep it as a unit scalar on write.
