### PR TITLE
ENH: Update stale-bot comment about issue closure

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 120
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 30
+daysUntilClose: 30000
 # Issues with these labels will never be considered stale
 exemptLabels:
   - 'Good first issue'
@@ -10,7 +10,6 @@ staleLabel: 'status:Backlog'
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
Do not suggest that the issue will be closed.

`closeComment` is already set to `false`, which suggests that the issue
should not be closed. But, also set `daysUntilClose` to avoid closure.