### PR TITLE
ENH: Avoid duplicated code in `itk::HistogramThresholdImageFilter`

### DIFF
--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -20,6 +20,7 @@
 #define itkHistogramThresholdImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "itkImageToHistogramFilter.h"
 #include "itkHistogram.h"
 #include "itkHistogramThresholdCalculator.h"
 
@@ -111,6 +112,9 @@ public:
   using CalculatorType = HistogramThresholdCalculator<HistogramType, InputPixelType>;
   using CalculatorPointer = typename CalculatorType::Pointer;
 
+  using HistogramGeneratorType = Statistics::ImageToHistogramFilter<InputImageType>;
+  using HistogramGeneratorPointer = typename HistogramGeneratorType::Pointer;
+
   /** Image related type alias. */
   static constexpr unsigned int InputImageDimension = InputImageType::ImageDimension;
   static constexpr unsigned int OutputImageDimension = OutputImageType::ImageDimension;
@@ -197,6 +201,9 @@ protected:
   void
   GenerateData() override;
 
+  /** Set up the histogram generator. */
+  void
+  SetUpHistogramGenerator(HistogramGeneratorPointer histogramGenerator);
 
   void
   VerifyPreconditions() ITKv5_CONST override


### PR DESCRIPTION
Refactor `itk::HistogramThresholdImageFilter` to avoid duplicated code,
and thus prevent potential bugs that can go unnoticed.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)