### PR TITLE
COMP: itkResampleImageTest8 ~ProjectTransform mark as override

### DIFF
--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -111,7 +111,7 @@ protected:
   ProjectTransform()
     : Transform<double, 3, 2>(0)
   {}
-  ~ProjectTransform() = default;
+  ~ProjectTransform() override = default;
 
 }; // class ProjectTransform
 


### PR DESCRIPTION
To address:

[CTest: warning matched] /Users/builder/externalModules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx:114:3: warning: '~ProjectTransform' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
  ~ProjectTransform() = default;
  ^
[CTest: warning matched] /Users/builder/externalModules/Core/Transform/include/itkTransform.h:559:3: note: overridden virtual function is here
  ~Transform() override = default;
  ^