### PR TITLE
BUG: Cannot apply operator stream::<< to new enum type

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -342,7 +342,29 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream 
   Superclass::PrintSelf(os, indent);
 
   os << "Sigma: " << m_Sigma << std::endl;
-  os << "Order: " << m_Order << std::endl;
+  switch (m_Order)
+  {
+    case GaussianOrderEnum::ZeroOrder:
+    {
+      os << "Order: Zero" << std::endl;
+      break;
+    }
+    case GaussianOrderEnum::FirstOrder:
+    {
+      os << "Order: First" << std::endl;
+      break;
+    }
+    case GaussianOrderEnum::SecondOrder:
+    {
+      os << "Order: Second" << std::endl;
+      break;
+    }
+    default:
+    {
+      os << "Order: Undefined" << std::endl;
+      break;
+    }
+  }
   os << "NormalizeAcrossScale: " << m_NormalizeAcrossScale << std::endl;
 }
 } // end namespace itk


### PR DESCRIPTION
On Visual Studio 2017, compiling ITK with a program that asked
itkRecursiveGaussianImageFilter to print itself would result
in an undefined symbol error during linkage.   That undefined
symbol was for the stream::<< operator applied to GaussianOrderEnum
type.   That usage occurred in the PrintSelf function of the
Recursive Guassian class.   Here that operator is replaced by
a switch statement on the enum and custom strings.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)