### PR TITLE
DOC: Remove FindPython3 robust remark

### DIFF
--- a/CMake/ITKSetPython3Vars.cmake
+++ b/CMake/ITKSetPython3Vars.cmake
@@ -5,7 +5,6 @@
 # If the cmake variable "PYTHON_DEVELOPMENT_REQUIRED" is set to ON
 # then the development environments are found.
 
-# Prefer to use more robust FindPython3 module if greater than cmake 3.12.0
 if("${CMAKE_VERSION}" VERSION_LESS_EQUAL "3.12.0")
   # Use of PythonInterp and PythonLibs is deprecated since cmake version 3.12.0
   # Only use deprecated mechanisms for older versions of cmake


### PR DESCRIPTION
The FindPython3 module has required half a dozen work arounds for broken
behavior and is still causing a failing Windows CI build.
