### PR TITLE
ENH: update remote module RTK

### DIFF
--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -41,5 +41,5 @@ itk_fetch_module(RTK
     "Reconstruction Toolkit (RTK) http://www.openrtk.org/"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/RTK.git
-  GIT_TAG cf109ba95fb81a9f37a21895c0e455367aeddac0
+  GIT_TAG "f43ecb2a8c4438cc7abb47f371e4981f0f07b67e"
 )


### PR DESCRIPTION
The current RTK version does not compile with ITK master due to the change in the ITKGDCM dependency. We are still investigating issue SimonRit/RTK#340 so I would suggest to merge this PR only if the tagging of ITK v5.1 is not postponed. `git shortlog cf109ba..f43ecb2 | grep -v "Merge pull request"` gives:

Antoine Robert (8):
      BUG: Use real image type as input of Hilbert filter
      COMP: Fix wrapping when building ITK with dimension 1
      ENH: wrap image file reader and writer for dimension 1
      ENH: wrap NumpyBridge for dimension 1
      ENH: Add quadratic penalization to OSEM algorithm
      STYLE: Use override instead of ITK_OVERRIDE
      STYLE: Use default member initialization
      BUG: Change member type from float to double in Zeng projectors

Aurélien Coussat (7):
      PERF: reduced size of application tests
      STYLE: fixed format in rtkIterationCommands.h
      ENH: ProgressReporter for FDK reconstruction
      BUG: solve memory leak in rtkcheckimagequality
      ENH: filters check whether their geometry is set
      ENH: default projectors for all iterative filters
      ENH: set division threshold for SART

Lucas Gandel (5):
      ENH: Add rtkSimulatedGeometry python application
      COMP: Set latest available itk version in setup.py
      ENH: Add ITK clang-format linter check
      ENH: Apply clang-format to PR with tag action:ApplyClangFormat
      STYLE: Exclude gengetopt and lpsolve folders from clang formatting

Simon Rit (31):
      STYLE: remove unused kernel parameter in Cuda forward projection
      DOC: change CMake variable name for RTK git tag
      SYTLE: remove unused examples/CMakeLists.txt
      ENH: use latest ITK v5.1 version for python packages
      COMP: remove MacOS and Windows self-hosted Cuda python packages
      ENH: wrap RTK image IO
      BUG: minimize disk space in Linux Azure pipelines to avoid saturation
      BUG: wrong target libraries in FirstReconstruction examples
      COMP: fix wrong header guard for rtkProgressCommands.h
      STYLE: fix ITK clang-format to a few RTK source files
      COMP: fix missing ITKGDCM dependency
      BUG: fix wrappings for 1D and double
      STYLE: fix ITK clang-format
      COMP: remove warnings due to unhandled enum value