### PR TITLE
ENH: Explicitly instantiate MultiThreaderBase methods

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -216,6 +216,13 @@ namespace itk
 #  endif
 #endif
 
+#if defined(ITKCommon_EXPORTS)
+//   We are building this library
+#  define ITKCommon_EXPORT_EXPLICIT ITK_TEMPLATE_EXPORT
+#else
+//   We are using this library
+#  define ITKCommon_EXPORT_EXPLICIT ITKCommon_EXPORT
+#endif
 
 //-*-*-*
 // The following deprecations should be removed in ITKV6 and later

--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -252,21 +252,6 @@ ExposeMetaData(const MetaDataDictionary & Dictionary, const std::string key, T &
 
 /** Explicit instantiations */
 #ifndef ITK_TEMPLATE_EXPLICIT_MetaDataObject
-// Explicit instantiation is required to ensure correct dynamic_cast
-// behavior across shared libraries.
-//
-// IMPORTANT: Since within the same compilation unit,
-//            ITK_TEMPLATE_EXPLICIT_<classname> defined and undefined states
-//            need to be considered. This code *MUST* be *OUTSIDE* the header
-//            guards.
-//
-#if defined(ITKCommon_EXPORTS)
-//   We are building this library
-#  define ITKCommon_EXPORT_EXPLICIT ITK_TEMPLATE_EXPORT
-#else
-//   We are using this library
-#  define ITKCommon_EXPORT_EXPLICIT ITKCommon_EXPORT
-#endif
 namespace itk
 {
 
@@ -301,5 +286,4 @@ extern template class ITKCommon_EXPORT_EXPLICIT MetaDataObject<Matrix<double>>;
 ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
-#undef ITKCommon_EXPORT_EXPLICIT
 #endif

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -466,3 +466,50 @@ ITKCommon_EXPORT std::ostream &
 
 } // end namespace itk
 #endif
+
+#ifndef ITK_TEMPLATE_EXPLICIT_MultiThreaderBase
+
+namespace itk
+{
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegion<1>(const ImageRegion<1> &, TemplatedThreadingFunctorType<1>, ProcessObject *);
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegion<2>(const ImageRegion<2> &, TemplatedThreadingFunctorType<2>, ProcessObject *);
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegion<3>(const ImageRegion<3> &, TemplatedThreadingFunctorType<3>, ProcessObject *);
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegion<4>(const ImageRegion<4> &, TemplatedThreadingFunctorType<4>, ProcessObject *);
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegion<5>(const ImageRegion<5> &,
+                                             TemplatedThreadingFunctorType<5> funcP,
+                                             ProcessObject *);
+
+
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegionRestrictDirection<1>(unsigned int,
+                                                              const ImageRegion<1> &,
+                                                              TemplatedThreadingFunctorType<1>,
+                                                              ProcessObject *);
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegionRestrictDirection<2>(unsigned int,
+                                                              const ImageRegion<2> &,
+                                                              TemplatedThreadingFunctorType<2>,
+                                                              ProcessObject *);
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegionRestrictDirection<3>(unsigned int,
+                                                              const ImageRegion<3> &,
+                                                              TemplatedThreadingFunctorType<3>,
+                                                              ProcessObject *);
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegionRestrictDirection<4>(unsigned int,
+                                                              const ImageRegion<4> &,
+                                                              TemplatedThreadingFunctorType<4>,
+                                                              ProcessObject *);
+extern template void ITKCommon_EXPORT_EXPLICIT
+                     MultiThreaderBase::ParallelizeImageRegionRestrictDirection<5>(unsigned int,
+                                                              const ImageRegion<5> &,
+                                                              TemplatedThreadingFunctorType<5>,
+                                                              ProcessObject *);
+
+} // namespace itk
+#endif

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -25,6 +25,7 @@
  *  please refer to the NOTICE file at the top of the ITK source tree.
  *
  *=========================================================================*/
+#define ITK_TEMPLATE_EXPLICIT_MultiThreaderBase
 #include "itkMultiThreaderBase.h"
 #include "itkPlatformMultiThreader.h"
 #if defined(ITK_USE_PTHREADS) || defined(ITK_USE_WIN32_THREADS)
@@ -649,5 +650,53 @@ MultiThreaderBase::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 MultiThreaderBaseGlobals * MultiThreaderBase::m_PimplGlobals;
+
+
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegion<1>(const ImageRegion<1> &           requestedRegion,
+                                             TemplatedThreadingFunctorType<1> funcP,
+                                             ProcessObject *                  filter);
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegion<2>(const ImageRegion<2> &           requestedRegion,
+                                             TemplatedThreadingFunctorType<2> funcP,
+                                             ProcessObject *                  filter);
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegion<3>(const ImageRegion<3> &           requestedRegion,
+                                             TemplatedThreadingFunctorType<3> funcP,
+                                             ProcessObject *                  filter);
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegion<4>(const ImageRegion<4> &           requestedRegion,
+                                             TemplatedThreadingFunctorType<4> funcP,
+                                             ProcessObject *                  filter);
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegion<5>(const ImageRegion<5> &           requestedRegion,
+                                             TemplatedThreadingFunctorType<5> funcP,
+                                             ProcessObject *                  filter);
+
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegionRestrictDirection<1>(unsigned int,
+                                                              const ImageRegion<1> &,
+                                                              TemplatedThreadingFunctorType<1>,
+                                                              ProcessObject *);
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegionRestrictDirection<2>(unsigned int,
+                                                              const ImageRegion<2> &,
+                                                              TemplatedThreadingFunctorType<2>,
+                                                              ProcessObject *);
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegionRestrictDirection<3>(unsigned int,
+                                                              const ImageRegion<3> &,
+                                                              TemplatedThreadingFunctorType<3>,
+                                                              ProcessObject *);
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegionRestrictDirection<4>(unsigned int,
+                                                              const ImageRegion<4> &,
+                                                              TemplatedThreadingFunctorType<4>,
+                                                              ProcessObject *);
+template void ITKCommon_EXPORT
+              MultiThreaderBase::ParallelizeImageRegionRestrictDirection<5>(unsigned int,
+                                                              const ImageRegion<5> &,
+                                                              TemplatedThreadingFunctorType<5>,
+                                                              ProcessObject *);
 
 } // namespace itk


### PR DESCRIPTION
The MultiThreaderBase ParallelizeImageRegion methods are explicitly
instantiated in the ITK Common library for common dimensions of
1-5. This will improve compilation time, reduce the size of binaries
and may improve execution time from reduced code size.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
