### PR TITLE
BUG: Fix threshold variable type/value in histogram threshold calc classes

### DIFF
--- a/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdCalculator.hxx
@@ -44,17 +44,17 @@ MaximumEntropyThresholdCalculator<THistogram, TOutput>::GenerateData()
 
   unsigned int size = histogram->GetSize(0);
 
-  int                 threshold = -1;
-  int                 ih, it;
-  int                 first_bin;
-  int                 last_bin;
-  double              tot_ent;          // total entropy
-  double              max_ent;          // max entropy
-  double              ent_back;         // entropy of the background pixels at a given threshold
-  double              ent_obj;          // entropy of the object pixels at a given threshold
-  std::vector<double> norm_histo(size); // normalized histogram
-  std::vector<double> P1(size);         // cumulative normalized histogram
-  std::vector<double> P2(size);
+  typename HistogramType::InstanceIdentifier threshold = 0;
+  int                                        ih, it;
+  int                                        first_bin;
+  int                                        last_bin;
+  double                                     tot_ent;          // total entropy
+  double                                     max_ent;          // max entropy
+  double                                     ent_back;         // entropy of the background pixels at a given threshold
+  double                                     ent_obj;          // entropy of the object pixels at a given threshold
+  std::vector<double>                        norm_histo(size); // normalized histogram
+  std::vector<double>                        P1(size);         // cumulative normalized histogram
+  std::vector<double>                        P2(size);
 
   const double tolerance = itk::NumericTraits<double>::epsilon();
 

--- a/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.hxx
@@ -44,10 +44,10 @@ MomentsThresholdCalculator<THistogram, TOutput>::GenerateData()
 
   unsigned int size = histogram->GetSize(0);
 
-  double total = histogram->GetTotalFrequency();
-  double m0 = 1.0, m1 = 0.0, m2 = 0.0, m3 = 0.0, sum = 0.0, p0 = 0.0;
-  double cd, c0, c1, z0, z1; // auxiliary variables
-  int    threshold = -1;
+  double                                     total = histogram->GetTotalFrequency();
+  double                                     m0 = 1.0, m1 = 0.0, m2 = 0.0, m3 = 0.0, sum = 0.0, p0 = 0.0;
+  double                                     cd, c0, c1, z0, z1; // auxiliary variables
+  typename HistogramType::InstanceIdentifier threshold = 0;
 
   std::vector<double> histo(size);
   for (unsigned i = 0; i < size; i++)

--- a/Modules/Filtering/Thresholding/include/itkShanbhagThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkShanbhagThresholdCalculator.hxx
@@ -44,19 +44,19 @@ ShanbhagThresholdCalculator<THistogram, TOutput>::GenerateData()
 
   unsigned int size = histogram->GetSize(0);
 
-  const double        tolerance = 2.220446049250313E-16;
-  int                 threshold;
-  int                 ih, it;
-  int                 first_bin;
-  int                 last_bin;
-  double              term;
-  double              tot_ent;          // total entropy
-  double              min_ent;          // max entropy
-  double              ent_back;         // entropy of the background pixels at a given threshold
-  double              ent_obj;          // entropy of the object pixels at a given threshold
-  std::vector<double> norm_histo(size); // normalized histogram
-  std::vector<double> P1(size);         // cumulative normalized histogram
-  std::vector<double> P2(size);
+  const double                               tolerance = 2.220446049250313E-16;
+  typename HistogramType::InstanceIdentifier threshold = 0;
+  int                                        ih, it;
+  int                                        first_bin;
+  int                                        last_bin;
+  double                                     term;
+  double                                     tot_ent;          // total entropy
+  double                                     min_ent;          // max entropy
+  double                                     ent_back;         // entropy of the background pixels at a given threshold
+  double                                     ent_obj;          // entropy of the object pixels at a given threshold
+  std::vector<double>                        norm_histo(size); // normalized histogram
+  std::vector<double>                        P1(size);         // cumulative normalized histogram
+  std::vector<double>                        P2(size);
 
   int total = histogram->GetTotalFrequency();
 
@@ -97,7 +97,6 @@ ShanbhagThresholdCalculator<THistogram, TOutput>::GenerateData()
 
   // Calculate the total entropy each gray-level and find the threshold that
   // maximizes it
-  threshold = -1;
   min_ent = itk::NumericTraits<double>::max();
 
   for (it = first_bin; it <= last_bin; it++)

--- a/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.hxx
@@ -44,14 +44,14 @@ YenThresholdCalculator<THistogram, TOutput>::GenerateData()
 
   unsigned int size = histogram->GetSize(0);
 
-  int                 threshold;
-  int                 ih, it;
-  double              crit;
-  double              max_crit;
-  std::vector<double> norm_histo(size); // normalized histogram
-  std::vector<double> P1(size);         // cumulative normalized histogram
-  std::vector<double> P1_sq(size);
-  std::vector<double> P2_sq(size);
+  typename HistogramType::InstanceIdentifier threshold = 0;
+  int                                        ih, it;
+  double                                     crit;
+  double                                     max_crit;
+  std::vector<double>                        norm_histo(size); // normalized histogram
+  std::vector<double>                        P1(size);         // cumulative normalized histogram
+  std::vector<double>                        P1_sq(size);
+  std::vector<double>                        P2_sq(size);
 
   int total = histogram->GetTotalFrequency();
 
@@ -79,7 +79,6 @@ YenThresholdCalculator<THistogram, TOutput>::GenerateData()
   }
 
   // Find the threshold that maximizes the criterion
-  threshold = -1;
   max_crit = itk::NumericTraits<double>::NonpositiveMin();
   for (it = 0; (unsigned)it < size; it++)
   {


### PR DESCRIPTION
Fix `threshold` local variable type and default to a zero value in
histogram threshold calculator classes.

Also, assign the default value when the variable is declared.

Fixes the runtime exception error mentioned in [this
comment](https://github.com/InsightSoftwareConsortium/ITK/pull/511#issuecomment-496063122)
and [this other
one](https://github.com/InsightSoftwareConsortium/ITK/pull/511#issuecomment-601404461).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)