### PR TITLE
COMP: Fix -Wstrict-overflow warning in itkImageRegionConstIteratorWithIndex [backport to release branch]

### DIFF
--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
@@ -32,8 +32,8 @@ ImageRegionConstIteratorWithIndex<TImage>::operator++()
   this->m_Remaining = false;
   for (unsigned int in = 0; in < TImage::ImageDimension; in++)
   {
-    this->m_PositionIndex[in]++;
-    if (this->m_PositionIndex[in] < this->m_EndIndex[in])
+    const IndexValueType positionIndex = ++this->m_PositionIndex[in];
+    if (positionIndex < this->m_EndIndex[in])
     {
       this->m_Position += this->m_OffsetTable[in];
       this->m_Remaining = true;


### PR DESCRIPTION
Backport of 93be179376 to the release branch . Original PR was #1727

This commit fixes the following warning 3D Slicer warning:

```
  In file included from /path/to/Slicer-Release/ITK/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h:196:0,
                   from /path/to/Slicer-Release/ITK/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h:21,
                   from /path/to/Slicer-Release/ITK/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h:21,
                   from /path/to/Slicer-Release/ITK/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx:24,
                   from /path/to/Slicer-Release/ITK/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h:120,
                   from /path/to/Slicer-Release/ITK/Modules/Filtering/ImageGrid/include/itkPadImageFilter.h:21,
                   from /path/to/Slicer-Release/ITK/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.h:21,
                   from /path/to/Slicer/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx:1:
  /path/to/Slicer-Release/ITK/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx: In member function ‘void itk::PadImageFilterBase<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const OutputImageRegionType&) [with TInputImage = itk::Image<float, 3u>; TOutputImage = itk::Image<float, 3u>; itk::PadImageFilterBase<TInputImage, TOutputImage>::OutputImageRegionType = itk::ImageRegion<3u>]’:
  /path/to/Slicer-Release/ITK/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx:36:5: warning: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Wstrict-overflow]
       if (this->m_PositionIndex[in] < this->m_EndIndex[in])
       ^
```
