### PR TITLE
DOC: Update .mailmap to consolidate author identification

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,11 +5,13 @@ Gaëtan Lehmann <gaetan.lehmann@jouy.inra.fr>
 Arnaud Gelas <arnaudgelas@gmail.com> <arnaud_gelas@hms.harvard.edu>
 Alexandre Gouaillard <agouaillard@gmail.com>
 Andrew Wasem <drewwasem@gmail.com>
-Matthew McCormick <matt.mccormick@kitware.com>
-Matthew McCormick <matt@mmmccormick.com>
+Matthew McCormick <matt.mccormick@kitware.com> <matt@mmmccormick.com>
 Brian Avants <stnava@gmail.com>
 Nick Tustison <ntustison@gmail.com>
 Xiaoxiao Liu <liuxiaoxiao@gmail.com>
 Francois Budin <francois.budin@kitware.com> <francois.budin@gmail.com>
-Dženan Zukić <dzenan.zukic@kitware.com>
-Dženan Zukić <dzenanz@gmail.com>
+Dženan Zukić <dzenan.zukic@kitware.com> Dzenan Zukic <dzenanz@gmail.com>
+Davis Vigneault <davis.vigneault@gmail.com>
+Yann Le Poul <le-poul@biologie.uni-muenchen.de>
+Lucas Gandel <lucas.gandel@kitware.com>
+Ramraj Chandradevan <cramraj8@gmail.com>


### PR DESCRIPTION
Use consistent names in release notes, etc. by setting .mailmap entries.
See *MAPPING AUTHORS* in `git help shortlog`.