### PR TITLE
COMP: Suppress compiler warning about value trucation

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
@@ -77,7 +77,6 @@ ShiftScaleImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread,
   ThreadIdType                  threadId)
 {
-  RealType value;
 
   ImageRegionConstIterator<TInputImage> it(this->m_InputImage, outputRegionForThread);
   ImageRegionIterator<TOutputImage>     ot(this->m_OutputImage, outputRegionForThread);
@@ -88,13 +87,13 @@ ShiftScaleImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   // shift and scale the input pixels
   while (!it.IsAtEnd())
   {
-    value = (static_cast<RealType>(it.Get()) + m_Shift) * m_Scale;
+    const RealType value = (static_cast<RealType>(it.Get()) + m_Shift) * m_Scale;
     if (value < NumericTraits<OutputImagePixelType>::NonpositiveMin())
     {
       ot.Set(NumericTraits<OutputImagePixelType>::NonpositiveMin());
       m_ThreadUnderflow[threadId]++;
     }
-    else if (value > NumericTraits<OutputImagePixelType>::max())
+    else if (value > static_cast<RealType>(NumericTraits<OutputImagePixelType>::max()))
     {
       ot.Set(NumericTraits<OutputImagePixelType>::max());
       m_ThreadOverflow[threadId]++;


### PR DESCRIPTION
ITKv5/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx:97:22:
  warning: implicit conversion from 'itk::NumericTraits<unsigned long>::ValueType' (aka 'unsigned long') to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Wimplicit-int-float-conversion]
    else if (value > NumericTraits<OutputImagePixelType>::max())
                   ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ITKv5/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.h:105:3:
note: in instantiation of member function 'itk::ShiftScaleImageFilter<itk::Image<int, 3>, itk::Image<unsigned long, 3> >::ThreadedGenerateData' requested here
  ShiftScaleImageFilter();
  ^
