### PR TITLE
ENH: Gracefully convert non-contiguous NumPy arrays

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -92,9 +92,8 @@
 
         assert ndarr.ndim in ( 2, 3, 4 ), \
             "Only arrays of 2, 3 or 4 dimensions are supported."
-        if( not ndarr.flags['C_CONTIGUOUS'] and not ndarr.flags['F_CONTIGUOUS'] ):
-            raise ValueError("Array memory is not contiguous. Try converting your array with "
-                  + "`ascontiguousarray()` or `copy()` or use `GetImageFromArray()`")
+        if not ndarr.flags['C_CONTIGUOUS'] and not ndarr.flags['F_CONTIGUOUS']:
+            ndarr = numpy.ascontiguousarray(ndarr)
 
         if ( ndarr.ndim == 3 and is_vector ) or (ndarr.ndim == 4):
             if( ndarr.flags['C_CONTIGUOUS'] ):

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -210,22 +210,13 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         image = itk.image_from_array(array)
 
     def test_non_contiguous_array(self):
-        "Check that a non-contiguous array raises the appropriate error"
+        "Check that a non-contiguous array can be converted to an itk.Image without issue"
 
         data = np.random.random((10, 10, 10))
         data = data[..., 0]   # slicing the array makes it non-contiguous
         assert not data.flags['C_CONTIGUOUS']
         assert not data.flags['F_CONTIGUOUS']
-        try:
-            itk.image_from_array(data)
-        except ValueError as e:
-            assert str(e) == ("Array memory is not contiguous. "
-                              "Try converting your array with "
-                              "`ascontiguousarray()` or `copy()` "
-                              "or use `GetImageFromArray()`")
-        else:
-            assert False
-
+        image = itk.image_from_array(data)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Instead of raising an exception when converting a NumPy array to an
itk.Image, just make the array contiguous with numpy.ascontiguousarray.
This improves ease of use, and internal conversion is a better default
behavior.

Closes #1243 