### PR TITLE
ENH: Wrap unsigned long long for image reading writing

### DIFF
--- a/Modules/Core/Common/wrapping/itkImageSource.wrap
+++ b/Modules/Core/Common/wrapping/itkImageSource.wrap
@@ -1,6 +1,6 @@
 itk_wrap_class("itk::ImageSource" POINTER)
   # Force uchar and ulong image sources for saving in 8 bits and watershed filter
-  UNIQUE(image_types "UC;RGBUC;RGBAUC;UL;${ITKM_IT};${WRAP_ITK_ALL_TYPES}")
+  UNIQUE(image_types "UC;RGBUC;RGBAUC;UL;ULL;${ITKM_IT};${WRAP_ITK_ALL_TYPES}")
   itk_wrap_image_filter("${image_types}" 1)
 
   UNIQUE(to_types "${WRAP_ITK_SCALAR};UC")

--- a/Modules/Core/Common/wrapping/itkImageToImageFilterA.wrap
+++ b/Modules/Core/Common/wrapping/itkImageToImageFilterA.wrap
@@ -1,7 +1,7 @@
 itk_wrap_class("itk::ImageToImageFilter" POINTER)
   # Wrap from each scalar type to each other, and also to uchar (for 8-bit saving)
   # and to ulong (for watershed).
-  UNIQUE(from_types "UC;${WRAP_ITK_SCALAR}")
+  UNIQUE(from_types "UC;ULL;${WRAP_ITK_SCALAR}")
   UNIQUE(to_types "UC;UL;${ITKM_IT};${WRAP_ITK_SCALAR}")
   itk_wrap_image_filter_combinations("${from_types}" "${to_types}")
 

--- a/Modules/Core/Common/wrapping/itkNumericTraits.wrap
+++ b/Modules/Core/Common/wrapping/itkNumericTraits.wrap
@@ -18,7 +18,7 @@ endif()
 # the superclass
 itk_wrap_class(std::numeric_limits EXPLICIT_SPECIALIZATION)
   # the basic types
-  foreach(t UC US UI UL SC SS SI SL F D LD B)
+  foreach(t UC US UI UL ULL SC SS SI SL F D LD B)
     itk_wrap_template("${ITKM_${t}}" "${ITKT_${t}}")
   endforeach()
 itk_end_wrap_class()
@@ -26,7 +26,7 @@ itk_end_wrap_class()
 
 itk_wrap_class("itk::NumericTraits" EXPLICIT_SPECIALIZATION)
   # the basic types
-  foreach(t UC US UI UL SC SS SI SL F D LD B)
+  foreach(t UC US UI UL ULL SC SS SI SL F D LD B)
     itk_wrap_template("${ITKM_${t}}" "${ITKT_${t}}")
   endforeach()
 

--- a/Modules/Filtering/ImageFilterBase/wrapping/itkCastImageFilter.wrap
+++ b/Modules/Filtering/ImageFilterBase/wrapping/itkCastImageFilter.wrap
@@ -20,4 +20,9 @@ itk_wrap_class("itk::CastImageFilter" POINTER_WITH_SUPERCLASS)
   if(NOT ITK_WRAP_unsigned_long)
     itk_wrap_image_filter_combinations("${ITKM_IT}" "${WRAP_ITK_INT}")
   endif()
+
+  # Enable casting 64 bit unsigned int to smaller integer types
+  if(ITK_WRAP_unsigned_long OR NOT ${ITKM_IT} STREQUAL "ULL")
+    itk_wrap_image_filter_combinations("ULL" "${WRAP_ITK_INT}")
+  endif()
 itk_end_wrap_class()

--- a/Modules/IO/ImageBase/wrapping/itkImageFileReader.wrap
+++ b/Modules/IO/ImageBase/wrapping/itkImageFileReader.wrap
@@ -1,6 +1,6 @@
 itk_wrap_class("itk::ImageFileReader" POINTER)
   # Force uchar image IO
-  UNIQUE(image_types "UC;${WRAP_ITK_ALL_TYPES}")
+  UNIQUE(image_types "ULL;UC;${WRAP_ITK_ALL_TYPES}")
   itk_wrap_image_filter("${image_types}" 1)
 
   UNIQUE(to_types "${WRAP_ITK_SCALAR};UC")

--- a/Modules/IO/ImageBase/wrapping/itkImageFileWriter.wrap
+++ b/Modules/IO/ImageBase/wrapping/itkImageFileWriter.wrap
@@ -1,6 +1,6 @@
 itk_wrap_class("itk::ImageFileWriter" POINTER)
   # Force uchar image IO
-  UNIQUE(image_types "UC;RGBUC;${WRAP_ITK_ALL_TYPES}")
+  UNIQUE(image_types "ULL;UC;RGBUC;${WRAP_ITK_ALL_TYPES}")
   itk_wrap_image_filter("${image_types}" 1)
 
   UNIQUE(to_types "${WRAP_ITK_SCALAR};UC")

--- a/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
@@ -212,7 +212,7 @@ def pixel_type_from_IO(pixel, component, dimension):
 dimensions = [2, 3]
 component_type_dic= {"float":itk.F, "double":itk.D,
         "unsigned_char":itk.UC, "unsigned_short":itk.US, "unsigned_int":itk.UI,
-        "unsigned_long":itk.UL, "char":itk.SC, "short":itk.SS,
+        "unsigned_long":itk.UL, "unsigned_long_long":itk.ULL, "char":itk.SC, "short":itk.SS,
         "int":itk.SI, "long":itk.SL, "bool":itk.B}
 pixel_types = ['scalar', 'rgb', 'rgba', 'offset', 'vector', 'point',
                'covariant_vector', 'symmetric_second_rank_tensor',


### PR DESCRIPTION
Support reading and writing unsigned integer images. unsigned long long
is wrapped since this is supported by the IO classes and 64-bit across
platforms.

An image can be read with:

  image = itk.imread('filepath.mha', itk.ULL)

and cast for further processing.
