### PR TITLE
DOC: Add Stephen R. Aylward to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -15,3 +15,4 @@ Davis Vigneault <davis.vigneault@gmail.com>
 Yann Le Poul <le-poul@biologie.uni-muenchen.de>
 Lucas Gandel <lucas.gandel@kitware.com>
 Ramraj Chandradevan <cramraj8@gmail.com>
+Stephen R. Aylward <stephen.aylward@kitware.com>


### PR DESCRIPTION
Use consistent names in release notes, etc. by setting .mailmap entries.

See MAPPING AUTHORS in git help shortlog.

`git shortlog` now outputs the single "Stephen R. Aylward" versus a mix of "Stephen R.
Aylward" and "Stephen Aylward".

Will the real @aylward please stand up? :-)