### PR TITLE
BUG: TBB build requires consistent exception options

### DIFF
--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -194,3 +194,13 @@ if(UNIX)
     target_link_libraries(ITKCommon LINK_PUBLIC ${CMAKE_DL_LIBS})
   endif()
 endif()
+
+if(ITK_USE_TBB)
+  # https://software.intel.com/en-us/node/506139
+  # The macro TBB_DEPRECATED controls deprecated features.
+  #      Define it to 0 to remove deprecated Intel® Threading Building Blocks (Intel® TBB) 2.1 interfaces.
+  target_compile_definitions( ITKCommon PUBLIC TBB_DEPRECATED=0)
+  # The macro TBB_USE_CAPTURED_EXCEPTION controls rethrow of exceptions within the library.
+  #      Define TBB_USE_CAPTURED_EXCEPTION=0 to request rethrow of the exact exception.
+  target_compile_definitions( ITKCommon PUBLIC TBB_USE_CAPTURED_EXCEPTION=0)
+endif()


### PR DESCRIPTION
The "itkAbortProcessObjectTest" fails unless all compilation
units successfully pass exceptions.

The following tests FAILED:
	413 - itkAbortProcessObjectTest (Failed)
➜  ITKv5-RelWithDebInfo-build ctest -V -R itkAbortProcessObjectTest
UpdateCTestConfiguration  from :/Users/johnsonhj/src/BRAINSTools-sysclang-RelWithDebInfo/ITKv5-RelWithDebInfo-build/DartConfiguration.tcl
Parse Config file:/Users/johnsonhj/src/BRAINSTools-sysclang-RelWithDebInfo/ITKv5-RelWithDebInfo-build/DartConfiguration.tcl
    Start 413: itkAbortProcessObjectTest

413: Test command: /Users/johnsonhj/src/BRAINSTools-sysclang-RelWithDebInfo/BRAINSTools-RelWithDebInfo-EPRelWithDebInfo-build/bin/ITKCommon1TestDriver "itkAbortProcessObjectTest"
413: Test timeout computed to be: 1500
413: ExtractImageFilter (0x7fbb8ef54430)
413:
413:   DirectionCollapseStrategy: ExtractImageFilterEnums::DirectionCollapseStrategy::DIRECTIONCOLLAPSETOUNKOWN
413:
413: Setting AbortGenerateDataOn()
413: TBB Warning: Exact exception propagation is requested by application but the linked library is built without support for it
413: Setting AbortGenerateDataOn()
413: ITK test driver caught an exception:
413: /Users/johnsonhj/src/BRAINSTools-sysclang-RelWithDebInfo/ITKv5/Modules/Core/Common/include/itkTotalProgressReporter.h:70:
413: Object ExtractImageFilter: AbortGenerateDataOn
1/1 Test #413: itkAbortProcessObjectTest ........***Failed    0.05 sec

0% tests passed, 1 tests failed out of 1

Label Time Summary:
ITKCommon    =   0.05 sec*proc (1 test)

=====
When compiled with proper defines, exception handeling is performed correctly.
