### PR TITLE
COMP: Missing defition of ITK_DISALLOW_COPY_AND_ASSIGN

### DIFF
--- a/Modules/Core/Common/include/itkSTLConstContainerAdaptor.h
+++ b/Modules/Core/Common/include/itkSTLConstContainerAdaptor.h
@@ -18,6 +18,8 @@
 #ifndef itkSTLConstContainerAdaptor_h
 #define itkSTLConstContainerAdaptor_h
 
+#include <itkMacro.h>
+
 namespace itk
 {
 /** \class STLConstContainerAdaptor


### PR DESCRIPTION
Need to `#include <itkMacro.h>` for definition
of ITK_DISALLOW_COPY_AND_ASSIGN.