### PR TITLE
ENH: Add data() and size() member functions to FixedArray

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -317,6 +317,18 @@ public:
     return m_InternalArray;
   }
 
+  ValueType *
+  data()
+  {
+    return m_InternalArray;
+  }
+
+  const ValueType *
+  data() const
+  {
+    return m_InternalArray;
+  }
+
   /** Get various iterators to the array. */
   Iterator
   Begin();
@@ -410,9 +422,14 @@ public:
     return this->crend();
   }
 
+  /** Size of the container */
   SizeType
   Size() const;
 
+  SizeType
+  size() const;
+
+  /** Set all the elements of the container to the input value. */
   void
   Fill(const ValueType &);
 

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -162,6 +162,13 @@ FixedArray<TValue, VLength>::Size() const
   return VLength;
 }
 
+template <typename TValue, unsigned int VLength>
+typename FixedArray<TValue, VLength>::SizeType
+FixedArray<TValue, VLength>::size() const
+{
+  return VLength;
+}
+
 /**
  * Fill all elements of the array with the given value.
  */

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -274,3 +274,20 @@ TEST(FixedArray, IteratorIncrementReturnValue)
   Check_iterators_increment_return_value<double, 2>();
   Check_iterators_increment_return_value<int, 3>();
 }
+
+// Tests data() and size() works
+TEST(FixedArray, StdMemberFunctionsWork)
+{
+  using FixedArrayType = itk::FixedArray<double, 3>;
+  auto d3arr = FixedArrayType(3);
+  d3arr[0] = 1;
+  d3arr[1] = 2;
+  d3arr[2] = 3;
+  // size
+  EXPECT_EQ(d3arr.size(), 3);
+  // const and non-const data
+  const auto cdata = d3arr.data();
+  EXPECT_EQ(cdata[0], 1);
+  d3arr.data()[0] = 10;
+  EXPECT_EQ(cdata[0], 10);
+}


### PR DESCRIPTION
This unifies the interface of FixedArray with std containers.

New names for already existing functionality:
- `data()` is exactly the same as `GetDataPointer()`
- `size()` the same as `Size()`

And as a result of this common interface, we can use the python
utility method `itk.GetArrayViewFromVnlVector` in `itk.Point`,
and all other classes derived from `FixedArray`.


## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [NA] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [NA] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
