### PR TITLE
STYLE: Prefer making deleted functions public

### DIFF
--- a/Modules/Bridge/VtkGlue/include/vtkCaptureScreen.h
+++ b/Modules/Bridge/VtkGlue/include/vtkCaptureScreen.h
@@ -28,6 +28,8 @@ template <typename TImageWriter>
 class vtkCaptureScreen
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(vtkCaptureScreen);
+
   using ImageWriterType = TImageWriter;
 
   vtkCaptureScreen(vtkRenderWindow * iRenderer)
@@ -35,7 +37,6 @@ public:
   {}
 
   vtkCaptureScreen() = default;
-
   ~vtkCaptureScreen() = default;
 
   void
@@ -52,10 +53,6 @@ public:
   }
 
 private:
-  vtkCaptureScreen(const vtkCaptureScreen &) = delete;
-  void
-  operator=(const vtkCaptureScreen &) = delete;
-
   vtkRenderWindow * m_Renderer{ nullptr };
 
   void

--- a/Modules/Compatibility/Deprecated/include/itkTreeChangeEvent.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeChangeEvent.h
@@ -37,6 +37,9 @@ public:
   using Self = TreeChangeEvent;
   using Superclass = ModifiedEvent;
 
+  Self &
+  operator=(const Self &) = delete;
+
   /** Constructor */
   TreeChangeEvent()
     : m_ChangePosition(nullptr)
@@ -83,10 +86,6 @@ public:
 
 protected:
   const TreeIteratorBase<TTreeType> * m_ChangePosition;
-
-private:
-  void
-  operator=(const Self &) = delete;
 };
 
 /**  \class TreeNodeChangeEvent
@@ -130,7 +129,6 @@ public:
     : TreeChangeEvent<TTreeType>(s)
   {}
 
-private:
   void
   operator=(const Self &) = delete;
 };
@@ -180,7 +178,6 @@ public:
     : TreeChangeEvent<TTreeType>(s)
   {}
 
-private:
   void
   operator=(const Self &) = delete;
 };
@@ -230,7 +227,6 @@ public:
     : TreeChangeEvent<TTreeType>(s)
   {}
 
-private:
   void
   operator=(const Self &) = delete;
 };
@@ -275,7 +271,6 @@ public:
     : TreeRemoveEvent<TTreeType>(s)
   {}
 
-private:
   void
   operator=(const Self &) = delete;
 };

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -264,6 +264,9 @@ public:
     : Superclass(radius, const_cast<ImageType *>(ptr), region)
   {}
 
+  /** Copy constructor */
+  ConstShapedNeighborhoodIterator(const ConstShapedNeighborhoodIterator &) = delete;
+
   // Expose the following methods from the superclass.  This is a
   // restricted subset of the methods available for
   // ConstNeighborhoodIterator.
@@ -418,10 +421,6 @@ protected:
 
   bool          m_CenterIsActive{ false };
   IndexListType m_ActiveIndexList;
-
-private:
-  /** Copy constructor */
-  ConstShapedNeighborhoodIterator(const ConstShapedNeighborhoodIterator &) = delete;
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkEventObject.h
+++ b/Modules/Core/Common/include/itkEventObject.h
@@ -63,6 +63,9 @@ public:
 
   EventObject(const EventObject &) = default;
 
+  EventObject &
+  operator=(const EventObject &) = delete;
+
   /** Virtual destructor needed  */
   virtual ~EventObject() = default;
 
@@ -98,10 +101,6 @@ protected:
 
   virtual void
   PrintTrailer(std::ostream & os, Indent indent) const;
-
-private:
-  void
-  operator=(const EventObject &) = delete;
 };
 
 /** Generic inserter operator for EventObject and its subclasses. */

--- a/Modules/Core/Common/include/itkFloatingPointExceptions.h
+++ b/Modules/Core/Common/include/itkFloatingPointExceptions.h
@@ -55,6 +55,11 @@ struct ExceptionGlobals;
 class ITKCommon_EXPORT FloatingPointExceptions
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FloatingPointExceptions);
+  // default constructor required for wrapping to succeed
+  FloatingPointExceptions() = default;
+  virtual ~FloatingPointExceptions() = default;
+
   using ExceptionActionEnum = FloatingPointExceptionsEnums::ExceptionAction;
 #if !defined(ITK_LEGACY_REMOVE)
   /**Exposes enum values at class level for backwards compatibility*/
@@ -108,11 +113,6 @@ public:
   HasFloatingPointExceptionsSupport();
 
 private:
-  FloatingPointExceptions() = default;
-  FloatingPointExceptions(const FloatingPointExceptions &) = delete;
-  void
-  operator=(const FloatingPointExceptions &) = delete;
-
   itkGetGlobalDeclarationMacro(ExceptionGlobals, PimplGlobals);
   /** static member that controls what happens during an exception */
   static ExceptionGlobals * m_PimplGlobals;

--- a/Modules/Core/Common/include/itkNumberToString.h
+++ b/Modules/Core/Common/include/itkNumberToString.h
@@ -44,10 +44,6 @@ class ITK_TEMPLATE_EXPORT NumberToString
 public:
   std::string
   operator()(TValue val);
-
-private:
-  NumberToString &
-  operator=(const NumberToString &) = delete;
 };
 
 // declaration of specialization

--- a/Modules/Core/Common/include/itkSTLConstContainerAdaptor.h
+++ b/Modules/Core/Common/include/itkSTLConstContainerAdaptor.h
@@ -46,6 +46,8 @@ template <typename TContainer>
 class STLConstContainerAdaptor
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(STLConstContainerAdaptor);
+
   using AdapteeType = const TContainer;
 
   using ElementType = const typename AdapteeType::Element;
@@ -53,14 +55,6 @@ public:
 
 private:
   AdapteeType & m_AdapteeRef;
-
-  /** hide the copy constructor to allow only direct construction of the adapter
-   */
-  STLConstContainerAdaptor(const STLConstContainerAdaptor & r) = delete;
-
-  /* hide and avoid operator= */
-  const STLConstContainerAdaptor &
-  operator=(const STLConstContainerAdaptor & r) = delete;
 
 public:
   STLConstContainerAdaptor(AdapteeType & adaptee)

--- a/Modules/Core/Common/include/itkSTLContainerAdaptor.h
+++ b/Modules/Core/Common/include/itkSTLContainerAdaptor.h
@@ -43,6 +43,8 @@ template <typename TContainer>
 class STLContainerAdaptor
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(STLContainerAdaptor);
+
   using AdapteeType = TContainer;
 
   using ElementType = typename AdapteeType::Element;
@@ -50,14 +52,6 @@ public:
 
 private:
   AdapteeType & m_AdapteeRef;
-
-  /** hide the copy constructor to allow only direct construction of the adapter
-   */
-  STLContainerAdaptor(const STLContainerAdaptor & r) = delete;
-
-  /* hide and avoid operator= */
-  const STLContainerAdaptor &
-  operator=(const STLContainerAdaptor & r) = delete;
 
 public:
   STLContainerAdaptor(AdapteeType & adaptee)

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -218,6 +218,9 @@ public:
   /** Virtual destructor */
   ~ShapedNeighborhoodIterator() override = default;
 
+  /** Copy constructor */
+  ShapedNeighborhoodIterator(const ShapedNeighborhoodIterator & o) = delete;
+
   /** Constructor which establishes the region size, neighborhood, and image
    * over which to walk. */
   ShapedNeighborhoodIterator(const SizeType & radius, const ImageType * ptr, const RegionType & region)
@@ -260,9 +263,6 @@ public:
 
 protected:
   friend Superclass;
-
-  /** Copy constructor */
-  ShapedNeighborhoodIterator(const ShapedNeighborhoodIterator & o) = delete;
 
   using NeighborIndexType = typename Superclass::NeighborIndexType;
 };

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.h
@@ -40,6 +40,8 @@ class ITK_TEMPLATE_EXPORT SymmetricEllipsoidInteriorExteriorSpatialFunction
   : public InteriorExteriorSpatialFunction<VDimension, TInput>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SymmetricEllipsoidInteriorExteriorSpatialFunction);
+
   /** Standard class type aliases. */
   using Self = SymmetricEllipsoidInteriorExteriorSpatialFunction;
   using Superclass = InteriorExteriorSpatialFunction<VDimension>;
@@ -80,10 +82,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  SymmetricEllipsoidInteriorExteriorSpatialFunction(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
-
   /** The center of the ellipsoid. */
   InputType m_Center;
 

--- a/Modules/Core/GPUCommon/include/itkGPUImageOps.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageOps.h
@@ -44,8 +44,6 @@ public:
   /** Get OpenCL Kernel source as a string, creates a GetOpenCLSource method */
   itkGetOpenCLSourceFromKernelMacro(GPUImageOpsKernel);
 };
-
-
 } // end of namespace itk
 
 #endif

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.h
@@ -55,6 +55,8 @@ class ITK_TEMPLATE_EXPORT VectorLinearInterpolateNearestNeighborExtrapolateImage
   : public VectorInterpolateImageFunction<TInputImage, TCoordRep>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VectorLinearInterpolateNearestNeighborExtrapolateImageFunction);
+
   /** Standard class type aliases. */
   using Self = VectorLinearInterpolateNearestNeighborExtrapolateImageFunction;
   using Superclass = VectorInterpolateImageFunction<TInputImage, TCoordRep>;
@@ -139,10 +141,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  VectorLinearInterpolateNearestNeighborExtrapolateImageFunction(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
-
   /** Number of neighbors used in the interpolation */
   static const unsigned int m_Neighbors;
 };

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
@@ -48,6 +48,8 @@ template <typename TInputMesh, typename TOutputMesh, typename TSpatialFunction>
 class ITK_TEMPLATE_EXPORT InteriorExteriorMeshFilter : public MeshToMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(InteriorExteriorMeshFilter);
+
   /** Standard class type aliases. */
   using Self = InteriorExteriorMeshFilter;
   using Superclass = MeshToMeshFilter<TInputMesh, TOutputMesh>;
@@ -90,11 +92,6 @@ protected:
 
   /** Transform applied to all the mesh points. */
   typename SpatialFunctionType::Pointer m_SpatialFunction;
-
-private:
-  InteriorExteriorMeshFilter(const InteriorExteriorMeshFilter &) = delete;
-  void
-  operator=(const InteriorExteriorMeshFilter &) = delete;
 };
 } // end namespace itk
 

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.h
@@ -68,6 +68,8 @@ template <typename TImageType>
 class ITK_TEMPLATE_EXPORT PipelineMonitorImageFilter : public ImageToImageFilter<TImageType, TImageType>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(PipelineMonitorImageFilter);
+
   using Self = PipelineMonitorImageFilter;
   using Superclass = ImageToImageFilter<TImageType, TImageType>;
   using Pointer = SmartPointer<Self>;
@@ -216,10 +218,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  PipelineMonitorImageFilter(const PipelineMonitorImageFilter &) = delete;
-  void
-  operator=(const PipelineMonitorImageFilter &) = delete;
-
   bool m_ClearPipelineOnGenerateOutputInformation;
 
   unsigned int m_NumberOfUpdates;
@@ -236,7 +234,6 @@ private:
   SpacingType     m_UpdatedOutputSpacing;
   ImageRegionType m_UpdatedOutputLargestPossibleRegion;
 };
-
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Transform/include/itkAffineTransform.h
+++ b/Modules/Core/Transform/include/itkAffineTransform.h
@@ -101,6 +101,8 @@ class ITK_TEMPLATE_EXPORT AffineTransform
   : public MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(AffineTransform);
+
   /** Standard type alias   */
   using Self = AffineTransform;
   using Superclass = MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>;
@@ -282,11 +284,6 @@ protected:
   /** Print contents of an AffineTransform */
   void
   PrintSelf(std::ostream & s, Indent indent) const override;
-
-private:
-  AffineTransform(const Self & other) = delete;
-  const Self &
-  operator=(const Self &) = delete;
 }; // class AffineTransform
 
 } // namespace itk

--- a/Modules/Core/Transform/include/itkCenteredAffineTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredAffineTransform.h
@@ -34,6 +34,8 @@ template <typename TParametersValueType = double, unsigned int NDimensions = 3>
 class ITK_TEMPLATE_EXPORT CenteredAffineTransform : public AffineTransform<TParametersValueType, NDimensions>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(CenteredAffineTransform);
+
   /** Standard type alias   */
   using Self = CenteredAffineTransform;
   using Superclass = AffineTransform<TParametersValueType, NDimensions>;
@@ -116,12 +118,6 @@ protected:
 
   /** Destroy an CenteredAffineTransform object */
   ~CenteredAffineTransform() override = default;
-
-private:
-  CenteredAffineTransform(const Self & other) = delete;
-  const Self &
-  operator=(const Self &) = delete;
-
 }; // class CenteredAffineTransform
 } // namespace itk
 

--- a/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.h
+++ b/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.h
@@ -36,6 +36,8 @@ class ITK_TEMPLATE_EXPORT FixedCenterOfRotationAffineTransform
   : public ScalableAffineTransform<TParametersValueType, NDimensions>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FixedCenterOfRotationAffineTransform);
+
   /** Standard type alias   */
   using Self = FixedCenterOfRotationAffineTransform;
   using Superclass = ScalableAffineTransform<TParametersValueType, NDimensions>;
@@ -123,11 +125,6 @@ protected:
 
   /** Destroy an FixedCenterOfRotationAffineTransform object   */
   ~FixedCenterOfRotationAffineTransform() override = default;
-
-private:
-  FixedCenterOfRotationAffineTransform(const Self & other) = delete;
-  const Self &
-  operator=(const Self &) = delete;
 }; // class FixedCenterOfRotationAffineTransform
 } // namespace itk
 

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -107,6 +107,8 @@ class ITK_TEMPLATE_EXPORT MatrixOffsetTransformBase
   : public Transform<TParametersValueType, NInputDimensions, NOutputDimensions>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MatrixOffsetTransformBase);
+
   /** Standard type alias   */
   using Self = MatrixOffsetTransformBase;
   using Superclass = Transform<TParametersValueType, NInputDimensions, NOutputDimensions>;
@@ -575,10 +577,6 @@ protected:
   itkGetConstMacro(Singular, bool);
 
 private:
-  MatrixOffsetTransformBase(const Self & other) = delete;
-  const Self &
-  operator=(const Self &) = delete;
-
   MatrixType                m_Matrix;        // Matrix of the transformation
   OutputVectorType          m_Offset;        // Offset of the transformation
   mutable InverseMatrixType m_InverseMatrix; // Inverse of the matrix

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.h
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.h
@@ -34,6 +34,8 @@ template <typename TParametersValueType = double, unsigned int NDimensions = 3>
 class ITK_TEMPLATE_EXPORT ScalableAffineTransform : public AffineTransform<TParametersValueType, NDimensions>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ScalableAffineTransform);
+
   /** Standard type alias   */
   using Self = ScalableAffineTransform;
   using Superclass = AffineTransform<TParametersValueType, NDimensions>;
@@ -160,10 +162,6 @@ protected:
   }
 
 private:
-  ScalableAffineTransform(const Self & other) = delete;
-  const Self &
-  operator=(const Self &) = delete;
-
   double          m_Scale[NDimensions];
   InputVectorType m_MatrixScale;
 }; // class ScalableAffineTransform

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
@@ -32,6 +32,8 @@ template <typename TInput, typename TOutput, typename TCriterion>
 class DecimationQuadEdgeMeshFilter : public QuadEdgeMeshToQuadEdgeMeshFilter<TInput, TOutput>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(DecimationQuadEdgeMeshFilter);
+
   using Self = DecimationQuadEdgeMeshFilter;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -118,11 +120,6 @@ protected:
 
   /** Cache pointer to output to use in inner loops */
   OutputMeshType * m_OutputMesh;
-
-private:
-  DecimationQuadEdgeMeshFilter(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
@@ -38,6 +38,8 @@ class ITK_TEMPLATE_EXPORT DelaunayConformingQuadEdgeMeshFilter
   : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(DelaunayConformingQuadEdgeMeshFilter);
+
   /** Basic types. */
   using Self = DelaunayConformingQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;
@@ -207,11 +209,6 @@ protected:
 
     return (std::acos(dotA) + std::acos(dotB) - itk::Math::pi);
   }
-
-private:
-  DelaunayConformingQuadEdgeMeshFilter(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // end namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
@@ -35,6 +35,8 @@ class DiscretePrincipalCurvaturesQuadEdgeMeshFilter
   : public DiscreteCurvatureQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(DiscretePrincipalCurvaturesQuadEdgeMeshFilter);
+
   using Self = DiscretePrincipalCurvaturesQuadEdgeMeshFilter;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -150,11 +152,6 @@ protected:
   {
     return std::max(static_cast<OutputCurvatureType>(0.), m_Mean * m_Mean - m_Gaussian);
   }
-
-private:
-  DiscretePrincipalCurvaturesQuadEdgeMeshFilter(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
@@ -41,6 +41,8 @@ class ITK_TEMPLATE_EXPORT EdgeDecimationQuadEdgeMeshFilter
   : public DecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(EdgeDecimationQuadEdgeMeshFilter);
+
   using Self = EdgeDecimationQuadEdgeMeshFilter;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -306,11 +308,6 @@ protected:
    */
   bool
   IsCriterionSatisfied() override;
-
-private:
-  EdgeDecimationQuadEdgeMeshFilter(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.h
@@ -93,6 +93,8 @@ template <typename TInputMesh, typename TOutputMesh>
 class ITK_TEMPLATE_EXPORT NormalQuadEdgeMeshFilter : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(NormalQuadEdgeMeshFilter);
+
   using Self = NormalQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;
   using Pointer = SmartPointer<Self>;
@@ -201,11 +203,6 @@ protected:
    */
   void
   GenerateData() override;
-
-private:
-  NormalQuadEdgeMeshFilter(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
@@ -36,6 +36,8 @@ template <typename TMesh,
 class QuadEdgeMeshDecimationCriterion : public Object
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(QuadEdgeMeshDecimationCriterion);
+
   using Self = QuadEdgeMeshDecimationCriterion;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -96,11 +98,6 @@ protected:
   SizeValueType m_NumberOfElements;
 
   MeasureType m_MeasureBound;
-
-private:
-  QuadEdgeMeshDecimationCriterion(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 
 /**
@@ -116,6 +113,8 @@ template <typename TMesh,
 class NumberOfPointsCriterion : public QuadEdgeMeshDecimationCriterion<TMesh, TElement, TMeasure, TPriorityQueueWrapper>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(NumberOfPointsCriterion);
+
   using Self = NumberOfPointsCriterion;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -142,11 +141,6 @@ public:
 protected:
   NumberOfPointsCriterion() = default;
   ~NumberOfPointsCriterion() = default;
-
-private:
-  NumberOfPointsCriterion(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 
 /**
@@ -162,6 +156,8 @@ template <typename TMesh,
 class NumberOfFacesCriterion : public QuadEdgeMeshDecimationCriterion<TMesh, TElement, TMeasure, TPriorityQueueWrapper>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(NumberOfFacesCriterion);
+
   using Self = NumberOfFacesCriterion;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -191,11 +187,6 @@ public:
 protected:
   NumberOfFacesCriterion() = default;
   ~NumberOfFacesCriterion() override = default;
-
-private:
-  NumberOfFacesCriterion(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 
 /**
@@ -212,6 +203,8 @@ class MaxMeasureBoundCriterion
   : public QuadEdgeMeshDecimationCriterion<TMesh, TElement, TMeasure, TPriorityQueueWrapper>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MaxMeasureBoundCriterion);
+
   using Self = MaxMeasureBoundCriterion;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -243,11 +236,6 @@ protected:
     : Superclass()
   {}
   ~MaxMeasureBoundCriterion() override = default;
-
-private:
-  MaxMeasureBoundCriterion(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 
 /**
@@ -264,6 +252,8 @@ class MinMeasureBoundCriterion
   : public QuadEdgeMeshDecimationCriterion<TMesh, TElement, TMeasure, TPriorityQueueWrapper>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MinMeasureBoundCriterion);
+
   using Self = MinMeasureBoundCriterion;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -291,11 +281,6 @@ public:
 protected:
   MinMeasureBoundCriterion() = default;
   ~MinMeasureBoundCriterion() = default;
-
-private:
-  MinMeasureBoundCriterion(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // namespace itk
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.h
@@ -58,6 +58,8 @@ template <typename TInputMesh, typename TOutputMesh = TInputMesh>
 class ITK_TEMPLATE_EXPORT SmoothingQuadEdgeMeshFilter : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SmoothingQuadEdgeMeshFilter);
+
   using Self = SmoothingQuadEdgeMeshFilter;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -131,11 +133,6 @@ protected:
 
   void
   GenerateData() override;
-
-private:
-  SmoothingQuadEdgeMeshFilter(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // namespace itk
 

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
@@ -49,6 +49,16 @@ public:
   /** Determine the output data type. */
   using OutputComponentType = typename OutputConvertTraits::ComponentType;
   using Self = ConvertPixelBuffer;
+
+  // Remove all constructor/ destructor / assignments for class with only static member functions.
+  ConvertPixelBuffer(const ConvertPixelBuffer &) = delete;
+  ConvertPixelBuffer(ConvertPixelBuffer &&) = delete;
+  ConvertPixelBuffer &
+  operator=(const ConvertPixelBuffer &) = delete;
+  ConvertPixelBuffer &
+  operator=(ConvertPixelBuffer &&) = delete;
+  virtual ~ConvertPixelBuffer() = delete;
+
   /** General method converts from one type to another. */
   static void
   Convert(InputPixelType * inputData, int inputNumberOfComponents, OutputPixelType * outputData, size_t size);
@@ -163,10 +173,6 @@ protected:
   template <typename UComponentType>
   static typename EnableIfC<NumericTraits<UComponentType>::IsInteger, UComponentType>::Type
   DefaultAlphaValue();
-
-private:
-  ConvertPixelBuffer() = delete;
-  ~ConvertPixelBuffer() = delete;
 };
 } // namespace itk
 

--- a/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.h
+++ b/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.h
@@ -35,16 +35,21 @@ template <typename InputPixelType, typename T, typename OutputConvertTraits>
 class ITK_TEMPLATE_EXPORT ConvertPixelBuffer<InputPixelType, Array<T>, OutputConvertTraits>
 {
 public:
+  // Remove all constructor/ destructor / assignments for class with only static member functions.
+  ConvertPixelBuffer(const ConvertPixelBuffer &) = delete;
+  ConvertPixelBuffer(ConvertPixelBuffer &&) = delete;
+  ConvertPixelBuffer &
+  operator=(const ConvertPixelBuffer &) = delete;
+  ConvertPixelBuffer &
+  operator=(ConvertPixelBuffer &&) = delete;
+  virtual ~ConvertPixelBuffer() = delete;
+
   /** Determine the output data type. */
   using OutputComponentType = typename OutputConvertTraits::ComponentType;
 
   /** General method converts from one type to another. */
   static void
   Convert(InputPixelType * inputData, int inputNumberOfComponents, Array<T> * outputData, size_t size);
-
-private:
-  ConvertPixelBuffer() = delete;
-  ~ConvertPixelBuffer() = delete;
 };
 } // namespace itk
 

--- a/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.h
+++ b/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.h
@@ -35,16 +35,21 @@ template <typename InputPixelType, typename T, typename OutputConvertTraits>
 class ITK_TEMPLATE_EXPORT ConvertPixelBuffer<InputPixelType, VariableLengthVector<T>, OutputConvertTraits>
 {
 public:
+  // Remove all constructor/ destructor / assignments for class with only static member functions.
+  ConvertPixelBuffer(const ConvertPixelBuffer &) = delete;
+  ConvertPixelBuffer(ConvertPixelBuffer &&) = delete;
+  ConvertPixelBuffer &
+  operator=(const ConvertPixelBuffer &) = delete;
+  ConvertPixelBuffer &
+  operator=(ConvertPixelBuffer &&) = delete;
+  virtual ~ConvertPixelBuffer() = delete;
+
   /** Determine the output data type. */
   using OutputComponentType = typename OutputConvertTraits::ComponentType;
 
   /** General method converts from one type to another. */
   static void
   Convert(InputPixelType * inputData, int inputNumberOfComponents, VariableLengthVector<T> * outputData, size_t size);
-
-private:
-  ConvertPixelBuffer() = delete;
-  ~ConvertPixelBuffer() = delete;
 };
 } // namespace itk
 

--- a/Modules/Nonunit/Review/include/itkConstrainedRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkConstrainedRegionBasedLevelSetFunctionSharedData.h
@@ -62,6 +62,8 @@ class ConstrainedRegionBasedLevelSetFunctionSharedData
   : public RegionBasedLevelSetFunctionSharedData<TInputImage, TFeatureImage, TSingleData>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ConstrainedRegionBasedLevelSetFunctionSharedData);
+
   using Self = ConstrainedRegionBasedLevelSetFunctionSharedData;
   using Superclass = RegionBasedLevelSetFunctionSharedData<TInputImage, TFeatureImage, TSingleData>;
   using Pointer = SmartPointer<Self>;
@@ -180,11 +182,6 @@ protected:
     : Superclass()
   {}
   ~ConstrainedRegionBasedLevelSetFunctionSharedData() override = default;
-
-private:
-  ConstrainedRegionBasedLevelSetFunctionSharedData(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // end namespace itk
 

--- a/Modules/Nonunit/Review/include/itkUnconstrainedRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkUnconstrainedRegionBasedLevelSetFunctionSharedData.h
@@ -62,6 +62,8 @@ class UnconstrainedRegionBasedLevelSetFunctionSharedData
   : public RegionBasedLevelSetFunctionSharedData<TInputImage, TFeatureImage, TSingleData>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(UnconstrainedRegionBasedLevelSetFunctionSharedData);
+
   using Self = UnconstrainedRegionBasedLevelSetFunctionSharedData;
   using Superclass = RegionBasedLevelSetFunctionSharedData<TInputImage, TFeatureImage, TSingleData>;
   using Pointer = SmartPointer<Self>;
@@ -139,11 +141,6 @@ protected:
     : Superclass()
   {}
   ~UnconstrainedRegionBasedLevelSetFunctionSharedData() override = default;
-
-private:
-  UnconstrainedRegionBasedLevelSetFunctionSharedData(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 };
 } // end namespace itk
 

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
@@ -54,6 +54,8 @@ namespace fem
 class ITKFEM_EXPORT LinearSystemWrapper : public Solution
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LinearSystemWrapper);
+
   using Self = LinearSystemWrapper;
   using Superclass = Solution;
   using Pointer = Self *;
@@ -530,13 +532,6 @@ private:
                                         ColumnArray & newNumbering,
                                         unsigned int  nextRowNumber,
                                         unsigned int  matrixIndex = 0);
-
-  /** Copy constructor is not allowed. */
-  LinearSystemWrapper(const LinearSystemWrapper &) = delete;
-
-  /** Asignment operator is not allowed. */
-  const LinearSystemWrapper &
-  operator=(const LinearSystemWrapper &) = delete;
 };
 
 class ITK_ABI_EXPORT FEMExceptionLinearSystem : public FEMException

--- a/Modules/Numerics/Optimizers/include/itkFRPROptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkFRPROptimizer.h
@@ -70,6 +70,7 @@ extern ITKOptimizers_EXPORT std::ostream &
 class ITKOptimizers_EXPORT FRPROptimizer : public PowellOptimizer
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FRPROptimizer);
   /** Standard "Self" type alias. */
   using Self = FRPROptimizer;
   using Superclass = PowellOptimizer;
@@ -124,8 +125,6 @@ protected:
   LineOptimize(ParametersType * p, ParametersType & xi, double * val, ParametersType & tempCoord);
 
 private:
-  FRPROptimizer(const FRPROptimizer &) = delete;
-
   using OptimizationEnum = FRPROptimizerEnums::Optimization;
 #if !defined(ITK_LEGACY_REMOVE)
   /**Exposes enums values for backwards compatibility*/

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -437,6 +437,13 @@ public:
   class Iterator : public ConstIterator
   {
   public:
+    Iterator() = delete;
+    Iterator(const Self * histogram) = delete;
+    Iterator(InstanceIdentifier id, const Self * histogram) = delete;
+    Iterator(const ConstIterator & it) = delete;
+    ConstIterator &
+    operator=(const ConstIterator & it) = delete;
+
     Iterator(Self * histogram)
       : ConstIterator(histogram)
     {}
@@ -463,16 +470,6 @@ public:
 
       return histogram->SetFrequency(this->m_Id, value);
     }
-
-  private:
-    // To ensure const-correctness these method must not be in the public API.
-    // The are not implemented, since they should never be called.
-    Iterator() = delete;
-    Iterator(const Self * histogram) = delete;
-    Iterator(InstanceIdentifier id, const Self * histogram) = delete;
-    Iterator(const ConstIterator & it) = delete;
-    ConstIterator &
-    operator=(const ConstIterator & it) = delete;
   }; // end of iterator class
 
   Iterator

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
@@ -150,6 +150,8 @@ public:
     friend class ImageToListSampleAdaptor;
 
   public:
+    ConstIterator() = delete;
+
     ConstIterator(const ImageToListSampleAdaptor * adaptor) { *this = adaptor->Begin(); }
 
     ConstIterator(const ConstIterator & iter)
@@ -212,7 +214,6 @@ public:
     {}
 
   private:
-    ConstIterator() = delete;
     ImageConstIteratorType        m_Iter;
     mutable MeasurementVectorType m_MeasurementVectorCache;
     InstanceIdentifier            m_InstanceIdentifier;
@@ -227,6 +228,13 @@ public:
     friend class ImageToListSampleAdaptor;
 
   public:
+    Iterator() = delete;
+    Iterator(const Self * adaptor) = delete;
+    Iterator(const ImageConstIteratorType & iter, InstanceIdentifier iid) = delete;
+    Iterator(const ConstIterator & it) = delete;
+    ConstIterator &
+    operator=(const ConstIterator & it) = delete;
+
     Iterator(Self * adaptor)
       : ConstIterator(adaptor)
     {}
@@ -246,16 +254,6 @@ public:
     Iterator(const ImageIteratorType & iter, InstanceIdentifier iid)
       : ConstIterator(iter, iid)
     {}
-
-  private:
-    // To ensure const-correctness these method must not be in the public API.
-    // The are purposly not implemented, since they should never be called.
-    Iterator() = delete;
-    Iterator(const Self * adaptor) = delete;
-    Iterator(const ImageConstIteratorType & iter, InstanceIdentifier iid) = delete;
-    Iterator(const ConstIterator & it) = delete;
-    ConstIterator &
-    operator=(const ConstIterator & it) = delete;
   };
 
   /** returns an iterator that points to the beginning of the container */

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
@@ -164,6 +164,8 @@ public:
     friend class ImageToNeighborhoodSampleAdaptor;
 
   public:
+    ConstIterator() = delete;
+
     ConstIterator(const ImageToNeighborhoodSampleAdaptor * adaptor) { *this = adaptor->Begin(); }
 
     ConstIterator(const ConstIterator & iter)
@@ -228,7 +230,6 @@ public:
     }
 
   private:
-    ConstIterator() = delete;
     mutable MeasurementVectorType m_MeasurementVectorCache;
     InstanceIdentifier            m_InstanceIdentifier;
   };
@@ -244,6 +245,12 @@ public:
     friend class ImageToNeighborhoodSampleAdaptor;
 
   public:
+    Iterator() = delete;
+    Iterator(const Self * adaptor) = delete;
+    Iterator(const ConstIterator & it) = delete;
+    ConstIterator &
+    operator=(const ConstIterator & it) = delete;
+
     Iterator(Self * adaptor)
       : ConstIterator(adaptor)
     {}
@@ -264,15 +271,6 @@ public:
     Iterator(NeighborhoodIteratorType iter, InstanceIdentifier iid)
       : ConstIterator(iter, iid)
     {}
-
-  private:
-    // To ensure const-correctness these method must not be in the public API.
-    // The are not implemented, since they should never be called.
-    Iterator() = delete;
-    Iterator(const Self * adaptor) = delete;
-    Iterator(const ConstIterator & it) = delete;
-    ConstIterator &
-    operator=(const ConstIterator & it) = delete;
   };
 
   /** returns an iterator that points to the beginning of the container */

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
@@ -190,6 +190,8 @@ public:
     friend class JointDomainImageToListSampleAdaptor;
 
   public:
+    ConstIterator() = delete;
+
     ConstIterator(const JointDomainImageToListSampleAdaptor * adaptor) { *this = adaptor->Begin(); }
 
     ConstIterator(const ConstIterator & iter)
@@ -252,7 +254,6 @@ public:
     }
 
   private:
-    ConstIterator() = delete;
     mutable MeasurementVectorType               m_MeasurementVectorCache;
     InstanceIdentifier                          m_InstanceIdentifier;
     const JointDomainImageToListSampleAdaptor * m_Adaptor;
@@ -267,6 +268,12 @@ public:
     friend class JointDomainImageToListSampleAdaptor;
 
   public:
+    Iterator() = delete;
+    Iterator(const Self * adaptor) = delete;
+    Iterator(const ConstIterator & it) = delete;
+    ConstIterator &
+    operator=(const ConstIterator & it) = delete;
+
     Iterator(Self * adaptor)
       : ConstIterator(adaptor)
     {}
@@ -286,15 +293,6 @@ public:
     Iterator(const JointDomainImageToListSampleAdaptor * adaptor, InstanceIdentifier iid)
       : ConstIterator(adaptor, iid)
     {}
-
-  private:
-    // To ensure const-correctness these method must not be in the public API.
-    // The are purposly not implemented, since they should never be called.
-    Iterator() = delete;
-    Iterator(const Self * adaptor) = delete;
-    Iterator(const ConstIterator & it) = delete;
-    ConstIterator &
-    operator=(const ConstIterator & it) = delete;
   };
 
   /** returns an iterator that points to the beginning of the container */

--- a/Modules/Numerics/Statistics/include/itkKdTree.h
+++ b/Modules/Numerics/Statistics/include/itkKdTree.h
@@ -586,6 +586,7 @@ public:
       : m_FarthestNeighborIndex(0)
       , m_Distances(cache_vector)
     {}
+    NearestNeighbors() = delete;
 
     /** Destructor */
     ~NearestNeighbors() = default;
@@ -644,7 +645,6 @@ public:
     }
 
   private:
-    NearestNeighbors() = delete;
     /** The index of the farthest neighbor among k-neighbors */
     unsigned int m_FarthestNeighborIndex;
 

--- a/Modules/Numerics/Statistics/include/itkListSample.h
+++ b/Modules/Numerics/Statistics/include/itkListSample.h
@@ -146,6 +146,8 @@ public:
       m_InstanceIdentifier = iter.m_InstanceIdentifier;
     }
 
+    ConstIterator() = delete;
+
     ConstIterator &
     operator=(const ConstIterator & iter)
     {
@@ -201,7 +203,6 @@ public:
     }
 
   private:
-    ConstIterator() = delete;
     using InternalIterator = typename InternalDataContainerType::const_iterator;
     InternalIterator   m_Iter;
     InstanceIdentifier m_InstanceIdentifier;
@@ -216,6 +217,13 @@ public:
     friend class ListSample;
 
   public:
+    Iterator() = delete;
+    Iterator(const Self * sample) = delete;
+    Iterator(typename InternalDataContainerType::const_iterator iter, InstanceIdentifier iid) = delete;
+    Iterator(const ConstIterator & it) = delete;
+    ConstIterator &
+    operator=(const ConstIterator & it) = delete;
+
     Iterator(Self * sample)
       : ConstIterator(sample)
     {}
@@ -235,16 +243,6 @@ public:
     Iterator(typename InternalDataContainerType::iterator iter, InstanceIdentifier iid)
       : ConstIterator(iter, iid)
     {}
-
-  private:
-    // To ensure const-correctness these method must not be in the public API.
-    // The are purposly not implemented, since they should never be called.
-    Iterator() = delete;
-    Iterator(const Self * sample) = delete;
-    Iterator(typename InternalDataContainerType::const_iterator iter, InstanceIdentifier iid) = delete;
-    Iterator(const ConstIterator & it) = delete;
-    ConstIterator &
-    operator=(const ConstIterator & it) = delete;
   };
 
   /** returns an iterator that points to the beginning of the container */

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
@@ -209,20 +209,17 @@ public:
       return *this;
     }
 
-  protected:
-    Iterator(PointsContainerIteratorType iter, InstanceIdentifier iid)
-      : ConstIterator(iter, iid)
-    {}
-
-  private:
-    // To ensure const-correctness these method must not be in the public API.
-    // The are not implemented, since they should never be called.
     Iterator() = delete;
     Iterator(const Self * adaptor) = delete;
     Iterator(PointsContainerConstIteratorType iter, InstanceIdentifier iid) = delete;
     Iterator(const ConstIterator & it) = delete;
     ConstIterator &
     operator=(const ConstIterator & it) = delete;
+
+  protected:
+    Iterator(PointsContainerIteratorType iter, InstanceIdentifier iid)
+      : ConstIterator(iter, iid)
+    {}
   };
 
   /** returns an iterator that points to the beginning of the container */

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
@@ -116,6 +116,8 @@ public:
       this->m_InstanceIdentifier = iter.m_InstanceIdentifier;
     }
 
+    ConstIterator() = delete;
+
     ConstIterator &
     operator=(const ConstIterator & iter)
     {
@@ -171,7 +173,6 @@ public:
     }
 
   private:
-    ConstIterator() = delete;
     VectorContainerConstIterator m_Iter;
     InstanceIdentifier           m_InstanceIdentifier;
   };
@@ -184,6 +185,13 @@ public:
     friend class VectorContainerToListSampleAdaptor;
 
   public:
+    Iterator() = delete;
+    Iterator(const Self * adaptor) = delete;
+    Iterator(VectorContainerConstIterator iter, InstanceIdentifier iid) = delete;
+    Iterator(const ConstIterator & it) = delete;
+    ConstIterator &
+    operator=(const ConstIterator & it) = delete;
+
     Iterator(Self * adaptor)
       : ConstIterator(adaptor)
     {}
@@ -203,16 +211,6 @@ public:
     Iterator(VectorContainerIterator iter, InstanceIdentifier iid)
       : ConstIterator(iter, iid)
     {}
-
-  private:
-    // To ensure const-correctness these method must not be in the public API.
-    // The are not implemented, since they should never be called.
-    Iterator() = delete;
-    Iterator(const Self * adaptor) = delete;
-    Iterator(VectorContainerConstIterator iter, InstanceIdentifier iid) = delete;
-    Iterator(const ConstIterator & it) = delete;
-    ConstIterator &
-    operator=(const ConstIterator & it) = delete;
   };
 
   /** returns an iterator that points to the beginning of the container */

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.h
@@ -96,6 +96,8 @@ public:
   class ITK_TEMPLATE_EXPORT DataType
   {
   public:
+    DataType() = delete;
+
     DataType(std::string iName)
       : m_Name(std::move(iName))
       , m_Computed(false)
@@ -119,9 +121,6 @@ public:
       this->m_Value = iData.m_Value;
       this->m_Computed = iData.m_Computed;
     }
-
-  private:
-    DataType() = delete;
   };
 
   /** \struct LevelSetDataType

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.h
@@ -40,6 +40,8 @@ template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT LevelSetDomainMapImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LevelSetDomainMapImageFilter);
+
   using Self = LevelSetDomainMapImageFilter;
   using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
   using Pointer = SmartPointer<Self>;
@@ -134,10 +136,6 @@ protected:
 
 private:
   DomainMapType m_DomainMap;
-
-  LevelSetDomainMapImageFilter(Self &) = delete;
-  void
-  operator=(const Self &) = delete;
 
   const InputImageType * m_InputImage;
   OutputImageType *      m_OutputImage;

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
@@ -48,6 +48,8 @@ template <typename TInputImage, typename TClassifiedImage>
 class ITK_TEMPLATE_EXPORT RGBGibbsPriorFilter : public MRFImageFilter<TInputImage, TClassifiedImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RGBGibbsPriorFilter);
+
   /** Standard "Self" type alias. */
   using Self = RGBGibbsPriorFilter;
   using Superclass = MRFImageFilter<TInputImage, TClassifiedImage>;
@@ -221,10 +223,6 @@ protected:
 #endif
 
 private:
-  RGBGibbsPriorFilter(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
-
   using InputImageSizeType = typename TInputImage::SizeType;
 
   InputImageConstPointer m_InputImage;            /** the input */


### PR DESCRIPTION
With C++11, explicitly deleted functions can be moved from private to public. Originally in C++98, this was required. The majority of these changes required moving a class's copy constructor and assignment operator. In the case of both, they were replaced with:
```
public:
ITK_DISALLOW_COPY_AND_ASSIGN(<<CLASSNAME>>);
```

Otherwise, the delete statement was simply moved.


