### PR TITLE
BUG: Use ITK_WRAP_IMAGE_DIMS in ViewImage.wrap

### DIFF
--- a/Modules/Bridge/VtkGlue/wrapping/itkViewImage.wrap
+++ b/Modules/Bridge/VtkGlue/wrapping/itkViewImage.wrap
@@ -1,7 +1,6 @@
 itk_wrap_class("itk::ViewImage")
   UNIQUE(types "${WRAP_ITK_SCALAR}")
-  UNIQUE(dims "2;3")
-  foreach(d ${dims})
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${types})
       itk_wrap_template("${ITKM_I${t}${d}}" "${ITKT_I${t}${d}}")
     endforeach()


### PR DESCRIPTION
Instead of hard-coded `2;3` dimensions