### PR TITLE
ENH: Consistent use of typed enums, naming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,8 +258,8 @@ set(ITK_MODULES_DIR "${ITK_BINARY_DIR}/${ITK_INSTALL_PACKAGE_DIR}/Modules")
 # Provide compatibility options.
 # During major release updates deprecated interface may be needed for backwards compatibility
 cmake_dependent_option(ITK_LEGACY_REMOVE
-  "Remove current legacy code completely." ON
-  "ITK_WRAPPING" OFF)
+  "Remove current legacy code completely." OFF
+  "NOT ITK_WRAPPING" ON)
 
 # During minor releases bugs may be identified that identify broken interface, or
 # useless interfaces that need to be retained to not break backwards compatibilty.

--- a/Examples/DataRepresentation/Containers/TreeContainer.cxx
+++ b/Examples/DataRepresentation/Containers/TreeContainer.cxx
@@ -163,7 +163,7 @@ main(int, char *[])
 
 
   // Software Guide : BeginCodeSnippet
-  if (childIt.GetType() != itk::TreeIteratorBaseNodeType::CHILD)
+  if (childIt.GetType() != itk::TreeIteratorBaseNodeEnum::CHILD)
   {
     std::cerr << "Error: The iterator was not of type CHILD." << std::endl;
     return EXIT_FAILURE;

--- a/Examples/Filtering/LaplacianRecursiveGaussianImageFilter1.cxx
+++ b/Examples/Filtering/LaplacianRecursiveGaussianImageFilter1.cxx
@@ -177,11 +177,11 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  filterX1->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
-  filterY1->SetOrder(itk::EnumGaussianOrderType::SecondOrder);
+  filterX1->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
+  filterY1->SetOrder(itk::GaussianOrderEnum::SecondOrder);
 
-  filterX2->SetOrder(itk::EnumGaussianOrderType::SecondOrder);
-  filterY2->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
+  filterX2->SetOrder(itk::GaussianOrderEnum::SecondOrder);
+  filterY2->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/SmoothingRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/SmoothingRecursiveGaussianImageFilter.cxx
@@ -171,8 +171,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  filterX->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
-  filterY->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
+  filterX->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
+  filterY->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/SpatialObjects/DTITubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/DTITubeSpatialObject.cxx
@@ -85,9 +85,9 @@ main(int, char *[])
     pnt[2] = i + 2;
     p.SetPositionInObjectSpace(pnt);
     p.SetRadiusInObjectSpace(1);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::FA, i);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::ADC, 2 * i);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::GA, 3 * i);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::FA, i);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::ADC, 2 * i);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::GA, 3 * i);
     p.AddField("Lambda1", 4 * i);
     p.AddField("Lambda2", 5 * i);
     p.AddField("Lambda3", 6 * i);
@@ -149,14 +149,11 @@ main(int, char *[])
     std::cout << "Point #" << i << std::endl;
     std::cout << "Position: " << (*it).GetPositionInObjectSpace() << std::endl;
     std::cout << "Radius: " << (*it).GetRadiusInObjectSpace() << std::endl;
-    std::cout << "FA: "
-              << (*it).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::FA)
+    std::cout << "FA: " << (*it).GetField(itk::DTITubeSpatialObjectPointFieldEnum::FA)
               << std::endl;
-    std::cout << "ADC: "
-              << (*it).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::ADC)
+    std::cout << "ADC: " << (*it).GetField(itk::DTITubeSpatialObjectPointFieldEnum::ADC)
               << std::endl;
-    std::cout << "GA: "
-              << (*it).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::GA)
+    std::cout << "GA: " << (*it).GetField(itk::DTITubeSpatialObjectPointFieldEnum::GA)
               << std::endl;
     std::cout << "Lambda1: " << (*it).GetField("Lambda1") << std::endl;
     std::cout << "Lambda2: " << (*it).GetField("Lambda2") << std::endl;

--- a/Examples/SpatialObjects/MeshSpatialObject.cxx
+++ b/Examples/SpatialObjects/MeshSpatialObject.cxx
@@ -76,7 +76,7 @@ main(int, char *[])
   }
 
   myMesh->SetCellsAllocationMethod(
-    itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+    itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
   CellAutoPointer testCell1;
   testCell1.TakeOwnership(new TetraCellType);
   testCell1->SetPointIds(tetraPoints);

--- a/Modules/Core/Common/include/itkChildTreeIterator.hxx
+++ b/Modules/Core/Common/include/itkChildTreeIterator.hxx
@@ -84,7 +84,7 @@ template <typename TTreeType>
 typename ChildTreeIterator<TTreeType>::NodeType
 ChildTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeType::CHILD;
+  return TreeIteratorBaseNodeEnum::CHILD;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Core/Common/include/itkExtractImageFilter.h
+++ b/Modules/Core/Common/include/itkExtractImageFilter.h
@@ -24,11 +24,11 @@
 
 namespace itk
 {
-/** \class ExtractImageFilterCollapseStrategy
+/** \class ExtractImageFilterCollapseStrategyEnum
  * \ingroup ITKCommon
  * Strategy to be used to collapse phsycial space dimensions
  */
-enum class ExtractImageFilterCollapseStrategy : uint8_t
+enum class ExtractImageFilterCollapseStrategyEnum : uint8_t
 {
   DIRECTIONCOLLAPSETOUNKOWN = 0,
   DIRECTIONCOLLAPSETOIDENTITY = 1,
@@ -135,8 +135,8 @@ public:
   using InputImageSizeType = typename TInputImage::SizeType;
 
   /** Backwards compatibility for enum values */
-  using DIRECTIONCOLLAPSESTRATEGY = ExtractImageFilterCollapseStrategy;
-  using DirectionCollapseStrategyEnum = ExtractImageFilterCollapseStrategy;
+  using DIRECTIONCOLLAPSESTRATEGY = ExtractImageFilterCollapseStrategyEnum;
+  using DirectionCollapseStrategyEnum = ExtractImageFilterCollapseStrategyEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -175,15 +175,15 @@ public:
    * is 3D+time, and that the 3D sub-space is properly defined.
    */
   void
-  SetDirectionCollapseToStrategy(const ExtractImageFilterCollapseStrategy choosenStrategy)
+  SetDirectionCollapseToStrategy(const ExtractImageFilterCollapseStrategyEnum choosenStrategy)
   {
     switch (choosenStrategy)
     {
-      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
-      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
-      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
+      case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS:
+      case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY:
+      case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX:
         break;
-      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
+      case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN:
       default:
         itkExceptionMacro(<< "Invalid Strategy Chosen for itk::ExtractImageFilter");
     }
@@ -207,21 +207,21 @@ public:
   void
   SetDirectionCollapseToGuess()
   {
-    this->SetDirectionCollapseToStrategy(ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS);
+    this->SetDirectionCollapseToStrategy(ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS);
   }
 
   /** \sa SetDirectionCollapseToStrategy */
   void
   SetDirectionCollapseToIdentity()
   {
-    this->SetDirectionCollapseToStrategy(ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY);
+    this->SetDirectionCollapseToStrategy(ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY);
   }
 
   /** \sa SetDirectionCollapseToStrategy */
   void
   SetDirectionCollapseToSubmatrix()
   {
-    this->SetDirectionCollapseToStrategy(ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX);
+    this->SetDirectionCollapseToStrategy(ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX);
   }
 
 
@@ -300,12 +300,12 @@ protected:
   OutputImageRegionType m_OutputImageRegion;
 
 private:
-  ExtractImageFilterCollapseStrategy m_DirectionCollapseStrategy;
+  ExtractImageFilterCollapseStrategyEnum m_DirectionCollapseStrategy;
 };
 
 /** Define how to print enumerations */
 extern ITKCommon_EXPORT std::ostream &
-                        operator<<(std::ostream & out, const ExtractImageFilterCollapseStrategy value);
+                        operator<<(std::ostream & out, const ExtractImageFilterCollapseStrategyEnum value);
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -30,7 +30,7 @@ namespace itk
  */
 template <typename TInputImage, typename TOutputImage>
 ExtractImageFilter<TInputImage, TOutputImage>::ExtractImageFilter()
-  : m_DirectionCollapseStrategy(ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN)
+  : m_DirectionCollapseStrategy(ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN)
 {
   Superclass::InPlaceOff();
   this->DynamicMultiThreadingOn();
@@ -208,12 +208,12 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     {
       switch (m_DirectionCollapseStrategy)
       {
-        case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
+        case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY:
         {
           outputDirection.SetIdentity();
         }
         break;
-        case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
+        case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX:
         {
           if (vnl_determinant(outputDirection.GetVnlMatrix()) == 0.0)
           {
@@ -221,7 +221,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
           }
         }
         break;
-        case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
+        case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS:
         {
           if (vnl_determinant(outputDirection.GetVnlMatrix()) == 0.0)
           {
@@ -229,7 +229,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
           }
         }
         break;
-        case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
+        case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN:
         default:
         {
           itkExceptionMacro(

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.h
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.h
@@ -22,11 +22,11 @@
 
 namespace itk
 {
-/** \class RotationPlaneType
+/** \class RotationPlaneEnum
  *  \ingroup ITKCommon
  *  Enumerations for Frustum rotation type
  */
-enum class RotationPlaneType : uint8_t
+enum class RotationPlaneEnum : uint8_t
 {
   RotateInXZPlane = 1,
   RotateInYZPlane
@@ -70,12 +70,12 @@ public:
   using OutputType = typename Superclass::OutputType;
 
   /** Rotate the frustum in the XZ or the YZ plane. */
-  using FrustumRotationPlaneType = RotationPlaneType;
+  using FrustumRotationPlaneType = RotationPlaneEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr FrustumRotationPlaneType RotateInXZPlane = FrustumRotationPlaneType::RotateInXZPlane;
-  static constexpr FrustumRotationPlaneType RotateInYZPlane = FrustumRotationPlaneType::RotateInYZPlane;
+  static constexpr FrustumRotationPlaneType RotateInXZPlane = RotationPlaneEnum::RotateInXZPlane;
+  static constexpr FrustumRotationPlaneType RotateInYZPlane = RotationPlaneEnum::RotateInYZPlane;
 #endif
 
   /** Evaluates the function at a given position. */
@@ -128,7 +128,7 @@ private:
 
 /** Define how to print enumerations */
 extern ITKCommon_EXPORT std::ostream &
-                        operator<<(std::ostream & out, const RotationPlaneType value);
+                        operator<<(std::ostream & out, const RotationPlaneEnum value);
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 template <unsigned int VDimension, typename TInput>
 FrustumSpatialFunction<VDimension, TInput>::FrustumSpatialFunction()
-  : m_RotationPlane(RotationPlaneType::RotateInXZPlane)
+  : m_RotationPlane(RotationPlaneEnum::RotateInXZPlane)
 {
   m_Apex.Fill(0.0f);
 }
@@ -56,7 +56,7 @@ FrustumSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position)
     }
   }
 
-  if (m_RotationPlane == RotationPlaneType::RotateInXZPlane)
+  if (m_RotationPlane == RotationPlaneEnum::RotateInXZPlane)
   {
     const double dx = relativePosition[0];
     const double dy = relativePosition[1];
@@ -83,7 +83,7 @@ FrustumSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position)
 
     return 1;
   }
-  else if (m_RotationPlane == RotationPlaneType::RotateInYZPlane)
+  else if (m_RotationPlane == RotationPlaneEnum::RotateInYZPlane)
   {
     const double dx = relativePosition[0];
     const double dy = relativePosition[1];

--- a/Modules/Core/Common/include/itkInOrderTreeIterator.h
+++ b/Modules/Core/Common/include/itkInOrderTreeIterator.h
@@ -78,7 +78,7 @@ template <typename TTreeType>
 typename InOrderTreeIterator<TTreeType>::NodeType
 InOrderTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeType::INORDER;
+  return TreeIteratorBaseNodeEnum::INORDER;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Core/Common/include/itkLeafTreeIterator.h
+++ b/Modules/Core/Common/include/itkLeafTreeIterator.h
@@ -109,7 +109,7 @@ template <typename TTreeType>
 typename LeafTreeIterator<TTreeType>::NodeType
 LeafTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeType ::LEAF;
+  return TreeIteratorBaseNodeEnum ::LEAF;
 }
 
 /** Return true if the next value exists */

--- a/Modules/Core/Common/include/itkLevelOrderTreeIterator.hxx
+++ b/Modules/Core/Common/include/itkLevelOrderTreeIterator.hxx
@@ -76,7 +76,7 @@ template <typename TTreeType>
 typename LevelOrderTreeIterator<TTreeType>::NodeType
 LevelOrderTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeType::LEVELORDER;
+  return TreeIteratorBaseNodeEnum::LEVELORDER;
 }
 
 /** Return true if the next value exists */

--- a/Modules/Core/Common/include/itkLoggerBase.h
+++ b/Modules/Core/Common/include/itkLoggerBase.h
@@ -23,7 +23,7 @@
 #include "ITKCommonExport.h"
 #ifdef DEBUG
 #  undef DEBUG // HDF5 publicly exports this define when built in debug mode
-// That messes up the DEBUG enumeration in PriorityLevelType.
+// That messes up the DEBUG enumeration in PriorityLevelEnum.
 #endif
 
 namespace itk
@@ -52,12 +52,12 @@ public:
 
   using OutputType = MultipleLogOutput::OutputType;
 
-  /** \class PriorityLevelType
+  /** \class PriorityLevelEnum
    *  \ingroup ITKCommon
    * Definition of types of messages. These codes will be used to regulate
    * the level of detail of messages reported to the final outputs
    */
-  enum class PriorityLevelType : uint8_t
+  enum class PriorityLevelEnum : uint8_t
   {
     MUSTFLUSH = 0,
     FATAL,
@@ -70,13 +70,13 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr PriorityLevelType MUSTFLUSH = PriorityLevelType::MUSTFLUSH;
-  static constexpr PriorityLevelType FATAL = PriorityLevelType::FATAL;
-  static constexpr PriorityLevelType CRITICAL = PriorityLevelType::CRITICAL;
-  static constexpr PriorityLevelType WARNING = PriorityLevelType::WARNING;
-  static constexpr PriorityLevelType INFO = PriorityLevelType::INFO;
-  static constexpr PriorityLevelType DEBUG = PriorityLevelType::DEBUG;
-  static constexpr PriorityLevelType NOTSET = PriorityLevelType::NOTSET;
+  static constexpr PriorityLevelEnum MUSTFLUSH = PriorityLevelEnum::MUSTFLUSH;
+  static constexpr PriorityLevelEnum FATAL = PriorityLevelEnum::FATAL;
+  static constexpr PriorityLevelEnum CRITICAL = PriorityLevelEnum::CRITICAL;
+  static constexpr PriorityLevelEnum WARNING = PriorityLevelEnum::WARNING;
+  static constexpr PriorityLevelEnum INFO = PriorityLevelEnum::INFO;
+  static constexpr PriorityLevelEnum DEBUG = PriorityLevelEnum::DEBUG;
+  static constexpr PriorityLevelEnum NOTSET = PriorityLevelEnum::NOTSET;
 #endif
 
   itkSetStringMacro(Name);
@@ -114,13 +114,13 @@ public:
 
   /** Provides a default formatted log entry */
   virtual std::string
-  BuildFormattedEntry(PriorityLevelType level, std::string const & content);
+  BuildFormattedEntry(PriorityLevelEnum level, std::string const & content);
 
   /** Set the priority level for the current logger. Only messages that have
    * priorities equal or greater than the one set here will be posted to the
    * current outputs */
   virtual void
-  SetPriorityLevel(PriorityLevelType level)
+  SetPriorityLevel(PriorityLevelEnum level)
   {
     m_PriorityLevel = level;
   }
@@ -128,19 +128,19 @@ public:
   /** Get the priority level for the current logger. Only messages that have
    * priorities equal or greater than the one set here will be posted to the
    * current outputs */
-  virtual PriorityLevelType
+  virtual PriorityLevelEnum
   GetPriorityLevel() const
   {
     return m_PriorityLevel;
   }
 
   virtual void
-  SetLevelForFlushing(PriorityLevelType level)
+  SetLevelForFlushing(PriorityLevelEnum level)
   {
     m_LevelForFlushing = level;
   }
 
-  virtual PriorityLevelType
+  virtual PriorityLevelEnum
   GetLevelForFlushing() const
   {
     return m_LevelForFlushing;
@@ -151,43 +151,43 @@ public:
   AddLogOutput(OutputType * output);
 
   virtual void
-  Write(PriorityLevelType level, std::string const & content);
+  Write(PriorityLevelEnum level, std::string const & content);
 
   /** Helper methods */
   void
   Debug(std::string const & message)
   {
-    this->Write(LoggerBase::PriorityLevelType::DEBUG, message);
+    this->Write(LoggerBase::PriorityLevelEnum::DEBUG, message);
   }
 
   void
   Info(std::string const & message)
   {
-    this->Write(LoggerBase::PriorityLevelType::INFO, message);
+    this->Write(LoggerBase::PriorityLevelEnum::INFO, message);
   }
 
   void
   Warning(std::string const & message)
   {
-    this->Write(LoggerBase::PriorityLevelType::WARNING, message);
+    this->Write(LoggerBase::PriorityLevelEnum::WARNING, message);
   }
 
   void
   Critical(std::string const & message)
   {
-    this->Write(LoggerBase::PriorityLevelType::CRITICAL, message);
+    this->Write(LoggerBase::PriorityLevelEnum::CRITICAL, message);
   }
 
   void
   Error(std::string const & message)
   {
-    this->Write(LoggerBase::PriorityLevelType::CRITICAL, message);
+    this->Write(LoggerBase::PriorityLevelEnum::CRITICAL, message);
   }
 
   void
   Fatal(std::string const & message)
   {
-    this->Write(LoggerBase::PriorityLevelType::FATAL, message);
+    this->Write(LoggerBase::PriorityLevelEnum::FATAL, message);
   }
 
   virtual void
@@ -205,9 +205,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 protected:
-  PriorityLevelType m_PriorityLevel;
+  PriorityLevelEnum m_PriorityLevel;
 
-  PriorityLevelType m_LevelForFlushing;
+  PriorityLevelEnum m_LevelForFlushing;
 
   MultipleLogOutput::Pointer m_Output;
 
@@ -223,7 +223,7 @@ private:
 
 // Define how to print enumeration
 extern ITKCommon_EXPORT std::ostream &
-                        operator<<(std::ostream & out, const LoggerBase::PriorityLevelType value);
+                        operator<<(std::ostream & out, const LoggerBase::PriorityLevelEnum value);
 } // namespace itk
 
 #endif // itkLoggerBase_h

--- a/Modules/Core/Common/include/itkLoggerManager.h
+++ b/Modules/Core/Common/include/itkLoggerManager.h
@@ -53,7 +53,7 @@ public:
   /** New macro for creation of through a Smart Pointer */
   itkNewMacro(Self);
 
-  using PriorityLevelType = Logger::PriorityLevelType;
+  using PriorityLevelEnum = Logger::PriorityLevelEnum;
 
   using OutputType = Logger::OutputType;
 
@@ -65,14 +65,14 @@ public:
   /** create a logger and add it into LoggerManager */
   LoggerPointer
   CreateLogger(const NameType &  name,
-               PriorityLevelType level,
-               PriorityLevelType levelForFlushing = LoggerBase::PriorityLevelType::MUSTFLUSH);
+               PriorityLevelEnum level,
+               PriorityLevelEnum levelForFlushing = LoggerBase::PriorityLevelEnum::MUSTFLUSH);
 
   /** create a thread logger and add it into LoggerManager */
   ThreadLoggerPointer
   CreateThreadLogger(const NameType &  name,
-                     PriorityLevelType level,
-                     PriorityLevelType levelForFlushing = LoggerBase::PriorityLevelType::MUSTFLUSH);
+                     PriorityLevelEnum level,
+                     PriorityLevelEnum levelForFlushing = LoggerBase::PriorityLevelEnum::MUSTFLUSH);
 
   /** Registers a logger */
   void
@@ -82,16 +82,16 @@ public:
   GetLogger(const NameType & name);
 
   void
-  SetPriorityLevel(PriorityLevelType level);
+  SetPriorityLevel(PriorityLevelEnum level);
 
   void
-  SetLevelForFlushing(PriorityLevelType level);
+  SetLevelForFlushing(PriorityLevelEnum level);
 
   void
   AddLogOutput(OutputType * output);
 
   void
-  Write(PriorityLevelType level, std::string const & content);
+  Write(PriorityLevelEnum level, std::string const & content);
 
   void
   Flush();

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.h
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.h
@@ -69,7 +69,7 @@ public:
   itkNewMacro(Self);
 
   using OutputType = typename SimpleLoggerType::OutputType;
-  using PriorityLevelType = typename SimpleLoggerType::PriorityLevelType;
+  using PriorityLevelEnum = typename SimpleLoggerType::PriorityLevelEnum;
   using DelayType = unsigned int;
 
 #if !defined(ITK_LEGACY_REMOVE)
@@ -85,18 +85,18 @@ public:
    * priorities equal or greater than the one set here will be posted to the
    * current outputs */
   void
-  SetPriorityLevel(PriorityLevelType level) override;
+  SetPriorityLevel(PriorityLevelEnum level) override;
 
   /** Get the priority level for the current logger. Only messages that have
    * priorities equal or greater than the one set here will be posted to the
    * current outputs */
-  PriorityLevelType
+  PriorityLevelEnum
   GetPriorityLevel() const override;
 
   void
-  SetLevelForFlushing(PriorityLevelType level) override;
+  SetLevelForFlushing(PriorityLevelEnum level) override;
 
-  PriorityLevelType
+  PriorityLevelEnum
   GetLevelForFlushing() const override;
 
   /** Set the delay in milliseconds between checks to see if there are any
@@ -116,7 +116,7 @@ public:
   AddLogOutput(OutputType * output) override;
 
   void
-  Write(PriorityLevelType level, std::string const & content) override;
+  Write(PriorityLevelEnum level, std::string const & content) override;
 
   void
   Flush() override;
@@ -140,7 +140,7 @@ private:
 
   using MessageContainerType = std::queue<std::string>;
 
-  using LevelContainerType = std::queue<PriorityLevelType>;
+  using LevelContainerType = std::queue<PriorityLevelEnum>;
 
   using OutputContainerType = std::queue<typename OutputType::Pointer>;
 

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
@@ -29,7 +29,7 @@ namespace itk
  * current outputs */
 template <typename SimpleLoggerType>
 void
-LoggerThreadWrapper<SimpleLoggerType>::SetPriorityLevel(PriorityLevelType level)
+LoggerThreadWrapper<SimpleLoggerType>::SetPriorityLevel(PriorityLevelEnum level)
 {
   this->m_Mutex.lock();
   this->m_OperationQ.push(LoggerThreadWrapperOperationType::SET_PRIORITY_LEVEL);
@@ -41,18 +41,18 @@ LoggerThreadWrapper<SimpleLoggerType>::SetPriorityLevel(PriorityLevelType level)
  * priorities equal or greater than the one set here will be posted to the
  * current outputs */
 template <typename SimpleLoggerType>
-typename SimpleLoggerType::PriorityLevelType
+typename SimpleLoggerType::PriorityLevelEnum
 LoggerThreadWrapper<SimpleLoggerType>::GetPriorityLevel() const
 {
   this->m_Mutex.lock();
-  PriorityLevelType level = this->m_PriorityLevel;
+  PriorityLevelEnum level = this->m_PriorityLevel;
   this->m_Mutex.unlock();
   return level;
 }
 
 template <typename SimpleLoggerType>
 void
-LoggerThreadWrapper<SimpleLoggerType>::SetLevelForFlushing(PriorityLevelType level)
+LoggerThreadWrapper<SimpleLoggerType>::SetLevelForFlushing(PriorityLevelEnum level)
 {
   this->m_Mutex.lock();
   this->m_LevelForFlushing = level;
@@ -62,11 +62,11 @@ LoggerThreadWrapper<SimpleLoggerType>::SetLevelForFlushing(PriorityLevelType lev
 }
 
 template <typename SimpleLoggerType>
-typename SimpleLoggerType::PriorityLevelType
+typename SimpleLoggerType::PriorityLevelEnum
 LoggerThreadWrapper<SimpleLoggerType>::GetLevelForFlushing() const
 {
   this->m_Mutex.lock();
-  PriorityLevelType level = this->m_LevelForFlushing;
+  PriorityLevelEnum level = this->m_LevelForFlushing;
   this->m_Mutex.unlock();
   return level;
 }
@@ -103,7 +103,7 @@ LoggerThreadWrapper<SimpleLoggerType>::AddLogOutput(OutputType * output)
 
 template <typename SimpleLoggerType>
 void
-LoggerThreadWrapper<SimpleLoggerType>::Write(PriorityLevelType level, std::string const & content)
+LoggerThreadWrapper<SimpleLoggerType>::Write(PriorityLevelEnum level, std::string const & content)
 {
   this->m_Mutex.lock();
   if (this->m_PriorityLevel >= level)

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -110,7 +110,7 @@ public:
 
   /** Currently supported types of multi-threader implementations.
    * Last will change with additional implementations. */
-  enum class ThreaderType : int8_t
+  enum class ThreaderEnum : int8_t
   {
     Platform = 0,
     First = Platform,
@@ -119,27 +119,30 @@ public:
     Last = TBB,
     Unknown = -1
   };
+#if !defined(ITK_LEGACY_REMOVE)
+  using ThreaderType = ThreaderEnum;
+#endif
 
   /** Convert a threader name into its enum type. */
-  static ThreaderType
+  static ThreaderEnum
   ThreaderTypeFromString(std::string threaderString);
 
   /** Convert a threader enum type into a string for displaying or logging. */
   static std::string
-  ThreaderTypeToString(ThreaderType threader)
+  ThreaderTypeToString(ThreaderEnum threader)
   {
     switch (threader)
     {
-      case ThreaderType::Platform:
+      case ThreaderEnum::Platform:
         return "Platform";
         break;
-      case ThreaderType::Pool:
+      case ThreaderEnum::Pool:
         return "Pool";
         break;
-      case ThreaderType::TBB:
+      case ThreaderEnum::TBB:
         return "TBB";
         break;
-      case ThreaderType::Unknown:
+      case ThreaderEnum::Unknown:
       default:
         return "Unknown";
         break;
@@ -158,8 +161,8 @@ public:
    * If the SetGlobalDefaultThreaderType API is ever used by the developer,
    * the developer's choice is respected over the environment variables. */
   static void
-  SetGlobalDefaultThreader(ThreaderType threaderType);
-  static ThreaderType
+  SetGlobalDefaultThreader(ThreaderEnum threaderType);
+  static ThreaderEnum
   GetGlobalDefaultThreader();
 
   /** Set/Get the value which is used to initialize the NumberOfThreads in the
@@ -459,7 +462,7 @@ private:
 };
 
 ITKCommon_EXPORT std::ostream &
-                 operator<<(std::ostream & os, const MultiThreaderBase::ThreaderType & threader);
+                 operator<<(std::ostream & os, const MultiThreaderBase::ThreaderEnum & threader);
 
 } // end namespace itk
 #endif

--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -102,14 +102,14 @@ public:
   static void
   RegisterFactoryInternal(ObjectFactoryBase *);
 
-  /** \class InsertionPositionType
+  /** \class InsertionPositionEnum
    *
    *  \ingroup ITKCommon
    *
    *  Position at which the new factory will be registered in the
    *  internal factory container.
    */
-  enum class InsertionPositionType : uint8_t
+  enum class InsertionPositionEnum : uint8_t
   {
     INSERT_AT_FRONT,
     INSERT_AT_BACK,
@@ -118,23 +118,23 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr InsertionPositionType INSERT_AT_FRONT = InsertionPositionType::INSERT_AT_FRONT;
-  static constexpr InsertionPositionType INSERT_AT_BACK = InsertionPositionType::INSERT_AT_BACK;
-  static constexpr InsertionPositionType INSERT_AT_POSITION = InsertionPositionType::INSERT_AT_POSITION;
+  static constexpr InsertionPositionEnum INSERT_AT_FRONT = InsertionPositionEnum::INSERT_AT_FRONT;
+  static constexpr InsertionPositionEnum INSERT_AT_BACK = InsertionPositionEnum::INSERT_AT_BACK;
+  static constexpr InsertionPositionEnum INSERT_AT_POSITION = InsertionPositionEnum::INSERT_AT_POSITION;
 #endif
 
   /** Register a factory so it can be used to create itk objects.
    *
-   * When InsertionPositionType::INSERT_AT_POSITION is selected, a third argument must be provided
+   * When InsertionPositionEnum::INSERT_AT_POSITION is selected, a third argument must be provided
    * with the actual integer number of the intended position. The position
    * number must be in the range [0, numberOfRegisteredFactories-1].
    *
    * Usage should be any of the following:
    *
    * itk::ObjectFactoryBase::RegisterFactory( newFactory1 ); // at back
-   * itk::ObjectFactoryBase::RegisterFactory( newFactory2, InsertionPositionType::INSERT_AT_FRONT );
-   * itk::ObjectFactoryBase::RegisterFactory( newFactory3, InsertionPositionType::INSERT_AT_BACK );
-   * itk::ObjectFactoryBase::RegisterFactory( newFactory4, InsertionPositionType::INSERT_AT_POSITION, 5 );
+   * itk::ObjectFactoryBase::RegisterFactory( newFactory2, InsertionPositionEnum::INSERT_AT_FRONT );
+   * itk::ObjectFactoryBase::RegisterFactory( newFactory3, InsertionPositionEnum::INSERT_AT_BACK );
+   * itk::ObjectFactoryBase::RegisterFactory( newFactory4, InsertionPositionEnum::INSERT_AT_POSITION, 5 );
    *
    * If the position value is out of range, an exception will be
    * thrown.
@@ -143,7 +143,7 @@ public:
    */
   static bool
   RegisterFactory(ObjectFactoryBase *,
-                  InsertionPositionType where = InsertionPositionType::INSERT_AT_BACK,
+                  InsertionPositionEnum where = InsertionPositionEnum::INSERT_AT_BACK,
                   size_t                position = 0);
 
   /** Remove a factory from the list of registered factories. */
@@ -302,7 +302,7 @@ private:
 
 // Define how to print enumeration
 extern ITKCommon_EXPORT std::ostream &
-                        operator<<(std::ostream & out, const ObjectFactoryBase::InsertionPositionType value);
+                        operator<<(std::ostream & out, const ObjectFactoryBase::InsertionPositionEnum value);
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkPostOrderTreeIterator.h
+++ b/Modules/Core/Common/include/itkPostOrderTreeIterator.h
@@ -92,7 +92,7 @@ template <typename TTreeType>
 typename PostOrderTreeIterator<TTreeType>::NodeType
 PostOrderTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeType::POSTORDER;
+  return TreeIteratorBaseNodeEnum::POSTORDER;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Core/Common/include/itkPreOrderTreeIterator.h
+++ b/Modules/Core/Common/include/itkPreOrderTreeIterator.h
@@ -78,7 +78,7 @@ template <typename TTreeType>
 typename PreOrderTreeIterator<TTreeType>::NodeType
 PreOrderTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeType::PREORDER;
+  return TreeIteratorBaseNodeEnum::PREORDER;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Core/Common/include/itkRootTreeIterator.h
+++ b/Modules/Core/Common/include/itkRootTreeIterator.h
@@ -77,7 +77,7 @@ template <typename TTreeType>
 typename RootTreeIterator<TTreeType>::NodeType
 RootTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeType::ROOT;
+  return TreeIteratorBaseNodeEnum::ROOT;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -111,11 +111,14 @@ permuteColumnsWithSortIndices(QMatrix & eigenVectors, const std::vector<int> & i
 }
 } // end namespace detail
 
-/** \class OrderType
+/** \class EigenValueOrderEnum
  * \ingroup ITKCommon
  * Order of eigen values
+ * OrderByValue:      lambda_1 < lambda_2 < ....
+ * OrderByMagnitude:  |lambda_1| < |lambda_2| < .....
+ * DoNotOrder:        Default order of eigen values obtained after QL method
  */
-enum class OrderType : uint8_t
+enum class EigenValueOrderEnum : uint8_t
 {
   OrderByValue = 1,
   OrderByMagnitude,
@@ -162,17 +165,17 @@ class ITK_TEMPLATE_EXPORT SymmetricEigenAnalysis
 {
 public:
   /** Enables reverse compatibility for enumeration values */
-  using EigenValueOrderType = OrderType;
+  using EigenValueOrderType = EigenValueOrderEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr EigenValueOrderType OrderByValue = EigenValueOrderType::OrderByValue;
-  static constexpr EigenValueOrderType OrderByMagnitude = EigenValueOrderType::OrderByMagnitude;
-  static constexpr EigenValueOrderType DoNotOrder = EigenValueOrderType::DoNotOrder;
+  static constexpr EigenValueOrderType OrderByValue = EigenValueOrderEnum::OrderByValue;
+  static constexpr EigenValueOrderType OrderByMagnitude = EigenValueOrderEnum::OrderByMagnitude;
+  static constexpr EigenValueOrderType DoNotOrder = EigenValueOrderEnum::DoNotOrder;
 #endif
 
   SymmetricEigenAnalysis()
-    : m_OrderEigenValues(OrderType::OrderByValue)
+    : m_OrderEigenValues(EigenValueOrderEnum::OrderByValue)
   {}
 
   SymmetricEigenAnalysis(const unsigned int dimension)
@@ -180,7 +183,7 @@ public:
 
     m_Dimension(dimension)
     , m_Order(dimension)
-    , m_OrderEigenValues(OrderType::OrderByValue)
+    , m_OrderEigenValues(EigenValueOrderEnum::OrderByValue)
   {}
 
   ~SymmetricEigenAnalysis() = default;
@@ -253,18 +256,18 @@ public:
   {
     if (b)
     {
-      m_OrderEigenValues = OrderType::OrderByValue;
+      m_OrderEigenValues = EigenValueOrderEnum::OrderByValue;
     }
     else
     {
-      m_OrderEigenValues = OrderType::DoNotOrder;
+      m_OrderEigenValues = EigenValueOrderEnum::DoNotOrder;
     }
   }
 
   bool
   GetOrderEigenValues() const
   {
-    return (m_OrderEigenValues == OrderType::OrderByValue);
+    return (m_OrderEigenValues == EigenValueOrderEnum::OrderByValue);
   }
 
   /** Set/Get methods to order the eigen value magnitudes in ascending order.
@@ -275,18 +278,18 @@ public:
   {
     if (b)
     {
-      m_OrderEigenValues = OrderType::OrderByMagnitude;
+      m_OrderEigenValues = EigenValueOrderEnum::OrderByMagnitude;
     }
     else
     {
-      m_OrderEigenValues = OrderType::DoNotOrder;
+      m_OrderEigenValues = EigenValueOrderEnum::DoNotOrder;
     }
   }
 
   bool
   GetOrderEigenMagnitudes() const
   {
-    return (m_OrderEigenValues == OrderType::OrderByMagnitude);
+    return (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude);
   }
 
   /** Set the dimension of the input matrix A. A is a square matrix of
@@ -534,7 +537,7 @@ private:
      * The eigenvectors are normalized to have (Euclidean) norm equal to one. */
     const auto & eigenVectors = solver.eigenvectors();
 
-    if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       auto copyEigenValues = eigenValues;
       auto copyEigenVectors = eigenVectors;
@@ -597,7 +600,7 @@ private:
      * eigenvalue number $ k $ as returned by eigenvalues().
      * The eigenvectors are normalized to have (Euclidean) norm equal to one. */
     const auto & eigenVectors = solver.eigenvectors();
-    if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       auto copyEigenValues = eigenValues;
       auto copyEigenVectors = eigenVectors;
@@ -658,7 +661,7 @@ private:
     using EigenSolverType = Eigen::SelfAdjointEigenSolver<EigenLibMatrixType>;
     EigenSolverType solver(inputMatrix, Eigen::EigenvaluesOnly);
     auto            eigenValues = solver.eigenvalues();
-    if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       detail::sortEigenValuesByMagnitude(eigenValues, m_Dimension);
     }
@@ -695,7 +698,7 @@ private:
     using EigenSolverType = Eigen::SelfAdjointEigenSolver<EigenLibMatrixType>;
     EigenSolverType solver(inputMatrix, Eigen::EigenvaluesOnly);
     auto            eigenValues = solver.eigenvalues();
-    if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       detail::sortEigenValuesByMagnitude(eigenValues, m_Dimension);
     }
@@ -726,17 +729,17 @@ class ITK_TEMPLATE_EXPORT SymmetricEigenAnalysisFixedDimension
 {
 public:
   /** Enables reverse compatibility for enumeration values */
-  using EigenValueOrderType = OrderType;
+  using EigenValueOrderType = EigenValueOrderEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr EigenValueOrderType OrderByValue = EigenValueOrderType::OrderByValue;
-  static constexpr EigenValueOrderType OrderByMagnitude = EigenValueOrderType::OrderByMagnitude;
-  static constexpr EigenValueOrderType DoNotOrder = EigenValueOrderType::DoNotOrder;
+  static constexpr EigenValueOrderType OrderByValue = EigenValueOrderEnum::OrderByValue;
+  static constexpr EigenValueOrderType OrderByMagnitude = EigenValueOrderEnum::OrderByMagnitude;
+  static constexpr EigenValueOrderType DoNotOrder = EigenValueOrderEnum::DoNotOrder;
 #endif
 
   SymmetricEigenAnalysisFixedDimension()
-    : m_OrderEigenValues(OrderType::OrderByValue)
+    : m_OrderEigenValues(EigenValueOrderEnum::OrderByValue)
   {}
   ~SymmetricEigenAnalysisFixedDimension() = default;
 
@@ -794,34 +797,34 @@ public:
   {
     if (b)
     {
-      m_OrderEigenValues = OrderType::OrderByValue;
+      m_OrderEigenValues = EigenValueOrderEnum::OrderByValue;
     }
     else
     {
-      m_OrderEigenValues = OrderType::DoNotOrder;
+      m_OrderEigenValues = EigenValueOrderEnum::DoNotOrder;
     }
   }
   bool
   GetOrderEigenValues() const
   {
-    return (m_OrderEigenValues == OrderType::OrderByValue);
+    return (m_OrderEigenValues == EigenValueOrderEnum::OrderByValue);
   }
   void
   SetOrderEigenMagnitudes(const bool b)
   {
     if (b)
     {
-      m_OrderEigenValues = OrderType::OrderByMagnitude;
+      m_OrderEigenValues = EigenValueOrderEnum::OrderByMagnitude;
     }
     else
     {
-      m_OrderEigenValues = OrderType::DoNotOrder;
+      m_OrderEigenValues = EigenValueOrderEnum::DoNotOrder;
     }
   }
   bool
   GetOrderEigenMagnitudes() const
   {
-    return (m_OrderEigenValues == OrderType::OrderByMagnitude);
+    return (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude);
   }
   constexpr unsigned int
   GetOrder() const
@@ -894,7 +897,7 @@ private:
      * eigenvalue number $ k $ as returned by eigenvalues().
      * The eigenvectors are normalized to have (Euclidean) norm equal to one. */
     const auto & eigenVectors = solver.eigenvectors();
-    if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       auto copyEigenValues = eigenValues;
       auto copyEigenVectors = eigenVectors;
@@ -955,7 +958,7 @@ private:
      * The eigenvectors are normalized to have (Euclidean) norm equal to one. */
     const auto & eigenVectors = solver.eigenvectors();
 
-    if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       auto copyEigenValues = eigenValues;
       auto copyEigenVectors = eigenVectors;
@@ -1010,7 +1013,7 @@ private:
     using EigenSolverType = Eigen::SelfAdjointEigenSolver<EigenLibMatrixType>;
     EigenSolverType solver(inputMatrix, Eigen::EigenvaluesOnly);
     auto            eigenValues = solver.eigenvalues();
-    if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       detail::sortEigenValuesByMagnitude(eigenValues, VDimension);
     }
@@ -1047,7 +1050,7 @@ private:
     using EigenSolverType = Eigen::SelfAdjointEigenSolver<EigenLibMatrixType>;
     EigenSolverType solver(inputMatrix, Eigen::EigenvaluesOnly);
     auto            eigenValues = solver.eigenvalues();
-    if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       detail::sortEigenValuesByMagnitude(eigenValues, VDimension);
     }

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -27,7 +27,7 @@ template <typename TMatrix, typename TVector, typename TEigenMatrix>
 unsigned int
 SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValues(const TMatrix & A, TVector & D) const
 {
-  if (m_UseEigenLibrary && m_OrderEigenValues != OrderType::DoNotOrder)
+  if (m_UseEigenLibrary && m_OrderEigenValues != EigenValueOrderEnum::DoNotOrder)
   {
     return ComputeEigenValuesWithEigenLibrary(A, D);
   }
@@ -532,7 +532,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
 
     p = d[l] + f;
 
-    if (m_OrderEigenValues == OrderType::OrderByValue)
+    if (m_OrderEigenValues == EigenValueOrderEnum::OrderByValue)
     {
       // Order by value
       for (i = l; i > 0; --i)
@@ -545,7 +545,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
       }
       d[i] = p;
     }
-    else if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+    else if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
     {
       // Order by magnitude. Make eigenvalues positive
       for (i = l; i > 0; --i)
@@ -691,7 +691,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
   }
 
   // Order eigenvalues and eigenvectors
-  if (m_OrderEigenValues == OrderType::OrderByValue)
+  if (m_OrderEigenValues == EigenValueOrderEnum::OrderByValue)
   {
     // Order by value
     for (i = 0; i < m_Order - 1; ++i)
@@ -724,7 +724,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
       }
     }
   }
-  else if (m_OrderEigenValues == OrderType::OrderByMagnitude)
+  else if (m_OrderEigenValues == EigenValueOrderEnum::OrderByMagnitude)
   {
     // Order by magnitude
     for (i = 0; i < m_Order - 1; ++i)

--- a/Modules/Core/Common/include/itkThreadLogger.h
+++ b/Modules/Core/Common/include/itkThreadLogger.h
@@ -53,7 +53,7 @@ public:
 
   using OutputType = Logger::OutputType;
 
-  using PriorityLevelType = Logger::PriorityLevelType;
+  using PriorityLevelEnum = Logger::PriorityLevelEnum;
 
   using DelayType = unsigned int;
 
@@ -71,18 +71,18 @@ public:
    * priorities equal or greater than the one set here will be posted to the
    * current outputs. */
   void
-  SetPriorityLevel(PriorityLevelType level) override;
+  SetPriorityLevel(PriorityLevelEnum level) override;
 
   /** Get the priority level for the current logger. Only messages that have
    * priorities equal or greater than the one set here will be posted to the
    * current outputs. */
-  PriorityLevelType
+  PriorityLevelEnum
   GetPriorityLevel() const override;
 
   void
-  SetLevelForFlushing(PriorityLevelType level) override;
+  SetLevelForFlushing(PriorityLevelEnum level) override;
 
-  PriorityLevelType
+  PriorityLevelEnum
   GetLevelForFlushing() const override;
 
   /** Set the delay in milliseconds between checks to see if there are any
@@ -102,7 +102,7 @@ public:
   AddLogOutput(OutputType * output) override;
 
   void
-  Write(PriorityLevelType level, std::string const & content) override;
+  Write(PriorityLevelEnum level, std::string const & content) override;
 
   void
   Flush() override;
@@ -129,7 +129,7 @@ private:
 
   using MessageContainerType = std::queue<std::string>;
 
-  using LevelContainerType = std::queue<PriorityLevelType>;
+  using LevelContainerType = std::queue<PriorityLevelEnum>;
 
   using OutputContainerType = std::queue<OutputType::Pointer>;
 

--- a/Modules/Core/Common/include/itkTreeIteratorBase.h
+++ b/Modules/Core/Common/include/itkTreeIteratorBase.h
@@ -22,11 +22,11 @@
 
 namespace itk
 {
-/** \class TreeIteratorBaseNodeType
+/** \class TreeIteratorBaseNodeEnum
  * \ingroup ITKCommon
  * Enumerations for node type
  */
-enum class TreeIteratorBaseNodeType : uint8_t
+enum class TreeIteratorBaseNodeEnum : uint8_t
 {
   UNDEFIND = 0,
   PREORDER = 1,
@@ -65,7 +65,7 @@ public:
   using ChildIdentifier = typename TreeNodeType::ChildIdentifier;
 
   /** Backwards compatibility for enum values */
-  using NodeType = TreeIteratorBaseNodeType;
+  using NodeType = TreeIteratorBaseNodeEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility

--- a/Modules/Core/Common/src/itkExtractImageFilter.cxx
+++ b/Modules/Core/Common/src/itkExtractImageFilter.cxx
@@ -21,21 +21,21 @@ namespace itk
 {
 /** Define how to print enumeration */
 std::ostream &
-operator<<(std::ostream & out, const ExtractImageFilterCollapseStrategy value)
+operator<<(std::ostream & out, const ExtractImageFilterCollapseStrategyEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
-        return "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN";
-      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
-        return "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY";
-      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
-        return "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX";
-      case ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
-        return "ExtractImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS";
+      case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN:
+        return "ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN";
+      case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY:
+        return "ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY";
+      case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX:
+        return "ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX";
+      case ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS:
+        return "ExtractImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS";
       default:
-        return "INVALID VALUE FOR ExtractImageFilterCollapseStrategy";
+        return "INVALID VALUE FOR ExtractImageFilterCollapseStrategyEnum";
     }
   }();
 }

--- a/Modules/Core/Common/src/itkFrustumSpatialFunction.cxx
+++ b/Modules/Core/Common/src/itkFrustumSpatialFunction.cxx
@@ -20,14 +20,14 @@
 namespace itk
 {
 std::ostream &
-operator<<(std::ostream & out, const RotationPlaneType value)
+operator<<(std::ostream & out, const RotationPlaneEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case RotationPlaneType::RotateInXZPlane:
+      case RotationPlaneEnum::RotateInXZPlane:
         return "FrustumSpatialFunction< VDimension, TInput >::FrustumRotationPlaneType::RotateInXZPlane";
-      case RotationPlaneType::RotateInYZPlane:
+      case RotationPlaneEnum::RotateInYZPlane:
         return "FrustumSpatialFunction< VDimension, TInput >::FrustumRotationPlaneType::RotateInYZPlane";
       default:
         return "INVALID VALUE FOR RotationPlaneType";

--- a/Modules/Core/Common/src/itkLoggerBase.cxx
+++ b/Modules/Core/Common/src/itkLoggerBase.cxx
@@ -22,8 +22,8 @@ namespace itk
 {
 LoggerBase::LoggerBase()
 {
-  this->m_PriorityLevel = LoggerBase::PriorityLevelType::NOTSET;
-  this->m_LevelForFlushing = LoggerBase::PriorityLevelType::MUSTFLUSH;
+  this->m_PriorityLevel = LoggerBase::PriorityLevelEnum::NOTSET;
+  this->m_LevelForFlushing = LoggerBase::PriorityLevelEnum::MUSTFLUSH;
   this->m_Clock = RealTimeClock::New();
   this->m_Output = MultipleLogOutput::New();
   this->m_TimeStampFormat = REALVALUE;
@@ -44,7 +44,7 @@ LoggerBase::AddLogOutput(OutputType * output)
 }
 
 void
-LoggerBase::Write(PriorityLevelType level, std::string const & content)
+LoggerBase::Write(PriorityLevelEnum level, std::string const & content)
 {
   if (this->m_PriorityLevel >= level)
   {
@@ -63,7 +63,7 @@ LoggerBase::Flush()
 }
 
 std::string
-LoggerBase ::BuildFormattedEntry(PriorityLevelType level, std::string const & content)
+LoggerBase ::BuildFormattedEntry(PriorityLevelEnum level, std::string const & content)
 {
   static std::string m_LevelString[] = { "(MUSTFLUSH) ", "(FATAL) ", "(CRITICAL) ", "(WARNING) ",
                                          "(INFO) ",      "(DEBUG) ", "(NOTSET) " };
@@ -103,27 +103,27 @@ LoggerBase::PrintSelf(std::ostream & os, Indent indent) const
 
 /** Print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const LoggerBase::PriorityLevelType value)
+operator<<(std::ostream & out, const LoggerBase::PriorityLevelEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case LoggerBase::PriorityLevelType::MUSTFLUSH:
-        return "LoggerBase::PriorityLevelType::MUSTFLUSH";
-      case LoggerBase::PriorityLevelType::FATAL:
-        return "LoggerBase::PriorityLevelType::FATAL";
-      case LoggerBase::PriorityLevelType::CRITICAL:
-        return "LoggerBase::PriorityLevelType::CRITICAL";
-      case LoggerBase::PriorityLevelType::WARNING:
-        return "LoggerBase::PriorityLevelType::WARNING";
-      case LoggerBase::PriorityLevelType::INFO:
-        return "LoggerBase::PriorityLevelType::INFO";
-      case LoggerBase::PriorityLevelType::DEBUG:
-        return "LoggerBase::PriorityLevelType::DEBUG";
-      case LoggerBase::PriorityLevelType::NOTSET:
-        return "LoggerBase::PriorityLevelType::NOTSET";
+      case LoggerBase::PriorityLevelEnum::MUSTFLUSH:
+        return "LoggerBase::PriorityLevelEnum::MUSTFLUSH";
+      case LoggerBase::PriorityLevelEnum::FATAL:
+        return "LoggerBase::PriorityLevelEnum::FATAL";
+      case LoggerBase::PriorityLevelEnum::CRITICAL:
+        return "LoggerBase::PriorityLevelEnum::CRITICAL";
+      case LoggerBase::PriorityLevelEnum::WARNING:
+        return "LoggerBase::PriorityLevelEnum::WARNING";
+      case LoggerBase::PriorityLevelEnum::INFO:
+        return "LoggerBase::PriorityLevelEnum::INFO";
+      case LoggerBase::PriorityLevelEnum::DEBUG:
+        return "LoggerBase::PriorityLevelEnum::DEBUG";
+      case LoggerBase::PriorityLevelEnum::NOTSET:
+        return "LoggerBase::PriorityLevelEnum::NOTSET";
       default:
-        return "INVALID VALUE FOR LoggerBase::PriorityLevelType";
+        return "INVALID VALUE FOR LoggerBase::PriorityLevelEnum";
     }
   }();
 }

--- a/Modules/Core/Common/src/itkLoggerManager.cxx
+++ b/Modules/Core/Common/src/itkLoggerManager.cxx
@@ -21,7 +21,7 @@ namespace itk
 {
 /** create a logger and add it into LoggerManager */
 LoggerManager::LoggerPointer
-LoggerManager::CreateLogger(const NameType & name, PriorityLevelType level, PriorityLevelType levelForFlushing)
+LoggerManager::CreateLogger(const NameType & name, PriorityLevelEnum level, PriorityLevelEnum levelForFlushing)
 {
   Logger::Pointer logger = Logger::New();
 
@@ -34,7 +34,7 @@ LoggerManager::CreateLogger(const NameType & name, PriorityLevelType level, Prio
 
 /** create a thread logger and add it into LoggerManager */
 LoggerManager::ThreadLoggerPointer
-LoggerManager::CreateThreadLogger(const NameType & name, PriorityLevelType level, PriorityLevelType levelForFlushing)
+LoggerManager::CreateThreadLogger(const NameType & name, PriorityLevelEnum level, PriorityLevelEnum levelForFlushing)
 {
   ThreadLogger::Pointer logger = ThreadLogger::New();
 
@@ -66,7 +66,7 @@ LoggerManager::GetLogger(const NameType & name)
 }
 
 void
-LoggerManager::SetPriorityLevel(PriorityLevelType level)
+LoggerManager::SetPriorityLevel(PriorityLevelEnum level)
 {
   auto itr = this->m_LoggerSet.begin();
 
@@ -78,7 +78,7 @@ LoggerManager::SetPriorityLevel(PriorityLevelType level)
 }
 
 void
-LoggerManager::SetLevelForFlushing(PriorityLevelType level)
+LoggerManager::SetLevelForFlushing(PriorityLevelEnum level)
 {
   auto itr = this->m_LoggerSet.begin();
 
@@ -102,7 +102,7 @@ LoggerManager::AddLogOutput(OutputType * output)
 }
 
 void
-LoggerManager::Write(PriorityLevelType level, std::string const & content)
+LoggerManager::Write(PriorityLevelEnum level, std::string const & content)
 {
   auto itr = this->m_LoggerSet.begin();
 

--- a/Modules/Core/Common/src/itkLoggerOutput.cxx
+++ b/Modules/Core/Common/src/itkLoggerOutput.cxx
@@ -35,7 +35,7 @@ LoggerOutput::DisplayText(const char * t)
 {
   if (this->m_Logger)
   {
-    this->m_Logger->Write(LoggerBase::PriorityLevelType::INFO, t);
+    this->m_Logger->Write(LoggerBase::PriorityLevelEnum::INFO, t);
   }
 }
 
@@ -47,7 +47,7 @@ LoggerOutput::DisplayErrorText(const char * t)
 {
   if (this->m_Logger)
   {
-    this->m_Logger->Write(LoggerBase::PriorityLevelType::CRITICAL, t);
+    this->m_Logger->Write(LoggerBase::PriorityLevelEnum::CRITICAL, t);
   }
 }
 
@@ -59,7 +59,7 @@ LoggerOutput::DisplayWarningText(const char * t)
 {
   if (this->m_Logger)
   {
-    this->m_Logger->Write(LoggerBase::PriorityLevelType::WARNING, t);
+    this->m_Logger->Write(LoggerBase::PriorityLevelEnum::WARNING, t);
   }
 }
 
@@ -71,7 +71,7 @@ LoggerOutput::DisplayGenericOutputText(const char * t)
 {
   if (this->m_Logger)
   {
-    this->m_Logger->Write(LoggerBase::PriorityLevelType::INFO, t);
+    this->m_Logger->Write(LoggerBase::PriorityLevelEnum::INFO, t);
   }
 }
 
@@ -83,7 +83,7 @@ LoggerOutput::DisplayDebugText(const char * t)
 {
   if (this->m_Logger)
   {
-    this->m_Logger->Write(LoggerBase::PriorityLevelType::DEBUG, t);
+    this->m_Logger->Write(LoggerBase::PriorityLevelEnum::DEBUG, t);
   }
 }
 

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -62,13 +62,13 @@ struct MultiThreaderBaseGlobals
   // ITK_GLOBAL_DEFAULT_THREADER. If that is not present, then
   // ITK_USE_THREADPOOL is examined.
 #if defined(ITK_USE_TBB)
-    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderType::TBB)
+    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderEnum::TBB)
     ,
 #elif defined(POOL_MULTI_THREADER_AVAILABLE)
-    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderType::Pool)
+    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderEnum::Pool)
     ,
 #else
-    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderType::Platform)
+    m_GlobalDefaultThreader(MultiThreaderBase::ThreaderEnum::Platform)
     ,
 #endif
     m_GlobalMaximumNumberOfThreads(ITK_MAX_THREADS)
@@ -88,7 +88,7 @@ struct MultiThreaderBaseGlobals
   // be used. This defaults to the environmental variable
   // ITK_GLOBAL_DEFAULT_THREADER. If that is not present, then
   // ITK_USE_THREADPOOL is examined.
-  MultiThreaderBase::ThreaderType m_GlobalDefaultThreader;
+  MultiThreaderBase::ThreaderEnum m_GlobalDefaultThreader;
 
   // Global variable defining the maximum number of threads that can be used.
   //  The m_GlobalMaximumNumberOfThreads must always be less than or equal to
@@ -112,23 +112,23 @@ MultiThreaderBase::SetGlobalDefaultUseThreadPool(const bool GlobalDefaultUseThre
 {
   if (GlobalDefaultUseThreadPool)
   {
-    SetGlobalDefaultThreader(ThreaderType::Pool);
+    SetGlobalDefaultThreader(ThreaderEnum::Pool);
   }
   else
   {
-    SetGlobalDefaultThreader(ThreaderType::Platform);
+    SetGlobalDefaultThreader(ThreaderEnum::Platform);
   }
 }
 
 bool
 MultiThreaderBase::GetGlobalDefaultUseThreadPool()
 {
-  return (GetGlobalDefaultThreader() == ThreaderType::Pool);
+  return (GetGlobalDefaultThreader() == ThreaderEnum::Pool);
 }
 #endif
 
 void
-MultiThreaderBase::SetGlobalDefaultThreader(ThreaderType threaderType)
+MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum threaderType)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -136,7 +136,7 @@ MultiThreaderBase::SetGlobalDefaultThreader(ThreaderType threaderType)
   m_PimplGlobals->GlobalDefaultThreaderTypeIsInitialized = true;
 }
 
-MultiThreaderBase::ThreaderType
+MultiThreaderBase::ThreaderEnum
 MultiThreaderBase ::GetGlobalDefaultThreader()
 {
   // This method must be concurrent thread safe
@@ -155,8 +155,8 @@ MultiThreaderBase ::GetGlobalDefaultThreader()
       if (itksys::SystemTools::GetEnv("ITK_GLOBAL_DEFAULT_THREADER", envVar))
       {
         envVar = itksys::SystemTools::UpperCase(envVar);
-        ThreaderType threaderT = ThreaderTypeFromString(envVar);
-        if (threaderT != ThreaderType::Unknown)
+        ThreaderEnum threaderT = ThreaderTypeFromString(envVar);
+        if (threaderT != ThreaderEnum::Unknown)
         {
           MultiThreaderBase::SetGlobalDefaultThreader(threaderT);
         }
@@ -173,14 +173,14 @@ You should now use ITK_GLOBAL_DEFAULT_THREADER\
         if (envVar != "NO" && envVar != "OFF" && envVar != "FALSE")
         {
 #ifdef __EMSCRIPTEN__
-          MultiThreaderBase::SetGlobalDefaultThreader(ThreaderType::Platform);
+          MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum::Platform);
 #else
-          MultiThreaderBase::SetGlobalDefaultThreader(ThreaderType::Pool);
+          MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum::Pool);
 #endif
         }
         else
         {
-          MultiThreaderBase::SetGlobalDefaultThreader(ThreaderType::Platform);
+          MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum::Platform);
         }
       }
 
@@ -191,25 +191,25 @@ You should now use ITK_GLOBAL_DEFAULT_THREADER\
   return m_PimplGlobals->m_GlobalDefaultThreader;
 }
 
-MultiThreaderBase::ThreaderType
+MultiThreaderBase::ThreaderEnum
 MultiThreaderBase ::ThreaderTypeFromString(std::string threaderString)
 {
   threaderString = itksys::SystemTools::UpperCase(threaderString);
   if (threaderString == "PLATFORM")
   {
-    return ThreaderType::Platform;
+    return ThreaderEnum::Platform;
   }
   else if (threaderString == "POOL")
   {
-    return ThreaderType::Pool;
+    return ThreaderEnum::Pool;
   }
   else if (threaderString == "TBB")
   {
-    return ThreaderType::TBB;
+    return ThreaderEnum::TBB;
   }
   else
   {
-    return ThreaderType::Unknown;
+    return ThreaderEnum::Unknown;
   }
 }
 
@@ -405,18 +405,18 @@ MultiThreaderBase::New()
   Pointer smartPtr = ::itk::ObjectFactory<MultiThreaderBase>::Create();
   if (smartPtr == nullptr)
   {
-    ThreaderType threaderType = GetGlobalDefaultThreader();
+    ThreaderEnum threaderType = GetGlobalDefaultThreader();
     switch (threaderType)
     {
-      case ThreaderType::Platform:
+      case ThreaderEnum::Platform:
         return PlatformMultiThreader::New();
-      case ThreaderType::Pool:
+      case ThreaderEnum::Pool:
 #if defined(POOL_MULTI_THREADER_AVAILABLE)
         return PoolMultiThreader::New();
 #else
         itkGenericExceptionMacro("ITK has been built without PoolMultiThreader support!");
 #endif
-      case ThreaderType::TBB:
+      case ThreaderEnum::TBB:
 #if defined(ITK_USE_TBB)
         return TBBMultiThreader::New();
 #else
@@ -627,7 +627,7 @@ MultiThreaderBase ::ParallelizeImageRegionHelper(void * arg)
 }
 
 std::ostream &
-operator<<(std::ostream & os, const MultiThreaderBase::ThreaderType & threader)
+operator<<(std::ostream & os, const MultiThreaderBase::ThreaderEnum & threader)
 {
   os << MultiThreaderBase::ThreaderTypeToString(threader) << "MultiThreader";
   return os;

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -563,7 +563,7 @@ ObjectFactoryBase ::RegisterFactoryInternal(ObjectFactoryBase * factory)
  * Add a factory to the registered list
  */
 bool
-ObjectFactoryBase ::RegisterFactory(ObjectFactoryBase * factory, InsertionPositionType where, size_t position)
+ObjectFactoryBase ::RegisterFactory(ObjectFactoryBase * factory, InsertionPositionEnum where, size_t position)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -610,27 +610,27 @@ ObjectFactoryBase ::RegisterFactory(ObjectFactoryBase * factory, InsertionPositi
   //
   switch (where)
   {
-    case InsertionPositionType::INSERT_AT_BACK:
+    case InsertionPositionEnum::INSERT_AT_BACK:
     {
       if (position)
       {
         itkGenericExceptionMacro(
-          << "position argument must not be used with InsertionPositionType::INSERT_AT_BACK option");
+          << "position argument must not be used with InsertionPositionEnum::INSERT_AT_BACK option");
       }
       m_PimplGlobals->m_RegisteredFactories->push_back(factory);
       break;
     }
-    case InsertionPositionType::INSERT_AT_FRONT:
+    case InsertionPositionEnum::INSERT_AT_FRONT:
     {
       if (position)
       {
         itkGenericExceptionMacro(
-          << "position argument must not be used with InsertionPositionType::INSERT_AT_FRONT option");
+          << "position argument must not be used with InsertionPositionEnum::INSERT_AT_FRONT option");
       }
       m_PimplGlobals->m_RegisteredFactories->push_front(factory);
       break;
     }
-    case InsertionPositionType::INSERT_AT_POSITION:
+    case InsertionPositionEnum::INSERT_AT_POSITION:
     {
       const size_t numberOfFactories = m_PimplGlobals->m_RegisteredFactories->size();
       if (position < numberOfFactories)
@@ -965,19 +965,19 @@ ObjectFactoryBasePrivate * ObjectFactoryBase::m_PimplGlobals;
 
 /** Print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const ObjectFactoryBase::InsertionPositionType value)
+operator<<(std::ostream & out, const ObjectFactoryBase::InsertionPositionEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT:
-        return "ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT";
-      case ObjectFactoryBase::InsertionPositionType::INSERT_AT_BACK:
-        return "ObjectFactoryBase::InsertionPositionType::INSERT_AT_BACK";
-      case ObjectFactoryBase::InsertionPositionType::INSERT_AT_POSITION:
-        return "ObjectFactoryBase::InsertionPositionType::INSERT_AT_POSITION";
+      case ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_FRONT:
+        return "ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_FRONT";
+      case ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_BACK:
+        return "ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_BACK";
+      case ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_POSITION:
+        return "ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_POSITION";
       default:
-        return "INVALID VALUE FOR ObjectFactoryBase::InsertionPositionType";
+        return "INVALID VALUE FOR ObjectFactoryBase::InsertionPositionEnum";
     }
   }();
 }

--- a/Modules/Core/Common/src/itkSymmetricEigenAnalysis.cxx
+++ b/Modules/Core/Common/src/itkSymmetricEigenAnalysis.cxx
@@ -20,19 +20,19 @@
 namespace itk
 {
 std::ostream &
-operator<<(std::ostream & out, const OrderType value)
+operator<<(std::ostream & out, const EigenValueOrderEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case OrderType::OrderByValue:
-        return "OrderType::OrderByValue";
-      case OrderType::OrderByMagnitude:
-        return "OrderType::OrderByMagnitude";
-      case OrderType::DoNotOrder:
-        return "OrderType::DoNotOrder";
+      case EigenValueOrderEnum::OrderByValue:
+        return "EigenValueOrderEnum::OrderByValue";
+      case EigenValueOrderEnum::OrderByMagnitude:
+        return "EigenValueOrderEnum::OrderByMagnitude";
+      case EigenValueOrderEnum::DoNotOrder:
+        return "EigenValueOrderEnum::DoNotOrder";
       default:
-        return "INVALID VALUE FOR OrderType";
+        return "INVALID VALUE FOR EigenValueOrderEnum";
     }
   }();
 }

--- a/Modules/Core/Common/src/itkThreadLogger.cxx
+++ b/Modules/Core/Common/src/itkThreadLogger.cxx
@@ -39,7 +39,7 @@ ThreadLogger ::~ThreadLogger()
 }
 
 void
-ThreadLogger ::SetPriorityLevel(PriorityLevelType level)
+ThreadLogger ::SetPriorityLevel(PriorityLevelEnum level)
 {
   this->m_Mutex.lock();
   this->m_OperationQ.push(SET_PRIORITY_LEVEL);
@@ -47,17 +47,17 @@ ThreadLogger ::SetPriorityLevel(PriorityLevelType level)
   this->m_Mutex.unlock();
 }
 
-Logger::PriorityLevelType
+Logger::PriorityLevelEnum
 ThreadLogger ::GetPriorityLevel() const
 {
   this->m_Mutex.lock();
-  PriorityLevelType level = this->m_PriorityLevel;
+  PriorityLevelEnum level = this->m_PriorityLevel;
   this->m_Mutex.unlock();
   return level;
 }
 
 void
-ThreadLogger ::SetLevelForFlushing(PriorityLevelType level)
+ThreadLogger ::SetLevelForFlushing(PriorityLevelEnum level)
 {
   this->m_Mutex.lock();
   this->m_LevelForFlushing = level;
@@ -66,11 +66,11 @@ ThreadLogger ::SetLevelForFlushing(PriorityLevelType level)
   this->m_Mutex.unlock();
 }
 
-Logger::PriorityLevelType
+Logger::PriorityLevelEnum
 ThreadLogger ::GetLevelForFlushing() const
 {
   this->m_Mutex.lock();
-  PriorityLevelType level = this->m_LevelForFlushing;
+  PriorityLevelEnum level = this->m_LevelForFlushing;
   this->m_Mutex.unlock();
   return level;
 }
@@ -102,7 +102,7 @@ ThreadLogger ::AddLogOutput(OutputType * output)
 }
 
 void
-ThreadLogger ::Write(PriorityLevelType level, std::string const & content)
+ThreadLogger ::Write(PriorityLevelEnum level, std::string const & content)
 {
   this->m_Mutex.lock();
   this->m_OperationQ.push(WRITE);

--- a/Modules/Core/Common/src/itkTreeIteratorBase.cxx
+++ b/Modules/Core/Common/src/itkTreeIteratorBase.cxx
@@ -21,29 +21,29 @@ namespace itk
 {
 /** Print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const TreeIteratorBaseNodeType value)
+operator<<(std::ostream & out, const TreeIteratorBaseNodeEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case TreeIteratorBaseNodeType::UNDEFIND:
-        return "TreeIteratorBaseNodeType::UNDEFIND";
-      case TreeIteratorBaseNodeType::PREORDER:
-        return "TreeIteratorBaseNodeType::PREORDER";
-      case TreeIteratorBaseNodeType::INORDER:
-        return "TreeIteratorBaseNodeType::INORDER";
-      case TreeIteratorBaseNodeType::POSTORDER:
-        return "TreeIteratorBaseNodeType::POSTORDER";
-      case TreeIteratorBaseNodeType::LEVELORDER:
-        return "TreeIteratorBaseNodeType::LEVELORDER";
-      case TreeIteratorBaseNodeType::CHILD:
-        return "TreeIteratorBaseNodeType::CHILD";
-      case TreeIteratorBaseNodeType::ROOT:
-        return "TreeIteratorBaseNodeType::ROOT";
-      case TreeIteratorBaseNodeType::LEAF:
-        return "TreeIteratorBaseNodeType::LEAF";
+      case TreeIteratorBaseNodeEnum::UNDEFIND:
+        return "TreeIteratorBaseNodeEnum::UNDEFIND";
+      case TreeIteratorBaseNodeEnum::PREORDER:
+        return "TreeIteratorBaseNodeEnum::PREORDER";
+      case TreeIteratorBaseNodeEnum::INORDER:
+        return "TreeIteratorBaseNodeEnum::INORDER";
+      case TreeIteratorBaseNodeEnum::POSTORDER:
+        return "TreeIteratorBaseNodeEnum::POSTORDER";
+      case TreeIteratorBaseNodeEnum::LEVELORDER:
+        return "TreeIteratorBaseNodeEnum::LEVELORDER";
+      case TreeIteratorBaseNodeEnum::CHILD:
+        return "TreeIteratorBaseNodeEnum::CHILD";
+      case TreeIteratorBaseNodeEnum::ROOT:
+        return "TreeIteratorBaseNodeEnum::ROOT";
+      case TreeIteratorBaseNodeEnum::LEAF:
+        return "TreeIteratorBaseNodeEnum::LEAF";
       default:
-        return "INVALID VALUE FOR TreeIteratorBaseNodeType";
+        return "INVALID VALUE FOR TreeIteratorBaseNodeEnum";
     }
   }();
 }

--- a/Modules/Core/Common/test/itkLogTester.h
+++ b/Modules/Core/Common/test/itkLogTester.h
@@ -43,22 +43,22 @@ public:
   void
   log()
   {
-    itkLogMacro(PriorityLevelType::DEBUG, "DEBUG message by itkLogMacro\n");
-    itkLogMacro(PriorityLevelType::INFO, "INFO message by itkLogMacro\n");
-    itkLogMacro(PriorityLevelType::WARNING, "WARNING message by itkLogMacro\n");
-    itkLogMacro(PriorityLevelType::CRITICAL, "CRITICAL message by itkLogMacro\n");
-    itkLogMacro(PriorityLevelType::FATAL, "FATAL message by itkLogMacro\n");
-    itkLogMacro(PriorityLevelType::MUSTFLUSH, "MUSTFLUSH message by itkLogMacro\n");
+    itkLogMacro(PriorityLevelEnum::DEBUG, "DEBUG message by itkLogMacro\n");
+    itkLogMacro(PriorityLevelEnum::INFO, "INFO message by itkLogMacro\n");
+    itkLogMacro(PriorityLevelEnum::WARNING, "WARNING message by itkLogMacro\n");
+    itkLogMacro(PriorityLevelEnum::CRITICAL, "CRITICAL message by itkLogMacro\n");
+    itkLogMacro(PriorityLevelEnum::FATAL, "FATAL message by itkLogMacro\n");
+    itkLogMacro(PriorityLevelEnum::MUSTFLUSH, "MUSTFLUSH message by itkLogMacro\n");
   }
   static void
   logStatic(LogTester * tester)
   {
-    itkLogMacroStatic(tester, PriorityLevelType::DEBUG, "DEBUG message by itkLogMacroStatic\n");
-    itkLogMacroStatic(tester, PriorityLevelType::INFO, "INFO message by itkLogMacroStatic\n");
-    itkLogMacroStatic(tester, PriorityLevelType::WARNING, "WARNING message by itkLogMacroStatic\n");
-    itkLogMacroStatic(tester, PriorityLevelType::CRITICAL, "CRITICAL message by itkLogMacroStatic\n");
-    itkLogMacroStatic(tester, PriorityLevelType::FATAL, "FATAL message by itkLogMacroStatic\n");
-    itkLogMacroStatic(tester, PriorityLevelType::MUSTFLUSH, "MUSTFLUSH message by itkLogMacroStatic\n");
+    itkLogMacroStatic(tester, PriorityLevelEnum::DEBUG, "DEBUG message by itkLogMacroStatic\n");
+    itkLogMacroStatic(tester, PriorityLevelEnum::INFO, "INFO message by itkLogMacroStatic\n");
+    itkLogMacroStatic(tester, PriorityLevelEnum::WARNING, "WARNING message by itkLogMacroStatic\n");
+    itkLogMacroStatic(tester, PriorityLevelEnum::CRITICAL, "CRITICAL message by itkLogMacroStatic\n");
+    itkLogMacroStatic(tester, PriorityLevelEnum::FATAL, "FATAL message by itkLogMacroStatic\n");
+    itkLogMacroStatic(tester, PriorityLevelEnum::MUSTFLUSH, "MUSTFLUSH message by itkLogMacroStatic\n");
   }
 
 private:

--- a/Modules/Core/Common/test/itkLoggerManagerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerManagerTest.cxx
@@ -45,12 +45,12 @@ itkLoggerManagerTest(int argc, char * argv[])
     itk::LoggerManager::Pointer manager = itk::LoggerManager::New();
 
     itk::Logger::Pointer logger = manager->CreateLogger("org.itk.logTester.logger",
-                                                        itk::LoggerBase::PriorityLevelType::DEBUG,
-                                                        itk::LoggerBase::PriorityLevelType::CRITICAL);
+                                                        itk::LoggerBase::PriorityLevelEnum::DEBUG,
+                                                        itk::LoggerBase::PriorityLevelEnum::CRITICAL);
 
     itk::ThreadLogger::Pointer t_logger = manager->CreateThreadLogger("org.itk.ThreadLogger",
-                                                                      itk::LoggerBase::PriorityLevelType::WARNING,
-                                                                      itk::LoggerBase::PriorityLevelType::CRITICAL);
+                                                                      itk::LoggerBase::PriorityLevelEnum::WARNING,
+                                                                      itk::LoggerBase::PriorityLevelEnum::CRITICAL);
 
     std::cout << "Testing itk::LoggerManager" << std::endl;
 
@@ -70,14 +70,14 @@ itkLoggerManagerTest(int argc, char * argv[])
     std::cout << "  But the logged messages will be in order." << std::endl;
     std::cout << "  Each line is an atom for synchronization." << std::endl;
     // Writing by the logger
-    manager->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message.\n");
+    manager->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message.\n");
     std::cout << "  Message #1" << std::endl;
-    manager->Write(itk::LoggerBase::PriorityLevelType::INFO, "This is the INFO message.\n");
-    manager->Write(itk::LoggerBase::PriorityLevelType::WARNING, "This is the WARNING message.\n");
+    manager->Write(itk::LoggerBase::PriorityLevelEnum::INFO, "This is the INFO message.\n");
+    manager->Write(itk::LoggerBase::PriorityLevelEnum::WARNING, "This is the WARNING message.\n");
     std::cout << "  Message #2" << std::endl;
-    manager->Write(itk::LoggerBase::PriorityLevelType::CRITICAL, "This is the CRITICAL message.\n");
-    manager->Write(itk::Logger::PriorityLevelType::FATAL, "This is the FATAL message.\n");
-    manager->Write(itk::LoggerBase::PriorityLevelType::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
+    manager->Write(itk::LoggerBase::PriorityLevelEnum::CRITICAL, "This is the CRITICAL message.\n");
+    manager->Write(itk::Logger::PriorityLevelEnum::FATAL, "This is the FATAL message.\n");
+    manager->Write(itk::LoggerBase::PriorityLevelEnum::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
     std::cout << "  Message #3" << std::endl;
     itk::Logger * pLogger;
     pLogger = manager->GetLogger("org.itk.logTester.logger");
@@ -85,7 +85,7 @@ itkLoggerManagerTest(int argc, char * argv[])
     {
       throw "LoggerManager::GetLogger() failed";
     }
-    pLogger->Write(itk::LoggerBase::PriorityLevelType::INFO,
+    pLogger->Write(itk::LoggerBase::PriorityLevelEnum::INFO,
                    "This is the message from the logger got from a LoggerManager");
     if (manager->GetLogger("abc") != nullptr)
     {

--- a/Modules/Core/Common/test/itkLoggerOutputTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerOutputTest.cxx
@@ -49,8 +49,8 @@ itkLoggerOutputTest(int argc, char * argv[])
 
     // Setting the logger
     logger->SetName("org.itk.rootLogger");
-    logger->SetPriorityLevel(itk::LoggerBase::PriorityLevelType::INFO);
-    logger->SetLevelForFlushing(itk::LoggerBase::PriorityLevelType::CRITICAL);
+    logger->SetPriorityLevel(itk::LoggerBase::PriorityLevelEnum::INFO);
+    logger->SetLevelForFlushing(itk::LoggerBase::PriorityLevelEnum::CRITICAL);
 
     std::cout << "  Adding console and file stream LogOutputs" << std::endl;
     logger->AddLogOutput(coutput);

--- a/Modules/Core/Common/test/itkLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerTest.cxx
@@ -48,8 +48,8 @@ itkLoggerTest(int argc, char * argv[])
 
     // Setting the logger
     logger->SetName("org.itk.rootLogger");
-    logger->SetPriorityLevel(itk::LoggerBase::PriorityLevelType::INFO);
-    logger->SetLevelForFlushing(itk::LoggerBase::PriorityLevelType::CRITICAL);
+    logger->SetPriorityLevel(itk::LoggerBase::PriorityLevelEnum::INFO);
+    logger->SetLevelForFlushing(itk::LoggerBase::PriorityLevelEnum::CRITICAL);
 
     std::cout << "  Adding console and file stream LogOutputs" << std::endl;
     logger->AddLogOutput(coutput);
@@ -71,12 +71,12 @@ itkLoggerTest(int argc, char * argv[])
 
     // Writing by the logger
     std::cout << "  Writing by itk::Logger" << std::endl;
-    logger->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::INFO, "This is the INFO message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::WARNING, "This is the WARNING message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::CRITICAL, "This is the CRITICAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::FATAL, "This is the FATAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, "This is the INFO message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::WARNING, "This is the WARNING message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::CRITICAL, "This is the CRITICAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::FATAL, "This is the FATAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
     logger->Flush();
 
     itk::LoggerBase::TimeStampFormatType timeStampFormat = itk::LoggerBase::HUMANREADABLE;
@@ -90,12 +90,12 @@ itkLoggerTest(int argc, char * argv[])
 
 
     std::cout << "  Writing by itk::Logger in Human Readable format" << std::endl;
-    logger->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::INFO, "This is the INFO message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::WARNING, "This is the WARNING message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::CRITICAL, "This is the CRITICAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::FATAL, "This is the FATAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, "This is the INFO message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::WARNING, "This is the WARNING message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::CRITICAL, "This is the CRITICAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::FATAL, "This is the FATAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
     logger->Flush();
 
 
@@ -109,12 +109,12 @@ itkLoggerTest(int argc, char * argv[])
     }
 
     std::cout << "  Writing by itk::Logger in Human Readable style with new format" << std::endl;
-    logger->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::INFO, "This is the INFO message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::WARNING, "This is the WARNING message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::CRITICAL, "This is the CRITICAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::FATAL, "This is the FATAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, "This is the INFO message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::WARNING, "This is the WARNING message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::CRITICAL, "This is the CRITICAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::FATAL, "This is the FATAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
     logger->Flush();
   }
   catch (...)

--- a/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
@@ -53,37 +53,37 @@ public:
   itkNewMacro(Self);
 
   std::string
-  BuildFormattedEntry(PriorityLevelType level, std::string const & content) override
+  BuildFormattedEntry(PriorityLevelEnum level, std::string const & content) override
   {
     std::string HeaderLevelStart("");
     std::string HeaderLevelStop("");
     switch (level)
     {
-      case PriorityLevelType::MUSTFLUSH:
+      case PriorityLevelEnum::MUSTFLUSH:
         HeaderLevelStart = ("<H1>");
         HeaderLevelStop = ("</H1>");
         break;
-      case PriorityLevelType::FATAL:
+      case PriorityLevelEnum::FATAL:
         HeaderLevelStart = ("<H2>");
         HeaderLevelStop = ("</H2>");
         break;
-      case PriorityLevelType::CRITICAL:
+      case PriorityLevelEnum::CRITICAL:
         HeaderLevelStart = ("<H3>");
         HeaderLevelStop = ("</H3>");
         break;
-      case PriorityLevelType::WARNING:
+      case PriorityLevelEnum::WARNING:
         HeaderLevelStart = ("<H4>");
         HeaderLevelStop = ("</H4>");
         break;
-      case PriorityLevelType::INFO:
+      case PriorityLevelEnum::INFO:
         HeaderLevelStart = ("<H5>");
         HeaderLevelStop = ("</H5>");
         break;
-      case PriorityLevelType::DEBUG:
+      case PriorityLevelEnum::DEBUG:
         HeaderLevelStart = ("<H6>");
         HeaderLevelStop = ("</H6>");
         break;
-      case PriorityLevelType::NOTSET:
+      case PriorityLevelEnum::NOTSET:
         HeaderLevelStart = ("<H7>");
         HeaderLevelStop = ("</H7>");
         break;
@@ -119,11 +119,11 @@ ThreadedGenerateLogMessages2(void * arg)
       {
         std::ostringstream msg;
         msg << threadPrefix << "unpacked arg\n";
-        threadData.logger->Write(itk::LoggerBase::PriorityLevelType::INFO, msg.str());
+        threadData.logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, msg.str());
         threadData.logger->Flush();
         msg.str("");
         msg << threadPrefix << "Done logging\n";
-        threadData.logger->Write(itk::LoggerBase::PriorityLevelType::INFO, msg.str());
+        threadData.logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, msg.str());
         // std::cout << msg.str() << std::endl;
       }
       // do stuff
@@ -186,8 +186,8 @@ itkLoggerThreadWrapperTest(int argc, char * argv[])
 
     // Setting the logger
     logger->SetName("org.itk.threadLogger");
-    logger->SetPriorityLevel(itk::LoggerBase::PriorityLevelType::INFO);
-    logger->SetLevelForFlushing(itk::LoggerBase::PriorityLevelType::CRITICAL);
+    logger->SetPriorityLevel(itk::LoggerBase::PriorityLevelEnum::INFO);
+    logger->SetLevelForFlushing(itk::LoggerBase::PriorityLevelEnum::CRITICAL);
 
     // Exercising PrintSelf()
     logger->Print(std::cout);
@@ -215,14 +215,14 @@ itkLoggerThreadWrapperTest(int argc, char * argv[])
     std::cout << "  But the logged messages will be in order." << std::endl;
     std::cout << "  Each line is an atom for synchronization." << std::endl;
     // Writing by the logger
-    logger->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message.\n");
     std::cout << "  Message #1" << std::endl;
-    logger->Write(itk::LoggerBase::PriorityLevelType::INFO, "This is the INFO message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::WARNING, "This is the WARNING message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, "This is the INFO message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::WARNING, "This is the WARNING message.\n");
     std::cout << "  Message #2" << std::endl;
-    logger->Write(itk::LoggerBase::PriorityLevelType::CRITICAL, "This is the CRITICAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::FATAL, "This is the FATAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::CRITICAL, "This is the CRITICAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::FATAL, "This is the FATAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
     std::cout << "  Message #3" << std::endl;
     logger->Flush();
     std::cout << "  Flushing by the ThreadLogger is synchronized." << std::endl;
@@ -239,7 +239,7 @@ itkLoggerThreadWrapperTest(int argc, char * argv[])
 
     std::cout << "Testing SetDelay method" << std::endl;
     logger->SetDelay(1);
-    logger->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "DEBUG message to tests SetDelay.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "DEBUG message to tests SetDelay.\n");
     logger->Flush();
     std::cout << "Ended multi-threaded portion of test." << std::endl;
 
@@ -254,28 +254,28 @@ itkLoggerThreadWrapperTest(int argc, char * argv[])
     std::cout << "Testing itk::LoggerThreadWrapper" << std::endl;
 
     logger2->SetName("org.itk.threadLogger");
-    logger2->SetPriorityLevel(itk::LoggerBase::PriorityLevelType::INFO);
-    logger2->SetLevelForFlushing(itk::LoggerBase::PriorityLevelType::CRITICAL);
+    logger2->SetPriorityLevel(itk::LoggerBase::PriorityLevelEnum::INFO);
+    logger2->SetLevelForFlushing(itk::LoggerBase::PriorityLevelEnum::CRITICAL);
 
     logger2->AddLogOutput(coutput2);
 
     logger2->SetDelay(10);
 
-    logger2->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message 1.\n");
+    logger2->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message 1.\n");
     itksys::SystemTools::Delay(1000);
-    logger2->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message 2.\n");
+    logger2->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message 2.\n");
     itksys::SystemTools::Delay(1000);
-    logger2->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message 3.\n");
+    logger2->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message 3.\n");
     itksys::SystemTools::Delay(1000);
-    logger2->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message 4.\n");
+    logger2->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message 4.\n");
     itksys::SystemTools::Delay(1000);
-    logger2->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message 5.\n");
+    logger2->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message 5.\n");
     itksys::SystemTools::Delay(1000);
-    logger2->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message 6.\n");
+    logger2->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message 6.\n");
 
     logger2->SetDelay(1000);
-    logger2->SetPriorityLevel(itk::LoggerBase::PriorityLevelType::INFO);
-    logger2->SetLevelForFlushing(itk::LoggerBase::PriorityLevelType::CRITICAL);
+    logger2->SetPriorityLevel(itk::LoggerBase::PriorityLevelEnum::INFO);
+    logger2->SetLevelForFlushing(itk::LoggerBase::PriorityLevelEnum::CRITICAL);
     logger2->Flush();
   }
   catch (...)

--- a/Modules/Core/Common/test/itkMultiThreaderTypeFromEnvironmentTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderTypeFromEnvironmentTest.cxx
@@ -21,10 +21,10 @@
 #include <type_traits>
 #include <set>
 
-using ThreaderType = itk::MultiThreaderBase::ThreaderType;
+using ThreaderEnum = itk::MultiThreaderBase::ThreaderEnum;
 
 bool
-checkThreaderByName(ThreaderType expectedThreaderType)
+checkThreaderByName(ThreaderEnum expectedThreaderType)
 {
   using ImageType = itk::Image<unsigned, 3>;
   // any filter type which does not manually specify threader type will do
@@ -54,8 +54,8 @@ itkMultiThreaderTypeFromEnvironmentTest(int argc, char * argv[])
 
   bool success = true;
 
-  ThreaderType expectedThreaderType = itk::MultiThreaderBase::ThreaderTypeFromString(argv[1]);
-  ThreaderType realThreaderType = itk::MultiThreaderBase::GetGlobalDefaultThreader();
+  ThreaderEnum expectedThreaderType = itk::MultiThreaderBase::ThreaderTypeFromString(argv[1]);
+  ThreaderEnum realThreaderType = itk::MultiThreaderBase::GetGlobalDefaultThreader();
 
   if (realThreaderType != expectedThreaderType)
   {
@@ -67,9 +67,9 @@ itkMultiThreaderTypeFromEnvironmentTest(int argc, char * argv[])
   success &= checkThreaderByName(expectedThreaderType);
 
   // check that developer's choice for default is respected
-  std::set<ThreaderType> threadersToTest = { ThreaderType::Platform, ThreaderType::Pool };
+  std::set<ThreaderEnum> threadersToTest = { ThreaderEnum::Platform, ThreaderEnum::Pool };
 #ifdef ITK_USE_TBB
-  threadersToTest.insert(ThreaderType::TBB);
+  threadersToTest.insert(ThreaderEnum::TBB);
 #endif // ITK_USE_TBB
   for (auto thType : threadersToTest)
   {
@@ -81,7 +81,7 @@ itkMultiThreaderTypeFromEnvironmentTest(int argc, char * argv[])
   // 1. insert it into threadersToTest set
   // 2. add tests to Modules/Core/Common/test/CMakeLists.txt similarily to tests for other multi-threaders
   // 3. rewrite the condition below to use whatever is really the last threader type
-  itkAssertOrThrowMacro(ThreaderType::TBB == ThreaderType::Last,
+  itkAssertOrThrowMacro(ThreaderEnum::TBB == ThreaderEnum::Last,
                         "All multi-threader implementation have to be tested!");
 
   if (success)

--- a/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
@@ -169,7 +169,7 @@ itkObjectFactoryTest3(int, char *[])
   itk::ObjectFactoryBase::RegisterFactory(factory1);
   itk::ObjectFactoryBase::RegisterFactory(factory2);
   itk::ObjectFactoryBase::RegisterFactory(factory3);
-  itk::ObjectFactoryBase::RegisterFactory(factory4, itk::ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT);
+  itk::ObjectFactoryBase::RegisterFactory(factory4, itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_FRONT);
 
   descriptionList.push_back("factory4");
   descriptionList.push_back("factory1");
@@ -184,7 +184,7 @@ itkObjectFactoryTest3(int, char *[])
   }
 
 
-  itk::ObjectFactoryBase::RegisterFactory(factory5, itk::ObjectFactoryBase::InsertionPositionType::INSERT_AT_BACK);
+  itk::ObjectFactoryBase::RegisterFactory(factory5, itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_BACK);
   descriptionList.push_back("factory5");
 
   result = ListRegisteredFactories("TryC", descriptionList);
@@ -196,7 +196,7 @@ itkObjectFactoryTest3(int, char *[])
 
 
   itk::ObjectFactoryBase::RegisterFactory(
-    factory6, itk::ObjectFactoryBase::InsertionPositionType::INSERT_AT_POSITION, 3);
+    factory6, itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_POSITION, 3);
   descriptionList.clear();
   descriptionList.push_back("factory4"); // position 0
   descriptionList.push_back("factory1"); // position 1
@@ -213,7 +213,7 @@ itkObjectFactoryTest3(int, char *[])
   }
 
 
-  itk::ObjectFactoryBase::RegisterFactory(factory7, itk::ObjectFactoryBase::InsertionPositionType::INSERT_AT_BACK);
+  itk::ObjectFactoryBase::RegisterFactory(factory7, itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_BACK);
   descriptionList.push_back("factory7");
 
   result = ListRegisteredFactories("TryE", descriptionList);

--- a/Modules/Core/Common/test/itkThreadLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadLoggerTest.cxx
@@ -50,11 +50,11 @@ ThreadedGenerateLogMessages(void * arg)
       {
         std::ostringstream msg;
         msg << threadPrefix << "unpacked arg\n";
-        threadData.logger->Write(itk::LoggerBase::PriorityLevelType::INFO, msg.str());
+        threadData.logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, msg.str());
         threadData.logger->Flush();
         msg.str("");
         msg << threadPrefix << "Done logging\n";
-        threadData.logger->Write(itk::LoggerBase::PriorityLevelType::INFO, msg.str());
+        threadData.logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, msg.str());
         // std::cout << msg.str() << std::endl;
       }
       // do stuff
@@ -117,8 +117,8 @@ itkThreadLoggerTest(int argc, char * argv[])
 
     // Setting the logger
     logger->SetName("org.itk.threadLogger");
-    logger->SetPriorityLevel(itk::LoggerBase::PriorityLevelType::INFO);
-    logger->SetLevelForFlushing(itk::LoggerBase::PriorityLevelType::CRITICAL);
+    logger->SetPriorityLevel(itk::LoggerBase::PriorityLevelEnum::INFO);
+    logger->SetLevelForFlushing(itk::LoggerBase::PriorityLevelEnum::CRITICAL);
 
     std::cout << "  Adding console and file stream LogOutputs" << std::endl;
     logger->AddLogOutput(coutput);
@@ -143,14 +143,14 @@ itkThreadLoggerTest(int argc, char * argv[])
     std::cout << "  But the logged messages will be in order." << std::endl;
     std::cout << "  Each line is an atom for synchronization." << std::endl;
     // Writing by the logger
-    logger->Write(itk::LoggerBase::PriorityLevelType::DEBUG, "This is the DEBUG message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::DEBUG, "This is the DEBUG message.\n");
     std::cout << "  Message #1" << std::endl;
-    logger->Write(itk::LoggerBase::PriorityLevelType::INFO, "This is the INFO message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::WARNING, "This is the WARNING message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::INFO, "This is the INFO message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::WARNING, "This is the WARNING message.\n");
     std::cout << "  Message #2" << std::endl;
-    logger->Write(itk::LoggerBase::PriorityLevelType::CRITICAL, "This is the CRITICAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::FATAL, "This is the FATAL message.\n");
-    logger->Write(itk::LoggerBase::PriorityLevelType::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::CRITICAL, "This is the CRITICAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::FATAL, "This is the FATAL message.\n");
+    logger->Write(itk::LoggerBase::PriorityLevelEnum::MUSTFLUSH, "This is the MUSTFLUSH message.\n");
     std::cout << "  Message #3" << std::endl;
     logger->Flush();
     std::cout << "  Flushing by the ThreadLogger is synchronized." << std::endl;

--- a/Modules/Core/Common/test/itkTreeContainerTest.cxx
+++ b/Modules/Core/Common/test/itkTreeContainerTest.cxx
@@ -127,7 +127,7 @@ itkTreeContainerTest(int, char *[])
 
   std::cout << "Testing other features : ";
 
-  if (childIt2.GetType() != itk::TreeIteratorBaseNodeType::CHILD)
+  if (childIt2.GetType() != itk::TreeIteratorBaseNodeEnum::CHILD)
   {
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Common/wrapping/itkExtractImageFilter.wrap
+++ b/Modules/Core/Common/wrapping/itkExtractImageFilter.wrap
@@ -1,7 +1,7 @@
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkExtractImageFilter.h")
 
-itk_wrap_simple_class("itk::ExtractImageFilterCollapseStrategy" ENUM)
+itk_wrap_simple_class("itk::ExtractImageFilterCollapseStrategyEnum" ENUM)
 
 itk_wrap_class("itk::ExtractImageFilter" POINTER)
   itk_wrap_image_filter("${WRAP_ITK_ALL_TYPES}" 2)

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFilterEnum.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFilterEnum.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkGPUFiniteDifferenceFilterTypeEnum_h
-#define itkGPUFiniteDifferenceFilterTypeEnum_h
+#ifndef itkGPUFiniteDifferenceFilterEnum_h
+#define itkGPUFiniteDifferenceFilterEnum_h
 
 #include <iostream>
 #include "ITKGPUFiniteDifferenceExport.h"
@@ -24,17 +24,17 @@
 namespace itk
 {
 /**
- * \class GPUFiniteDifferenceFilterTypeEnum
+ * \class GPUFiniteDifferenceFilterEnum
  * \ingroup ITKGPUFiniteDifference
  */
-enum class GPUFiniteDifferenceFilterTypeEnum : uint8_t
+enum class GPUFiniteDifferenceFilterEnum : uint8_t
 {
-  UNINITIALIZED = 0,
-  INITIALIZED = 1
+  UNINITIALIZED,
+  INITIALIZED
 };
 /** Define how to print enumeration values */
 extern ITKGPUFiniteDifference_EXPORT std::ostream &
-                                     operator<<(std::ostream & out, const GPUFiniteDifferenceFilterTypeEnum value);
+                                     operator<<(std::ostream & out, const GPUFiniteDifferenceFilterEnum value);
 } // end namespace itk
 
 #endif

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
@@ -22,7 +22,7 @@
 #include "itkGPUFiniteDifferenceFunction.h"
 #include "itkFiniteDifferenceImageFilter.h"
 #include "itkTimeProbe.h"
-#include "itkGPUFiniteDifferenceFilterTypeEnum.h"
+#include "itkGPUFiniteDifferenceFilterEnum.h"
 
 namespace itk
 {
@@ -101,7 +101,7 @@ public:
   }
 
   /** Enables backwards compatibility for enum values */
-  using FilterStateType = GPUFiniteDifferenceFilterTypeEnum;
+  using FilterStateType = GPUFiniteDifferenceFilterEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility

--- a/Modules/Core/GPUFiniteDifference/src/CMakeLists.txt
+++ b/Modules/Core/GPUFiniteDifference/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(ITKGPUFiniteDifference_SRCS
-  itkGPUFiniteDifferenceFilterTypeEnum.cxx
+  itkGPUFiniteDifferenceFilterEnum.cxx
 )
 
 if (ITK_USE_GPU)

--- a/Modules/Core/GPUFiniteDifference/src/itkGPUFiniteDifferenceFilterEnum.cxx
+++ b/Modules/Core/GPUFiniteDifference/src/itkGPUFiniteDifferenceFilterEnum.cxx
@@ -15,23 +15,23 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include "itkGPUFiniteDifferenceFilterTypeEnum.h"
+#include "itkGPUFiniteDifferenceFilterEnum.h"
 
 namespace itk
 {
 std::ostream &
-operator<<(std::ostream & out, const GPUFiniteDifferenceFilterTypeEnum value)
+operator<<(std::ostream & out, const GPUFiniteDifferenceFilterEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case GPUFiniteDifferenceFilterTypeEnum::UNINITIALIZED:
+      case GPUFiniteDifferenceFilterEnum::UNINITIALIZED:
         return "GPUFiniteDifferenceImageFilter<TInputImage,TOutputImage,TParentImageFilter>::FilterStateType::"
                "UNINITIALIZED";
-      case GPUFiniteDifferenceFilterTypeEnum::INITIALIZED:
-        return "GPUFiniteDifferenceFilterTypeEnum::INITIALIZED";
+      case GPUFiniteDifferenceFilterEnum::INITIALIZED:
+        return "GPUFiniteDifferenceFilterEnum::INITIALIZED";
       default:
-        return "INVALID VALUE FOR GPUFiniteDifferenceFilterTypeEnum";
+        return "INVALID VALUE FOR GPUFiniteDifferenceFilterEnum";
     }
   }();
 }

--- a/Modules/Core/GPUFiniteDifference/wrapping/itkGPUFiniteDifferenceFilterEnum.wrap
+++ b/Modules/Core/GPUFiniteDifference/wrapping/itkGPUFiniteDifferenceFilterEnum.wrap
@@ -1,0 +1,1 @@
+itk_wrap_simple_class("itk::GPUFiniteDifferenceFilterEnum" ENUM)

--- a/Modules/Core/GPUFiniteDifference/wrapping/itkGPUFiniteDifferenceFilterTypeEnum.wrap
+++ b/Modules/Core/GPUFiniteDifference/wrapping/itkGPUFiniteDifferenceFilterTypeEnum.wrap
@@ -1,1 +1,0 @@
-itk_wrap_simple_class("itk::GPUFiniteDifferenceFilterTypeEnum" ENUM)

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -40,11 +40,11 @@
 
 namespace itk
 {
-/** \class MeshClassCellsAllocationMethodType
+/** \class MeshClassCellsAllocationMethodEnum
  * \ingroup ITKMesh
  * Enum defining the possible methods used to allocate memory for
  * the Cells */
-enum class MeshClassCellsAllocationMethodType : uint8_t
+enum class MeshClassCellsAllocationMethodEnum : uint8_t
 {
   CellsAllocationMethodUndefined,
   CellsAllocatedAsStaticArray,
@@ -150,7 +150,7 @@ public:
   static constexpr unsigned int MaxTopologicalDimension = TMeshTraits::MaxTopologicalDimension;
 
   /** Enables backwards compatibility for enum values */
-  using CellsAllocationMethodType = MeshClassCellsAllocationMethodType;
+  using CellsAllocationMethodType = MeshClassCellsAllocationMethodEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -504,7 +504,7 @@ private:
 
 /** Define how to print enumeration */
 extern ITKMesh_EXPORT std::ostream &
-                      operator<<(std::ostream & out, const MeshClassCellsAllocationMethodType value);
+                      operator<<(std::ostream & out, const MeshClassCellsAllocationMethodEnum value);
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -982,7 +982,7 @@ Mesh<TPixelType, VDimension, TMeshTraits>::Mesh()
   m_CellLinksContainer = CellLinksContainer::New();
   m_BoundingBox = BoundingBoxType::New();
   m_BoundaryAssignmentsContainers = BoundaryAssignmentsContainerVector(MaxTopologicalDimension);
-  m_CellsAllocationMethod = MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell;
+  m_CellsAllocationMethod = MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell;
 }
 
 /**
@@ -1038,21 +1038,21 @@ Mesh<TPixelType, VDimension, TMeshTraits>::ReleaseCellsMemory()
   {
     switch (m_CellsAllocationMethod)
     {
-      case MeshClassCellsAllocationMethodType::CellsAllocationMethodUndefined:
+      case MeshClassCellsAllocationMethodEnum::CellsAllocationMethodUndefined:
       {
         // The user forgot to tell the mesh about how he allocated
         // the cells. No responsible guess can be made here. Call for help.
         itkGenericExceptionMacro(<< "Cells Allocation Method was not specified. See SetCellsAllocationMethod()");
         break;
       }
-      case MeshClassCellsAllocationMethodType::CellsAllocatedAsStaticArray:
+      case MeshClassCellsAllocationMethodEnum::CellsAllocatedAsStaticArray:
       {
         // The cells will be naturally destroyed when
         // the original array goes out of scope.
         itkDebugMacro("CellsAllocatedAsStaticArray ");
         break;
       }
-      case MeshClassCellsAllocationMethodType::CellsAllocatedAsADynamicArray:
+      case MeshClassCellsAllocationMethodEnum::CellsAllocatedAsADynamicArray:
       {
         // the pointer to the first Cell is assumed to be the
         // base pointer of the array
@@ -1063,7 +1063,7 @@ Mesh<TPixelType, VDimension, TMeshTraits>::ReleaseCellsMemory()
         itkDebugMacro("CellsAllocatedAsADynamicArray");
         break;
       }
-      case MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell:
+      case MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell:
       {
         itkDebugMacro("CellsAllocatedDynamicallyCellByCell start");
         // It is assumed that every cell was allocated independently.

--- a/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
@@ -50,7 +50,7 @@ RegularSphereMeshSource<TOutputMesh>::GenerateData()
 
   typename OutputMeshType::Pointer outputMesh = this->GetOutput();
 
-  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   PointsContainerPointer myPoints = outputMesh->GetPoints();
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -105,7 +105,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellParameters()
   OutputMeshPointer outputMesh = this->GetOutput();
 
   // Ensure that cells will be deallocated by the Mesh.
-  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   SimplexVisitorInterfacePointer simplexVisitor = SimplexVisitorInterfaceType::New();
   simplexVisitor->mesh = outputMesh;

--- a/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
@@ -74,7 +74,7 @@ SphereMeshSource<TOutputMesh>::GenerateData()
 
   outputMesh->GetPoints()->Reserve(numpts);
 
-  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   PointsContainerPointer             myPoints = outputMesh->GetPoints();
   typename PointsContainer::Iterator point = myPoints->Begin();

--- a/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
@@ -46,7 +46,7 @@ VTKPolyDataReader<TOutputMesh>::GenerateData()
 {
   typename OutputMeshType::Pointer outputMesh = this->GetOutput();
 
-  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   if (m_FileName.empty())
   {

--- a/Modules/Core/Mesh/src/itkMesh.cxx
+++ b/Modules/Core/Mesh/src/itkMesh.cxx
@@ -21,21 +21,21 @@ namespace itk
 {
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const MeshClassCellsAllocationMethodType value)
+operator<<(std::ostream & out, const MeshClassCellsAllocationMethodEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case MeshClassCellsAllocationMethodType::CellsAllocationMethodUndefined:
-        return "MeshClassCellsAllocationMethodType::CellsAllocationMethodUndefined";
-      case MeshClassCellsAllocationMethodType::CellsAllocatedAsStaticArray:
-        return "MeshClassCellsAllocationMethodType::CellsAllocatedAsStaticArray";
-      case MeshClassCellsAllocationMethodType::CellsAllocatedAsADynamicArray:
-        return "MeshClassCellsAllocationMethodType::CellsAllocatedAsADynamicArray";
-      case MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell:
-        return "MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell";
+      case MeshClassCellsAllocationMethodEnum::CellsAllocationMethodUndefined:
+        return "MeshClassCellsAllocationMethodEnum::CellsAllocationMethodUndefined";
+      case MeshClassCellsAllocationMethodEnum::CellsAllocatedAsStaticArray:
+        return "MeshClassCellsAllocationMethodEnum::CellsAllocatedAsStaticArray";
+      case MeshClassCellsAllocationMethodEnum::CellsAllocatedAsADynamicArray:
+        return "MeshClassCellsAllocationMethodEnum::CellsAllocatedAsADynamicArray";
+      case MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell:
+        return "MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell";
       default:
-        return "INVALID VALUE FOR MeshClassCellsAllocationMethodType";
+        return "INVALID VALUE FOR MeshClassCellsAllocationMethodEnum";
     }
   }();
 }

--- a/Modules/Core/Mesh/test/itkMeshSpatialObjectIOTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshSpatialObjectIOTest.cxx
@@ -55,7 +55,7 @@ itkMeshSpatialObjectIOTest(int argc, char * argv[])
     mesh->SetPoint(i, PointType(testPointCoords[i]));
   }
 
-  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
   CellAutoPointer testCell1;
   testCell1.TakeOwnership(new TetraCellType);
   testCell1->SetPointIds(tetraPoints);

--- a/Modules/Core/Mesh/test/itkMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshTest.cxx
@@ -180,7 +180,7 @@ itkMeshTest(int, char *[])
   /**
    * Specify the method used for allocating cells
    */
-  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   /**
    * Create the test cell. Note that testCell is a generic auto

--- a/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
@@ -105,7 +105,7 @@ itkQuadrilateralCellTest(int, char *[])
   /**
    * Specify the method used for allocating cells
    */
-  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   /**
    * Create the test cell. Note that testCell is a generic auto

--- a/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest2.cxx
+++ b/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest2.cxx
@@ -39,7 +39,7 @@ itkRegularSphereMeshSourceTest2(int, char *[])
 
   MeshType::Pointer mesh1 = source1->GetOutput();
 
-  if (mesh1->GetCellsAllocationMethod() != itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell)
+  if (mesh1->GetCellsAllocationMethod() != itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell)
   {
     std::cerr << "mesh1->GetCellsAllocationMethod() != MeshType::CellsAllocatedDynamicallyCellByCell" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Mesh/test/itkSimplexMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshTest.cxx
@@ -66,7 +66,7 @@ itkSimplexMeshTest(int, char *[])
   /**
    * Specify the method used for allocating cells
    */
-  simplexMesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  simplexMesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
 
   /**

--- a/Modules/Core/Mesh/test/itkTriangleCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleCellTest.cxx
@@ -106,7 +106,7 @@ itkTriangleCellTest(int, char *[])
   /**
    * Specify the method used for allocating cells
    */
-  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   /**
    * Create the test cell. Note that testCell is a generic auto

--- a/Modules/Core/Mesh/wrapping/itkMeshBase.wrap
+++ b/Modules/Core/Mesh/wrapping/itkMeshBase.wrap
@@ -5,7 +5,7 @@ UNIQUE(types "${WRAP_ITK_SCALAR};D")
 
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkMesh.h")
-itk_wrap_simple_class("itk::MeshClassCellsAllocationMethodType" ENUM)
+itk_wrap_simple_class("itk::MeshClassCellsAllocationMethodEnum" ENUM)
 set(WRAPPER_AUTO_INCLUDE_HEADERS ON)
 
 itk_wrap_class("itk::Mesh" POINTER)

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
@@ -84,7 +84,7 @@ itkQuadEdgeMeshPolygonCellTest(int, char *[])
   /**
    * Specify the method used for allocating cells
    */
-  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   /**
    * Create the test cell. Note that testCell is a generic auto

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
@@ -24,11 +24,11 @@
 
 namespace itk
 {
-/** \class DTITubeSpatialObjectPointFieldEnumType
+/** \class DTITubeSpatialObjectPointFieldEnum
  * \ingroup ITKSpatialObjects
  * If you add a type here you need to modify the TranslateEnumToChar
  to translate the enum to a string */
-enum class DTITubeSpatialObjectPointFieldEnumType : uint8_t
+enum class DTITubeSpatialObjectPointFieldEnum : uint8_t
 {
   FA = 0,
   ADC = 1,
@@ -57,7 +57,7 @@ public:
   using FieldListType = std::vector<FieldType>;
 
   /** Enables backwards compatibility for enum values */
-  using FieldEnumType = DTITubeSpatialObjectPointFieldEnumType;
+  using FieldEnumType = DTITubeSpatialObjectPointFieldEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -149,7 +149,7 @@ protected:
 
 /** Define how to print enumerations */
 extern ITKSpatialObjects_EXPORT std::ostream &
-                                operator<<(std::ostream & out, const DTITubeSpatialObjectPointFieldEnumType value);
+                                operator<<(std::ostream & out, const DTITubeSpatialObjectPointFieldEnum value);
 } // end of namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -78,7 +78,7 @@ MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectToSpatialObjec
   // Add Cells
   using CellType = typename MeshType::CellType;
   using CellAutoPointer = typename CellType::CellAutoPointer;
-  mesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  mesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   for (unsigned int celltype = 0; celltype < MET_NUM_CELL_TYPES; celltype++)
   {

--- a/Modules/Core/SpatialObjects/src/itkDTITubeSpatialObjectPoint.cxx
+++ b/Modules/Core/SpatialObjects/src/itkDTITubeSpatialObjectPoint.cxx
@@ -21,19 +21,19 @@ namespace itk
 {
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const DTITubeSpatialObjectPointFieldEnumType value)
+operator<<(std::ostream & out, const DTITubeSpatialObjectPointFieldEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case DTITubeSpatialObjectPointFieldEnumType::FA:
-        return "DTITubeSpatialObjectPointFieldEnumType::FA";
-      case DTITubeSpatialObjectPointFieldEnumType::ADC:
-        return "DTITubeSpatialObjectPointFieldEnumType::ADC";
-      case DTITubeSpatialObjectPointFieldEnumType::GA:
-        return "DTITubeSpatialObjectPointFieldEnumType::GA";
+      case DTITubeSpatialObjectPointFieldEnum::FA:
+        return "DTITubeSpatialObjectPointFieldEnum::FA";
+      case DTITubeSpatialObjectPointFieldEnum::ADC:
+        return "DTITubeSpatialObjectPointFieldEnum::ADC";
+      case DTITubeSpatialObjectPointFieldEnum::GA:
+        return "DTITubeSpatialObjectPointFieldEnum::GA";
       default:
-        return "INVALID VALUE FOR DTITubeSpatialObjectPointFieldEnumType";
+        return "INVALID VALUE FOR DTITubeSpatialObjectPointFieldEnum";
     }
   }();
 }

--- a/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
@@ -47,7 +47,7 @@ itkMeshSpatialObjectTest(int, char *[])
     mesh->SetPoint(i, PointType(testPointCoords[i]));
   }
 
-  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  mesh->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
   CellAutoPointer testCell1;
   testCell1.TakeOwnership(new TetraCellType);
   testCell1->SetPointIds(tetraPoints);
@@ -153,7 +153,7 @@ itkMeshSpatialObjectTest(int, char *[])
 
   MeshType::PointIdentifier trianglePoint2[] = { 1, 2, 3 };
 
-  meshTriangle->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  meshTriangle->SetCellsAllocationMethod(itk::MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
   CellAutoPointer testCell3;
   testCell3.TakeOwnership(new TriangleCellType);
   testCell3->SetPointIds(trianglePoint1);

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -78,9 +78,9 @@ itkSpatialObjectDuplicatorTest(int, char *[])
     p.SetGreen(i + 1);
     p.SetBlue(i + 2);
     p.SetAlpha(i + 3);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::FA, i);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::ADC, 2 * i);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::GA, 3 * i);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::FA, i);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::ADC, 2 * i);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::GA, 3 * i);
     p.AddField("Lambda1", 4 * i);
     p.AddField("Lambda2", 5 * i);
     p.AddField("Lambda3", 6 * i);
@@ -138,21 +138,21 @@ itkSpatialObjectDuplicatorTest(int, char *[])
       // Testing the color of the tube points
       if (itk::Math::NotExactlyEquals((*jdti).GetRed(), value))
       {
-        std::cout << " [FAILED] : RGBColormapFilterEnumType::Red : found " << (*jdti).GetRed() << " instead of "
-                  << value << std::endl;
+        std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*jdti).GetRed() << " instead of " << value
+                  << std::endl;
         return EXIT_FAILURE;
       }
 
       if (itk::Math::NotExactlyEquals((*jdti).GetGreen(), value + 1))
       {
-        std::cout << " [FAILED] : RGBColormapFilterEnumType::Green : found " << (*jdti).GetGreen() << " instead of "
+        std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*jdti).GetGreen() << " instead of "
                   << value + 1 << std::endl;
         return EXIT_FAILURE;
       }
 
       if (itk::Math::NotExactlyEquals((*jdti).GetBlue(), value + 2))
       {
-        std::cout << "[FAILED] : RGBColormapFilterEnumType::Blue : found " << (*jdti).GetBlue() << " instead of "
+        std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << (*jdti).GetBlue() << " instead of "
                   << value + 2 << std::endl;
         return EXIT_FAILURE;
       }
@@ -163,17 +163,17 @@ itkSpatialObjectDuplicatorTest(int, char *[])
         return EXIT_FAILURE;
       }
 
-      if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::FA), value))
+      if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnum::FA), value))
       {
         std::cout << " [FAILED] : FA : found " << (*jdti).GetField("FA") << " instead of " << value << std::endl;
         return EXIT_FAILURE;
       }
-      if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::ADC), value * 2))
+      if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnum::ADC), value * 2))
       {
         std::cout << " [FAILED] : ADC : found " << (*jdti).GetField("ADC") << " instead of " << value * 2 << std::endl;
         return EXIT_FAILURE;
       }
-      if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::GA), value * 3))
+      if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnum::GA), value * 3))
       {
         std::cout << " [FAILED] : GA : found " << (*jdti).GetField("FA") << " instead of " << value * 3 << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/wrapping/itkDTITubeSpatialObjectPoint.wrap
+++ b/Modules/Core/SpatialObjects/wrapping/itkDTITubeSpatialObjectPoint.wrap
@@ -4,7 +4,7 @@ if(has_d_3)
   set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
   itk_wrap_include("itkDTITubeSpatialObjectPoint.h")
 
-  itk_wrap_simple_class("itk::DTITubeSpatialObjectPointFieldEnumType" ENUM)
+  itk_wrap_simple_class("itk::DTITubeSpatialObjectPointFieldEnum" ENUM)
 
   itk_wrap_class("itk::DTITubeSpatialObjectPoint")
     itk_wrap_template(3 3)

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
@@ -26,10 +26,10 @@ namespace itk
 {
 namespace Testing
 {
-/** \class TestExtractSliceImageFilterCollapseStrategy
+/** \class TestExtractSliceImageFilterCollapseStrategyEnum
  * \ingroup ITKTestKernel
  */
-enum class TestExtractSliceImageFilterCollapseStrategy : uint8_t
+enum class TestExtractSliceImageFilterCollapseStrategyEnum : uint8_t
 {
   DIRECTIONCOLLAPSETOUNKOWN = 0,
   DIRECTIONCOLLAPSETOIDENTITY = 1,
@@ -127,8 +127,8 @@ public:
   using InputImageSizeType = typename TInputImage::SizeType;
 
   /** Enables backwards compatibility for enum values */
-  using DIRECTIONCOLLAPSESTRATEGY = TestExtractSliceImageFilterCollapseStrategy;
-  using DirectionCollaspeStrategyEnum = TestExtractSliceImageFilterCollapseStrategy;
+  using DIRECTIONCOLLAPSESTRATEGY = TestExtractSliceImageFilterCollapseStrategyEnum;
+  using DirectionCollaspeStrategyEnum = TestExtractSliceImageFilterCollapseStrategyEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -171,11 +171,11 @@ public:
   {
     switch (choosenStrategy)
     {
-      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
-      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
-      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
+      case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS:
+      case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY:
+      case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX:
         break;
-      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
+      case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN:
       default:
         itkExceptionMacro(<< "Invalid Strategy Chosen for itk::ExtractSliceImageFilter");
     }
@@ -199,21 +199,21 @@ public:
   void
   SetDirectionCollapseToGuess()
   {
-    this->SetDirectionCollapseToStrategy(TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS);
+    this->SetDirectionCollapseToStrategy(TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS);
   }
 
   /** \sa SetDirectionCollapseToStrategy */
   void
   SetDirectionCollapseToIdentity()
   {
-    this->SetDirectionCollapseToStrategy(TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY);
+    this->SetDirectionCollapseToStrategy(TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY);
   }
 
   /** \sa SetDirectionCollapseToStrategy */
   void
   SetDirectionCollapseToSubmatrix()
   {
-    this->SetDirectionCollapseToStrategy(TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX);
+    this->SetDirectionCollapseToStrategy(TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX);
   }
 
 
@@ -297,7 +297,7 @@ private:
 /** Define how to print enumerations */
 // TestKernal is not a shared library, so no EXPORT
 extern std::ostream &
-operator<<(std::ostream & out, const TestExtractSliceImageFilterCollapseStrategy value);
+operator<<(std::ostream & out, const TestExtractSliceImageFilterCollapseStrategyEnum value);
 } // end namespace Testing
 } // end namespace itk
 

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -30,7 +30,7 @@ namespace Testing
 
 template <typename TInputImage, typename TOutputImage>
 ExtractSliceImageFilter<TInputImage, TOutputImage>::ExtractSliceImageFilter()
-  : m_DirectionCollaspeStrategy(TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN)
+  : m_DirectionCollaspeStrategy(TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN)
 {
   this->DynamicMultiThreadingOn();
 }
@@ -202,12 +202,12 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   // length cosine vector, reset the directions to identity.
   switch (m_DirectionCollaspeStrategy)
   {
-    case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
+    case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY:
     {
       outputDirection.SetIdentity();
     }
     break;
-    case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
+    case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX:
     {
       if (vnl_determinant(outputDirection.GetVnlMatrix()) == 0.0)
       {
@@ -215,7 +215,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
       }
     }
     break;
-    case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
+    case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS:
     {
       if (vnl_determinant(outputDirection.GetVnlMatrix()) == 0.0)
       {
@@ -223,7 +223,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
       }
     }
     break;
-    case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
+    case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN:
     default:
     {
       itkExceptionMacro(

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -813,7 +813,7 @@ int
 HashTestImage(const char * testImageFilename, const std::vector<std::string> & baselineMD5Vector)
 {
   itk::ImageIOBase::Pointer iobase =
-    itk::ImageIOFactory::CreateImageIO(testImageFilename, itk::ImageIOFactory::FileModeType::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(testImageFilename, itk::ImageIOFactory::FileModeEnum::ReadMode);
 
   if (iobase.IsNull())
   {

--- a/Modules/Core/TestKernel/src/itkTestingExtractSliceImageFilter.cxx
+++ b/Modules/Core/TestKernel/src/itkTestingExtractSliceImageFilter.cxx
@@ -23,21 +23,21 @@ namespace Testing
 {
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const TestExtractSliceImageFilterCollapseStrategy value)
+operator<<(std::ostream & out, const TestExtractSliceImageFilterCollapseStrategyEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN:
-        return "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN";
-      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY:
-        return "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY";
-      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX:
-        return "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX";
-      case TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS:
-        return "TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS";
+      case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN:
+        return "TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN";
+      case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY:
+        return "TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY";
+      case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX:
+        return "TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX";
+      case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS:
+        return "TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS";
       default:
-        return "INVALID VALUE FOR TestExtractSliceImageFilterCollapseStrategy";
+        return "INVALID VALUE FOR TestExtractSliceImageFilterCollapseStrategyEnum";
     }
   }();
 }

--- a/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
+++ b/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
@@ -88,40 +88,40 @@ itkTestingExtractSliceImageFilterTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(extractRegion, filter->GetExtractionRegion());
 
   FilterType::DIRECTIONCOLLAPSESTRATEGY strategy =
-    itk::Testing::TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN;
+    itk::Testing::TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN;
 
   ITK_TEST_SET_GET_VALUE(strategy, filter->GetDirectionCollapseToStrategy());
   ITK_TRY_EXPECT_EXCEPTION(filter->Update());
 
   ITK_TRY_EXPECT_EXCEPTION(filter->SetDirectionCollapseToStrategy(
-    itk::Testing::TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN));
+    itk::Testing::TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN));
 
   filter->SetDirectionCollapseToIdentity();
-  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY;
+  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY;
   ITK_TEST_SET_GET_VALUE(strategy, filter->GetDirectionCollapseToStrategy());
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
   filter->SetDirectionCollapseToGuess();
-  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS;
+  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS;
   ITK_TEST_SET_GET_VALUE(strategy, filter->GetDirectionCollapseToStrategy());
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
   filter->SetDirectionCollapseToSubmatrix();
-  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX;
+  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX;
   ITK_TEST_SET_GET_VALUE(strategy, filter->GetDirectionCollapseToStrategy());
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOIDENTITY;
+  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOIDENTITY;
   filter->SetDirectionCollapseToStrategy(strategy);
   ITK_TEST_SET_GET_VALUE(strategy, filter->GetDirectionCollapseToStrategy());
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOGUESS;
+  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS;
   filter->SetDirectionCollapseToStrategy(strategy);
   ITK_TEST_SET_GET_VALUE(strategy, filter->GetDirectionCollapseToStrategy());
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategy::DIRECTIONCOLLAPSETOSUBMATRIX;
+  strategy = itk::Testing::TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX;
   filter->SetDirectionCollapseToStrategy(strategy);
   ITK_TEST_SET_GET_VALUE(strategy, filter->GetDirectionCollapseToStrategy());
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
@@ -110,7 +110,7 @@ public:
   /** Parameters type.   */
   using ParametersType = typename Superclass::ParametersType;
   using FixedParametersType = typename Superclass::FixedParametersType;
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** Jacobian type.   */
   using JacobianType = typename Superclass::JacobianType;
@@ -170,12 +170,12 @@ public:
   }
 
 
-  /** Overrides the TransformCategoryType to  UnknownTransformCategory. Even though
+  /** Overrides the TransformCategoryEnum to  UnknownTransformCategory. Even though
   this class derives from AffineTransform, its not a linear transform */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return Self::TransformCategoryType::UnknownTransformCategory;
+    return Self::TransformCategoryEnum::UnknownTransformCategory;
   }
 
   /** Defines that the forward transform goes from azimuth,elevation to

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -67,7 +67,7 @@ public:
   using InverseJacobianPositionType = typename Superclass::InverseJacobianPositionType;
 
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** The number of parameters defining this transform. */
   using NumberOfParametersType = typename Superclass::NumberOfParametersType;
@@ -311,10 +311,10 @@ public:
   virtual NumberOfParametersType
   GetNumberOfParametersPerDimension() const = 0;
 
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return Self::TransformCategoryType::BSpline;
+    return Self::TransformCategoryEnum::BSpline;
   }
 
   unsigned int

--- a/Modules/Core/Transform/include/itkCompositeTransform.h
+++ b/Modules/Core/Transform/include/itkCompositeTransform.h
@@ -120,7 +120,7 @@ public:
   using JacobianPositionType = typename Superclass::JacobianPositionType;
   using InverseJacobianPositionType = typename Superclass::InverseJacobianPositionType;
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
   /** Standard coordinate point type for this class. */
   using InputPointType = typename Superclass::InputPointType;
   using OutputPointType = typename Superclass::OutputPointType;
@@ -329,7 +329,7 @@ public:
    * are linear, then return category Linear. Otherwise if all
    * transforms set to optimize are DisplacementFields, then
    * return DisplacementField category. */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override;
 
   /** Get/Set Parameter functions work on the current list of transforms

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -33,14 +33,14 @@ CompositeTransform<TParametersValueType, NDimensions>::CompositeTransform()
 }
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::TransformCategoryType
+typename CompositeTransform<TParametersValueType, NDimensions>::TransformCategoryEnum
 CompositeTransform<TParametersValueType, NDimensions>::GetTransformCategory() const
 {
   // Check if linear
   bool isLinearTransform = this->IsLinear();
   if (isLinearTransform)
   {
-    return Self::TransformCategoryType::Linear;
+    return Self::TransformCategoryEnum::Linear;
   }
 
   // Check if displacement field
@@ -48,7 +48,7 @@ CompositeTransform<TParametersValueType, NDimensions>::GetTransformCategory() co
   for (signed long tind = static_cast<signed long>(this->GetNumberOfTransforms()) - 1; tind >= 0; tind--)
   {
     if (this->GetNthTransformToOptimize(tind) && (this->GetNthTransformConstPointer(tind)->GetTransformCategory() !=
-                                                  Self::TransformCategoryType::DisplacementField))
+                                                  Self::TransformCategoryEnum::DisplacementField))
     {
       isDisplacementFieldTransform = false;
       break;
@@ -57,11 +57,11 @@ CompositeTransform<TParametersValueType, NDimensions>::GetTransformCategory() co
 
   if (isDisplacementFieldTransform)
   {
-    return Self::TransformCategoryType::DisplacementField;
+    return Self::TransformCategoryEnum::DisplacementField;
   }
   else
   {
-    return Self::TransformCategoryType::UnknownTransformCategory;
+    return Self::TransformCategoryEnum::UnknownTransformCategory;
   }
 }
 

--- a/Modules/Core/Transform/include/itkIdentityTransform.h
+++ b/Modules/Core/Transform/include/itkIdentityTransform.h
@@ -82,7 +82,7 @@ public:
   using InverseJacobianPositionType = typename Superclass::InverseJacobianPositionType;
 
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** Standard vector type for this class. */
   using InputVectorType = Vector<TParametersValueType, Self::InputSpaceDimension>;
@@ -209,10 +209,10 @@ public:
    *
    * \f[ T( a*P + b*Q ) = a * T(P) + b * T(Q) \f]
    */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return Self::TransformCategoryType::Linear;
+    return Self::TransformCategoryEnum::Linear;
   }
 
   /** Get the Fixed Parameters. */

--- a/Modules/Core/Transform/include/itkKernelTransform.h
+++ b/Modules/Core/Transform/include/itkKernelTransform.h
@@ -90,7 +90,7 @@ public:
   using InverseJacobianPositionType = typename Superclass::InverseJacobianPositionType;
 
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** Standard coordinate point type for this class. */
   using InputPointType = typename Superclass::InputPointType;
@@ -218,10 +218,10 @@ public:
   /** This transform is not linear, because the transformation of a linear
    * combination of points is not equal to the linear combination of the
    * transformations of individual points */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return Self::TransformCategoryType::Spline;
+    return Self::TransformCategoryEnum::Spline;
   }
 
   /** Stiffness of the spline.  A stiffness of zero results in the

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -136,7 +136,7 @@ public:
   using InverseJacobianPositionType = typename Superclass::InverseJacobianPositionType;
 
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** Standard scalar type for this class */
   using ScalarType = typename Superclass::ScalarType;
@@ -203,10 +203,10 @@ public:
   /** Indicates the category transform.
    *  e.g. an affine transform, or a local one, e.g. a deformation field.
    */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return Self::TransformCategoryType::Linear;
+    return Self::TransformCategoryEnum::Linear;
   }
 
   /** Set matrix of an MatrixOffsetTransformBase

--- a/Modules/Core/Transform/include/itkMultiTransform.h
+++ b/Modules/Core/Transform/include/itkMultiTransform.h
@@ -95,7 +95,7 @@ public:
   using JacobianPositionType = typename Superclass::JacobianPositionType;
   using InverseJacobianPositionType = typename Superclass::InverseJacobianPositionType;
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /* Types relative to the container transform. */
 
@@ -244,7 +244,7 @@ public:
 
   /** If all sub-transforms are of the same category, return that category.
    * Otherwise return UnknownTransformCategory. */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override;
 
   /** Get/Set Parameter functions work on all sub-transforms.

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -34,16 +34,16 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::MultiTransfor
 }
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
-typename MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::TransformCategoryType
+typename MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::TransformCategoryEnum
 MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetTransformCategory() const
 {
   // If all sub-transforms are the same, return that type. Otherwise
   // return Unknown.
-  TransformCategoryType result = Self::TransformCategoryType::UnknownTransformCategory;
+  TransformCategoryEnum result = Self::TransformCategoryEnum::UnknownTransformCategory;
 
   for (SizeValueType tind = 0; tind < this->GetNumberOfTransforms(); tind++)
   {
-    const TransformCategoryType type = this->GetNthTransformConstPointer(tind)->GetTransformCategory();
+    const TransformCategoryEnum type = this->GetNthTransformConstPointer(tind)->GetTransformCategory();
     if (tind == 0)
     {
       result = type;
@@ -52,7 +52,7 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetTransformC
     {
       if (type != result)
       {
-        result = Self::TransformCategoryType::UnknownTransformCategory;
+        result = Self::TransformCategoryEnum::UnknownTransformCategory;
         break;
       }
     }

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -449,21 +449,21 @@ public:
   std::string
   GetTransformTypeAsString() const override;
 
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** Indicates the category transform.
    *  e.g. an affine transform, or a local one, e.g. a deformation field.
    */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return Superclass::TransformCategoryType::UnknownTransformCategory;
+    return Superclass::TransformCategoryEnum::UnknownTransformCategory;
   }
 
   virtual bool
   IsLinear() const
   {
-    return (this->GetTransformCategory() == Superclass::TransformCategoryType::Linear);
+    return (this->GetTransformCategory() == Superclass::TransformCategoryEnum::Linear);
   }
 
   /**

--- a/Modules/Core/Transform/include/itkTransformBase.h
+++ b/Modules/Core/Transform/include/itkTransformBase.h
@@ -123,7 +123,7 @@ public:
   virtual std::string
   GetTransformTypeAsString() const = 0;
 
-  enum class TransformCategoryType : uint8_t
+  enum class TransformCategoryEnum : uint8_t
   {
     UnknownTransformCategory = 0,
     Linear = 1,
@@ -135,16 +135,16 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr TransformCategoryType UnknownTransformCategory = TransformCategoryType::UnknownTransformCategory;
-  static constexpr TransformCategoryType Linear = TransformCategoryType::Linear;
-  static constexpr TransformCategoryType BSpline = TransformCategoryType::BSpline;
-  static constexpr TransformCategoryType Spline = TransformCategoryType::Spline;
-  static constexpr TransformCategoryType DisplacementField = TransformCategoryType::DisplacementField;
-  static constexpr TransformCategoryType VelocityField = TransformCategoryType::VelocityField;
+  static constexpr TransformCategoryEnum UnknownTransformCategory = TransformCategoryEnum::UnknownTransformCategory;
+  static constexpr TransformCategoryEnum Linear = TransformCategoryEnum::Linear;
+  static constexpr TransformCategoryEnum BSpline = TransformCategoryEnum::BSpline;
+  static constexpr TransformCategoryEnum Spline = TransformCategoryEnum::Spline;
+  static constexpr TransformCategoryEnum DisplacementField = TransformCategoryEnum::DisplacementField;
+  static constexpr TransformCategoryEnum VelocityField = TransformCategoryEnum::VelocityField;
 #endif
 
   /** Get transform category */
-  virtual TransformCategoryType
+  virtual TransformCategoryEnum
   GetTransformCategory() const = 0;
 
 protected:
@@ -164,9 +164,9 @@ using TransformBase = TransformBaseTemplate<double>;
 
 // Define how to print enumeration
 extern ITKTransform_EXPORT std::ostream &
-                           operator<<(std::ostream & out, const typename TransformBaseTemplate<double>::TransformCategoryType value);
+                           operator<<(std::ostream & out, const typename TransformBaseTemplate<double>::TransformCategoryEnum value);
 extern ITKTransform_EXPORT std::ostream &
-                           operator<<(std::ostream & out, const typename TransformBaseTemplate<float>::TransformCategoryType value);
+                           operator<<(std::ostream & out, const typename TransformBaseTemplate<float>::TransformCategoryEnum value);
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -98,7 +98,7 @@ public:
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** This method returns the value of the offset of the
    * TranslationTransform. */
@@ -220,10 +220,10 @@ public:
   /** Indicates the category transform.
    *  e.g. an affine transform, or a local one, e.g. a deformation field.
    */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return Self::TransformCategoryType::Linear;
+    return Self::TransformCategoryEnum::Linear;
   }
 
   /** Set the fixed parameters and update internal transformation.

--- a/Modules/Core/Transform/src/itkTransformBase.cxx
+++ b/Modules/Core/Transform/src/itkTransformBase.cxx
@@ -23,49 +23,49 @@ namespace itk
 {
 /** Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const typename TransformBaseTemplate<double>::TransformCategoryType value)
+operator<<(std::ostream & out, const typename TransformBaseTemplate<double>::TransformCategoryEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case TransformBaseTemplate<double>::TransformCategoryType::UnknownTransformCategory:
-        return "TransformBaseTemplate<double>::TransformCategoryType::UnknownTransformCategory";
-      case TransformBaseTemplate<double>::TransformCategoryType::Linear:
-        return "TransformBaseTemplate<double>::TransformCategoryType::Linear";
-      case TransformBaseTemplate<double>::TransformCategoryType::BSpline:
-        return "TransformBaseTemplate<double>::TransformCategoryType::BSpline";
-      case TransformBaseTemplate<double>::TransformCategoryType::Spline:
-        return "TransformBaseTemplate<double>::TransformCategoryType::Spline";
-      case TransformBaseTemplate<double>::TransformCategoryType::DisplacementField:
-        return "TransformBaseTemplate<double>::TransformCategoryType::DisplacementField";
-      case TransformBaseTemplate<double>::TransformCategoryType::VelocityField:
-        return "TransformBaseTemplate<double>::TransformCategoryType::VelocityField";
+      case TransformBaseTemplate<double>::TransformCategoryEnum::UnknownTransformCategory:
+        return "TransformBaseTemplate<double>::TransformCategoryEnum::UnknownTransformCategory";
+      case TransformBaseTemplate<double>::TransformCategoryEnum::Linear:
+        return "TransformBaseTemplate<double>::TransformCategoryEnum::Linear";
+      case TransformBaseTemplate<double>::TransformCategoryEnum::BSpline:
+        return "TransformBaseTemplate<double>::TransformCategoryEnum::BSpline";
+      case TransformBaseTemplate<double>::TransformCategoryEnum::Spline:
+        return "TransformBaseTemplate<double>::TransformCategoryEnum::Spline";
+      case TransformBaseTemplate<double>::TransformCategoryEnum::DisplacementField:
+        return "TransformBaseTemplate<double>::TransformCategoryEnum::DisplacementField";
+      case TransformBaseTemplate<double>::TransformCategoryEnum::VelocityField:
+        return "TransformBaseTemplate<double>::TransformCategoryEnum::VelocityField";
       default:
-        return "INVALID VALUE FOR TransformBaseTemplate<double>::TransformCategoryType";
+        return "INVALID VALUE FOR TransformBaseTemplate<double>::TransformCategoryEnum";
     }
   }();
 }
 /** Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const typename TransformBaseTemplate<float>::TransformCategoryType value)
+operator<<(std::ostream & out, const typename TransformBaseTemplate<float>::TransformCategoryEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case TransformBaseTemplate<float>::TransformCategoryType::UnknownTransformCategory:
-        return "TransformBaseTemplate<float>::TransformCategoryType::UnknownTransformCategory";
-      case TransformBaseTemplate<float>::TransformCategoryType::Linear:
-        return "TransformBaseTemplate<float>::TransformCategoryType::Linear";
-      case TransformBaseTemplate<float>::TransformCategoryType::BSpline:
-        return "TransformBaseTemplate<float>::TransformCategoryType::BSpline";
-      case TransformBaseTemplate<float>::TransformCategoryType::Spline:
-        return "TransformBaseTemplate<float>::TransformCategoryType::Spline";
-      case TransformBaseTemplate<float>::TransformCategoryType::DisplacementField:
-        return "TransformBaseTemplate<float>::TransformCategoryType::DisplacementField";
-      case TransformBaseTemplate<float>::TransformCategoryType::VelocityField:
-        return "TransformBaseTemplate<float>::TransformCategoryType::VelocityField";
+      case TransformBaseTemplate<float>::TransformCategoryEnum::UnknownTransformCategory:
+        return "TransformBaseTemplate<float>::TransformCategoryEnum::UnknownTransformCategory";
+      case TransformBaseTemplate<float>::TransformCategoryEnum::Linear:
+        return "TransformBaseTemplate<float>::TransformCategoryEnum::Linear";
+      case TransformBaseTemplate<float>::TransformCategoryEnum::BSpline:
+        return "TransformBaseTemplate<float>::TransformCategoryEnum::BSpline";
+      case TransformBaseTemplate<float>::TransformCategoryEnum::Spline:
+        return "TransformBaseTemplate<float>::TransformCategoryEnum::Spline";
+      case TransformBaseTemplate<float>::TransformCategoryEnum::DisplacementField:
+        return "TransformBaseTemplate<float>::TransformCategoryEnum::DisplacementField";
+      case TransformBaseTemplate<float>::TransformCategoryEnum::VelocityField:
+        return "TransformBaseTemplate<float>::TransformCategoryEnum::VelocityField";
       default:
-        return "INVALID VALUE FOR TransformBaseTemplate<float>::TransformCategoryType";
+        return "INVALID VALUE FOR TransformBaseTemplate<float>::TransformCategoryEnum";
     }
   }();
 }

--- a/Modules/Core/Transform/test/itkAzimuthElevationToCartesianTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAzimuthElevationToCartesianTransformTest.cxx
@@ -141,7 +141,7 @@ itkAzimuthElevationToCartesianTransformTest(int, char *[])
   // Check if itkAzimuthElevationToCartesianTransform returns the correct
   // TransformCategory.
   if (transform->GetTransformCategory() !=
-      AzimuthElevationToCartesianTransformType::TransformCategoryType::UnknownTransformCategory)
+      AzimuthElevationToCartesianTransformType::TransformCategoryEnum::UnknownTransformCategory)
   {
     std::cout << "itkAzimuthElevationToCartesianTransformTest failed" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -619,7 +619,7 @@ itkMultiTransformTest(int, char *[])
   ITK_TRY_EXPECT_EXCEPTION(multiTransform->SetFixedParameters(parametersTruth));
 
   /* GetTransformCategory */
-  if (multiTransform->GetTransformCategory() != MultiTransformType::TransformCategoryType::UnknownTransformCategory)
+  if (multiTransform->GetTransformCategory() != MultiTransformType::TransformCategoryEnum::UnknownTransformCategory)
   {
     std::cout << "ERROR: GetTransformCategory returned " << multiTransform->GetTransformCategory()
               << " instead of Unknown." << std::endl;

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
@@ -24,10 +24,10 @@
 
 namespace itk
 {
-/** \class RGBColormapFilterEnumType
+/** \class RGBColormapFilterEnum
  * \ingroup ITKColormap
  * Enum type that provides for an easy interface to existing colormaps. */
-enum class RGBColormapFilterEnumType : uint8_t
+enum class RGBColormapFilterEnum : uint8_t
 {
   Red,
   Green,
@@ -53,7 +53,7 @@ enum class RGBColormapFilterEnumType : uint8_t
  *
  * The input image's scalar pixel values are mapped into a color map.
  * The color map is specified by passing the SetColormap function one of the
- * predefined maps. The following selects the "RGBColormapFilterEnumType::Hot" colormap:
+ * predefined maps. The following selects the "RGBColormapFilterEnum::Hot" colormap:
    \code
    RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
    colormapImageFilter->SetColormap( RGBFilterType::Hot );
@@ -130,7 +130,7 @@ public:
   itkGetModifiableObjectMacro(Colormap, ColormapType);
 
   /** Reverse compatibility for enum values */
-  using ColormapEnumType = RGBColormapFilterEnumType;
+  using ColormapEnumType = RGBColormapFilterEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -212,7 +212,7 @@ private:
 
 /** Define how to print enumerations */
 extern ITKColormap_EXPORT std::ostream &
-                          operator<<(std::ostream & out, const RGBColormapFilterEnumType value);
+                          operator<<(std::ostream & out, const RGBColormapFilterEnum value);
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
@@ -129,28 +129,28 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::SetColormap(ColormapE
 {
   switch (map)
   {
-    case RGBColormapFilterEnumType::Red:
+    case RGBColormapFilterEnum::Red:
     {
       using SpecificColormapType = Function::RedColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Green:
+    case RGBColormapFilterEnum::Green:
     {
       using SpecificColormapType = Function::GreenColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Blue:
+    case RGBColormapFilterEnum::Blue:
     {
       using SpecificColormapType = Function::BlueColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Grey:
+    case RGBColormapFilterEnum::Grey:
     default:
     {
       using SpecificColormapType = Function::GreyColormapFunction<InputImagePixelType, OutputImagePixelType>;
@@ -158,70 +158,70 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::SetColormap(ColormapE
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Hot:
+    case RGBColormapFilterEnum::Hot:
     {
       using SpecificColormapType = Function::HotColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Cool:
+    case RGBColormapFilterEnum::Cool:
     {
       using SpecificColormapType = Function::CoolColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Spring:
+    case RGBColormapFilterEnum::Spring:
     {
       using SpecificColormapType = Function::SpringColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Summer:
+    case RGBColormapFilterEnum::Summer:
     {
       using SpecificColormapType = Function::SummerColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Autumn:
+    case RGBColormapFilterEnum::Autumn:
     {
       using SpecificColormapType = Function::AutumnColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Winter:
+    case RGBColormapFilterEnum::Winter:
     {
       using SpecificColormapType = Function::WinterColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Copper:
+    case RGBColormapFilterEnum::Copper:
     {
       using SpecificColormapType = Function::CopperColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::Jet:
+    case RGBColormapFilterEnum::Jet:
     {
       using SpecificColormapType = Function::JetColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::HSV:
+    case RGBColormapFilterEnum::HSV:
     {
       using SpecificColormapType = Function::HSVColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();
       this->SetColormap(colormap);
       break;
     }
-    case RGBColormapFilterEnumType::OverUnder:
+    case RGBColormapFilterEnum::OverUnder:
     {
       using SpecificColormapType = Function::OverUnderColormapFunction<InputImagePixelType, OutputImagePixelType>;
       typename SpecificColormapType::Pointer colormap = SpecificColormapType::New();

--- a/Modules/Filtering/Colormap/src/itkScalarToRGBColormapImageFilter.cxx
+++ b/Modules/Filtering/Colormap/src/itkScalarToRGBColormapImageFilter.cxx
@@ -21,41 +21,41 @@ namespace itk
 {
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const RGBColormapFilterEnumType value)
+operator<<(std::ostream & out, const RGBColormapFilterEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case RGBColormapFilterEnumType::Red:
-        return "RGBColormapFilterEnumType::Red";
-      case RGBColormapFilterEnumType::Green:
-        return "RGBColormapFilterEnumType::Green";
-      case RGBColormapFilterEnumType::Blue:
-        return "RGBColormapFilterEnumType::Blue";
-      case RGBColormapFilterEnumType::Grey:
-        return "RGBColormapFilterEnumType::Grey";
-      case RGBColormapFilterEnumType::Hot:
-        return "RGBColormapFilterEnumType::Hot";
-      case RGBColormapFilterEnumType::Cool:
-        return "RGBColormapFilterEnumType::Cool";
-      case RGBColormapFilterEnumType::Spring:
-        return "RGBColormapFilterEnumType";
-      case RGBColormapFilterEnumType::Summer:
-        return "RGBColormapFilterEnumType::Summer";
-      case RGBColormapFilterEnumType::Autumn:
-        return "RGBColormapFilterEnumType::Autumn";
-      case RGBColormapFilterEnumType::Winter:
-        return "RGBColormapFilterEnumType::Winter";
-      case RGBColormapFilterEnumType::Copper:
-        return "RGBColormapFilterEnumType::Copper";
-      case RGBColormapFilterEnumType::Jet:
-        return "RGBColormapFilterEnumType::Jet";
-      case RGBColormapFilterEnumType::HSV:
-        return "RGBColormapFilterEnumType::HSV";
-      case RGBColormapFilterEnumType::OverUnder:
-        return "RGBColormapFilterEnumType::OverUnder";
+      case RGBColormapFilterEnum::Red:
+        return "RGBColormapFilterEnum::Red";
+      case RGBColormapFilterEnum::Green:
+        return "RGBColormapFilterEnum::Green";
+      case RGBColormapFilterEnum::Blue:
+        return "RGBColormapFilterEnum::Blue";
+      case RGBColormapFilterEnum::Grey:
+        return "RGBColormapFilterEnum::Grey";
+      case RGBColormapFilterEnum::Hot:
+        return "RGBColormapFilterEnum::Hot";
+      case RGBColormapFilterEnum::Cool:
+        return "RGBColormapFilterEnum::Cool";
+      case RGBColormapFilterEnum::Spring:
+        return "RGBColormapFilterEnum";
+      case RGBColormapFilterEnum::Summer:
+        return "RGBColormapFilterEnum::Summer";
+      case RGBColormapFilterEnum::Autumn:
+        return "RGBColormapFilterEnum::Autumn";
+      case RGBColormapFilterEnum::Winter:
+        return "RGBColormapFilterEnum::Winter";
+      case RGBColormapFilterEnum::Copper:
+        return "RGBColormapFilterEnum::Copper";
+      case RGBColormapFilterEnum::Jet:
+        return "RGBColormapFilterEnum::Jet";
+      case RGBColormapFilterEnum::HSV:
+        return "RGBColormapFilterEnum::HSV";
+      case RGBColormapFilterEnum::OverUnder:
+        return "RGBColormapFilterEnum::OverUnder";
       default:
-        return "INVALID VALUE FOR RGBColormapFilterEnumType";
+        return "INVALID VALUE FOR RGBColormapFilterEnum";
     }
   }();
 }

--- a/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterTest.cxx
@@ -69,73 +69,73 @@ itkScalarToRGBColormapImageFilterTest(int argc, char * argv[])
 
   if (colormapString == "red")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Red);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Red);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Red);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Red);
   }
   else if (colormapString == "green")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Green);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Green);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Green);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Green);
   }
   else if (colormapString == "blue")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Blue);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Blue);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Blue);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Blue);
   }
   else if (colormapString == "grey")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Grey);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Grey);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Grey);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Grey);
   }
   else if (colormapString == "cool")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Cool);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Cool);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Cool);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Cool);
   }
   else if (colormapString == "hot")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Hot);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Hot);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Hot);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Hot);
   }
   else if (colormapString == "spring")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Spring);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Spring);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Spring);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Spring);
   }
   else if (colormapString == "autumn")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Autumn);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Autumn);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Autumn);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Autumn);
   }
   else if (colormapString == "winter")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Winter);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Winter);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Winter);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Winter);
   }
   else if (colormapString == "copper")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Copper);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Copper);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Copper);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Copper);
   }
   else if (colormapString == "summer")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Summer);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Summer);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Summer);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Summer);
   }
   else if (colormapString == "jet")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Jet);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::Jet);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::Jet);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::Jet);
   }
   else if (colormapString == "hsv")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::HSV);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::HSV);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::HSV);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::HSV);
   }
   else if (colormapString == "overunder")
   {
-    rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::OverUnder);
-    vfilter->SetColormap(itk::RGBColormapFilterEnumType::OverUnder);
+    rgbfilter->SetColormap(itk::RGBColormapFilterEnum::OverUnder);
+    vfilter->SetColormap(itk::RGBColormapFilterEnum::OverUnder);
   }
   else if (colormapString == "custom")
   {

--- a/Modules/Filtering/Colormap/wrapping/itkScalarToRGBColormapImageFilter.wrap
+++ b/Modules/Filtering/Colormap/wrapping/itkScalarToRGBColormapImageFilter.wrap
@@ -1,7 +1,7 @@
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkScalarToRGBColormapImageFilter.h")
 
-itk_wrap_simple_class("itk::RGBColormapFilterEnumType" ENUM)
+itk_wrap_simple_class("itk::RGBColormapFilterEnum" ENUM)
 
 itk_wrap_class("itk::ScalarToRGBColormapImageFilter" POINTER)
   # Wrap itk::IdentifierType to create colormaps from the output of watershed

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
@@ -89,7 +89,7 @@ ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::ComputeConvolut
   {
     optionalFilterWeights += 0.1f;
   }
-  if (this->GetOutputRegionMode() == ConvolutionImageFilterOutputRegionType::VALID)
+  if (this->GetOutputRegionMode() == ConvolutionImageFilterOutputRegionEnum::VALID)
   {
     optionalFilterWeights += 0.1f;
   }
@@ -139,7 +139,7 @@ ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::ComputeConvolut
   convolutionFilter->ReleaseDataFlagOn();
   progress->RegisterInternalFilter(convolutionFilter, 1.0f - optionalFilterWeights);
 
-  if (this->GetOutputRegionMode() == ConvolutionImageFilterOutputRegionType::SAME)
+  if (this->GetOutputRegionMode() == ConvolutionImageFilterOutputRegionEnum::SAME)
   {
     // Graft the output of the convolution filter onto this filter's
     // output.

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -24,11 +24,11 @@
 
 namespace itk
 {
-/** \class ConvolutionImageFilterOutputRegionType
+/** \class ConvolutionImageFilterOutputRegionEnum
  * \ingroup ITKConvolution
  * Output region mode type enumeration
  */
-enum class ConvolutionImageFilterOutputRegionType : uint8_t
+enum class ConvolutionImageFilterOutputRegionEnum : uint8_t
 {
   SAME = 0,
   VALID
@@ -94,12 +94,12 @@ public:
   itkBooleanMacro(Normalize);
 
   /** Reverse compatibility for enumerations */
-  using OutputRegionModeType = ConvolutionImageFilterOutputRegionType;
+  using OutputRegionModeEnum = ConvolutionImageFilterOutputRegionEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr OutputRegionModeType SAME = OutputRegionModeType::SAME;
-  static constexpr OutputRegionModeType VALID = OutputRegionModeType::VALID;
+  static constexpr OutputRegionModeEnum SAME = OutputRegionModeEnum::SAME;
+  static constexpr OutputRegionModeEnum VALID = OutputRegionModeEnum::VALID;
 #endif
 
   /** Sets the output region mode. If set to SAME, the output region
@@ -111,8 +111,8 @@ public:
    * (no extrapolated contributions from the boundary condition are
    * needed). The output is therefore smaller than the input
    * region. Default output region mode is SAME. */
-  itkSetEnumMacro(OutputRegionMode, OutputRegionModeType);
-  itkGetEnumMacro(OutputRegionMode, OutputRegionModeType);
+  itkSetEnumMacro(OutputRegionMode, OutputRegionModeEnum);
+  itkGetEnumMacro(OutputRegionMode, OutputRegionModeEnum);
   virtual void
   SetOutputRegionModeToSame();
   virtual void
@@ -145,12 +145,12 @@ private:
   DefaultBoundaryConditionType m_DefaultBoundaryCondition;
   BoundaryConditionPointerType m_BoundaryCondition;
 
-  OutputRegionModeType m_OutputRegionMode;
+  OutputRegionModeEnum m_OutputRegionMode;
 };
 
 /** Define how to print enumerations */
 extern ITKConvolution_EXPORT std::ostream &
-                             operator<<(std::ostream & out, const ConvolutionImageFilterOutputRegionType value);
+                             operator<<(std::ostream & out, const ConvolutionImageFilterOutputRegionEnum value);
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 template <typename TInputImage, typename TKernelImage, typename TOutputImage>
 ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::ConvolutionImageFilterBase()
-  : m_OutputRegionMode(ConvolutionImageFilterOutputRegionType::SAME)
+  : m_OutputRegionMode(ConvolutionImageFilterOutputRegionEnum::SAME)
 {
   this->AddRequiredInputName("KernelImage");
 
@@ -39,7 +39,7 @@ ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::GenerateOut
   // behavior corresponds to SAME output region mode.
   Superclass::GenerateOutputInformation();
 
-  if (m_OutputRegionMode == ConvolutionImageFilterOutputRegionType::VALID)
+  if (m_OutputRegionMode == ConvolutionImageFilterOutputRegionEnum::VALID)
   {
     OutputRegionType validRegion = this->GetValidRegion();
 
@@ -96,14 +96,14 @@ template <typename TInputImage, typename TKernelImage, typename TOutputImage>
 void
 ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::SetOutputRegionModeToSame()
 {
-  this->SetOutputRegionMode(ConvolutionImageFilterOutputRegionType::SAME);
+  this->SetOutputRegionMode(ConvolutionImageFilterOutputRegionEnum::SAME);
 }
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage>
 void
 ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::SetOutputRegionModeToValid()
 {
-  this->SetOutputRegionMode(ConvolutionImageFilterOutputRegionType::VALID);
+  this->SetOutputRegionMode(ConvolutionImageFilterOutputRegionEnum::VALID);
 }
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage>
@@ -117,11 +117,11 @@ ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::PrintSelf(s
   os << indent << "OutputRegionMode: ";
   switch (m_OutputRegionMode)
   {
-    case OutputRegionModeType::SAME:
+    case OutputRegionModeEnum::SAME:
       os << "SAME";
       break;
 
-    case OutputRegionModeType::VALID:
+    case OutputRegionModeEnum::VALID:
       os << "VALID";
       break;
 

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -329,7 +329,7 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
   extractFilter->GraftOutput(this->GetOutput());
 
   // Set up the crop sizes.
-  if (this->GetOutputRegionMode() == ConvolutionImageFilterOutputRegionType::SAME)
+  if (this->GetOutputRegionMode() == ConvolutionImageFilterOutputRegionEnum::SAME)
   {
     InputRegionType sameRegion = this->GetInput()->GetLargestPossibleRegion();
     extractFilter->SetExtractionRegion(sameRegion);

--- a/Modules/Filtering/Convolution/src/itkConvolutionImageFilterBase.cxx
+++ b/Modules/Filtering/Convolution/src/itkConvolutionImageFilterBase.cxx
@@ -21,17 +21,17 @@ namespace itk
 {
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const ConvolutionImageFilterOutputRegionType value)
+operator<<(std::ostream & out, const ConvolutionImageFilterOutputRegionEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case ConvolutionImageFilterOutputRegionType::SAME:
-        return "ConvolutionImageFilterOutputRegionType::SAME";
-      case ConvolutionImageFilterOutputRegionType::VALID:
-        return "ConvolutionImageFilterOutputRegionType::VALID";
+      case ConvolutionImageFilterOutputRegionEnum::SAME:
+        return "ConvolutionImageFilterOutputRegionEnum::SAME";
+      case ConvolutionImageFilterOutputRegionEnum::VALID:
+        return "ConvolutionImageFilterOutputRegionEnum::VALID";
       default:
-        return "INVALID VALUE FOR ConvolutionImageFilterOutputRegionType";
+        return "INVALID VALUE FOR ConvolutionImageFilterOutputRegionEnum";
     }
   }();
 }

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
@@ -123,29 +123,29 @@ itkConvolutionImageFilterTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  convoluter->SetOutputRegionMode(itk::ConvolutionImageFilterOutputRegionType::SAME);
-  if (convoluter->GetOutputRegionMode() != itk::ConvolutionImageFilterOutputRegionType::SAME)
+  convoluter->SetOutputRegionMode(itk::ConvolutionImageFilterOutputRegionEnum::SAME);
+  if (convoluter->GetOutputRegionMode() != itk::ConvolutionImageFilterOutputRegionEnum::SAME)
   {
     std::cerr << "SetOutputRegionMode() error when argument is SAME" << std::endl;
     return EXIT_FAILURE;
   }
 
-  convoluter->SetOutputRegionMode(itk::ConvolutionImageFilterOutputRegionType::VALID);
-  if (convoluter->GetOutputRegionMode() != itk::ConvolutionImageFilterOutputRegionType::VALID)
+  convoluter->SetOutputRegionMode(itk::ConvolutionImageFilterOutputRegionEnum::VALID);
+  if (convoluter->GetOutputRegionMode() != itk::ConvolutionImageFilterOutputRegionEnum::VALID)
   {
     std::cerr << "SetOutputRegionMode() error when argument is VALID" << std::endl;
     return EXIT_FAILURE;
   }
 
   convoluter->SetOutputRegionModeToSame();
-  if (convoluter->GetOutputRegionMode() != itk::ConvolutionImageFilterOutputRegionType::SAME)
+  if (convoluter->GetOutputRegionMode() != itk::ConvolutionImageFilterOutputRegionEnum::SAME)
   {
     std::cerr << "SetOutputRegionModeToSame() error" << std::endl;
     return EXIT_FAILURE;
   }
 
   convoluter->SetOutputRegionModeToValid();
-  if (convoluter->GetOutputRegionMode() != itk::ConvolutionImageFilterOutputRegionType::VALID)
+  if (convoluter->GetOutputRegionMode() != itk::ConvolutionImageFilterOutputRegionEnum::VALID)
   {
     std::cerr << "SetOutputRegionModeToValid() error" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
@@ -132,13 +132,13 @@ itkFFTConvolutionImageFilterTest(int argc, char * argv[])
     std::string outputRegionMode(argv[6]);
     if (outputRegionMode == "SAME")
     {
-      convoluter->SetOutputRegionMode(itk::ConvolutionImageFilterOutputRegionType::SAME);
-      ITK_TEST_SET_GET_VALUE(itk::ConvolutionImageFilterOutputRegionType::SAME, convoluter->GetOutputRegionMode());
+      convoluter->SetOutputRegionMode(itk::ConvolutionImageFilterOutputRegionEnum::SAME);
+      ITK_TEST_SET_GET_VALUE(itk::ConvolutionImageFilterOutputRegionEnum::SAME, convoluter->GetOutputRegionMode());
     }
     else if (outputRegionMode == "VALID")
     {
-      convoluter->SetOutputRegionMode(itk::ConvolutionImageFilterOutputRegionType::VALID);
-      ITK_TEST_SET_GET_VALUE(itk::ConvolutionImageFilterOutputRegionType::VALID, convoluter->GetOutputRegionMode());
+      convoluter->SetOutputRegionMode(itk::ConvolutionImageFilterOutputRegionEnum::VALID);
+      ITK_TEST_SET_GET_VALUE(itk::ConvolutionImageFilterOutputRegionEnum::VALID, convoluter->GetOutputRegionMode());
     }
     else
     {
@@ -150,12 +150,12 @@ itkFFTConvolutionImageFilterTest(int argc, char * argv[])
     if (outputRegionMode == "SAME")
     {
       convoluter->SetOutputRegionModeToSame();
-      ITK_TEST_SET_GET_VALUE(ConvolutionFilterType::OutputRegionModeType::SAME, convoluter->GetOutputRegionMode());
+      ITK_TEST_SET_GET_VALUE(ConvolutionFilterType::OutputRegionModeEnum::SAME, convoluter->GetOutputRegionMode());
     }
     else
     {
       convoluter->SetOutputRegionModeToValid();
-      ITK_TEST_SET_GET_VALUE(ConvolutionFilterType::OutputRegionModeType::VALID, convoluter->GetOutputRegionMode());
+      ITK_TEST_SET_GET_VALUE(ConvolutionFilterType::OutputRegionModeEnum::VALID, convoluter->GetOutputRegionMode());
     }
   }
 

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTestInt.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTestInt.cxx
@@ -74,13 +74,13 @@ itkFFTConvolutionImageFilterTestInt(int argc, char * argv[])
     if (outputRegionMode == "SAME")
     {
       convolver->SetOutputRegionModeToSame();
-      ITK_TEST_SET_GET_VALUE(itk::ConvolutionImageFilterOutputRegionType::SAME, convolver->GetOutputRegionMode());
+      ITK_TEST_SET_GET_VALUE(itk::ConvolutionImageFilterOutputRegionEnum::SAME, convolver->GetOutputRegionMode());
       std::cout << "OutputRegionMode set to SAME." << std::endl;
     }
     else if (outputRegionMode == "VALID")
     {
       convolver->SetOutputRegionModeToValid();
-      ITK_TEST_SET_GET_VALUE(itk::ConvolutionImageFilterOutputRegionType::VALID, convolver->GetOutputRegionMode());
+      ITK_TEST_SET_GET_VALUE(itk::ConvolutionImageFilterOutputRegionEnum::VALID, convolver->GetOutputRegionMode());
       std::cout << "OutputRegionMode set to VALID." << std::endl;
     }
     else

--- a/Modules/Filtering/Convolution/wrapping/itkConvolutionImageFilterBase.wrap
+++ b/Modules/Filtering/Convolution/wrapping/itkConvolutionImageFilterBase.wrap
@@ -1,7 +1,7 @@
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkConvolutionImageFilterBase.h")
 
-itk_wrap_simple_class("itk::ConvolutionImageFilterOutputRegionType" ENUM)
+itk_wrap_simple_class("itk::ConvolutionImageFilterOutputRegionEnum" ENUM)
 
 itk_wrap_class("itk::ConvolutionImageFilterBase" POINTER)
   itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2)

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -30,11 +30,11 @@
 #include "ITKDiffusionTensorImageExport.h"
 namespace itk
 {
-/** \class GradientEnumeration
+/** \class GradientEnum
  * \ingroup ITKDiffusionTensorImage
  * enum to indicate if the gradient image is specified as a single multi-
  * component image or as several separate images */
-enum class GradientEnumeration : uint8_t
+enum class GradientEnum : uint8_t
 {
   GradientIsInASingleImage = 1,
   GradientIsInManyImages,
@@ -211,7 +211,7 @@ public:
   void
   SetReferenceImage(ReferenceImageType * referenceImage)
   {
-    if (m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInASingleImage)
+    if (m_GradientImageTypeEnumeration == GradientEnum::GradientIsInASingleImage)
     {
       itkExceptionMacro(<< "Cannot call both methods:"
                         << "AddGradientImage and SetGradientImage. Please call only one of them.");
@@ -219,7 +219,7 @@ public:
 
     this->ProcessObject::SetNthInput(0, referenceImage);
 
-    m_GradientImageTypeEnumeration = GradientEnumeration::GradientIsInManyImages;
+    m_GradientImageTypeEnumeration = GradientEnum::GradientIsInManyImages;
   }
 
   /** Get reference image */
@@ -301,7 +301,7 @@ protected:
   VerifyPreconditions() ITKv5_CONST override;
 
   /** Enables backwards compatibility for enum values */
-  using GradientImageTypeEnumeration = GradientEnumeration;
+  using GradientImageTypeEnumeration = GradientEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -342,7 +342,7 @@ private:
 
 /** Define how to print enum values */
 extern ITKDiffusionTensorImage_EXPORT std::ostream &
-                                      operator<<(std::ostream & out, const GradientEnumeration value);
+                                      operator<<(std::ostream & out, const GradientEnum value);
 } // namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -44,7 +44,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   m_NumberOfGradientDirections = 0;
   m_NumberOfBaselineImages = 1;
   m_Threshold = NumericTraits<ReferencePixelType>::min();
-  m_GradientImageTypeEnumeration = GradientEnumeration::Else;
+  m_GradientImageTypeEnumeration = GradientEnum::Else;
   m_GradientDirectionContainer = nullptr;
   m_TensorBasis.set_identity();
   m_BValue = 1.0;
@@ -72,7 +72,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   // we must have a container of (numberOfInputs-1) itk::Image. Check to make
   // sure
   if ((numberOfInputs == 1 || (numberOfInputs == 2 && this->m_MaskImagePresent)) &&
-      m_GradientImageTypeEnumeration != GradientEnumeration::GradientIsInASingleImage)
+      m_GradientImageTypeEnumeration != GradientEnum::GradientIsInASingleImage)
   {
     std::string gradientImageClassName(this->ProcessObject::GetInput(0)->GetNameOfClass());
     if (strcmp(gradientImageClassName.c_str(), "VectorImage") != 0)
@@ -110,7 +110,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   typename MaskImageType::DirectionType maskDirection = maskImage->GetDirection();
   typename MaskImageType::DirectionType refDirection;
 
-  if (m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInManyImages)
+  if (m_GradientImageTypeEnumeration == GradientEnum::GradientIsInManyImages)
   {
     auto * refImage = static_cast<ReferenceImageType *>(this->ProcessObject::GetInput(0));
     refSize = refImage->GetLargestPossibleRegion().GetSize();
@@ -118,7 +118,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
     refSpacing = refImage->GetSpacing();
     refDirection = refImage->GetDirection();
   }
-  else if (m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInASingleImage)
+  else if (m_GradientImageTypeEnumeration == GradientEnum::GradientIsInASingleImage)
   {
     auto * gradientImage = static_cast<GradientImagesType *>(this->ProcessObject::GetInput(0));
     refSize = gradientImage->GetLargestPossibleRegion().GetSize();
@@ -189,7 +189,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   // 2. If the Gradients have been specified in a single multi-component image,
   // one iterator will suffice to do the same.
 
-  if (m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInManyImages)
+  if (m_GradientImageTypeEnumeration == GradientEnum::GradientIsInManyImages)
   {
     typename ReferenceImageType::Pointer refImage = static_cast<ReferenceImageType *>(this->ProcessObject::GetInput(0));
     ImageRegionConstIteratorWithIndex<ReferenceImageType> it(refImage, outputRegionForThread);
@@ -294,7 +294,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
     }
   }
   // The gradients are specified in a single multi-component image
-  else if (m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInASingleImage)
+  else if (m_GradientImageTypeEnumeration == GradientEnum::GradientIsInASingleImage)
   {
     using GradientIteratorType = ImageRegionConstIteratorWithIndex<GradientImagesType>;
     using GradientVectorType = typename GradientImagesType::PixelType;
@@ -458,7 +458,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
                                            TTensorPixelType,
                                            TMaskImageType>::GetGradientImage(unsigned index) const
 {
-  if (m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInASingleImage)
+  if (m_GradientImageTypeEnumeration == GradientEnum::GradientIsInASingleImage)
   {
     itkExceptionMacro(<< "Cannot retrieve individual gradient Image if "
                       << "all gradients are in a single image.");
@@ -482,7 +482,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
 {
   // Make sure crazy users did not call both AddGradientImage and
   // SetGradientImage
-  if (m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInASingleImage)
+  if (m_GradientImageTypeEnumeration == GradientEnum::GradientIsInASingleImage)
   {
     itkExceptionMacro(<< "Cannot call both methods:"
                       << "AddGradientImage and SetGradientImage. Please call only one of them.");
@@ -499,7 +499,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
                                               gradientDirection / gradientDirection.two_norm());
   ++m_NumberOfGradientDirections;
   this->ProcessObject::SetNthInput(m_NumberOfGradientDirections + 1, const_cast<GradientImageType *>(gradientImage));
-  m_GradientImageTypeEnumeration = GradientEnumeration::GradientIsInManyImages;
+  m_GradientImageTypeEnumeration = GradientEnum::GradientIsInManyImages;
 }
 
 template <typename TReferenceImagePixelType,
@@ -516,7 +516,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
 {
   // Make sure crazy users did not call both AddGradientImage and
   // SetGradientImage
-  if (m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInManyImages)
+  if (m_GradientImageTypeEnumeration == GradientEnum::GradientIsInManyImages)
   {
     itkExceptionMacro(<< "Cannot call both methods:"
                       << "AddGradientImage and SetGradientImage. Please call only one of them.");
@@ -552,7 +552,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   }
 
   this->ProcessObject::SetNthInput(0, const_cast<GradientImagesType *>(gradientImage));
-  m_GradientImageTypeEnumeration = GradientEnumeration::GradientIsInASingleImage;
+  m_GradientImageTypeEnumeration = GradientEnum::GradientIsInASingleImage;
 }
 
 template <typename TReferenceImagePixelType,
@@ -611,11 +611,11 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   os << indent << "NumberOfBaselineImages: " << m_NumberOfBaselineImages << std::endl;
   os << indent << "Threshold for reference B0 image: " << m_Threshold << std::endl;
   os << indent << "BValue: " << m_BValue << std::endl;
-  if (this->m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInManyImages)
+  if (this->m_GradientImageTypeEnumeration == GradientEnum::GradientIsInManyImages)
   {
     os << indent << "Gradient images haven been supplied " << std::endl;
   }
-  else if (this->m_GradientImageTypeEnumeration == GradientEnumeration::GradientIsInManyImages)
+  else if (this->m_GradientImageTypeEnumeration == GradientEnum::GradientIsInManyImages)
   {
     os << indent << "A multicomponent gradient image has been supplied" << std::endl;
   }

--- a/Modules/Filtering/DiffusionTensorImage/src/itkDiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/src/itkDiffusionTensor3DReconstructionImageFilter.cxx
@@ -20,19 +20,19 @@
 namespace itk
 {
 std::ostream &
-operator<<(std::ostream & out, const GradientEnumeration value)
+operator<<(std::ostream & out, const GradientEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case GradientEnumeration::GradientIsInASingleImage:
-        return "GradientEnumeration::GradientIsInASingleImage";
-      case GradientEnumeration::GradientIsInManyImages:
-        return "GradientEnumeration::GradientIsInManyImages";
-      case GradientEnumeration::Else:
-        return "GradientEnumeration::Else";
+      case GradientEnum::GradientIsInASingleImage:
+        return "GradientEnum::GradientIsInASingleImage";
+      case GradientEnum::GradientIsInManyImages:
+        return "GradientEnum::GradientIsInManyImages";
+      case GradientEnum::Else:
+        return "GradientEnum::Else";
       default:
-        return "INVALID VALUE FOR GradientEnumeration";
+        return "INVALID VALUE FOR GradientEnum";
     }
   }();
 }

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
@@ -64,7 +64,7 @@ public:
   using ParametersValueType = typename Superclass::ParametersValueType;
 
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** The number of parameters defining this transform. */
   using NumberOfParametersType = typename Superclass::NumberOfParametersType;

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
@@ -118,7 +118,7 @@ public:
   using InverseJacobianPositionType = typename Superclass::InverseJacobianPositionType;
 
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** The number of parameters defining this transform. */
   using NumberOfParametersType = typename Superclass::NumberOfParametersType;
@@ -405,10 +405,10 @@ public:
   SetIdentity();
 
   /** This transform is not linear. */
-  TransformCategoryType
+  TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return Self::TransformCategoryType::DisplacementField;
+    return Self::TransformCategoryEnum::DisplacementField;
   }
 
   NumberOfParametersType

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -63,7 +63,7 @@ public:
   using ParametersValueType = typename Superclass::ParametersValueType;
 
   /** Transform category type. */
-  using TransformCategoryType = typename Superclass::TransformCategoryType;
+  using TransformCategoryEnum = typename Superclass::TransformCategoryEnum;
 
   /** The number of parameters defining this transform. */
   using NumberOfParametersType = typename Superclass::NumberOfParametersType;

--- a/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
@@ -105,7 +105,7 @@ itkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
   const std::string pixelTypeString(argv[3]);
 
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(inputImageFileName, itk::ImageIOFactory::FileModeType::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(inputImageFileName, itk::ImageIOFactory::FileModeEnum::ReadMode);
   imageIO->SetFileName(inputImageFileName);
   imageIO->ReadImageInformation();
   const unsigned int dimension = imageIO->GetNumberOfDimensions();

--- a/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
@@ -103,7 +103,7 @@ itkFFTWComplexToComplexFFTImageFilterTest(int argc, char * argv[])
   const std::string pixelTypeString(argv[3]);
 
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(inputImageFileName, itk::ImageIOFactory::FileModeType::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(inputImageFileName, itk::ImageIOFactory::FileModeEnum::ReadMode);
   imageIO->SetFileName(inputImageFileName);
   imageIO->ReadImageInformation();
   const unsigned int dimension = imageIO->GetNumberOfDimensions();

--- a/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
@@ -87,7 +87,7 @@ itkVnlComplexToComplexFFTImageFilterTest(int argc, char * argv[])
   const std::string pixelTypeString(argv[3]);
 
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(inputImageFileName, itk::ImageIOFactory::FileModeType::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(inputImageFileName, itk::ImageIOFactory::FileModeEnum::ReadMode);
   imageIO->SetFileName(inputImageFileName);
   imageIO->ReadImageInformation();
   const unsigned int dimension = imageIO->GetNumberOfDimensions();

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -35,7 +35,7 @@ Hessian3DToVesselnessMeasureImageFilter<TPixel>::Hessian3DToVesselnessMeasureIma
 
   // Hessian( Image ) = Jacobian( Gradient ( Image ) )  is symmetric
   m_SymmetricEigenValueFilter = EigenAnalysisFilterType::New();
-  m_SymmetricEigenValueFilter->OrderEigenValuesBy(Functor::OrderTypeOfEigenValue::OrderByValue);
+  m_SymmetricEigenValueFilter->OrderEigenValuesBy(EigenValueOrderEnum::OrderByValue);
 }
 
 template <typename TPixel>

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -38,7 +38,7 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::HessianRecursive
   for (unsigned int i = 0; i < numberOfSmoothingFilters; i++)
   {
     GaussianFilterPointer filter = GaussianFilterType::New();
-    filter->SetOrder(EnumGaussianOrderType::ZeroOrder);
+    filter->SetOrder(GaussianOrderEnum::ZeroOrder);
     filter->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
     filter->InPlaceOn();
     filter->ReleaseDataFlagOn();
@@ -48,10 +48,10 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::HessianRecursive
   m_DerivativeFilterA = DerivativeFilterAType::New();
   m_DerivativeFilterB = DerivativeFilterBType::New();
 
-  m_DerivativeFilterA->SetOrder(EnumGaussianOrderType::FirstOrder);
+  m_DerivativeFilterA->SetOrder(GaussianOrderEnum::FirstOrder);
   m_DerivativeFilterA->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
 
-  m_DerivativeFilterB->SetOrder(EnumGaussianOrderType::FirstOrder);
+  m_DerivativeFilterB->SetOrder(GaussianOrderEnum::FirstOrder);
   m_DerivativeFilterB->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
 
   m_DerivativeFilterA->SetInput(this->GetInput());
@@ -223,8 +223,8 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
       // to smooth one of the other directions.
       if (dimb == dima)
       {
-        m_DerivativeFilterA->SetOrder(EnumGaussianOrderType::SecondOrder);
-        m_DerivativeFilterB->SetOrder(EnumGaussianOrderType::ZeroOrder);
+        m_DerivativeFilterA->SetOrder(GaussianOrderEnum::SecondOrder);
+        m_DerivativeFilterB->SetOrder(GaussianOrderEnum::ZeroOrder);
 
         // only need the output of m_DerivativeFilterA once
         m_DerivativeFilterB->InPlaceOn();
@@ -262,8 +262,8 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
       }
       else
       {
-        m_DerivativeFilterA->SetOrder(EnumGaussianOrderType::FirstOrder);
-        m_DerivativeFilterB->SetOrder(EnumGaussianOrderType::FirstOrder);
+        m_DerivativeFilterA->SetOrder(GaussianOrderEnum::FirstOrder);
+        m_DerivativeFilterB->SetOrder(GaussianOrderEnum::FirstOrder);
 
         if (dimb < ImageDimension - 1)
         {

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -37,14 +37,14 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::LaplacianRecur
   for (unsigned int i = 0; i < NumberOfSmoothingFilters; i++)
   {
     m_SmoothingFilters[i] = GaussianFilterType::New();
-    m_SmoothingFilters[i]->SetOrder(EnumGaussianOrderType::ZeroOrder);
+    m_SmoothingFilters[i]->SetOrder(GaussianOrderEnum::ZeroOrder);
     m_SmoothingFilters[i]->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
     m_SmoothingFilters[i]->ReleaseDataFlagOn();
     m_SmoothingFilters[i]->InPlaceOn();
   }
 
   m_DerivativeFilter = DerivativeFilterType::New();
-  m_DerivativeFilter->SetOrder(EnumGaussianOrderType::SecondOrder);
+  m_DerivativeFilter->SetOrder(GaussianOrderEnum::SecondOrder);
   m_DerivativeFilter->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
   m_DerivativeFilter->ReleaseDataFlagOn();
   m_DerivativeFilter->InPlaceOff();

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -35,7 +35,7 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage,
   m_NormalizeAcrossScale = false;
 
   m_DerivativeFilter = DerivativeFilterType::New();
-  m_DerivativeFilter->SetOrder(EnumGaussianOrderType::FirstOrder);
+  m_DerivativeFilter->SetOrder(GaussianOrderEnum::FirstOrder);
   m_DerivativeFilter->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
   m_DerivativeFilter->InPlaceOff();
   m_DerivativeFilter->ReleaseDataFlagOn();
@@ -43,7 +43,7 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage,
   for (unsigned int i = 0; i < ImageDimension - 1; i++)
   {
     m_SmoothingFilters[i] = GaussianFilterType::New();
-    m_SmoothingFilters[i]->SetOrder(EnumGaussianOrderType::ZeroOrder);
+    m_SmoothingFilters[i]->SetOrder(GaussianOrderEnum::ZeroOrder);
     m_SmoothingFilters[i]->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
     m_SmoothingFilters[i]->InPlaceOn();
   }

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -43,7 +43,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GradientRecursi
     for (unsigned int i = 0; i != imageDimensionMinus1; ++i)
     {
       m_SmoothingFilters[i] = GaussianFilterType::New();
-      m_SmoothingFilters[i]->SetOrder(EnumGaussianOrderType::ZeroOrder);
+      m_SmoothingFilters[i]->SetOrder(GaussianOrderEnum::ZeroOrder);
       m_SmoothingFilters[i]->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
       m_SmoothingFilters[i]->InPlaceOn();
       m_SmoothingFilters[i]->ReleaseDataFlagOn();
@@ -51,7 +51,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GradientRecursi
   }
 
   m_DerivativeFilter = DerivativeFilterType::New();
-  m_DerivativeFilter->SetOrder(EnumGaussianOrderType::FirstOrder);
+  m_DerivativeFilter->SetOrder(GaussianOrderEnum::FirstOrder);
   m_DerivativeFilter->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
   m_DerivativeFilter->ReleaseDataFlagOn();
   m_DerivativeFilter->InPlaceOff();

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
@@ -109,7 +109,7 @@ itkGradientImageFilterTest2(int argc, char * argv[])
   const std::string outfname = argv[2];
 
   itk::ImageIOBase::Pointer iobase =
-    itk::ImageIOFactory::CreateImageIO(infname.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(infname.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
 
   if (iobase.IsNull())
   {

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -203,7 +203,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   // can be used if the transformation is linear. Transform respond
   // to the IsLinear() call.
   if (!isSpecialCoordinatesImage &&
-      this->GetTransform()->GetTransformCategory() == TransformType::TransformCategoryType::Linear)
+      this->GetTransform()->GetTransformCategory() == TransformType::TransformCategoryEnum::Linear)
   {
     this->LinearThreadedGenerateData(outputRegionForThread);
     return;
@@ -542,7 +542,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   // Check whether we can use upstream streaming for resampling. Upstream streaming
   // can be used if the transformation is linear. Transform respond
   // to the IsLinear() call.
-  if (!isSpecialCoordinatesImage && transform->GetTransformCategory() == TransformType::TransformCategoryType::Linear)
+  if (!isSpecialCoordinatesImage && transform->GetTransformCategory() == TransformType::TransformCategoryEnum::Linear)
   {
     typename TInputImage::RegionType inputRequestedRegion;
     inputRequestedRegion = ImageAlgorithm::EnlargeRegionOverBox(output->GetRequestedRegion(), output, input, transform);

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -51,10 +51,10 @@ public:
   itkTypeMacro(NonlinearAffineTransform, AffineTransform);
 
   /** Override this so not linear. See test below. */
-  typename itk::TransformBaseTemplate<TCoordRepType>::TransformCategoryType
+  typename itk::TransformBaseTemplate<TCoordRepType>::TransformCategoryEnum
   GetTransformCategory() const override
   {
-    return itk::TransformBaseTemplate<TCoordRepType>::TransformCategoryType::UnknownTransformCategory;
+    return itk::TransformBaseTemplate<TCoordRepType>::TransformCategoryEnum::UnknownTransformCategory;
   }
 };
 } // namespace

--- a/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
@@ -41,12 +41,9 @@ namespace Functor
  * OrderByMagnitude:  |lambda_1| < |lambda_2| < .....
  * DoNotOrder:        Default order of eigen values obtained after QL method
  */
-enum class OrderTypeOfEigenValue : uint8_t
-{
-  OrderByValue = 1,
-  OrderByMagnitude,
-  DoNotOrder
-};
+#if !defined(ITK_LEGACY_REMOVE)
+using OrderTypeOfEigenValue = EigenValueOrderEnum;
+#endif
 
 template <typename TInput, typename TOutput>
 class SymmetricEigenAnalysisFunction
@@ -89,13 +86,13 @@ public:
     return m_Calculator.GetDimension();
   }
 
-  using EigenValueOrderType = OrderTypeOfEigenValue;
+  using EigenValueOrderType = EigenValueOrderEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr EigenValueOrderType OrderByValue = EigenValueOrderType::OrderByValue;
-  static constexpr EigenValueOrderType OrderByMagnitude = EigenValueOrderType::OrderByMagnitude;
-  static constexpr EigenValueOrderType DoNotOrder = EigenValueOrderType::DoNotOrder;
+  static constexpr EigenValueOrderType OrderByValue = EigenValueOrderEnum::OrderByValue;
+  static constexpr EigenValueOrderType OrderByMagnitude = EigenValueOrderEnum::OrderByMagnitude;
+  static constexpr EigenValueOrderType DoNotOrder = EigenValueOrderEnum::DoNotOrder;
 #endif
 
   /** Order eigen values. Default is to OrderByValue:  lambda_1 <
@@ -103,11 +100,11 @@ public:
   void
   OrderEigenValuesBy(EigenValueOrderType order)
   {
-    if (order == OrderTypeOfEigenValue::OrderByMagnitude)
+    if (order == EigenValueOrderEnum::OrderByMagnitude)
     {
       m_Calculator.SetOrderEigenMagnitudes(true);
     }
-    else if (order == OrderTypeOfEigenValue::DoNotOrder)
+    else if (order == EigenValueOrderEnum::DoNotOrder)
     {
       m_Calculator.SetOrderEigenValues(false);
     }
@@ -154,7 +151,7 @@ public:
   }
 
   /** Reverse compatibility for enum values */
-  using EigenValueOrderType = OrderTypeOfEigenValue;
+  using EigenValueOrderType = EigenValueOrderEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -168,11 +165,11 @@ public:
   void
   OrderEigenValuesBy(EigenValueOrderType order)
   {
-    if (order == OrderTypeOfEigenValue::OrderByMagnitude)
+    if (order == EigenValueOrderEnum::OrderByMagnitude)
     {
       m_Calculator.SetOrderEigenMagnitudes(true);
     }
-    else if (order == OrderTypeOfEigenValue::DoNotOrder)
+    else if (order == EigenValueOrderEnum::DoNotOrder)
     {
       m_Calculator.SetOrderEigenValues(false);
     }
@@ -184,7 +181,7 @@ private:
 
 /** Define how to print enumerations */
 extern ITKImageIntensity_EXPORT std::ostream &
-                                operator<<(std::ostream & out, const OrderTypeOfEigenValue value);
+                                operator<<(std::ostream & out, const EigenValueOrderEnum value);
 
 } // end namespace Functor
 

--- a/Modules/Filtering/ImageIntensity/src/itkSymmetricEigenAnalysisImageFilter.cxx
+++ b/Modules/Filtering/ImageIntensity/src/itkSymmetricEigenAnalysisImageFilter.cxx
@@ -23,19 +23,19 @@ namespace Functor
 {
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const OrderTypeOfEigenValue value)
+operator<<(std::ostream & out, const EigenValueOrderEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case OrderTypeOfEigenValue::OrderByValue:
-        return "OrderTypeOfEigenValue::OrderByValue";
-      case OrderTypeOfEigenValue::OrderByMagnitude:
-        return "OrderTypeOfEigenValue::OrderByMagnitude";
-      case OrderTypeOfEigenValue::DoNotOrder:
-        return "OrderTypeOfEigenValue::DoNotOrder";
+      case EigenValueOrderEnum::OrderByValue:
+        return "EigenValueOrderEnum::OrderByValue";
+      case EigenValueOrderEnum::OrderByMagnitude:
+        return "EigenValueOrderEnum::OrderByMagnitude";
+      case EigenValueOrderEnum::DoNotOrder:
+        return "EigenValueOrderEnum::DoNotOrder";
       default:
-        return "INVALID VALUE FOR OrderTypeOfEigenValue";
+        return "INVALID VALUE FOR EigenValueOrderEnum";
     }
   }();
 }

--- a/Modules/Filtering/ImageIntensity/wrapping/itkSymmetricEigenAnalysisImageFilter.wrap
+++ b/Modules/Filtering/ImageIntensity/wrapping/itkSymmetricEigenAnalysisImageFilter.wrap
@@ -1,4 +1,8 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
+itk_wrap_include("itkSymmetricEigenAnalysisImageFilter.h")
 itk_wrap_include("itkSymmetricSecondRankTensor.h")
+
+itk_wrap_simple_class("itk::EigenValueOrderEnum" ENUM)
 
 itk_wrap_class("itk::SymmetricEigenAnalysisImageFilter" POINTER_WITH_2_SUPERCLASSES)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h
@@ -28,10 +28,10 @@ namespace itk
 #  define TEMPINPLACELABELMAPSTRICT STRICT
 #  undef STRICT
 #endif
-/**\class ChoiceMethod
+/**\class ChoiceMethodEnum
  *  \ingroup ITKLabelMap
  */
-enum class ChoiceMethod : uint8_t
+enum class ChoiceMethodEnum : uint8_t
 {
   KEEP = 0,
   AGGREGATE = 1,
@@ -119,7 +119,7 @@ public:
 #endif
 
   /** Enables backwards compatibility for enum values */
-  using MethodChoice = ChoiceMethod;
+  using MethodChoice = ChoiceMethodEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -161,7 +161,7 @@ private:
 
 /** Define how to print enumerations */
 extern ITKLabelMap_EXPORT std::ostream &
-                          operator<<(std::ostream & out, const ChoiceMethod value);
+                          operator<<(std::ostream & out, const ChoiceMethodEnum value);
 
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
@@ -27,7 +27,7 @@ namespace itk
 template <typename TImage>
 MergeLabelMapFilter<TImage>::MergeLabelMapFilter()
 {
-  this->m_Method = ChoiceMethod::KEEP;
+  this->m_Method = ChoiceMethodEnum::KEEP;
 }
 
 template <typename TImage>
@@ -39,22 +39,22 @@ MergeLabelMapFilter<TImage>::GenerateData()
 
   switch (this->m_Method)
   {
-    case ChoiceMethod::KEEP:
+    case ChoiceMethodEnum::KEEP:
     {
       this->MergeWithKeep();
       break;
     }
-    case ChoiceMethod::AGGREGATE:
+    case ChoiceMethodEnum::AGGREGATE:
     {
       this->MergeWithAggregate();
       break;
     }
-    case ChoiceMethod::PACK:
+    case ChoiceMethodEnum::PACK:
     {
       this->MergeWithPack();
       break;
     }
-    case ChoiceMethod::STRICT:
+    case ChoiceMethodEnum::STRICT:
     {
       this->MergeWithStrict();
       break;

--- a/Modules/Filtering/LabelMap/src/itkMergeLabelMapFilter.cxx
+++ b/Modules/Filtering/LabelMap/src/itkMergeLabelMapFilter.cxx
@@ -21,21 +21,21 @@ namespace itk
 {
 /**Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const ChoiceMethod value)
+operator<<(std::ostream & out, const ChoiceMethodEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case ChoiceMethod::KEEP:
-        return "ChoiceMethod::KEEP";
-      case ChoiceMethod::AGGREGATE:
-        return "ChoiceMethod::AGGREGATE";
-      case ChoiceMethod::PACK:
-        return "ChoiceMethod::PACK";
-      case ChoiceMethod::STRICT:
-        return "ChoiceMethod::STRICT";
+      case ChoiceMethodEnum::KEEP:
+        return "ChoiceMethodEnum::KEEP";
+      case ChoiceMethodEnum::AGGREGATE:
+        return "ChoiceMethodEnum::AGGREGATE";
+      case ChoiceMethodEnum::PACK:
+        return "ChoiceMethodEnum::PACK";
+      case ChoiceMethodEnum::STRICT:
+        return "ChoiceMethodEnum::STRICT";
       default:
-        return "INVALID VALUE FOR ChoiceMethod";
+        return "INVALID VALUE FOR ChoiceMethodEnum";
     }
   }();
 }

--- a/Modules/Filtering/LabelMap/test/itkMergeLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkMergeLabelMapFilterTest1.cxx
@@ -74,11 +74,11 @@ itkMergeLabelMapFilterTest1(int argc, char * argv[])
   using MethodChoice = ChangeType::MethodChoice;
   auto method = static_cast<MethodChoice>(std::stoi(argv[6]));
 
-  change->SetMethod(itk::ChoiceMethod::STRICT);
-  ITK_TEST_SET_GET_VALUE(itk::ChoiceMethod::STRICT, change->GetMethod());
+  change->SetMethod(itk::ChoiceMethodEnum::STRICT);
+  ITK_TEST_SET_GET_VALUE(itk::ChoiceMethodEnum::STRICT, change->GetMethod());
 
-  change->SetMethod(itk::ChoiceMethod::KEEP);
-  ITK_TEST_SET_GET_VALUE(itk::ChoiceMethod::KEEP, change->GetMethod());
+  change->SetMethod(itk::ChoiceMethodEnum::KEEP);
+  ITK_TEST_SET_GET_VALUE(itk::ChoiceMethodEnum::KEEP, change->GetMethod());
 
   change->SetMethod(method);
   itk::SimpleFilterWatcher watcher6(change, "filter");

--- a/Modules/Filtering/LabelMap/wrapping/itkMergeLabelMapFilter.wrap
+++ b/Modules/Filtering/LabelMap/wrapping/itkMergeLabelMapFilter.wrap
@@ -1,7 +1,7 @@
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkMergeLabelMapFilter.h")
 
-itk_wrap_simple_class("itk::ChoiceMethod" ENUM)
+itk_wrap_simple_class("itk::ChoiceMethodEnum" ENUM)
 
 itk_wrap_class("itk::MergeLabelMapFilter" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
@@ -23,12 +23,12 @@
 
 namespace itk
 {
-/**\class EnumGaussianOrderType
+/**\class GaussianOrderEnum
  * \ingroup ITKSmoothing
  * Enum type that indicates if the filter applies the equivalent operation
    of convolving with a gaussian, first derivative of a gaussian or the
    second derivative of a gaussian.  */
-enum class EnumGaussianOrderType : uint8_t
+enum class GaussianOrderEnum : uint8_t
 {
   ZeroOrder,
   FirstOrder,
@@ -100,7 +100,7 @@ public:
   itkSetMacro(Sigma, ScalarRealType);
 
   /** Enables backwards compatibility for enum values */
-  using OrderEnumType = EnumGaussianOrderType;
+  using OrderEnumType = GaussianOrderEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -240,7 +240,7 @@ private:
 
 /** Define how to print enumerations */
 extern ITKSmoothing_EXPORT std::ostream &
-                           operator<<(std::ostream & out, const EnumGaussianOrderType value);
+                           operator<<(std::ostream & out, const GaussianOrderEnum value);
 
 } // end namespace itk
 

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -30,7 +30,7 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::RecursiveGaussianImageF
 {
   m_Sigma = 1.0;
   m_NormalizeAcrossScale = false;
-  m_Order = EnumGaussianOrderType::ZeroOrder;
+  m_Order = GaussianOrderEnum::ZeroOrder;
 }
 
 /**
@@ -40,7 +40,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetZeroOrder()
 {
-  this->SetOrder(EnumGaussianOrderType::ZeroOrder);
+  this->SetOrder(GaussianOrderEnum::ZeroOrder);
 }
 
 /**
@@ -50,7 +50,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetFirstOrder()
 {
-  this->SetOrder(EnumGaussianOrderType::FirstOrder);
+  this->SetOrder(GaussianOrderEnum::FirstOrder);
 }
 
 /**
@@ -60,7 +60,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSecondOrder()
 {
-  this->SetOrder(EnumGaussianOrderType::SecondOrder);
+  this->SetOrder(GaussianOrderEnum::SecondOrder);
 }
 
 /**
@@ -124,7 +124,7 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
 
   switch (m_Order)
   {
-    case EnumGaussianOrderType::ZeroOrder:
+    case GaussianOrderEnum::ZeroOrder:
     {
       // Approximation of convolution with a gaussian.
       ComputeNCoefficients(
@@ -139,7 +139,7 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
       this->ComputeRemainingCoefficients(symmetric);
       break;
     }
-    case EnumGaussianOrderType::FirstOrder:
+    case GaussianOrderEnum::FirstOrder:
     {
       if (this->GetNormalizeAcrossScale())
       {
@@ -162,7 +162,7 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
       this->ComputeRemainingCoefficients(symmetric);
       break;
     }
-    case EnumGaussianOrderType::SecondOrder:
+    case GaussianOrderEnum::SecondOrder:
     {
       if (this->GetNormalizeAcrossScale())
       {

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
@@ -36,7 +36,7 @@ SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SmoothingRecur
   // indicate that the running in-place in the 3rd dimension the
   // performance actually declines compared to not in-place methods.
   m_FirstSmoothingFilter = FirstGaussianFilterType::New();
-  m_FirstSmoothingFilter->SetOrder(EnumGaussianOrderType::ZeroOrder);
+  m_FirstSmoothingFilter->SetOrder(GaussianOrderEnum::ZeroOrder);
   m_FirstSmoothingFilter->SetDirection(ImageDimension - 1);
   m_FirstSmoothingFilter->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
   m_FirstSmoothingFilter->ReleaseDataFlagOn();
@@ -45,7 +45,7 @@ SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SmoothingRecur
   for (unsigned int i = 0; i < ImageDimension - 1; i++)
   {
     m_SmoothingFilters[i] = InternalGaussianFilterType::New();
-    m_SmoothingFilters[i]->SetOrder(EnumGaussianOrderType::ZeroOrder);
+    m_SmoothingFilters[i]->SetOrder(GaussianOrderEnum::ZeroOrder);
     m_SmoothingFilters[i]->SetNormalizeAcrossScale(m_NormalizeAcrossScale);
     m_SmoothingFilters[i]->SetDirection(i);
     m_SmoothingFilters[i]->ReleaseDataFlagOn();

--- a/Modules/Filtering/Smoothing/src/itkRecursiveGaussianImageFilter.cxx
+++ b/Modules/Filtering/Smoothing/src/itkRecursiveGaussianImageFilter.cxx
@@ -21,16 +21,16 @@ namespace itk
 {
 /** Define how to print enumerations. */
 std::ostream &
-operator<<(std::ostream & out, const EnumGaussianOrderType value)
+operator<<(std::ostream & out, const GaussianOrderEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case EnumGaussianOrderType::ZeroOrder:
+      case GaussianOrderEnum::ZeroOrder:
         return "EnumType::ZeroOrder";
-      case EnumGaussianOrderType::FirstOrder:
+      case GaussianOrderEnum::FirstOrder:
         return "EnumType::FirstOrder";
-      case EnumGaussianOrderType::SecondOrder:
+      case GaussianOrderEnum::SecondOrder:
         return "EnumType::SecondOrder";
       default:
         return "INVALID VALUE FOR EnumType";

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnTensorsTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnTensorsTest.cxx
@@ -83,8 +83,8 @@ itkRecursiveGaussianImageFiltersOnTensorsTest(int, char *[])
   FilterType::Pointer filterY = FilterType::New();
   filterX->SetDirection(0); // 0 --> X direction
   filterY->SetDirection(1); // 1 --> Y direction
-  filterX->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
-  filterY->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
+  filterX->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
+  filterY->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
   filterX->SetNormalizeAcrossScale(false);
   filterY->SetNormalizeAcrossScale(false);
   filterX->SetInput(inputImage);

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnVectorImageTest.cxx
@@ -82,8 +82,8 @@ itkRecursiveGaussianImageFiltersOnVectorImageTest(int, char *[])
   FilterType::Pointer filterY = FilterType::New();
   filterX->SetDirection(0); // 0 --> X direction
   filterY->SetDirection(1); // 1 --> Y direction
-  filterX->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
-  filterY->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
+  filterX->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
+  filterY->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
   filterX->SetNormalizeAcrossScale(false);
   filterY->SetNormalizeAcrossScale(false);
   filterX->SetInput(inputImage);

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersTest.cxx
@@ -116,7 +116,7 @@ itkRecursiveGaussianImageFiltersTest(int, char *[])
     // Connect the input images
     filter->SetInput(inputImage);
     filter->SetDirection(2); // apply along Z
-    filter->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
+    filter->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
 
 
     // Execute the filter
@@ -132,7 +132,7 @@ itkRecursiveGaussianImageFiltersTest(int, char *[])
     // Connect the input images
     filter1->SetInput(inputImage);
     filter1->SetDirection(2); // apply along Z
-    filter1->SetOrder(itk::EnumGaussianOrderType::FirstOrder);
+    filter1->SetOrder(itk::GaussianOrderEnum::FirstOrder);
 
 
     // Execute the filter1
@@ -146,7 +146,7 @@ itkRecursiveGaussianImageFiltersTest(int, char *[])
     // Connect the input images
     filter2->SetInput(inputImage);
     filter2->SetDirection(2); // apply along Z
-    filter2->SetOrder(itk::EnumGaussianOrderType::SecondOrder);
+    filter2->SetOrder(itk::GaussianOrderEnum::SecondOrder);
 
     // Execute the filter2
     std::cout << "Executing Second Derivative filter...";
@@ -475,8 +475,8 @@ itkRecursiveGaussianImageFiltersTest(int, char *[])
     filter->SetSigma(1);
 
     // coverage for set/get methods
-    filter->SetOrder(itk::EnumGaussianOrderType::ZeroOrder);
-    if (itk::EnumGaussianOrderType::ZeroOrder != filter->GetOrder())
+    filter->SetOrder(itk::GaussianOrderEnum::ZeroOrder);
+    if (itk::GaussianOrderEnum::ZeroOrder != filter->GetOrder())
     {
       std::cerr << "SetOrder/GetOrder failure!" << std::endl;
       return EXIT_FAILURE;

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianScaleSpaceTest1.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianScaleSpaceTest1.cxx
@@ -79,10 +79,10 @@ NormalizeSineWave(double frequencyPerImage, unsigned int order, double pixelSpac
   switch (order)
   {
     case 1:
-      filter->SetOrder(itk::EnumGaussianOrderType::FirstOrder);
+      filter->SetOrder(itk::GaussianOrderEnum::FirstOrder);
       break;
     case 2:
-      filter->SetOrder(itk::EnumGaussianOrderType::SecondOrder);
+      filter->SetOrder(itk::GaussianOrderEnum::SecondOrder);
       break;
     default:
       std::cerr << " only support order 1 and 2" << std::endl;

--- a/Modules/Filtering/Smoothing/wrapping/itkRecursiveGaussianImageFilter.wrap
+++ b/Modules/Filtering/Smoothing/wrapping/itkRecursiveGaussianImageFilter.wrap
@@ -1,3 +1,8 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
+itk_wrap_include("itkRecursiveGaussianImageFilter.h")
+
+itk_wrap_simple_class("itk::GaussianOrderEnum" ENUM)
+
 itk_wrap_class("itk::RecursiveGaussianImageFilter" POINTER)
   itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2)
 itk_end_wrap_class()

--- a/Modules/Filtering/Smoothing/wrapping/itkSmoothingRecursiveGaussianImageFilter.wrap
+++ b/Modules/Filtering/Smoothing/wrapping/itkSmoothingRecursiveGaussianImageFilter.wrap
@@ -1,7 +1,7 @@
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkSmoothingRecursiveGaussianImageFilter.h")
 
-itk_wrap_simple_class("itk::EnumGaussianOrderType" ENUM)
+itk_wrap_simple_class("itk::GaussianOrderEnum" ENUM)
 
 itk_wrap_class("itk::SmoothingRecursiveGaussianImageFilter" POINTER)
   itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2 2+)

--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -325,11 +325,11 @@ public:
   }
 #endif
 
-  /** \class TCompressionType
+  /** \class CompressionEnum
    *
    * \ingroup ITKIOGDCM
    * Set/Get a compression type to use. */
-  enum class TCompressionType : uint8_t
+  enum class CompressionEnum : uint8_t
   {
     JPEG = 0,
     JPEG2000,
@@ -339,14 +339,14 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr TCompressionType JPEG = TCompressionType::JPEG;
-  static constexpr TCompressionType JPEG2000 = TCompressionType::JPEG2000;
-  static constexpr TCompressionType JPEGLS = TCompressionType::JPEGLS;
-  static constexpr TCompressionType RLE = TCompressionType::RLE;
+  static constexpr CompressionEnum JPEG = CompressionEnum::JPEG;
+  static constexpr CompressionEnum JPEG2000 = CompressionEnum::JPEG2000;
+  static constexpr CompressionEnum JPEGLS = CompressionEnum::JPEGLS;
+  static constexpr CompressionEnum RLE = CompressionEnum::RLE;
 #endif
 
-  itkSetEnumMacro(CompressionType, TCompressionType);
-  itkGetEnumMacro(CompressionType, TCompressionType);
+  itkSetEnumMacro(CompressionType, CompressionEnum);
+  itkGetEnumMacro(CompressionType, CompressionEnum);
 
   void
   InternalSetCompressor(const std::string & _compressor) override;
@@ -396,8 +396,8 @@ private:
 
   /** defines whether this image is a 2D out of a 2D image
    *  or a 2D out of a 3D image. */
-  unsigned int     m_GlobalNumberOfDimensions;
-  TCompressionType m_CompressionType;
+  unsigned int    m_GlobalNumberOfDimensions;
+  CompressionEnum m_CompressionType;
 
   ImageIOBase::IOComponentType m_InternalComponentType;
   InternalHeader *             m_DICOMHeader;
@@ -405,7 +405,7 @@ private:
 
 // Define how to print enumeration
 extern ITKIOGDCM_EXPORT std::ostream &
-                        operator<<(std::ostream & out, const GDCMImageIO::TCompressionType value);
+                        operator<<(std::ostream & out, const GDCMImageIO::CompressionEnum value);
 
 } // end namespace itk
 

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1249,11 +1249,11 @@ GDCMImageIO::Write(const void * buffer)
   if (m_UseCompression)
   {
     gdcm::ImageChangeTransferSyntax change;
-    if (m_CompressionType == TCompressionType::JPEG)
+    if (m_CompressionType == CompressionEnum::JPEG)
     {
       change.SetTransferSyntax(gdcm::TransferSyntax::JPEGLosslessProcess14_1);
     }
-    else if (m_CompressionType == TCompressionType::JPEG2000)
+    else if (m_CompressionType == CompressionEnum::JPEG2000)
     {
       change.SetTransferSyntax(gdcm::TransferSyntax::JPEG2000Lossless);
     }
@@ -1525,11 +1525,11 @@ GDCMImageIO::InternalSetCompressor(const std::string & _compressor)
 
   if (_compressor == "" || _compressor == "JPEG2000")
   {
-    m_CompressionType = TCompressionType::JPEG2000;
+    m_CompressionType = CompressionEnum::JPEG2000;
   }
   else if (_compressor == "JPEG")
   {
-    m_CompressionType = TCompressionType::JPEG;
+    m_CompressionType = CompressionEnum::JPEG;
   }
   else
   {
@@ -1574,21 +1574,21 @@ GDCMImageIO::PrintSelf(std::ostream & os, Indent indent) const
 
 /** Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const GDCMImageIO::TCompressionType value)
+operator<<(std::ostream & out, const GDCMImageIO::CompressionEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case GDCMImageIO::TCompressionType::JPEG:
-        return "GDCMImageIO::TCompressionType::JPEG";
-      case GDCMImageIO::TCompressionType::JPEG2000:
-        return "GDCMImageIO::TCompressionType::JPEG2000";
-      case GDCMImageIO::TCompressionType::JPEGLS:
-        return "GDCMImageIO::TCompressionType::JPEGLS";
-      case GDCMImageIO::TCompressionType::RLE:
-        return "GDCMImageIO::TCompressionType::RLE";
+      case GDCMImageIO::CompressionEnum::JPEG:
+        return "GDCMImageIO::CompressionEnum::JPEG";
+      case GDCMImageIO::CompressionEnum::JPEG2000:
+        return "GDCMImageIO::CompressionEnum::JPEG2000";
+      case GDCMImageIO::CompressionEnum::JPEGLS:
+        return "GDCMImageIO::CompressionEnum::JPEGLS";
+      case GDCMImageIO::CompressionEnum::RLE:
+        return "GDCMImageIO::CompressionEnum::RLE";
       default:
-        return "INVALID VALUE FOR GDCMImageIO::TCompressionType";
+        return "INVALID VALUE FOR GDCMImageIO::CompressionEnum";
     }
   }();
 }

--- a/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
@@ -117,7 +117,7 @@ itkGDCMImageIOTest2(int argc, char * argv[])
 
   // Save as JPEG 2000 Lossless
   // Explicitely specify which compression type to use
-  dicomIO->SetCompressionType(itk::GDCMImageIO::TCompressionType::JPEG2000);
+  dicomIO->SetCompressionType(itk::GDCMImageIO::CompressionEnum::JPEG2000);
   // Request compression of the ImageIO
   writer->UseCompressionOn();
   writer->SetFileName(output_j2k.c_str());
@@ -133,7 +133,7 @@ itkGDCMImageIOTest2(int argc, char * argv[])
   }
 
   // Save as JPEG Lossless
-  dicomIO->SetCompressionType(itk::GDCMImageIO::TCompressionType::JPEG);
+  dicomIO->SetCompressionType(itk::GDCMImageIO::CompressionEnum::JPEG);
   writer->SetFileName(output_jpll.c_str());
   try
   {

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -98,7 +98,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
 
   if (m_UserSpecifiedImageIO == false) // try creating via factory
   {
-    m_ImageIO = ImageIOFactory::CreateImageIO(this->GetFileName().c_str(), ImageIOFactory::FileModeType::ReadMode);
+    m_ImageIO = ImageIOFactory::CreateImageIO(this->GetFileName().c_str(), ImageIOFactory::FileModeEnum::ReadMode);
   }
 
   if (m_ImageIO.IsNull())

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -109,7 +109,7 @@ ImageFileWriter<TInputImage>::Write()
       itkDebugMacro(<< "ImageIO exists but doesn't know how to write file:" << m_FileName);
       itkDebugMacro(<< "Attempting creation of ImageIO with a factory for file:" << m_FileName);
     }
-    m_ImageIO = ImageIOFactory::CreateImageIO(m_FileName.c_str(), ImageIOFactory::FileModeType::WriteMode);
+    m_ImageIO = ImageIOFactory::CreateImageIO(m_FileName.c_str(), ImageIOFactory::FileModeEnum::WriteMode);
     m_FactorySpecifiedImageIO = true;
   }
 

--- a/Modules/IO/ImageBase/include/itkImageIOFactory.h
+++ b/Modules/IO/ImageBase/include/itkImageIOFactory.h
@@ -48,11 +48,11 @@ public:
   /** Convenient type alias. */
   using ImageIOBasePointer = ::itk::ImageIOBase::Pointer;
 
-  /** \class FileModeType
+  /** \class FileModeEnum
    *
    * \ingroup ITKIOImageBase
    * Mode in which the files is intended to be used */
-  enum class FileModeType : uint8_t
+  enum class FileModeEnum : uint8_t
   {
     ReadMode,
     WriteMode
@@ -60,13 +60,13 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr FileModeType ReadMode = FileModeType::ReadMode;
-  static constexpr FileModeType WriteMode = FileModeType::WriteMode;
+  static constexpr FileModeEnum ReadMode = FileModeEnum::ReadMode;
+  static constexpr FileModeEnum WriteMode = FileModeEnum::WriteMode;
 #endif
   /** Create the appropriate ImageIO depending on the particulars of the file.
    */
   static ImageIOBasePointer
-  CreateImageIO(const char * path, FileModeType mode);
+  CreateImageIO(const char * path, FileModeEnum mode);
 
 protected:
   ImageIOFactory();
@@ -75,7 +75,7 @@ protected:
 
 // Define how to print enumeration
 extern ITKIOImageBase_EXPORT std::ostream &
-                             operator<<(std::ostream & out, const ImageIOFactory::FileModeType value);
+                             operator<<(std::ostream & out, const ImageIOFactory::FileModeEnum value);
 
 } // end namespace itk
 

--- a/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
@@ -30,7 +30,7 @@ std::mutex createImageIOLock;
 }
 
 ImageIOBase::Pointer
-ImageIOFactory::CreateImageIO(const char * path, FileModeType mode)
+ImageIOFactory::CreateImageIO(const char * path, FileModeEnum mode)
 {
   std::list<ImageIOBase::Pointer> possibleImageIO;
 
@@ -50,14 +50,14 @@ ImageIOFactory::CreateImageIO(const char * path, FileModeType mode)
   }
   for (auto & k : possibleImageIO)
   {
-    if (mode == FileModeType::ReadMode)
+    if (mode == FileModeEnum::ReadMode)
     {
       if (k->CanReadFile(path))
       {
         return k;
       }
     }
-    else if (mode == FileModeType::WriteMode)
+    else if (mode == FileModeEnum::WriteMode)
     {
       if (k->CanWriteFile(path))
       {
@@ -70,17 +70,17 @@ ImageIOFactory::CreateImageIO(const char * path, FileModeType mode)
 
 /** Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const ImageIOFactory::FileModeType value)
+operator<<(std::ostream & out, const ImageIOFactory::FileModeEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case ImageIOFactory::FileModeType::ReadMode:
-        return "ImageIOFactory::FileModeType::ReadMode";
-      case ImageIOFactory::FileModeType::WriteMode:
-        return "ImageIOFactory::FileModeType::WriteMode";
+      case ImageIOFactory::FileModeEnum::ReadMode:
+        return "ImageIOFactory::FileModeEnum::ReadMode";
+      case ImageIOFactory::FileModeEnum::WriteMode:
+        return "ImageIOFactory::FileModeEnum::WriteMode";
       default:
-        return "INVALID VALUE FOR ImageIOFactory::FileModeType";
+        return "INVALID VALUE FOR ImageIOFactory::FileModeEnum";
     }
   }();
 }

--- a/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
@@ -218,7 +218,7 @@ itkImageIOBaseTest(int, char *[])
       // Create an instance of ImageIOBase. It does not matter that 'test' is not a valid image to read,
       // we just want the ImageIOBase object.
       itk::ImageIOBase::Pointer imageIOBase =
-        itk::ImageIOFactory::CreateImageIO("test", itk::ImageIOFactory::FileModeType::ReadMode);
+        itk::ImageIOFactory::CreateImageIO("test", itk::ImageIOFactory::FileModeEnum::ReadMode);
       for (size_t i = 0; i < listComponentSize; ++i)
       {
         std::string componentTypeString = imageIOBase->GetComponentTypeAsString(listComponentType[i]);

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -775,7 +775,7 @@ itkMINCImageIOTest(int ac, char * av[])
   }
 
   itk::ObjectFactoryBase::RegisterFactory(itk::MINCImageIOFactory::New(),
-                                          itk::ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT);
+                                          itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_FRONT);
 
   int result(0);
   // stright forward test

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -484,7 +484,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Ge
 
   if (m_UserSpecifiedMeshIO == false) // try creating via factory
   {
-    m_MeshIO = MeshIOFactory::CreateMeshIO(m_FileName.c_str(), MeshIOFactory::FileModeType::ReadMode);
+    m_MeshIO = MeshIOFactory::CreateMeshIO(m_FileName.c_str(), MeshIOFactory::FileModeEnum::ReadMode);
   }
 
   if (m_MeshIO.IsNull())

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -91,7 +91,7 @@ MeshFileWriter<TInputMesh>::Write()
     if (m_MeshIO.IsNull())
     {
       itkDebugMacro(<< "Attempting factory creation of MeshIO for file: " << m_FileName);
-      m_MeshIO = MeshIOFactory::CreateMeshIO(m_FileName.c_str(), MeshIOFactory::FileModeType::WriteMode);
+      m_MeshIO = MeshIOFactory::CreateMeshIO(m_FileName.c_str(), MeshIOFactory::FileModeEnum::WriteMode);
       m_FactorySpecifiedMeshIO = true;
     }
     else
@@ -100,7 +100,7 @@ MeshFileWriter<TInputMesh>::Write()
       {
         itkDebugMacro(<< "MeshIO exists but doesn't know how to write file:" << m_FileName);
         itkDebugMacro(<< "Attempting creation of MeshIO with a factory for file:" << m_FileName);
-        m_MeshIO = MeshIOFactory::CreateMeshIO(m_FileName.c_str(), MeshIOFactory::FileModeType::WriteMode);
+        m_MeshIO = MeshIOFactory::CreateMeshIO(m_FileName.c_str(), MeshIOFactory::FileModeEnum::WriteMode);
         m_FactorySpecifiedMeshIO = true;
       }
     }

--- a/Modules/IO/MeshBase/include/itkMeshIOFactory.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOFactory.h
@@ -58,11 +58,11 @@ public:
   /** Convenient type alias. */
   using MeshIOBasePointer = ::itk::MeshIOBase::Pointer;
 
-  /** \class FileModeType
+  /** \class FileModeEnum
    *
    * \ingroup ITKIOMeshBase
    * Mode in which the files is intended to be used */
-  enum class FileModeType : uint8_t
+  enum class FileModeEnum : uint8_t
   {
     ReadMode,
     WriteMode
@@ -70,13 +70,13 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr FileModeType ReadMode = FileModeType::ReadMode;
-  static constexpr FileModeType WriteMode = FileModeType::WriteMode;
+  static constexpr FileModeEnum ReadMode = FileModeEnum::ReadMode;
+  static constexpr FileModeEnum WriteMode = FileModeEnum::WriteMode;
 #endif
 
   /** Create the appropriate MeshIO depending on the particulars of the file. */
   static MeshIOBasePointer
-  CreateMeshIO(const char * path, FileModeType mode);
+  CreateMeshIO(const char * path, FileModeEnum mode);
 
 protected:
   MeshIOFactory();
@@ -85,7 +85,7 @@ protected:
 
 // Define how to print enumeration
 extern ITKIOMeshBase_EXPORT std::ostream &
-                            operator<<(std::ostream & out, const MeshIOFactory::FileModeType value);
+                            operator<<(std::ostream & out, const MeshIOFactory::FileModeEnum value);
 
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
@@ -27,7 +27,7 @@ MeshIOFactory ::~MeshIOFactory() = default;
 
 
 MeshIOBase::Pointer
-MeshIOFactory ::CreateMeshIO(const char * path, FileModeType mode)
+MeshIOFactory ::CreateMeshIO(const char * path, FileModeEnum mode)
 {
   std::list<MeshIOBase::Pointer> possibleMeshIO;
 
@@ -47,14 +47,14 @@ MeshIOFactory ::CreateMeshIO(const char * path, FileModeType mode)
 
   for (auto & k : possibleMeshIO)
   {
-    if (mode == FileModeType::ReadMode)
+    if (mode == FileModeEnum::ReadMode)
     {
       if (k->CanReadFile(path))
       {
         return k;
       }
     }
-    else if (mode == FileModeType::WriteMode)
+    else if (mode == FileModeEnum::WriteMode)
     {
       if (k->CanWriteFile(path))
       {
@@ -68,17 +68,17 @@ MeshIOFactory ::CreateMeshIO(const char * path, FileModeType mode)
 
 /**Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const MeshIOFactory::FileModeType value)
+operator<<(std::ostream & out, const MeshIOFactory::FileModeEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case MeshIOFactory::FileModeType::ReadMode:
-        return "MeshIOFactory::FileModeType::ReadMode";
-      case MeshIOFactory::FileModeType::WriteMode:
-        return "MeshIOFactory::FileModeType::WriteMode";
+      case MeshIOFactory::FileModeEnum::ReadMode:
+        return "MeshIOFactory::FileModeEnum::ReadMode";
+      case MeshIOFactory::FileModeEnum::WriteMode:
+        return "MeshIOFactory::FileModeEnum::WriteMode";
       default:
-        return "INVALID VALUE FOR MeshIOFactory::FileModeType";
+        return "INVALID VALUE FOR MeshIOFactory::FileModeEnum";
     }
   }();
 }

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -108,10 +108,10 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     p.SetGreen(i + 1);
     p.SetBlue(i + 2);
     p.SetAlpha(i + 3);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::FA, i);
-    p.SetField(itk::DTITubeSpatialObjectPointFieldEnumType::FA, i + 1);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::ADC, 2 * i);
-    p.AddField(itk::DTITubeSpatialObjectPointFieldEnumType::GA, 3 * i);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::FA, i);
+    p.SetField(itk::DTITubeSpatialObjectPointFieldEnum::FA, i + 1);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::ADC, 2 * i);
+    p.AddField(itk::DTITubeSpatialObjectPointFieldEnum::GA, 3 * i);
     p.AddField("Lambda1", 4 * i);
     p.AddField("Lambda2", 5 * i);
     p.AddField("Lambda3", 6 * i);
@@ -480,7 +480,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
         // Testing the color of the tube points
         if (itk::Math::NotExactlyEquals((*j).GetRed(), value))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnumType::Red : found " << (*j).GetRed() << " instead of " << value
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*j).GetRed() << " instead of " << value
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -488,7 +488,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
         if (itk::Math::NotExactlyEquals((*j).GetGreen(), value + 1))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnumType::Green : found " << (*j).GetGreen() << " instead of "
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*j).GetGreen() << " instead of "
                     << value + 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -496,7 +496,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
         if (itk::Math::NotExactlyEquals((*j).GetBlue(), value + 2))
         {
-          std::cout << "[FAILED] : RGBColormapFilterEnumType::Blue : found " << (*j).GetBlue() << " instead of "
+          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << (*j).GetBlue() << " instead of "
                     << value + 2 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -554,15 +554,15 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
         // Testing the color of the tube points
         if (itk::Math::NotExactlyEquals((*jv).GetRed(), value))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnumType::Red : found " << (*jv).GetRed() << " instead of "
-                    << value << std::endl;
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*jv).GetRed() << " instead of " << value
+                    << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
         if (itk::Math::NotExactlyEquals((*jv).GetGreen(), value + 1))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnumType::Green : found " << (*jv).GetGreen() << " instead of "
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*jv).GetGreen() << " instead of "
                     << value + 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -570,7 +570,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
         if (itk::Math::NotExactlyEquals((*jv).GetBlue(), value + 2))
         {
-          std::cout << "[FAILED] : RGBColormapFilterEnumType::Blue : found " << (*jv).GetBlue() << " instead of "
+          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << (*jv).GetBlue() << " instead of "
                     << value + 2 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -667,15 +667,15 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
         // Testing the color of the tube points
         if (itk::Math::NotExactlyEquals((*jdti).GetRed(), value))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnumType::Red : found " << (*jdti).GetRed() << " instead of "
-                    << value << std::endl;
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*jdti).GetRed() << " instead of " << value
+                    << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
 
         if (itk::Math::NotExactlyEquals((*jdti).GetGreen(), value + 1))
         {
-          std::cout << " [FAILED] : RGBColormapFilterEnumType::Green : found " << (*jdti).GetGreen() << " instead of "
+          std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*jdti).GetGreen() << " instead of "
                     << value + 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -683,7 +683,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
         if (itk::Math::NotExactlyEquals((*jdti).GetBlue(), value + 2))
         {
-          std::cout << "[FAILED] : RGBColormapFilterEnumType::Blue : found " << (*jdti).GetBlue() << " instead of "
+          std::cout << "[FAILED] : RGBColormapFilterEnum::Blue : found " << (*jdti).GetBlue() << " instead of "
                     << value + 2 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
@@ -696,20 +696,20 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
           return EXIT_FAILURE;
         }
 
-        if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::FA), value + 1))
+        if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnum::FA), value + 1))
         {
           std::cout << " [FAILED] : FA : found " << (*jdti).GetField("FA") << " instead of " << value + 1 << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::ADC), value * 2))
+        if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnum::ADC), value * 2))
         {
           std::cout << " [FAILED] : ADC : found " << (*jdti).GetField("ADC") << " instead of " << value * 2
                     << std::endl;
           delete mySceneChildren;
           return EXIT_FAILURE;
         }
-        if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnumType::GA), value * 3))
+        if (itk::Math::NotExactlyEquals((*jdti).GetField(itk::DTITubeSpatialObjectPointFieldEnum::GA), value * 3))
         {
           std::cout << " [FAILED] : GA : found " << (*jdti).GetField("FA") << " instead of " << value * 3 << std::endl;
           delete mySceneChildren;
@@ -878,15 +878,15 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
           // Testing the color of the tube points
           if (itk::Math::NotExactlyEquals((*pit).GetRed(), value))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Red : found " << (*pit).GetRed() << " instead of "
-                      << value << std::endl;
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*pit).GetRed() << " instead of " << value
+                      << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
           if (itk::Math::NotExactlyEquals((*pit).GetGreen(), value + 1))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Green : found " << (*pit).GetGreen() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*pit).GetGreen() << " instead of "
                       << value + 1 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
@@ -894,7 +894,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
           if (itk::Math::NotExactlyEquals((*pit).GetBlue(), value + 2))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Blue : found " << (*pit).GetBlue() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << (*pit).GetBlue() << " instead of "
                       << value + 2 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
@@ -948,15 +948,15 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
           // Testing the color of the tube points
           if (itk::Math::NotExactlyEquals((*pit).GetRed(), value))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Red : found " << (*pit).GetRed() << " instead of "
-                      << value << std::endl;
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*pit).GetRed() << " instead of " << value
+                      << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
           if (itk::Math::NotExactlyEquals((*pit).GetGreen(), value + 1))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Green : found " << (*pit).GetGreen() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*pit).GetGreen() << " instead of "
                       << value + 1 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
@@ -964,7 +964,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
           if (itk::Math::NotExactlyEquals((*pit).GetBlue(), value + 2))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Blue : found " << (*pit).GetBlue() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << (*pit).GetBlue() << " instead of "
                       << value + 2 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
@@ -1022,15 +1022,15 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
           // Testing the color of the tube points
           if (itk::Math::NotExactlyEquals((*pit).GetRed(), value))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Red : found " << (*pit).GetRed() << " instead of "
-                      << value << std::endl;
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Red : found " << (*pit).GetRed() << " instead of " << value
+                      << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
           }
 
           if (itk::Math::NotExactlyEquals((*pit).GetGreen(), value + 1))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Green : found " << (*pit).GetGreen() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Green : found " << (*pit).GetGreen() << " instead of "
                       << value + 1 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;
@@ -1038,7 +1038,7 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
           if (itk::Math::NotExactlyEquals((*pit).GetBlue(), value + 2))
           {
-            std::cout << " [FAILED] : RGBColormapFilterEnumType::Blue : found " << (*pit).GetBlue() << " instead of "
+            std::cout << " [FAILED] : RGBColormapFilterEnum::Blue : found " << (*pit).GetBlue() << " instead of "
                       << value + 2 << std::endl;
             delete mySceneChildren;
             return EXIT_FAILURE;

--- a/Modules/IO/TransformBase/include/itkTransformIOFactory.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOFactory.h
@@ -25,10 +25,10 @@
 namespace itk
 {
 
-/** \class TransformIOFactorFileModeType
+/** \class TransformIOFactorFileModeEnum
  * \ingroup ITKIOTransformBase
  * Mode in which the files is intended to be used */
-enum class TransformIOFactoryFileModeType : uint8_t
+enum class TransformIOFactoryFileModeEnum : uint8_t
 {
   ReadMode,
   WriteMode
@@ -36,13 +36,13 @@ enum class TransformIOFactoryFileModeType : uint8_t
 #if !defined(ITK_LEGACY_REMOVE)
 // We need to expose the enum values at the class level
 // for backwards compatibility
-static constexpr TransformIOFactoryFileModeType ReadMode = TransformIOFactoryFileModeType::ReadMode;
-static constexpr TransformIOFactoryFileModeType WriteMode = TransformIOFactoryFileModeType::WriteMode;
+static constexpr TransformIOFactoryFileModeEnum ReadMode = TransformIOFactoryFileModeEnum::ReadMode;
+static constexpr TransformIOFactoryFileModeEnum WriteMode = TransformIOFactoryFileModeEnum::WriteMode;
 #endif
 
 // Define how to print enumeration
 extern ITKIOTransformBase_EXPORT std::ostream &
-                                 operator<<(std::ostream & out, const TransformIOFactoryFileModeType value);
+                                 operator<<(std::ostream & out, const TransformIOFactoryFileModeEnum value);
 
 /** \class TransformIOFactoryTemplate
  * \brief Create instances of TransformIO objects using an object factory.
@@ -72,7 +72,7 @@ public:
    *  the particulars of the file.
    */
   static TransformIOBasePointer
-  CreateTransformIO(const char * path, TransformIOFactoryFileModeType mode);
+  CreateTransformIO(const char * path, TransformIOFactoryFileModeEnum mode);
 
 protected:
   TransformIOFactoryTemplate();

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -94,7 +94,7 @@ TransformFileReaderTemplate<TParametersValueType>::Update()
     using TransformFactoryIOType = TransformIOFactoryTemplate<TParametersValueType>;
     m_TransformIO = TransformFactoryIOType::CreateTransformIO(
       m_FileName.c_str(),
-      /*TransformIOFactoryTemplate<TParametersValueType>::*/ TransformIOFactoryFileModeType::ReadMode);
+      /*TransformIOFactoryTemplate<TParametersValueType>::*/ TransformIOFactoryFileModeEnum::ReadMode);
     if (m_TransformIO.IsNull())
     {
       std::ostringstream msg;

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -132,7 +132,7 @@ TransformFileWriterTemplate<TParametersValueType>::Update()
   {
     using TransformFactoryIOType = TransformIOFactoryTemplate<TParametersValueType>;
     m_TransformIO =
-      TransformFactoryIOType::CreateTransformIO(m_FileName.c_str(), TransformIOFactoryFileModeType::WriteMode);
+      TransformFactoryIOType::CreateTransformIO(m_FileName.c_str(), TransformIOFactoryFileModeEnum::WriteMode);
 
     if (m_TransformIO.IsNull())
     {

--- a/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
@@ -30,7 +30,7 @@ TransformIOFactoryTemplate<TParametersValueType>::~TransformIOFactoryTemplate() 
 template <typename TParametersValueType>
 typename TransformIOBaseTemplate<TParametersValueType>::Pointer
 TransformIOFactoryTemplate<TParametersValueType>::CreateTransformIO(const char *                   path,
-                                                                    TransformIOFactoryFileModeType mode)
+                                                                    TransformIOFactoryFileModeEnum mode)
 {
   typename std::list<typename TransformIOBaseTemplate<TParametersValueType>::Pointer> possibleTransformIO;
   for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkTransformIOBaseTemplate"))
@@ -43,14 +43,14 @@ TransformIOFactoryTemplate<TParametersValueType>::CreateTransformIO(const char *
   }
   for (auto k = possibleTransformIO.begin(); k != possibleTransformIO.end(); ++k)
   {
-    if (mode == TransformIOFactoryFileModeType::ReadMode)
+    if (mode == TransformIOFactoryFileModeEnum::ReadMode)
     {
       if ((*k)->CanReadFile(path))
       {
         return *k;
       }
     }
-    else if (mode == TransformIOFactoryFileModeType::WriteMode)
+    else if (mode == TransformIOFactoryFileModeEnum::WriteMode)
     {
       if ((*k)->CanWriteFile(path))
       {
@@ -63,17 +63,17 @@ TransformIOFactoryTemplate<TParametersValueType>::CreateTransformIO(const char *
 
 /** Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const TransformIOFactoryFileModeType value)
+operator<<(std::ostream & out, const TransformIOFactoryFileModeEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case TransformIOFactoryFileModeType::ReadMode:
-        return "TransformIOFactoryFileModeType::ReadMode";
-      case TransformIOFactoryFileModeType::WriteMode:
-        return "TransformIOFactoryFileModeType::WriteMode";
+      case TransformIOFactoryFileModeEnum::ReadMode:
+        return "TransformIOFactoryFileModeEnum::ReadMode";
+      case TransformIOFactoryFileModeEnum::WriteMode:
+        return "TransformIOFactoryFileModeEnum::WriteMode";
       default:
-        return "INVALID VALUE FOR TransformIOFactoryFileModeType";
+        return "INVALID VALUE FOR TransformIOFactoryFileModeEnum";
     }
   }();
 }

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -729,7 +729,7 @@ int
 itkIOTransformMINCTest(int argc, char * argv[])
 {
   itk::ObjectFactoryBase::RegisterFactory(itk::MINCImageIOFactory::New(),
-                                          itk::ObjectFactoryBase::InsertionPositionType::INSERT_AT_FRONT);
+                                          itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_FRONT);
 
   if (argc > 1)
   {

--- a/Modules/IO/XML/include/itkDOMReader.hxx
+++ b/Modules/IO/XML/include/itkDOMReader.hxx
@@ -38,9 +38,9 @@ DOMReader<TOutput>::DOMReader()
   this->m_Logger->AddLogOutput(defout);
   // settings that may be important
   this->m_Logger->SetName(this->GetNameOfClass());
-  this->m_Logger->SetPriorityLevel(Logger::PriorityLevelType::NOTSET); // log everything
+  this->m_Logger->SetPriorityLevel(Logger::PriorityLevelEnum::NOTSET); // log everything
   this->m_Logger->SetLevelForFlushing(
-    Logger::PriorityLevelType::MUSTFLUSH); // never flush (MUSTFLUSH actually leads to no flush, a bug in Logger)
+    Logger::PriorityLevelEnum::MUSTFLUSH); // never flush (MUSTFLUSH actually leads to no flush, a bug in Logger)
   // some other settings
   this->m_Logger->SetTimeStampFormat(Logger::HUMANREADABLE);
   this->m_Logger->SetHumanReadableFormat("%Y-%b-%d %H:%M:%S"); // time stamp format

--- a/Modules/IO/XML/include/itkDOMWriter.hxx
+++ b/Modules/IO/XML/include/itkDOMWriter.hxx
@@ -39,9 +39,9 @@ DOMWriter<TInput>::DOMWriter()
   this->m_Logger->AddLogOutput(defout);
   // settings that may be important
   this->m_Logger->SetName(this->GetNameOfClass());
-  this->m_Logger->SetPriorityLevel(Logger::PriorityLevelType::NOTSET); // log everything
+  this->m_Logger->SetPriorityLevel(Logger::PriorityLevelEnum::NOTSET); // log everything
   this->m_Logger->SetLevelForFlushing(
-    Logger::PriorityLevelType::MUSTFLUSH); // never flush (MUSTFLUSH actually leads to no flush, a bug in Logger)
+    Logger::PriorityLevelEnum::MUSTFLUSH); // never flush (MUSTFLUSH actually leads to no flush, a bug in Logger)
   // some other settings
   this->m_Logger->SetTimeStampFormat(Logger::HUMANREADABLE);
   this->m_Logger->SetHumanReadableFormat("%Y-%b-%d %H:%M:%S"); // time stamp format

--- a/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
@@ -63,7 +63,7 @@ itkLabelGeometryImageFilterTest(int argc, char * argv[])
   // Determine the dimension of the image and template the filter over
   // this dimension.
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(intensityImageName.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(intensityImageName.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
   imageIO->SetFileName(intensityImageName);
   imageIO->ReadImageInformation();
   const size_t ImageDimension = imageIO->GetNumberOfDimensions();

--- a/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
@@ -66,11 +66,11 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(GradientDescentOptimizer, SingleValuedNonLinearOptimizer);
 
-  /** \class StopConditionType
+  /** \class StopConditionEnum
    *
    * \ingroup ITKOptimizers
    * Codes of stopping conditions */
-  enum class StopConditionType : uint8_t
+  enum class StopConditionEnum : uint8_t
   {
     MaximumNumberOfIterations,
     MetricError
@@ -78,8 +78,8 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr StopConditionType MaximumNumberOfIterations = StopConditionType::MaximumNumberOfIterations;
-  static constexpr StopConditionType MetricError = StopConditionType::MetricError;
+  static constexpr StopConditionEnum MaximumNumberOfIterations = StopConditionEnum::MaximumNumberOfIterations;
+  static constexpr StopConditionEnum MetricError = StopConditionEnum::MetricError;
 #endif
 
   /** Methods to configure the cost function. */
@@ -144,7 +144,7 @@ public:
   itkGetConstReferenceMacro(Value, double);
 
   /** Get Stop condition. */
-  itkGetConstReferenceMacro(StopCondition, StopConditionType);
+  itkGetConstReferenceMacro(StopCondition, StopConditionEnum);
   const std::string
   GetStopConditionDescription() const override;
 
@@ -167,7 +167,7 @@ protected:
 private:
   bool               m_Stop{ false };
   double             m_Value{ 0.0 };
-  StopConditionType  m_StopCondition{ StopConditionType::MaximumNumberOfIterations };
+  StopConditionEnum  m_StopCondition{ StopConditionEnum::MaximumNumberOfIterations };
   SizeValueType      m_NumberOfIterations{ 100 };
   SizeValueType      m_CurrentIteration{ 0 };
   std::ostringstream m_StopConditionDescription;
@@ -175,7 +175,7 @@ private:
 
 // Define how to print enumeration
 extern ITKOptimizers_EXPORT std::ostream &
-                            operator<<(std::ostream & out, const GradientDescentOptimizer::StopConditionType value);
+                            operator<<(std::ostream & out, const GradientDescentOptimizer::StopConditionEnum value);
 
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
@@ -47,11 +47,11 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(RegularStepGradientDescentBaseOptimizer, SingleValuedNonLinearOptimizer);
 
-  /** \class StopConditionType
+  /** \class StopConditionEnum
    *
    * \ingroup ITKOptimizers
    * Codes of stopping conditions. */
-  enum class StopConditionType : uint8_t
+  enum class StopConditionEnum : uint8_t
   {
     GradientMagnitudeTolerance = 1,
     StepTooSmall = 2,
@@ -63,12 +63,12 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr StopConditionType GradientMagnitudeTolerance = StopConditionType::GradientMagnitudeTolerance;
-  static constexpr StopConditionType StepTooSmall = StopConditionType::StepTooSmall;
-  static constexpr StopConditionType ImageNotAvailable = StopConditionType::ImageNotAvailable;
-  static constexpr StopConditionType CostFunctionError = StopConditionType::CostFunctionError;
-  static constexpr StopConditionType MaximumNumberOfIterations = StopConditionType::MaximumNumberOfIterations;
-  static constexpr StopConditionType Unknown = StopConditionType::Unknown;
+  static constexpr StopConditionEnum GradientMagnitudeTolerance = StopConditionEnum::GradientMagnitudeTolerance;
+  static constexpr StopConditionEnum StepTooSmall = StopConditionEnum::StepTooSmall;
+  static constexpr StopConditionEnum ImageNotAvailable = StopConditionEnum::ImageNotAvailable;
+  static constexpr StopConditionEnum CostFunctionError = StopConditionEnum::CostFunctionError;
+  static constexpr StopConditionEnum MaximumNumberOfIterations = StopConditionEnum::MaximumNumberOfIterations;
+  static constexpr StopConditionEnum Unknown = StopConditionEnum::Unknown;
 #endif
   /** Specify whether to minimize or maximize the cost function. */
   itkSetMacro(Maximize, bool);
@@ -122,7 +122,7 @@ public:
   itkGetConstReferenceMacro(NumberOfIterations, SizeValueType);
   itkGetConstReferenceMacro(GradientMagnitudeTolerance, double);
   itkGetConstMacro(CurrentIteration, unsigned int);
-  itkGetConstReferenceMacro(StopCondition, StopConditionType);
+  itkGetConstReferenceMacro(StopCondition, StopConditionEnum);
   itkGetConstReferenceMacro(Value, MeasureType);
   itkGetConstReferenceMacro(Gradient, DerivativeType);
 
@@ -170,7 +170,7 @@ protected:
   double             m_MinimumStepLength;
   double             m_CurrentStepLength;
   double             m_RelaxationFactor;
-  StopConditionType  m_StopCondition;
+  StopConditionEnum  m_StopCondition;
   SizeValueType      m_NumberOfIterations;
   SizeValueType      m_CurrentIteration;
   std::ostringstream m_StopConditionDescription;
@@ -178,7 +178,7 @@ protected:
 
 // Define how to print enumeration
 extern ITKOptimizers_EXPORT std::ostream &
-                            operator<<(std::ostream & out, const RegularStepGradientDescentBaseOptimizer::StopConditionType value);
+                            operator<<(std::ostream & out, const RegularStepGradientDescentBaseOptimizer::StopConditionEnum value);
 
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -58,11 +58,11 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(SPSAOptimizer, SingleValuedNonLinearOptimizer);
 
-  /** \class StopConditionType
+  /** \class StopConditionEnum
    *
    * \ingroup ITKOptimizers
    * Codes of stopping conditions */
-  enum class StopConditionType : uint8_t
+  enum class StopConditionEnum : uint8_t
   {
     Unknown,
     MaximumNumberOfIterations,
@@ -72,10 +72,10 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr StopConditionType Unknown = StopConditionType::Unknown;
-  static constexpr StopConditionType MaximumNumberOfIterations = StopConditionType::MaximumNumberOfIterations;
-  static constexpr StopConditionType BelowTolerance = StopConditionType::BelowTolerance;
-  static constexpr StopConditionType MetricError = StopConditionType::MetricError;
+  static constexpr StopConditionEnum Unknown = StopConditionEnum::Unknown;
+  static constexpr StopConditionEnum MaximumNumberOfIterations = StopConditionEnum::MaximumNumberOfIterations;
+  static constexpr StopConditionEnum BelowTolerance = StopConditionEnum::BelowTolerance;
+  static constexpr StopConditionEnum MetricError = StopConditionEnum::MetricError;
 #endif
   /** Advance one step following the gradient direction. */
   virtual void
@@ -123,7 +123,7 @@ public:
   itkGetConstMacro(CurrentIteration, SizeValueType);
 
   /** Get Stop condition. */
-  itkGetConstMacro(StopCondition, StopConditionType);
+  itkGetConstMacro(StopCondition, StopConditionEnum);
 
   /** Get the current LearningRate (a_k) */
   itkGetConstMacro(LearningRate, double);
@@ -259,7 +259,7 @@ protected:
 
   bool m_Stop{ false };
 
-  StopConditionType m_StopCondition;
+  StopConditionEnum m_StopCondition;
 
   double m_StateOfConvergence;
 
@@ -310,7 +310,7 @@ private:
 
 // Define how to print enumeration
 extern ITKOptimizers_EXPORT std::ostream &
-                            operator<<(std::ostream & out, const SPSAOptimizer::StopConditionType value);
+                            operator<<(std::ostream & out, const SPSAOptimizer::StopConditionEnum value);
 
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -96,7 +96,7 @@ GradientDescentOptimizer ::ResumeOptimization()
     {
       // An exception has occurred.
       // Terminate immediately.
-      m_StopCondition = StopConditionType::MetricError;
+      m_StopCondition = StopConditionEnum::MetricError;
       m_StopConditionDescription << "Metric error";
       StopOptimization();
 
@@ -117,7 +117,7 @@ GradientDescentOptimizer ::ResumeOptimization()
     if (m_CurrentIteration >= m_NumberOfIterations)
     {
       m_StopConditionDescription << "Maximum number of iterations (" << m_NumberOfIterations << ") exceeded.";
-      m_StopCondition = StopConditionType::MaximumNumberOfIterations;
+      m_StopCondition = StopConditionEnum::MaximumNumberOfIterations;
       StopOptimization();
       break;
     }
@@ -187,17 +187,17 @@ GradientDescentOptimizer ::AdvanceOneStep()
 
 /** Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const GradientDescentOptimizer::StopConditionType value)
+operator<<(std::ostream & out, const GradientDescentOptimizer::StopConditionEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case GradientDescentOptimizer::StopConditionType::MaximumNumberOfIterations:
-        return "GradientDescentOptimizer::StopConditionType::MaximumNumberOfIterations";
-      case GradientDescentOptimizer::StopConditionType::MetricError:
-        return "GradientDescentOptimizer::StopConditionType::MetricError";
+      case GradientDescentOptimizer::StopConditionEnum::MaximumNumberOfIterations:
+        return "GradientDescentOptimizer::StopConditionEnum::MaximumNumberOfIterations";
+      case GradientDescentOptimizer::StopConditionEnum::MetricError:
+        return "GradientDescentOptimizer::StopConditionEnum::MetricError";
       default:
-        return "INVALID VALUE FOR GradientDescentOptimizer::StopConditionType";
+        return "INVALID VALUE FOR GradientDescentOptimizer::StopConditionEnum";
     }
   }();
 }

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -39,7 +39,7 @@ RegularStepGradientDescentBaseOptimizer ::RegularStepGradientDescentBaseOptimize
   m_Maximize = false;
   m_CostFunction = nullptr;
   m_CurrentStepLength = 0;
-  m_StopCondition = StopConditionType::Unknown;
+  m_StopCondition = StopConditionEnum::Unknown;
   m_Gradient.Fill(0.0f);
   m_PreviousGradient.Fill(0.0f);
   m_RelaxationFactor = 0.5;
@@ -57,7 +57,7 @@ RegularStepGradientDescentBaseOptimizer ::StartOptimization()
   m_CurrentStepLength = m_MaximumStepLength;
   m_CurrentIteration = 0;
 
-  m_StopCondition = StopConditionType::Unknown;
+  m_StopCondition = StopConditionEnum::Unknown;
   m_StopConditionDescription.str("");
   m_StopConditionDescription << this->GetNameOfClass() << ": ";
 
@@ -96,7 +96,7 @@ RegularStepGradientDescentBaseOptimizer ::ResumeOptimization()
   {
     if (m_CurrentIteration >= m_NumberOfIterations)
     {
-      m_StopCondition = StopConditionType::MaximumNumberOfIterations;
+      m_StopCondition = StopConditionEnum::MaximumNumberOfIterations;
       m_StopConditionDescription << "Maximum number of iterations (" << m_NumberOfIterations << ") exceeded.";
       this->StopOptimization();
       break;
@@ -110,7 +110,7 @@ RegularStepGradientDescentBaseOptimizer ::ResumeOptimization()
     }
     catch (ExceptionObject & excp)
     {
-      m_StopCondition = StopConditionType::CostFunctionError;
+      m_StopCondition = StopConditionEnum::CostFunctionError;
       m_StopConditionDescription << "Cost function error after " << m_CurrentIteration << " iterations. "
                                  << excp.GetDescription();
       this->StopOptimization();
@@ -188,7 +188,7 @@ RegularStepGradientDescentBaseOptimizer ::AdvanceOneStep()
 
   if (gradientMagnitude < m_GradientMagnitudeTolerance)
   {
-    m_StopCondition = StopConditionType::GradientMagnitudeTolerance;
+    m_StopCondition = StopConditionEnum::GradientMagnitudeTolerance;
     m_StopConditionDescription << "Gradient magnitude tolerance met after " << m_CurrentIteration
                                << " iterations. Gradient magnitude (" << gradientMagnitude
                                << ") is less than gradient magnitude tolerance (" << m_GradientMagnitudeTolerance
@@ -214,7 +214,7 @@ RegularStepGradientDescentBaseOptimizer ::AdvanceOneStep()
 
   if (m_CurrentStepLength < m_MinimumStepLength)
   {
-    m_StopCondition = StopConditionType::StepTooSmall;
+    m_StopCondition = StopConditionEnum::StepTooSmall;
     m_StopConditionDescription << "Step too small after " << m_CurrentIteration << " iterations. Current step ("
                                << m_CurrentStepLength << ") is less than minimum step (" << m_MinimumStepLength << ").";
     this->StopOptimization();
@@ -274,23 +274,23 @@ RegularStepGradientDescentBaseOptimizer ::PrintSelf(std::ostream & os, Indent in
 
 /**Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const RegularStepGradientDescentBaseOptimizer::StopConditionType value)
+operator<<(std::ostream & out, const RegularStepGradientDescentBaseOptimizer::StopConditionEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case RegularStepGradientDescentBaseOptimizer::StopConditionType::GradientMagnitudeTolerance:
-        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::GradientMagnitudeTolerance";
-      case RegularStepGradientDescentBaseOptimizer::StopConditionType::StepTooSmall:
-        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::StepTooSmall";
-      case RegularStepGradientDescentBaseOptimizer::StopConditionType::ImageNotAvailable:
-        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::ImageNotAvailable";
-      case RegularStepGradientDescentBaseOptimizer::StopConditionType::CostFunctionError:
-        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::CostFunctionError";
-      case RegularStepGradientDescentBaseOptimizer::StopConditionType::MaximumNumberOfIterations:
-        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::MaximumNumberOfIterations";
-      case RegularStepGradientDescentBaseOptimizer::StopConditionType::Unknown:
-        return "RegularStepGradientDescentBaseOptimizer::StopConditionType::Unknown";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionEnum::GradientMagnitudeTolerance:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionEnum::GradientMagnitudeTolerance";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionEnum::StepTooSmall:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionEnum::StepTooSmall";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionEnum::ImageNotAvailable:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionEnum::ImageNotAvailable";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionEnum::CostFunctionError:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionEnum::CostFunctionError";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionEnum::MaximumNumberOfIterations:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionEnum::MaximumNumberOfIterations";
+      case RegularStepGradientDescentBaseOptimizer::StopConditionEnum::Unknown:
+        return "RegularStepGradientDescentBaseOptimizer::StopConditionEnum::Unknown";
       default:
         return "INVALID VALUE FOR ";
     }

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -31,7 +31,7 @@ SPSAOptimizer ::SPSAOptimizer()
 
   m_CurrentIteration = 0;
   m_Maximize = false;
-  m_StopCondition = StopConditionType::Unknown;
+  m_StopCondition = StopConditionEnum::Unknown;
   m_StateOfConvergenceDecayRate = 0.9;
   m_Tolerance = 1e-06;
   m_StateOfConvergence = 0;
@@ -136,7 +136,7 @@ SPSAOptimizer ::StartOptimization()
   }
 
   m_CurrentIteration = 0;
-  m_StopCondition = StopConditionType::Unknown;
+  m_StopCondition = StopConditionEnum::Unknown;
   m_StateOfConvergence = 0.0;
 
   this->SetCurrentPosition(this->GetInitialPosition());
@@ -169,7 +169,7 @@ SPSAOptimizer ::ResumeOptimization()
 
     if (m_CurrentIteration >= m_MaximumNumberOfIterations)
     {
-      m_StopCondition = StopConditionType::MaximumNumberOfIterations;
+      m_StopCondition = StopConditionEnum::MaximumNumberOfIterations;
       StopOptimization();
       break;
     }
@@ -177,7 +177,7 @@ SPSAOptimizer ::ResumeOptimization()
     /** Check convergence */
     if ((m_StateOfConvergence < m_Tolerance) && (m_CurrentIteration >= m_MinimumNumberOfIterations))
     {
-      m_StopCondition = StopConditionType::BelowTolerance;
+      m_StopCondition = StopConditionEnum::BelowTolerance;
       StopOptimization();
       break;
     }
@@ -234,7 +234,7 @@ SPSAOptimizer ::AdvanceOneStep()
   {
     // An exception has occurred.
     // Terminate immediately.
-    m_StopCondition = StopConditionType::MetricError;
+    m_StopCondition = StopConditionEnum::MetricError;
     StopOptimization();
     // Pass exception to caller
     throw err;
@@ -468,17 +468,17 @@ SPSAOptimizer::GetStopConditionDescription() const
   reason << this->GetNameOfClass() << ": ";
   switch (m_StopCondition)
   {
-    case StopConditionType::Unknown:
+    case StopConditionEnum::Unknown:
       reason << "Unknown stop condition";
       break;
-    case StopConditionType::MaximumNumberOfIterations:
+    case StopConditionEnum::MaximumNumberOfIterations:
       reason << "Maximum number of iterations exceeded. Number of iterations is " << m_MaximumNumberOfIterations;
       break;
-    case StopConditionType::BelowTolerance:
+    case StopConditionEnum::BelowTolerance:
       reason << "Below tolerance. "
              << "Tolerance is " << m_Tolerance;
       break;
-    case StopConditionType::MetricError:
+    case StopConditionEnum::MetricError:
       reason << "Metric error";
       break;
     default:
@@ -490,21 +490,21 @@ SPSAOptimizer::GetStopConditionDescription() const
 
 /** Print enum values */
 std::ostream &
-operator<<(std::ostream & out, const SPSAOptimizer::StopConditionType value)
+operator<<(std::ostream & out, const SPSAOptimizer::StopConditionEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case SPSAOptimizer::StopConditionType::Unknown:
-        return "SPSAOptimizer::StopConditionType::Unknown";
-      case SPSAOptimizer::StopConditionType::MaximumNumberOfIterations:
-        return "SPSAOptimizer::StopConditionType::MaximumNumberOfIterations";
-      case SPSAOptimizer::StopConditionType::BelowTolerance:
-        return "SPSAOptimizer::StopConditionType::BelowTolerance";
-      case SPSAOptimizer::StopConditionType::MetricError:
-        return "SPSAOptimizer::StopConditionType::MetricError";
+      case SPSAOptimizer::StopConditionEnum::Unknown:
+        return "SPSAOptimizer::StopConditionEnum::Unknown";
+      case SPSAOptimizer::StopConditionEnum::MaximumNumberOfIterations:
+        return "SPSAOptimizer::StopConditionEnum::MaximumNumberOfIterations";
+      case SPSAOptimizer::StopConditionEnum::BelowTolerance:
+        return "SPSAOptimizer::StopConditionEnum::BelowTolerance";
+      case SPSAOptimizer::StopConditionEnum::MetricError:
+        return "SPSAOptimizer::StopConditionEnum::MetricError";
       default:
-        return "INVALID VALUE FOR SPSAOptimizer::StopConditionType";
+        return "INVALID VALUE FOR SPSAOptimizer::StopConditionEnum";
     }
   }();
 }

--- a/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
@@ -191,11 +191,11 @@ itkSPSAOptimizerTest(int, char *[])
     if (itk::Math::abs(finalPosition[j] - trueParameters[j]) > 0.01)
       pass = false;
   }
-  if (itkOptimizer->GetStopCondition() == itk::SPSAOptimizer::StopConditionType::Unknown)
+  if (itkOptimizer->GetStopCondition() == itk::SPSAOptimizer::StopConditionEnum::Unknown)
   {
     pass = false;
   }
-  if (itkOptimizer->GetStopCondition() == itk::SPSAOptimizer::StopConditionType::MetricError)
+  if (itkOptimizer->GetStopCondition() == itk::SPSAOptimizer::StopConditionEnum::MetricError)
   {
     pass = false;
   }

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
@@ -61,7 +61,7 @@ public:
     CONVERGENCE_CHECKER_PASSED,
     GRADIENT_MAGNITUDE_TOLEARANCE,
     OTHER_ERROR
-  } StopConditionType;
+  } StopConditionEnum;
 
   /** Stop condition return string type */
   using StopConditionReturnStringType = typename Superclass::StopConditionReturnStringType;
@@ -93,7 +93,7 @@ public:
   itkGetConstReferenceMacro(Gradient, DerivativeType);
 
   /** Get stop condition enum */
-  itkGetConstReferenceMacro(StopCondition, StopConditionType);
+  itkGetConstReferenceMacro(StopCondition, StopConditionEnum);
 
   /** Set the number of iterations. */
   void
@@ -221,7 +221,7 @@ protected:
 
   /* Common variables for optimization control and reporting */
   bool                         m_Stop{ false };
-  StopConditionType            m_StopCondition;
+  StopConditionEnum            m_StopCondition;
   StopConditionDescriptionType m_StopConditionDescription;
 
   /** Current gradient */

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -79,7 +79,7 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
 
   os << indent << "Stop: " << (this->m_Stop ? "On" : "Off") << std::endl;
   os << indent
-     << "StopCondition: " << static_cast<typename NumericTraits<StopConditionType>::PrintType>(this->m_StopCondition)
+     << "StopCondition: " << static_cast<typename NumericTraits<StopConditionEnum>::PrintType>(this->m_StopCondition)
      << std::endl;
   os << indent << "StopConditionDescription: " << this->m_StopConditionDescription.str() << std::endl;
   os << indent << "Gradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(this->m_Gradient)

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
@@ -104,7 +104,7 @@ public:
   using IndexRangeType = typename Superclass::IndexRangeType;
   using ScalesType = typename Superclass::ScalesType;
   using ParametersType = typename Superclass::ParametersType;
-  using StopConditionType = typename Superclass::StopConditionType;
+  using StopConditionEnum = typename Superclass::StopConditionEnum;
 
   /** Set/Get the learning rate to apply. It is overridden by
    *  automatic learning rate estimation if enabled. See main documentation.

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
@@ -70,7 +70,7 @@ public:
   using OptimizersListType = std::vector<LocalOptimizerPointer>;
   using OptimizersListSizeType = typename OptimizersListType::size_type;
 
-  using StopConditionType = typename Superclass::StopConditionType;
+  using StopConditionEnum = typename Superclass::StopConditionEnum;
 
   /** Stop condition return string type */
   using StopConditionReturnStringType = typename Superclass::StopConditionReturnStringType;
@@ -93,7 +93,7 @@ public:
   using MetricValuesListType = std::vector<MeasureType>;
 
   /** Get stop condition enum */
-  const StopConditionType &
+  const StopConditionEnum &
   GetStopCondition() const override
   {
     return this->m_StopCondition;
@@ -139,7 +139,7 @@ protected:
 
   /* Common variables for optimization control and reporting */
   bool                         m_Stop{ false };
-  StopConditionType            m_StopCondition;
+  StopConditionEnum            m_StopCondition;
   StopConditionDescriptionType m_StopConditionDescription;
   OptimizersListType           m_OptimizersList;
   MetricValuesListType         m_MetricValuesList;

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
@@ -23,10 +23,10 @@
 
 namespace itk
 {
-/** \class StopType
+/** \class StopEnum
  *  \ingroup ITKOptimizersv4
  * Codes of stopping conditions. */
-enum class StopType : uint8_t
+enum class StopEnum : uint8_t
 {
   MAXIMUM_NUMBER_OF_ITERATIONS,
   COSTFUNCTION_ERROR,
@@ -78,16 +78,16 @@ public:
   using LocalOptimizerPointer = typename LocalOptimizerType::Pointer;
 
   /** Enables backwards compatibility for enum values */
-  using StopConditionType = StopType;
+  using StopConditionEnum = StopEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr StopConditionType MAXIMUM_NUMBER_OF_ITERATIONS = StopConditionType::MAXIMUM_NUMBER_OF_ITERATIONS;
-  static constexpr StopConditionType COSTFUNCTION_ERROR = StopConditionType::COSTFUNCTION_ERROR;
-  static constexpr StopConditionType UPDATE_PARAMETERS_ERROR = StopConditionType::UPDATE_PARAMETERS_ERROR;
-  static constexpr StopConditionType STEP_TOO_SMALL = StopConditionType::STEP_TOO_SMALL;
-  static constexpr StopConditionType CONVERGENCE_CHECKER_PASSED = StopConditionType::CONVERGENCE_CHECKER_PASSED;
-  static constexpr StopConditionType OTHER_ERROR = StopConditionType::OTHER_ERROR;
+  static constexpr StopConditionEnum MAXIMUM_NUMBER_OF_ITERATIONS = StopConditionEnum::MAXIMUM_NUMBER_OF_ITERATIONS;
+  static constexpr StopConditionEnum COSTFUNCTION_ERROR = StopConditionEnum::COSTFUNCTION_ERROR;
+  static constexpr StopConditionEnum UPDATE_PARAMETERS_ERROR = StopConditionEnum::UPDATE_PARAMETERS_ERROR;
+  static constexpr StopConditionEnum STEP_TOO_SMALL = StopConditionEnum::STEP_TOO_SMALL;
+  static constexpr StopConditionEnum CONVERGENCE_CHECKER_PASSED = StopConditionEnum::CONVERGENCE_CHECKER_PASSED;
+  static constexpr StopConditionEnum OTHER_ERROR = StopConditionEnum::OTHER_ERROR;
 #endif
 
   /** Stop condition return string type */
@@ -112,7 +112,7 @@ public:
   using MetricValuesListType = std::vector<MeasureType>;
 
   /** Get stop condition enum */
-  itkGetConstReferenceMacro(StopCondition, StopConditionType);
+  itkGetConstReferenceMacro(StopCondition, StopConditionEnum);
 
   /** Create an instance of the local optimizer */
   void
@@ -172,7 +172,7 @@ protected:
 
   /* Common variables for optimization control and reporting */
   bool                         m_Stop{ false };
-  StopConditionType            m_StopCondition;
+  StopConditionEnum            m_StopCondition;
   StopConditionDescriptionType m_StopConditionDescription;
   ParametersListType           m_ParametersList;
   MetricValuesListType         m_MetricValuesList;
@@ -187,7 +187,7 @@ using MultiStartOptimizerv4 = MultiStartOptimizerv4Template<double>;
 
 /** Define how to print enumerations */
 extern ITKOptimizersv4_EXPORT std::ostream &
-                              operator<<(std::ostream & out, const StopType value);
+                              operator<<(std::ostream & out, const StopEnum value);
 
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -29,7 +29,7 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::MultiStartOptimize
 
 {
   this->m_NumberOfIterations = static_cast<SizeValueType>(0);
-  this->m_StopCondition = StopType::MAXIMUM_NUMBER_OF_ITERATIONS;
+  this->m_StopCondition = StopEnum::MAXIMUM_NUMBER_OF_ITERATIONS;
   this->m_StopConditionDescription << this->GetNameOfClass() << ": ";
 
   this->m_BestParametersIndex = static_cast<ParameterListSizeType>(0);
@@ -207,7 +207,7 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::ResumeOptimization
     {
       this->m_StopConditionDescription << "Maximum number of iterations (" << this->m_NumberOfIterations
                                        << ") exceeded.";
-      this->m_StopCondition = StopType::MAXIMUM_NUMBER_OF_ITERATIONS;
+      this->m_StopCondition = StopEnum::MAXIMUM_NUMBER_OF_ITERATIONS;
       this->StopOptimization();
       break;
     }

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -205,7 +205,7 @@ bool
 ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParametersValueType>::HasLocalSupport() const
 {
   return (this->m_MovingTransform->GetTransformCategory() ==
-          MovingTransformType::TransformCategoryType::DisplacementField);
+          MovingTransformType::TransformCategoryEnum::DisplacementField);
 }
 
 template <unsigned int TFixedDimension,

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
@@ -24,22 +24,22 @@
 
 namespace itk
 {
-/** \class SourceTypeOfGradient
+/** \class GradientSourceEnum
  * \ingroup ITKOptimizersv4
  * Source of the gradient(s) used by the metric
  * (e.g. image gradients, in the case of
  * image to image metrics). Defaults to Moving. */
-enum class SourceTypeOfGradient : uint8_t
+enum class GradientSourceEnum : uint8_t
 {
   GRADIENT_SOURCE_FIXED = 0,
   GRADIENT_SOURCE_MOVING,
   GRADIENT_SOURCE_BOTH
 };
 
-/** \class CategoryTypeForMetric
+/** \class MetricCategoryEnum
  * \ingroup ITKOptimizersv4
  */
-enum class CategoryTypeForMetric : uint8_t
+enum class MetricCategoryEnum : uint8_t
 {
   UNKNOWN_METRIC = 0,
   OBJECT_METRIC = 1,
@@ -113,7 +113,7 @@ public:
   itkGetConstObjectMacro(MovingObject, ObjectType);
 
   /** Enables backwards compatibility for enum values */
-  using GradientSourceType = SourceTypeOfGradient;
+  using GradientSourceType = GradientSourceEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -251,9 +251,9 @@ using ObjectToObjectMetricBase = ObjectToObjectMetricBaseTemplate<double>;
 
 /** Define how to print enumerations */
 extern ITKOptimizersv4_EXPORT std::ostream &
-                              operator<<(std::ostream & out, const SourceTypeOfGradient value);
+                              operator<<(std::ostream & out, const GradientSourceEnum value);
 extern ITKOptimizersv4_EXPORT std::ostream &
-                              operator<<(std::ostream & out, const CategoryTypeForMetric value);
+                              operator<<(std::ostream & out, const MetricCategoryEnum value);
 
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
@@ -28,7 +28,7 @@ template <typename TInternalComputationValueType>
 ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::ObjectToObjectMetricBaseTemplate()
 {
   // Don't call SetGradientSource, to avoid valgrind warning.
-  this->m_GradientSource = SourceTypeOfGradient::GRADIENT_SOURCE_MOVING;
+  this->m_GradientSource = GradientSourceEnum::GRADIENT_SOURCE_MOVING;
   this->m_Value = NumericTraits<MeasureType>::ZeroValue();
 }
 
@@ -37,8 +37,8 @@ template <typename TInternalComputationValueType>
 bool
 ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::GetGradientSourceIncludesFixed() const
 {
-  return m_GradientSource == SourceTypeOfGradient::GRADIENT_SOURCE_FIXED ||
-         m_GradientSource == SourceTypeOfGradient::GRADIENT_SOURCE_BOTH;
+  return m_GradientSource == GradientSourceEnum::GRADIENT_SOURCE_FIXED ||
+         m_GradientSource == GradientSourceEnum::GRADIENT_SOURCE_BOTH;
 }
 
 //-------------------------------------------------------------------
@@ -46,8 +46,8 @@ template <typename TInternalComputationValueType>
 bool
 ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::GetGradientSourceIncludesMoving() const
 {
-  return m_GradientSource == SourceTypeOfGradient::GRADIENT_SOURCE_MOVING ||
-         m_GradientSource == SourceTypeOfGradient::GRADIENT_SOURCE_BOTH;
+  return m_GradientSource == GradientSourceEnum::GRADIENT_SOURCE_MOVING ||
+         m_GradientSource == GradientSourceEnum::GRADIENT_SOURCE_BOTH;
 }
 
 //-------------------------------------------------------------------
@@ -68,13 +68,13 @@ ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::PrintSelf(std::
   os << indent << "GradientSourceType: ";
   switch (m_GradientSource)
   {
-    case SourceTypeOfGradient::GRADIENT_SOURCE_FIXED:
+    case GradientSourceEnum::GRADIENT_SOURCE_FIXED:
       os << "GRADIENT_SOURCE_FIXED";
       break;
-    case SourceTypeOfGradient::GRADIENT_SOURCE_MOVING:
+    case GradientSourceEnum::GRADIENT_SOURCE_MOVING:
       os << "GRADIENT_SOURCE_MOVING";
       break;
-    case SourceTypeOfGradient::GRADIENT_SOURCE_BOTH:
+    case GradientSourceEnum::GRADIENT_SOURCE_BOTH:
       os << "GRADIENT_SOURCE_BOTH";
       break;
     default:

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
@@ -81,7 +81,7 @@ public:
   using MeasureType = typename Superclass::MeasureType;
   using DerivativeType = typename Superclass::DerivativeType;
   using IndexRangeType = typename Superclass::IndexRangeType;
-  using StopConditionType = typename Superclass::StopConditionType;
+  using StopConditionEnum = typename Superclass::StopConditionEnum;
 
   /** Type for Hessian matrix in the Quasi-Newton method */
   using HessianType = itk::Array2D<TInternalComputationValueType>;

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
@@ -31,10 +31,10 @@
 
 namespace itk
 {
-/** \class StrategyTypeForSampling
+/** \class SamplingStrategyEnum
  * \ingroup ITKOptimizersv4
  * The strategies to sample physical points in the virtual domain. */
-enum class StrategyTypeForSampling : uint8_t
+enum class SamplingStrategyEnum : uint8_t
 {
   FullDomainSampling = 0,
   CornerSampling,
@@ -114,7 +114,7 @@ public:
   using VirtualPointSetPointer = typename TMetric::VirtualPointSetPointer;
 
   /** Enables backwards compatibility for enum values */
-  using SamplingStrategyType = StrategyTypeForSampling;
+  using SamplingStrategyType = SamplingStrategyEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
@@ -326,7 +326,7 @@ private:
 
 /** Define how to print enumerations */
 extern ITKOptimizersv4_EXPORT std::ostream &
-                              operator<<(std::ostream & out, const StrategyTypeForSampling value);
+                              operator<<(std::ostream & out, const SamplingStrategyEnum value);
 
 } // namespace itk
 

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -37,7 +37,7 @@ RegistrationParameterScalesEstimator<TMetric>::RegistrationParameterScalesEstima
   this->m_NumberOfRandomSamples = 0;
 
   // default sampling strategy
-  this->m_SamplingStrategy = StrategyTypeForSampling::FullDomainSampling;
+  this->m_SamplingStrategy = SamplingStrategyEnum::FullDomainSampling;
 
   // the default radius of the central region for sampling
   this->m_CentralRegionRadius = 5;
@@ -128,12 +128,12 @@ bool
 RegistrationParameterScalesEstimator<TMetric>::IsDisplacementFieldTransform()
 {
   if (this->m_TransformForward && this->m_Metric->GetMovingTransform()->GetTransformCategory() ==
-                                    MovingTransformType::TransformCategoryType::DisplacementField)
+                                    MovingTransformType::TransformCategoryEnum::DisplacementField)
   {
     return true;
   }
   else if (!this->m_TransformForward && this->m_Metric->GetFixedTransform()->GetTransformCategory() ==
-                                          FixedTransformType::TransformCategoryType::DisplacementField)
+                                          FixedTransformType::TransformCategoryEnum::DisplacementField)
   {
     return true;
   }
@@ -147,12 +147,12 @@ RegistrationParameterScalesEstimator<TMetric>::IsBSplineTransform()
   bool isBSplineTransform = false;
 
   if (this->m_TransformForward && this->m_Metric->GetMovingTransform()->GetTransformCategory() ==
-                                    MovingTransformType::TransformCategoryType::BSpline)
+                                    MovingTransformType::TransformCategoryEnum::BSpline)
   {
     isBSplineTransform = true;
   }
   else if (!this->m_TransformForward && this->m_Metric->GetFixedTransform()->GetTransformCategory() ==
-                                          FixedTransformType::TransformCategoryType::BSpline)
+                                          FixedTransformType::TransformCategoryEnum::BSpline)
   {
     isBSplineTransform = true;
   }
@@ -179,7 +179,7 @@ RegistrationParameterScalesEstimator<TMetric>::IsBSplineTransform()
         {
           if (compositeTransform->GetNthTransformToOptimize(tind) &&
               (compositeTransform->GetNthTransformConstPointer(tind)->GetTransformCategory() !=
-               MovingTransformType::TransformCategoryType::BSpline))
+               MovingTransformType::TransformCategoryEnum::BSpline))
           {
             isBSplineTransform = false;
             break;
@@ -201,7 +201,7 @@ RegistrationParameterScalesEstimator<TMetric>::IsBSplineTransform()
         {
           if (compositeTransform->GetNthTransformToOptimize(tind) &&
               (compositeTransform->GetNthTransformConstPointer(tind)->GetTransformCategory() !=
-               FixedTransformType::TransformCategoryType::BSpline))
+               FixedTransformType::TransformCategoryEnum::BSpline))
           {
             isBSplineTransform = false;
             break;
@@ -343,19 +343,19 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomain()
                       " yet this->m_VirtualDomainPointSet has not been assigned. ");
   }
 
-  if (m_SamplingStrategy == StrategyTypeForSampling::VirtualDomainPointSetSampling)
+  if (m_SamplingStrategy == SamplingStrategyEnum::VirtualDomainPointSetSampling)
   {
     this->SampleVirtualDomainWithPointSet();
   }
-  else if (m_SamplingStrategy == StrategyTypeForSampling::CornerSampling)
+  else if (m_SamplingStrategy == SamplingStrategyEnum::CornerSampling)
   {
     this->SampleVirtualDomainWithCorners();
   }
-  else if (m_SamplingStrategy == StrategyTypeForSampling::RandomSampling)
+  else if (m_SamplingStrategy == SamplingStrategyEnum::RandomSampling)
   {
     this->SampleVirtualDomainRandomly();
   }
-  else if (m_SamplingStrategy == StrategyTypeForSampling::CentralRegionSampling)
+  else if (m_SamplingStrategy == SamplingStrategyEnum::CentralRegionSampling)
   {
     this->SampleVirtualDomainWithCentralRegion();
   }
@@ -383,19 +383,19 @@ RegistrationParameterScalesEstimator<TMetric>::SetScalesSamplingStrategy()
 {
   if (this->m_VirtualDomainPointSet)
   {
-    this->SetSamplingStrategy(StrategyTypeForSampling::VirtualDomainPointSetSampling);
+    this->SetSamplingStrategy(SamplingStrategyEnum::VirtualDomainPointSetSampling);
   }
   else if (this->TransformHasLocalSupportForScalesEstimation())
   {
-    this->SetSamplingStrategy(StrategyTypeForSampling::CentralRegionSampling);
+    this->SetSamplingStrategy(SamplingStrategyEnum::CentralRegionSampling);
   }
   else if (this->CheckGeneralAffineTransform())
   {
-    this->SetSamplingStrategy(StrategyTypeForSampling::CornerSampling);
+    this->SetSamplingStrategy(SamplingStrategyEnum::CornerSampling);
   }
   else
   {
-    this->SetSamplingStrategy(StrategyTypeForSampling::RandomSampling);
+    this->SetSamplingStrategy(SamplingStrategyEnum::RandomSampling);
     this->SetNumberOfRandomSamples(SizeOfSmallDomain);
   }
 }
@@ -409,20 +409,20 @@ RegistrationParameterScalesEstimator<TMetric>::SetStepScaleSamplingStrategy()
 {
   if (this->m_VirtualDomainPointSet)
   {
-    this->SetSamplingStrategy(StrategyTypeForSampling::VirtualDomainPointSetSampling);
+    this->SetSamplingStrategy(SamplingStrategyEnum::VirtualDomainPointSetSampling);
   }
   else if (this->TransformHasLocalSupportForScalesEstimation())
   {
     // Have to use FullDomainSampling for a transform with local support
-    this->SetSamplingStrategy(StrategyTypeForSampling::FullDomainSampling);
+    this->SetSamplingStrategy(SamplingStrategyEnum::FullDomainSampling);
   }
   else if (this->CheckGeneralAffineTransform())
   {
-    this->SetSamplingStrategy(StrategyTypeForSampling::CornerSampling);
+    this->SetSamplingStrategy(SamplingStrategyEnum::CornerSampling);
   }
   else
   {
-    this->SetSamplingStrategy(StrategyTypeForSampling::RandomSampling);
+    this->SetSamplingStrategy(SamplingStrategyEnum::RandomSampling);
     this->SetNumberOfRandomSamples(SizeOfSmallDomain);
   }
 }

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -56,7 +56,7 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateScales(ScalesType & p
   {
     // FIXME: remove if we end up not using this
     // if( this->MetricIsPointSetToPointSetType() )
-    if (this->GetSamplingStrategy() == StrategyTypeForSampling::VirtualDomainPointSetSampling)
+    if (this->GetSamplingStrategy() == SamplingStrategyEnum::VirtualDomainPointSetSampling)
     {
       // Use the first virtual point since the center of the virtual domain
       // may not line up with a sample point.

--- a/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.h
@@ -73,7 +73,7 @@ public:
   using IndexRangeType = typename Superclass::IndexRangeType;
   using ScalesType = typename Superclass::ScalesType;
   using ParametersType = typename Superclass::ParametersType;
-  using StopConditionType = typename Superclass::StopConditionType;
+  using StopConditionEnum = typename Superclass::StopConditionEnum;
 
   /** Compensated summation type. */
   using CompensatedSummationType = CompensatedSummation<InternalComputationValueType>;

--- a/Modules/Numerics/Optimizersv4/src/itkMultiStartOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkMultiStartOptimizerv4.cxx
@@ -21,25 +21,25 @@ namespace itk
 {
 /**Define how to print enumerations. */
 std::ostream &
-operator<<(std::ostream & out, const StopType value)
+operator<<(std::ostream & out, const StopEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case StopType::MAXIMUM_NUMBER_OF_ITERATIONS:
-        return "StopType::MAXIMUM_NUMBER_OF_ITERATIONS";
-      case StopType::COSTFUNCTION_ERROR:
-        return "StopType::COSTFUNCTION_ERROR";
-      case StopType::UPDATE_PARAMETERS_ERROR:
-        return "StopType::UPDATE_PARAMETERS_ERROR";
-      case StopType::STEP_TOO_SMALL:
-        return "StopType::STEP_TOO_SMALL";
-      case StopType::CONVERGENCE_CHECKER_PASSED:
-        return "StopType::CONVERGENCE_CHECKER_PASSED";
-      case StopType::OTHER_ERROR:
-        return "StopType::OTHER_ERROR";
+      case StopEnum::MAXIMUM_NUMBER_OF_ITERATIONS:
+        return "StopEnum::MAXIMUM_NUMBER_OF_ITERATIONS";
+      case StopEnum::COSTFUNCTION_ERROR:
+        return "StopEnum::COSTFUNCTION_ERROR";
+      case StopEnum::UPDATE_PARAMETERS_ERROR:
+        return "StopEnum::UPDATE_PARAMETERS_ERROR";
+      case StopEnum::STEP_TOO_SMALL:
+        return "StopEnum::STEP_TOO_SMALL";
+      case StopEnum::CONVERGENCE_CHECKER_PASSED:
+        return "StopEnum::CONVERGENCE_CHECKER_PASSED";
+      case StopEnum::OTHER_ERROR:
+        return "StopEnum::OTHER_ERROR";
       default:
-        return "INVALID VALUE FOR StopType";
+        return "INVALID VALUE FOR StopEnum";
     }
   }();
 }

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectMetricBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectMetricBase.cxx
@@ -21,42 +21,42 @@ namespace itk
 {
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const SourceTypeOfGradient value)
+operator<<(std::ostream & out, const GradientSourceEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case SourceTypeOfGradient::GRADIENT_SOURCE_FIXED:
-        return "SourceTypeOfGradient::GRADIENT_SOURCE_FIXED";
-      case SourceTypeOfGradient::GRADIENT_SOURCE_MOVING:
-        return "SourceTypeOfGradient::GRADIENT_SOURCE_MOVING";
-      case SourceTypeOfGradient::GRADIENT_SOURCE_BOTH:
-        return "SourceTypeOfGradient::GRADIENT_SOURCE_BOTH";
+      case GradientSourceEnum::GRADIENT_SOURCE_FIXED:
+        return "GradientSourceEnum::GRADIENT_SOURCE_FIXED";
+      case GradientSourceEnum::GRADIENT_SOURCE_MOVING:
+        return "GradientSourceEnum::GRADIENT_SOURCE_MOVING";
+      case GradientSourceEnum::GRADIENT_SOURCE_BOTH:
+        return "GradientSourceEnum::GRADIENT_SOURCE_BOTH";
       default:
-        return "INVALID VALUE FOR SourceTypeOfGradient";
+        return "INVALID VALUE FOR GradientSourceEnum";
     }
   }();
 }
 
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const CategoryTypeForMetric value)
+operator<<(std::ostream & out, const MetricCategoryEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case CategoryTypeForMetric::UNKNOWN_METRIC:
-        return "CategoryTypeForMetric::UNKNOWN_METRIC";
-      case CategoryTypeForMetric::OBJECT_METRIC:
-        return "CategoryTypeForMetric::OBJECT_METRIC";
-      case CategoryTypeForMetric::IMAGE_METRIC:
-        return "CategoryTypeForMetric::IMAGE_METRIC";
-      case CategoryTypeForMetric::POINT_SET_METRIC:
-        return "CategoryTypeForMetric::POINT_SET_METRIC";
-      case CategoryTypeForMetric::MULTI_METRIC:
-        return "CategoryTypeForMetric::MULTI_METRIC";
+      case MetricCategoryEnum::UNKNOWN_METRIC:
+        return "MetricCategoryEnum::UNKNOWN_METRIC";
+      case MetricCategoryEnum::OBJECT_METRIC:
+        return "MetricCategoryEnum::OBJECT_METRIC";
+      case MetricCategoryEnum::IMAGE_METRIC:
+        return "MetricCategoryEnum::IMAGE_METRIC";
+      case MetricCategoryEnum::POINT_SET_METRIC:
+        return "MetricCategoryEnum::POINT_SET_METRIC";
+      case MetricCategoryEnum::MULTI_METRIC:
+        return "MetricCategoryEnum::MULTI_METRIC";
       default:
-        return "INVALID VALUE FOR CategoryTypeForMetric";
+        return "INVALID VALUE FOR MetricCategoryEnum";
     }
   }();
 }

--- a/Modules/Numerics/Optimizersv4/src/itkRegistrationParameterScalesEstimator.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkRegistrationParameterScalesEstimator.cxx
@@ -21,23 +21,23 @@ namespace itk
 {
 /** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const StrategyTypeForSampling value)
+operator<<(std::ostream & out, const SamplingStrategyEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case StrategyTypeForSampling::FullDomainSampling:
-        return "StrategyTypeForSampling::FullDomainSampling";
-      case StrategyTypeForSampling::CornerSampling:
-        return "StrategyTypeForSampling::CornerSampling";
-      case StrategyTypeForSampling::RandomSampling:
-        return "StrategyTypeForSampling::RandomSampling";
-      case StrategyTypeForSampling::CentralRegionSampling:
-        return "StrategyTypeForSampling::CentralRegionSampling";
-      case StrategyTypeForSampling::VirtualDomainPointSetSampling:
-        return "StrategyTypeForSampling::VirtualDomainPointSetSampling";
+      case SamplingStrategyEnum::FullDomainSampling:
+        return "SamplingStrategyEnum::FullDomainSampling";
+      case SamplingStrategyEnum::CornerSampling:
+        return "SamplingStrategyEnum::CornerSampling";
+      case SamplingStrategyEnum::RandomSampling:
+        return "SamplingStrategyEnum::RandomSampling";
+      case SamplingStrategyEnum::CentralRegionSampling:
+        return "SamplingStrategyEnum::CentralRegionSampling";
+      case SamplingStrategyEnum::VirtualDomainPointSetSampling:
+        return "SamplingStrategyEnum::VirtualDomainPointSetSampling";
       default:
-        return "INVALID VALUE FOR StrategyTypeForSampling";
+        return "INVALID VALUE FOR SamplingStrategyEnum";
     }
   }();
 }

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
@@ -159,7 +159,7 @@ public:
   EstimateScales(ScalesType & parameterScales) override
   {
     this->CheckAndSetInputs();
-    this->SetSamplingStrategy(itk::StrategyTypeForSampling::RandomSampling);
+    this->SetSamplingStrategy(itk::SamplingStrategyEnum::RandomSampling);
     this->SetNumberOfRandomSamples(1000);
     this->SampleVirtualDomain();
 

--- a/Modules/Numerics/Optimizersv4/wrapping/itkObjectToObjectMetricBase.wrap
+++ b/Modules/Numerics/Optimizersv4/wrapping/itkObjectToObjectMetricBase.wrap
@@ -1,8 +1,8 @@
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkObjectToObjectMetricBase.h")
 
-itk_wrap_simple_class("itk::SourceTypeOfGradient" ENUM)
-itk_wrap_simple_class("itk::CategoryTypeForMetric" ENUM)
+itk_wrap_simple_class("itk::GradientSourceEnum" ENUM)
+itk_wrap_simple_class("itk::MetricCategoryEnum" ENUM)
 
 itk_wrap_class("itk::ObjectToObjectMetricBaseTemplate" POINTER)
   UNIQUE(types "D;${WRAP_ITK_REAL}")

--- a/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
@@ -166,7 +166,7 @@ itkBlockMatchingImageFilterTest(int argc, char * argv[])
   using RGBFilterType = itk::ScalarToRGBColormapImageFilter<InputImageType, OutputImageType>;
   RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
 
-  colormapImageFilter->SetColormap(itk::RGBColormapFilterEnumType::Grey);
+  colormapImageFilter->SetColormap(itk::RGBColormapFilterEnum::Grey);
   colormapImageFilter->SetInput(reader->GetOutput());
   try
   {

--- a/Modules/Registration/FEM/test/itkVTKTetrahedralMeshReader.hxx
+++ b/Modules/Registration/FEM/test/itkVTKTetrahedralMeshReader.hxx
@@ -52,7 +52,7 @@ VTKTetrahedralMeshReader<TOutputMesh>::GenerateData()
 {
   OutputMeshType * outputMesh = this->GetOutput();
 
-  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
+  outputMesh->SetCellsAllocationMethod(MeshClassCellsAllocationMethodEnum::CellsAllocatedDynamicallyCellByCell);
 
   if (m_FileName == "")
   {

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.hxx
@@ -42,7 +42,7 @@ CorrelationImageToImageMetricv4<TFixedImage,
   m_HelperDenseThreader = CorrelationHelperDenseThreaderType::New();
   m_HelperSparseThreader = CorrelationHelperSparseThreaderType::New();
 
-  if (this->m_MovingTransform->GetTransformCategory() == MovingTransformType::TransformCategoryType::DisplacementField)
+  if (this->m_MovingTransform->GetTransformCategory() == MovingTransformType::TransformCategoryEnum::DisplacementField)
   {
     itkExceptionMacro("does not support displacement field transforms!!");
   }

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.hxx
@@ -37,7 +37,7 @@ DemonsImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalCo
   this->m_SparseGetValueAndDerivativeThreader = DemonsSparseGetValueAndDerivativeThreaderType::New();
 
   // Unlike most other metrics, this defaults to using fixed image gradients
-  this->SetGradientSource(SourceTypeOfGradient::GRADIENT_SOURCE_FIXED);
+  this->SetGradientSource(GradientSourceEnum::GRADIENT_SOURCE_FIXED);
 
   this->m_Normalizer = NumericTraits<TInternalComputationValueType>::OneValue();
   this->m_DenominatorThreshold = static_cast<TInternalComputationValueType>(1e-9);
@@ -55,7 +55,7 @@ DemonsImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalCo
 {
   // Make sure user has not set to use both moving and fixed image
   // gradients
-  if (this->GetGradientSource() == SourceTypeOfGradient::GRADIENT_SOURCE_BOTH)
+  if (this->GetGradientSource() == GradientSourceEnum::GRADIENT_SOURCE_BOTH)
   {
     itkExceptionMacro("GradientSource has been set to GRADIENT_SOURCE_BOTH. "
                       "You must choose either GRADIENT_SOURCE_MOVING or "
@@ -64,7 +64,7 @@ DemonsImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalCo
 
   // Verify that the transform has local support, and its number of local
   // parameters equals the dimensionality of the image gradient source.
-  if (this->m_MovingTransform->GetTransformCategory() != MovingTransformType::TransformCategoryType::DisplacementField)
+  if (this->m_MovingTransform->GetTransformCategory() != MovingTransformType::TransformCategoryEnum::DisplacementField)
   {
     itkExceptionMacro("The moving transform must be a displacement field transform");
   }
@@ -72,7 +72,7 @@ DemonsImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalCo
   // compute the normalizer
   ImageDimensionType                dimension;
   typename TFixedImage::SpacingType imageSpacing;
-  if (this->GetGradientSource() == SourceTypeOfGradient::GRADIENT_SOURCE_FIXED)
+  if (this->GetGradientSource() == GradientSourceEnum::GRADIENT_SOURCE_FIXED)
   {
     imageSpacing = this->m_FixedImage->GetSpacing();
     dimension = FixedImageDimension;

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
@@ -69,7 +69,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner,
       // Not pre-allocated since it may not be used
       // this->m_GetValueAndDerivativePerThreadVariables[i].MovingTransformJacobianPositional
       if (this->m_Associate->m_MovingTransform->GetTransformCategory() ==
-          MovingTransformType::TransformCategoryType::DisplacementField)
+          MovingTransformType::TransformCategoryEnum::DisplacementField)
       {
         /* For transforms with local support, e.g. displacement field,
          * use a single derivative container that's updated by region
@@ -105,7 +105,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner,
     if (this->m_Associate->GetComputeDerivative())
     {
       if (this->m_Associate->m_MovingTransform->GetTransformCategory() !=
-          MovingTransformType::TransformCategoryType::DisplacementField)
+          MovingTransformType::TransformCategoryEnum::DisplacementField)
       {
         /* Be sure to init to 0 here, because the threader may not use
          * all the threads if the region is better split into fewer
@@ -138,7 +138,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner,
   if (this->m_Associate->GetComputeDerivative())
   {
     if (this->m_Associate->m_MovingTransform->GetTransformCategory() !=
-        MovingTransformType::TransformCategoryType::DisplacementField)
+        MovingTransformType::TransformCategoryEnum::DisplacementField)
     {
       for (NumberOfParametersType p = 0; p < this->m_Associate->GetNumberOfParameters(); p++)
       {
@@ -172,7 +172,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner,
     if (this->m_Associate->GetComputeDerivative())
     {
       if (this->m_Associate->m_MovingTransform->GetTransformCategory() !=
-          MovingTransformType::TransformCategoryType::DisplacementField)
+          MovingTransformType::TransformCategoryEnum::DisplacementField)
       {
         *(this->m_Associate->m_DerivativeResult) /= this->m_Associate->m_NumberOfValidPoints;
       }
@@ -287,7 +287,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreaderBase<TDomainPartitioner, TImage
   StorePointDerivativeResult(const VirtualIndexType & virtualIndex, const ThreadIdType threadId)
 {
   if (this->m_Associate->m_MovingTransform->GetTransformCategory() !=
-      MovingTransformType::TransformCategoryType::DisplacementField)
+      MovingTransformType::TransformCategoryEnum::DisplacementField)
   {
     /* Global support */
     if (this->m_Associate->GetUseFloatingPointCorrection())

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -347,7 +347,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
   SizeValueType movingParzenBin = 0;
 
   const bool transformIsDisplacement = this->m_MattesAssociate->m_MovingTransform->GetTransformCategory() ==
-                                       MovingTransformType::TransformCategoryType::DisplacementField;
+                                       MovingTransformType::TransformCategoryEnum::DisplacementField;
   while (pdfMovingIndex <= pdfMovingIndexMax)
   {
     const auto val =

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.hxx
@@ -46,7 +46,7 @@ PointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputation
   this->m_FixedTransformedPointSetTime = this->GetMTime();
 
   // We iterate over the fixed points to calculate the value and derivative.
-  this->SetGradientSource(SourceTypeOfGradient::GRADIENT_SOURCE_FIXED);
+  this->SetGradientSource(GradientSourceEnum::GRADIENT_SOURCE_FIXED);
 
   this->m_HaveWarnedAboutNumberOfValidPoints = false;
 

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -123,8 +123,8 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   metric->SetMovingTransform(displacementTransform);
 
   /* Test 1st with fixed image gradient source. This is the default */
-  metric->SetGradientSource(itk::SourceTypeOfGradient::GRADIENT_SOURCE_FIXED);
-  if (metric->GetGradientSource() != itk::SourceTypeOfGradient::GRADIENT_SOURCE_FIXED)
+  metric->SetGradientSource(itk::GradientSourceEnum::GRADIENT_SOURCE_FIXED);
+  if (metric->GetGradientSource() != itk::GradientSourceEnum::GRADIENT_SOURCE_FIXED)
   {
     std::cerr << "Failed setting fixed image gradient source." << std::endl;
     return EXIT_FAILURE;
@@ -191,8 +191,8 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
    * to have the fixed image used for image gradients.  */
   metric->SetFixedTransform(translationTransform);
   metric->SetMovingTransform(displacementTransform);
-  metric->SetGradientSource(itk::SourceTypeOfGradient::GRADIENT_SOURCE_MOVING);
-  if (metric->GetGradientSource() != itk::SourceTypeOfGradient::GRADIENT_SOURCE_MOVING)
+  metric->SetGradientSource(itk::GradientSourceEnum::GRADIENT_SOURCE_MOVING);
+  if (metric->GetGradientSource() != itk::GradientSourceEnum::GRADIENT_SOURCE_MOVING)
   {
     std::cerr << "Failed setting moving image gradient source." << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -148,7 +148,7 @@ itkEuclideanDistancePointSetMetricRegistrationTestRun(unsigned int              
   std::cout << "Optimizer scales: " << optimizer->GetScales() << std::endl;
   std::cout << "Optimizer learning rate: " << optimizer->GetLearningRate() << std::endl;
   std::cout << "Moving-source final value: " << optimizer->GetCurrentMetricValue() << std::endl;
-  if (transform->GetTransformCategory() == TTransform::TransformCategoryType::DisplacementField)
+  if (transform->GetTransformCategory() == TTransform::TransformCategoryEnum::DisplacementField)
   {
     std::cout << "local-support transform non-zero parameters: " << std::endl;
     typename TTransform::ParametersType params = transform->GetParameters();

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -274,7 +274,7 @@ ImageToImageMetricv4TestComputeIdentityTruthValues(const ImageToImageMetricv4Tes
       }
 
       if (metric->GetMovingTransform()->GetTransformCategory() ==
-          MovingTransformType::TransformCategoryType::DisplacementField)
+          MovingTransformType::TransformCategoryEnum::DisplacementField)
       {
         truthDerivative[count * metric->GetNumberOfLocalParameters() + par] = sum;
       }
@@ -291,7 +291,7 @@ ImageToImageMetricv4TestComputeIdentityTruthValues(const ImageToImageMetricv4Tes
   // Take the averages
   truthValue /= metric->GetNumberOfValidPoints();
   if (metric->GetMovingTransform()->GetTransformCategory() !=
-      MovingTransformType::TransformCategoryType::DisplacementField)
+      MovingTransformType::TransformCategoryEnum::DisplacementField)
   {
     truthDerivative /= metric->GetNumberOfValidPoints();
   }
@@ -480,7 +480,7 @@ itkImageToImageMetricv4Test(int, char ** const)
   metric->SetFixedTransform(fixedTransform);
   metric->SetMovingTransform(movingTransform);
   // Tell the metric to compute image gradients for both fixed and moving.
-  metric->SetGradientSource(itk::SourceTypeOfGradient::GRADIENT_SOURCE_BOTH);
+  metric->SetGradientSource(itk::GradientSourceEnum::GRADIENT_SOURCE_BOTH);
 
   // Enable ITK debugging output
   metric->SetDebug(false);
@@ -581,7 +581,7 @@ itkImageToImageMetricv4Test(int, char ** const)
   metric->SetUseFixedImageGradientFilter(true);
   metric->SetUseMovingImageGradientFilter(true);
   // Tell the metric to compute image gradients for both fixed and moving.
-  metric->SetGradientSource(itk::SourceTypeOfGradient::GRADIENT_SOURCE_BOTH);
+  metric->SetGradientSource(itk::GradientSourceEnum::GRADIENT_SOURCE_BOTH);
 
   // Evaluate the metric
   std::cout << "* Testing with identity DisplacementFieldTransform for moving image..." << std::endl;
@@ -607,7 +607,7 @@ itkImageToImageMetricv4Test(int, char ** const)
   movingTransform->SetIdentity();
   metric->SetMovingTransform(movingTransform);
   metric->SetFixedTransform(fixedTransform);
-  metric->SetGradientSource(itk::SourceTypeOfGradient::GRADIENT_SOURCE_BOTH);
+  metric->SetGradientSource(itk::GradientSourceEnum::GRADIENT_SOURCE_BOTH);
   metric->SetUseFixedImageGradientFilter(false);
   metric->SetUseMovingImageGradientFilter(false);
 

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
@@ -101,7 +101,7 @@ itkVotingBinaryImageFilterTest(int argc, char * argv[])
 
 
   itk::ImageIOBase::Pointer iobase =
-    itk::ImageIOFactory::CreateImageIO(infname.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(infname.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
 
   if (iobase.IsNull())
   {

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
@@ -32,10 +32,10 @@
 
 namespace itk
 {
-/** \class MRFStopType
+/** \class MRFStopEnum
  *  \ingroup ITKMarkovRandomFieldsClassifiers
  * Enum to get the stopping condition of the MRF filter*/
-enum class MRFStopType : uint8_t
+enum class MRFStopEnum : uint8_t
 {
   MaximumNumberOfIterations = 1,
   ErrorTolerance
@@ -294,17 +294,17 @@ public:
   }
 
   /** Backwards compatibility for enumerations */
-  using StopConditionType = MRFStopType;
+  using StopConditionEnum = MRFStopEnum;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr StopConditionType MaximumNumberOfIterations = StopConditionType::MaximumNumberOfIterations;
-  static constexpr StopConditionType ErrorTolerance = StopConditionType::ErrorTolerance;
+  static constexpr StopConditionEnum MaximumNumberOfIterations = StopConditionEnum::MaximumNumberOfIterations;
+  static constexpr StopConditionEnum ErrorTolerance = StopConditionEnum::ErrorTolerance;
 #endif
 
   /** Get condition that stops the MRF filter (Number of Iterations
    * / Error tolerance ) */
-  itkGetConstReferenceMacro(StopCondition, StopConditionType);
+  itkGetConstReferenceMacro(StopCondition, StopConditionEnum);
 
   /* Get macro for number of iterations */
   itkGetConstReferenceMacro(NumberOfIterations, unsigned int);
@@ -396,7 +396,7 @@ private:
   double            m_SmoothingFactor{ 1 };
   double *          m_ClassProbability{ nullptr }; // Class liklihood
   unsigned int      m_NumberOfIterations{ 0 };
-  StopConditionType m_StopCondition;
+  StopConditionEnum m_StopCondition;
 
   LabelStatusImagePointer m_LabelStatusImage;
 
@@ -421,7 +421,7 @@ private:
 
 /** Define how to print enumerations. */
 extern ITKMarkovRandomFieldsClassifiers_EXPORT std::ostream &
-                                               operator<<(std::ostream & out, const MRFStopType value);
+                                               operator<<(std::ostream & out, const MRFStopEnum value);
 
 } // namespace itk
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 template <typename TInputImage, typename TClassifiedImage>
 MRFImageFilter<TInputImage, TClassifiedImage>::MRFImageFilter()
-  : m_StopCondition(MRFStopType::MaximumNumberOfIterations)
+  : m_StopCondition(MRFStopEnum::MaximumNumberOfIterations)
   , m_ClassifierPtr(nullptr)
 {
   if ((int)InputImageDimension != (int)ClassifiedImageDimension)
@@ -433,11 +433,11 @@ MRFImageFilter<TInputImage, TClassifiedImage>::ApplyMRFImageFilter()
   // Determine stop condition
   if (m_NumberOfIterations >= m_MaximumNumberOfIterations)
   {
-    m_StopCondition = MRFStopType::MaximumNumberOfIterations;
+    m_StopCondition = MRFStopEnum::MaximumNumberOfIterations;
   }
   else if (m_ErrorCounter <= maxNumPixelError)
   {
-    m_StopCondition = MRFStopType::ErrorTolerance;
+    m_StopCondition = MRFStopEnum::ErrorTolerance;
   }
 } // ApplyMRFImageFilter
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/src/itkMRFImageFilter.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/src/itkMRFImageFilter.cxx
@@ -20,17 +20,17 @@
 namespace itk
 {
 std::ostream &
-operator<<(std::ostream & out, const MRFStopType value)
+operator<<(std::ostream & out, const MRFStopEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case MRFStopType::MaximumNumberOfIterations:
-        return "MRFStopType::MaximumNumberOfIterations";
-      case MRFStopType::ErrorTolerance:
-        return "MRFStopType::ErrorTolerance";
+      case MRFStopEnum::MaximumNumberOfIterations:
+        return "MRFStopEnum::MaximumNumberOfIterations";
+      case MRFStopEnum::ErrorTolerance:
+        return "MRFStopEnum::ErrorTolerance";
       default:
-        return "MRFStopType";
+        return "MRFStopEnum";
     }
   }();
 }

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOFactoryTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOFactoryTest.cxx
@@ -59,7 +59,7 @@ test_OpenCVVideoIOFactory(char * input, char * output, SizeValueType cameraNumbe
   //////
   std::cout << "Trying to create IO for reading from file..." << std::endl;
   itk::VideoIOBase::Pointer ioReadFile =
-    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::ReadFileMode, input);
+    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeEnum::ReadFileMode, input);
   if (!ioReadFile)
   {
     std::cerr << "Did not create valid VideoIO for reading from file " << std::endl;
@@ -82,7 +82,7 @@ test_OpenCVVideoIOFactory(char * input, char * output, SizeValueType cameraNumbe
     std::stringstream ss;
     ss << cameraNumber;
     itk::VideoIOBase::Pointer ioReadCamera =
-      itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::ReadCameraMode, ss.str().c_str());
+      itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeEnum::ReadCameraMode, ss.str().c_str());
     if (!ioReadCamera)
     {
       std::cerr << "Did not create valid VideoIO for reading from camera" << std::endl;
@@ -95,7 +95,7 @@ test_OpenCVVideoIOFactory(char * input, char * output, SizeValueType cameraNumbe
   //////
   std::cout << "Trying to create IO for writing to file..." << std::endl;
   itk::VideoIOBase::Pointer ioWrite =
-    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::WriteMode, output);
+    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeEnum::WriteMode, output);
   if (!ioWrite)
   {
     std::cerr << "Did not create valid VideoIO for writing " << std::endl;

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -174,7 +174,7 @@ template <typename TOutputVideoStream>
 void
 VideoFileReader<TOutputVideoStream>::InitializeVideoIO()
 {
-  m_VideoIO = itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::ReadFileMode, m_FileName.c_str());
+  m_VideoIO = itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeEnum::ReadFileMode, m_FileName.c_str());
   m_VideoIO->SetFileName(m_FileName.c_str());
   m_VideoIO->ReadImageInformation();
 

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -273,7 +273,7 @@ VideoFileWriter<TInputVideoStream>::InitializeVideoIO()
 {
   if (m_FileName.length() != 0)
   {
-    m_VideoIO = itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::WriteMode, m_FileName.c_str());
+    m_VideoIO = itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeEnum::WriteMode, m_FileName.c_str());
 
     // Return true if a VideoIO was successfully created
     if (!m_VideoIO.IsNull())

--- a/Modules/Video/IO/include/itkVideoIOBase.h
+++ b/Modules/Video/IO/include/itkVideoIOBase.h
@@ -73,10 +73,10 @@ public:
 
   /*-------- This part of the interface deals with reading data. ------ */
 
-  /** \class ReadType
+  /** \class ReadFromEnum
    * \ingroup ITKVideoIO
    * Enum used to define weather to read from a file or a camera */
-  enum class ReadType : uint8_t
+  enum class ReadFromEnum : uint8_t
   {
     ReadFromFile,
     ReadFromCamera
@@ -84,8 +84,8 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr ReadType ReadFromFile = ReadType::ReadFromFile;
-  static constexpr ReadType ReadFromCamera = ReadType::ReadFromCamera;
+  static constexpr ReadFromEnum ReadFromFile = ReadFromEnum::ReadFromFile;
+  static constexpr ReadFromEnum ReadFromCamera = ReadFromEnum::ReadFromCamera;
 #endif
 
   /** Set to reading from file */
@@ -97,10 +97,10 @@ public:
   SetReadFromCamera() = 0;
 
   /** Get the current read type */
-  ReadType
-  GetReadType()
+  ReadFromEnum
+  GetReadFrom()
   {
-    return this->m_ReadType;
+    return this->m_ReadFrom;
   }
 
   /** Return whether or not the VideoIO can read from a camera. The cameraID
@@ -145,7 +145,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Member Variables */
-  ReadType           m_ReadType{ ReadType::ReadFromFile };
+  ReadFromEnum       m_ReadFrom{ ReadFromEnum::ReadFromFile };
   TemporalRatioType  m_FramesPerSecond{ 0.0 };
   FrameOffsetType    m_FrameTotal;
   FrameOffsetType    m_CurrentFrame;
@@ -159,7 +159,7 @@ protected:
 
 // Define how to print enumeration
 extern ITKVideoIO_EXPORT std::ostream &
-                         operator<<(std::ostream & out, const VideoIOBase::ReadType value);
+                         operator<<(std::ostream & out, const VideoIOBase::ReadFromEnum value);
 
 } // end namespace itk
 

--- a/Modules/Video/IO/include/itkVideoIOFactory.h
+++ b/Modules/Video/IO/include/itkVideoIOFactory.h
@@ -46,10 +46,10 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
-  /** \class IOModeType
+  /** \class IOModeEnum
    * \ingroup ITKVideoIO
    * Mode in which the VideoIO is intended to be used */
-  enum class IOModeType : uint8_t
+  enum class IOModeEnum : uint8_t
   {
     ReadFileMode,
     ReadCameraMode,
@@ -58,9 +58,9 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr IOModeType ReadFileMode = IOModeType::ReadFileMode;
-  static constexpr IOModeType ReadCameraMode = IOModeType::ReadCameraMode;
-  static constexpr IOModeType WriteMode = IOModeType::WriteMode;
+  static constexpr IOModeEnum ReadFileMode = IOModeEnum::ReadFileMode;
+  static constexpr IOModeEnum ReadCameraMode = IOModeEnum::ReadCameraMode;
+  static constexpr IOModeEnum WriteMode = IOModeEnum::WriteMode;
 #endif
   /** Runtime type information (and related methods). **/
   itkTypeMacro(VideoIOFactory, Object);
@@ -71,7 +71,7 @@ public:
    *        from a camera
    */
   static VideoIOBase::Pointer
-  CreateVideoIO(IOModeType mode, const char * arg);
+  CreateVideoIO(IOModeEnum mode, const char * arg);
 
 protected:
   VideoIOFactory();
@@ -80,7 +80,7 @@ protected:
 
 // Define how to print enumeration
 extern ITKVideoIO_EXPORT std::ostream &
-                         operator<<(std::ostream & out, const VideoIOFactory::IOModeType value);
+                         operator<<(std::ostream & out, const VideoIOFactory::IOModeEnum value);
 
 } // end namespace itk
 

--- a/Modules/Video/IO/src/itkFileListVideoIO.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIO.cxx
@@ -89,7 +89,7 @@ FileListVideoIO::SetReadFromFile()
 {
   if (!m_ReaderOpen && !m_WriterOpen)
   {
-    m_ReadType = ReadType::ReadFromFile;
+    m_ReadFrom = ReadFromEnum::ReadFromFile;
   }
   else
   {
@@ -122,7 +122,7 @@ FileListVideoIO::CanReadFile(const char * filename)
 
   // Make sure we can instantiate an ImageIO to read the first file
   ImageIOBase::Pointer ioTemp =
-    ImageIOFactory::CreateImageIO(fileList[0].c_str(), ImageIOFactory::FileModeType::ReadMode);
+    ImageIOFactory::CreateImageIO(fileList[0].c_str(), ImageIOFactory::FileModeEnum::ReadMode);
   if (ioTemp.IsNull())
   {
     return false;
@@ -141,7 +141,7 @@ void
 FileListVideoIO::ReadImageInformation()
 {
   // Open from a file
-  if (m_ReadType == ReadType::ReadFromFile)
+  if (m_ReadFrom == ReadFromEnum::ReadFromFile)
   {
 
     // Make sure file can be read
@@ -185,7 +185,7 @@ FileListVideoIO::ReadImageInformation()
   }
 
   // Open capture from a camera
-  else if (m_ReadType == ReadType::ReadFromCamera)
+  else if (m_ReadFrom == ReadFromEnum::ReadFromCamera)
   {
     itkExceptionMacro("FileListVideoIO cannot read from a camera");
   }
@@ -284,7 +284,7 @@ FileListVideoIO::CanWriteFile(const char * filename)
 
   // Make sure we can instantiate an ImageIO to write the first file
   ImageIOBase::Pointer ioTemp =
-    ImageIOFactory::CreateImageIO(fileList[0].c_str(), ImageIOFactory::FileModeType::WriteMode);
+    ImageIOFactory::CreateImageIO(fileList[0].c_str(), ImageIOFactory::FileModeEnum::WriteMode);
   if (ioTemp.IsNull())
   {
     return false;
@@ -380,10 +380,10 @@ FileListVideoIO::OpenReader()
   }
 
   // If neither reader nor writer is currently open, open the reader
-  if (m_ReadType == ReadType::ReadFromFile)
+  if (m_ReadFrom == ReadFromEnum::ReadFromFile)
   {
     // Use the ImageIOFactory to instantiate a working ImageIO
-    m_ImageIO = ImageIOFactory::CreateImageIO(m_FileNames[0].c_str(), ImageIOFactory::FileModeType::ReadMode);
+    m_ImageIO = ImageIOFactory::CreateImageIO(m_FileNames[0].c_str(), ImageIOFactory::FileModeEnum::ReadMode);
     if (!m_ImageIO.IsNull())
     {
       m_ReaderOpen = true;
@@ -393,7 +393,7 @@ FileListVideoIO::OpenReader()
       itkExceptionMacro("Video failed to open");
     }
   }
-  else if (m_ReadType == ReadType::ReadFromCamera)
+  else if (m_ReadFrom == ReadFromEnum::ReadFromCamera)
   {
     itkExceptionMacro("FileListVideoIO doesn't support reading from camera");
   }
@@ -424,7 +424,7 @@ FileListVideoIO::OpenWriter()
   }
 
   // If neither reader nor writer is currently open, open the writer
-  m_ImageIO = ImageIOFactory::CreateImageIO(m_FileNames[0].c_str(), ImageIOFactory::FileModeType::WriteMode);
+  m_ImageIO = ImageIOFactory::CreateImageIO(m_FileNames[0].c_str(), ImageIOFactory::FileModeEnum::WriteMode);
   if (!m_ImageIO.IsNull())
   {
     m_WriterOpen = true;
@@ -451,7 +451,7 @@ FileListVideoIO::ResetMembers()
   m_LastIFrame = 0;
 
   // Default to reading from a file
-  m_ReadType = ReadType::ReadFromFile;
+  m_ReadFrom = ReadFromEnum::ReadFromFile;
 
   // Members from ImageIOBase
   m_PixelType = SCALAR;

--- a/Modules/Video/IO/src/itkVideoIOBase.cxx
+++ b/Modules/Video/IO/src/itkVideoIOBase.cxx
@@ -42,17 +42,17 @@ VideoIOBase::PrintSelf(std::ostream & os, Indent indent) const
 
 /** Print Enumerations */
 std::ostream &
-operator<<(std::ostream & out, const VideoIOBase::ReadType value)
+operator<<(std::ostream & out, const VideoIOBase::ReadFromEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case VideoIOBase::ReadType::ReadFromFile:
-        return "VideoIOBase::ReadType::ReadFromFile";
-      case VideoIOBase::ReadType::ReadFromCamera:
-        return "VideoIOBase::ReadType::ReadFromCamera";
+      case VideoIOBase::ReadFromEnum::ReadFromFile:
+        return "VideoIOBase::ReadFromEnum::ReadFromFile";
+      case VideoIOBase::ReadFromEnum::ReadFromCamera:
+        return "VideoIOBase::ReadFromEnum::ReadFromCamera";
       default:
-        return "INVALID VALUE FOR VideoIOBase::ReadType";
+        return "INVALID VALUE FOR VideoIOBase::ReadFromEnum";
     }
   }();
 }

--- a/Modules/Video/IO/src/itkVideoIOFactory.cxx
+++ b/Modules/Video/IO/src/itkVideoIOFactory.cxx
@@ -25,7 +25,7 @@
 namespace itk
 {
 VideoIOBase::Pointer
-VideoIOFactory::CreateVideoIO(IOModeType mode, const char * arg)
+VideoIOFactory::CreateVideoIO(IOModeEnum mode, const char * arg)
 {
   std::list<VideoIOBase::Pointer> possibleVideoIO;
   for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkVideoIOBase"))
@@ -48,7 +48,7 @@ VideoIOFactory::CreateVideoIO(IOModeType mode, const char * arg)
   {
 
     // Check file readability if reading from file
-    if (mode == IOModeType::ReadFileMode)
+    if (mode == IOModeEnum::ReadFileMode)
     {
       if (j->CanReadFile(arg))
       {
@@ -57,7 +57,7 @@ VideoIOFactory::CreateVideoIO(IOModeType mode, const char * arg)
     }
 
     // Check camera readability if reading from camera
-    else if (mode == IOModeType::ReadCameraMode)
+    else if (mode == IOModeEnum::ReadCameraMode)
     {
       int cameraIndex = std::stoi(arg);
       if (j->CanReadCamera(cameraIndex))
@@ -67,7 +67,7 @@ VideoIOFactory::CreateVideoIO(IOModeType mode, const char * arg)
     }
 
     // Check file writability if writing
-    else if (mode == IOModeType::WriteMode)
+    else if (mode == IOModeEnum::WriteMode)
     {
       if (j->CanWriteFile(arg))
       {
@@ -81,19 +81,19 @@ VideoIOFactory::CreateVideoIO(IOModeType mode, const char * arg)
 }
 /** Print Enumerations */
 std::ostream &
-operator<<(std::ostream & out, const VideoIOFactory::IOModeType value)
+operator<<(std::ostream & out, const VideoIOFactory::IOModeEnum value)
 {
   return out << [value] {
     switch (value)
     {
-      case VideoIOFactory::IOModeType::ReadFileMode:
-        return "VideoIOFactory::IOModeType::ReadFileMode";
-      case VideoIOFactory::IOModeType::ReadCameraMode:
-        return "VideoIOFactory::IOModeType::ReadCameraMode";
-      case VideoIOFactory::IOModeType::WriteMode:
-        return "VideoIOFactory::IOModeType::WriteMode";
+      case VideoIOFactory::IOModeEnum::ReadFileMode:
+        return "VideoIOFactory::IOModeEnum::ReadFileMode";
+      case VideoIOFactory::IOModeEnum::ReadCameraMode:
+        return "VideoIOFactory::IOModeEnum::ReadCameraMode";
+      case VideoIOFactory::IOModeEnum::WriteMode:
+        return "VideoIOFactory::IOModeEnum::WriteMode";
       default:
-        return "INVALID VALUE FOR VideoIOFactory::IOModeType";
+        return "INVALID VALUE FOR VideoIOFactory::IOModeEnum";
     }
   }();
 }

--- a/Modules/Video/IO/test/itkFileListVideoIOFactoryTest.cxx
+++ b/Modules/Video/IO/test/itkFileListVideoIOFactoryTest.cxx
@@ -46,7 +46,7 @@ test_FileListVideoIOFactory(const char * input, char * output, itk::SizeValueTyp
   //////
   std::cout << "Trying to create IO for reading from file..." << std::endl;
   itk::VideoIOBase::Pointer ioReadFile =
-    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::ReadFileMode, input);
+    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeEnum::ReadFileMode, input);
   if (!ioReadFile)
   {
     std::cerr << "Did not create valid VideoIO for reading from file " << std::endl;
@@ -58,7 +58,7 @@ test_FileListVideoIOFactory(const char * input, char * output, itk::SizeValueTyp
   //////
   std::cout << "Trying to create IO for writing to file..." << std::endl;
   itk::VideoIOBase::Pointer ioWrite =
-    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeType::WriteMode, output);
+    itk::VideoIOFactory::CreateVideoIO(itk::VideoIOFactory::IOModeEnum::WriteMode, output);
   if (!ioWrite)
   {
     std::cerr << "Did not create valid VideoIO for writing " << std::endl;

--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -552,7 +552,7 @@ def imread(filename, pixel_type=None, fallback_only=False):
         increase_dimension=False
         kwargs={'FileName':filename}
     if pixel_type:
-        imageIO = itk.ImageIOFactory.CreateImageIO(io_filename, itk.ImageIOFactory.FileModeType_ReadMode)
+        imageIO = itk.ImageIOFactory.CreateImageIO(io_filename, itk.ImageIOFactory.FileModeEnum_ReadMode)
         if not imageIO:
             raise RuntimeError("No ImageIO is registered to handle the given file.")
         imageIO.SetFileName(io_filename)
@@ -611,7 +611,7 @@ def meshread(filename, pixel_type=None, fallback_only=False):
     increase_dimension=False
     kwargs={'FileName':filename}
     if pixel_type:
-        meshIO = itk.MeshIOFactory.CreateMeshIO(io_filename, itk.MeshIOFactory.FileModeType_ReadMode)
+        meshIO = itk.MeshIOFactory.CreateMeshIO(io_filename, itk.MeshIOFactory.FileModeEnum_ReadMode)
         if not meshIO:
             raise RuntimeError("No MeshIO is registered to handle the given file.")
         meshIO.SetFileName(io_filename)

--- a/Wrapping/Generators/Python/itkTemplate.py
+++ b/Wrapping/Generators/Python/itkTemplate.py
@@ -539,7 +539,7 @@ keyword arguments: %s""" % ", ".join(primary_input_methods))
         if "ImageIO" in kwargs:
             imageIO = kwargs["ImageIO"]
         else:
-            imageIO = itk.ImageIOFactory.CreateImageIO(inputFileName, itk.ImageIOFactory.FileModeType_ReadMode)
+            imageIO = itk.ImageIOFactory.CreateImageIO(inputFileName, itk.ImageIOFactory.FileModeEnum_ReadMode)
         if not imageIO:
             msg = ""
             if not os.path.isfile(inputFileName):
@@ -595,7 +595,7 @@ keyword arguments: %s""" % ", ".join(primary_input_methods))
         if "MeshIO" in kwargs:
             meshIO = kwargs["MeshIO"]
         else:
-            meshIO = itk.MeshIOFactory.CreateMeshIO(inputFileName, itk.MeshIOFactory.FileModeType_ReadMode)
+            meshIO = itk.MeshIOFactory.CreateMeshIO(inputFileName, itk.MeshIOFactory.FileModeEnum_ReadMode)
         if not meshIO:
             msg = ""
             if not os.path.isfile(inputFileName):


### PR DESCRIPTION
Consistently use strongly typed enums and using a consistent naming
convention:

`<Description>Enum`

That is, `Enum` comes at the end, consistently. We remove `Type` that is
at the end of some enum's currently for brievity (everything is strongly typed).

The Python API for strongly typed enum's is

`<Description>Enum_<EnumValue1>`
`<Description>Enum_<EnumValue2>`
[...]

Follow-up on: e9da13c75e9dc0a835c274a7c535f5ca39559b77 c9d8271d0c813c08dfb35310233d0c3ad69a094c as discussed in PR #1353 