### PR TITLE
COMP: Add ITK patches for DCMTK

### DIFF
--- a/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
+++ b/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
@@ -1,14 +1,22 @@
 # Set GIT tag here for use in multiple CMakeLists.txt
 #
 set(DCMTK_GIT_REPOSITORY "https://github.com/InsightSoftwareConsortium/DCMTK.git")
-# 2018.01.16 patched
+# 2020.02.14 patched
 # Patch list:
-# COMP: Uses ITK PNG instead of system PNG
-# BUG: when using ITK_ZLIB, wasn't finding zlib header
-# COMP: Set 3rd party package CMake variables only if needed
-# COMP: Mods to allow using ITK libs
-# Support CMAKE_CROSSCOMPILING_EMULATOR
-# Support the generation of arith.h with Emscription
-# Do not use non-type template argument -1 in variadic template
 
-set(DCMTK_GIT_TAG "14393c0baa743469b5826bea724c048e221dd08b") # 20200215 master
+ #Francois Budin (1):
+       #COMP: Uses ITK PNG instead of system PNG
+
+ #Hans Johnson (1):
+       #COMP: Mods to allow using ITK libs
+
+ #Jean-Christophe Fillion-Robin (1):
+       #COMP: Set 3rd party package CMake variables only if needed
+
+ #Matt McCormick (2):
+       #Support CMAKE_CROSSCOMPILING_EMULATOR
+       #Support the generation of arith.h with Emscription
+
+
+
+set(DCMTK_GIT_TAG "972d43e13acde08c186f6e02816b18d2fbaba4cc") # 20200214_DCMTK_PATCHES_FOR_ITK


### PR DESCRIPTION
These are required to use the name-mangled ITK internal third party
libraries and add Emscripten support.
