### PR TITLE
ENH: Add UnsignedPower(base, exp) and UnsignedProduct(a, b) to itk::Math

### DIFF
--- a/Modules/Core/Common/test/itkMathTest.cxx
+++ b/Modules/Core/Common/test/itkMathTest.cxx
@@ -22,6 +22,44 @@
 #include "itkTestingMacros.h"
 
 #include <iostream>
+#include <limits>
+#include <type_traits> // For is_same.
+
+constexpr auto maxUnsignedValue = std::numeric_limits<std::uintmax_t>::max();
+
+using itk::Math::UnsignedPower;
+using itk::Math::UnsignedProduct;
+
+static_assert((UnsignedPower(0, 1) == 0) && (UnsignedPower(0, 2) == 0) && (UnsignedPower(0, 3) == 0),
+              "Check powers of zero");
+static_assert((UnsignedPower(1, 0) == 1) && (UnsignedPower(1, 1) == 1) && (UnsignedPower(1, 2) == 1),
+              "Check powers of one");
+static_assert((UnsignedPower(2, 0) == 1) && (UnsignedPower(3, 0) == 1) && (UnsignedPower(maxUnsignedValue, 0) == 1),
+              "Check zero as exponent");
+static_assert((UnsignedPower(2, 1) == 2) && (UnsignedPower(3, 1) == 3) &&
+                (UnsignedPower(maxUnsignedValue, 1) == maxUnsignedValue),
+              "Check one as exponent");
+static_assert((UnsignedPower(2, 2) == 4) && (UnsignedPower(2, 3) == 8), "Check powers of two");
+static_assert((UnsignedPower(3, 2) == 9) && (UnsignedPower(3, 3) == 27), "Check powers of three");
+static_assert(UnsignedPower(2, std::numeric_limits<std::uintmax_t>::digits - 1) ==
+                (std::uintmax_t{ 1 } << (std::numeric_limits<std::uintmax_t>::digits - 1)),
+              "Check 2^63 (at least when uintmax_t is 64 bits)");
+
+static_assert(std::is_same<decltype(UnsignedPower(1, 1)), std::uintmax_t>::value,
+              "The return type of UnsignedPower should be uintmax_t by default.");
+static_assert(std::is_same<decltype(UnsignedPower<std::uint8_t>(1, 1)), std::uint8_t>::value &&
+                std::is_same<decltype(UnsignedPower<std::uint16_t>(1, 1)), std::uint16_t>::value &&
+                std::is_same<decltype(UnsignedPower<std::uint32_t>(1, 1)), std::uint32_t>::value,
+              "UnsignedPower allows specifying the return type by its template argument.");
+
+static_assert((UnsignedProduct(0, 0) == 0) && (UnsignedProduct(0, 1) == 0) && (UnsignedProduct(1, 0) == 0) &&
+                (UnsignedProduct(1, 1) == 1),
+              "Check all product combinations of zero and one");
+static_assert((UnsignedProduct(2, 3) == 6) && (UnsignedProduct(3, 2) == 6), "Check 2*3 and 3*2");
+static_assert((UnsignedProduct(1, maxUnsignedValue) == maxUnsignedValue) &&
+                (UnsignedProduct(maxUnsignedValue, 1) == maxUnsignedValue),
+              "Check products with the maximum unsigned value");
+
 
 template <typename T1, typename T2>
 inline int

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -20,6 +20,7 @@
 
 #include "itkLabelObject.h"
 #include "itkLabelMap.h"
+#include "itkMath.h"
 #include "itkAffineTransform.h"
 
 namespace itk
@@ -321,20 +322,6 @@ public:
 
   using VectorType = Vector<double, VImageDimension>;
 
-
-private:
-  template <size_t VX, unsigned short VY>
-  struct IntegerPow
-  {
-    static const size_t Result = VX * IntegerPow<VX, VY - 1>::Result;
-  };
-
-  template <size_t VX>
-  struct IntegerPow<VX, 0>
-  {
-    static constexpr size_t Result = 1;
-  };
-
 public:
   using OrientedBoundingBoxDirectionType = MatrixType;
 
@@ -343,7 +330,7 @@ public:
   using OrientedBoundingBoxSizeType = Vector<double, VImageDimension>;
 
   using OrientedBoundingBoxVerticesType =
-    FixedArray<OrientedBoundingBoxPointType, IntegerPow<2, ImageDimension>::Result>;
+    FixedArray<OrientedBoundingBoxPointType, Math::UnsignedPower<unsigned int>(2, ImageDimension)>;
 
 
   const RegionType &


### PR DESCRIPTION
Added `constexpr` functions `UnsignedPower(base, exponent)` and
`UnsignedProduct(a, b)` to the `itk::Math` namespace.

Especially `UnsignedPower` appears interesting, as it allows estimating
the number of voxels of an N-dimensional hypercube at compile-time
without conversions between `unsigned` and floating point.
`UnsignedProduct` is a helper function of `UnsignedPower`, but it is also
being used in `itk::Experimental::ConnectedImageNeighborhoodShape`, with
this commit.

Allowed specifying the return type by a template argument, as requested
by Bradley @blowekamp

Replaced `ShapeLabelObject::IntegerPow` by a call to `UnsignedPower`, as
suggested by Bradley @blowekamp

