### PR TITLE
ENH: Wrap ComposeImageFilter for complex types

### DIFF
--- a/Modules/Filtering/ImageCompose/wrapping/itkComposeImageFilter.wrap
+++ b/Modules/Filtering/ImageCompose/wrapping/itkComposeImageFilter.wrap
@@ -46,4 +46,12 @@ itk_wrap_class("itk::ComposeImageFilter" POINTER)
     itk_wrap_image_filter_types(US RGBUS)
   endif()
 
+  if(ITK_WRAP_complex_float AND ITK_WRAP_float)
+    itk_wrap_image_filter_types(F CF)
+  endif()
+
+  if(ITK_WRAP_complex_double AND ITK_WRAP_double)
+    itk_wrap_image_filter_types(D CD)
+  endif()
+
 itk_end_wrap_class()


### PR DESCRIPTION
This allows for combining real and imaginary images into complex images. 

Closes #1581

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- :no_entry_sign: Adds the License notice to new files.
- [X] Adds Python wrapping.
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
