### PR TITLE
BUG: Disable dynamic threading in noise filter.

### DIFF
--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.h
@@ -106,7 +106,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
 
 private:

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -30,14 +30,15 @@ template <class TInputImage, class TOutputImage>
 AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::AdditiveGaussianNoiseImageFilter()
 
 {
-  this->DynamicMultiThreadingOn();
+  this->DynamicMultiThreadingOff();
   this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
 void
-AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
-  const OutputImageRegionType & outputRegionForThread)
+AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
+  const OutputImageRegionType & outputRegionForThread,
+  ThreadIdType)
 {
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput(0);

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.h
@@ -126,7 +126,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
 private:
   double               m_Probability{ 0.01 };

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -31,14 +31,15 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::SaltAndPepperNoiseImag
   : m_SaltValue(NumericTraits<OutputImagePixelType>::max())
   , m_PepperValue(NumericTraits<OutputImagePixelType>::NonpositiveMin())
 {
-  this->DynamicMultiThreadingOn();
+  this->DynamicMultiThreadingOff();
   this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
 void
-SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
-  const OutputImageRegionType & outputRegionForThread)
+SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
+  const OutputImageRegionType & outputRegionForThread,
+  ThreadIdType)
 {
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput(0);

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.h
@@ -143,7 +143,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
 
 private:

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -31,14 +31,15 @@ template <class TInputImage, class TOutputImage>
 ShotNoiseImageFilter<TInputImage, TOutputImage>::ShotNoiseImageFilter()
 
 {
-  this->DynamicMultiThreadingOn();
+  this->DynamicMultiThreadingOff();
   this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
 void
-ShotNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
-  const OutputImageRegionType & outputRegionForThread)
+ShotNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
+  const OutputImageRegionType & outputRegionForThread,
+  ThreadIdType)
 {
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput(0);

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.h
@@ -102,7 +102,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
 private:
   double m_StandardDeviation{ 1.0 };

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -31,14 +31,15 @@ template <class TInputImage, class TOutputImage>
 SpeckleNoiseImageFilter<TInputImage, TOutputImage>::SpeckleNoiseImageFilter()
 
 {
-  this->DynamicMultiThreadingOn();
+  this->DynamicMultiThreadingOff();
   this->ThreaderUpdateProgressOff();
 }
 
 template <class TInputImage, class TOutputImage>
 void
-SpeckleNoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
-  const OutputImageRegionType & outputRegionForThread)
+SpeckleNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
+  const OutputImageRegionType & outputRegionForThread,
+  ThreadIdType)
 {
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput(0);


### PR DESCRIPTION
With the TBB threader the results were dependent on how the regions
were dynamically split.

The noise filters are designed to be reproducible for a fixed seed and
a number of threads. The implementation requires that the image is
split into fix deterministic regions.

Closes #1794.