### PR TITLE
COMP: reformulate a self-assignment to fix -Wself-assign-overloaded w…

### DIFF
--- a/Modules/Core/Common/test/itkImageIORegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageIORegionGTest.cxx
@@ -79,7 +79,11 @@ void
 Expect_CopyAssignableToSelf(const T & value)
 {
   T self(value);
-  self = self;
+
+  // Slight contortion to avoid self-assignment warning with 'self = self'.
+  const T& referenceToSelf = self;
+  self = referenceToSelf;
+
   EXPECT_EQ(self, value);
 }
 


### PR DESCRIPTION
…arning

The warning was:

Modules/Core/Common/test/itkImageIORegionGTest.cxx:82:8: warning: explicitly assigning value of variable of type 'T' to itself [-Wself-assign-overloaded]
  self = self;
  ~~~~ ^ ~~~~
