### PR TITLE
ENH: Simplification of the ImageSeriesReader nonuniform sampling detection

### DIFF
--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
@@ -45,28 +45,15 @@ itkImageSeriesReaderSamplingTest(int ac, char * av[])
     Reader3DType::Pointer reader = Reader3DType::New();
     reader->SetFileNames(fnames);
     reader->Update();
-    bool globalNonUniformSampling = false;
-    if (itk::ExposeMetaData<bool>(
-          reader->GetOutput()->GetMetaDataDictionary(), "ITK_non_uniform_sampling", globalNonUniformSampling) &&
-        globalNonUniformSampling)
-    {
-      std::cout << "output ITK_non_uniform_sampling detected " << std::endl;
-    }
-    else
-    {
-      std::cout << "output ITK_non_uniform_sampling not found" << std::endl;
-      return EXIT_FAILURE;
-    }
-
-    double globalSamplingDeviation = 0.0;
+    double maxSamplingDeviation = 0.0;
     if (itk::ExposeMetaData<double>(
-          reader->GetOutput()->GetMetaDataDictionary(), "ITK_non_uniform_sampling_deviation", globalSamplingDeviation))
+          reader->GetOutput()->GetMetaDataDictionary(), "ITK_non_uniform_sampling_deviation", maxSamplingDeviation))
     {
-      std::cout << "output ITK_non_uniform_sampling_deviation = " << globalSamplingDeviation << std::endl;
+      std::cout << "global ITK_non_uniform_sampling_deviation detected : " << maxSamplingDeviation << std::endl;
     }
     else
     {
-      std::cout << "output ITK_non_uniform_sampling_deviation not found" << std::endl;
+      std::cout << "global ITK_non_uniform_sampling_deviation not found" << std::endl;
       return EXIT_FAILURE;
     }
 
@@ -74,14 +61,14 @@ itkImageSeriesReaderSamplingTest(int ac, char * av[])
     for (auto d : *reader->GetMetaDataDictionaryArray())
     {
       itk::MetaDataDictionary theMetadata = *d;
-      bool                    nonUniformSampling = false;
-      if (itk::ExposeMetaData<bool>(theMetadata, "ITK_non_uniform_sampling", nonUniformSampling) && nonUniformSampling)
+      double                  samplingDeviation = 0.0;
+      if (itk::ExposeMetaData<double>(theMetadata, "ITK_non_uniform_sampling_deviation", samplingDeviation))
       {
-        std::cout << "slice ITK_non_uniform_sampling detected" << std::endl;
+        std::cout << "slice ITK_non_uniform_sampling_deviation detected: " << samplingDeviation << std::endl;
       }
       else
       {
-        std::cout << "slice ITK_non_uniform_sampling not detected" << std::endl;
+        std::cout << "slice ITK_non_uniform_sampling_deviation not detected" << std::endl;
       }
     }
   }


### PR DESCRIPTION
ENH: Now ImageSeriesReader reports only maximum deviance from expected slice thinckness for the whole volume and also per-slice information in the metadata entry ITK_non_uniform_sampling_deviation. 


<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [ ] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
