### PR TITLE
BUG: Use GDCM as private dependency in ITKIOGDCM

### DIFF
--- a/Modules/IO/GDCM/ITKKWStyleOverwrite.txt
+++ b/Modules/IO/GDCM/ITKKWStyleOverwrite.txt
@@ -1,0 +1,1 @@
+itkGDCMSeriesFileNames\.h Namespace Disable

--- a/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
+++ b/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
@@ -22,8 +22,13 @@
 #include "itkObjectFactory.h"
 #include "itkMacro.h"
 #include <vector>
-#include "gdcmSerieHelper.h"
 #include "ITKIOGDCMExport.h"
+
+// forward declaration, to remove compile dependency on GDCM library
+namespace gdcm
+{
+class SerieHelper;
+}
 
 namespace itk
 {
@@ -162,10 +167,7 @@ public:
    * \warning User need to set SetUseSeriesDetails(true)
    */
   void
-  AddSeriesRestriction(const std::string & tag)
-  {
-    m_SerieHelper->AddRestriction(tag);
-  }
+  AddSeriesRestriction(const std::string & tag);
 
   /** Parse any sequences in the DICOM file. Defaults to false
    *  to skip sequences. This makes loading DICOM files faster when
@@ -184,8 +186,8 @@ public:
   itkBooleanMacro(LoadPrivateTags);
 
 protected:
-  GDCMSeriesFileNames() = default;
-  ~GDCMSeriesFileNames() override { delete m_SerieHelper; }
+  GDCMSeriesFileNames();
+  ~GDCMSeriesFileNames() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -201,7 +203,7 @@ private:
   FileNamesContainerType m_OutputFileNames;
 
   /** Internal structure to order serie from one directory */
-  gdcm::SerieHelper * m_SerieHelper = new gdcm::SerieHelper();
+  std::unique_ptr<gdcm::SerieHelper> m_SerieHelper;
 
   /** Internal structure to keep the list of series UIDs */
   SeriesUIDContainerType m_SeriesUIDs;

--- a/Modules/IO/GDCM/itk-module.cmake
+++ b/Modules/IO/GDCM/itk-module.cmake
@@ -6,8 +6,9 @@ itk_module(ITKIOGDCM
   ENABLE_SHARED
   DEPENDS
     ITKCommon
-    ITKGDCM
     ITKIOImageBase
+  PRIVATE_DEPENDS
+    ITKGDCM
   TEST_DEPENDS
     ITKTestKernel
     ITKGDCM

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -21,9 +21,19 @@
 #include "itkGDCMSeriesFileNames.h"
 #include "itksys/SystemTools.hxx"
 #include "itkProgressReporter.h"
+#include "gdcmSerieHelper.h"
 
 namespace itk
 {
+
+
+GDCMSeriesFileNames::GDCMSeriesFileNames()
+  : m_SerieHelper{ new gdcm::SerieHelper() }
+{}
+
+GDCMSeriesFileNames::~GDCMSeriesFileNames() = default;
+
+
 void
 GDCMSeriesFileNames::SetInputDirectory(const char * name)
 {
@@ -33,6 +43,12 @@ GDCMSeriesFileNames::SetInputDirectory(const char * name)
   }
   std::string fname = name;
   this->SetInputDirectory(fname);
+}
+
+void
+GDCMSeriesFileNames::AddSeriesRestriction(const std::string & tag)
+{
+  m_SerieHelper->AddRestriction(tag);
 }
 
 void


### PR DESCRIPTION
Make the third partly library a private dependency, for the ITK GDCM
ImageIO modules. This follows best practices of data encapsulation.

Move the implementation of the destructor to the cxx file as a best
practice as it ensure intonation of the vtable in the library.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
