### PR TITLE
COMP: Update CastXML binary for Visual Studio 2019

### DIFF
--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
   # If 64 bit Windows build host, use the CastXML binary
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
 
-    set(_castxml_hash 315a6acef496b9d0dc9a8e0414119c22d1e1e866b8862b6372f587821c1741ac084460b1cd41b3772c4aae3922025e708c86b0a82c8a6d9952093d5e7ed9122d)
+    set(_castxml_hash b8b6f0aff11fe89ab2fcd1949cc75f2c2378a7bc408827a004396deb5ff5a9976bffe8a597f8db1b74c886ea39eb905e610dce8f5bd7586a4d6c196d7349da8d)
     set(_castxml_url "https://data.kitware.com/api/v1/file/hashsum/sha512/${_castxml_hash}/download")
     set(_download_castxml_binaries 1)
 


### PR DESCRIPTION
Address:

  C:/Program Files (x86)/Microsoft Visual Studio/2019/Professional/VC/Tools/MSVC/14.25.28610/include\intrin0.h(255,36): error G7F5978A3: constexpr declaration of '__builtin_assume_aligned' follows non-constexpr declaration

With an update to CastXML 2020-03-31 Git master and LLVM 10.0.0.
