### PR TITLE
ENH: Bump macOS Azure CI images to 10.14

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -12,7 +12,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: macOS-10.14
   steps:
     - checkout: self
       clean: true

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -12,7 +12,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: macOS-10.14
   steps:
     - checkout: self
       clean: true


### PR DESCRIPTION
Azure Pipelines is discontinuing support for the 10.13 images.