### PR TITLE
ENH: Changed NIFTI IO to support different flavors of Analyze readers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,23 @@ if (ITKV3_COMPATIBILITY)
   message(FATAL_ERROR "ITKV3_COMPATIBILITY is removed starting in ITK version 5.0, this option is no longer valid.")
 endif()
 
+# Chose flavour of Analyze reader
+set(ITK_NIFTI_IO_ANALYZE_FLAVOR_DOC_STRING "Which flavour of Analyze reader to use by default")
+
+set(ITK_NIFTI_IO_ANALYZE_FLAVOR "ITK4Warning" CACHE STRING ${ITK_NIFTI_IO_ANALYZE_FLAVOR_DOC_STRING})
+
+set_property(CACHE ITK_NIFTI_IO_ANALYZE_FLAVOR PROPERTY STRINGS ITK4Warning ITK4 SPM FSL Reject)
+
+if( NOT ("${ITK_NIFTI_IO_ANALYZE_FLAVOR}" STREQUAL "ITK4Warning" OR
+         "${ITK_NIFTI_IO_ANALYZE_FLAVOR}" STREQUAL "ITK4" OR
+         "${ITK_NIFTI_IO_ANALYZE_FLAVOR}" STREQUAL "SPM" OR
+         "${ITK_NIFTI_IO_ANALYZE_FLAVOR}" STREQUAL "FSL" OR
+         "${ITK_NIFTI_IO_ANALYZE_FLAVOR}" STREQUAL "Reject"
+         ) )
+  set(ITK_NIFTI_IO_ANALYZE_FLAVOR "ITK4Warning" CACHE STRING ${ITK_NIFTI_IO_ANALYZE_FLAVOR_DOC_STRING} FORCE)
+endif()
+
+
 #-----------------------------------------------------------------------------
 # ITK build classes that are in the review process
 # ITK_USE_REVIEW is deprecated, only kept for backward compatibility

--- a/Modules/IO/ImageBase/include/itkIOTestHelper.h
+++ b/Modules/IO/ImageBase/include/itkIOTestHelper.h
@@ -31,12 +31,18 @@ class IOTestHelper
 public:
   template <typename TImage>
   static typename TImage::Pointer
-  ReadImage(const std::string & fileName, const bool zeroOrigin = false)
+  ReadImage(const std::string &           fileName,
+            const bool                    zeroOrigin = false,
+            typename ImageIOBase::Pointer imageio = nullptr)
   {
     using ReaderType = itk::ImageFileReader<TImage>;
 
     typename ReaderType::Pointer reader = ReaderType::New();
     {
+      if (imageio)
+      {
+        reader->SetImageIO(imageio);
+      }
       reader->SetFileName(fileName.c_str());
       try
       {
@@ -69,13 +75,18 @@ public:
 
   template <typename ImageType, typename ImageIOType>
   static void
-  WriteImage(typename ImageType::Pointer & image, const std::string & filename)
+  WriteImage(typename ImageType::Pointer & image,
+             const std::string &           filename,
+             typename ImageIOType::Pointer imageio = nullptr)
   {
 
     using WriterType = itk::ImageFileWriter<ImageType>;
     typename WriterType::Pointer writer = WriterType::New();
 
-    typename ImageIOType::Pointer imageio(ImageIOType::New());
+    if (imageio.IsNull())
+    {
+      imageio = ImageIOType::New();
+    }
 
     writer->SetImageIO(imageio);
 

--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -27,6 +27,30 @@
 
 namespace itk
 {
+
+
+/** \class Analyze75Flavor
+ * \ingroup ITKIONIFTI
+ * Enum used to define way to treat legacy Analyze75 files
+ */
+enum class Analyze75Flavor : uint8_t
+{
+  /** Behavior introduced in ITK4.0 by NIFTI reader interpreting Analyze files */
+  AnalyzeITK4 = 4,
+  /** Will ignore orientation code and negative pixel dimensions */
+  AnalyzeFSL = 3,
+  /** Will ignore orientation code and respect negative pixel dimensions */
+  AnalyzeSPM = 2,
+  /** Same as AnalyzeITK4 but will show warning about deprecated file format (Default)*/
+  AnalyzeITK4Warning = 1,
+  /** Reject Analyze files as potentially wrong  */
+  AnalyzeReject = 0
+};
+
+/** Define how to print enumerations */
+extern ITKIONIFTI_EXPORT std::ostream &
+                         operator<<(std::ostream & out, const Analyze75Flavor value);
+
 /** \class NiftiImageIO
  *
  * \author Hans J. Johnson, The University of Iowa 2002
@@ -70,6 +94,7 @@ public:
     /** Some other file format, or file system error. */
     OtherOrError = -1,
   };
+
 
   /** Reads the file to determine if it can be read with this ImageIO implementation,
    * and to determine what kind of file it is (Analyze vs NIfTI). Note that the value
@@ -131,10 +156,10 @@ public:
 
   /** A mode to allow the Nifti filter to read and write to the LegacyAnalyze75 format as interpreted by
    * the nifti library maintainers.  This format does not properly respect the file orientation fields.
-   * By default this is set to true.
+   * By default this is set by configuration option ITK_NIFTI_IO_ANALYZE_FLAVOR
    */
-  itkSetMacro(LegacyAnalyze75Mode, bool);
-  itkGetConstMacro(LegacyAnalyze75Mode, bool);
+  itkSetMacro(LegacyAnalyze75Mode, Analyze75Flavor);
+  itkGetConstMacro(LegacyAnalyze75Mode, Analyze75Flavor);
 
 protected:
   NiftiImageIO();
@@ -188,8 +213,10 @@ private:
 
   IOComponentType m_OnDiskComponentType{ UNKNOWNCOMPONENTTYPE };
 
-  bool m_LegacyAnalyze75Mode{ true };
+  Analyze75Flavor m_LegacyAnalyze75Mode;
 };
+
+
 } // end namespace itk
 
 #endif // itkNiftiImageIO_h

--- a/Modules/IO/NIFTI/src/CMakeLists.txt
+++ b/Modules/IO/NIFTI/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+configure_file(itkNiftiImageIOConfigurePrivate.h.in itkNiftiImageIOConfigurePrivate.h @ONLY)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
 set(ITKIONIFTI_SRCS
   itkNiftiImageIOFactory.cxx
   itkNiftiImageIO.cxx

--- a/Modules/IO/NIFTI/src/itkNiftiImageIOConfigurePrivate.h.in
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIOConfigurePrivate.h.in
@@ -1,0 +1,27 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkNiftiImageIOConfigurePrivate_h
+#define itkNiftiImageIOConfigurePrivate_h
+
+// This file is intended to hold preprocessor macros only used internally by
+// IO/NIFTI module and should not be installed.
+
+// Analyze default flavour
+#define ITK_NIFTI_IO_ANALYZE_FLAVOR_DEFAULT Analyze75Flavor::Analyze@ITK_NIFTI_IO_ANALYZE_FLAVOR@
+
+#endif //itkNiftiImageIOConfigurePrivate_h

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
@@ -125,13 +125,15 @@ itkNiftiImageIOTest(int ac, char * av[])
   if (ac > 1) // This is a mechanism for reading unsigned char images for testing.
   {
     using ImageType = itk::Image<unsigned char, 3>;
-    ImageType::Pointer input;
+    ImageType::Pointer         input;
+    itk::NiftiImageIO::Pointer imageIO = itk::NiftiImageIO::New();
+    // enable old behavior of NIFTI reader
+    imageIO->SetLegacyAnalyze75Mode(itk::Analyze75Flavor::AnalyzeITK4);
     for (int imagenameindex = 1; imagenameindex < ac; imagenameindex++)
     {
-      // std::cout << "Attempting to read " << av[imagenameindex] << std::endl;
       try
       {
-        input = itk::IOTestHelper::ReadImage<ImageType>(std::string(av[imagenameindex]));
+        input = itk::IOTestHelper::ReadImage<ImageType>(std::string(av[imagenameindex]), false, imageIO);
       }
       catch (const itk::ExceptionObject & e)
       {
@@ -216,6 +218,7 @@ itkNiftiImageIOTest(int ac, char * av[])
       std::cerr << "Error writing Nifti file type double" << std::endl;
       rval += cur_return;
     }
+    std::cout << "Prefix:" << prefix << std::endl;
     rval += TestNiftiByteSwap(prefix);
   }
   // Tests added to increase code coverage.

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
@@ -44,7 +44,7 @@ WriteNiftiTestFiles(const std::string & prefix)
   if (!little_hdr.is_open())
     return EXIT_FAILURE;
   std::cout << "NiftiLittleEndian written" << std::endl;
-  little_hdr.write(reinterpret_cast<const char *>(LittleEndian_hdr), sizeof(LittleEndian_hdr));
+  little_hdr.write(reinterpret_cast<const char *>(&NiftiLittleEndian), sizeof(NiftiLittleEndian));
   little_hdr.close();
   std::ofstream little_img((prefix + "NiftiLittleEndian.img").c_str(), std::ios::binary | std::ios::out);
   if (!little_img.is_open())
@@ -54,7 +54,7 @@ WriteNiftiTestFiles(const std::string & prefix)
   std::ofstream big_hdr((prefix + "NiftiBigEndian.hdr").c_str(), std::ios::binary | std::ios::out);
   if (!big_hdr.is_open())
     return EXIT_FAILURE;
-  big_hdr.write(reinterpret_cast<const char *>(BigEndian_hdr), sizeof(BigEndian_hdr));
+  big_hdr.write(reinterpret_cast<const char *>(&NiftiBigEndian), sizeof(NiftiBigEndian));
   big_hdr.close();
   std::ofstream big_img((prefix + "NiftiBigEndian.img").c_str(), std::ios::binary | std::ios::out);
   if (!big_img.is_open())

--- a/Modules/IO/NIFTI/wrapping/itkNiftiImageIO.wrap
+++ b/Modules/IO/NIFTI/wrapping/itkNiftiImageIO.wrap
@@ -1,2 +1,7 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
+itk_wrap_include("itkNiftiImageIO.h")
+itk_wrap_include("itkNiftiImageIOFactory.h")
+
 itk_wrap_simple_class("itk::NiftiImageIO" POINTER)
 itk_wrap_simple_class("itk::NiftiImageIOFactory" POINTER)
+itk_wrap_simple_class("itk::Analyze75Flavor" ENUM)


### PR DESCRIPTION
Changed ITK NIFTI Reader, according to the discussion from https://discourse.itk.org/t/nifti-file-orientation-change-between-2019-08-26-and-itk-v5-1rc01/2594 .
New behaviour is to reject Analyze files, unless one of the flavours is specified:

Reject Analyze files (default) to avoid confusion:
`imageIO->SetLegacyAnalyze75Mode(itk::NiftiImageIO::AnalyzeReject);`
Use NIFTI reader behaviour introduced in ITK v4 (ignore orientation code, flip dimensions if step size is negative):
`imageIO->SetLegacyAnalyze75Mode(itk::NiftiImageIO::AnalyzeITK4);`
Simulate SPM reader, mode similar to depricated Analyze reader from ITK3 (interpret orientation code, flip dimensions if step size is negative):
`imageIO->SetLegacyAnalyze75Mode(itk::NiftiImageIO::AnalyzeSPM);`
Simulate FSL reader (respect orientation code, ignore negative step size):
`imageIO->SetLegacyAnalyze75Mode(itk::NiftiImageIO::AnalyzeFSL);`

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
