### PR TITLE
BUG: Have a single histogram threshold calculator for intermodes threshold

### DIFF
--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
@@ -17,132 +17,39 @@
  *=========================================================================*/
 #ifndef itkHistogramThresholdImageFilter_hxx
 #define itkHistogramThresholdImageFilter_hxx
-#include "itkHistogramThresholdImageFilter.h"
 
-#include "itkImageToHistogramFilter.h"
-#include "itkMaskedImageToHistogramFilter.h"
-#include "itkBinaryThresholdImageFilter.h"
-#include "itkMaskImageFilter.h"
-#include "itkProgressAccumulator.h"
+#include "itkHistogramThresholdImageFilter.h"
 
 namespace itk
 {
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage>
 HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::HistogramThresholdImageFilter()
-  : m_InsideValue(NumericTraits<OutputPixelType>::max())
-  , m_OutsideValue(NumericTraits<OutputPixelType>::ZeroValue())
-  , m_Threshold(NumericTraits<InputPixelType>::ZeroValue())
-  , m_MaskValue(NumericTraits<MaskPixelType>::max())
+{}
 
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+typename HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::CalculatorType *
+HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::GetCalculator()
 {
-  this->SetNumberOfRequiredOutputs(1);
-
-  // implicit:
-  // #0 "Primary" required
-
-  // #1 "MaskImage" optional
-  Self::AddOptionalInputName("MaskImage", 1);
-
-  if (typeid(ValueType) == typeid(signed char) || typeid(ValueType) == typeid(unsigned char) ||
-      typeid(ValueType) == typeid(char))
-  {
-    m_AutoMinimumMaximum = false;
-  }
-  else
-  {
-    m_AutoMinimumMaximum = true;
-  }
+  return m_Calculator;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::GenerateData()
+HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::SetCalculator(CalculatorType * calculator)
 {
+  m_Calculator = calculator;
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::VerifyPreconditions() ITKv5_CONST
+{
+  Superclass::VerifyPreconditions();
+
   if (m_Calculator.IsNull())
   {
     itkExceptionMacro(<< "No threshold calculator set.");
-  }
-  typename ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
-  progress->SetMiniPipelineFilter(this);
-
-  using HistogramGeneratorType = itk::Statistics::ImageToHistogramFilter<InputImageType>;
-  typename HistogramGeneratorType::Pointer histogramGenerator = HistogramGeneratorType::New();
-
-  using MaskedHistogramGeneratorType = itk::Statistics::MaskedImageToHistogramFilter<InputImageType, MaskImageType>;
-  typename MaskedHistogramGeneratorType::Pointer maskedhistogramGenerator = MaskedHistogramGeneratorType::New();
-
-  if (this->GetMaskImage())
-  {
-    maskedhistogramGenerator->SetInput(this->GetInput());
-    maskedhistogramGenerator->SetMaskImage(this->GetMaskImage());
-    maskedhistogramGenerator->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
-    typename HistogramType::SizeType hsize(this->GetInput()->GetNumberOfComponentsPerPixel());
-    hsize.Fill(this->GetNumberOfHistogramBins());
-    maskedhistogramGenerator->SetHistogramSize(hsize);
-    maskedhistogramGenerator->SetAutoMinimumMaximum(this->GetAutoMinimumMaximum());
-    maskedhistogramGenerator->SetMaskValue(this->GetMaskValue());
-    progress->RegisterInternalFilter(maskedhistogramGenerator, .4f);
-
-    m_Calculator->SetInput(maskedhistogramGenerator->GetOutput());
-    m_Calculator->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
-  }
-  else
-  {
-    histogramGenerator->SetInput(this->GetInput());
-    histogramGenerator->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
-    typename HistogramType::SizeType hsize(this->GetInput()->GetNumberOfComponentsPerPixel());
-    hsize.Fill(this->GetNumberOfHistogramBins());
-    histogramGenerator->SetHistogramSize(hsize);
-    histogramGenerator->SetAutoMinimumMaximum(this->GetAutoMinimumMaximum());
-    progress->RegisterInternalFilter(histogramGenerator, .4f);
-
-    m_Calculator->SetInput(histogramGenerator->GetOutput());
-    m_Calculator->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
-  }
-  progress->RegisterInternalFilter(m_Calculator, .2f);
-
-  using ThresholderType = BinaryThresholdImageFilter<TInputImage, TOutputImage>;
-  typename ThresholderType::Pointer thresholder = ThresholderType::New();
-  thresholder->SetInput(this->GetInput());
-  thresholder->SetLowerThreshold(NumericTraits<InputPixelType>::NonpositiveMin());
-  thresholder->SetUpperThresholdInput(m_Calculator->GetOutput());
-  thresholder->SetInsideValue(this->GetInsideValue());
-  thresholder->SetOutsideValue(this->GetOutsideValue());
-  thresholder->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
-  progress->RegisterInternalFilter(thresholder, .4f);
-
-  using MaskType = MaskImageFilter<TOutputImage, TMaskImage>;
-  typename MaskType::Pointer masker = MaskType::New();
-
-  if ((this->GetMaskOutput()) && (this->GetMaskImage()))
-  {
-    masker->SetInput(thresholder->GetOutput());
-    masker->SetInput2(this->GetMaskImage());
-    masker->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
-    progress->RegisterInternalFilter(masker, .4f);
-    masker->GraftOutput(this->GetOutput());
-    masker->Update();
-    this->GraftOutput(masker->GetOutput());
-  }
-  else
-  {
-    thresholder->GraftOutput(this->GetOutput());
-    thresholder->Update();
-    this->GraftOutput(thresholder->GetOutput());
-  }
-  m_Threshold = m_Calculator->GetThreshold();
-  m_Calculator->SetInput(nullptr);
-}
-
-template <typename TInputImage, typename TOutputImage, typename TMaskImage>
-void
-HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::GenerateInputRequestedRegion()
-{
-  auto * input = const_cast<TInputImage *>(this->GetInput());
-  if (input)
-  {
-    input->SetRequestedRegionToLargestPossibleRegion();
   }
 }
 
@@ -152,19 +59,8 @@ HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::PrintSelf(
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
-     << std::endl;
-  os << indent << "InsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_InsideValue)
-     << std::endl;
-  os << indent
-     << "Threshold (computed): " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold)
-     << std::endl;
-  os << indent << "MaskValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_MaskValue)
-     << std::endl;
   itkPrintSelfObjectMacro(Calculator);
-  os << indent << "NumberOfHistogramBins: " << m_NumberOfHistogramBins << std::endl;
-  os << indent << "AutoMinimumMaximm: " << m_AutoMinimumMaximum << std::endl;
-  os << indent << "MaskOutput: " << m_MaskOutput << std::endl;
 }
+
 } // end namespace itk
 #endif

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilterBase.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilterBase.h
@@ -1,0 +1,216 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkHistogramThresholdImageFilterBase_h
+#define itkHistogramThresholdImageFilterBase_h
+
+#include "itkImageToImageFilter.h"
+#include "itkHistogram.h"
+#include "itkHistogramThresholdCalculator.h"
+
+namespace itk
+{
+
+/**
+ *\class HistogramThresholdImageFilterBase
+ * \brief Base class for histogram threshold image filters.
+ *
+ * This filter creates a binary thresholded image that separates an
+ * image into foreground and background components.
+ *
+ * The filter also has the option of providing a mask, in which case
+ * the histogram and therefore the threshold is computed from the
+ * parts of the mask with values indicated by MaskValue. The output
+ * image is, by default, masked by the same image. This output
+ * masking can be disabled using SetMaskOutput(false). Note that there
+ * is an inconsistency here. The MaskImageFilter (used internally)
+ * masks by non zero values, where as the MaskedImageToHistogramFilter
+ * uses explicit values. If this does not match your usage then the
+ * output masking will need to be managed by the user.
+ *
+ * \author Richard Beare. Department of Medicine, Monash University,
+ * Melbourne, Australia.
+ * \author Gaetan Lehmann. Biologie du Developpement et de la Reproduction, INRA de Jouy-en-Josas, France.
+ *
+ * This implementation was taken from the Insight Journal paper:
+ * https://hdl.handle.net/10380/3279  or
+ * http://www.insight-journal.org/browse/publication/811
+ *
+ * \ingroup Multithreaded
+ * \ingroup ITKThresholding
+ */
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
+class ITK_TEMPLATE_EXPORT HistogramThresholdImageFilterBase : public ImageToImageFilter<TInputImage, TOutputImage>
+{
+public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(HistogramThresholdImageFilterBase);
+
+  /** Standard Self type alias */
+  using Self = HistogramThresholdImageFilterBase;
+  using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Runtime information support. */
+  itkTypeMacro(HistogramThresholdImageFilterBase, ImageToImageFilter);
+
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using MaskImageType = TMaskImage;
+
+  /** Image pixel value type alias. */
+  using InputPixelType = typename InputImageType::PixelType;
+  using OutputPixelType = typename OutputImageType::PixelType;
+  using MaskPixelType = typename MaskImageType::PixelType;
+
+  /** Image related type alias. */
+  using InputImagePointer = typename InputImageType::Pointer;
+  using OutputImagePointer = typename OutputImageType::Pointer;
+  using MaskImagePointer = typename MaskImageType::Pointer;
+
+  using InputSizeType = typename InputImageType::SizeType;
+  using InputIndexType = typename InputImageType::IndexType;
+  using InputImageRegionType = typename InputImageType::RegionType;
+  using OutputSizeType = typename OutputImageType::SizeType;
+  using OutputIndexType = typename OutputImageType::IndexType;
+  using OutputImageRegionType = typename OutputImageType::RegionType;
+  using MaskSizeType = typename MaskImageType::SizeType;
+  using MaskIndexType = typename MaskImageType::IndexType;
+  using MaskImageRegionType = typename MaskImageType::RegionType;
+
+  using ValueType = typename NumericTraits<InputPixelType>::ValueType;
+  using ValueRealType = typename NumericTraits<ValueType>::RealType;
+  using HistogramType = Statistics::Histogram<ValueRealType>;
+  using HistogramPointer = typename HistogramType::Pointer;
+  using HistogramConstPointer = typename HistogramType::ConstPointer;
+  using HistogramSizeType = typename HistogramType::SizeType;
+  using HistogramMeasurementType = typename HistogramType::MeasurementType;
+  using HistogramMeasurementVectorType = typename HistogramType::MeasurementVectorType;
+
+  using CalculatorType = HistogramThresholdCalculator<HistogramType, InputPixelType>;
+  using CalculatorPointer = typename CalculatorType::Pointer;
+
+  /** Image related type alias. */
+  static constexpr unsigned int InputImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = OutputImageType::ImageDimension;
+  static constexpr unsigned int MaskImageDimension = MaskImageType::ImageDimension;
+
+  /** Set and Get the mask image */
+  itkSetInputMacro(MaskImage, TMaskImage);
+  itkGetInputMacro(MaskImage, TMaskImage);
+
+  /** Set the input image */
+  void
+  SetInput1(const TInputImage * input)
+  {
+    this->SetInput(input);
+  }
+
+  /** Set the marker image */
+  void
+  SetInput2(const TMaskImage * input)
+  {
+    this->SetMaskImage(input);
+  }
+
+  /** Set the "outside" pixel value. The default value
+   * NumericTraits<OutputPixelType>::ZeroValue(). */
+  itkSetMacro(OutsideValue, OutputPixelType);
+
+  /** Get the "outside" pixel value. */
+  itkGetConstMacro(OutsideValue, OutputPixelType);
+
+  /** Set the "inside" pixel value. The default value
+   * NumericTraits<OutputPixelType>::max() */
+  itkSetMacro(InsideValue, OutputPixelType);
+
+  /** Get the "inside" pixel value. */
+  itkGetConstMacro(InsideValue, OutputPixelType);
+
+  /** Set the number of histogram bins */
+  itkSetMacro(NumberOfHistogramBins, unsigned int);
+  itkGetConstMacro(NumberOfHistogramBins, unsigned int);
+
+  /** Does histogram generator compute min and max from data?
+   * Default is true for all but char types */
+  itkSetMacro(AutoMinimumMaximum, bool);
+  itkGetConstMacro(AutoMinimumMaximum, bool);
+  itkBooleanMacro(AutoMinimumMaximum);
+
+  /** Do you want the output to be masked by the mask used in
+   * histogram construction. Only relevant if masking is in
+   * use. Default is true. */
+  itkSetMacro(MaskOutput, bool);
+  itkGetConstMacro(MaskOutput, bool);
+  itkBooleanMacro(MaskOutput);
+
+  /** The value in the mask image, if used, indicating voxels that
+  should be included. Default is the max of pixel type, as in the
+  MaskedImageToHistogramFilter */
+  itkSetMacro(MaskValue, MaskPixelType);
+  itkGetConstMacro(MaskValue, MaskPixelType);
+
+  /** Get the computed threshold. */
+  itkGetConstMacro(Threshold, InputPixelType);
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  // Begin concept checking
+  itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputPixelType>));
+  itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputPixelType>));
+  itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
+  // End concept checking
+#endif
+
+  /** Set/Get the calculator to use to compute the threshold */
+  virtual void
+  SetCalculator(CalculatorType *){};
+  virtual CalculatorType *
+  GetCalculator()
+  {
+    return nullptr;
+  };
+
+protected:
+  HistogramThresholdImageFilterBase();
+  ~HistogramThresholdImageFilterBase() override = default;
+
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+
+  void
+  GenerateInputRequestedRegion() override;
+  virtual void
+  GenerateData() override;
+
+  OutputPixelType m_InsideValue;
+  OutputPixelType m_OutsideValue;
+  InputPixelType  m_Threshold;
+  MaskPixelType   m_MaskValue;
+  unsigned        m_NumberOfHistogramBins{ 256 };
+  bool            m_AutoMinimumMaximum;
+  bool            m_MaskOutput{ true };
+};
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "itkHistogramThresholdImageFilterBase.hxx"
+#endif
+
+#endif

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilterBase.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilterBase.hxx
@@ -1,0 +1,168 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkHistogramThresholdImageFilterBase_hxx
+#define itkHistogramThresholdImageFilterBase_hxx
+
+#include "itkHistogramThresholdImageFilterBase.h"
+#include "itkMaskedImageToHistogramFilter.h"
+#include "itkBinaryThresholdImageFilter.h"
+#include "itkMaskImageFilter.h"
+#include "itkProgressAccumulator.h"
+
+namespace itk
+{
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+HistogramThresholdImageFilterBase<TInputImage, TOutputImage, TMaskImage>::HistogramThresholdImageFilterBase()
+  : m_InsideValue(NumericTraits<OutputPixelType>::max())
+  , m_OutsideValue(NumericTraits<OutputPixelType>::ZeroValue())
+  , m_Threshold(NumericTraits<InputPixelType>::ZeroValue())
+  , m_MaskValue(NumericTraits<MaskPixelType>::max())
+
+{
+  this->SetNumberOfRequiredOutputs(1);
+
+  // implicit:
+  // #0 "Primary" required
+
+  // #1 "MaskImage" optional
+  Self::AddOptionalInputName("MaskImage", 1);
+
+  if (typeid(ValueType) == typeid(signed char) || typeid(ValueType) == typeid(unsigned char) ||
+      typeid(ValueType) == typeid(char))
+  {
+    m_AutoMinimumMaximum = false;
+  }
+  else
+  {
+    m_AutoMinimumMaximum = true;
+  }
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+HistogramThresholdImageFilterBase<TInputImage, TOutputImage, TMaskImage>::GenerateInputRequestedRegion()
+{
+  auto * input = const_cast<TInputImage *>(this->GetInput());
+  if (input)
+  {
+    input->SetRequestedRegionToLargestPossibleRegion();
+  }
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+HistogramThresholdImageFilterBase<TInputImage, TOutputImage, TMaskImage>::GenerateData()
+{
+  CalculatorPointer calculator = this->GetCalculator();
+
+  typename ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
+  progress->SetMiniPipelineFilter(this);
+
+  using HistogramGeneratorType = itk::Statistics::ImageToHistogramFilter<InputImageType>;
+  typename HistogramGeneratorType::Pointer histogramGenerator = HistogramGeneratorType::New();
+
+  using MaskedHistogramGeneratorType = itk::Statistics::MaskedImageToHistogramFilter<InputImageType, MaskImageType>;
+  typename MaskedHistogramGeneratorType::Pointer maskedhistogramGenerator = MaskedHistogramGeneratorType::New();
+
+  typename HistogramType::SizeType hsize(this->GetInput()->GetNumberOfComponentsPerPixel());
+  hsize.Fill(this->GetNumberOfHistogramBins());
+
+  if (this->GetMaskImage())
+  {
+    maskedhistogramGenerator->SetInput(this->GetInput());
+    maskedhistogramGenerator->SetMaskImage(this->GetMaskImage());
+    maskedhistogramGenerator->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
+    maskedhistogramGenerator->SetHistogramSize(hsize);
+    maskedhistogramGenerator->SetAutoMinimumMaximum(this->GetAutoMinimumMaximum());
+    maskedhistogramGenerator->SetMaskValue(this->GetMaskValue());
+
+    progress->RegisterInternalFilter(maskedhistogramGenerator, .4f);
+
+    calculator->SetInput(maskedhistogramGenerator->GetOutput());
+  }
+  else
+  {
+    histogramGenerator->SetInput(this->GetInput());
+    histogramGenerator->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
+    histogramGenerator->SetHistogramSize(hsize);
+    histogramGenerator->SetAutoMinimumMaximum(this->GetAutoMinimumMaximum());
+
+    progress->RegisterInternalFilter(histogramGenerator, .4f);
+
+    calculator->SetInput(histogramGenerator->GetOutput());
+  }
+
+  calculator->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
+  progress->RegisterInternalFilter(calculator, .2f);
+
+  using ThresholderType = BinaryThresholdImageFilter<InputImageType, OutputImageType>;
+  typename ThresholderType::Pointer thresholder = ThresholderType::New();
+  thresholder->SetInput(this->GetInput());
+  thresholder->SetLowerThreshold(NumericTraits<InputPixelType>::NonpositiveMin());
+  thresholder->SetUpperThresholdInput(calculator->GetOutput());
+  thresholder->SetInsideValue(this->GetInsideValue());
+  thresholder->SetOutsideValue(this->GetOutsideValue());
+  thresholder->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
+  progress->RegisterInternalFilter(thresholder, .4f);
+
+  using MaskType = MaskImageFilter<OutputImageType, MaskImageType>;
+  typename MaskType::Pointer masker = MaskType::New();
+
+  if ((this->GetMaskOutput()) && (this->GetMaskImage()))
+  {
+    masker->SetInput(thresholder->GetOutput());
+    masker->SetInput2(this->GetMaskImage());
+    masker->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
+    progress->RegisterInternalFilter(masker, .4f);
+    masker->GraftOutput(this->GetOutput());
+    masker->Update();
+    this->GraftOutput(masker->GetOutput());
+  }
+  else
+  {
+    thresholder->GraftOutput(this->GetOutput());
+    thresholder->Update();
+    this->GraftOutput(thresholder->GetOutput());
+  }
+  this->m_Threshold = calculator->GetThreshold();
+  calculator->SetInput(nullptr);
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+HistogramThresholdImageFilterBase<TInputImage, TOutputImage, TMaskImage>::PrintSelf(std::ostream & os,
+                                                                                    Indent         indent) const
+{
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
+     << std::endl;
+  os << indent << "InsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_InsideValue)
+     << std::endl;
+  os << indent
+     << "Threshold (computed): " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold)
+     << std::endl;
+  os << indent << "MaskValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_MaskValue)
+     << std::endl;
+  os << indent << "NumberOfHistogramBins: " << m_NumberOfHistogramBins << std::endl;
+  os << indent << "AutoMinimumMaximm: " << m_AutoMinimumMaximum << std::endl;
+  os << indent << "MaskOutput: " << m_MaskOutput << std::endl;
+}
+} // end namespace itk
+#endif

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.hxx
@@ -1,0 +1,100 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkIntermodesThresholdImageFilter_hxx
+#define itkIntermodesThresholdImageFilter_hxx
+
+#include "itkIntermodesThresholdImageFilter.h"
+
+namespace itk
+{
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::IntermodesThresholdImageFilter()
+{
+  m_Calculator = IntermodesCalculatorType::New();
+  this->SetCalculator(m_Calculator);
+  m_Calculator->SetMaximumSmoothingIterations(10000);
+  m_Calculator->SetUseInterMode(true);
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::SetMaximumSmoothingIterations(
+  SizeValueType maxSmoothingIterations)
+{
+  m_Calculator->SetMaximumSmoothingIterations(maxSmoothingIterations);
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+SizeValueType
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::GetMaximumSmoothingIterations()
+{
+  return m_Calculator->GetMaximumSmoothingIterations();
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::SetUseInterMode(bool useIntermode)
+{
+  m_Calculator->SetUseInterMode(useIntermode);
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+bool
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::GetUseInterMode()
+{
+  return m_Calculator->GetUseInterMode();
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+typename IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::CalculatorType *
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::GetCalculator()
+{
+  return dynamic_cast<CalculatorType *>(m_Calculator.GetPointer());
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::SetCalculator(CalculatorType * calculator)
+{
+  m_Calculator = dynamic_cast<IntermodesCalculatorType *>(calculator);
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::VerifyPreconditions() ITKv5_CONST
+{
+  Superclass::VerifyPreconditions();
+
+  if (m_Calculator.IsNull())
+  {
+    itkExceptionMacro(<< "No threshold calculator set.");
+  }
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+void
+IntermodesThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+
+  itkPrintSelfObjectMacro(Calculator);
+}
+
+} // end namespace itk
+#endif

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -113,7 +113,7 @@ protected:
   void
   GenerateData() override
   {
-    auto calc = static_cast<CalculatorType *>(this->GetModifiableCalculator());
+    auto calc = static_cast<CalculatorType *>(this->GetCalculator());
     calc->SetReturnBinMidpoint(m_ReturnBinMidpoint);
     this->Superclass::GenerateData();
   }

--- a/Modules/Filtering/Thresholding/wrapping/itkHistogramThresholdImageFilterBase.wrap
+++ b/Modules/Filtering/Thresholding/wrapping/itkHistogramThresholdImageFilterBase.wrap
@@ -1,0 +1,3 @@
+itk_wrap_class("itk::HistogramThresholdImageFilterBase" POINTER)
+  itk_wrap_image_filter_combinations("${WRAP_ITK_SCALAR}" "${WRAP_ITK_INT}")
+itk_end_wrap_class()


### PR DESCRIPTION
Fix the threshold calculator inheritance issue in
`itk::IntermodesThresholdImageFilter` by having a single histogram
threshold calculator variable.

The class was declaring a histogram threshold calculator under the
`m_IntermodesCalculator` ivar, which was of type
`itk::IntermodesThresholdCalculator` type. At the same time, the class was
inheriting from `itk::HistogramThresholdImageFilter`, which was declaring
its own histogram threshod calculator `m_Calculator`, which was of type
`itk::HistogramThredholdCalculator`.

This was making the `itk::IntermodesThresholdImageFilter` objects to have
two histogram calculator instances, and given that the `GenerateData`
method was implemented in the parent class
(`itk::HistogramThresholdImageFilter`) and making use of the
`m_Calculator` ivar, this was yielding a runtime error.

Fixes the runtime exception error mentoned in [this
comment](https://github.com/InsightSoftwareConsortium/ITK/pull/511#issuecomment-497877457).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)
