### PR TITLE
ENH: Add boundary condition getters and setters

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
@@ -20,6 +20,7 @@
 
 #include "itkImageToImageFilter.h"
 #include "itkImage.h"
+#include "itkZeroFluxNeumannBoundaryCondition.h"
 
 namespace itk
 {
@@ -95,6 +96,18 @@ public:
    * of the two images is assumed to be the same. */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
+  /** Type of the pixel to use for intermediate results */
+  using RealOutputPixelType = typename NumericTraits< OutputPixelType >::RealType;
+  using RealOutputImageType = Image< OutputPixelType, ImageDimension >;
+  using RealOutputPixelValueType = typename NumericTraits<RealOutputPixelType>::ValueType;
+
+  /** Typedef to describe the boundary condition. */
+  using BoundaryConditionType = ImageBoundaryCondition< TInputImage >;
+  using InputBoundaryConditionPointerType = BoundaryConditionType *;
+  using InputDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition< TInputImage >;
+  using RealBoundaryConditionPointerType = ImageBoundaryCondition<RealOutputImageType> *;
+  using RealDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition< RealOutputImageType >;
+
   /** Typedef of double containers */
   using ArrayType = FixedArray<double, Self::ImageDimension>;
   using SigmaArrayType = ArrayType;
@@ -127,6 +140,12 @@ public:
    * FilterDimensionality to 2. */
   itkGetConstMacro(FilterDimensionality, unsigned int);
   itkSetMacro(FilterDimensionality, unsigned int);
+
+  /** Set/get the boundary condition. */
+  itkSetMacro(InputBoundaryCondition, InputBoundaryConditionPointerType);
+  itkGetConstMacro(InputBoundaryCondition, InputBoundaryConditionPointerType);
+  itkSetMacro(RealBoundaryCondition, RealBoundaryConditionPointerType);
+  itkGetConstMacro(RealBoundaryCondition, RealBoundaryConditionPointerType);
 
   /** Convenience Set methods for setting all dimensional parameters
    *  to the same values. */
@@ -291,6 +310,8 @@ protected:
     m_MaximumKernelWidth = 32;
     m_UseImageSpacing = true;
     m_FilterDimensionality = ImageDimension;
+    m_InputBoundaryCondition = &m_InputDefaultBoundaryCondition;
+    m_RealBoundaryCondition = &m_RealDefaultBoundaryCondition;
   }
 
   ~DiscreteGaussianImageFilter() override = default;
@@ -324,6 +345,20 @@ private:
 
   /** Flag to indicate whether to use image spacing */
   bool m_UseImageSpacing;
+
+  /** Pointer to a persistent boundary condition object used
+   ** for the image iterator. */
+  InputBoundaryConditionPointerType m_InputBoundaryCondition;
+
+  /** Default boundary condition */
+  InputDefaultBoundaryConditionType m_InputDefaultBoundaryCondition;
+
+  /** Boundary condition use for the intermediate filters */
+  RealBoundaryConditionPointerType m_RealBoundaryCondition;
+
+ /** Default boundary condition use for the intermediate filters */
+  RealDefaultBoundaryConditionType m_RealDefaultBoundaryCondition;
+
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "itkNullImageToImageFilterDriver.hxx"
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
+#include "itkConstantBoundaryCondition.h"
 
 int
 itkDiscreteGaussianImageFilterTest(int, char *[])
@@ -57,6 +58,14 @@ itkDiscreteGaussianImageFilterTest(int, char *[])
 
     filter->SetSigmaArray(sigma);
     ITK_TEST_SET_GET_VALUE(sigma, filter->GetSigmaArray());
+
+    // Set the boundary condition used by the filter
+    itk::ConstantBoundaryCondition<ImageType> constantBoundaryCondition;
+    filter->SetInputBoundaryCondition(&constantBoundaryCondition);
+    ITK_TEST_SET_GET_VALUE(&constantBoundaryCondition, filter->GetInputBoundaryCondition());
+
+    filter->SetRealBoundaryCondition(&constantBoundaryCondition);
+    ITK_TEST_SET_GET_VALUE(&constantBoundaryCondition, filter->GetRealBoundaryCondition());
 
     // set some parameters
     filter->SetVariance(1.0);


### PR DESCRIPTION
Add boundary condition setters and getters to DiscreteGaussianImageFilter.

We are currently trying to implement a new projector in RTK, and we need to use the DiscreteGaussianImageFilter with another boundary condition than the default one. 

The difficulty here is that the DiscreteGaussianImageFilter uses intermediate filter with real pixel type. In this PR, I implemented one setter and getter for boundary condition with input pixel type and another one for boundary condition with real pixel type. However, I'm not sure it's the best way to do since the user would have to set boundary condition with two different image type. 

Can you think of a better solution?

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ]  [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] : Adds the License notice to new files.
- [ ]  Adds Python wrapping.
- [ ]  Adds tests and baseline comparison (quantitative).
- [ ]  [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ]  Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
