### PR TITLE
Macro ignore extra semi colon and use anonymous exception passing

### DIFF
--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -256,15 +256,16 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Ge
         output->GetIndex(run, hIndex);
         output->IncreaseFrequencyOfIndex(hIndex, 1);
 
-        itkDebugStatement(typename HistogramType::IndexType tempMeasurementIndex;)
-          itkDebugStatement(output->GetIndex(run, tempMeasurementIndex);) itkDebugMacro(
-            "centerIndex<->index: " << static_cast<int>(centerPixelIntensity) << "@" << centerIndex << "<->"
-                                    << static_cast<int>(pixelIntensity) << "@" << index << ", Bin# "
-                                    << tempMeasurementIndex << ", Measurement: (" << run[0] << ", " << run[1] << ")"
-                                    << ", Center bin [" << this->GetOutput()->GetBinMinFromValue(0, run[0]) << ","
-                                    << this->GetOutput()->GetBinMaxFromValue(0, run[0]) << "]"
-                                    << "~[" << this->GetOutput()->GetBinMinFromValue(1, run[1]) << ","
-                                    << this->GetOutput()->GetBinMaxFromValue(1, run[1]) << "]" << std::endl);
+        itkDebugStatement(typename HistogramType::IndexType tempMeasurementIndex);
+        itkDebugStatement(output->GetIndex(run, tempMeasurementIndex));
+        itkDebugMacro("centerIndex<->index: " << static_cast<int>(centerPixelIntensity) << "@" << centerIndex << "<->"
+                                              << static_cast<int>(pixelIntensity) << "@" << index << ", Bin# "
+                                              << tempMeasurementIndex << ", Measurement: (" << run[0] << ", " << run[1]
+                                              << ")"
+                                              << ", Center bin [" << this->GetOutput()->GetBinMinFromValue(0, run[0])
+                                              << "," << this->GetOutput()->GetBinMaxFromValue(0, run[0]) << "]"
+                                              << "~[" << this->GetOutput()->GetBinMinFromValue(1, run[1]) << ","
+                                              << this->GetOutput()->GetBinMaxFromValue(1, run[1]) << "]" << std::endl);
       }
     }
   }

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -440,10 +440,10 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     fixedCentered.Fill(0.0);
     movingCentered.Fill(0.0);
 
-    itkDebugStatement(int ii = 0;)
+    itkDebugStatement(int ii = 0);
 
-      // Computations are relative to the Center of Rotation.
-      while (movingItr != m_MovingLandmarks.end())
+    // Computations are relative to the Center of Rotation.
+    while (movingItr != m_MovingLandmarks.end())
     {
       for (unsigned int i = 0; i < ImageDimension; i++)
       {
@@ -460,7 +460,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
         }
       }
 
-      itkDebugStatement(++ii;) itkDebugMacro(<< "f_" << ii << " = " << fixedCentered);
+      itkDebugStatement(++ii);
+      itkDebugMacro(<< "f_" << ii << " = " << fixedCentered);
       itkDebugMacro(<< "m_" << ii << " = " << movingCentered);
 
       ++movingItr;
@@ -613,8 +614,9 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     fixedCentered.Fill(0.0);
     movingCentered.Fill(0.0);
 
-    itkDebugStatement(int ii = 0;) double s_dot = 0;
-    double                                s_cross = 0;
+    itkDebugStatement(int ii = 0);
+    double s_dot = 0;
+    double s_cross = 0;
     // Computations are relative to the Center of Rotation.
     while (movingItr != m_MovingLandmarks.end())
     {
@@ -626,7 +628,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
       s_dot += (movingCentered[0] * fixedCentered[0]) + (movingCentered[1] * fixedCentered[1]);
       s_cross += (movingCentered[1] * fixedCentered[0]) - (movingCentered[0] * fixedCentered[1]);
 
-      itkDebugStatement(++ii;) itkDebugMacro(<< "f_" << ii << " = " << fixedCentered);
+      itkDebugStatement(++ii);
+      itkDebugMacro(<< "f_" << ii << " = " << fixedCentered);
       itkDebugMacro(<< "m_" << ii << " = " << movingCentered);
 
       ++movingItr;


### PR DESCRIPTION
Update exception macros to use anonymous exceptions for clang.