### PR TITLE
ENH: latest version of remote module RTK

### DIFF
--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -2,5 +2,5 @@
 itk_fetch_module(RTK
     "Reconstruction Toolkit (RTK) http://www.openrtk.org/"
   GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/RTK.git
-  GIT_TAG v2.1.0
+  GIT_TAG 3fc00efadef8324aba31f77390c3e562f9af5147
 )


### PR DESCRIPTION
It would be great to update RTK once again. Among other changes, note the fix SimonRit/RTK@8d213dfd5ddc81fadad313a4991985a1eaab9413 for the backward incompatible change on the ITK side which was less than one day before the release of v5.1rc01. Unfortunately, ITK v5.1rc01 does not compile with Module_RTK ON... If it makes it to v5.1rc02, I'll check that it compiles and then release RTK v2.2.0. Let me know if you prefer that I proceed differently (e.g. release RTK first, as I did for v2.1.0). Thanks for this and for the publicity in the release notes of v5.1rc01!