### PR TITLE
STYLE: Style fixes RecursiveSeparableImageFilter member functions

### DIFF
--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
@@ -174,7 +174,7 @@ protected:
 
 
   template <typename T1, typename T2>
-  inline void
+  static inline void
   MathEMAMAMAM(T1 &       out,
                const T1 & a1,
                const T2 & b1,
@@ -190,7 +190,7 @@ protected:
 
 
   template <typename T1, typename T2>
-  inline void
+  static inline void
   MathEMAMAMAM(VariableLengthVector<T1> &       out,
                const VariableLengthVector<T1> & a1,
                const T2 &                       b1,
@@ -213,7 +213,7 @@ protected:
   }
 
   template <typename T1, typename T2>
-  inline void
+  static inline void
   MathSMAMAMAM(T1 &       out,
                const T1 & a1,
                const T2 & b1,
@@ -228,7 +228,7 @@ protected:
   }
 
   template <typename T1, typename T2>
-  inline void
+  static inline void
   MathSMAMAMAM(VariableLengthVector<T1> &       out,
                const VariableLengthVector<T1> & a1,
                const T2 &                       b1,

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
@@ -137,7 +137,7 @@ protected:
    * outside of this routine (this avoids memory allocation and
    * deallocation in the inner loop of the overall algorithm. */
   void
-  FilterDataArray(RealType * outs, const RealType * data, RealType * scratch, SizeValueType ln);
+  FilterDataArray(RealType * outs, const RealType * data, RealType * scratch, SizeValueType ln) const;
 
 protected:
   /** Causal coefficients that multiply the input data. */

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
@@ -81,14 +81,14 @@ RecursiveSeparableImageFilter<TInputImage, TOutputImage>::GetInputImage()
  */
 template <typename TInputImage, typename TOutputImage>
 void
-RecursiveSeparableImageFilter<TInputImage, TOutputImage>::FilterDataArray(RealType *       outs,
-                                                                          const RealType * data,
-                                                                          RealType *       scratch,
-                                                                          SizeValueType    ln)
+RecursiveSeparableImageFilter<TInputImage, TOutputImage>::FilterDataArray(RealType * const       outs,
+                                                                          const RealType * const data,
+                                                                          RealType * const       scratch,
+                                                                          const SizeValueType    ln) const
 {
 
-  RealType * scratch1 = outs;
-  RealType * scratch2 = scratch;
+  RealType * const scratch1 = outs;
+  RealType * const scratch2 = scratch;
   /**
    * Causal direction pass
    */


### PR DESCRIPTION
Three style fixes of `RecursiveSeparableImageFilter` member functions:

- Declared `MathEMAMAMAM` and `MathSMAMAMAM` static
- Added `const` to `FilterDataArray`
- Replaced raw pointers by unique_ptr within `DynamicThreadedGenerateData`

