### PR TITLE
COMP: Workaround Clang 3.8 -Wundefined-inline warning Math UnsignedPower

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -805,10 +805,11 @@ UnsignedPower(const std::uintmax_t base, const std::uintmax_t exponent) ITK_NOEX
 
   // Uses recursive function calls because C++11 does not support other ways of
   // iterations for a constexpr function.
-  return (exponent == 0) ? (ITK_X_ASSERT(base > 0), 1)
-                         : (exponent == 1) ? base
-                                           : UnsignedProduct<TReturnType>(UnsignedPower(base, exponent / 2),
-                                                                          UnsignedPower(base, (exponent + 1) / 2));
+  return (exponent == 0)
+           ? (ITK_X_ASSERT(base > 0), 1)
+           : (exponent == 1) ? base
+                             : UnsignedProduct<TReturnType>(UnsignedPower<TReturnType>(base, exponent / 2),
+                                                            UnsignedPower<TReturnType>(base, (exponent + 1) / 2));
 }
 
 #undef ITK_X_ASSERT


### PR DESCRIPTION
RogueResearch13/Mac10.10-AppleClang-dbg-x86_64-static produced the
following warning, as reported by Dženan @dzenanz at pull request #1445:

> [CTest: warning matched] Modules/Core/Common/include/itkMath.h:802:1:
> warning: inline function `itk::Math::UnsignedPower<unsigned long>`
> is not defined [-Wundefined-inline]

It appears to be an old Clang 3.8.1 compiler issue. This commit aims to
work around the issue by passing `TReturnType` as template argument to
both of the recursive `UnsignedPower` function calls, inside the body
of `UnsignedPower`.