### PR TITLE
DOC: Set lang attribute for Doxygen docs

### DIFF
--- a/Documentation/Doxygen/DoxygenHeader.html
+++ b/Documentation/Doxygen/DoxygenHeader.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.15-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>


### PR DESCRIPTION
To help browsers identify the correct language the page was written in
and prevent requests to translate.