### PR TITLE
ENH: use RTK v2.1.0 (remote module)

### DIFF
--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -2,5 +2,5 @@
 itk_fetch_module(RTK
     "Reconstruction Toolkit (RTK) http://www.openrtk.org/"
   GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/RTK.git
-  GIT_TAG v2.0.1
+  GIT_TAG v2.1.0
 )


### PR DESCRIPTION
RTK has been regularly updated to account for ITK changes (master branch). I just released a new RTK version for inclusion in ITK v5.1rc01 (if it's still time). 