### PR TITLE
ENH: Update RTK for future proofing.

### DIFF
--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -2,5 +2,5 @@
 itk_fetch_module(RTK
     "Reconstruction Toolkit (RTK) http://www.openrtk.org/"
   GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/RTK.git
-  GIT_TAG 3fc00efadef8324aba31f77390c3e562f9af5147
+  GIT_TAG f0451dafae314c142d2ead540b8fde5f1f8a51d8
 )


### PR DESCRIPTION
Using explicit typecasts for future-proofing
enums.  RTK treats enum values as integers and
enumerations interchangeably for pushing onto
a stack of integers.  Using explicit static_casts
makes code future proof when enum class is used.
