### PR TITLE
BUG: reduced number of warnings for non-uniform sampling

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.h
@@ -169,6 +169,10 @@ public:
   itkGetConstReferenceMacro(UseStreaming, bool);
   itkBooleanMacro(UseStreaming);
 
+  /** Set the relative threshold for issuing warnings about non-uniform sampling */
+  itkSetMacro(SpacingWarningRelThreshold, double);
+  itkGetConstMacro(SpacingWarningRelThreshold, double);
+
 protected:
   ImageSeriesReader()
     : m_ImageIO(nullptr)
@@ -208,6 +212,8 @@ protected:
   bool m_UseStreaming{ true };
 
   bool m_SpacingDefined{ false };
+
+  double m_SpacingWarningRelThreshold{ 1e-4 };
 
 private:
   using ReaderType = ImageFileReader<TOutputImage>;

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -439,18 +439,12 @@ ImageSeriesReader<TOutputImage>::GenerateData()
         {
           nonUniformSampling = true;
           spacingDeviation = Math::abs(outputSpacing[this->m_NumberOfDimensionsInImage] - dirNnorm);
-          itkWarningMacro(<< "Non uniform sampling or missing slices detected , expected " << std::setprecision(14)
-                          << outputSpacing[this->m_NumberOfDimensionsInImage] << " got: " << dirNnorm
-                          << " Deviation of:" << spacingDeviation);
-
-          needToUpdateMetaDataDictionaryArray = true;
           if (spacingDeviation > maxSpacingDeviation)
           {
             maxSpacingDeviation = spacingDeviation;
-            EncapsulateMetaData<double>(output->GetMetaDataDictionary(),
-                                        "ITK_non_uniform_sampling_deviation",
-                                        maxSpacingDeviation); // maximum deviation
           }
+
+          needToUpdateMetaDataDictionaryArray = true;
         }
         prevSliceOrigin = sliceOrigin;
       }
@@ -476,8 +470,21 @@ ImageSeriesReader<TOutputImage>::GenerateData()
       }
       m_MetaDataDictionaryArray.push_back(newDictionary);
     }
-
   } // end per slice loop
+
+
+  if (maxSpacingDeviation > m_SpacingWarningRelThreshold * outputSpacing[this->m_NumberOfDimensionsInImage])
+  {
+    itkWarningMacro(<< "Non uniform sampling or missing slices detected,  maximum nonuniformity:"
+                    << maxSpacingDeviation);
+  }
+  if (maxSpacingDeviation > 0.0)
+  {
+    EncapsulateMetaData<double>(output->GetMetaDataDictionary(),
+                                "ITK_non_uniform_sampling_deviation",
+                                maxSpacingDeviation); // maximum deviation
+  }
+
 
   // update the time if we modified the meta array
   if (needToUpdateMetaDataDictionaryArray)


### PR DESCRIPTION
BUG: Related to #1607, now only one warning per series is emitted, when maximum 
slice sampling error is greater then 1e-6

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [ ] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [ ] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [ ] :no_entry_sign: Adds the License notice to new files.
- [ ] :no_entry_sign: Adds Python wrapping.
- [ ] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [ ] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [ ] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [ ] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
