### PR TITLE
COMP: Update remote module: TotalVariation

### DIFF
--- a/Modules/Remote/TotalVariation.remote.cmake
+++ b/Modules/Remote/TotalVariation.remote.cmake
@@ -7,5 +7,5 @@ Please refer to the documentation upstream for a detailed description:
 https://github.com/albarji/proxTV
 "
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
-  GIT_TAG fbab387c7c93bb58036d3e3d46bc34e7801a19dd
+  GIT_TAG e47fb5b1e2eef32cddb131d8ba47b78dbde9fbbd
 )


### PR DESCRIPTION
`git shortlog --no-merges fbab38..e47fb5`

```
Hans Johnson (3):
      STYLE: Remove CMake-language block-end command arguments
      ENH: Add .gitattributes to allow running ITK clang-formatting scripts
      DOC: Update copyright assignment to NumFOCUS

Jean-Christophe Fillion-Robin (1):
      COMP: Ensure proxTV dependencies are found when building against ITK build tree

Pablo Hernandez-Cerdan (5):
      BUG: Use ITKInternalEigen3_DIR to find Eigen
      Revert "COMP: Ensure proxTV dependencies are found when building against ITK build tree"
      COMP: CMake: Install proxTV in ITK standard folders
      DOC: Remove TODOs in Readme
      DOC: Update readme, remove duplicated license
```