### PR TITLE
COMP: fix type conversion error in GPUPDEDeformableRegistrationFilter

### DIFF
--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -333,7 +333,7 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
     blockSize = blockSize <= 64 ? blockSize : 64;
     // std::cout << "indir=" << indir << " blockSize=" << blockSize << std::endl;
 
-    for (unsigned long & i : localSize)
+    for (auto & i : localSize)
     {
       i = 1;
     }


### PR DESCRIPTION
`C:\Dev\ITK-git\Modules\Registration\GPUPDEDeformable\include\itkGPUPDEDeformableRegistrationFilter.hxx(336,1): error C2440: 'initializing': cannot convert from 'size_t' to 'unsigned long &'`
