### PR TITLE
ENH: Adding ComposeScaleSkewVersor 3D Transform

### DIFF
--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.h
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.h
@@ -145,10 +145,8 @@ public:
   void
   SetIdentity() override;
 
-  /** This method computes the Jacobian matrix of the transformation.
-   * given point or vector, returning the transformed point or
-   * vector. The rank of the Jacobian will also indicate if the
-   * transform is invertible at this point. */
+  /* This function is not implemented for this transform.  An exception
+   *   is thrown if this function is called. */
   void
   ComputeJacobianWithRespectToParameters(const InputPointType & p, JacobianType & jacobian) const override;
 

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.h
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.h
@@ -1,0 +1,196 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkComposeScaleSkewVersor3DTransform_h
+#define itkComposeScaleSkewVersor3DTransform_h
+
+#include <iostream>
+#include "itkVersorRigid3DTransform.h"
+
+namespace itk
+{
+/** \class ComposeScaleSkewVersor3DTransform
+ * \brief ComposeScaleSkewVersor3DTransform of a vector space (space coords)
+ *
+ * This transform applies a versor rotation and translation & scale/skew
+ * to the space
+ *
+ * The parameters for this transform can be set either using individual Set
+ * methods or in serialized form using SetParameters() and SetFixedParameters().
+ *
+ * The serialization of the optimizable parameters is an array of 12 elements.
+ * The first 3 elements are the components of the versor representation
+ * of 3D rotation. The next 3 parameters defines the translation in each
+ * dimension. The next 3 parameters defines scaling in each dimension.
+ * The last 3 parameters defines the skew.
+ *
+ * The serialization of the fixed parameters is an array of 3 elements defining
+ * the center of rotation.
+ *
+ *The transform can be described as:
+ * \f$ (\textbf{R}_v * \textbf{S} * \textbf{K})\textbf{x}  \f$
+ * where \f$\textbf{R}_v\f$ is the rotation matrix given the versor,
+ * where \f$\textbf{S}\f$ is the diagonal scale matrix.
+ * where \f$\textbf{K}\f$ is the upper triangle skew (shear) matrix.
+ *
+ * \ingroup ITKTransform
+ */
+template <typename TParametersValueType = double>
+class ITK_TEMPLATE_EXPORT ComposeScaleSkewVersor3DTransform : public VersorRigid3DTransform<TParametersValueType>
+{
+public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ComposeScaleSkewVersor3DTransform);
+
+  /** Standard class type aliases. */
+  using Self = ComposeScaleSkewVersor3DTransform;
+  using Superclass = VersorRigid3DTransform<TParametersValueType>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** New macro for creation of through a Smart Pointer. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ComposeScaleSkewVersor3DTransform, VersorRigid3DTransform);
+
+  /** Dimension of parameters. */
+  static constexpr unsigned int InputSpaceDimension = 3;
+  static constexpr unsigned int OutputSpaceDimension = 3;
+  static constexpr unsigned int ParametersDimension = 12;
+
+  /** Parameters Type   */
+  using ParametersType = typename Superclass::ParametersType;
+  using FixedParametersType = typename Superclass::FixedParametersType;
+  using JacobianType = typename Superclass::JacobianType;
+  using JacobianPositionType = typename Superclass::JacobianPositionType;
+  using InverseJacobianPositionType = typename Superclass::InverseJacobianPositionType;
+  using ScalarType = typename Superclass::ScalarType;
+  using InputPointType = typename Superclass::InputPointType;
+  using OutputPointType = typename Superclass::OutputPointType;
+  using InputVectorType = typename Superclass::InputVectorType;
+  using OutputVectorType = typename Superclass::OutputVectorType;
+  using InputVnlVectorType = typename Superclass::InputVnlVectorType;
+  using OutputVnlVectorType = typename Superclass::OutputVnlVectorType;
+  using InputCovariantVectorType = typename Superclass::InputCovariantVectorType;
+  using OutputCovariantVectorType = typename Superclass::OutputCovariantVectorType;
+  using MatrixType = typename Superclass::MatrixType;
+  using InverseMatrixType = typename Superclass::InverseMatrixType;
+  using CenterType = typename Superclass::CenterType;
+  using OffsetType = typename Superclass::OffsetType;
+  using TranslationType = typename Superclass::TranslationType;
+
+  using VersorType = typename Superclass::VersorType;
+  using AxisType = typename Superclass::AxisType;
+  using AngleType = typename Superclass::AngleType;
+
+  /** Scale & Skew Vector Type. */
+  using ScaleVectorType = Vector<TParametersValueType, 3>;
+  using SkewVectorType = Vector<TParametersValueType, 3>;
+
+  using ScaleVectorValueType = typename ScaleVectorType::ValueType;
+  using SkewVectorValueType = typename SkewVectorType::ValueType;
+  using TranslationValueType = typename TranslationType::ValueType;
+
+  using AxisValueType = typename Superclass::AxisValueType;
+  using ParametersValueType = typename Superclass::ParametersValueType;
+
+  /** Directly set the matrix of the transform.
+   *
+   * Orthogonality testing is bypassed in this case.
+   *
+   * \sa MatrixOffsetTransformBase::SetMatrix() */
+  void
+  SetMatrix(const MatrixType & matrix) override;
+  void
+  SetMatrix(const MatrixType & matrix, const TParametersValueType tolerance) override;
+
+  /** Set the transformation from a container of parameters
+   * This is typically used by optimizers.
+   * There are 12 parameters:
+   *   0-2   versor (right part)
+   *   3-5   translation
+   *   6-8   Scale
+   *   9-11  Skew
+   **  */
+  void
+  SetParameters(const ParametersType & parameters) override;
+
+  const ParametersType &
+  GetParameters() const override;
+
+  void
+  SetScale(const ScaleVectorType & scale);
+
+  itkGetConstReferenceMacro(Scale, ScaleVectorType);
+
+  void
+  SetSkew(const SkewVectorType & skew);
+
+  itkGetConstReferenceMacro(Skew, SkewVectorType);
+
+  void
+  SetIdentity() override;
+
+  /** This method computes the Jacobian matrix of the transformation.
+   * given point or vector, returning the transformed point or
+   * vector. The rank of the Jacobian will also indicate if the
+   * transform is invertible at this point. */
+  void
+  ComputeJacobianWithRespectToParameters(const InputPointType & p, JacobianType & jacobian) const override;
+
+protected:
+  ComposeScaleSkewVersor3DTransform();
+  ComposeScaleSkewVersor3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
+  ComposeScaleSkewVersor3DTransform(unsigned int paramDims);
+  ~ComposeScaleSkewVersor3DTransform() override = default;
+
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+
+  void
+  SetVarScale(const ScaleVectorType & scale)
+  {
+    m_Scale = scale;
+  }
+
+  void
+  SetVarSkew(const SkewVectorType & skew)
+  {
+    m_Skew = skew;
+  }
+
+  /** Compute the components of the rotation matrix in the superclass. */
+  void
+  ComputeMatrix() override;
+
+  void
+  ComputeMatrixParameters() override;
+
+private:
+  /**  Vector containing the scale. */
+  ScaleVectorType m_Scale;
+
+  /**  Vector containing the skew */
+  SkewVectorType m_Skew;
+}; // class ComposeScaleSkewVersor3DTransform
+} // namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "itkComposeScaleSkewVersor3DTransform.hxx"
+#endif
+
+#endif /* __ComposeScaleSkewVersor3DTransform_h */

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
@@ -1,0 +1,372 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkComposeScaleSkewVersor3DTransform_hxx
+#define itkComposeScaleSkewVersor3DTransform_hxx
+
+#include "itkComposeScaleSkewVersor3DTransform.h"
+#include "itkMath.h"
+
+#include "vnl/vnl_inverse.h"
+
+namespace itk
+{
+// Constructor with default arguments
+template <typename TParametersValueType>
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComposeScaleSkewVersor3DTransform()
+  : Superclass(ParametersDimension)
+{
+  m_Scale.Fill(NumericTraits<TParametersValueType>::OneValue());
+  m_Skew.Fill(NumericTraits<TParametersValueType>::ZeroValue());
+}
+
+// Constructor with arguments
+template <typename TParametersValueType>
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComposeScaleSkewVersor3DTransform(
+  unsigned int parametersDimension)
+  : Superclass(parametersDimension)
+{
+  m_Scale.Fill(1.0);
+  m_Skew.Fill(0.0);
+}
+
+// Constructor with arguments
+template <typename TParametersValueType>
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComposeScaleSkewVersor3DTransform(
+  const MatrixType &       matrix,
+  const OutputVectorType & offset)
+  : Superclass(matrix, offset)
+{
+  this->ComputeMatrixParameters();
+}
+
+// Directly set the matrix
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetMatrix(const MatrixType & matrix)
+{
+  // Any matrix should work - bypass orthogonality testing
+  using Baseclass = MatrixOffsetTransformBase<TParametersValueType, 3, 3>;
+  this->Baseclass::SetMatrix(matrix);
+}
+
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetMatrix(const MatrixType &         matrix,
+                                                                   const TParametersValueType itkNotUsed(tolerance))
+{
+  // Any matrix should work - bypass orthogonality testing
+  using Baseclass = MatrixOffsetTransformBase<TParametersValueType, 3, 3>;
+  this->Baseclass::SetMatrix(matrix);
+}
+
+// Set Parameters
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const ParametersType & parameters)
+{
+  itkDebugMacro(<< "Setting parameters " << parameters);
+
+  // Save parameters. Needed for proper operation of TransformUpdateParameters.
+  if (&parameters != &(this->m_Parameters))
+  {
+    this->m_Parameters = parameters;
+  }
+
+  // Transfer the versor part
+
+  AxisType axis;
+
+  double norm = parameters[0] * parameters[0];
+  axis[0] = parameters[0];
+  norm += parameters[1] * parameters[1];
+  axis[1] = parameters[1];
+  norm += parameters[2] * parameters[2];
+  axis[2] = parameters[2];
+  if (norm > 0)
+  {
+    norm = std::sqrt(norm);
+  }
+
+  double epsilon = 1e-10;
+  if (norm >= 1.0 - epsilon)
+  {
+    axis = axis / (norm + epsilon * norm);
+  }
+  VersorType newVersor;
+  newVersor.Set(axis);
+  this->SetVarVersor(newVersor);
+
+  itkDebugMacro(<< "Versor is now " << newVersor);
+
+  // Matrix must be defined before translation so that offset can be computed
+  // from translation
+  m_Scale[0] = parameters[6];
+  m_Scale[1] = parameters[7];
+  m_Scale[2] = parameters[8];
+
+  m_Skew[0] = parameters[9];
+  m_Skew[1] = parameters[10];
+  m_Skew[2] = parameters[11];
+
+  // Transfer the translation part
+  TranslationType newTranslation;
+  newTranslation[0] = parameters[3];
+  newTranslation[1] = parameters[4];
+  newTranslation[2] = parameters[5];
+
+  this->SetVarTranslation(newTranslation);
+  this->ComputeMatrix();
+  this->ComputeOffset();
+
+  // Modified is always called since we just have a pointer to the
+  // parameters and cannot know if the parameters have changed.
+  this->Modified();
+
+  itkDebugMacro(<< "After setting parameters ");
+}
+
+//
+// Get Parameters
+//
+// Parameters are ordered as:
+//
+// p[0:2] = right part of the versor (axis times std::sin(t/2))
+// p[3:5] = translation components
+// p[6:8] = Scale
+// p[9:11] = Skew {x, y, z}
+//
+
+template <typename TParametersValueType>
+const typename ComposeScaleSkewVersor3DTransform<TParametersValueType>::ParametersType &
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const
+{
+  itkDebugMacro(<< "Getting parameters ");
+
+  this->m_Parameters[0] = this->GetVersor().GetX();
+  this->m_Parameters[1] = this->GetVersor().GetY();
+  this->m_Parameters[2] = this->GetVersor().GetZ();
+
+  this->m_Parameters[3] = this->GetTranslation()[0];
+  this->m_Parameters[4] = this->GetTranslation()[1];
+  this->m_Parameters[5] = this->GetTranslation()[2];
+
+  this->m_Parameters[6] = this->GetScale()[0];
+  this->m_Parameters[7] = this->GetScale()[1];
+  this->m_Parameters[8] = this->GetScale()[2];
+
+  this->m_Parameters[9] = this->GetSkew()[0];
+  this->m_Parameters[10] = this->GetSkew()[1];
+  this->m_Parameters[11] = this->GetSkew()[2];
+
+  itkDebugMacro(<< "After getting parameters " << this->m_Parameters);
+
+  return this->m_Parameters;
+}
+
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetIdentity()
+{
+  m_Scale.Fill(NumericTraits<ScaleVectorValueType>::OneValue());
+  m_Skew.Fill(NumericTraits<SkewVectorValueType>::ZeroValue());
+  Superclass::SetIdentity();
+}
+
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetScale(const ScaleVectorType & scale)
+{
+  m_Scale = scale;
+  this->ComputeMatrix();
+  this->ComputeOffset();
+}
+
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetSkew(const SkewVectorType & skew)
+{
+  m_Skew = skew;
+  this->ComputeMatrix();
+  this->ComputeOffset();
+}
+
+// Compute the matrix
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeMatrix()
+{
+  this->Superclass::ComputeMatrix();
+
+  MatrixType newMatrix = this->GetMatrix();
+
+  MatrixType scaleM;
+  scaleM.SetIdentity();
+  scaleM[0][0] = m_Scale[0];
+  scaleM[1][1] = m_Scale[1];
+  scaleM[2][2] = m_Scale[2];
+
+  MatrixType skewM;
+  skewM(0, 0) = 1;
+  skewM(0, 1) = m_Skew[0];
+  skewM(0, 2) = m_Skew[1];
+  skewM(1, 0) = 0;
+  skewM(1, 1) = 1;
+  skewM(1, 2) = m_Skew[2];
+  skewM(2, 0) = 0;
+  skewM(2, 1) = 0;
+  skewM(2, 2) = 1;
+
+  MatrixType Q = scaleM * skewM;
+  MatrixType res = newMatrix * Q;
+
+  this->SetVarMatrix(res);
+}
+
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeMatrixParameters()
+{
+  MatrixType M = this->GetMatrix();
+
+  OutputVectorType scaleV;
+  scaleV[0] = M(0, 0);
+  scaleV[1] = M(1, 0);
+  scaleV[2] = M(2, 0);
+  m_Scale[0] = scaleV.GetVnlVector().magnitude();
+  M(0, 0) /= m_Scale[0];
+  M(1, 0) /= m_Scale[0];
+  M(2, 0) /= m_Scale[0];
+
+  double ortho = M(0, 0) * M(0, 1) + M(1, 0) * M(1, 1) + M(2, 0) * M(2, 1);
+  M(0, 1) -= ortho * M(0, 0);
+  M(1, 1) -= ortho * M(1, 0);
+  M(2, 1) -= ortho * M(2, 0);
+  scaleV[0] = M(0, 1);
+  scaleV[1] = M(1, 1);
+  scaleV[2] = M(2, 1);
+  m_Scale[1] = scaleV.GetVnlVector().magnitude();
+  M(0, 1) /= m_Scale[1];
+  M(1, 1) /= m_Scale[1];
+  M(2, 1) /= m_Scale[1];
+  m_Skew[0] = ortho / m_Scale[0];
+
+  double ortho0 = M(0, 0) * M(0, 2) + M(1, 0) * M(1, 2) + M(2, 0) * M(2, 2);
+  double ortho1 = M(0, 1) * M(0, 2) + M(1, 1) * M(1, 2) + M(2, 1) * M(2, 2);
+  M(0, 2) -= (ortho0 * M(0, 0) + ortho1 * M(0, 1));
+  M(1, 2) -= (ortho0 * M(1, 0) + ortho1 * M(1, 1));
+  M(2, 2) -= (ortho0 * M(2, 0) + ortho1 * M(2, 1));
+  scaleV[0] = M(0, 2);
+  scaleV[1] = M(1, 2);
+  scaleV[2] = M(2, 2);
+  m_Scale[2] = scaleV.GetVnlVector().magnitude();
+  M(0, 2) /= m_Scale[2];
+  M(1, 2) /= m_Scale[2];
+  M(2, 2) /= m_Scale[2];
+  m_Skew[1] = ortho0 / m_Scale[0];
+  m_Skew[2] = ortho1 / m_Scale[1];
+  if (vnl_determinant(M.GetVnlMatrix()) < 0)
+  {
+    m_Scale[0] *= -1;
+    M(0, 0) *= -1;
+    M(1, 0) *= -1;
+    M(2, 0) *= -1;
+  }
+
+  VersorType v;
+  v.Set(M);
+  this->SetVarVersor(v);
+}
+
+// Print self
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "Scale:       " << m_Scale << std::endl;
+  os << indent << "Skew:        " << m_Skew << std::endl;
+}
+
+template <typename TParametersValueType>
+void
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeJacobianWithRespectToParameters(
+  const InputPointType & p,
+  JacobianType &         jacobian) const
+{
+  using ValueType = typename VersorType::ValueType;
+
+  // compute derivatives with respect to rotation
+  const ValueType vx = this->GetVersor().GetX();
+  const ValueType vy = this->GetVersor().GetY();
+  const ValueType vz = this->GetVersor().GetZ();
+  const ValueType vw = this->GetVersor().GetW();
+
+  jacobian.SetSize(3, this->GetNumberOfLocalParameters());
+  jacobian.Fill(0.0);
+
+  const double px = p[0] - this->GetCenter()[0];
+  const double py = p[1] - this->GetCenter()[1];
+  const double pz = p[2] - this->GetCenter()[2];
+
+  const double vxx = vx * vx;
+  const double vyy = vy * vy;
+  const double vzz = vz * vz;
+  const double vww = vw * vw;
+
+  const double vxy = vx * vy;
+  const double vxz = vx * vz;
+  const double vxw = vx * vw;
+
+  const double vyz = vy * vz;
+  const double vyw = vy * vw;
+
+  const double vzw = vz * vw;
+
+  // compute Jacobian with respect to quaternion parameters
+  jacobian[0][0] = 2.0 * ((vyw + vxz) * py + (vzw - vxy) * pz) / vw;
+  jacobian[1][0] = 2.0 * ((vyw - vxz) * px - 2 * vxw * py + (vxx - vww) * pz) / vw;
+  jacobian[2][0] = 2.0 * ((vzw + vxy) * px + (vww - vxx) * py - 2 * vxw * pz) / vw;
+
+  jacobian[0][1] = 2.0 * (-2 * vyw * px + (vxw + vyz) * py + (vww - vyy) * pz) / vw;
+  jacobian[1][1] = 2.0 * ((vxw - vyz) * px + (vzw + vxy) * pz) / vw;
+  jacobian[2][1] = 2.0 * ((vyy - vww) * px + (vzw - vxy) * py - 2 * vyw * pz) / vw;
+
+  jacobian[0][2] = 2.0 * (-2 * vzw * px + (vzz - vww) * py + (vxw - vyz) * pz) / vw;
+  jacobian[1][2] = 2.0 * ((vww - vzz) * px - 2 * vzw * py + (vyw + vxz) * pz) / vw;
+  jacobian[2][2] = 2.0 * ((vxw + vyz) * px + (vyw - vxz) * py) / vw;
+
+  jacobian[0][3] = 1.0;
+  jacobian[1][4] = 1.0;
+  jacobian[2][5] = 1.0;
+
+  jacobian[0][6] = px;
+  jacobian[1][7] = py;
+  jacobian[2][8] = pz;
+
+  jacobian[0][9] = px; // These are incorrect!
+  jacobian[1][10] = py;
+  jacobian[2][11] = pz;
+
+  itkExceptionMacro(<< "Computing the Jacobian of a ComposeScaleSkewVersor3D"
+                    << " transform is not supported at this time.");
+}
+
+} // namespace itk
+
+#endif

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
@@ -306,9 +306,14 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::PrintSelf(std::ostream 
 template <typename TParametersValueType>
 void
 ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeJacobianWithRespectToParameters(
-  const InputPointType & p,
-  JacobianType &         jacobian) const
+  const InputPointType & itkNotUsed(p),
+  JacobianType &         itkNotUsed(jacobian)) const
 {
+  // This document how the jacobian can be computed for certain parameters;
+  //   however, the proper computation of the scale and skew parameters is
+  //   now given or computed, so ultimately an exception is thrown.
+
+  /*
   using ValueType = typename VersorType::ValueType;
 
   // compute derivatives with respect to rotation
@@ -355,13 +360,14 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeJacobianWithResp
   jacobian[1][4] = 1.0;
   jacobian[2][5] = 1.0;
 
-  jacobian[0][6] = px;
+  jacobian[0][6] = px; // These are incorrect!
   jacobian[1][7] = py;
   jacobian[2][8] = pz;
 
   jacobian[0][9] = px; // These are incorrect!
   jacobian[1][10] = py;
   jacobian[2][11] = pz;
+  */
 
   itkExceptionMacro(<< "Computing the Jacobian of a ComposeScaleSkewVersor3D"
                     << " transform is not supported at this time.");

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(ITKTransformTests
 itkFixedCenterOfRotationAffineTransformTest.cxx
 itkAffineTransformTest.cxx
 itkScaleSkewVersor3DTransformTest.cxx
+itkComposeScaleSkewVersor3DTransformTest.cxx
 itkEuler3DTransformTest.cxx
 itkCenteredRigid2DTransformTest.cxx
 itkEuler2DTransformTest.cxx
@@ -46,6 +47,9 @@ itk_add_test(NAME itkAffineTransformTest
       COMMAND ITKTransformTestDriver itkAffineTransformTest)
 itk_add_test(NAME itkScaleSkewVersor3DTransformTest
       COMMAND ITKTransformTestDriver itkScaleSkewVersor3DTransformTest)
+itk_add_test(NAME itkComposeScaleSkewVersor3DTransformTest
+      COMMAND ITKTransformTestDriver
+        itkComposeScaleSkewVersor3DTransformTest)
 itk_add_test(NAME itkEuler3DTransformTest
       COMMAND ITKTransformTestDriver itkEuler3DTransformTest)
 itk_add_test(NAME itkCenteredRigid2DTransformTest

--- a/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
@@ -1,0 +1,554 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+/**
+ *
+ *  This program illustrates the use of Similarity3DTransform
+ *
+ *  This transform performs: translation, rotation and uniform scaling.
+ *
+ */
+
+#include "itkComposeScaleSkewVersor3DTransform.h"
+#include <iostream>
+
+#include <vnl/vnl_sample.h>
+
+// -------------------------
+//
+//   Main code
+//
+// -------------------------
+int
+itkComposeScaleSkewVersor3DTransformTest(int, char *[])
+{
+
+  using ValueType = double;
+
+  const ValueType epsilon = 1e-12;
+
+  //  Versor Transform type
+  using TransformType = itk::ComposeScaleSkewVersor3DTransform<ValueType>;
+
+  //  Versor type
+  using VersorType = TransformType::VersorType;
+
+  //  Vector type
+  using VectorType = TransformType::InputVectorType;
+
+  //  Parameters type
+  using ParametersType = TransformType::ParametersType;
+
+  //  Rotation Matrix type
+  using MatrixType = TransformType::MatrixType;
+
+  {
+    std::cout << "Test default constructor... ";
+
+    TransformType::Pointer transform = TransformType::New();
+
+    VectorType axis(1.5);
+
+    ValueType angle = 120.0 * std::atan(1.0) / 45.0;
+
+    VersorType versor;
+    versor.Set(axis, angle);
+
+    ParametersType parameters(transform->GetNumberOfParameters()); // Number of parameters
+
+    parameters[0] = versor.GetX();
+    parameters[1] = versor.GetY();
+    parameters[2] = versor.GetZ();
+    parameters[3] = 0.0; // Translation
+    parameters[4] = 0.0;
+    parameters[5] = 0.0;
+    parameters[6] = 1.0;
+    parameters[7] = 1.0;
+    parameters[8] = 1.0;
+    parameters[9] = 0.0;
+    parameters[10] = 0.0;
+    parameters[11] = 0.0;
+
+    transform->SetParameters(parameters);
+
+    if (0.0 > epsilon)
+    {
+      std::cout << "Error ! " << std::endl;
+      return EXIT_FAILURE;
+    }
+    std::cout << " PASSED !" << std::endl;
+  }
+
+  {
+    std::cout << "Test initial rotation matrix " << std::endl;
+    TransformType::Pointer transform = TransformType::New();
+    MatrixType             matrix = transform->GetMatrix();
+    std::cout << "Matrix = " << std::endl;
+    std::cout << matrix << std::endl;
+  }
+
+  /* Create a Rigid 3D transform with rotation */
+
+  {
+    bool Ok = true;
+
+    TransformType::Pointer rotation = TransformType::New();
+
+    itk::Vector<double, 3> axis(1);
+
+    const double angle = (std::atan(1.0) / 45.0) * 120.0; // turn 120 degrees
+
+    // this rotation will permute the axis x->y, y->z, z->x
+    rotation->SetRotation(axis, angle);
+
+    TransformType::OffsetType offset = rotation->GetOffset();
+    std::cout << "pure Rotation test:  ";
+    std::cout << offset << std::endl;
+    for (unsigned int i = 0; i < 3; i++)
+    {
+      if (std::fabs(offset[i] - 0.0) > epsilon)
+      {
+        Ok = false;
+        break;
+      }
+    }
+
+    if (!Ok)
+    {
+      std::cerr << "Get Offset  differs from null in rotation " << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    VersorType versor;
+    versor.Set(axis, angle);
+
+    {
+      // Rotate an itk::Point
+      TransformType::InputPointType::ValueType pInit[3] = { 1, 4, 9 };
+      TransformType::InputPointType            p = pInit;
+      TransformType::OutputPointType           q;
+      q = versor.Transform(p);
+
+      TransformType::OutputPointType r;
+      r = rotation->TransformPoint(p);
+      for (unsigned int i = 0; i < 3; i++)
+      {
+        if (std::fabs(q[i] - r[i]) > epsilon)
+        {
+          Ok = false;
+          break;
+        }
+      }
+      if (!Ok)
+      {
+        std::cerr << "Error rotating point : " << p << std::endl;
+        std::cerr << "Result should be     : " << q << std::endl;
+        std::cerr << "Reported Result is   : " << r << std::endl;
+        return EXIT_FAILURE;
+      }
+      else
+      {
+        std::cout << "Ok rotating an itk::Point " << std::endl;
+      }
+    }
+
+    {
+      // Translate an itk::Vector
+      TransformType::InputVectorType::ValueType pInit[3] = { 1, 4, 9 };
+      TransformType::InputVectorType            p = pInit;
+      TransformType::OutputVectorType           q;
+      q = versor.Transform(p);
+
+      TransformType::OutputVectorType r;
+      r = rotation->TransformVector(p);
+      for (unsigned int i = 0; i < 3; i++)
+      {
+        if (std::fabs(q[i] - r[i]) > epsilon)
+        {
+          Ok = false;
+          break;
+        }
+      }
+      if (!Ok)
+      {
+        std::cerr << "Error rotating vector : " << p << std::endl;
+        std::cerr << "Result should be      : " << q << std::endl;
+        std::cerr << "Reported Result is    : " << r << std::endl;
+        return EXIT_FAILURE;
+      }
+      else
+      {
+        std::cout << "Ok rotating an itk::Vector " << std::endl;
+      }
+    }
+
+    {
+      // Translate an itk::CovariantVector
+      TransformType::InputCovariantVectorType::ValueType pInit[3] = { 1, 4, 9 };
+      TransformType::InputCovariantVectorType            p = pInit;
+      TransformType::OutputCovariantVectorType           q;
+      q = versor.Transform(p);
+
+      TransformType::OutputCovariantVectorType r;
+      r = rotation->TransformCovariantVector(p);
+      for (unsigned int i = 0; i < 3; i++)
+      {
+        if (std::fabs(q[i] - r[i]) > epsilon)
+        {
+          Ok = false;
+          break;
+        }
+      }
+      if (!Ok)
+      {
+        std::cerr << "Error rotating covariant vector : " << p << std::endl;
+        std::cerr << "Result should be                : " << q << std::endl;
+        std::cerr << "Reported Result is              : " << r << std::endl;
+        return EXIT_FAILURE;
+      }
+      else
+      {
+        std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
+      }
+    }
+
+    {
+      // Translate a vnl_vector
+      TransformType::InputVnlVectorType p;
+      p[0] = 1;
+      p[1] = 4;
+      p[2] = 9;
+
+      TransformType::OutputVnlVectorType q;
+      q = versor.Transform(p);
+
+      TransformType::OutputVnlVectorType r;
+      r = rotation->TransformVector(p);
+      for (unsigned int i = 0; i < 3; i++)
+      {
+        if (std::fabs(q[i] - r[i]) > epsilon)
+        {
+          Ok = false;
+          break;
+        }
+      }
+      if (!Ok)
+      {
+        std::cerr << "Error rotating vnl_vector : " << p << std::endl;
+        std::cerr << "Result should be          : " << q << std::endl;
+        std::cerr << "Reported Result is        : " << r << std::endl;
+        return EXIT_FAILURE;
+      }
+      else
+      {
+        std::cout << "Ok rotating an vnl_Vector " << std::endl;
+      }
+    }
+  }
+
+  /**  Exercise the SetCenter method  */
+  {
+    bool Ok = true;
+
+    TransformType::Pointer transform = TransformType::New();
+
+    itk::Vector<double, 3> axis(1);
+
+    const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
+
+    transform->SetRotation(axis, angle);
+
+    TransformType::InputPointType center;
+    center[0] = 31;
+    center[1] = 62;
+    center[2] = 93;
+
+    transform->SetCenter(center);
+
+    TransformType::OutputPointType transformedPoint;
+    transformedPoint = transform->TransformPoint(center);
+    for (unsigned int i = 0; i < 3; i++)
+    {
+      if (std::fabs(center[i] - transformedPoint[i]) > epsilon)
+      {
+        Ok = false;
+        break;
+      }
+    }
+
+    if (!Ok)
+    {
+      std::cerr << "The center point was not invariant to rotation " << std::endl;
+      return EXIT_FAILURE;
+    }
+    else
+    {
+      std::cout << "Ok center is invariant to rotation." << std::endl;
+    }
+
+    const unsigned int np = transform->GetNumberOfParameters();
+
+    ParametersType parameters(np); // Number of parameters
+    parameters.Fill(0.0);
+
+    VersorType versor;
+
+    // TODO: Test jacobian with non-zero skew
+
+    parameters[0] = versor.GetX(); // Rotation axis * sin(t/2)
+    parameters[1] = versor.GetY();
+    parameters[2] = versor.GetZ();
+    parameters[3] = 8.0; // Translation
+    parameters[4] = 7.0;
+    parameters[5] = 6.0;
+    parameters[6] = 1.0; // Scale
+    parameters[7] = 1.0;
+    parameters[8] = 1.0;
+    parameters[9] = 0.1; // Skew
+    parameters[10] = 0.1;
+    parameters[11] = 0.0;
+
+    transform->SetParameters(parameters);
+
+    ParametersType parameters2 = transform->GetParameters();
+
+    const double tolerance = 1e-8;
+    for (unsigned int p = 0; p < np; p++)
+    {
+      if (std::fabs(parameters[p] - parameters2[p]) > tolerance)
+      {
+        std::cerr << "Get/Set parameters: parameters do not match " << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+    std::cout << "Get/Set parameter check Passed !" << std::endl;
+  }
+
+  {
+    std::cout << " Exercise the SetIdentity() method " << std::endl;
+    TransformType::Pointer transform = TransformType::New();
+
+    itk::Vector<double, 3> axis(1);
+
+    const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
+
+    transform->SetRotation(axis, angle);
+
+    TransformType::InputPointType center;
+    center[0] = 31;
+    center[1] = 62;
+    center[2] = 93;
+
+    transform->SetCenter(center);
+
+    transform->SetIdentity();
+
+    const unsigned int np = transform->GetNumberOfParameters();
+
+    ParametersType parameters(np); // Number of parameters
+
+    VersorType versor;
+
+    parameters[0] = versor.GetX(); // Rotation axis * sin(t/2)
+    parameters[1] = versor.GetY();
+    parameters[2] = versor.GetZ();
+    parameters[3] = 0.0; // Translation
+    parameters[4] = 0.0;
+    parameters[5] = 0.0;
+    parameters[6] = 1.0; // Scale
+    parameters[7] = 1.0;
+    parameters[8] = 1.0;
+    parameters[9] = 0.0; // Skew
+    parameters[10] = 0.0;
+    parameters[11] = 0.0;
+
+    ParametersType parameters2 = transform->GetParameters();
+
+    const double tolerance = 1e-8;
+    for (unsigned int p = 0; p < np; p++)
+    {
+      std::cout << parameters[p] << " = " << parameters2[p] << std::endl;
+      if (std::fabs(parameters[p] - parameters2[p]) > tolerance)
+      {
+        std::cerr << "Identity parameters do not match" << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+    std::cout << "Identity parameters check Passed !" << std::endl;
+  }
+
+  {
+    std::cout << " Exercise the Scaling methods " << std::endl;
+    TransformType::Pointer transform = TransformType::New();
+
+    itk::Vector<double, 3> axis(1);
+    const double           angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
+    transform->SetRotation(axis, angle);
+
+    TransformType::InputPointType center;
+    center[0] = 31;
+    center[1] = 62;
+    center[2] = 93;
+    transform->SetCenter(center);
+
+    TransformType::OutputVectorType translation;
+    translation[0] = 17;
+    translation[1] = 19;
+    translation[2] = 23;
+    transform->SetTranslation(translation);
+
+    TransformType::ScaleVectorType scale;
+    scale.Fill(2.5);
+    transform->SetScale(scale);
+
+    TransformType::SkewVectorType skew;
+    skew.Fill(0);
+    skew[0] = 0.1;
+    skew[1] = 0.1;
+    transform->SetSkew(skew);
+
+    TransformType::ScaleVectorType rscale = transform->GetScale();
+
+    const double tolerance = 1e-8;
+    for (unsigned int j = 0; j < 3; j++)
+    {
+      if (std::fabs(rscale[j] - scale[j]) > tolerance)
+      {
+        std::cerr << "Error in Set/Get Scale() " << std::endl;
+        std::cerr << "Input scale: " << scale << std::endl;
+        std::cerr << "Output scale: " << rscale << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+
+    const unsigned int np = transform->GetNumberOfParameters();
+
+    ParametersType parameters(np); // Number of parameters
+
+    VersorType versor;
+    versor.Set(axis, angle);
+
+    parameters.Fill(0.0);
+    parameters[0] = versor.GetX(); // Rotation axis * sin(t/2)
+    parameters[1] = versor.GetY();
+    parameters[2] = versor.GetZ();
+    parameters[3] = translation[0];
+    parameters[4] = translation[1];
+    parameters[5] = translation[2];
+    parameters[6] = scale[0];
+    parameters[7] = scale[1];
+    parameters[8] = scale[2];
+    parameters[9] = skew[0];
+    parameters[10] = skew[1];
+    parameters[11] = skew[2];
+
+    ParametersType parameters2 = transform->GetParameters();
+    for (unsigned int p = 0; p < np; p++)
+    {
+      std::cout << parameters[p] << " = " << parameters2[p] << std::endl;
+      if (std::fabs(parameters[p] - parameters2[p]) > tolerance)
+      {
+        std::cerr << "Scale parameters do not match input " << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+    std::cout << "Scale parameters check Passed !" << std::endl;
+
+    std::cout << " Exercise the SetMatrix() method" << std::endl;
+    TransformType::Pointer transform2 = TransformType::New();
+    transform2->SetFixedParameters(transform->GetFixedParameters());
+    transform2->SetMatrix(transform->GetMatrix());
+    transform2->SetOffset(transform->GetOffset());
+
+    TransformType::Pointer transform3 = TransformType::New();
+    transform3->SetFixedParameters(transform2->GetFixedParameters());
+    transform3->SetParameters(transform2->GetParameters());
+
+    ParametersType parameters3 = transform3->GetParameters();
+    for (unsigned int p = 0; p < np; p++)
+    {
+      std::cout << parameters[p] << " = " << parameters3[p] << std::endl;
+      if (std::fabs(parameters[p] - parameters3[p]) > tolerance)
+      {
+        std::cerr << "SetMatrix parameters do not match input " << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+    std::cout << "SetMatrix parameters do match!" << std::endl;
+
+    int diff = 0;
+    for (unsigned int p = 0; p < 100; p++)
+    {
+      TransformType::InputPointType pnt;
+      for (unsigned int i = 0; i < 3; ++i)
+      {
+        pnt[i] = vnl_sample_uniform(-100, 100);
+      }
+
+      TransformType::OutputPointType tPnt;
+      tPnt = transform->TransformPoint(pnt);
+      TransformType::OutputPointType tPnt2;
+      tPnt2 = transform2->TransformPoint(pnt);
+      TransformType::OutputPointType tPnt3;
+      tPnt3 = transform3->TransformPoint(pnt);
+
+      for (unsigned int i = 0; i < 3; ++i)
+      {
+        if (fabs(tPnt[i] - tPnt2[i]) > 1e-7)
+        {
+          ++diff;
+        }
+        if (fabs(tPnt[i] - tPnt3[i]) > 1e-7)
+        {
+          ++diff;
+        }
+      }
+      if (diff != 0)
+      {
+        std::cerr << "SetMatrix() points do not match" << std::endl;
+        std::cout << "Point #" << p << std::endl;
+        std::cout << "idea = " << tPnt << std::endl;
+        std::cout << "t2 = " << tPnt2 << std::endl;
+        std::cout << "t3 = " << tPnt3 << std::endl;
+        std::cerr << "**************************************" << std::endl;
+        std::cerr << "Transform = " << transform << std::endl;
+        std::cerr << "**************************************" << std::endl;
+        std::cerr << "Transform2 = " << transform2 << std::endl;
+        std::cerr << "**************************************" << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+    std::cout << "SetMatrix() points check Passed !" << std::endl;
+
+#if 0 // TODO: Need to instrument inverse of ScaleVersor3DTransform
+      {
+      TransformType::Pointer tInverse = TransformType::New();
+      if(!transform->GetInverse(tInverse))
+        {
+        std::cout << "Cannot create inverse transform" << std::endl;
+        return EXIT_FAILURE;
+        }
+      std::cout << "translation: " << transform;
+      std::cout << "translationInverse: " << tInverse;
+      }
+#endif
+  }
+  std::cout << std::endl << "Test PASSED ! " << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
@@ -18,9 +18,9 @@
 
 /**
  *
- *  This program illustrates the use of Similarity3DTransform
+ *  This program illustrates the use of ComposeScaleSkewVersor3D transform.
  *
- *  This transform performs: translation, rotation and uniform scaling.
+ *  This transform performs: translation, rotation scaling, and skewing.
  *
  */
 

--- a/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
@@ -18,9 +18,14 @@
 
 /**
  *
- *  This program illustrates the use of Similarity3DTransform
+ *  This program illustrates the use of ScaleSkewVersor3DTransform
  *
- *  This transform performs: translation, rotation and uniform scaling.
+ *  This transform performs: translation, rotation, scaling, and skewing.
+ *
+ *  Note that this transform's parameters do not do what their names imply.
+ *  The scale and skew parameters actually have effects beyond simple scaling
+ *  and skewing (e.g., they induce rotations and scalings) because they
+ *  are added to the rotation matrix instead of composed with it.
  *
  */
 

--- a/Modules/Core/Transform/wrapping/itkComposeScaleSkewVersor3DTransform.wrap
+++ b/Modules/Core/Transform/wrapping/itkComposeScaleSkewVersor3DTransform.wrap
@@ -1,0 +1,6 @@
+itk_wrap_filter_dims(d3 3)
+if(d3)
+  itk_wrap_class("itk::ComposeScaleSkewVersor3DTransform" POINTER)
+    itk_wrap_template("${ITKM_D}" "${ITKT_D}")
+  itk_end_wrap_class()
+endif()


### PR DESCRIPTION
This transform uses matrix compose to combine matrix defined by
versor, scale, and skew parameters.  Implementing the
jacobian of this transform is left as an exercise for future
developers.