### PR TITLE
COMP: Add missing brackets to RelabelComponentsImageFilterGTest

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -137,8 +137,10 @@ TEST(RelabelComponentImageFilter, big_zero)
   using PixelType = unsigned short;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto image = ImageType::New();
-  image->SetRegions(typename ImageType::RegionType({ 512, 512, 512 }));
+  auto                           image = ImageType::New();
+  typename ImageType::RegionType region;
+  region.SetSize({ { 512, 512, 512 } });
+  image->SetRegions(region);
   image->Allocate(true);
 
   auto filter = itk::RelabelComponentImageFilter<ImageType, ImageType>::New();


### PR DESCRIPTION
To address the dashboard warning:

   Standard Error

[CTest: warning matched] /Users/builder/externalModules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx:141:54: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  image->SetRegions(typename ImageType::RegionType({ 512, 512, 512 }));
                                                     ^~~~~~~~~~~~~
                                                     {            }
[CTest: warning suppressed] 1 warning generated.
