### PR TITLE
clang-format lint and apply GitHub Actions

### DIFF
--- a/.github/workflows/apply-clang-format.yml
+++ b/.github/workflows/apply-clang-format.yml
@@ -1,0 +1,15 @@
+name: Apply clang-format to PR
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: InsightSoftwareConsortium/ITKApplyClangFormatAction@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -1,0 +1,13 @@
+name: clang-format linter
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -11,3 +11,5 @@ jobs:
       with:
         fetch-depth: 1
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
+      with:
+        error-message: 'Code is inconsistent with ITK Coding Style. Add the *action:ApplyClangFormat* PR label to correct.'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,9 @@ When a topic is submitted, it is tested across the three major platforms
 before being merged thanks to the [Azure DevOps Pipelines CI
 system](https://azure.microsoft.com/en-ca/services/devops/pipelines/),
 as well as the [CDash GitHub
-Checks](https://github.com/InsightSoftwareConsortium/ITKGitHubCDashStatus).
+Checks](https://github.com/InsightSoftwareConsortium/ITKGitHubCDashStatus),
+and [ITK Coding Style
+check](https://github.com/InsightSoftwareConsortium/ITKClangFormatLinterAction).
 
 If a platform configuration test failure appears to be a false positive, the
 test can be re-executed by adding a comment to the pull request with the
@@ -278,6 +280,10 @@ for further information on changing multiple commits -i.e. not only the last
 one, but further back in your history-, and the* Pro Git: Rebasing *resource on
 taking all the changes that were committed on one branch and replaying them on
 another one.*)
+
+If your topic branch fails the ITK Coding Style consistency check but is
+otherwise ready to merge, add the *action:ApplyClangFormat* label to the pull
+request. A bot will re-format all commits in the topic.
 
 Merge a Topic
 -------------

--- a/Utilities/Maintenance/clang-format.bash
+++ b/Utilities/Maintenance/clang-format.bash
@@ -82,6 +82,7 @@ test "$#" = 0 || die "$usage"
 # Find a default tool.
 tools='
   clang-format-8.0.0
+  clang-format-8
   clang-format
 '
 if test "x$clang_format" = "x"; then

--- a/Utilities/Maintenance/clang-format.bash
+++ b/Utilities/Maintenance/clang-format.bash
@@ -32,24 +32,24 @@ usage='usage: clang-format.bash [<options>] [--]
 help="$usage"'
 Example to format locally modified files:
 
-    Utilities/Scripts/clang-format.bash --modified
+    Utilities/Maintenance/clang-format.bash --modified
 
 Example to format locally modified files staged for commit:
 
-    Utilities/Scripts/clang-format.bash --cached
+    Utilities/Maintenance/clang-format.bash --cached
 
 Example to format files modified by the most recent commit:
 
-    Utilities/Scripts/clang-format.bash --amend
+    Utilities/Maintenance/clang-format.bash --amend
 
 Example to format all files:
 
-    Utilities/Scripts/clang-format.bash --tracked
+    Utilities/Maintenance/clang-format.bash --tracked
 
 Example to format the current topic:
 
     git filter-branch \
-      --tree-filter "Utilities/Scripts/clang-format.bash --tracked" \
+      --tree-filter "Utilities/Maintenance/clang-format.bash --tracked" \
       master..
 '
 


### PR DESCRIPTION
Add GitHub Actions to:

- Provide a status check that checks that the current pull request conforms to ITK's Coding Style with clang-format.
- Apply `clang-format` to a PR when the *action:ApplyClangFormat* label is added. This will run `clang-format` on all commits on the branch and force-push the branch, then remove the label. This label should be applied by someone with write access to the PR, i.e. the author or repository maintainers.

While the local Git hook catches most style changes, this provides an additional check and a convenient way to apply style updates on demand.

Moreover, these GitHub Actions can easily be applied to other repositories on GitHub.

Closes #1201 