### PR TITLE
Progress reporting revisionv5

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkVectorResampleImageFilter.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkVectorResampleImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkVectorResampleImageFilter.h"
 #include "itkIdentityTransform.h"
 #include "itkVectorLinearInterpolateImageFunction.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 
 namespace itk
@@ -42,6 +42,7 @@ VectorResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>
 
   m_DefaultPixelValue = NumericTraits<PixelType>::ZeroValue(m_DefaultPixelValue);
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage, typename TInterpolatorPrecisionType>
@@ -101,6 +102,8 @@ VectorResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>
   OutputImagePointer     outputPtr = this->GetOutput();
   InputImageConstPointer inputPtr = this->GetInput();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Create an iterator that will walk the output region for this thread.
   using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
 
@@ -151,6 +154,7 @@ VectorResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType>
     }
 
     ++outIt;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -21,6 +21,7 @@
 #include "itkImageSink.h"
 #include "itkProgressTransformer.h"
 #include "itkInputDataObjectConstIterator.h"
+#include "itkMultiThreaderBase.h"
 
 namespace itk
 {

--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -201,6 +201,7 @@ ImageSource<TOutputImage>::ClassicMultiThread(ThreadFunctionType callbackFunctio
     splitter->GetNumberOfSplits(outputPtr->GetRequestedRegion(), this->GetNumberOfWorkUnits());
 
   this->GetMultiThreader()->SetNumberOfWorkUnits(validThreads);
+  this->GetMultiThreader()->SetUpdateProgress(false);
   this->GetMultiThreader()->SetSingleMethod(callbackFunction, &str);
 
   this->GetMultiThreader()->SingleMethodExecute();
@@ -225,13 +226,17 @@ ImageSource<TOutputImage>::GenerateData()
   }
   else
   {
+    // give process object if progress reporting is to occur from the threader
+    Self * processObjectForThreader = this->GetThreaderUpdateProgress() ? this : nullptr;
+
     this->GetMultiThreader()->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
+    this->GetMultiThreader()->SetUpdateProgress(this->GetThreaderUpdateProgress());
     this->GetMultiThreader()->template ParallelizeImageRegion<OutputImageDimension>(
       this->GetOutput()->GetRequestedRegion(),
       [this](const OutputImageRegionType & outputRegionForThread) {
         this->DynamicThreadedGenerateData(outputRegionForThread);
       },
-      this);
+      processObjectForThreader);
   }
 
   // Call a method that can be overridden by a subclass to perform

--- a/Modules/Core/Common/include/itkProgressReporter.h
+++ b/Modules/Core/Common/include/itkProgressReporter.h
@@ -83,13 +83,13 @@ public:
       m_PixelsBeforeUpdate = m_PixelsPerUpdate;
       m_CurrentPixel += m_PixelsPerUpdate;
       // only thread 0 should update the progress of the filter
-      if (m_ThreadId == 0)
+      if (m_ThreadId == 0 && m_Filter)
       {
         m_Filter->UpdateProgress(static_cast<float>(m_CurrentPixel) * m_InverseNumberOfPixels * m_ProgressWeight +
                                  m_InitialProgress);
       }
       // all threads needs to check the abort flag
-      if (m_Filter->GetAbortGenerateData())
+      if (m_Filter && m_Filter->GetAbortGenerateData())
       {
         std::string    msg;
         ProcessAborted e(__FILE__, __LINE__);

--- a/Modules/Core/Common/include/itkTotalProgressReporter.h
+++ b/Modules/Core/Common/include/itkTotalProgressReporter.h
@@ -1,0 +1,132 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkTotalProgressReporter_h
+#define itkTotalProgressReporter_h
+
+#include "itkIntTypes.h"
+#include "itkProcessObject.h"
+
+namespace itk
+{
+/** \class TotalProgressReporter
+ *  \brief A progress reporter for concurrent threads.
+ *
+ * Each thread should construct their own instance of the class. The ProcessObject::IncrementProgress method will be
+ * called to update the progress from all threads. The ProcessObject's method will automatically create ProgressEvents
+ * when the pipeline invoking thread updates the progress.
+ *
+ * All threads concurrently contribute parts of the progress to the *total* number of pixels for all threads. This
+ * report will update the progress after a sufficient number of pixel to meet the numberOfUpdates requirement between
+ * all threads. Also when the object is deconstructed, all remaining pixels will increment the progress.
+ *
+ *
+ * \ingroup ITKCommon
+ */
+class ITKCommon_EXPORT TotalProgressReporter
+{
+public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TotalProgressReporter);
+
+  /** \brief Construct a TotalProgressReporter
+   *
+   * @param filter - the ProcessObject which whose progress will be updated. If nullptr then no updates will occur.
+   * @param totalNumberOfPixels - the number of pixels between all threads and chunks that will be updated
+   * @param numberOfUpdates - controls how often the ProcessObject's progress will be incremented
+   * @param progressWeight - A percentage of the filters progress, this total number of pixels will contribute
+   */
+  TotalProgressReporter(ProcessObject * filter,
+                        SizeValueType   totalNumberOfPixels,
+                        SizeValueType   numberOfUpdates = 100,
+                        float           progressWeight = 1.0f);
+
+  /** Destructor sets progress to 1 because the filter has finished.  */
+  ~TotalProgressReporter();
+
+  /** Called by a filter once per pixel.  */
+  void
+  CompletedPixel()
+  {
+    // Inline implementation for efficiency.
+    if (--m_PixelsBeforeUpdate == 0)
+    {
+      m_PixelsBeforeUpdate = m_PixelsPerUpdate;
+      m_CurrentPixel += m_PixelsPerUpdate;
+
+      if (m_Filter)
+      {
+        m_Filter->IncrementProgress(m_PixelsPerUpdate * m_InverseNumberOfPixels * m_ProgressWeight);
+
+        // all threads needs to check the abort flag
+        if (m_Filter->GetAbortGenerateData())
+        {
+          std::string    msg;
+          ProcessAborted e(__FILE__, __LINE__);
+          msg += "Object " + std::string(m_Filter->GetNameOfClass()) + ": AbortGenerateDataOn";
+          e.SetDescription(msg);
+          throw e;
+        }
+      }
+    }
+  }
+
+
+  /** Called by a filter when a chunk, region, scan-line, etc. is completed. */
+  void
+  Completed(SizeValueType count)
+  {
+
+    if (count >= m_PixelsBeforeUpdate)
+    {
+      SizeValueType total = static_cast<SizeValueType>(m_PixelsPerUpdate - m_PixelsBeforeUpdate) + count;
+      SizeValueType numberOfUpdates = total / m_PixelsPerUpdate;
+
+      m_PixelsBeforeUpdate = m_PixelsPerUpdate - total % m_PixelsPerUpdate;
+      m_CurrentPixel += numberOfUpdates * m_PixelsPerUpdate;
+
+      if (m_Filter)
+      {
+        m_Filter->IncrementProgress(numberOfUpdates * m_PixelsPerUpdate * m_InverseNumberOfPixels * m_ProgressWeight);
+
+        // all threads needs to check the abort flag
+        if (m_Filter->GetAbortGenerateData())
+        {
+          std::string    msg;
+          ProcessAborted e(__FILE__, __LINE__);
+          msg += "Object " + std::string(m_Filter->GetNameOfClass()) + ": AbortGenerateDataOn";
+          e.SetDescription(msg);
+          throw e;
+        }
+      }
+    }
+    else
+    {
+      m_PixelsBeforeUpdate -= count;
+    }
+  }
+
+protected:
+  ProcessObject * m_Filter;
+  float           m_InverseNumberOfPixels;
+  SizeValueType   m_CurrentPixel;
+  SizeValueType   m_PixelsPerUpdate;
+  SizeValueType   m_PixelsBeforeUpdate;
+  float           m_ProgressWeight;
+};
+} // end namespace itk
+
+#endif

--- a/Modules/Core/Common/include/itkUnaryFunctorImageFilter.hxx
+++ b/Modules/Core/Common/include/itkUnaryFunctorImageFilter.hxx
@@ -20,7 +20,7 @@
 
 #include "itkUnaryFunctorImageFilter.h"
 #include "itkImageScanlineIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -74,12 +74,6 @@ void
 UnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  const typename OutputImageRegionType::SizeType & regionSize = outputRegionForThread.GetSize();
-
-  if (regionSize[0] == 0)
-  {
-    return;
-  }
   const TInputImage * inputPtr = this->GetInput();
   TOutputImage *      outputPtr = this->GetOutput(0);
 
@@ -89,6 +83,8 @@ UnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction>::DynamicThreadedGe
   InputImageRegionType inputRegionForThread;
 
   this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
+
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   ImageScanlineConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
@@ -105,6 +101,7 @@ UnaryFunctorImageFilter<TInputImage, TOutputImage, TFunction>::DynamicThreadedGe
     }
     inputIt.NextLine();
     outputIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 } // end namespace itk

--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set(ITKCommon_SRCS
   itkLogOutput.cxx
   itkLoggerOutput.cxx
   itkProgressAccumulator.cxx
+  itkTotalProgressReporter.cxx
   itkNumericTraits.cxx
   itkHexahedronCellTopology.cxx
   itkIndent.cxx

--- a/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
+++ b/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
@@ -21,7 +21,7 @@
 #include "itkTestingMacros.h"
 #include "itkNumericTraits.h"
 #include "itkIntTypes.h"
-
+#include "itkMultiThreaderBase.h"
 
 namespace itk
 {
@@ -192,7 +192,7 @@ itkDataObjectAndProcessObjectTest(int, char *[])
   // EnlargeOutputRequestedRegion( DataObject *itkNotUsed(output) ){}
 
   // TODO: doesn't do anything for now, but should probably do something even without
-  // input nor outout
+  // input nor output
   mtime = process->GetMTime();
   process->ResetPipeline();
   ITK_TEST_SET_GET_VALUE(mtime, process->GetMTime());

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -31,13 +31,15 @@
 #include "itkRandomImageSource.h"
 #include "itkImageRegionIterator.h"
 #include "itkObjectFactory.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
+
 
 namespace itk
 {
 template <typename TOutputImage>
 RandomImageSource<TOutputImage>::RandomImageSource()
 {
+
   // Default image is 64 wide in each direction.
   for (unsigned int i = 0; i < TOutputImage::GetImageDimension(); i++)
   {
@@ -47,6 +49,7 @@ RandomImageSource<TOutputImage>::RandomImageSource()
   }
   m_Direction.SetIdentity();
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 
   m_Min = NumericTraits<OutputImagePixelType>::NonpositiveMin();
   m_Max = NumericTraits<OutputImagePixelType>::max();
@@ -219,10 +222,13 @@ RandomImageSource<TOutputImage>::DynamicThreadedGenerateData(const OutputImageRe
 {
   itkDebugMacro(<< "Generating a random image of scalars");
 
+
   using scalarType = typename TOutputImage::PixelType;
   typename TOutputImage::Pointer image = this->GetOutput(0);
 
   ImageRegionIterator<TOutputImage> it(image, outputRegionForThread);
+
+  TotalProgressReporter progress(this, image->GetRequestedRegion().GetNumberOfPixels());
 
   IndexValueType indSeed = outputRegionForThread.GetIndex(0);
   for (unsigned d = 1; d < OutputImageDimension; d++)
@@ -245,6 +251,7 @@ RandomImageSource<TOutputImage>::DynamicThreadedGenerateData(const OutputImageRe
     rnd = (1.0 - u) * dMin + u * dMax;
 
     it.Set((scalarType)rnd);
+    progress.CompletedPixel();
   }
 }
 } // end namespace itk

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkTestingExtractSliceImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "itkObjectFactory.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -32,6 +32,7 @@ template <typename TInputImage, typename TOutputImage>
 ExtractSliceImageFilter<TInputImage, TOutputImage>::ExtractSliceImageFilter()
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 
@@ -252,6 +253,8 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const TInputImage * inputPtr = this->GetInput();
   TOutputImage *      outputPtr = this->GetOutput();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Define the portion of the input to walk for this thread
   InputImageRegionType inputRegionForThread;
   this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
@@ -269,6 +272,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     outIt.Set(static_cast<OutputImagePixelType>(inIt.Get()));
     ++outIt;
     ++inIt;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -33,6 +33,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkMath.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -49,6 +50,7 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::StretchIntensityImageFil
   , m_OutputMaximum(NumericTraits<OutputPixelType>::max())
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -103,6 +105,8 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   const TInputImage * inputPtr = this->GetInput();
   TOutputImage *      outputPtr = this->GetOutput(0);
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   InputImageRegionType inputRegionForThread = outputRegionForThread;
 
   ImageRegionConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
@@ -125,6 +129,7 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
 
     ++inputIt;
     ++outputIt;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -23,7 +23,7 @@
 #include <climits>
 #include "itkNumericTraits.h"
 #include "itkNeighborhoodAlgorithm.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkMath.h"
 
@@ -38,6 +38,7 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::ObjectMorpholog
 
   m_UseBoundaryCondition = false;
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 
   m_ObjectValue = NumericTraits<PixelType>::OneValue();
 }
@@ -130,6 +131,7 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreaded
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>                        fC;
   faceList = fC(this->GetInput(), outputRegionForThread, m_Kernel.GetRadius());
 
+
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType::iterator fit;
 
   // Setup the kernel that spans the immediate neighbors of the current
@@ -137,6 +139,8 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreaded
   // pixel, i.e., is a boundary pixel
   RadiusType bKernelSize;
   bKernelSize.Fill(1);
+
+  TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 
   OutputNeighborhoodIteratorType oSNIter;
   InputNeighborhoodIteratorType  iSNIter;
@@ -164,6 +168,7 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreaded
       }
       ++iSNIter;
       ++oSNIter;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkScalarToRGBColormapImageFilter.h"
 
 #include "itkImageRegionIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 #include "itkRedColormapFunction.h"
 #include "itkGreenColormapFunction.h"
@@ -58,6 +58,7 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::ScalarToRGBColormapIm
 
   this->m_UseInputImageExtremaForScaling = true;
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 
   using DefaultColormapType = Function::GreyColormapFunction<InputImagePixelType, OutputImagePixelType>;
 
@@ -102,6 +103,8 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
   InputImagePointer  inputPtr = this->GetInput();
   OutputImagePointer outputPtr = this->GetOutput();
 
+  TotalProgressReporter progressReporter(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
+
   // Define the portion of the input to walk for this thread, using
   // the CallCopyOutputRegionToInputRegion method allows for the input
   // and output images to be different dimensions
@@ -120,6 +123,7 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
     outputIt.Set(this->m_Colormap->operator()(inputIt.Get()));
     ++inputIt;
     ++outputIt;
+    progressReporter.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -22,7 +22,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkImageRegionIterator.h"
 #include "itkConstNeighborhoodIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -33,6 +33,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
 {
   this->ProcessObject::SetNthInput(1, const_cast<TMaskImage *>(mask));
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TMaskImage, typename TOutputImage, typename TOperatorValueType>
@@ -146,6 +147,8 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
 
   faceList = faceCalculator(input, outputRegionForThread, this->GetOperator().GetRadius());
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   // Process non-boundary region and each of the boundary faces.
   // These are N-d regions which border the edge of the buffer.
   ConstNeighborhoodIterator<InputImageType> bit;
@@ -198,6 +201,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
 
         ++bit;
         ++it;
+        progress.CompletedPixel();
       }
     }
     else
@@ -212,7 +216,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
           // Compute the normalized correlation at this pixel.  The
           // template has already been normalized to mean zero and norm 1.
           // This simplifies the calculation to being just the correlation
-          // of the image neighborhod with the template, normalized by a
+          // of the image neighborhood with the template, normalized by a
           // function of the image neighborhood.
           sum = 0.0;
           sumOfSquares = 0.0;
@@ -239,6 +243,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
         ++bit;
         ++it;
         ++mit;
+        progress.CompletedPixel();
       }
     }
   }

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -25,7 +25,7 @@
 #include "itkArray.h"
 #include "itkImageMaskSpatialObject.h"
 #include "vnl/vnl_vector.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -50,6 +50,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   m_BValue = 1.0;
   m_MaskImagePresent = false;
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TReferenceImagePixelType,
@@ -192,6 +193,8 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   // 2. If the Gradients have been specified in a single multi-component image,
   // one iterator will suffice to do the same.
 
+  TotalProgressReporter progress(this, outputImage->GetRequestedRegion().GetNumberOfPixels());
+
   if (m_GradientImageTypeEnumeration ==
       DiffusionTensor3DReconstructionImageFilterEnums::GradientImageFormat::GradientIsInManyImages)
   {
@@ -290,6 +293,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
       oit.Set(tensor);
       ++oit;
       ++it;
+      progress.CompletedPixel();
     }
 
     for (unsigned int i = 0; i < gradientItContainer.size(); i++)
@@ -397,6 +401,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
       oit.Set(tensor);
       ++oit; // Output (reconstructed tensor image) iterator
       ++git; // Gradient  image iterator
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkImageRegionIterator.h"
 #include "itkZeroFluxNeumannBoundaryCondition.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkCastImageFilter.h"
 
 #include "itkMath.h"
@@ -41,6 +41,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   m_DerivativeWeights.Fill(1.0);
   m_HalfDerivativeWeights.Fill(0.5);
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TRealType, typename TOutputImage>
@@ -186,6 +187,8 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>::FaceListType::iterator fit;
   fit = faceList.begin();
 
+  TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
+
   // Process each of the data set faces.  The iterator is reinitialized on each
   // face so that it can determine whether or not to check for boundary
   // conditions.
@@ -202,6 +205,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
       it.Set(static_cast<OutputPixelType>(this->EvaluateAtNeighborhood(bit)));
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkTransformToDisplacementFieldFilter.h"
 
 #include "itkIdentityTransform.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageScanlineIterator.h"
 
@@ -190,6 +190,9 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
   PointType transformedPoint; // Coordinates of transformed pixel
   PixelType displacement;     // the difference
 
+
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   // Walk the output region
   outIt.GoToBegin();
   while (!outIt.IsAtEnd())
@@ -207,6 +210,7 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
       ++outIt;
     }
     outIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 

--- a/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkCheckerBoardImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkObjectFactory.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -31,6 +31,7 @@ CheckerBoardImageFilter<TImage>::CheckerBoardImageFilter()
 {
   m_CheckerPattern.Fill(4);
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TImage>
@@ -69,6 +70,8 @@ CheckerBoardImageFilter<TImage>::DynamicThreadedGenerateData(const ImageRegionTy
   outItr.GoToBegin();
   in1Itr.GoToBegin();
   in2Itr.GoToBegin();
+
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   typename InputImageType::SizeType size = input2Ptr->GetLargestPossibleRegion().GetSize();
 
@@ -110,6 +113,7 @@ CheckerBoardImageFilter<TImage>::DynamicThreadedGenerateData(const ImageRegionTy
     ++outItr;
     ++in1Itr;
     ++in2Itr;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
@@ -20,7 +20,7 @@
 
 #include "itkComposeImageFilter.h"
 #include "itkImageRegionIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -33,6 +33,7 @@ ComposeImageFilter<TInputImage, TOutputImage>::ComposeImageFilter()
   nbOfComponents = std::max(1, nbOfComponents); // require at least one input
   this->SetNumberOfRequiredInputs(nbOfComponents);
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 //----------------------------------------------------------------------------
@@ -111,6 +112,9 @@ ComposeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const
 {
   typename OutputImageType::Pointer outputImage = static_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 
+
+  TotalProgressReporter progress(this, outputImage->GetRequestedRegion().GetNumberOfPixels());
+
   ImageRegionIterator<OutputImageType> oit(outputImage, outputRegionForThread);
   oit.GoToBegin();
 
@@ -132,6 +136,7 @@ ComposeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const
     ComputeOutputPixel(pix, inputItContainer);
     oit.Set(pix);
     ++oit;
+    progress.CompletedPixel();
   }
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkJoinSeriesImageFilter.h"
 #include "itkProgressReporter.h"
 #include "itkImageAlgorithm.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -29,6 +30,7 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::JoinSeriesImageFilter()
 
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -234,10 +236,13 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   TOutputImage * output = this->GetOutput();
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   for (IndexValueType idx = begin; idx < end; ++idx)
   {
     outputRegion.SetIndex(InputImageDimension, idx);
     ImageAlgorithm::Copy(this->GetInput(idx), output, inputRegion, outputRegion);
+    progress.Completed(outputRegion.GetNumberOfPixels());
   }
 }
 

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkGaussianImageSource.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkZeroFluxNeumannBoundaryCondition.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkStatisticsImageFilter.h"
 
 namespace itk
@@ -43,6 +43,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::BilateralImageFilter()
   this->m_RangeMu = 4.0;  // can be bigger then DomainMu since we only
                           // index into a single table
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -254,13 +255,15 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   const double distanceToTableIndex = static_cast<double>(m_NumberOfRangeGaussianSamples) / m_DynamicRangeUsed;
 
-  // Process all the faces, the NeighborhoodIterator will deteremine
+  // Process all the faces, the NeighborhoodIterator will determine
   // whether a specified region needs to use the boundary conditions or
   // not.
   NeighborhoodIteratorType             b_iter;
   ImageRegionIterator<OutputImageType> o_iter;
   KernelConstIteratorType              k_it;
   KernelConstIteratorType              kernelEnd = m_GaussianKernel.End();
+
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
   for (fit = faceList.begin(); fit != faceList.end(); ++fit)
   {
@@ -312,6 +315,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
       ++b_iter;
       ++o_iter;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkSymmetricEigenAnalysis.h"
 #include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 #include "itkMath.h"
 
@@ -35,6 +36,7 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::HessianToObjec
 
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -55,6 +57,8 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::DynamicThreade
 {
   OutputImageType *      output = this->GetOutput();
   const InputImageType * input = this->GetInput();
+
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels(), 1000);
 
   // Calculator for computation of the eigen values
   using CalculatorType = SymmetricEigenAnalysisFixedDimension<ImageDimension, InputPixelType, EigenValueArrayType>;
@@ -94,6 +98,7 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::DynamicThreade
       oit.Set(NumericTraits<OutputPixelType>::ZeroValue());
       ++it;
       ++oit;
+      progress.CompletedPixel();
       continue;
     }
 
@@ -169,6 +174,7 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::DynamicThreade
 
     ++it;
     ++oit;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkOffset.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkSimpleContourExtractorImageFilter.h"
 
 namespace itk
@@ -36,6 +36,7 @@ SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::SimpleContourExtra
   , m_OutputBackgroundValue(NumericTraits<OutputPixelType>::ZeroValue())
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -60,6 +61,8 @@ SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   faceList = bC(input, outputRegionForThread, this->GetRadius());
 
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType::iterator fit;
+
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
   // Process each of the boundary faces.  These are N-d regions which border
   // the edge of the buffer.
@@ -110,6 +113,7 @@ SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
 
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.h
@@ -152,13 +152,7 @@ public:
 #endif
 
 protected:
-  ZeroCrossingBasedEdgeDetectionImageFilter()
-  {
-    m_Variance.Fill(1.0);
-    m_MaximumError.Fill(0.01);
-    m_BackgroundValue = NumericTraits<OutputImagePixelType>::ZeroValue();
-    m_ForegroundValue = NumericTraits<OutputImagePixelType>::OneValue();
-  }
+  ZeroCrossingBasedEdgeDetectionImageFilter();
 
   ~ZeroCrossingBasedEdgeDetectionImageFilter() override = default;
   void

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
@@ -26,6 +26,17 @@
 
 namespace itk
 {
+
+
+template <typename TInputImage, typename TOutputImage>
+ZeroCrossingBasedEdgeDetectionImageFilter<TInputImage, TOutputImage>::ZeroCrossingBasedEdgeDetectionImageFilter()
+{
+  m_Variance.Fill(1.0);
+  m_MaximumError.Fill(0.01);
+  m_BackgroundValue = NumericTraits<OutputImagePixelType>::ZeroValue();
+  m_ForegroundValue = NumericTraits<OutputImagePixelType>::OneValue();
+}
+
 template <typename TInputImage, typename TOutputImage>
 void
 ZeroCrossingBasedEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateData()

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkFixedArray.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkMath.h"
 
 namespace itk
@@ -35,6 +35,7 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::ZeroCrossingImageFilter()
   , m_ForegroundValue(NumericTraits<OutputImagePixelType>::OneValue())
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -113,6 +114,8 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType::iterator fit;
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   InputImagePixelType this_one, that, abs_this_one, abs_that;
   InputImagePixelType zero = NumericTraits<InputImagePixelType>::ZeroValue();
 
@@ -163,6 +166,7 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
       }
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
@@ -22,7 +22,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkImageRegionIterator.h"
 #include "itkConstNeighborhoodIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -33,6 +33,7 @@ MaskNeighborhoodOperatorImageFilter<TInputImage, TMaskImage, TOutputImage, TOper
 {
   this->ProcessObject::SetNthInput(1, const_cast<TMaskImage *>(mask));
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TMaskImage, typename TOutputImage, typename TOperatorValueType>
@@ -118,6 +119,8 @@ MaskNeighborhoodOperatorImageFilter<TInputImage, TMaskImage, TOutputImage, TOper
 
   faceList = faceCalculator(input, outputRegionForThread, this->GetOperator().GetRadius());
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   // Get the operator
   OutputNeighborhoodType noperator = this->GetOperator();
 
@@ -151,6 +154,7 @@ MaskNeighborhoodOperatorImageFilter<TInputImage, TMaskImage, TOutputImage, TOper
       ++bit;
       ++it;
       ++mit;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkMovingHistogramImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkOffset.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkNumericTraits.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageLinearConstIteratorWithIndex.h"
@@ -32,6 +32,7 @@ template <typename TInputImage, typename TOutputImage, typename TKernel, typenam
 MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::MovingHistogramImageFilter()
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOn();
 }
 
 // a modified version that uses line iterators and only moves the
@@ -48,6 +49,8 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
   OutputImageType *      outputImage = this->GetOutput();
   const InputImageType * inputImage = this->GetInput();
   RegionType             inputRegion = inputImage->GetRequestedRegion();
+
+  TotalProgressReporter progress(this, outputImage->GetRequestedRegion().GetNumberOfPixels());
 
   // initialize the histogram
   for (auto listIt = this->m_KernelOffsets.begin(); listIt != this->m_KernelOffsets.end(); listIt++)
@@ -166,6 +169,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
         HistVec[i] = HistVec[LineDirection];
       }
     }
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
   delete[] Steps;
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.h
@@ -158,6 +158,7 @@ protected:
   {
     m_BoundsCondition = static_cast<ImageBoundaryConditionPointerType>(&m_DefaultBoundaryCondition);
     this->DynamicMultiThreadingOn();
+    this->ThreaderUpdateProgressOff();
   }
   ~NeighborhoodOperatorImageFilter() override = default;
 

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkNeighborhoodInnerProduct.h"
 #include "itkImageRegionIterator.h"
 #include "itkConstNeighborhoodIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -100,6 +100,8 @@ NeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType>::
   typename FaceListType::iterator      fit;
   ImageRegionIterator<OutputImageType> it;
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   // Process non-boundary region and each of the boundary faces.
   // These are N-d regions which border the edge of the buffer.
   ConstNeighborhoodIterator<InputImageType> bit;
@@ -114,6 +116,7 @@ NeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType>::
       it.Value() = static_cast<typename OutputImageType::PixelType>(smartInnerProduct(bit, m_Operator));
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkOffset.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -32,6 +32,7 @@ template <typename TInputImage, typename TOutputImage>
 NoiseImageFilter<TInputImage, TOutputImage>::NoiseImageFilter()
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -56,6 +57,8 @@ NoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   faceList = bC(input, outputRegionForThread, this->GetRadius());
 
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType::iterator fit;
+
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
   InputRealType value;
   InputRealType sum;
@@ -92,6 +95,7 @@ NoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryFunctorImageFilter.hxx
@@ -20,7 +20,7 @@
 
 #include "itkTernaryFunctorImageFilter.h"
 #include "itkImageScanlineIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -34,6 +34,7 @@ TernaryFunctorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage
 {
   this->InPlaceOff();
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 /**
@@ -121,11 +122,6 @@ void
 TernaryFunctorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage, TFunction>::
   DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
-  const SizeValueType size0 = outputRegionForThread.GetSize(0);
-  if (size0 == 0)
-  {
-    return;
-  }
   // We use dynamic_cast since inputs are stored as DataObjects.  The
   // ImageToImageFilter::GetInput(int) always returns a pointer to a
   // TInputImage1 so it cannot be used for the second or third input.
@@ -134,6 +130,7 @@ TernaryFunctorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage
   Input3ImagePointer inputPtr3 = dynamic_cast<const TInputImage3 *>((ProcessObject::GetInput(2)));
   OutputImagePointer outputPtr = this->GetOutput(0);
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   ImageScanlineConstIterator<TInputImage1> inputIt1(inputPtr1, outputRegionForThread);
   ImageScanlineConstIterator<TInputImage2> inputIt2(inputPtr2, outputRegionForThread);
@@ -154,6 +151,7 @@ TernaryFunctorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage
     inputIt2.NextLine();
     inputIt3.NextLine();
     outputIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.h
@@ -162,7 +162,7 @@ protected:
    * execution model.  The original documentation of this method is
    * below.
    *
-   * \sa ProcessObject::GenerateOutputInformaton()  */
+   * \sa ProcessObject::GenerateOutputInformation()  */
   void
   GenerateOutputInformation() override;
 

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkUnaryGeneratorImageFilter.h"
 #include "itkImageScanlineIterator.h"
 #include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -98,6 +99,9 @@ UnaryGeneratorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
   const TInputImage * inputPtr = this->GetInput();
   TOutputImage *      outputPtr = this->GetOutput(0);
 
+  const SizeValueType   numberOfLinesToProcess = outputPtr->GetRequestedRegion().GetNumberOfPixels() / regionSize[0];
+  TotalProgressReporter progress(this, numberOfLinesToProcess);
+
   // Define the portion of the input to walk for this thread, using
   // the CallCopyOutputRegionToInputRegion method allows for the input
   // and output images to be different dimensions
@@ -119,6 +123,7 @@ UnaryGeneratorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
       ++inputIt;
       ++outputIt;
     }
+    progress.CompletedPixel();
     inputIt.NextLine();
     outputIt.NextLine();
   }

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
@@ -43,7 +43,7 @@ UnaryGeneratorImageFilter<TInputImage, TOutputImage>::UnaryGeneratorImageFilter(
  * the pipeline execution model.  The original documentation of this
  * method is below.
  *
- * \sa ProcessObject::GenerateOutputInformaton()
+ * \sa ProcessObject::GenerateOutputInformation()
  */
 template <typename TInputImage, typename TOutputImage>
 void
@@ -92,15 +92,10 @@ UnaryGeneratorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
 {
   const typename OutputImageRegionType::SizeType & regionSize = outputRegionForThread.GetSize();
 
-  if (regionSize[0] == 0)
-  {
-    return;
-  }
   const TInputImage * inputPtr = this->GetInput();
   TOutputImage *      outputPtr = this->GetOutput(0);
 
-  const SizeValueType   numberOfLinesToProcess = outputPtr->GetRequestedRegion().GetNumberOfPixels() / regionSize[0];
-  TotalProgressReporter progress(this, numberOfLinesToProcess);
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Define the portion of the input to walk for this thread, using
   // the CallCopyOutputRegionToInputRegion method allows for the input
@@ -123,7 +118,7 @@ UnaryGeneratorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
       ++inputIt;
       ++outputIt;
     }
-    progress.CompletedPixel();
+    progress.Completed(regionSize[0]);
     inputIt.NextLine();
     outputIt.NextLine();
   }

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.h
@@ -139,6 +139,7 @@ protected:
     : m_BoundsCondition(nullptr)
   {
     this->DynamicMultiThreadingOn();
+    this->ThreaderUpdateProgressOff();
   }
 
   ~VectorNeighborhoodOperatorImageFilter() override = default;

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkVectorNeighborhoodInnerProduct.h"
 #include "itkImageRegionIterator.h"
 #include "itkConstNeighborhoodIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -98,6 +98,8 @@ VectorNeighborhoodOperatorImageFilter<TInputImage, TOutputImage>::DynamicThreade
   faceList = faceCalculator(input, outputRegionForThread, m_Operator.GetRadius());
   typename FaceListType::iterator fit;
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   ImageRegionIterator<OutputImageType> it;
 
   // Process non-boundary region and then each of the boundary faces.
@@ -113,6 +115,7 @@ VectorNeighborhoodOperatorImageFilter<TInputImage, TOutputImage>::DynamicThreade
       it.Value() = smartInnerProduct(bit, m_Operator);
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -25,7 +25,7 @@
 #include "itkDerivativeOperator.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkOffset.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -40,6 +40,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
   this->m_UseImageSpacing = true;
   this->m_UseImageDirection = true;
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 //
@@ -156,6 +157,8 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType::iterator fit;
   fit = faceList.begin();
 
+  TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
+
   // Initialize the x_slice array
   ConstNeighborhoodIterator<InputImageType> nit = ConstNeighborhoodIterator<InputImageType>(radius, inputImage, *fit);
 
@@ -190,6 +193,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
 
       ++nit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
@@ -114,11 +114,7 @@ public:
 #endif
 
 protected:
-  GradientMagnitudeImageFilter()
-  {
-    m_UseImageSpacing = true;
-    this->DynamicMultiThreadingOn();
-  }
+  GradientMagnitudeImageFilter();
 
   ~GradientMagnitudeImageFilter() override = default;
 
@@ -141,7 +137,7 @@ protected:
   PrintSelf(std::ostream &, Indent) const override;
 
 private:
-  bool m_UseImageSpacing;
+  bool m_UseImageSpacing{ true };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -24,10 +24,19 @@
 #include "itkImageRegionIterator.h"
 #include "itkDerivativeOperator.h"
 #include "itkNeighborhoodAlgorithm.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
+
+
+template <typename TInputImage, typename TOutputImage>
+GradientMagnitudeImageFilter<TInputImage, TOutputImage>::GradientMagnitudeImageFilter()
+{
+  this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
+}
+
 template <typename TInputImage, typename TOutputImage>
 void
 GradientMagnitudeImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -135,6 +144,8 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<TInputImage>::FaceListType::iterator fit;
   fit = faceList.begin();
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   // Process non-boundary face
   nit = ConstNeighborhoodIterator<TInputImage>(radius, input, *fit);
 
@@ -165,6 +176,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
       it.Value() = static_cast<OutputPixelType>(std::sqrt(a));
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkImageRegionIterator.h"
 #include "itkZeroFluxNeumannBoundaryCondition.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkCastImageFilter.h"
 
 #include "itkMath.h"
@@ -48,6 +48,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Vector
     m_SqrtComponentWeights[i] = static_cast<TRealType>(1.0);
   }
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TRealType, typename TOutputImage>
@@ -221,6 +222,8 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>::FaceListType::iterator fit;
   fit = faceList.begin();
 
+  TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
+
   // Process each of the data set faces.  The iterator is reinitialized on each
   // face so that it can determine whether or not to check for boundary
   // conditions.
@@ -241,6 +244,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
           it.Set(this->EvaluateAtNeighborhood3D(bit));
           ++bit;
           ++it;
+          progress.CompletedPixel();
         }
       }
       else
@@ -250,6 +254,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
           it.Set(this->EvaluateAtNeighborhood(bit));
           ++bit;
           ++it;
+          progress.CompletedPixel();
         }
       }
     }
@@ -260,6 +265,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
         it.Set(this->NonPCEvaluateAtNeighborhood(bit));
         ++bit;
         ++it;
+        progress.CompletedPixel();
       }
     }
   }

--- a/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
@@ -20,7 +20,7 @@
 
 #include "itkCyclicShiftImageFilter.h"
 #include "itkNumericTraits.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 
 namespace itk
@@ -31,6 +31,7 @@ CyclicShiftImageFilter<TInputImage, TOutputImage>::CyclicShiftImageFilter()
 {
   m_Shift.Fill(NumericTraits<OffsetValueType>::ZeroValue());
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -60,6 +61,8 @@ CyclicShiftImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const IndexType outIdx = this->GetOutput()->GetLargestPossibleRegion().GetIndex();
   const SizeType  outSize = this->GetOutput()->GetLargestPossibleRegion().GetSize();
 
+  TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
+
   // Now iterate over the pixels of the output region for this thread.
   ImageRegionIteratorWithIndex<OutputImageType> outIt(this->GetOutput(), outputRegionForThread);
   for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
@@ -77,6 +80,7 @@ CyclicShiftImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     }
 
     outIt.Set(static_cast<OutputImagePixelType>(inputImage->GetPixel(index)));
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
@@ -20,7 +20,7 @@
 
 #include "itkFlipImageFilter.h"
 #include "itkImageScanlineIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -31,6 +31,7 @@ FlipImageFilter<TImage>::FlipImageFilter()
 {
   m_FlipAxes.Fill(false);
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TImage>
@@ -186,6 +187,8 @@ FlipImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType
     }
   }
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   outputIt.GoToBegin();
   while (!outputIt.IsAtEnd())
   {
@@ -213,7 +216,7 @@ FlipImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType
         outputIt.Set(inputIter.Get());
 
         ++outputIt;
-        // Read the input scaneline in reverse
+        // Read the input scanline in reverse
         --inputIter;
       }
     }
@@ -231,6 +234,7 @@ FlipImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType
     }
 
     outputIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkInterpolateImageFilter.h"
 
 #include "itkImageRegionIteratorWithIndex.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -42,6 +42,7 @@ InterpolateImageFilter<TInputImage, TOutputImage>::InterpolateImageFilter()
 
   m_IntermediateImage = nullptr;
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 
@@ -162,6 +163,8 @@ InterpolateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   IndexType           outputIndex;       // Index to current output pixel
   ContinuousIndexType intermediateIndex; // Coordinates of current intermediate image pixel
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Walk the output region
   while (!outIt.IsAtEnd())
   {
@@ -185,6 +188,7 @@ InterpolateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     }
 
     ++outIt;
+    progress.CompletedPixel();
   }
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.hxx
@@ -29,7 +29,7 @@
 #define itkInterpolateImagePointsFilter_hxx
 
 #include "itkInterpolateImagePointsFilter.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -42,6 +42,7 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
 
   this->SetNumberOfRequiredInputs(ImageDimension + 1);
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage, typename TCoordType, typename InterpolatorType>
@@ -89,6 +90,8 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
     coordIter[j] = temp;
   }
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Loop through each pixel and calculate interpolated value.
   ContinuousIndexType index;
   while (!outIter.IsAtEnd())
@@ -114,6 +117,7 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
       outIter.Set(m_DefaultPixelValue);
     }
     ++outIter;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -22,7 +22,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkObjectFactory.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include <vector>
 
 namespace itk
@@ -742,6 +742,8 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   using OutputIterator = ImageRegionIterator<TOutputImage>;
   using InputIterator = ImageRegionConstIterator<TInputImage>;
 
+  TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
+
   int                  oddRegionArray[ImageDimension];
   OutputImageIndexType currentOutputIndex;
   InputImageIndexType  currentInputIndex;
@@ -762,6 +764,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
       if (inputRegion == outputRegion) // this is an inner region which only needs to be copied
       {
         ImageAlgorithm::Copy(inputPtr, outputPtr, inputRegion, outputRegion);
+        progress.Completed(outputRegion.GetNumberOfPixels());
       }
       else // this is a padding region, which might need exponential decay
       {
@@ -789,6 +792,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
           const typename OutputImageType::PixelType outVal(RealPixelType(inIt.Get()) * decayFactor);
 
           outIt.Set(outVal);
+          progress.CompletedPixel();
         }
       }
     }

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkPermuteAxesImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkMacro.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -37,6 +37,7 @@ PermuteAxesImageFilter<TImage>::PermuteAxesImageFilter()
     m_InverseOrder[m_Order[j]] = j;
   }
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 /**
@@ -225,6 +226,8 @@ PermuteAxesImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageReg
   typename Superclass::InputImageConstPointer inputPtr = this->GetInput();
   typename Superclass::OutputImagePointer     outputPtr = this->GetOutput();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Setup output region iterator
   using OutputIterator = ImageRegionIteratorWithIndex<TImage>;
   OutputIterator outIt(outputPtr, outputRegionForThread);
@@ -246,6 +249,7 @@ PermuteAxesImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageReg
 
     // copy the input pixel to the output
     outIt.Set(inputPtr->GetPixel(inputIndex));
+    progress.CompletedPixel();
   }
 }
 } // namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkRegionOfInterestImageFilter.h"
 #include "itkImageAlgorithm.h"
 #include "itkObjectFactory.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkImage.h"
 
 namespace itk
@@ -31,6 +31,7 @@ template <typename TInputImage, typename TOutputImage>
 RegionOfInterestImageFilter<TInputImage, TOutputImage>::RegionOfInterestImageFilter()
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -108,6 +109,8 @@ RegionOfInterestImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   const TInputImage * inputPtr = this->GetInput();
   TOutputImage *      outputPtr = this->GetOutput();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Define the portion of the input to walk for this thread
   InputImageRegionType inputRegionForThread;
   inputRegionForThread.SetSize(outputRegionForThread.GetSize());
@@ -121,6 +124,7 @@ RegionOfInterestImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   inputRegionForThread.SetIndex(start);
 
   ImageAlgorithm::Copy(inputPtr, outputPtr, inputRegionForThread, outputRegionForThread);
+  progress.Completed(outputRegionForThread.GetNumberOfPixels());
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkResampleImageFilter.h"
 #include "itkObjectFactory.h"
 #include "itkIdentityTransform.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageScanlineIterator.h"
 #include "itkSpecialCoordinatesImage.h"
@@ -346,6 +346,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   const InputImageType * inputPtr = this->GetInput();
   const TransformType *  transformPtr = this->GetTransform();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Honor the SpecialCoordinatesImage isInside value returned
   // by TransformPhysicalPointToContinuousIndex
   using InputSpecialCoordinatesImageType = SpecialCoordinatesImage<InputPixelType, InputImageDimension>;
@@ -396,7 +398,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
         outIt.Set(Self::CastPixelWithBoundsChecking(value));
       }
     }
-
+    progress.CompletedPixel();
     ++outIt;
   }
 }
@@ -416,6 +418,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   // Create an iterator that will walk the output region for this thread.
   using OutputIterator = ImageScanlineIterator<TOutputImage>;
   OutputIterator outIt(outputPtr, outputRegionForThread);
+
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel
@@ -503,6 +507,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
       ++scanlineIndex;
     }
     outIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -32,7 +32,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkContinuousIndex.h"
 #include "itkObjectFactory.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -44,6 +44,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::ShrinkImageFilter()
     m_ShrinkFactors[j] = 1;
   }
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -111,6 +112,8 @@ ShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   InputImageConstPointer inputPtr = this->GetInput();
   OutputImagePointer     outputPtr = this->GetOutput();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Convert the factor for convenient multiplication
   unsigned int i;
 
@@ -168,6 +171,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     // Copy the input pixel to the output
     outIt.Set(inputPtr->GetPixel(inputIndex));
     ++outIt;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -33,7 +33,7 @@
 #include "itkMath.h"
 #include "itkContinuousIndex.h"
 #include "itkObjectFactory.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -45,6 +45,7 @@ SliceImageFilter<TInputImage, TOutputImage>::SliceImageFilter()
   m_Stop.Fill(NumericTraits<IndexValueType>::max());
   m_Step.Fill(1);
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
@@ -121,6 +122,8 @@ SliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   InputImageConstPointer inputPtr = this->GetInput();
   OutputImagePointer     outputPtr = this->GetOutput();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   const typename TInputImage::SizeType &  inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
   const typename TInputImage::IndexType & inputIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
 
@@ -152,6 +155,7 @@ SliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     // Copy the input pixel to the output
     outIt.Set(inputPtr->GetPixel(srcIndex));
     ++outIt;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkImageAlgorithm.h"
 #include "itkNumericTraits.h"
 #include "itkDefaultConvertPixelTraits.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkContinuousIndex.h"
 #include "itkMath.h"
 #include "itkTransform.h"
@@ -51,6 +51,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::WarpImageFilter(
 
   m_DefFieldSameInformation = false;
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage, typename TDisplacementField>
@@ -280,6 +281,8 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
   OutputImageType *             outputPtr = this->GetOutput();
   const DisplacementFieldType * fieldPtr = this->GetDisplacementField();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // iterator for the output image
   ImageRegionIteratorWithIndex<OutputImageType> outputIt(outputPtr, outputRegionForThread);
   IndexType                                     index;
@@ -318,6 +321,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
       }
       ++outputIt;
       ++fieldIt;
+      progress.CompletedPixel();
     }
   }
   else
@@ -346,6 +350,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
         outputIt.Set(m_EdgePaddingValue);
       }
       ++outputIt;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
@@ -21,7 +21,7 @@
 
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionIteratorWithIndex.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -46,6 +46,7 @@ WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::WarpVector
 
   m_Interpolator = static_cast<InterpolatorType *>(interp.GetPointer());
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 
@@ -144,7 +145,9 @@ WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThr
   OutputImagePointer       outputPtr = this->GetOutput();
   DisplacementFieldPointer fieldPtr = this->GetDisplacementField();
 
+
   ImageRegionIteratorWithIndex<OutputImageType> outputIt(outputPtr, outputRegionForThread);
+  TotalProgressReporter                         progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   ImageRegionIterator<DisplacementFieldType> fieldIt(fieldPtr, outputRegionForThread);
 
@@ -184,6 +187,7 @@ WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThr
     }
     ++outputIt;
     ++fieldIt;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
@@ -22,7 +22,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkObjectFactory.h"
 #include "itkNumericTraits.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkMath.h"
 
 #if !defined(ITK_LEGACY_REMOVE)
@@ -42,6 +42,7 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::VectorExpandImageFilter()
 
   m_Interpolator = static_cast<InterpolatorType *>(interp.GetPointer());
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 
@@ -115,6 +116,8 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
   OutputIterator outIt(outputPtr, outputRegionForThread);
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   // Define a few indices that will be used to translate from an input
   // pixel to and output pixel
   typename TOutputImage::IndexType               outputIndex;
@@ -156,6 +159,7 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
       itkExceptionMacro(<< "Interpolator outside buffer should never occur ");
     }
     ++outIt;
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -20,7 +20,7 @@
 
 #include "itkAdditiveGaussianNoiseImageFilter.h"
 #include "itkImageScanlineIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkNormalVariateGenerator.h"
 
 namespace itk
@@ -31,6 +31,7 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::AdditiveGaussianNoi
 
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
@@ -40,6 +41,8 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGene
 {
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput(0);
+
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Create a random generator per thread
   IndexValueType indSeed = 0;
@@ -76,6 +79,7 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGene
     }
     inputIt.NextLine();
     outputIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkSaltAndPepperNoiseImageFilter.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkImageScanlineIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -32,6 +32,7 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::SaltAndPepperNoiseImag
   , m_PepperValue(NumericTraits<OutputImagePixelType>::NonpositiveMin())
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
@@ -66,6 +67,8 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerat
   inputIt.GoToBegin();
   outputIt.GoToBegin();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   while (!inputIt.IsAtEnd())
   {
     while (!inputIt.IsAtEndOfLine())
@@ -93,6 +96,7 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerat
     }
     inputIt.NextLine();
     outputIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkShotNoiseImageFilter.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkImageScanlineIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkNormalVariateGenerator.h"
 
 namespace itk
@@ -32,6 +32,7 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::ShotNoiseImageFilter()
 
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
@@ -68,6 +69,8 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   inputIt.GoToBegin();
   outputIt.GoToBegin();
 
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+
   while (!inputIt.IsAtEnd())
   {
     while (!inputIt.IsAtEndOfLine())
@@ -103,6 +106,7 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     }
     inputIt.NextLine();
     outputIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -22,7 +22,7 @@
 #include "itkSpeckleNoiseImageFilter.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkImageScanlineIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -32,6 +32,7 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::SpeckleNoiseImageFilter()
 
 {
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
@@ -65,6 +66,8 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   inputIt.GoToBegin();
   outputIt.GoToBegin();
+
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Choose the value of the gamma distribution so that the mean is 1 and the
   // variance depends on the standard deviation
@@ -113,6 +116,7 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     }
     inputIt.NextLine();
     outputIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
@@ -22,7 +22,7 @@
 #include "itkGridImageSource.h"
 #include "itkImageLinearIteratorWithIndex.h"
 #include "itkImageRegionIteratorWithIndex.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -37,6 +37,7 @@ GridImageSource<TOutputImage>::GridImageSource()
 
   this->m_KernelFunction = dynamic_cast<KernelFunctionType *>(GaussianKernelFunction<double>::New().GetPointer());
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TOutputImage>
@@ -93,6 +94,8 @@ GridImageSource<TOutputImage>::DynamicThreadedGenerateData(const ImageRegionType
 {
   ImageType * output = this->GetOutput(0);
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   ImageRegionIteratorWithIndex<ImageType> It(output, outputRegionForThread);
 
   for (It.GoToBegin(); !It.IsAtEnd(); ++It)
@@ -104,6 +107,7 @@ GridImageSource<TOutputImage>::DynamicThreadedGenerateData(const ImageRegionType
       val *= this->m_PixelArrays->GetElement(i)[index[i]];
     }
     It.Set(static_cast<PixelType>(m_Scale * val));
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.h
@@ -64,7 +64,11 @@ public:
   itkNewMacro(Self);
 
 protected:
-  PhysicalPointImageSource() { this->DynamicMultiThreadingOn(); };
+  PhysicalPointImageSource()
+  {
+    this->DynamicMultiThreadingOn();
+    this->ThreaderUpdateProgressOff();
+  };
   ~PhysicalPointImageSource() override = default;
 
   void

--- a/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.hxx
@@ -20,7 +20,7 @@
 #define itkPhysicalPointImageSource_hxx
 
 #include "itkPhysicalPointImageSource.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 
 namespace itk
@@ -50,6 +50,8 @@ PhysicalPointImageSource<TOutputImage>::DynamicThreadedGenerateData(const Region
 {
   TOutputImage * image = this->GetOutput(0);
 
+  TotalProgressReporter progress(this, image->GetRequestedRegion().GetNumberOfPixels());
+
   ImageRegionIteratorWithIndex<TOutputImage> it(image, outputRegionForThread);
   PointType                                  pt;
   PixelType                                  px;
@@ -64,6 +66,7 @@ PhysicalPointImageSource<TOutputImage>::DynamicThreadedGenerateData(const Region
       px[i] = static_cast<typename PixelType::ValueType>(pt[i]);
     }
     it.Set(px);
+    progress.CompletedPixel();
   }
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkLabelOverlapMeasuresImageFilter.h"
 
 #include "itkImageRegionConstIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -21,7 +21,7 @@
 
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkImageScanlineConstIterator.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkProjectionImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkImageLinearConstIteratorWithIndex.h"
 
 namespace itk
@@ -281,6 +281,8 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
   // instantiate the accumulator
   AccumulatorType accumulator = this->NewAccumulator(projectionSize);
 
+  TotalProgressReporter progress(this, outputImage->GetRequestedRegion().GetNumberOfPixels());
+
   // ok, everything is ready... lets the linear iterator do its job !
   while (!iIt.IsAtEnd())
   {
@@ -329,6 +331,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
     outputImage->SetPixel(oIdx, static_cast<OutputPixelType>(accumulator.GetValue()));
 
     iIt.NextLine();
+    progress.CompletedPixel();
   }
 }
 

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.h
@@ -137,8 +137,6 @@ protected:
 
 private:
   typename InputImageType::Iterator m_LabelObjectIterator;
-  float                             m_InverseNumberOfLabelObjects{ 1.0f };
-  SizeValueType                     m_NumberOfLabelObjectsProcessed{ 1 };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkNumericTraits.h"
 #include "itkGrayscaleGeodesicErodeImageFilter.h"
 #include "itkNeighborhoodAlgorithm.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkProgressAccumulator.h"
 #include "itkIterationReporter.h"
 #include "itkImageRegionIterator.h"
@@ -40,6 +40,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GrayscaleGeodesicE
   this->SetNumberOfRequiredInputs(2);
   m_FullyConnected = false;
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -270,6 +271,8 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   // Set up the boundary condition to have no upwind derivatives
   ZeroFluxNeumannBoundaryCondition<TInputImage> BC;
 
+  TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
+
   // Neighborhood iterator.  Let's use a shaped neighborhood so we can
   // restrict the access to face connected neighbors. This iterator
   // will be applied to the marker image.
@@ -368,6 +371,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
       ++oIt;
       ++markerIt;
       ++maskIt;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkMaskedMovingHistogramImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkOffset.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkNumericTraits.h"
 
 #include "itkImageRegionIterator.h"
@@ -51,6 +51,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
   this->m_GenerateOutputMask = true;
   this->SetGenerateOutputMask(false);
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TMaskImage, typename TOutputImage, typename TKernel, typename THistogram>
@@ -140,6 +141,8 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
   const MaskImageType *  maskImage = this->GetMaskImage();
 
   RegionType inputRegion = inputImage->GetRequestedRegion();
+
+  TotalProgressReporter progress(this, inputRegion.GetNumberOfPixels());
 
   // initialize the histogram
   for (auto listIt = this->m_KernelOffsets.begin(); listIt != this->m_KernelOffsets.end(); listIt++)
@@ -235,6 +238,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
     }
     Steps[BestDirection] += LineLength;
     InLineIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
     if (InLineIt.IsAtEnd())
     {
       break;

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkNumericTraits.h"
 #include "itkMorphologyImageFilter.h"
 #include "itkNeighborhoodAlgorithm.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 namespace itk
 {
@@ -33,6 +33,7 @@ MorphologyImageFilter<TInputImage, TOutputImage, TKernel>::MorphologyImageFilter
   m_DefaultBoundaryCondition.SetConstant(NumericTraits<PixelType>::ZeroValue());
   m_BoundaryCondition = &m_DefaultBoundaryCondition;
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
@@ -49,6 +50,8 @@ MorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreadedGenera
   faceList = fC(this->GetInput(), outputRegionForThread, this->GetKernel().GetRadius());
 
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType::iterator fit;
+
+  TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 
   ImageRegionIterator<TOutputImage> o_iter;
 
@@ -71,6 +74,7 @@ MorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreadedGenera
       o_iter.Set(this->Evaluate(b_iter, kernelBegin, kernelEnd));
       ++b_iter;
       ++o_iter;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Filtering/Smoothing/test/itkMedianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMedianImageFilterTest.cxx
@@ -60,29 +60,6 @@ itkMedianImageFilterTest(int, char *[])
   // run the algorithm
   median->Update();
 
-  itk::ImageRegionIterator<FloatImage2DType> it;
-  it = itk::ImageRegionIterator<FloatImage2DType>(random->GetOutput(), random->GetOutput()->GetBufferedRegion());
-  std::cout << "Input image" << std::endl;
-  unsigned int i;
-  for (i = 1; !it.IsAtEnd(); ++i, ++it)
-  {
-    std::cout << "\t" << it.Get();
-    if ((i % 8) == 0)
-    {
-      std::cout << std::endl;
-    }
-  }
-
-  std::cout << "Output image" << std::endl;
-  it = itk::ImageRegionIterator<FloatImage2DType>(median->GetOutput(), median->GetOutput()->GetBufferedRegion());
-  for (i = 1; !it.IsAtEnd(); ++i, ++it)
-  {
-    std::cout << "\t" << it.Get();
-    if ((i % 8) == 0)
-    {
-      std::cout << std::endl;
-    }
-  }
 
   // Test the itkGetConstReferenceMacro
   const FloatImage2DType::SizeType & radius = median->GetRadius();

--- a/Modules/Filtering/Smoothing/test/itkMedianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMedianImageFilterTest.cxx
@@ -19,7 +19,7 @@
 #include "itkRandomImageSource.h"
 #include "itkMedianImageFilter.h"
 #include "itkTextOutput.h"
-
+#include "itkSimpleFilterWatcher.h"
 
 int
 itkMedianImageFilterTest(int, char *[])
@@ -36,7 +36,7 @@ itkMedianImageFilterTest(int, char *[])
   random->SetMax(1000.0);
 
   FloatImage2DType::SizeValueType randomSize[2];
-  randomSize[0] = randomSize[1] = 8;
+  randomSize[0] = randomSize[1] = 25;
   random->SetSize(randomSize);
 
   FloatImage2DType::SpacingValueType spacing[2] = { 0.7, 2.1 };
@@ -52,10 +52,11 @@ itkMedianImageFilterTest(int, char *[])
 
   // define the neighborhood size used for the median filter (5x5)
   FloatImage2DType::SizeType neighRadius;
-  neighRadius[0] = 1;
-  neighRadius[1] = 1;
+  neighRadius[0] = 5;
+  neighRadius[1] = 5;
   median->SetRadius(neighRadius);
 
+  itk::SimpleFilterWatcher watcher(median, "To watch progress updates");
   // run the algorithm
   median->Update();
 

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
@@ -32,7 +32,7 @@
 #include "itkImageScanlineIterator.h"
 #include "itkNumericTraits.h"
 #include "itkObjectFactory.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 #include "itkMacro.h"
 #include "itkMath.h"
 
@@ -47,6 +47,7 @@ ThresholdImageFilter<TImage>::ThresholdImageFilter()
 {
   this->InPlaceOff();
   this->DynamicMultiThreadingOn();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TImage>
@@ -95,15 +96,11 @@ template <typename TImage>
 void
 ThresholdImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
-  const SizeValueType size0 = outputRegionForThread.GetSize(0);
-  if (size0 == 0)
-  {
-    return;
-  }
-
   // Get the input and output pointers
   InputImagePointer  inputPtr = this->GetInput();
   OutputImagePointer outputPtr = this->GetOutput(0);
+
+  TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Define/declare an iterator that will walk the output region for this
   // thread.
@@ -134,6 +131,7 @@ ThresholdImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegio
     }
     inIt.NextLine();
     outIt.NextLine();
+    progress.Completed(outputRegionForThread.GetSize()[0]);
   }
 }
 

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkConstNeighborhoodIterator.h"
 #include <limits>
+#include "itkMultiThreaderBase.h"
 
 
 namespace itk

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -24,6 +24,7 @@
 #include "itkGradientRecursiveGaussianImageFilter.h"
 #include "itkSpatialObject.h"
 #include "itkCentralDifferenceImageFunction.h"
+#include "itkMultiThreaderBase.h"
 
 namespace itk
 {

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
@@ -246,7 +246,7 @@ public:
 #endif
 
 protected:
-  RelabelComponentImageFilter() { this->InPlaceOff(); }
+  RelabelComponentImageFilter();
   ~RelabelComponentImageFilter() override = default;
 
   /**

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkOffset.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 #include <vector>
 #include <algorithm>
@@ -38,6 +38,7 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::BinaryMedianImageFilter()
   m_Radius.Fill(1);
   m_ForegroundValue = NumericTraits<InputPixelType>::max();
   m_BackgroundValue = NumericTraits<InputPixelType>::ZeroValue();
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -108,6 +109,8 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType::iterator fit;
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
+
   // Process each of the boundary faces.  These are N-d regions which border
   // the edge of the buffer.
   for (fit = faceList.begin(); fit != faceList.end(); ++fit)
@@ -148,6 +151,7 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -23,7 +23,7 @@
 #include "itkNeighborhoodInnerProduct.h"
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodAlgorithm.h"
-#include "itkProgressReporter.h"
+#include "itkTotalProgressReporter.h"
 
 #include <vector>
 #include <algorithm>
@@ -38,6 +38,7 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::VotingBinaryImageFilter()
   m_BackgroundValue = NumericTraits<InputPixelType>::ZeroValue();
   m_BirthThreshold = 1;
   m_SurvivalThreshold = 1;
+  this->ThreaderUpdateProgressOff();
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -107,6 +108,7 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>::FaceListType::iterator fit;
 
+  TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
   // Process each of the boundary faces.  These are N-d regions which border
   // the edge of the buffer.
   for (fit = faceList.begin(); fit != faceList.end(); ++fit)
@@ -148,6 +150,7 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
       ++bit;
       ++it;
+      progress.CompletedPixel();
     }
   }
 }

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -19,6 +19,7 @@
 #define itkVideoSource_hxx
 
 #include "itkVideoSource.h"
+#include "itkMultiThreaderBase.h"
 
 namespace itk
 {


### PR DESCRIPTION
This is early in the hacking of revising the progress reporting system. The initial goal of this approach was to have one ProcessObject variable with the progress. This should allow all the different types of progress reporting to work together.

The progress reporting in the Multithreaders was commented out. After looking at the code a little I am wonder is much of progress reporting in the multithreads should be replaced by a separate progress reporting object.
