### PR TITLE
COMP: fixed compilation with AppleClang 7 and 8.

### DIFF
--- a/Documentation/SupportedCompilers.md
+++ b/Documentation/SupportedCompilers.md
@@ -12,6 +12,9 @@ ITK requires a compiler with C++11 support.
 # LLVM Clang
 * Clang 3.3 and later [should be supported](https://clang.llvm.org/cxx_status.html)
 
+# AppleClang
+* AppleClang 7.0.2 and later (from Xcode 7.2.1) [should be supported](https://en.wikipedia.org/wiki/Xcode#Version_history)
+
 # Intel C++ Compiler
 * Intel C++ 15.0.4 and later
 

--- a/Modules/Core/Common/test/itkImageIORegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageIORegionGTest.cxx
@@ -170,7 +170,7 @@ TEST(ImageIORegion, IsTwoDimensionalByDefault)
 
   EXPECT_EQ(itk::ImageIORegion(), expectedTwoDimensionalRegion);
 
-  const itk::ImageIORegion defaultInitializedRegion;
+  itk::ImageIORegion defaultInitializedRegion;
   EXPECT_EQ(defaultInitializedRegion, expectedTwoDimensionalRegion);
 }
 


### PR DESCRIPTION
Just removed a 'const' as suggested by Niels Dekker.

Also added a note to the supported compilers list about AppleClang.