### PR TITLE
DOC: .mailmap entry for ntustison@wustl.edu

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,7 +7,7 @@ Alexandre Gouaillard <agouaillard@gmail.com>
 Andrew Wasem <drewwasem@gmail.com>
 Matthew McCormick <matt.mccormick@kitware.com> <matt@mmmccormick.com>
 Brian Avants <stnava@gmail.com>
-Nick Tustison <ntustison@gmail.com>
+Nick Tustison <ntustison@gmail.com> <ntustison@wustl.edu>
 Xiaoxiao Liu <liuxiaoxiao@gmail.com>
 Francois Budin <francois.budin@kitware.com> <francois.budin@gmail.com>
 Dženan Zukić <dzenan.zukic@kitware.com> Dzenan Zukic <dzenanz@gmail.com>


### PR DESCRIPTION
Use consistent names in release notes, etc. by setting
.mailmap entries.

See MAPPING AUTHORS in git help shortlog.

`git shortlog` now outputs the single "Nick Tustison"
versus a mix of "Nick Tustison" and "Nicholas Tustison", the name
associated with the wustl.edu email.
