### PR TITLE
ENH: StopConditionRegularStepGradientDescentBaseOptimizer -> StopCond…

### DIFF
--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
@@ -31,11 +31,11 @@ namespace itk
 class RegularStepGradientDescentBaseOptimizerEnums
 {
 public:
-  /** \class StopConditionRegularStepGradientDescentBaseOptimizer
+  /** \class StopCondition
    *
    * \ingroup ITKOptimizers
    * Codes of stopping conditions. */
-  enum class StopConditionRegularStepGradientDescentBaseOptimizer : uint8_t
+  enum class StopCondition : uint8_t
   {
     GradientMagnitudeTolerance = 1,
     StepTooSmall = 2,
@@ -47,9 +47,7 @@ public:
 };
 // Define how to print enumeration
 extern ITKOptimizers_EXPORT std::ostream &
-                            operator<<(
-  std::ostream &                                                                                           out,
-  const RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer value);
+                            operator<<(std::ostream & out, const RegularStepGradientDescentBaseOptimizerEnums::StopCondition value);
 
 /** \class RegularStepGradientDescentBaseOptimizer
  * \brief Implement a gradient descent optimizer
@@ -74,23 +72,16 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(RegularStepGradientDescentBaseOptimizer, SingleValuedNonLinearOptimizer);
 
-  using StopConditionRegularStepGradientDescentBaseOptimizerEnum =
-    RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer;
+  using StopConditionEnum = RegularStepGradientDescentBaseOptimizerEnums::StopCondition;
 #if !defined(ITK_LEGACY_REMOVE)
   // We need to expose the enum values at the class level
   // for backwards compatibility
-  static constexpr StopConditionRegularStepGradientDescentBaseOptimizerEnum GradientMagnitudeTolerance =
-    StopConditionRegularStepGradientDescentBaseOptimizerEnum::GradientMagnitudeTolerance;
-  static constexpr StopConditionRegularStepGradientDescentBaseOptimizerEnum StepTooSmall =
-    StopConditionRegularStepGradientDescentBaseOptimizerEnum::StepTooSmall;
-  static constexpr StopConditionRegularStepGradientDescentBaseOptimizerEnum ImageNotAvailable =
-    StopConditionRegularStepGradientDescentBaseOptimizerEnum::ImageNotAvailable;
-  static constexpr StopConditionRegularStepGradientDescentBaseOptimizerEnum CostFunctionError =
-    StopConditionRegularStepGradientDescentBaseOptimizerEnum::CostFunctionError;
-  static constexpr StopConditionRegularStepGradientDescentBaseOptimizerEnum MaximumNumberOfIterations =
-    StopConditionRegularStepGradientDescentBaseOptimizerEnum::MaximumNumberOfIterations;
-  static constexpr StopConditionRegularStepGradientDescentBaseOptimizerEnum Unknown =
-    StopConditionRegularStepGradientDescentBaseOptimizerEnum::Unknown;
+  static constexpr StopConditionEnum GradientMagnitudeTolerance = StopConditionEnum::GradientMagnitudeTolerance;
+  static constexpr StopConditionEnum StepTooSmall = StopConditionEnum::StepTooSmall;
+  static constexpr StopConditionEnum ImageNotAvailable = StopConditionEnum::ImageNotAvailable;
+  static constexpr StopConditionEnum CostFunctionError = StopConditionEnum::CostFunctionError;
+  static constexpr StopConditionEnum MaximumNumberOfIterations = StopConditionEnum::MaximumNumberOfIterations;
+  static constexpr StopConditionEnum Unknown = StopConditionEnum::Unknown;
 #endif
   /** Specify whether to minimize or maximize the cost function. */
   itkSetMacro(Maximize, bool);
@@ -144,7 +135,7 @@ public:
   itkGetConstReferenceMacro(NumberOfIterations, SizeValueType);
   itkGetConstReferenceMacro(GradientMagnitudeTolerance, double);
   itkGetConstMacro(CurrentIteration, unsigned int);
-  itkGetConstReferenceMacro(StopCondition, StopConditionRegularStepGradientDescentBaseOptimizerEnum);
+  itkGetConstReferenceMacro(StopCondition, StopConditionEnum);
   itkGetConstReferenceMacro(Value, MeasureType);
   itkGetConstReferenceMacro(Gradient, DerivativeType);
 
@@ -184,18 +175,18 @@ protected:
   DerivativeType m_Gradient;
   DerivativeType m_PreviousGradient;
 
-  bool                                                     m_Stop{ false };
-  bool                                                     m_Maximize;
-  MeasureType                                              m_Value;
-  double                                                   m_GradientMagnitudeTolerance;
-  double                                                   m_MaximumStepLength;
-  double                                                   m_MinimumStepLength;
-  double                                                   m_CurrentStepLength;
-  double                                                   m_RelaxationFactor;
-  StopConditionRegularStepGradientDescentBaseOptimizerEnum m_StopCondition;
-  SizeValueType                                            m_NumberOfIterations;
-  SizeValueType                                            m_CurrentIteration;
-  std::ostringstream                                       m_StopConditionDescription;
+  bool               m_Stop{ false };
+  bool               m_Maximize;
+  MeasureType        m_Value;
+  double             m_GradientMagnitudeTolerance;
+  double             m_MaximumStepLength;
+  double             m_MinimumStepLength;
+  double             m_CurrentStepLength;
+  double             m_RelaxationFactor;
+  StopConditionEnum  m_StopCondition;
+  SizeValueType      m_NumberOfIterations;
+  SizeValueType      m_CurrentIteration;
+  std::ostringstream m_StopConditionDescription;
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -39,7 +39,7 @@ RegularStepGradientDescentBaseOptimizer ::RegularStepGradientDescentBaseOptimize
   m_Maximize = false;
   m_CostFunction = nullptr;
   m_CurrentStepLength = 0;
-  m_StopCondition = StopConditionRegularStepGradientDescentBaseOptimizerEnum::Unknown;
+  m_StopCondition = StopConditionEnum::Unknown;
   m_Gradient.Fill(0.0f);
   m_PreviousGradient.Fill(0.0f);
   m_RelaxationFactor = 0.5;
@@ -57,7 +57,7 @@ RegularStepGradientDescentBaseOptimizer ::StartOptimization()
   m_CurrentStepLength = m_MaximumStepLength;
   m_CurrentIteration = 0;
 
-  m_StopCondition = StopConditionRegularStepGradientDescentBaseOptimizerEnum::Unknown;
+  m_StopCondition = StopConditionEnum::Unknown;
   m_StopConditionDescription.str("");
   m_StopConditionDescription << this->GetNameOfClass() << ": ";
 
@@ -96,7 +96,7 @@ RegularStepGradientDescentBaseOptimizer ::ResumeOptimization()
   {
     if (m_CurrentIteration >= m_NumberOfIterations)
     {
-      m_StopCondition = StopConditionRegularStepGradientDescentBaseOptimizerEnum::MaximumNumberOfIterations;
+      m_StopCondition = StopConditionEnum::MaximumNumberOfIterations;
       m_StopConditionDescription << "Maximum number of iterations (" << m_NumberOfIterations << ") exceeded.";
       this->StopOptimization();
       break;
@@ -110,7 +110,7 @@ RegularStepGradientDescentBaseOptimizer ::ResumeOptimization()
     }
     catch (ExceptionObject & excp)
     {
-      m_StopCondition = StopConditionRegularStepGradientDescentBaseOptimizerEnum::CostFunctionError;
+      m_StopCondition = StopConditionEnum::CostFunctionError;
       m_StopConditionDescription << "Cost function error after " << m_CurrentIteration << " iterations. "
                                  << excp.GetDescription();
       this->StopOptimization();
@@ -188,7 +188,7 @@ RegularStepGradientDescentBaseOptimizer ::AdvanceOneStep()
 
   if (gradientMagnitude < m_GradientMagnitudeTolerance)
   {
-    m_StopCondition = StopConditionRegularStepGradientDescentBaseOptimizerEnum::GradientMagnitudeTolerance;
+    m_StopCondition = StopConditionEnum::GradientMagnitudeTolerance;
     m_StopConditionDescription << "Gradient magnitude tolerance met after " << m_CurrentIteration
                                << " iterations. Gradient magnitude (" << gradientMagnitude
                                << ") is less than gradient magnitude tolerance (" << m_GradientMagnitudeTolerance
@@ -214,7 +214,7 @@ RegularStepGradientDescentBaseOptimizer ::AdvanceOneStep()
 
   if (m_CurrentStepLength < m_MinimumStepLength)
   {
-    m_StopCondition = StopConditionRegularStepGradientDescentBaseOptimizerEnum::StepTooSmall;
+    m_StopCondition = StopConditionEnum::StepTooSmall;
     m_StopConditionDescription << "Step too small after " << m_CurrentIteration << " iterations. Current step ("
                                << m_CurrentStepLength << ") is less than minimum step (" << m_MinimumStepLength << ").";
     this->StopOptimization();
@@ -274,40 +274,33 @@ RegularStepGradientDescentBaseOptimizer ::PrintSelf(std::ostream & os, Indent in
 
 /** Print enum values */
 std::ostream &
-operator<<(
-  std::ostream &                                                                                           out,
-  const RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer value)
+operator<<(std::ostream & out, const RegularStepGradientDescentBaseOptimizerEnums::StopCondition value)
 {
   return out << [value] {
     switch (value)
     {
-      case RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        GradientMagnitudeTolerance:
+      case RegularStepGradientDescentBaseOptimizerEnums::StopCondition::GradientMagnitudeTolerance:
         return "itk::RegularStepGradientDescentBaseOptimizerEnums::"
-               "StopConditionRegularStepGradientDescentBaseOptimizer::GradientMagnitudeTolerance";
-      case RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        StepTooSmall:
+               "StopCondition::GradientMagnitudeTolerance";
+      case RegularStepGradientDescentBaseOptimizerEnums::StopCondition::StepTooSmall:
         return "itk::RegularStepGradientDescentBaseOptimizerEnums::"
-               "StopConditionRegularStepGradientDescentBaseOptimizer::StepTooSmall";
-      case RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        ImageNotAvailable:
+               "StopCondition::StepTooSmall";
+      case RegularStepGradientDescentBaseOptimizerEnums::StopCondition::ImageNotAvailable:
         return "itk::RegularStepGradientDescentBaseOptimizerEnums::"
-               "StopConditionRegularStepGradientDescentBaseOptimizer::ImageNotAvailable";
-      case RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        CostFunctionError:
+               "StopCondition::ImageNotAvailable";
+      case RegularStepGradientDescentBaseOptimizerEnums::StopCondition::CostFunctionError:
         return "itk::RegularStepGradientDescentBaseOptimizerEnums::"
-               "StopConditionRegularStepGradientDescentBaseOptimizer::CostFunctionError";
-      case RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        MaximumNumberOfIterations:
+               "StopCondition::CostFunctionError";
+      case RegularStepGradientDescentBaseOptimizerEnums::StopCondition::MaximumNumberOfIterations:
         return "itk::RegularStepGradientDescentBaseOptimizerEnums::"
-               "StopConditionRegularStepGradientDescentBaseOptimizer::MaximumNumberOfIterations";
-      case RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::Unknown:
+               "StopCondition::MaximumNumberOfIterations";
+      case RegularStepGradientDescentBaseOptimizerEnums::StopCondition::Unknown:
         return "itk::RegularStepGradientDescentBaseOptimizerEnums::"
-               "StopConditionRegularStepGradientDescentBaseOptimizer::Unknown";
+               "StopCondition::Unknown";
       default:
         return "INVALID VALUE FOR "
                "itk::RegularStepGradientDescentBaseOptimizerEnums::"
-               "StopConditionRegularStepGradientDescentBaseOptimizer";
+               "StopCondition";
     }
   }();
 }

--- a/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
@@ -279,26 +279,19 @@ itkRegularStepGradientDescentOptimizerTest(int, char *[])
   }
 
   // Test streaming enumeration for
-  // RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer elements
-  const std::set<
-    itk::RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer>
-    allStopConditionRegularStepGradientDescentBaseOptimizer{
-      itk::RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        GradientMagnitudeTolerance,
-      itk::RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        StepTooSmall,
-      itk::RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        ImageNotAvailable,
-      itk::RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        CostFunctionError,
-      itk::RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::
-        MaximumNumberOfIterations,
-      itk::RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer::Unknown
-    };
-  for (const auto & ee : allStopConditionRegularStepGradientDescentBaseOptimizer)
+  // RegularStepGradientDescentBaseOptimizerEnums::StopCondition elements
+  const std::set<itk::RegularStepGradientDescentBaseOptimizerEnums::StopCondition> allStopCondition{
+    itk::RegularStepGradientDescentBaseOptimizerEnums::StopCondition::GradientMagnitudeTolerance,
+    itk::RegularStepGradientDescentBaseOptimizerEnums::StopCondition::StepTooSmall,
+    itk::RegularStepGradientDescentBaseOptimizerEnums::StopCondition::ImageNotAvailable,
+    itk::RegularStepGradientDescentBaseOptimizerEnums::StopCondition::CostFunctionError,
+    itk::RegularStepGradientDescentBaseOptimizerEnums::StopCondition::MaximumNumberOfIterations,
+    itk::RegularStepGradientDescentBaseOptimizerEnums::StopCondition::Unknown
+  };
+  for (const auto & ee : allStopCondition)
   {
     std::cout << "STREAMED ENUM VALUE "
-                 "RegularStepGradientDescentBaseOptimizerEnums::StopConditionRegularStepGradientDescentBaseOptimizer: "
+                 "RegularStepGradientDescentBaseOptimizerEnums::StopCondition: "
               << ee << std::endl;
   }
 


### PR DESCRIPTION
…ition

The StopConditionRegularStepGradientDescentBaseOptimizer name is too
long. Context is already provided by the enclosing class,
RegularStepGradientDescentBaseOptimizerEnums. Remove the extra and use
the clear and concise "StopCondition".