### PR TITLE
COMP: Need to explicitly define std::min<> template values

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.hxx
@@ -271,7 +271,7 @@ RelabelComponentImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
   SizeValueType                                            i;
 
   // limit the number of objects to print
-  SizeValueType numPrint = std::min(m_NumberOfObjectsToPrint, m_SizeOfObjectsInPixels.size());
+  SizeValueType numPrint = std::min<SizeValueType>(m_NumberOfObjectsToPrint, m_SizeOfObjectsInPixels.size());
 
   for (i = 0, it = m_SizeOfObjectsInPixels.begin(), fit = m_SizeOfObjectsInPhysicalUnits.begin(); i < numPrint;
        ++it, ++fit, ++i)


### PR DESCRIPTION
Compiling with clang++-11 compiler identified ambiguous
types for min function.
