### PR TITLE
ENH: Use curl instead of wget in SourceTarball script

### DIFF
--- a/Documentation/Maintenance/Release.md
+++ b/Documentation/Maintenance/Release.md
@@ -372,11 +372,11 @@ This will generate tarballs for the source and testing data.
 
 ### Windows
 
-From a `git` bash shell with `wget` in `PATH`, run:
+From a Git Bash shell, run:
 
 ```sh
    ./Utilities/Maintenance/SourceTarball.bash --zip
-``
+```
 
 This should be done on Windows so that the sources have Windows-style newline
 endings.

--- a/Utilities/Maintenance/SourceTarball.bash
+++ b/Utilities/Maintenance/SourceTarball.bash
@@ -56,8 +56,7 @@ validate_MD5() {
 download_object() {
   algo="$1" ; hash="$2" ; path="$3"
   mkdir -p $(dirname "$path") &&
-  if wget "https://www.itk.org/files/ExternalData/$algo/$hash" -O "$path.tmp$$" 1>&2 || \
-     wget "https://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&checksum=${hash}&algorithm=${algo}" -O "$path.tmp$$" 1>&2; then
+  if curl -L "https://www.itk.org/files/ExternalData/$algo/$hash" -o "$path.tmp$$" 1>&2; then
     mv "$path.tmp$$" "$path"
   else
     rm -f "$path.tmp$$"


### PR DESCRIPTION
Ease use inside Git Bash on Windows.

Also remove Slicer Midas3 server, which is no longer used.
