### PR TITLE
DOC: Add Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ ITK: The Insight Toolkit
 [![PyPI](https://img.shields.io/pypi/v/itk.svg)](https://pypi.python.org/pypi/itk)
 [![Wheels](https://img.shields.io/pypi/wheel/itk.svg)](https://pypi.org/project/itk)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/InsightSoftwareConsortium/ITK/blob/master/LICENSE)
+[![DOI](https://zenodo.org/badge/800928.svg)](https://zenodo.org/badge/latestdoi/800928)
 
 | | C++ | Python |
 |:------:|:--------:|:--------:|


### PR DESCRIPTION
Adds a DOI to the code for software citation. The badge points to the DOI for the latest release. According to Zenodo docs, this is updated automatically on every new GitHub release.

