### PR TITLE
ENH: Fix anonymous exception passing

### DIFF
--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -48,6 +48,7 @@ namespace itk
 class ITKCommon_EXPORT ExceptionObject : public std::exception
 {
 public:
+  static constexpr const char * const default_exception_message = "Generic ExceptionObject";
   using Superclass = std::exception;
   /** Various types of constructors.  Note that these functions will be
    * called when children are instantiated.  The default constructor and
@@ -57,10 +58,10 @@ public:
                            unsigned int lineNumber = 0,
                            const char * desc = "None",
                            const char * loc = "Unknown");
-  explicit ExceptionObject(const std::string & file,
-                           unsigned int        lineNumber = 0,
-                           const std::string & desc = "None",
-                           const std::string & loc = "Unknown");
+  explicit ExceptionObject(std::string  file,
+                           unsigned int lineNumber = 0,
+                           std::string  desc = "None",
+                           std::string  loc = "Unknown");
   ExceptionObject(const ExceptionObject & orig) noexcept;
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -152,7 +152,7 @@ Int2EigenValueOrderEnum(const uint8_t value)
     default:
       break;
   }
-  itkGenericExceptionMacro(<< "Error: Invalid value for conversion.")
+  itkGenericExceptionMacro(<< "Error: Invalid value for conversion.");
 }
 
 #if !defined(ITK_LEGACY_REMOVE)

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -137,11 +137,9 @@ ExceptionObject::ExceptionObject(const char * file, unsigned int lineNumber, con
                                                             loc == nullptr ? "" : loc))
 {}
 
-ExceptionObject::ExceptionObject(const std::string & file,
-                                 unsigned int        lineNumber,
-                                 const std::string & desc,
-                                 const std::string & loc)
-  : m_ExceptionData(ReferenceCountedExceptionData::ConstNew(file, lineNumber, desc, loc))
+ExceptionObject::ExceptionObject(std::string file, unsigned int lineNumber, std::string desc, std::string loc)
+  : m_ExceptionData(
+      ReferenceCountedExceptionData::ConstNew(std::move(file), lineNumber, std::move(desc), std::move(loc)))
 {}
 
 ExceptionObject::ExceptionObject(const ExceptionObject & orig) noexcept

--- a/Modules/Video/IO/src/itkVideoIOFactory.cxx
+++ b/Modules/Video/IO/src/itkVideoIOFactory.cxx
@@ -38,9 +38,7 @@ VideoIOFactory::CreateVideoIO(IOModeEnum mode, const char * arg)
     }
     else
     {
-      itkSpecializedMessageExceptionMacro(ExceptionObject,
-                                          "VideoIO factory did not return "
-                                          "a VideoIOBase");
+      itkGenericExceptionMacro("VideoIO factory did not return a VideoIOBase");
     }
   }
 


### PR DESCRIPTION
https://stackoverflow.com/questions/53412425/throw-temporary-instead-of-local-variable-why

Fix warning about exception passing by named
values.  Make the derived exceptions have similar
interface to ExceptionObject.  Consolidate duplicated
code.  Prefer move semantics for constructors for
added efficiency.
