### PR TITLE
BUG: Remove duplicate wrapping of itk.MeshEnums

### DIFF
--- a/Modules/Core/Mesh/wrapping/itkMeshBase.wrap
+++ b/Modules/Core/Mesh/wrapping/itkMeshBase.wrap
@@ -3,9 +3,6 @@ itk_wrap_include("itkDefaultDynamicMeshTraits.h")
 
 UNIQUE(types "${WRAP_ITK_SCALAR};D")
 
-set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
-itk_wrap_include("itkMesh.h")
-itk_wrap_simple_class("itk::MeshEnums")
 set(WRAPPER_AUTO_INCLUDE_HEADERS ON)
 
 itk_wrap_class("itk::Mesh" POINTER)


### PR DESCRIPTION
Following strongly typed enums refactoring, this is now wrapped in
ITKCommon.

To address #1636 