### PR TITLE
BUG: Prevent integer underflow in CropImageFilter

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
@@ -111,6 +111,9 @@ protected:
   void
   GenerateOutputInformation() override;
 
+  void
+  VerifyInputInformation() ITKv5_CONST override;
+
 private:
   SizeType m_UpperBoundaryCropSize;
   SizeType m_LowerBoundaryCropSize;

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
@@ -44,6 +44,8 @@ CropImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   for (unsigned int i = 0; i < InputImageDimension; ++i)
   {
     idx[i] = input_idx[i] + m_LowerBoundaryCropSize[i];
+
+    assert(input_sz[i] >= (m_UpperBoundaryCropSize[i] + m_LowerBoundaryCropSize[i]));
     sz[i] = input_sz[i] - (m_UpperBoundaryCropSize[i] + m_LowerBoundaryCropSize[i]);
   }
 
@@ -54,6 +56,26 @@ CropImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   this->SetExtractionRegion(croppedRegion);
 
   Superclass::GenerateOutputInformation();
+}
+
+
+template <typename TInputImage, typename TOutputImage>
+void
+CropImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() ITKv5_CONST
+{
+  Superclass::VerifyInputInformation();
+
+  const TInputImage * inputPtr = this->GetInput();
+
+  InputImageSizeType input_sz = inputPtr->GetLargestPossibleRegion().GetSize();
+
+  for (unsigned int i = 0; i < InputImageDimension; ++i)
+  {
+    if (input_sz[i] < (m_UpperBoundaryCropSize[i] + m_LowerBoundaryCropSize[i]))
+    {
+      itkExceptionMacro("The input image's size " << input_sz << " is less than the total of the crop size!");
+    }
+  }
 }
 
 template <typename TInputImage, typename TOutputImage>


### PR DESCRIPTION
Check that the crop size is not greater that the image size to prevent
integer underflow.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
