### PR TITLE
COMP: Do not add -mcorei7 with Emscripten

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -218,7 +218,7 @@ function(check_compiler_optimization_flags c_optimization_flags_var cxx_optimiza
        list(APPEND InstructionSetOptimizationFlags
             /arch:SSE /arch:SSE2)
     endif()
-  else()
+  elseif(NOT EMSCRIPTEN)
     if (${CMAKE_C_COMPILER} MATCHES "icc.*$")
       set(USING_INTEL_ICC_COMPILER TRUE)
     endif()


### PR DESCRIPTION
To address:

  clang-6.0: warning: argument unused during compilation:
  '-march=corei7' [-Wunused-command-line-argument]

with Emscripten toolchain 1.39.4
