### PR TITLE
COMP: Named exception not passed along to next exception

### DIFF
--- a/Modules/Core/Common/include/itkSmapsFileParser.hxx
+++ b/Modules/Core/Common/include/itkSmapsFileParser.hxx
@@ -187,7 +187,7 @@ VMMapFileParser<TVMMapDataType>::ReadFile(const std::string & mapFileLocation)
   catch (const ExceptionObject & excp)
   {
     // propagate the exception
-    itkGenericExceptionMacro(<< "The vmmap file is an invalid file or contains errors");
+    itkGenericExceptionMacro(<< "The vmmap file is an invalid file or contains errors\n" << excp);
   }
 }
 } // end namespace itk


### PR DESCRIPTION
Core/Common/include/itkSmapsFileParser.hxx:187:34:
 warning: unused exception parameter 'excp' [-Wunused-exception-parameter]
  catch (const ExceptionObject & excp)

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->
