### PR TITLE
BUG: fix crash with multiple update in LabelStatisticsImageFilter

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -347,6 +347,13 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
+  void
+  BeforeStreamedGenerateData() override
+  {
+    this->AllocateOutputs();
+    m_LabelStatistics.clear();
+  }
+
   /** Do final mean and variance computation from data accumulated in threads.
    */
   void


### PR DESCRIPTION
Closes #1679.
