### PR TITLE
COMP: Implicit conversion warnings

### DIFF
--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -88,7 +88,10 @@ ColorTable<TPixel>::UseDiscreteColors()
   // set to NumericTraits<TPixel>::max().
   typename NumericTraits<TPixel>::RealType realMax(1.0 * scale + shift);
   TPixel                                   pixelMax(NumericTraits<TPixel>::max());
-  if (realMax < NumericTraits<TPixel>::max())
+  // Converting from TPixel to RealType may introduce a rounding error, so do static_cast
+  constexpr auto max_value_converted =
+    static_cast<typename NumericTraits<TPixel>::RealType>(NumericTraits<TPixel>::max());
+  if (realMax < max_value_converted)
   {
     pixelMax = static_cast<TPixel>(realMax);
   }
@@ -131,12 +134,15 @@ ColorTable<TPixel>::UseGrayColors(unsigned int n)
     delta = 0.0;
   }
 
+  // Converting from TPixel to RealType may introduce a rounding error, so do static_cast
+  constexpr auto max_value_converted =
+    static_cast<typename NumericTraits<TPixel>::RealType>(NumericTraits<TPixel>::max());
   for (i = 0; i < m_NumberOfColors; i++)
   {
     typename NumericTraits<TPixel>::RealType realGray(minimum + i * delta);
 
     TPixel gray = NumericTraits<TPixel>::max();
-    if (realGray < NumericTraits<TPixel>::max())
+    if (realGray < max_value_converted)
     {
       gray = static_cast<TPixel>(realGray);
     }
@@ -173,13 +179,16 @@ ColorTable<TPixel>::UseHeatColors(unsigned int n)
     scale = NumericTraits<TPixel>::OneValue();
     shift = NumericTraits<TPixel>::ZeroValue();
   }
+  // Converting from TPixel to RealType may introduce a rounding error, so do static_cast
+  constexpr auto max_value_converted =
+    static_cast<typename NumericTraits<TPixel>::RealType>(NumericTraits<TPixel>::max());
   for (i = 0; i < n / 2.0; i++)
   {
     //
     // avoid overflow
     typename NumericTraits<TPixel>::RealType realR(((i + 1) / (n / 2.0 + 1)) * scale + shift);
     TPixel                                   r(NumericTraits<TPixel>::max());
-    if (realR < NumericTraits<TPixel>::max())
+    if (realR < max_value_converted)
     {
       r = static_cast<TPixel>(realR);
     }
@@ -195,7 +204,7 @@ ColorTable<TPixel>::UseHeatColors(unsigned int n)
   {
     typename NumericTraits<TPixel>::RealType rdouble(1.0 * scale + shift);
     TPixel                                   r(NumericTraits<TPixel>::max());
-    if (rdouble < NumericTraits<TPixel>::max())
+    if (rdouble < max_value_converted)
     {
       r = static_cast<TPixel>(rdouble);
     }

--- a/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
@@ -100,16 +100,16 @@ TestClampFromTo()
 
   it.GoToBegin();
   ot.GoToBegin();
+  constexpr double expectedMin = static_cast<double>(itk::NumericTraits<TOutputPixelType>::NonpositiveMin());
+  constexpr double expectedMax = static_cast<double>(itk::NumericTraits<TOutputPixelType>::max());
   while (!it.IsAtEnd())
   {
-    TInputPixelType  inValue = it.Value();
-    TOutputPixelType outValue = ot.Value();
+    const TInputPixelType  inValue = it.Value();
+    const TOutputPixelType outValue = ot.Value();
+
+    const double dInValue = static_cast<double>(inValue);
+
     TOutputPixelType expectedValue;
-
-    auto   dInValue = static_cast<double>(inValue);
-    double expectedMin = itk::NumericTraits<TOutputPixelType>::NonpositiveMin();
-    double expectedMax = itk::NumericTraits<TOutputPixelType>::max();
-
     if (dInValue < expectedMin)
     {
       expectedValue = itk::NumericTraits<TOutputPixelType>::NonpositiveMin();


### PR DESCRIPTION
Core/Common/include/itkColorTable.hxx:182:17:
Core/Common/include/itkColorTable.hxx:198:19:
Core/Common/include/itkColorTable.hxx:91:17:
Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx:111:26:
Core/Common/include/itkColorTable.hxx:139:20: warning: implicit conversion from
'itk::NumericTraits<long long>::ValueType' (aka 'long long') to 'double'
changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-int-float-conversion]
