### PR TITLE
BUG: Use itk.array_from_image for __array__

### DIFF
--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -443,7 +443,7 @@ str = str
           def __array__(self, dtype=None):
               import itk
               import numpy as np
-              array = itk.array_view_from_image(self)
+              array = itk.array_from_image(self)
               return np.asarray(array, dtype=dtype)
       }
   }


### PR DESCRIPTION
Experimentation through use has found that the use of a view
for np.asarray can result in unexpected behavior or crashes.
