### PR TITLE
BUG: Missing backward compatible enumeration name

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.hxx
@@ -84,7 +84,7 @@ template <typename TTreeType>
 typename ChildTreeIterator<TTreeType>::NodeType
 ChildTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeEnum::CHILD;
+  return TreeIteratorBaseEnums::TreeIteratorBaseNode::CHILD;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Compatibility/Deprecated/include/itkInOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkInOrderTreeIterator.h
@@ -78,7 +78,7 @@ template <typename TTreeType>
 typename InOrderTreeIterator<TTreeType>::NodeType
 InOrderTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeEnum::INORDER;
+  return TreeIteratorBaseEnums::TreeIteratorBaseNode::INORDER;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Compatibility/Deprecated/include/itkLeafTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkLeafTreeIterator.h
@@ -109,7 +109,7 @@ template <typename TTreeType>
 typename LeafTreeIterator<TTreeType>::NodeType
 LeafTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeEnum ::LEAF;
+  return TreeIteratorBaseEnums::TreeIteratorBaseNode::LEAF;
 }
 
 /** Return true if the next value exists */

--- a/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.hxx
@@ -76,7 +76,7 @@ template <typename TTreeType>
 typename LevelOrderTreeIterator<TTreeType>::NodeType
 LevelOrderTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeEnum::LEVELORDER;
+  return TreeIteratorBaseEnums::TreeIteratorBaseNode::LEVELORDER;
 }
 
 /** Return true if the next value exists */

--- a/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
@@ -92,7 +92,7 @@ template <typename TTreeType>
 typename PostOrderTreeIterator<TTreeType>::NodeType
 PostOrderTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeEnum::POSTORDER;
+  return TreeIteratorBaseEnums::TreeIteratorBaseNode::POSTORDER;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Compatibility/Deprecated/include/itkPreOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPreOrderTreeIterator.h
@@ -78,7 +78,7 @@ template <typename TTreeType>
 typename PreOrderTreeIterator<TTreeType>::NodeType
 PreOrderTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeEnum::PREORDER;
+  return TreeIteratorBaseEnums::TreeIteratorBaseNode::PREORDER;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Compatibility/Deprecated/include/itkRootTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkRootTreeIterator.h
@@ -77,7 +77,7 @@ template <typename TTreeType>
 typename RootTreeIterator<TTreeType>::NodeType
 RootTreeIterator<TTreeType>::GetType() const
 {
-  return TreeIteratorBaseNodeEnum::ROOT;
+  return TreeIteratorBaseEnums::TreeIteratorBaseNode::ROOT;
 }
 
 /** Return true if the next node exists */

--- a/Modules/Compatibility/Deprecated/test/itkTreeContainerTest.cxx
+++ b/Modules/Compatibility/Deprecated/test/itkTreeContainerTest.cxx
@@ -127,7 +127,7 @@ itkTreeContainerTest(int, char *[])
 
   std::cout << "Testing other features : ";
 
-  if (childIt2.GetType() != itk::TreeIteratorBaseNodeEnum::CHILD)
+  if (childIt2.GetType() != itk::TreeIteratorBaseEnums::TreeIteratorBaseNode::CHILD)
   {
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -472,6 +472,22 @@ public:
   /** Get the geometric position of a point. */
   //  bool GetPointPosition(PointsContainer*, int localId, Point*)=0;
 
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Expose old names for backwards compatibility*/
+  constexpr static CommonEnums::CellGeometry VERTEX_CELL = CommonEnums::CellGeometry::VERTEX_CELL;
+  constexpr static CommonEnums::CellGeometry LINE_CELL = CommonEnums::CellGeometry::LINE_CELL;
+  constexpr static CommonEnums::CellGeometry TRIANGLE_CELL = CommonEnums::CellGeometry::TRIANGLE_CELL;
+  constexpr static CommonEnums::CellGeometry QUADRILATERAL_CELL = CommonEnums::CellGeometry::QUADRILATERAL_CELL;
+  constexpr static CommonEnums::CellGeometry POLYGON_CELL = CommonEnums::CellGeometry::POLYGON_CELL;
+  constexpr static CommonEnums::CellGeometry TETRAHEDRON_CELL = CommonEnums::CellGeometry::TETRAHEDRON_CELL;
+  constexpr static CommonEnums::CellGeometry HEXAHEDRON_CELL = CommonEnums::CellGeometry::HEXAHEDRON_CELL;
+  constexpr static CommonEnums::CellGeometry QUADRATIC_EDGE_CELL = CommonEnums::CellGeometry::QUADRATIC_EDGE_CELL;
+  constexpr static CommonEnums::CellGeometry QUADRATIC_TRIANGLE_CELL =
+    CommonEnums::CellGeometry::QUADRATIC_TRIANGLE_CELL;
+  constexpr static CommonEnums::CellGeometry LAST_ITK_CELL = CommonEnums::CellGeometry::LAST_ITK_CELL;
+  constexpr static CommonEnums::CellGeometry MAX_ITK_CELLS = CommonEnums::CellGeometry::MAX_ITK_CELLS;
+#endif
+
 protected:
   /** Store the set of cells using this boundary. */
   UsingCellsContainer m_UsingCells;

--- a/Modules/Core/Common/include/itkCommonEnums.h
+++ b/Modules/Core/Common/include/itkCommonEnums.h
@@ -160,6 +160,15 @@ using IOFileModeEnum = CommonEnums::IOFileMode;
 using IOByteOrderEnum = CommonEnums::IOByteOrder;
 using CellGeometryEnum = CommonEnums::CellGeometry;
 
+#if !defined(ITK_LEGACY_REMOVE)
+/** Expose old names for backwards compatibility*/
+using IOPixelType = CommonEnums::IOPixel;
+using IOComponentType = CommonEnums::IOComponent;
+using IOFileType = CommonEnums::IOFile;
+using IOFileModeType = CommonEnums::IOFileMode;
+using IOByteOrderType = CommonEnums::IOByteOrder;
+using CellGeometryType = CommonEnums::CellGeometry;
+#endif
 // Define how to print enumeration
 extern ITKCommon_EXPORT std::ostream &
                         operator<<(std::ostream & out, IOPixelEnum value);

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
@@ -54,6 +54,7 @@ public:
 };
 #if !defined(ITK_LEGACY_REMOVE)
 using RGBColormapFilterEnum = ScalarToRGBColormapImageFilterEnums::RGBColormapFilter;
+using RGBColormapFilterEnumType = ScalarToRGBColormapImageFilterEnums::RGBColormapFilter;
 // We need to expose the enum values at the class level
 // for backwards compatibility
 static constexpr RGBColormapFilterEnum Red = RGBColormapFilterEnum::Red;

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.h
@@ -192,7 +192,7 @@ private:
   struct HandleRGBPixel<RGBPixel<TValue>, VDimension>
   {
     using ValueType = TValue;
-    using PixelType = IOPixelEnum::RGBPixel<ValueType>;
+    using PixelType = RGBPixel<ValueType>;
     using ImageType = Image<PixelType, VDimension>;
 
     static void


### PR DESCRIPTION
Building deprecated code and remote modules identified a few missing backward compatibility issues.

Backward compatible enumerations for Remote Modules

Build the remote modules identified missing backward compatible
names that were missing.

Incomplete refactoring for deprecated enumeration.

Incorrect type change from enumeration update