### PR TITLE
BUG: restoring libPNG branch name for UpdateFromUpstream.sh

### DIFF
--- a/Modules/ThirdParty/PNG/UpdateFromUpstream.sh
+++ b/Modules/ThirdParty/PNG/UpdateFromUpstream.sh
@@ -3,7 +3,7 @@
 thirdparty_module_name='PNG'
 
 upstream_git_url='git://git.code.sf.net/p/libpng/code'
-upstream_git_branch='libpng-1.6.31-signed'
+upstream_git_branch='libpng16'
 
 snapshot_author_name='LIBPNG Upstream'
 snapshot_author_email='png-mng-implement@lists.sourceforge.net'


### PR DESCRIPTION
The change was accidental commit in
b644f1a3818c9dbbc9aa5751a311f01a109f4174.
