### PR TITLE
BUG: Update URL for GitSetup hooks checkout

### DIFF
--- a/Utilities/GitSetup/config
+++ b/Utilities/GitSetup/config
@@ -1,5 +1,5 @@
 [hooks]
-	url = https://public.kitware.com/GitSetup.git
+	url = https://github.com/InsightSoftwareConsortium/ITK.git
 [upstream]
 	url = https://github.com/InsightSoftwareConsortium/ITK.git
 	remote = upstream


### PR DESCRIPTION
The GitSetup repo on `public.kitware.com` will be removed.  Use our own repo's hooks branch.
