### PR TITLE
COMP: Condition HDF5 HDopen on _MSC_VER definition

### DIFF
--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Defl.c
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Defl.c
@@ -288,7 +288,12 @@ H5D__efl_read(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t size
             HGOTO_ERROR(H5E_EFL, H5E_OVERFLOW, FAIL, "external file address overflowed")
         if(H5_combine_path(dset->shared->extfile_prefix, efl->slot[u].name, &full_name) < 0)
             HGOTO_ERROR(H5E_EFL, H5E_NOSPACE, FAIL, "can't build external file name")
+#if defined(H5_HAVE_WIN32_API) && !defined(_MSC_VER)
+/* With MinGW, pass the required third argument to the HDopen macro, which is ignored by _open. */
+        if((fd = HDopen(full_name, O_RDONLY, NULL)) < 0)
+#else
         if((fd = HDopen(full_name, O_RDONLY)) < 0)
+#endif
             HGOTO_ERROR(H5E_EFL, H5E_CANTOPENFILE, FAIL, "unable to open external raw data file")
         if(HDlseek(fd, (HDoff_t)(efl->slot[u].offset + (HDoff_t)skip), SEEK_SET) < 0)
             HGOTO_ERROR(H5E_EFL, H5E_SEEKERROR, FAIL, "unable to seek in external raw data file")

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5win32defs.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5win32defs.h
@@ -69,6 +69,7 @@ typedef __int64             h5_stat_size_t;
   #endif /* H5_HAVE_STRTOULL */
 #endif /* MSC_VER < 1800 */
 
+#ifdef _MSC_VER
 /* _O_BINARY must be set in Windows to avoid CR-LF <-> LF EOL
  * transformations when performing I/O. Note that this will
  * produce Unix-style text files, though.
@@ -77,6 +78,7 @@ typedef __int64             h5_stat_size_t;
  * where the comma is dropped if nothing is passed to the ellipsis.
  */
 #define HDopen(S,F,...)       _open(S, F | _O_BINARY, __VA_ARGS__)
+#endif
 
 /*
  * The (void*) cast just avoids a compiler warning in H5_HAVE_VISUAL_STUDIO
@@ -107,10 +109,11 @@ struct timespec
 #define HDroundf(V)         Wroundf(V)
 #endif /* MSC_VER < 1700 */
 
-#else
+#endif /* H5_HAVE_VISUAL_STUDIO */
+#ifndef _MSC_VER
 // For MinGW, etc.
 #define HDopen(S,F,M)       _open(S, F | _O_BINARY, M)
-#endif /* H5_HAVE_VISUAL_STUDIO */
+#endif
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
H5_HAVE_VISUAL_STUDIO may be defined if Visual Studio is present on the
build system even if MinGW-w64 is the currently used compiler.
