### PR TITLE
COMP: Remove gcc #ifdef around usage of `= default`

### DIFF
--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -138,7 +138,7 @@ public:
     }
   }
 
-#if defined(__GNUC__) && (__GNUC__ > 5)
+#if defined(__GNUC__) && (__GNUC__ > 5) && !defined(__clang__)
   ~QuadrilateralCell() override = default;
 #else
   ~QuadrilateralCell() override{};

--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -138,7 +138,7 @@ public:
     }
   }
 
-#if defined(__GNUC__) && (__GNUC__ > 5) && !defined(__clang__)
+#if defined(__GNUC__) && (__GNUC__ > 5) || defined(__clang__)
   ~QuadrilateralCell() override = default;
 #else
   ~QuadrilateralCell() override{};

--- a/Modules/Core/Common/include/itkTriangleCell.h
+++ b/Modules/Core/Common/include/itkTriangleCell.h
@@ -150,7 +150,7 @@ public:
   TriangleCell()
     : m_PointIds(NumberOfPoints, NumericTraits<PointIdentifier>::max())
   {}
-#if defined(__GNUC__) && (__GNUC__ > 5)
+#if defined(__GNUC__) && (__GNUC__ > 5) && !defined(__clang__)
   ~TriangleCell() override = default;
 #else
   ~TriangleCell() override{};

--- a/Modules/Core/Common/include/itkTriangleCell.h
+++ b/Modules/Core/Common/include/itkTriangleCell.h
@@ -150,7 +150,7 @@ public:
   TriangleCell()
     : m_PointIds(NumberOfPoints, NumericTraits<PointIdentifier>::max())
   {}
-#if defined(__GNUC__) && (__GNUC__ > 5) && !defined(__clang__)
+#if defined(__GNUC__) && (__GNUC__ > 5) || defined(__clang__)
   ~TriangleCell() override = default;
 #else
   ~TriangleCell() override{};

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -552,7 +552,7 @@ protected:
 
   Transform();
   Transform(NumberOfParametersType NumberOfParameters);
-#if defined(__GNUC__) && __GNUC__ < 6
+#if defined(__GNUC__) && __GNUC__ < 6 && !defined(__clang__)
   ~Transform() override{};
 #else
   ~Transform() override = default;

--- a/Modules/Core/Transform/include/itkTransformBase.h
+++ b/Modules/Core/Transform/include/itkTransformBase.h
@@ -151,7 +151,7 @@ public:
   GetTransformCategory() const = 0;
 
 protected:
-#if defined(__GNUC__) && __GNUC__ < 6
+#if defined(__GNUC__) && __GNUC__ < 6 && !defined(__clang__)
   // A bug in some versions of the gcc 5.4.0 compiler
   // result in a linker error when = default is requested
   TransformBaseTemplate(){};


### PR DESCRIPTION
`#ifdef` were apparently introduced to fix a bug in gcc 5.4.0 (according to the comment in itkTransformBase.h). However this is done testing `__GNUC__` macro, which can be wrong when using Clang. Clang typically defines it to 4. When ITK is compiled with gcc and then a software using ITK is compiled with clang, this leads to linking errors, such as :

```
/home/fbridault/dev/sight/src/sight/SrcLib/core/fwTools/include/fwTools/Dispatcher.hpp:201:24: note: in instantiation of function template specialization 'fwTools::Dispatcher<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_item<double, boost::mpl::v_item<float, boost::mpl::vector8<signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long>, 0>, 0>, 1>, 1>, 1>, 1>, 1>, 1>, 1>, 1>, itkOp::LabelingFilter>::invoke<fwTools::DynamicType, itkOp::LabelingFilter::Parameters>' requested here
/home/fbridault/dev/sight/src/sight/SrcLib/core/fwTools/include/fwTools/Dispatcher.hpp:201:24: note: in instantiation of function template specialization 'fwTools::Dispatcher<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_item<double, boost::mpl::v_item<float, boost::mpl::vector8<signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long>, 0>, 0>, 1>, 1>, 1>, 1>, 1>, 1>, 1>, itkOp::LabelingFilter>::invoke<fwTools::DynamicType, itkOp::LabelingFilter::Parameters>' requested here
/home/fbridault/dev/sight/src/sight/SrcLib/core/fwTools/include/fwTools/Dispatcher.hpp:201:24: note: (skipping 2 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
/home/fbridault/dev/sight/src/sight/SrcLib/core/fwTools/include/fwTools/Dispatcher.hpp:201:24: note: in instantiation of function template specialization 'fwTools::Dispatcher<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_item<double, boost::mpl::v_item<float, boost::mpl::vector8<signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long>, 0>, 0>, 1>, 1>, 1>, 1>, itkOp::LabelingFilter>::invoke<fwTools::DynamicType, itkOp::LabelingFilter::Parameters>' requested here
/home/fbridault/dev/sight/src/sight/SrcLib/core/fwTools/include/fwTools/Dispatcher.hpp:201:24: note: in instantiation of function template specialization 'fwTools::Dispatcher<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_item<double, boost::mpl::v_item<float, boost::mpl::vector8<signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long>, 0>, 0>, 1>, 1>, 1>, itkOp::LabelingFilter>::invoke<fwTools::DynamicType, itkOp::LabelingFilter::Parameters>' requested here
/home/fbridault/dev/sight/src/sight/SrcLib/core/fwTools/include/fwTools/Dispatcher.hpp:201:24: note: in instantiation of function template specialization 'fwTools::Dispatcher<boost::mpl::v_mask<boost::mpl::v_mask<boost::mpl::v_item<double, boost::mpl::v_item<float, boost::mpl::vector8<signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long>, 0>, 0>, 1>, 1>, itkOp::LabelingFilter>::invoke<fwTools::DynamicType, itkOp::LabelingFilter::Parameters>' requested here
/home/fbridault/dev/sight/src/sight/SrcLib/core/fwTools/include/fwTools/Dispatcher.hpp:201:24: note: in instantiation of function template specialization 'fwTools::Dispatcher<boost::mpl::v_mask<boost::mpl::v_item<double, boost::mpl::v_item<float, boost::mpl::vector8<signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long>, 0>, 0>, 1>, itkOp::LabelingFilter>::invoke<fwTools::DynamicType, itkOp::LabelingFilter::Parameters>' requested here
/home/fbridault/dev/sight/src/sight-nonfree/SrcLib/operators/itkOp/src/itkOp/Labeling.cpp:77:73: note: in instantiation of function template specialization 'fwTools::Dispatcher<boost::mpl::v_item<double, boost::mpl::v_item<float, boost::mpl::vector8<signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long>, 0>, 0>, itkOp::LabelingFilter>::invoke<fwTools::DynamicType, itkOp::LabelingFilter::Parameters>' requested here
    ::fwTools::Dispatcher< ::fwTools::IntrinsicTypes, LabelingFilter >::invoke( type, params );
                                                                        ^
30 warnings generated.
[85/104 1.9/sec] Linking CXX executable bin/itkRegistrationOpTest-0.0
FAILED: bin/itkRegistrationOpTest-0.0 
: && /usr/bin/clang++-8  -g   itkRegistrationOpTest/CMakeFiles/itkRegistrationOpTest.dir/tu/src/AutomaticRegistrationTest.cpp.o itkRegistrationOpTest/CMakeFiles/itkRegistrationOpTest.dir/tu/src/MIPMatchingRegistrationTest.cpp.o itkRegistrationOpTest/CMakeFiles/itkRegistrationOpTest.dir/tu/src/ResamplerTest.cpp.o itkRegistrationOpTest/CMakeFiles/itkRegistrationOpTest.dir/src/cppunit_main.cpp.o  -o bin/itkRegistrationOpTest-0.0  -Wl,-rpath,/home/fbridault/dev/sight/build/debug/lib/sight:/home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib:/home/fbridault/.conan/data/cppunit/1.14.0-r4/sight/stable/package/db39b6b198d91ae2e3f1df12a47bb80fa85aea03/lib:/home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib:/home/fbridault/.conan/data/camp/0.8.3-r2/sight/stable/package/e62b3ac6074cbe40dcac7250b8b296dbc33a79c4/lib:/home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib  lib/sight/libfwTest.so.0.1  lib/sight/libfwVtkIO.so.0.1  lib/sight/libitkRegistrationOp.so.0.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKSpatialObjects-5.0.so.1  /home/fbridault/.conan/data/cppunit/1.14.0-r4/sight/stable/package/db39b6b198d91ae2e3f1df12a47bb80fa85aea03/lib/libcppunit.so  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkFiltersModeling-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkIOLegacy-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkIOExport-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkIOImage-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkIOXML-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkIOXMLParser-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkIOCore-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkRenderingContext2D-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkRenderingGL2PSOpenGL2-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkRenderingFreeType-8.2.so.1  /usr/lib/x86_64-linux-gnu/libfreetype.so  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkRenderingOpenGL2-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkRenderingCore-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkFiltersGeometry-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkFiltersGeneral-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkFiltersCore-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkCommonExecutionModel-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkCommonDataModel-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkCommonMisc-8.2.so.1  /usr/lib/x86_64-linux-gnu/libSM.so  /usr/lib/x86_64-linux-gnu/libICE.so  /usr/lib/x86_64-linux-gnu/libX11.so  /usr/lib/x86_64-linux-gnu/libXext.so  /usr/lib/x86_64-linux-gnu/libXt.so  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkCommonTransforms-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkCommonMath-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkCommonSystem-8.2.so.1  /home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib/libvtkCommonCore-8.2.so.1  /usr/lib/x86_64-linux-gnu/libGLEW.so  lib/sight/libfwItkIO.so.0.1  lib/sight/libfwDataIO.so.0.2  lib/sight/libfwDataTools.so.0.1  lib/sight/libfwServices.so.0.1  lib/sight/libfwActivities.so.0.1  lib/sight/libfwDataCamp.so.0.1  lib/sight/libfwMath.so.0.1  lib/sight/libfwRuntime.so.0.3  /usr/lib/x86_64-linux-gnu/libxml2.so  lib/sight/libfwMedDataTools.so.0.1  lib/sight/libfwMedData.so.0.1  lib/sight/libfwData.so.0.1  lib/sight/libfwMemory.so.0.1  lib/sight/libfwCamp.so.0.1  /home/fbridault/.conan/data/camp/0.8.3-r2/sight/stable/package/e62b3ac6074cbe40dcac7250b8b296dbc33a79c4/lib/libcamp.so.0.8.3  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_iostreams.so  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_regex.so  lib/sight/libfwJobs.so.0.1  lib/sight/libfwCom.so.0.1  lib/sight/libfwTools.so.0.1  lib/sight/libfwThread.so.0.1  lib/sight/libfwCore.so.0.1  -lstdc++fs  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_log.so  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_filesystem.so  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_thread.so  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_date_time.so  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_regex.so  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_chrono.so  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_atomic.so  /home/fbridault/.conan/data/boost/1.69.0-r4/sight/stable/package/eedfc6186f44b3f46936babef177d5192dd3b6d7/lib/libboost_log_setup.so  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKIOJPEG-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKIOImageBase-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKCommon-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKVNLInstantiation-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvnl_algo-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvnl-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkv3p_netlib-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitknetlib-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvcl-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKMetaIO-5.0.so.1  /usr/lib/x86_64-linux-gnu/libz.so  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitksys-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkopenjpeg-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKOptimizersv4-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKOptimizers-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKStatistics-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkNetlibSlatec-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKTransform-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKCommon-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitksys-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKVNLInstantiation-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvnl_algo-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvnl-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkv3p_netlib-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitknetlib-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvcl-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKTransform-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKCommon-5.0.so.1  -lpthread  -lm  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitksys-5.0.so.1  -ldl  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libITKVNLInstantiation-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvnl_algo-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvnl-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkv3p_netlib-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitknetlib-5.0.so.1  /home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib/libitkvcl-5.0.so.1  -lm  -Wl,-rpath-link,/home/fbridault/.conan/data/vtk/8.2.0-r4/sight/stable/package/4e241ac8e808ac0c29e32e74a2a474e282ced635/lib:/home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/lib && :
itkRegistrationOpTest/CMakeFiles/itkRegistrationOpTest.dir/tu/src/AutomaticRegistrationTest.cpp.o: In function `~Transform':
/home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/include/ITK-5.0/itkTransform.h:545: undefined reference to `itk::TransformBaseTemplate<double>::~TransformBaseTemplate()'
itkRegistrationOpTest/CMakeFiles/itkRegistrationOpTest.dir/tu/src/AutomaticRegistrationTest.cpp.o: In function `Transform':
/home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/include/ITK-5.0/itkTransform.h:543: undefined reference to `itk::TransformBaseTemplate<double>::TransformBaseTemplate()'
itkRegistrationOpTest/CMakeFiles/itkRegistrationOpTest.dir/tu/src/AutomaticRegistrationTest.cpp.o: In function `Transform':
/home/fbridault/.conan/data/itk/5.0.1-r2/sight/stable/package/ce546329f104a87dfe03b402962f6e73f2a009c4/include/ITK-5.0/itkTransform.hxx:49: undefined reference to `itk::TransformBaseTemplate<double>::~TransformBaseTemplate()'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I could have done the check in a more robust way, but I propose instead to simply remove the `#ifdef`. `= default` is now used in many places in ITK for constructors and destructors, so I don't think testing is still useful, especially since ITK >= 5.x compiles only with C++11.

## PR Checklist

- :no_entry_sign: [Makes breaking changes]
- :no_entry_sign: [Makes design changes]
- :no_entry_sign: Adds the License notice to new files.
- :no_entry_sign: Adds Python wrapping.
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: [Adds test data]
- :no_entry_sign: Adds Examples to [ITKExamples]
- :no_entry_sign: Adds Documentation.

