### PR TITLE
BUG: Fetch full depth in apply-clang-format action

### DIFF
--- a/.github/workflows/apply-clang-format.yml
+++ b/.github/workflows/apply-clang-format.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+         fetch-depth: 0
     - uses: InsightSoftwareConsortium/ITKApplyClangFormatAction@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The default fetch depth is 1.

To prevent:

   reference is not a tree: 518349019984699b8d35a953bf4fc8a4324897fa
  Git checkout failed on shallow repository, this might because of git fetch with depth '1' doesn't include the checkout commit '518349019984699b8d35a953bf4fc8a4324897fa'.