### PR TITLE
COMP: non-C-compatible type given name for linkage

### DIFF
--- a/Modules/Core/Common/test/itkTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkTimeStampTest.cxx
@@ -24,7 +24,7 @@
 // A helper struct for the test, the idea is to have one timestamp per thread.
 // To ease the writing of the test, we use  MultiThreaderBase::SingleMethodExecute
 // with an array of timestamps in the shared data
-using TimeStampTestHelper = struct
+using TimeStampTestHelper = struct TimeStampTestHelperStruct
 {
   std::vector<itk::TimeStamp> timestamps;
   std::vector<unsigned long>  counters;


### PR DESCRIPTION
Resolves #1711

ITK/Modules/Core/Common/test/itkTimeStampTest.cxx:27:35: warning:
anonymous non-C-compatible type given name for linkage purposes by alias
declaration; add a tag name here [-Wnon-c-typedef-for-linkage] using

TimeStampTestHelper = struct
                           ^
                            TimeStampTestHelper

Due to a recent (but retroactive) C++ rule change, only sufficiently
C-compatible classes are permitted to be given a typedef name for
linkage purposes. Add an enabled-by-default warning for these cases, and
rephrase existing error for the case where we encounter the typedef
name for linkage after we've already computed and used a wrong linkage
in terms of the new rule.
