### PR TITLE
COMP: Fix suggested brace around initialization warnings

### DIFF
--- a/Modules/Core/Mesh/test/itkMeshCellDataTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshCellDataTest.cxx
@@ -38,12 +38,12 @@ itkMeshCellDataTest(int, char *[])
   // 0      2------4
 
   const auto mesh = TMesh::New();
-  mesh->SetPoint(0, TPoint{ { 0.0, 0.0 } });
-  mesh->SetPoint(1, TPoint{ { 0.0, 1.0 } });
-  mesh->SetPoint(2, TPoint{ { 1.0, 0.0 } });
-  mesh->SetPoint(3, TPoint{ { 1.0, 1.0 } });
-  mesh->SetPoint(4, TPoint{ { 4.0, 0.0 } });
-  mesh->SetPoint(5, TPoint{ { 5.0, 1.0 } });
+  mesh->SetPoint(0, TPoint{ { { 0.0, 0.0 } } });
+  mesh->SetPoint(1, TPoint{ { { 0.0, 1.0 } } });
+  mesh->SetPoint(2, TPoint{ { { 1.0, 0.0 } } });
+  mesh->SetPoint(3, TPoint{ { { 1.0, 1.0 } } });
+  mesh->SetPoint(4, TPoint{ { { 4.0, 0.0 } } });
+  mesh->SetPoint(5, TPoint{ { { 5.0, 1.0 } } });
 
   {
     TCell::CellAutoPointer cellpointer;

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -160,7 +160,7 @@ TEST(RelabelComponentImageFilter, big_random)
 
 
   auto randomSource = itk::RandomImageSource<ImageType>::New();
-  randomSource->SetSize({ 512, 512, 512 });
+  randomSource->SetSize({ { 512, 512, 512 } });
   randomSource->SetMin(0);
   randomSource->Update();
 


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
