### PR TITLE
ENH: gitattributes: verify that code adheres to flake8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,14 +27,16 @@ vxl_doxy.pl      crlf=input
 zap.pl           crlf=input
 
 
-# Custom attribute to mark sources as using our C++/C code style.
+# Custom attribute to mark sources as using our C++/C/Python code style.
 [attr]our-c-style  whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,clangformat
+[attr]our-py-style whitespace=tab-in-indent,no-lf-at-eof  format.flake8
 
 *.c              our-c-style
 *.h              our-c-style
 *.cxx            our-c-style
 *.hxx            our-c-style
 *.txx            our-c-style
+*.py             our-py-style
 *.txt            whitespace=tab-in-indent,no-lf-at-eof
 *.cmake          whitespace=tab-in-indent,no-lf-at-eof
 


### PR DESCRIPTION
@thewtex @bradking 

However, local testing shows that the codebase is not flake8-clean. This should be deferred until that is the case (the robot only looks at changed files for `flake8` enforcement, so this PR is clean).

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)