### PR TITLE
DOC: .mailmap entry for Hans J. Johnson

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,6 @@
 # See "git help shortlog" section "MAPPING AUTHORS"
 Luis Ibanez <luis.ibanez@kitware.com>
-Hans Johnson <hans-johnson@uiowa.edu> <hans.j.johnson@gmail.com>
+Hans J. Johnson <hans-johnson@uiowa.edu> Hans Johnson <hans.j.johnson@gmail.com>
 Gaëtan Lehmann <gaetan.lehmann@jouy.inra.fr>
 Arnaud Gelas <arnaudgelas@gmail.com> <arnaud_gelas@hms.harvard.edu>
 Alexandre Gouaillard <agouaillard@gmail.com>


### PR DESCRIPTION
Use consistent names in release notes, etc. by setting .mailmap entries.

See MAPPING AUTHORS in git help shortlog.

`git shortlog` now outputs the single "Hans J. Johnson" versus a mix of "Hans J. Johnson" and "Hans Johnson".

Will the real @hjmjohnson  please stand up? :-)