### PR TITLE
COMP: Use nullptr rather than 0 in IOFactoryRegisterRegisterList (3x)

### DIFF
--- a/CMake/itkImageIOFactoryRegisterManager.h.in
+++ b/CMake/itkImageIOFactoryRegisterManager.h.in
@@ -49,7 +49,7 @@ namespace {
 
   void (*ImageIOFactoryRegisterRegisterList[])(void) = {
     @LIST_OF_FACTORY_NAMES@
-    0};
+    nullptr};
   ImageIOFactoryRegisterManager ImageIOFactoryRegisterManagerInstance(ImageIOFactoryRegisterRegisterList);
 
 }

--- a/CMake/itkMeshIOFactoryRegisterManager.h.in
+++ b/CMake/itkMeshIOFactoryRegisterManager.h.in
@@ -49,7 +49,7 @@ namespace {
 
   void (*MeshIOFactoryRegisterRegisterList[])(void) = {
     @LIST_OF_FACTORY_NAMES@
-    0};
+    nullptr};
   MeshIOFactoryRegisterManager MeshIOFactoryRegisterManagerInstance(MeshIOFactoryRegisterRegisterList);
 
 }

--- a/CMake/itkTransformIOFactoryRegisterManager.h.in
+++ b/CMake/itkTransformIOFactoryRegisterManager.h.in
@@ -49,7 +49,7 @@ namespace {
 
   void (*TransformIOFactoryRegisterRegisterList[])(void) = {
     @LIST_OF_FACTORY_NAMES@
-    0};
+    nullptr};
   TransformIOFactoryRegisterManager TransformIOFactoryRegisterManagerInstance(TransformIOFactoryRegisterRegisterList);
 
 }


### PR DESCRIPTION
Three "IOFactoryRegisterManager.h.in" files each declared an array of function
pointers, "IOFactoryRegisterRegisterList", which was terminated by `0`. This
triggered a Visual C++ (VS2017) Code Analysis warning:

> warning C26477: Use 'nullptr' rather than 0 or NULL (es.47).

Fixed by replacing `0` by `nullptr`.