### PR TITLE
COMP: Conditional python3 package finding

### DIFF
--- a/CMake/ITKModuleExternal.cmake
+++ b/CMake/ITKModuleExternal.cmake
@@ -11,20 +11,8 @@ if(NOT EXISTS ${ITK_CMAKE_DIR}/ITKModuleMacros.cmake)
   message(FATAL_ERROR "Modules can only be built against an ITK build tree; they cannot be built against an ITK install tree.")
 endif()
 
-if(ITK_WRAP_PYTHON)
-  if(DEFINED Python3_EXECUTABLE)
-    set(_specified_Python3_EXECUTABLE ${Python3_EXECUTABLE})
-  endif()
-  find_package(Python3 COMPONENTS Interpreter Development)
-  set(Python3_EXECUTABLE ${_specified_Python3_EXECUTABLE} CACHE INTERNAL
-    "Path to the Python interpreter" FORCE)
-else()
-  find_package(Python3 COMPONENTS Interpreter)
-endif()
-if(NOT Python3_EXECUTABLE AND _Python3_EXECUTABLE)
-  set(Python3_EXECUTABLE ${_Python3_EXECUTABLE} CACHE INTERNAL
-    "Path to the Python interpreter" FORCE)
-endif()
+set(PYTHON_DEVELOPMENT_REQUIRED ${ITK_WRAP_PYTHON})
+include(ITKSetPython3Vars)
 
 # To hide dependent variables
 include(CMakeDependentOption)

--- a/CMake/ITKSetPython3Vars.cmake
+++ b/CMake/ITKSetPython3Vars.cmake
@@ -1,0 +1,54 @@
+# This file provides a work-around to provide consistent
+# python3 cmake variables for cmake versions pre/post 3.12.0
+# NOTE: Only python 3 versions 3.5 and above are searched for.
+
+# If the cmake variable "PYTHON_DEVELOPMENT_REQUIRED" is set to ON
+# then the development environments are found.
+
+# Prefer to use more robust FindPython3 module if greater than cmake 3.12.0
+if("${CMAKE_VERSION}" VERSION_LESS_EQUAL "3.12.0")
+  # Use of PythonInterp and PythonLibs is deprecated since cmake version 3.12.0
+  # Only use deprecated mechanisms for older versions of cmake
+  set(Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6 3.5)
+  find_package(PythonInterp)
+  if(PYTHON_DEVELOPMENT_REQUIRED)
+    find_package(PythonLibs REQUIRED)
+    # check for version mismatch.
+    if(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND
+        AND NOT(PYTHON_VERSION_STRING VERSION_EQUAL PYTHONLIBS_VERSION_STRING))
+      message(FATAL_ERROR "Python executable (\"${PYTHON_VERSION_STRING}\") and library (\"${PYTHONLIBS_VERSION_STRING}\") version mismatch.")
+    endif()
+  endif()
+  if(PYTHON_VERSION_STRING VERSION_LESS 3.5)
+    # if python version is less than 3.5, unset so that it appears that no python version is found.
+    # to emulate the same behavior as find(Python3 ..) from cmake 3.12.0+
+    unset(PYTHON_EXECUTABLE)
+    unset(PYTHONINTERP_FOUND)
+    unset(PYTHON_VERSION_STRING)
+    unset(PYTHON_INCLUDE_DIRS)
+  else()
+    ## For forward compatibility with cmake 3.12.0 or greater, emulate variable names from FindPython3.cmake
+    set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
+    set(Python3_Interpreter_FOUND ${PYTHONINTERP_FOUND})
+    set(Python3_VERSION ${PYTHON_VERSION_STRING})
+
+    set(Python3_Development_FOUND ${PYTHONLIBS_FOUND})
+    set(Python3_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
+    set(Python3_LIBRARIES    ${PYTHON_LIBRARIES})
+  endif()
+else()
+  if(PYTHON_DEVELOPMENT_REQUIRED)
+    if(DEFINED Python3_EXECUTABLE)
+      set(_specified_Python3_EXECUTABLE ${Python3_EXECUTABLE})
+    endif()
+    find_package(Python3 COMPONENTS Interpreter Development)
+    set(Python3_EXECUTABLE ${_specified_Python3_EXECUTABLE} CACHE INTERNAL
+      "Path to the Python interpreter" FORCE)
+  else()
+    find_package(Python3 COMPONENTS Interpreter)
+  endif()
+  if(NOT Python3_EXECUTABLE AND _Python3_EXECUTABLE)
+    set(Python3_EXECUTABLE ${_Python3_EXECUTABLE} CACHE INTERNAL
+      "Path to the Python interpreter" FORCE)
+  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,53 +535,8 @@ endif()
 install(FILES "LICENSE" "NOTICE" "README.md" DESTINATION ${ITK_INSTALL_DOC_DIR} COMPONENT Runtime)
 
 if(BUILD_TESTING OR ITK_BUILD_DOCUMENTATION OR ITK_WRAP_PYTHON)
-  # Prefer to use more robust FindPython3 module if greater than cmake 3.12.0
-  if("${CMAKE_VERSION}" VERSION_LESS_EQUAL "3.12.0")
-    # Use of PythonInterp and PythonLibs is deprecated since cmake version 3.12.0
-    # Only use deprecated mechanisms for older versions of cmake
-    set(Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6 3.5)
-    find_package(PythonInterp)
-    if(ITK_WRAP_PYTHON)
-      find_package(PythonLibs REQUIRED)
-      # check for version mismatch.
-      if(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND
-          AND NOT(PYTHON_VERSION_STRING VERSION_EQUAL PYTHONLIBS_VERSION_STRING))
-        message(FATAL_ERROR "Python executable (\"${PYTHON_VERSION_STRING}\") and library (\"${PYTHONLIBS_VERSION_STRING}\") version mismatch.")
-      endif()
-    endif()
-    if(PYTHON_VERSION_STRING VERSION_LESS 3.5)
-      # if python version is less than 3.5, unset so that it appears that no python version is found.
-      # to emulate the same behavior as find(Python3 ..) from cmake 3.12.0+
-      unset(PYTHON_EXECUTABLE)
-      unset(PYTHONINTERP_FOUND)
-      unset(PYTHON_VERSION_STRING)
-      unset(PYTHON_INCLUDE_DIRS)
-    else()
-      ## For forward compatibility with cmake 3.12.0 or greater, emulate variable names from FindPython3.cmake
-      set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
-      set(Python3_Interpreter_FOUND ${PYTHONINTERP_FOUND})
-      set(Python3_VERSION ${PYTHON_VERSION_STRING})
-
-      set(Python3_Development_FOUND ${PYTHONLIBS_FOUND})
-      set(Python3_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
-      set(Python3_LIBRARIES    ${PYTHON_LIBRARIES})
-    endif()
-  else()
-    if(ITK_WRAP_PYTHON)
-      if(DEFINED Python3_EXECUTABLE)
-        set(_specified_Python3_EXECUTABLE ${Python3_EXECUTABLE})
-      endif()
-      find_package(Python3 COMPONENTS Interpreter Development)
-      set(Python3_EXECUTABLE ${_specified_Python3_EXECUTABLE} CACHE INTERNAL
-        "Path to the Python interpreter" FORCE)
-    else()
-      find_package(Python3 COMPONENTS Interpreter)
-    endif()
-    if(NOT Python3_EXECUTABLE AND _Python3_EXECUTABLE)
-      set(Python3_EXECUTABLE ${_Python3_EXECUTABLE} CACHE INTERNAL
-        "Path to the Python interpreter" FORCE)
-    endif()
-  endif()
+  set(PYTHON_DEVELOPMENT_REQUIRED ${ITK_WRAP_PYTHON})
+  include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKSetPython3Vars.cmake)
 
   if(ITK_WRAP_PYTHON AND Python3_VERSION VERSION_LESS 3.5)
     message(FATAL_ERROR "Python versions less than 3.5 are not supported for wrapping. Python version: \"${Python3_VERSION}\".")


### PR DESCRIPTION
The code needed to find python3 packages has been consolidated
so that it may be reused for external modules.

This attempts to address the issues identified in #1700 by re-using a previous paradigm for the case of external module dependency on python.

@SimonRit This solution has not been tested with RTK

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
