### PR TITLE
DOC: Fix missing \ingroup ITKIODCMTK

### DIFF
--- a/Modules/IO/DCMTK/include/itkDCMTKImageIO.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKImageIO.h
@@ -31,6 +31,7 @@ namespace itk
 /**\class DCMTKImageIOEnums
  * \brief Enums used by the DCMTKImageIO class
  * \ingroup IOFilters
+ * \ingroup ITKIODCMTK
  */
 class DCMTKImageIOEnums
 {
@@ -38,6 +39,7 @@ public:
   /**
    *\class LogLevel
    * \ingroup IOFilters
+   * \ingroup ITKIODCMTK
    * enum for DCMTK log level.  These are defined here without
    *  reference to DCMTK library enumerations, to avoid including
    * dcmtk headers in this header.


### PR DESCRIPTION
Modules/IO/DCMTK/include/itkDCMTKImageIO.h:31: error: "\ingroup non" not set in class DCMTKImageIOEnums.
Modules/IO/DCMTK/include/itkDCMTKImageIO.h:38: error: "\ingroup ITKIODCMTK" not set in class LogLevel.

1/1 Test #850: ITKIODCMTKInDoxygenGroup .........***Failed    0.04 sec
