### PR TITLE
BUG: operator() can not be const

### DIFF
--- a/Modules/Bridge/VtkGlue/include/vtkCaptureScreen.h
+++ b/Modules/Bridge/VtkGlue/include/vtkCaptureScreen.h
@@ -47,7 +47,7 @@ public:
   }
 
   void
-  operator()(vtkRenderWindow * iRenderer, const std::string & iFileName) const
+  operator()(vtkRenderWindow * iRenderer, const std::string & iFileName)
   {
     m_Renderer = iRenderer;
     Capture(m_Renderer, iFileName);


### PR DESCRIPTION
The member variable is changed, so the operator() can not be const.

Bug identified with clang10 compilation