### PR TITLE
BUG: CurvatureRegistrationFilter fix logic re: depends on FFTW

### DIFF
--- a/Modules/Filtering/FFT/wrapping/itkFFTWGlobalConfiguration.wrap
+++ b/Modules/Filtering/FFT/wrapping/itkFFTWGlobalConfiguration.wrap
@@ -1,4 +1,4 @@
-if(ITK_USE_FFTWF OR ITK_USE_FFTWD)
+if((ITK_USE_FFTWF OR ITK_USE_FFTWD) AND NOT ITK_USE_CUFFTW )
   itk_wrap_simple_class("itk::FFTWGlobalConfiguration")
 
   set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)

--- a/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.h
@@ -21,7 +21,7 @@
 #include "itkPDEDeformableRegistrationFilter.h"
 #include "itkMeanSquareRegistrationFunction.h"
 
-#if !defined(ITK_USE_CUFFTW) && defined(ITK_USE_FFTWF) || defined(ITK_USE_FFTWD)
+#if !defined(ITK_USE_CUFFTW) && (defined(ITK_USE_FFTWF) || defined(ITK_USE_FFTWD))
 #  include "fftw3.h"
 
 namespace itk

--- a/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
@@ -17,7 +17,8 @@
  *=========================================================================*/
 #ifndef itkCurvatureRegistrationFilter_hxx
 #define itkCurvatureRegistrationFilter_hxx
-#if defined(ITK_USE_FFTWF) || defined(ITK_USE_FFTWD)
+#if !defined(ITK_USE_CUFFTW) && (defined(ITK_USE_FFTWF) || defined(ITK_USE_FFTWD))
+
 #  include "itkCurvatureRegistrationFilter.h"
 
 #  include "itkImageRegionIterator.h"


### PR DESCRIPTION
Conditional in .h file did not implement intended logic (resulting in compilation error when used, e.g., with Python wrapping enabled) and logic was not duplicated in .hxx file (resulting in .hxx definitions without a corresponding .h).
