### PR TITLE
ENH: added metadata flag to contain maximum deviation in series reader

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -298,6 +298,7 @@ ImageSeriesReader<TOutputImage>::GenerateData()
 
   typename TOutputImage::PointType   prevSliceOrigin = output->GetOrigin();
   typename TOutputImage::SpacingType outputSpacing = output->GetSpacing();
+  double                             maxSpacingDeviation = 0.0;
   bool                               prevSliceIsValid = false;
 
   for (int i = 0; i != numberOfFiles; ++i)
@@ -443,6 +444,13 @@ ImageSeriesReader<TOutputImage>::GenerateData()
                                     true); // set metadata for the series reader output
 
           needToUpdateMetaDataDictionaryArray = true;
+          if (Math::abs(outputSpacing[this->m_NumberOfDimensionsInImage] - dirNnorm) > maxSpacingDeviation)
+          {
+            maxSpacingDeviation = Math::abs(outputSpacing[this->m_NumberOfDimensionsInImage] - dirNnorm);
+            EncapsulateMetaData<double>(output->GetMetaDataDictionary(),
+                                        "ITK_non_uniform_sampling_deviation",
+                                        maxSpacingDeviation); // maximum deviation
+          }
         }
         prevSliceOrigin = sliceOrigin;
       }

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
@@ -58,6 +58,18 @@ itkImageSeriesReaderSamplingTest(int ac, char * av[])
       return EXIT_FAILURE;
     }
 
+    double globalSamplingDeviation = 0.0;
+    if (itk::ExposeMetaData<double>(
+          reader->GetOutput()->GetMetaDataDictionary(), "ITK_non_uniform_sampling_deviation", globalSamplingDeviation))
+    {
+      std::cout << "output ITK_non_uniform_sampling_deviation = " << globalSamplingDeviation << std::endl;
+    }
+    else
+    {
+      std::cout << "output ITK_non_uniform_sampling_deviation not found" << std::endl;
+      return EXIT_FAILURE;
+    }
+
     // iterate over all slices to detect offending slice
     for (auto d : *reader->GetMetaDataDictionaryArray())
     {


### PR DESCRIPTION
ENH: aded metadata tag for maximum deviation from expected slice spacing in ImageSeriesReader.
 
@seanm
<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
