### PR TITLE
BUG: SetLabelForUndecidedPixels value ignored.

### DIFF
--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -395,7 +395,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
     }
 
     // now determine the label with the maximum W
-    auto        winningLabel = static_cast<OutputPixelType>(this->m_TotalLabelCount);
+    auto        winningLabel = this->m_LabelForUndecidedPixels;
     WeightsType winningLabelW = 0;
     for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
     {
@@ -406,7 +406,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
       }
       else if (!(W[ci] < winningLabelW))
       {
-        winningLabel = static_cast<OutputPixelType>(this->m_TotalLabelCount);
+        winningLabel = this->m_LabelForUndecidedPixels;
       }
     }
 

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
@@ -35,7 +35,7 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   // Correct combinations of input images
   const unsigned int combinationABC[8] = { 0, 1, 2, 3, 4, 5, 6, 9 };
   const unsigned int combinationAB[8] = { 8, 1, 8, 8, 4, 8, 8, 8 };
-  const unsigned int combinationABundecided255[8] = { 8, 1, 8, 8, 4, 8, 8, 8 };
+  const unsigned int combinationABundecided255[8] = { 255, 1, 255, 255, 4, 255, 255, 255 };
 
   // Declare the type of the index to access images
   using myIndexType = itk::Index<myDimension>;


### PR DESCRIPTION
The user requested label for undecided values was ignored and the
maxLabel+1 was always used. The test also had a bug in its ground
truth values.