### PR TITLE
ENH: Update SCIFIO remote module to 2019-12-11 Git master

### DIFF
--- a/Modules/Remote/SCIFIO.remote.cmake
+++ b/Modules/Remote/SCIFIO.remote.cmake
@@ -1,5 +1,5 @@
 itk_fetch_module(SCIFIO
   "SCIFIO (Bioformats) ImageIO plugin for ITK"
   GIT_REPOSITORY ${git_protocol}://github.com/scifio/scifio-imageio.git
-  GIT_TAG 5081a00976cd67c782715a6df2bd4db1071eac3c
+  GIT_TAG 5ea114902b8da5de6ccde139237b6e39409b7730
   )


### PR DESCRIPTION
 Matt McCormick (6):
   ENH: Update bundled JRE to Java 11
   ENH: Bump bio-formats version to 6.3.0
   ENH: Add Azure Pipelines configuration
   DOC: Add Azure Pipeline CI badge to README
   COMP: Avoid getenv with Visual Studio
   BUG: Remove Python packages from the testing configuration
