### PR TITLE
BUG: remove assertion which frequently fails

### DIFF
--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -247,7 +247,6 @@ protected:
       diffSum += diff;
     }
 
-    assert(diffSum > 0); // we are checking potential neighbors, index difference must exist
     if (!this->m_FullyConnected)
     {
       return (diffSum <= 1); // indices can differ only along one dimension


### PR DESCRIPTION
We are not checking difference along dimension zero,
so it is possible for diffSum to be 0 despite neighbors being different.

This is a follow-up to #1589.