### PR TITLE
BUG: Fix BUILD_SHARED_LIBS state consistency for HDF5

### DIFF
--- a/Modules/ThirdParty/HDF5/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/CMakeLists.txt
@@ -1,6 +1,12 @@
 project(ITKHDF5)
 set(ITKHDF5_THIRD_PARTY 1)
 
+# Reset BUILD_SHARED_LIBS to ITK_BUILD_SHARED_LIBS
+# that keeps track of the initial state of the root
+# project BUILD_SHARED_LIBS option (which could be
+# modified before reaching this point)
+set(BUILD_SHARED_LIBS ${ITK_BUILD_SHARED_LIBS})
+
 if (BUILD_SHARED_LIBS)
    add_definitions(-DH5_BUILT_AS_DYNAMIC_LIB=1)
 endif()

--- a/Modules/ThirdParty/HDF5/itk-module-init.cmake
+++ b/Modules/ThirdParty/HDF5/itk-module-init.cmake
@@ -1,7 +1,8 @@
 option(ITK_USE_SYSTEM_HDF5 "Use an outside build of HDF5." ${ITK_USE_SYSTEM_LIBRARIES})
 mark_as_advanced(ITK_USE_SYSTEM_HDF5)
+
 if(ITK_USE_SYSTEM_HDF5)
-  if(BUILD_SHARED_LIBS)
+  if(ITK_BUILD_SHARED_LIBS)
     find_package(HDF5 QUIET NO_MODULE COMPONENTS CXX C shared)
   else()
     find_package(HDF5 QUIET NO_MODULE COMPONENTS CXX C static)


### PR DESCRIPTION
Reset BUILD_SHARED_LIBS to the root project initial state in case
this option is modified before processing the configuration of
a third-party module.

Closes #1658