### PR TITLE
DOC: updating zenodo authors' ORCIDs and affiliations

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,21 +1,27 @@
 {
   "creators": [
     {
-      "name": "Ibanez, Luis"
+      "affiliation": "Google Inc, Kitware Inc, University of North Carolina at Chapel Hill, Université de Rennes 1, Universidad Industrial de Santander",
+      "name": "Ibanez, Luis",
+      "orcid": "0000-0003-2712-8584"
     },
     {
+      "affiliation": "GE Research",
       "name": "Lorensen, Bill"
     },
     {
-      "affiliation": "Kitware, Inc",
+      "affiliation": "Kitware Inc",
       "name": "McCormick, Matthew",
       "orcid": "0000-0001-9475-3756"
     },
     {
+      "affiliation": "Kitware Inc",
       "name": "King, Brad"
     },
     {
-      "name": "Blezek, Daniel"
+      "affiliation": "Mayo Clinic, Mayo Clinic Graduate School for Biomedical Sciences",
+      "name": "Blezek, Daniel",
+      "orcid": "0000-0002-6498-6273"
     },
     {
       "affiliation": "University of Iowa",
@@ -26,7 +32,9 @@
       "name": "Lowekamp, Bradley"
     },
     {
-      "name": "Jomier, Julien"
+      "affiliation": "Kitware SAS, Kitware Inc",
+      "name": "Jomier, Julien",
+      "orcid": "0000-0002-9020-3770"
     },
     {
       "name": "Miller, Jim"
@@ -70,16 +78,22 @@
       "name": "Schroeder, Will"
     },
     {
-      "name": "R. Aylward, Stephen"
+      "affiliation": "Kitware Inc",
+      "name": "R. Aylward, Stephen",
+      "orcid": "0000-0002-7862-8856"
     },
     {
-      "name": "Zuki\u0107, D\u017eenan"
+      "affiliation": "Kitware Inc, University of Siegen",
+      "name": "Zukić, Dženan",
+      "orcid": "0000-0002-9546-9703"
     },
     {
       "name": "Liu, Xiaoxiao"
     },
     {
-      "name": "Avants, Brian"
+      "affiliation": "University of Pennsylvania",
+      "name": "Avants, Brian",
+      "orcid": "0000-0002-4212-3362"
     },
     {
       "name": "Dekker, Niels"
@@ -91,13 +105,12 @@
       "name": "Popoff, Michka"
     },
     {
-      "name": "Tustison, Nick"
+      "affiliation": "University of California Irvine, University of Virginia, Washington University in Saint Louis, Brigham Young University",
+      "name": "Tustison, Nick",
+      "orcid": "0000-0001-9418-5103"
     },
     {
       "name": "Hart, Gabe"
-    },
-    {
-      "name": "Zuki\u0107, D\u017eenan"
     },
     {
       "name": "McBride, Sean"
@@ -133,11 +146,6 @@
       "name": "Quammen, Cory"
     },
     {
-      "affiliation": "Universit\u00e9 de Sherbrooke",
-      "name": "Legarreta, Jon Haitz",
-      "orcid": "0000-0002-9661-1396"
-    },
-    {
       "name": "Jin, Yinpeng"
     },
     {
@@ -168,11 +176,6 @@
       "name": "Hughett, Paul"
     },
     {
-      "affiliation": "University of Iowa",
-      "name": "Johnson, Hans",
-      "orcid": "0000-0001-9513-2660"
-    },
-    {
       "name": "Doria, David"
     },
     {
@@ -182,7 +185,9 @@
       "name": "Cole, David"
     },
     {
-      "name": "Fillion-Robin, Jean-Christophe"
+      "affiliation": "Kitware Inc",
+      "name": "Fillion-Robin, Jean-Christophe",
+      "orcid": "0000-0002-9688-8950"
     },
     {
       "name": "Turner, Wes"


### PR DESCRIPTION
Also removing duplicate entries. ORCIDs taken from https://github.com/InsightSoftwareConsortium/ITK/pull/1597#issuecomment-586381631.
