### PR TITLE
ENH: Change ivar name in `itk::IntermodesThresholdImageFilter`

### DIFF
--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
@@ -94,8 +94,8 @@ public:
   using CalculatorType = IntermodesThresholdCalculator<HistogramType, InputPixelType>;
 
 
-  itkSetMacro(MaxSmoothingIterations, SizeValueType);
-  itkGetMacro(MaxSmoothingIterations, SizeValueType);
+  itkSetMacro(MaximumSmoothingIterations, SizeValueType);
+  itkGetMacro(MaximumSmoothingIterations, SizeValueType);
 
   /** Select whether midpoint (intermode=true) or minimum between
      peaks is used. */
@@ -111,7 +111,7 @@ protected:
   IntermodesThresholdImageFilter()
   {
     auto calculator = CalculatorType::New();
-    calculator->SetMaximumSmoothingIterations(m_MaxSmoothingIterations);
+    calculator->SetMaximumSmoothingIterations(m_MaximumSmoothingIterations);
     calculator->SetUseInterMode(m_UseInterMode);
     Superclass::SetCalculator(calculator);
   }
@@ -131,7 +131,7 @@ protected:
   GenerateData() override
   {
     auto calculator = static_cast<CalculatorType *>(this->Superclass::GetModifiableCalculator());
-    calculator->SetMaximumSmoothingIterations(m_MaxSmoothingIterations);
+    calculator->SetMaximumSmoothingIterations(m_MaximumSmoothingIterations);
     calculator->SetUseInterMode(m_UseInterMode);
     this->Superclass::GenerateData();
   }
@@ -141,12 +141,12 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);
-    os << indent << "MaxSmoothingIterations: " << m_MaxSmoothingIterations << std::endl;
-    os << indent << "UseIterMode: " << m_UseInterMode << std::endl;
+    os << indent << "MaximumSmoothingIterations: " << m_MaximumSmoothingIterations << std::endl;
+    os << indent << "UseInterMode: " << m_UseInterMode << std::endl;
   }
 
 private:
-  SizeValueType m_MaxSmoothingIterations{ 1000 };
+  SizeValueType m_MaximumSmoothingIterations{ 1000 };
   bool          m_UseInterMode{ true };
 };
 


### PR DESCRIPTION
Change the `m_MaxSmoothingIterations` ivar name in
`itk::IntermodesThresholdImageFilter`
to `m_MaximumSmoothingIterations`
so that the Set/Get methods match the ones previous to the change in
6dc4948017858006200d57491459c49b3cbc5765.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)