### PR TITLE
BUG: Remove debug console prints from GPU kernels

### DIFF
--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -127,8 +127,6 @@ GPUReduction<TElement>::GetReductionKernel(int whichKernel, int blockSize, int i
   defines << "#define T ";
   GetTypenameInString(typeid(TElement), defines);
 
-  std::cout << "Defines: " << defines.str() << std::endl;
-
   const char * GPUSource = GPUReduction::GetOpenCLSource();
 
   // load and build program

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.hxx
@@ -59,7 +59,6 @@ GPUDenseFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilte
 
   // assumes input and output pixel type is same
   defines << "#define PIXELDIM " << GetPixelDimension(typeid(typename TOutputImage::PixelType)) << "\n";
-  std::cout << "Defines: " << defines.str() << std::endl;
 
   const char * GPUSource = GPUDenseFiniteDifferenceImageFilter::GetOpenCLSource();
 

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.hxx
@@ -106,7 +106,6 @@ GPUGradientNDAnisotropicDiffusionFunction<TImage>::GPUGradientNDAnisotropicDiffu
 #else
   defines << "#define ARGTYPE " << pixeltypename << "\n";
 #endif
-  std::cout << "Defines: " << defines.str() << std::endl;
 
   const char * GPUSource = GPUGradientNDAnisotropicDiffusionFunction::GetOpenCLSource();
 

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.hxx
@@ -44,8 +44,8 @@ GPUScalarAnisotropicDiffusionFunction<TImage>::GPUScalarAnisotropicDiffusionFunc
   defines << "#define DIM_" << ImageDimension << "\n";
 
   defines << "#define PIXELTYPE ";
+
   GetTypenameInString(typeid(typename TImage::PixelType), defines);
-  std::cout << "Defines: " << defines.str() << std::endl;
 
   const char * GPUSource = GPUScalarAnisotropicDiffusionFunction::GetOpenCLSource();
 

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
@@ -104,8 +104,6 @@ GPUNeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType
   defines << "#define OPTYPE ";
   GetTypenameInString(typeid(TOperatorValueType), defines);
 
-  std::cout << "Defines: " << defines.str() << std::endl;
-
   const char * GPUSource = GPUNeighborhoodOperatorImageFilter::GetOpenCLSource();
 
   // load and build program

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
@@ -92,7 +92,6 @@ GPUBinaryThresholdImageFilter<TInputImage, TOutputImage>::GPUBinaryThresholdImag
     itkExceptionMacro(<< excpMsg.str().c_str());
   }
 
-  std::cout << "Defines: " << defines.str() << std::endl;
   const char * GPUSource = GPUBinaryThresholdImageFilter::GetOpenCLSource();
 
   // load and build program

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -84,7 +84,6 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GP
 
   defines << "#define OUTPIXELTYPE ";
   GetTypenameInString(typeid(typename TDisplacementField::PixelType::ValueType), defines);
-  std::cout << "Defines: " << defines.str() << std::endl;
 
   const char * GPUSource = GPUDemonsRegistrationFunction::GetOpenCLSource();
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -62,8 +62,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   defines << "#define OUTPIXELTYPE ";
   GetTypenameInString(typeid(DeformationScalarType), defines);
 
-  std::cout << "Defines: " << defines.str() << std::endl;
-
   using GPUCodeType = const char *;
   GPUCodeType GPUSource = GPUPDEDeformableRegistrationFilter::GetOpenCLSource();
 


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
