### PR TITLE
BUG: fix null pointer dereference in itkInOrderTreeIterator.h:102

### DIFF
--- a/Modules/Core/Common/include/itkInOrderTreeIterator.h
+++ b/Modules/Core/Common/include/itkInOrderTreeIterator.h
@@ -99,6 +99,10 @@ const typename InOrderTreeIterator<TTreeType>::ValueType &
 InOrderTreeIterator<TTreeType>::Next()
 {
   this->m_Position = const_cast<TreeNodeType *>(FindNextNode());
+  if (this->m_Position == nullptr)
+  {
+    return this->m_Root->Get(); // value irrelevant, but we have to return something
+  }
   return this->m_Position->Get();
 }
 


### PR DESCRIPTION
/Users/builder/external/ITK/Modules/Core/Common/include/itkInOrderTreeIterator.h:102:28: runtime error: member call on null pointer of type 'itk::TreeNode<int>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/builder/external/ITK/Modules/Core/Common/include/itkInOrderTreeIterator.h:102:28
