### PR TITLE
ENH: Add Label PR GitHub Action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+type:Compiler:
+    title: "^COMP:.*"
+
+type:Bug:
+    title: "^BUG:.*"
+
+area:Documentation:
+    title: "^DOC:.*"
+
+type:Enhancement:
+    title: "^ENH:.*"
+
+type:Performance:
+    title: "^PERF:.*"
+
+type:Style:
+    title: "^STYLE:.*"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,13 @@
+name: Label PRs
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: srvaroa/labeler@master
+      env:
+            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Applies a PR based the title prefix, which defaults to the commit prefix
for single-commit topics.

Closes #60

Note: this will be currently limited to PR's created from `InsightSoftwareConsortium/ITK` branches (requires repository write permission) per:

- https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token
- https://github.com/actions/labeler/issues/12

We could experiment with developers with write access creating PR's from the ITK repository.