### PR TITLE
DOC: Remove CONTRIBUTING note about ApplyClangFormat action

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,10 +281,6 @@ one, but further back in your history-, and the* Pro Git: Rebasing *resource on
 taking all the changes that were committed on one branch and replaying them on
 another one.*)
 
-If your topic branch fails the ITK Coding Style consistency check but is
-otherwise ready to merge, add the *action:ApplyClangFormat* label to the pull
-request. A bot will re-format all commits in the topic.
-
 Merge a Topic
 -------------
 


### PR DESCRIPTION
As of 2020-01-08, this action [currently does not work from forked
repositories](https://github.community/t5/GitHub-Actions/Token-permissions-for-forks-once-again/td-p/33839)
because the [*GITHUB_TOKEN* has limited
permissions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#permissions-for-the-github_token). Branches need to be created on the upstream repository.