### PR TITLE
ENH: Adding function to SOToImageFilter simplify output definition

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
@@ -90,6 +90,18 @@ public:
   const InputSpatialObjectType *
   GetInput(unsigned int idx);
 
+  /** Generate an output image that matches the origin,
+   * size, direction, and spacing of this image. */
+  template <class TMatchImage>
+  void
+  SetMatchImage(TMatchImage * matchImage)
+  {
+    this->SetOrigin(matchImage->GetOrigin());
+    this->SetSpacing(matchImage->GetSpacing());
+    this->SetDirection(matchImage->GetDirection());
+    this->SetSize(matchImage->GetLargestPossibleRegion().GetSize());
+  }
+
   /** Spacing (size of a pixel) of the output image. The
    * spacing is the geometric distance between image samples.
    * It is stored internally as double, but may be set from

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
@@ -92,14 +92,14 @@ public:
 
   /** Generate an output image that matches the origin,
    * size, direction, and spacing of this image. */
-  template <class TMatchImage>
+  template <class TReferenceImage>
   void
-  SetMatchImage(TMatchImage * matchImage)
+  SetReferenceImage(TReferenceImage * refImage)
   {
-    this->SetOrigin(matchImage->GetOrigin());
-    this->SetSpacing(matchImage->GetSpacing());
-    this->SetDirection(matchImage->GetDirection());
-    this->SetSize(matchImage->GetLargestPossibleRegion().GetSize());
+    this->SetOrigin(refImage->GetOrigin());
+    this->SetSpacing(refImage->GetSpacing());
+    this->SetDirection(refImage->GetDirection());
+    this->SetSize(refImage->GetLargestPossibleRegion().GetSize());
   }
 
   /** Spacing (size of a pixel) of the output image. The


### PR DESCRIPTION
Added SetMatchImage( img ) function.   The size, spacing, directions,
etc of the image passed to this function are used to define the
output image format of the filter.