### PR TITLE
ENH: ndim, shape, and dtype attributes for itk.Image

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -26,15 +26,13 @@
 
         itksize = image.GetLargestPossibleRegion().GetSize()
         dim     = len(itksize)
-        shape   = []
-        for idx in range(dim):
-            shape.append(int(itksize[idx]))
+        shape   = [int(itksize[idx]) for idx in range(dim)]
 
         if(image.GetNumberOfComponentsPerPixel() > 1):
             shape = [image.GetNumberOfComponentsPerPixel(), ] + shape
 
         if keep_axes == False:
-            shape = shape[::-1]
+            shape.reverse()
 
         pixelType     = "@PixelType@"
         numpydatatype = _get_numpy_pixelid(pixelType)

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -58,6 +58,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
 
         self.assertEqual(0, diff)
         assert(hasattr(convertedscalarImage, 'base'))
+        self.assertEqual(scalarndarr.ndim, convertedscalarImage.ndim)
+        self.assertEqual(scalarndarr.dtype, convertedscalarImage.dtype)
+        self.assertTupleEqual(scalarndarr.shape, convertedscalarImage.shape)
 
     def test_NumPyBridge_itkScalarImageDeepCopy(self):
         "Try to convert all pixel types to NumPy array view with a deep copy"
@@ -104,6 +107,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         vectorndarr           = itk.PyBuffer[VectorImageType].GetArrayViewFromImage(vectorImage)
 
         convertedvectorImage  = itk.PyBuffer[VectorImageType].GetImageViewFromArray(vectorndarr, is_vector=True)
+        self.assertEqual(vectorndarr.ndim, convertedvectorImage.ndim)
+        self.assertEqual(vectorndarr.dtype, convertedvectorImage.dtype)
+        self.assertTupleEqual(vectorndarr.shape, convertedvectorImage.shape)
 
     def test_NumPyBridge_itkRGBImage(self):
         "Try to convert an RGB ITK image to NumPy array view"
@@ -124,6 +130,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         rgbndarr              = itk.PyBuffer[RGBImageType].GetArrayViewFromImage(rgbImage)
 
         convertedRGBImage     = itk.PyBuffer[RGBImageType].GetImageViewFromArray(rgbndarr, is_vector=True)
+        self.assertEqual(rgbndarr.ndim, convertedRGBImage.ndim)
+        self.assertEqual(rgbndarr.dtype, convertedRGBImage.dtype)
+        self.assertTupleEqual(rgbndarr.shape, convertedRGBImage.shape)
 
     def test_NumPyBridge_itkRGBAImage(self):
         "Try to convert an RGBA ITK image to NumPy array view"
@@ -144,6 +153,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         rgbandarr             = itk.PyBuffer[RGBAImageType].GetArrayViewFromImage(rgbaImage)
 
         convertedRGBAImage    = itk.PyBuffer[RGBAImageType].GetImageViewFromArray(rgbandarr, is_vector=True)
+        self.assertEqual(rgbandarr.ndim, convertedRGBAImage.ndim)
+        self.assertEqual(rgbandarr.dtype, convertedRGBAImage.dtype)
+        self.assertTupleEqual(rgbandarr.shape, convertedRGBAImage.shape)
 
     def test_NumPyBridge_itkVectorPixelImage(self):
         "Try to convert an ITK image with vector pixels to NumPy array view"
@@ -164,6 +176,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         vectorndarr           = itk.PyBuffer[VectorImageType].GetArrayViewFromImage(vectorImage)
 
         convertedVectorImage  = itk.PyBuffer[VectorImageType].GetImageViewFromArray(vectorndarr, is_vector=True)
+        self.assertEqual(vectorndarr.ndim, convertedVectorImage.ndim)
+        self.assertEqual(vectorndarr.dtype, convertedVectorImage.dtype)
+        self.assertTupleEqual(vectorndarr.shape, convertedVectorImage.shape)
 
     def test_NumPyBridge_FortranOrder(self):
         "Try to convert an ITK image to / from a NumPy array with Fortran order"

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -416,6 +416,42 @@ str = str
                 """Internal method to keep a reference when creating a view of a NumPy array."""
                 self.base = base
 
+            @property
+            def ndim(self):
+                """Equivalant to the np.ndarray ndim attribute when converted
+                to an image with itk.array_view_from_image."""
+                spatial_dims = self.GetImageDimension()
+                if self.GetNumberOfComponentsPerPixel() > 1:
+                    return spatial_dims + 1
+                else:
+                    return spatial_dims
+
+            @property
+            def shape(self):
+                """Equivalant to the np.ndarray shape attribute when converted
+                to an image with itk.array_view_from_image."""
+                itksize = self.GetLargestPossibleRegion().GetSize()
+                dim = len(itksize)
+                result = [int(itksize[idx]) for idx in range(dim)]
+
+                if(self.GetNumberOfComponentsPerPixel() > 1):
+                    result = [self.GetNumberOfComponentsPerPixel(), ] + result
+                result.reverse()
+                return tuple(result)
+
+            @property
+            def dtype(self):
+                """Equivalant to the np.ndarray dtype attribute when converted
+                to an image with itk.array_view_from_image."""
+                import itk
+                first_template_arg = itk.template(self)[1][0]
+                if hasattr(first_template_arg, 'dtype'):
+                    return first_template_arg.dtype
+                else:
+                    # Multi-component pixel types, e.g. Vector,
+                    # CovariantVector, etc.
+                    return itk.template(first_template_arg)[1][0].dtype
+
             def SetDirection(self, direction):
                 import itkHelpers
                 if itkHelpers.is_arraylike(direction):

--- a/Wrapping/Generators/Python/itkHelpers.py
+++ b/Wrapping/Generators/Python/itkHelpers.py
@@ -56,7 +56,7 @@ def accept_numpy_array_like_xarray(image_filter):
                     have_xarray_input = True
                     image = itk.image_from_xarray(arg)
                     args_list[index] = image
-            elif is_arraylike(arg):
+            elif not isinstance(arg, itk.Object) and is_arraylike(arg):
                 have_array_input = True
                 array = np.asarray(arg)
                 image = itk.image_view_from_array(array)
@@ -69,7 +69,7 @@ def accept_numpy_array_like_xarray(image_filter):
                     have_xarray_input = True
                     image = itk.image_from_xarray(value)
                     kwargs[key] = image
-                elif is_arraylike(value):
+                elif not isinstance(value, itk.Object) and is_arraylike(value):
                     have_array_input = True
                     array = np.asarray(value)
                     image = itk.image_view_from_array(array)

--- a/Wrapping/Generators/Python/itkTypes.py
+++ b/Wrapping/Generators/Python/itkTypes.py
@@ -16,13 +16,20 @@
 #
 #==========================================================================*/
 
+import os
+HAVE_NUMPY = True
+try:
+  import numpy as np
+except ImportError:
+  HAVE_NUMPY = False
 
 class itkCType:
     __cTypes__ = {}
 
-    def __init__(self, name, shortName):
+    def __init__(self, name, short_name, np_dtype=None):
         self.name = name
-        self.short_name = shortName
+        self.short_name = short_name
+        self.dtype = np_dtype
 
         itkCType.__cTypes__[self.name] = self
 
@@ -49,17 +56,37 @@ class itkCType:
     GetCType = staticmethod(GetCType)
 
 
-F = itkCType("float", "F")
-D = itkCType("double", "D")
-LD = itkCType("long double", "LD")
-UC = itkCType("unsigned char", "UC")
-US = itkCType("unsigned short", "US")
-UI = itkCType("unsigned int", "UI")
-UL = itkCType("unsigned long", "UL")
-ULL = itkCType("unsigned long long", "ULL")
-SC = itkCType("signed char", "SC")
-SS = itkCType("signed short", "SS")
-SI = itkCType("signed int", "SI")
-SL = itkCType("signed long", "SL")
-SLL = itkCType("signed long long", "SLL")
-B = itkCType("bool", "B")
+if HAVE_NUMPY:
+    F = itkCType("float", "F", np.float32)
+    D = itkCType("double", "D", np.float64)
+    LD = itkCType("long double", "LD", np.float128)
+    UC = itkCType("unsigned char", "UC", np.uint8)
+    US = itkCType("unsigned short", "US", np.uint16)
+    UI = itkCType("unsigned int", "UI", np.uint32)
+    if os.name == 'nt':
+        UL = itkCType("unsigned long", "UL", np.uintl32)
+        SL = itkCType("signed long", "SL", np.intl32)
+    else:
+        UL = itkCType("unsigned long", "UL", np.uint64)
+        SL = itkCType("signed long", "SL", np.int64)
+    ULL = itkCType("unsigned long long", "ULL", np.uint64)
+    SC = itkCType("signed char", "SC", np.int8)
+    SS = itkCType("signed short", "SS", np.int16)
+    SI = itkCType("signed int", "SI", np.int32)
+    SLL = itkCType("signed long long", "SLL", np.int64)
+    B = itkCType("bool", "B", np.bool)
+else:
+    F = itkCType("float", "F")
+    D = itkCType("double", "D")
+    LD = itkCType("long double", "LD")
+    UC = itkCType("unsigned char", "UC")
+    US = itkCType("unsigned short", "US")
+    UI = itkCType("unsigned int", "UI")
+    UL = itkCType("unsigned long", "UL")
+    ULL = itkCType("unsigned long long", "ULL")
+    SC = itkCType("signed char", "SC")
+    SS = itkCType("signed short", "SS")
+    SI = itkCType("signed int", "SI")
+    SL = itkCType("signed long", "SL")
+    SLL = itkCType("signed long long", "SLL")
+    B = itkCType("bool", "B")


### PR DESCRIPTION
This provide the same values when converted to a np.ndarray with
itk.array_view_from_image. They are used to identify data types that
provide a NumPy array-like interface.