### PR TITLE
ENH: Make the histogram generator set up method private

### DIFF
--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -201,10 +201,6 @@ protected:
   void
   GenerateData() override;
 
-  /** Set up the histogram generator. */
-  void
-  SetUpHistogramGenerator(HistogramGeneratorPointer histogramGenerator);
-
   void
   VerifyPreconditions() ITKv5_CONST override
   {
@@ -216,6 +212,10 @@ protected:
   }
 
 private:
+  /** Set up the histogram generator. */
+  void
+  SetUpHistogramGenerator(HistogramGeneratorPointer histogramGenerator);
+
   OutputPixelType   m_InsideValue;
   OutputPixelType   m_OutsideValue;
   InputPixelType    m_Threshold;


### PR DESCRIPTION
Make the `itk::HistogramThresholdImageFilter::SetUpHistogramGenerator`
method introduced in commit 4217cc0 be `private`: no child classes should
be able to call the method since it is an essential step in the parent's
`GenerateData` method.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)