### PR TITLE
Fixing a few of Visual Studio static analysis warnings

### DIFF
--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.hxx
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.hxx
@@ -28,7 +28,7 @@ BackwardDifferenceOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients
 {
   CoefficientVector coeff(3);
 
-  coeff[0] = -1.0f * NumericTraits<PixelType>::OneValue();
+  coeff[0] = -1.0 * NumericTraits<PixelType>::OneValue();
   coeff[1] = NumericTraits<PixelType>::OneValue();
   coeff[2] = NumericTraits<PixelType>::ZeroValue();
 

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.hxx
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.hxx
@@ -30,7 +30,7 @@ ForwardDifferenceOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients(
   CoefficientVector coeff(3);
 
   coeff[0] = NumericTraits<PixelType>::ZeroValue();
-  coeff[1] = -1.0f * NumericTraits<PixelType>::OneValue();
+  coeff[1] = -1.0 * NumericTraits<PixelType>::OneValue();
   coeff[2] = NumericTraits<PixelType>::OneValue();
 
   return coeff;

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -110,7 +110,7 @@ public:
 
   /** Currently supported types of multi-threader implementations.
    * Last will change with additional implementations. */
-  enum ThreaderType
+  enum class ThreaderType : int8_t
   {
     Platform = 0,
     First = Platform,
@@ -237,7 +237,7 @@ ITK_GCC_PRAGMA_DIAG_POP()
     ThreadIdType       NumberOfWorkUnits;
     void *             UserData;
     ThreadFunctionType ThreadFunction;
-    enum
+    enum class ThreadExitCodeType : uint8_t
     {
       SUCCESS,
       ITK_EXCEPTION,
@@ -245,6 +245,14 @@ ITK_GCC_PRAGMA_DIAG_POP()
       STD_EXCEPTION,
       UNKNOWN
     } ThreadExitCode;
+#if !defined(ITK_LEGACY_REMOVE)
+    static constexpr ThreadExitCodeType SUCCESS = ThreadExitCodeType::SUCCESS;
+    static constexpr ThreadExitCodeType ITK_EXCEPTION = ThreadExitCodeType::ITK_EXCEPTION;
+    static constexpr ThreadExitCodeType ITK_PROCESS_ABORTED_EXCEPTION =
+      ThreadExitCodeType::ITK_PROCESS_ABORTED_EXCEPTION;
+    static constexpr ThreadExitCodeType STD_EXCEPTION = ThreadExitCodeType::STD_EXCEPTION;
+    static constexpr ThreadExitCodeType UNKNOWN = ThreadExitCodeType::UNKNOWN;
+#endif
   };
 
   /** Execute the SingleMethod (as define by SetSingleMethod) using

--- a/Modules/Core/Common/include/itkPlatformMultiThreader.h
+++ b/Modules/Core/Common/include/itkPlatformMultiThreader.h
@@ -147,7 +147,7 @@ It can affect all MultiThreaderBase's derived classes in ITK");
 
   struct WorkUnitInfo : MultiThreaderBase::WorkUnitInfo
   {
-    int *                       ActiveFlag;
+    int *                       ActiveFlag = nullptr;
     std::shared_ptr<std::mutex> ActiveFlagLock;
   };
 

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -451,23 +451,23 @@ MultiThreaderBase ::SingleMethodProxy(void * arg)
   try
   {
     (*threadInfoStruct->ThreadFunction)(arg);
-    threadInfoStruct->ThreadExitCode = WorkUnitInfo::SUCCESS;
+    threadInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeType::SUCCESS;
   }
   catch (ProcessAborted &)
   {
-    threadInfoStruct->ThreadExitCode = WorkUnitInfo::ITK_PROCESS_ABORTED_EXCEPTION;
+    threadInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeType::ITK_PROCESS_ABORTED_EXCEPTION;
   }
   catch (ExceptionObject &)
   {
-    threadInfoStruct->ThreadExitCode = WorkUnitInfo::ITK_EXCEPTION;
+    threadInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeType::ITK_EXCEPTION;
   }
   catch (std::exception &)
   {
-    threadInfoStruct->ThreadExitCode = WorkUnitInfo::STD_EXCEPTION;
+    threadInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeType::STD_EXCEPTION;
   }
   catch (...)
   {
-    threadInfoStruct->ThreadExitCode = WorkUnitInfo::UNKNOWN;
+    threadInfoStruct->ThreadExitCode = WorkUnitInfo::ThreadExitCodeType::UNKNOWN;
   }
 
   return ITK_THREAD_RETURN_DEFAULT_VALUE;

--- a/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
@@ -210,7 +210,7 @@ PlatformMultiThreader::SingleMethodExecute()
 
       this->SpawnWaitForSingleMethodThread(process_id[thread_loop]);
 
-      if (m_ThreadInfoArray[thread_loop].ThreadExitCode != WorkUnitInfo::SUCCESS)
+      if (m_ThreadInfoArray[thread_loop].ThreadExitCode != WorkUnitInfo::ThreadExitCodeType::SUCCESS)
       {
         exceptionOccurred = true;
       }


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
