### PR TITLE
ENH: Allow copy and noexcept move of BackwardDifferenceOperator objects

### DIFF
--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
@@ -34,6 +34,9 @@ namespace itk
  * NeighborhoodOperator that should be applied to a Neighborhood using the
  * inner product.
  *
+ * \note BackwardDifferenceOperator does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \ingroup Operators
  * \ingroup ITKCommon
  *
@@ -45,17 +48,12 @@ template <typename TPixel, unsigned int TDimension = 2, typename TAllocator = Ne
 class ITK_TEMPLATE_EXPORT BackwardDifferenceOperator : public NeighborhoodOperator<TPixel, TDimension, TAllocator>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BackwardDifferenceOperator);
-
   /** Standard class type aliases. */
   using Self = BackwardDifferenceOperator;
   using Superclass = NeighborhoodOperator<TPixel, TDimension, TAllocator>;
 
   /** From Superclass */
   using PixelType = typename Superclass::PixelType;
-
-  /** Constructor. */
-  BackwardDifferenceOperator() = default;
 
 protected:
   /** Necessary to work around a compiler bug in VC++. */

--- a/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
@@ -47,6 +47,9 @@ static_assert(std::is_nothrow_move_assignable<itk::NeighborhoodOperator<int, 3>>
 
 static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::AnnulusOperator<int>>(),
               "AnnulusOperator should be default-constructible, copyable, noexcept movable, and destructible.");
+static_assert(
+  IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::BackwardDifferenceOperator<int>>(),
+  "BackwardDifferenceOperator should be default-constructible, copyable, noexcept movable, and destructible.");
 static_assert(IsDefaultConstructibleCopyableNoThrowMovableAndDestructible<itk::DerivativeOperator<int>>(),
               "DerivativeOperator should be default-constructible, copyable, noexcept movable, and destructible.");
 static_assert(


### PR DESCRIPTION
This commit allows copying `BackwardDifferenceOperator` objects, and
also adds fast, non-throwing move-semantics. It follows the C++ "Rule
of Zero".

This is a spin-off from pull request #1417 "STYLE: C++ Rule of Zero for
Neighborhood Operators, support nothrow move", commit 85d476455d208d4bd98f573412da0915cab9c1d2

`BackwardDifferenceOperator` was missing from PR #1417, because it
disallowed copying, unlike the other neighborhood operators. Dženan
@dzenanz suggested fixing this particular neighborhood operator in a
separate pull request.