### PR TITLE
Update vxl 20200214

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_sparse_lm.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_sparse_lm.cxx
@@ -608,7 +608,7 @@ public:
   }
 
   double
-  mest(int /*k*/, double ek2)
+  mest(int /*k*/, double ek2) const
   {
     // Beaton-Tukey
     if (ek2 > scale2_)
@@ -621,7 +621,7 @@ public:
   }
 
   double
-  d_mest(int /*k*/, double ek2)
+  d_mest(int /*k*/, double ek2) const
   {
     // Beaton-Tukey
     if (ek2 > scale2_)

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_symmetric_eigensystem.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_symmetric_eigensystem.cxx
@@ -91,7 +91,7 @@ test_symmetric_eigensystem()
     constexpr unsigned n = 20000;
 
     double fixed_data[n][3];
-    unsigned int fixed_time=0;
+    unsigned int fixed_time = 0;
     {
       double M11, M12, M13, M22, M23, M33;
       // Generate a random system
@@ -108,12 +108,12 @@ test_symmetric_eigensystem()
         const auto timer_01 = std::chrono::high_resolution_clock::now();
         vnl_symmetric_eigensystem_compute_eigenvals(M11, M12, M13, M22, M23, M33, c[0], c[1], c[2]);
         const auto timer_02 = std::chrono::high_resolution_clock::now();
-        fixed_time += (timer_02 - timer_01).count(); 
+        fixed_time += (timer_02 - timer_01).count();
       }
     }
 
     double netlib_data[n][3];
-    unsigned int netlib_time=0;
+    unsigned int netlib_time = 0;
     {
       // Generate same random system
       vnl_random rng(5);

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_diag_matrix.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_diag_matrix.h
@@ -132,7 +132,9 @@ class VNL_EXPORT vnl_diag_matrix
     (void)c;
 #if VNL_CONFIG_CHECK_BOUNDS
     if (r >= this->size())                  // If invalid size specified
+      {
       vnl_error_matrix_row_index("get", r); // Raise exception
+      }
 #endif
     diagonal_[r] = v;
   }
@@ -142,8 +144,10 @@ class VNL_EXPORT vnl_diag_matrix
     assert(r == c);
     (void)c;
 #if VNL_CONFIG_CHECK_BOUNDS
-  if (r >= this->size())                  // If invalid size specified
-    vnl_error_matrix_row_index("get", r); // Raise exception
+    if (r >= this->size())                  // If invalid size specified
+      {
+      vnl_error_matrix_row_index("get", r); // Raise exception
+      }
 #endif
     return diagonal_[r];
   }

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_real_polynomial.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_real_polynomial.cxx
@@ -40,8 +40,9 @@ vnl_real_polynomial_evaluate(double const * a, int n, T const & x)
 //: Instantiate templates before use
 template double vnl_real_polynomial_evaluate
 SELECT(double)(double const *, int, double const &);
-template std::complex<double> vnl_real_polynomial_evaluate
-SELECT(std::complex<double>)(double const *, int, std::complex<double> const &);
+template std::complex<double> vnl_real_polynomial_evaluate SELECT(std::complex<double>)(double const *,
+                                                                                        int,
+                                                                                        std::complex<double> const &);
 
 //: Evaluate polynomial at value x
 double


### PR DESCRIPTION
Avoid new compiler warnings:
```
ITK/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_diag_matrix.h:148:5: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
```
Adding appropriate {} and indentation fixes.

