### PR TITLE
ENH: Bump MetaIO to address style and const params

### DIFF
--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArray.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArray.cxx
@@ -582,7 +582,7 @@ CanRead(const char *_headerName) const
 {
   // First check the extension
   std::string fname = _headerName;
-  if( fname == "" )
+  if( fname.empty() )
     {
     return false;
     }

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArrow.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaArrow.cxx
@@ -46,12 +46,12 @@ MetaArrow(const char *_headerName)
 
 //
 MetaArrow::
-MetaArrow(const MetaArrow *_Arrow)
+MetaArrow(const MetaArrow *_arrow)
 :MetaObject()
 {
   if(META_DEBUG)  std::cout << "MetaArrow()" << std::endl;
   Clear();
-  CopyInfo(_Arrow);
+  CopyInfo(_arrow);
 }
 
 MetaArrow::

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaCommand.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaCommand.cxx
@@ -392,7 +392,7 @@ GetValueAsBool(std::string optionName,
                std::string fieldName)
 {
   std::string fieldname = fieldName;
-  if(fieldName == "")
+  if(fieldName.empty())
     {
     fieldname = optionName;
     }
@@ -432,7 +432,7 @@ GetValueAsBool(Option option,
                std::string fieldName)
 {
   std::string fieldname = fieldName;
-  if(fieldName == "")
+  if(fieldName.empty())
     {
     fieldname = option.name;
     }
@@ -454,7 +454,7 @@ GetValueAsBool(Option option,
       }
     ++itField;
     }
-  return 0;
+  return false;
 }
 
 /** Return the value of the option as a float */
@@ -463,7 +463,7 @@ GetValueAsFloat(std::string optionName,
                 std::string fieldName)
 {
   std::string fieldname = fieldName;
-  if(fieldName == "")
+  if(fieldName.empty())
     {
     fieldname = optionName;
     }
@@ -494,7 +494,7 @@ GetValueAsFloat(Option option,
                 std::string fieldName)
 {
   std::string fieldname = fieldName;
-  if(fieldName == "")
+  if(fieldName.empty())
     {
     fieldname = option.name;
     }
@@ -517,7 +517,7 @@ GetValueAsInt(std::string optionName,
               std::string fieldName)
 {
   std::string fieldname = fieldName;
-  if(fieldName == "")
+  if(fieldName.empty())
     {
     fieldname = optionName;
     }
@@ -548,7 +548,7 @@ GetValueAsInt(Option option,
               std::string fieldName)
 {
   std::string fieldname = fieldName;
-  if(fieldName == "")
+  if(fieldName.empty())
     {
     fieldname = option.name;
     }
@@ -571,7 +571,7 @@ GetValueAsString(std::string optionName,
                  std::string fieldName)
 {
   std::string fieldname = fieldName;
-  if(fieldName == "")
+  if(fieldName.empty())
     {
     fieldname = optionName;
     }
@@ -602,7 +602,7 @@ GetValueAsString(Option option,
                  std::string fieldName)
 {
   std::string fieldname = fieldName;
-  if(fieldName == "")
+  if(fieldName.empty())
     {
     fieldname = option.name;
     }
@@ -688,12 +688,12 @@ ListOptions()
     std::cout << "Option #" << i << std::endl;
     std::cout << "   Name: " <<  (*it).name.c_str()
                         << std::endl;
-    if((*it).tag.size() > 0)
+    if(!(*it).tag.empty())
       {
       std::cout << "   Tag: " << (*it).tag.c_str()
                           << std::endl;
       }
-    if((*it).longtag.size() > 0)
+    if(!(*it).longtag.empty())
       {
       std::cout << "   LongTag: " << (*it).longtag.c_str()
                           << std::endl;
@@ -875,7 +875,7 @@ void MetaCommand::WriteXMLOptionToCout(std::string optionName,
 
   std::vector<Field>::const_iterator itField = (*it).fields.begin();
 
-  std::string optionType = "";
+  std::string optionType;
 
   if((*itField).type == MetaCommand::STRING
      && ( (*itField).externaldata == MetaCommand::DATA_IN
@@ -897,7 +897,7 @@ void MetaCommand::WriteXMLOptionToCout(std::string optionName,
     }
   else
     {
-    optionType = this->TypeToString((*itField).type).c_str();
+    optionType = this->TypeToString((*itField).type);
     }
 
   std::cout << "<" << optionType.c_str()
@@ -908,7 +908,7 @@ void MetaCommand::WriteXMLOptionToCout(std::string optionName,
                       << std::endl;
   // Label is the description for now
   std::string label = (*it).label;
-  if(label.size()==0)
+  if(label.empty())
     {
     label = (*it).name;
     }
@@ -917,12 +917,12 @@ void MetaCommand::WriteXMLOptionToCout(std::string optionName,
                       << std::endl;
   std::cout << "<description>" << (*it).description.c_str()
                       << "</description>" << std::endl;
-  if((*it).tag.size()>0) // use the single by default flag if any
+  if(!(*it).tag.empty()) // use the single by default flag if any
     {
     std::cout << "<flag>" << (*it).tag.c_str() << "</flag>"
                         << std::endl;
     }
-  else if((*it).longtag.size()>0)
+  else if(!(*it).longtag.empty())
     {
     std::cout << "<longflag>" << (*it).longtag.c_str() << "</longflag>"
                         << std::endl;
@@ -933,7 +933,7 @@ void MetaCommand::WriteXMLOptionToCout(std::string optionName,
     index++;
     }
 
-  if((*itField).value.size()>0)
+  if(!(*itField).value.empty())
     {
     std::cout << "<default>" << (*itField).value.c_str() << "</default>"
                         << std::endl;
@@ -1003,7 +1003,7 @@ void MetaCommand::ListOptionsSlicerXML()
     std::cout << "  <label>" << (*itGroup).name.c_str()
                         <<  "</label>" <<  std::endl;
 
-    if((*itGroup).description.size() == 0)
+    if((*itGroup).description.empty())
       {
       std::cout << "  <description>" << (*itGroup).name.c_str()
                           << "</description>" <<  std::endl;
@@ -1049,7 +1049,7 @@ void MetaCommand::ListOptionsSlicerXML()
 
       if(!optionIsGrouped)
         {
-        this->WriteXMLOptionToCout((*it).name.c_str(),index);
+        this->WriteXMLOptionToCout((*it).name,index);
         }
       ++it;
       } // end loop option
@@ -1095,7 +1095,7 @@ ParseXML(const char* buffer)
   m_OptionVector.clear();
   std::string buf = this->GetXML(buffer,"option",0);
   long pos = 0;
-  while(buf.size() > 0)
+  while(!buf.empty())
     {
     Option option;
     option.userDefined = false;
@@ -1212,7 +1212,7 @@ ListOptionsSimplified(bool extended)
   it = m_OptionVector.begin();
   while(it != m_OptionVector.end())
     {
-    if((*it).tag.size() > 0 || (*it).longtag.size() > 0)
+    if(!(*it).tag.empty() || !(*it).longtag.empty())
       {
       ntags++;
       }
@@ -1252,8 +1252,8 @@ ListOptionsSimplified(bool extended)
     it = m_OptionVector.begin();
     while(it != m_OptionVector.end())
       {
-      if( (count == 1 && ( (*it).tag.size() > 0 || (*it).longtag.size() > 0 ))
-         || (count == 2 && ( (*it).tag.size() == 0 && (*it).longtag.size() == 0 )) )
+      if( (count == 1 && ( !(*it).tag.empty() || !(*it).longtag.empty() ))
+         || (count == 2 && ( (*it).tag.empty() && (*it).longtag.empty() )) )
         {
         if(!(*it).required)
           {
@@ -1263,11 +1263,11 @@ ListOptionsSimplified(bool extended)
           {
           std::cout << "   ";
           }
-        if((*it).tag.size() > 0)
+        if(!(*it).tag.empty())
           {
           std::cout << "-" << (*it).tag.c_str() << " ";
           }
-        if((*it).longtag.size() > 0)
+        if(!(*it).longtag.empty())
           {
           std::cout << "--" << (*it).longtag.c_str() << " ";
           }
@@ -1307,23 +1307,23 @@ ListOptionsSimplified(bool extended)
           }
         std::cout << std::endl;
 
-        if((*it).description.size()>0)
+        if(!(*it).description.empty())
           {
           std::cout << "      = " << (*it).description.c_str();
           std::cout << std::endl;
           itField = (*it).fields.begin();
           while(itField != (*it).fields.end())
             {
-            if((*itField).description.size() > 0
-               || (*itField).value.size() > 0)
+            if(!(*itField).description.empty()
+               || !(*itField).value.empty())
               {
               std::cout << "        With: "
                                   << (*itField).name.c_str();
-              if((*itField).description.size() > 0)
+              if(!(*itField).description.empty())
                 {
                 std::cout << " = " << (*itField).description.c_str();
                 }
-              if((*itField).value.size() > 0)
+              if(!(*itField).value.empty())
                 {
                 std::cout << " (Default = "
                                     << (*itField).value.c_str() << ")";
@@ -1448,7 +1448,7 @@ ExportGAD(bool dynamic)
     options = m_ParsedOptionVector;
     }
 
-  if(m_Name=="")
+  if(m_Name.empty())
     {
     std::cout << "Set the name of the application using SetName()"
                         << std::endl;
@@ -1578,7 +1578,7 @@ ExportGAD(bool dynamic)
     file << "   <group name=\"" << (*it).name.c_str();
     file << "\" syntax=\"";
 
-    if((*it).tag.size()>0)
+    if(!(*it).tag.empty())
       {
       file << "-" << (*it).tag.c_str() << " ";
       }
@@ -1622,12 +1622,12 @@ ExportGAD(bool dynamic)
       file << "\" type=\"" << this->TypeToString((*itFields).type).c_str();
       file << "\"";
 
-      if((*itFields).rangeMin != "")
+      if(!(*itFields).rangeMin.empty())
         {
         file << " rangeMin=\"" << (*itFields).rangeMin.c_str() << "\"";
         }
 
-      if((*itFields).rangeMax != "")
+      if(!(*itFields).rangeMax.empty())
         {
         file << " rangeMax=\"" << (*itFields).rangeMax.c_str() << "\"";
         }
@@ -1698,7 +1698,7 @@ ExportGAD(bool dynamic)
 
 
 /** Parse the command line */
-bool MetaCommand::Parse(int argc, char* argv[])
+bool MetaCommand::Parse(int argc, char** const argv)
 {
   m_GotXMLFlag = false;
   m_ExecutableName = argv[0];
@@ -1719,7 +1719,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
   // Fill in the results
   m_ParsedOptionVector.clear();
   bool inArgument = false;
-  std::string tag = "";
+  std::string tag;
   std::string args;
 
   unsigned long currentField = 0; // current field position
@@ -1728,7 +1728,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
   unsigned int optionalValuesRemaining=0;
   bool isComplete = false; // check if the option should be parse until
                            // the next tag is found
-  std::string completeString = "";
+  std::string completeString;
 
   bool exportGAD = false;
   for(unsigned int i=1;i<(unsigned int)argc;i++)
@@ -1912,7 +1912,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
       bool found = false;
       while(it != m_OptionVector.end())
         {
-        if((pos >= currentField) && ((*it).tag=="" && (*it).longtag==""))
+        if((pos >= currentField) && ((*it).tag.empty() && (*it).longtag.empty()))
           {
           currentOption = pos;
           valuesRemaining = static_cast<unsigned int>((*it).fields.size());
@@ -1938,7 +1938,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
     // We collect the values
     if(isComplete && (int)i<argc)
       {
-      if(completeString.size()==0)
+      if(completeString.empty())
         {
         completeString = argv[i];
         }
@@ -2061,7 +2061,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
       bool defined = true;
       while(itFields != (*it).fields.end())
         {
-        if((*itFields).value == "")
+        if((*itFields).value.empty())
           {
           defined = false;
           }
@@ -2070,7 +2070,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
 
       if(!defined)
         {
-        if((*it).tag.size()>0 || (*it).longtag.size()>0)
+        if(!(*it).tag.empty() || !(*it).longtag.empty())
           {
           std::cout << "Field " << (*it).tag.c_str()
                               << " is required but not defined"
@@ -2108,16 +2108,16 @@ bool MetaCommand::Parse(int argc, char* argv[])
       if(((*itFields).type == INT ||
         (*itFields).type == FLOAT ||
         (*itFields).type == CHAR)
-        && ((*itFields).value != "")
+        && (!(*itFields).value.empty())
         )
         {
         // Check the range min
         if(
-          (((*itFields).rangeMin != "")
+          ((!(*itFields).rangeMin.empty())
           && (atof((*itFields).rangeMin.c_str())
               > atof((*itFields).value.c_str())))
           ||
-          (((*itFields).rangeMax != "")
+          ((!(*itFields).rangeMax.empty())
           && (atof((*itFields).rangeMax.c_str())
               < atof((*itFields).value.c_str())))
           )

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaCommand.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaCommand.h
@@ -183,7 +183,7 @@ public:
 
   bool OptionExistsByMinusTag(std::string minusTag);
 
-  bool Parse(int argc, char* argv[]);
+  bool Parse(int argc, char** const argv);
 
   /** Given an XML buffer fill in the command line arguments */
   bool ParseXML(const char* buffer);

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaContour.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaContour.cxx
@@ -75,12 +75,12 @@ MetaContour(const char *_headerName)
 
 //
 MetaContour::
-MetaContour(const MetaContour *_Contour)
+MetaContour(const MetaContour *_contour)
 :MetaObject()
 {
   if(META_DEBUG)  std::cout << "MetaContour()" << std::endl;
   Clear();
-  CopyInfo(_Contour);
+  CopyInfo(_contour);
 }
 
 

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaDTITube.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaDTITube.cxx
@@ -108,12 +108,12 @@ MetaDTITube(const char *_headerName)
 
 
 MetaDTITube::
-MetaDTITube(const MetaDTITube *_DTITube)
+MetaDTITube(const MetaDTITube *_dtiTube)
 :MetaObject()
 {
   if(META_DEBUG)  std::cout << "MetaDTITube()" << std::endl;
   Clear();
-  CopyInfo(_DTITube);
+  CopyInfo(_dtiTube);
 }
 
 
@@ -332,7 +332,7 @@ M_SetupWriteFields()
     ++itFields;
     }
 
-  if(m_PointDim.size()>0)
+  if(!m_PointDim.empty())
     {
     mF = new MET_FieldRecordType;
     MET_InitWriteField(mF, "PointDim", MET_STRING,

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaFEMObject.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaFEMObject.cxx
@@ -1,6 +1,6 @@
 /*=========================================================================
  *
- *  Copyright NumFOCUS
+ *  Copyright Insight Software Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -62,17 +62,13 @@ FEMObjectElement::
   delete []m_NodesId;
 }
 
-FEMObjectLoad::FEMObjectLoad()
-{
-}
+FEMObjectLoad::FEMObjectLoad() = default;
 
 FEMObjectLoad::~FEMObjectLoad()
 {
-  for(std::vector<FEMObjectMFCTerm *>::iterator it = this->m_LHS.begin();
-      it != this->m_LHS.end();
-      ++it)
+  for(auto & it : this->m_LHS)
     {
-    delete (*it);
+    delete it;
     }
   this->m_LHS.clear();
   this->m_RHS.clear();
@@ -370,7 +366,7 @@ M_Read()
     this->SkipWhiteSpace();              // skip comments and whitespaces
     if ( this->m_ReadStream->eof() )
       {
-      return 0;              // end of stream. all was good
+      return false;              // end of stream. all was good
       }
     char c;
     if ( ( c = static_cast<char>(this->m_ReadStream->get()) ) != '<' )

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaFEMObject.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaFEMObject.h
@@ -1,6 +1,6 @@
 /*=========================================================================
  *
- *  Copyright NumFOCUS
+ *  Copyright Insight Software Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaForm.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaForm.cxx
@@ -390,11 +390,11 @@ Name() const
 }
 
 void  MetaForm::
-Name(const char *_Name)
+Name(const char *_name)
 {
-  if(_Name != nullptr)
+  if(_name != nullptr)
     {
-    strcpy(m_Name, _Name);
+    strcpy(m_Name, _name);
     }
   else
     {

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaImage.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaImage.cxx
@@ -1158,7 +1158,7 @@ M_GetTagValue(const std::string & buffer, const char* tag) const
     }
 
   // Get the element data filename
-  std::string value = "";
+  std::string value;
   bool firstspace = true;
   size_t index = pos2+1;
   while(index<buffer.size()
@@ -1185,7 +1185,7 @@ CanRead(const char *_headerName) const
 {
   // First check the extension
   std::string fname = _headerName;
-  if(  fname == "" )
+  if(  fname.empty() )
     {
     return false;
     }
@@ -1214,7 +1214,7 @@ CanRead(const char *_headerName) const
   // Now check the file content
   std::ifstream inputStream;
 
-  openReadStream(inputStream, fname.c_str());
+  openReadStream(inputStream, fname);
 
   if( inputStream.fail() )
     {
@@ -1524,7 +1524,7 @@ ReadStream(int _nDims,
         {
         std::string tempFName(fName);
         tempFName += extensions[ii];
-        openReadStream(*readStreamTemp,tempFName.c_str());
+        openReadStream(*readStreamTemp,tempFName);
         if(readStreamTemp->is_open())
           {
           if(ii > 0)
@@ -2042,8 +2042,8 @@ bool  MetaImage::
 M_WriteElementsROI(std::ofstream * _fstream,
                    const void * _data,
                    std::streampos _dataPos,
-                   int * _indexMin,
-                   int* _indexMax )
+                   const int * _indexMin,
+                   const int* _indexMax )
 {
   const char* data = static_cast<const char*>(_data);
 
@@ -3067,7 +3067,7 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
         {
         std::string tempFName(fName);
         tempFName += extensions[ii];
-        openReadStream(*readStreamTemp,tempFName.c_str());
+        openReadStream(*readStreamTemp,tempFName);
         if(readStreamTemp->is_open())
           {
           if(ii > 0)

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaImage.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaImage.h
@@ -380,8 +380,8 @@ class METAIO_EXPORT MetaImage : public MetaObject
     bool  M_WriteElementsROI(std::ofstream * _fstream,
                              const void * _data,
                              std::streampos _dataPos,
-                             int * _indexMin,
-                             int* _indexMax);
+                             const int * _indexMin,
+                             const int* _indexMax);
 
     bool  M_WriteElementData(std::ofstream * _fstream,
                              const void * _data,

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaMesh.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaMesh.cxx
@@ -83,9 +83,9 @@ MetaMesh()
   if(META_DEBUG) std::cout << "MetaMesh()" << std::endl;
   m_NPoints = 0;
 
-  for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
+  for(auto & i : m_CellListArray)
     {
-    m_CellListArray[i] = nullptr;
+    i = nullptr;
     }
   Clear();
 }
@@ -98,9 +98,9 @@ MetaMesh(const char *_headerName)
   if(META_DEBUG)  std::cout << "MetaMesh()" << std::endl;
   m_NPoints = 0;
 
-  for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
+  for(auto & i : m_CellListArray)
     {
-    m_CellListArray[i] = nullptr;
+    i = nullptr;
     }
   Clear();
   Read(_headerName);
@@ -113,9 +113,9 @@ MetaMesh(const MetaMesh *_mesh)
 {
   if(META_DEBUG)  std::cout << "MetaMesh()" << std::endl;
   m_NPoints = 0;
-  for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
+  for(auto & i : m_CellListArray)
     {
-    m_CellListArray[i] = nullptr;
+    i = nullptr;
     }
   Clear();
   CopyInfo(_mesh);
@@ -130,9 +130,9 @@ MetaMesh(unsigned int dim)
 {
   if(META_DEBUG) std::cout << "MetaMesh()" << std::endl;
   m_NPoints = 0;
-  for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
+  for(auto & i : m_CellListArray)
     {
-    m_CellListArray[i] = nullptr;
+    i = nullptr;
     }
   Clear();
 }
@@ -142,10 +142,10 @@ MetaMesh::
 ~MetaMesh()
 {
   Clear();
-  for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
+  for(auto & i : m_CellListArray)
     {
-    delete m_CellListArray[i];
-    m_CellListArray[i] = nullptr;
+    delete i;
+    i = nullptr;
     }
 
   M_Destroy();
@@ -240,21 +240,21 @@ Clear()
 }
 
   // Initialize the new array
-  for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
+  for(auto & i : m_CellListArray)
     {
-    if(m_CellListArray[i])
+    if(i)
       {
       // Delete the list of pointers to cells.
-      CellListType::iterator it_cell = m_CellListArray[i]->begin();
-      while(it_cell != m_CellListArray[i]->end())
+      CellListType::iterator it_cell = i->begin();
+      while(it_cell != i->end())
       {
         MeshCell* cell = *it_cell;
         ++it_cell;
         delete cell;
       }
-      delete m_CellListArray[i];
+      delete i;
       }
-    m_CellListArray[i] = new CellListType;
+    i = new CellListType;
     }
 
   m_PointList.clear();
@@ -353,9 +353,9 @@ M_SetupWriteFields()
   m_Fields.push_back(mF);
 
   unsigned int numberOfCellTypes = 0;
-  for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
+  for(auto & i : m_CellListArray)
     {
-    if(m_CellListArray[i]->size()>0)
+    if(!i->empty())
       {
       numberOfCellTypes++;
       }
@@ -1237,7 +1237,7 @@ M_Write()
   // Loop trough the array of cell types and write them if they exists
   for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
     {
-    if(m_CellListArray[i]->size()>0)
+    if(!m_CellListArray[i]->empty())
       {
       // clear the fields and add new fields for a new write
       MetaObject::ClearFields();

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaObject.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaObject.cxx
@@ -941,11 +941,11 @@ ElementSpacing(int _i, double _value)
 
 
 void  MetaObject::
-Name(const char *_Name)
+Name(const char *_name)
 {
-  if(_Name != nullptr)
+  if(_name != nullptr)
     {
-    strcpy(m_Name, _Name);
+    strcpy(m_Name, _name);
     }
 }
 
@@ -1957,7 +1957,7 @@ bool MetaObject
   MET_FieldRecordType* mFr = new MET_FieldRecordType;
   MET_InitReadField(mFr,_fieldName, _type, _required,_dependsOn,_length);
   m_UserDefinedReadFields.push_back(mFr);
-  return 1;
+  return true;
 }
 
 void MetaObject::M_PrepareNewReadStream()

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaOutput.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaOutput.cxx
@@ -357,7 +357,7 @@ std::string MetaOutput::GetHostip()
     address++;
 }
 
-  std::string m_ip = "";
+  std::string m_ip;
   if (m_numaddrs != 0)
 {
     memcpy(&addr, phe->h_addr_list[m_numaddrs-1], sizeof(struct in_addr));
@@ -427,7 +427,7 @@ std::string MetaOutput::GenerateXML(const char* filename)
       continue;
       }
 
-    typedef std::vector<MetaCommand::Field> CmdFieldVector;
+    using CmdFieldVector = std::vector<MetaCommand::Field>;
     CmdFieldVector::const_iterator itField = (*itInput).fields.begin();
     CmdFieldVector::const_iterator itFieldEnd = (*itInput).fields.end();
     while(itField != itFieldEnd)
@@ -449,11 +449,11 @@ std::string MetaOutput::GenerateXML(const char* filename)
         }
       buffer += " value=\"" + (*itField).value + "\"";
       buffer += " type=\"" + m_MetaCommand->TypeToString((*itField).type) + "\"";
-      if((*itField).rangeMin != "")
+      if(!(*itField).rangeMin.empty())
         {
         buffer += " rangeMin=\"" + (*itField).rangeMin + "\"";
         }
-      if((*itField).rangeMax != "")
+      if(!(*itField).rangeMax.empty())
         {
         buffer += " rangeMax=\"" + (*itField).rangeMax + "\"";
         }
@@ -485,7 +485,7 @@ std::string MetaOutput::GenerateXML(const char* filename)
     buffer += " type=\""+ this->TypeToString((*itOutput).type) + "\"";
 
     unsigned int index = 0;
-    typedef std::vector<std::string> VectorType;
+    using VectorType = std::vector<std::string>;
     VectorType::const_iterator itValue = (*itOutput).value.begin();
     while(itValue != (*itOutput).value.end())
       {
@@ -576,7 +576,7 @@ void MetaOutput::Write()
       if(dynamic_cast<MetaFileOutputStream*>(*itStream))
         {
         std::string filename = ((MetaFileOutputStream*)(*itStream))
-                                      ->GetFileName().c_str();
+                                      ->GetFileName();
         (*itStream)->Write(this->GenerateXML(filename.c_str()).c_str());
         }
       else

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaScene.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaScene.cxx
@@ -203,7 +203,7 @@ Read(const char *_headerName)
 
     const std::string objectType = MET_ReadType(*m_ReadStream);
     if(!strncmp(objectType.c_str(),"Tube",4) ||
-      ((objectType.size()==0) && !strcmp(suf, "tre")))
+      ((objectType.empty()) && !strcmp(suf, "tre")))
       {
       char* subtype = MET_ReadSubType(*m_ReadStream);
       if(!strncmp(subtype,"Vessel",6))
@@ -247,7 +247,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"Ellipse",7) ||
-      ((objectType.size()==0) && !strcmp(suf, "elp")))
+      ((objectType.empty()) && !strcmp(suf, "elp")))
       {
       MetaEllipse* ellipse = new MetaEllipse();
       ellipse->SetEvent(m_Event);
@@ -256,7 +256,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"Contour",7) ||
-      ((objectType.size()==0) && !strcmp(suf, "ctr")))
+      ((objectType.empty()) && !strcmp(suf, "ctr")))
       {
       MetaContour* contour = new MetaContour();
       contour->SetEvent(m_Event);
@@ -273,7 +273,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"Gaussian",8) ||
-      ((objectType.size()==0) && !strcmp(suf, "gau")))
+      ((objectType.empty()) && !strcmp(suf, "gau")))
       {
       MetaGaussian* gaussian = new MetaGaussian();
       gaussian->SetEvent(m_Event);
@@ -282,7 +282,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"Image",5) ||
-      ((objectType.size()==0) &&
+      ((objectType.empty()) &&
        (!strcmp(suf, "mhd") || !strcmp(suf, "mha"))))
       {
       MetaImage* image = new MetaImage();
@@ -293,7 +293,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"Blob",4) ||
-      ((objectType.size()==0) && !strcmp(suf, "blb")))
+      ((objectType.empty()) && !strcmp(suf, "blb")))
       {
       MetaBlob* blob = new MetaBlob();
       blob->SetEvent(m_Event);
@@ -302,7 +302,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"Landmark",8) ||
-      ((objectType.size()==0) && !strcmp(suf, "ldm")))
+      ((objectType.empty()) && !strcmp(suf, "ldm")))
       {
       MetaLandmark* landmark = new MetaLandmark();
       landmark->SetEvent(m_Event);
@@ -311,7 +311,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"Surface",5) ||
-      ((objectType.size()==0) && !strcmp(suf, "suf")))
+      ((objectType.empty()) && !strcmp(suf, "suf")))
       {
       MetaSurface* surface = new MetaSurface();
       surface->SetEvent(m_Event);
@@ -319,8 +319,8 @@ Read(const char *_headerName)
       m_ObjectList.push_back(surface);
       }
 
-    else if(!strncmp(objectType.c_str(),"Line",5) ||
-      ((objectType.size()==0) && !strcmp(suf, "lin")))
+    else if(!strncmp(objectType.c_str(),"Line",4) ||
+      ((objectType.empty()) && !strcmp(suf, "lin")))
       {
       MetaLine* line = new MetaLine();
       line->SetEvent(m_Event);
@@ -329,7 +329,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"Group",5) ||
-      ((objectType.size()==0) && !strcmp(suf, "grp")))
+      ((objectType.empty()) && !strcmp(suf, "grp")))
       {
       MetaGroup* group = new MetaGroup();
       group->SetEvent(m_Event);
@@ -338,7 +338,7 @@ Read(const char *_headerName)
       }
 
     else if(!strncmp(objectType.c_str(),"AffineTransform",15) ||
-      ((objectType.size()==0) && !strcmp(suf, "trn")))
+      ((objectType.empty()) && !strcmp(suf, "trn")))
       {
       MetaGroup* group = new MetaGroup();
       group->SetEvent(m_Event);
@@ -346,7 +346,7 @@ Read(const char *_headerName)
       m_ObjectList.push_back(group);
       }
     else if(!strncmp(objectType.c_str(),"Mesh",4) ||
-      ((objectType.size()==0) && !strcmp(suf, "msh")))
+      ((objectType.empty()) && !strcmp(suf, "msh")))
       {
       MetaMesh* mesh = new MetaMesh();
       mesh->SetEvent(m_Event);
@@ -354,7 +354,7 @@ Read(const char *_headerName)
       m_ObjectList.push_back(mesh);
       }
     else if(!strncmp(objectType.c_str(),"FEMObject",9) ||
-            ((objectType.size()==0) && !strcmp(suf, "fem")))
+            ((objectType.empty()) && !strcmp(suf, "fem")))
       {
       MetaFEMObject* femobject = new MetaFEMObject();
       femobject->SetEvent(m_Event);

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaTypes.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaTypes.h
@@ -193,10 +193,6 @@ typedef struct
                                   //   meta data
    } MET_FieldRecordType;
 
-// Emulate C++11 snprintf on old MSVC.
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-#define snprintf _snprintf
-#endif
 
 #if (METAIO_USE_NAMESPACE)
 };

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaUtils.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaUtils.cxx
@@ -532,7 +532,7 @@ std::streamoff MET_UncompressStream(std::ifstream * stream,
   // Try to find the current seek position in the compressed
   // and uncompressed stream from the compressionTable
   // The table is stored in order
-  if(compressionTable->offsetList.size()>0)
+  if(!compressionTable->offsetList.empty())
     {
     MET_CompressionOffsetListType::const_iterator it = compressionTable->offsetList.end();
     --it;
@@ -1010,7 +1010,7 @@ static bool MET_IsComplete(std::vector<MET_FieldRecordType *> * fields)
 //
 bool MET_Read(std::istream &fp,
               std::vector<MET_FieldRecordType *> * fields,
-              char _MET_SeperatorChar, bool oneLine, bool display_warnings,
+              char _met_SeperatorChar, bool oneLine, bool display_warnings,
               std::vector<MET_FieldRecordType *> * newFields)
 {
 
@@ -1020,7 +1020,7 @@ bool MET_Read(std::istream &fp,
 
   std::vector<MET_FieldRecordType *>::iterator fieldIter;
 
-  MET_SeperatorChar = _MET_SeperatorChar;
+  MET_SeperatorChar = _met_SeperatorChar;
 
   bool found;
 
@@ -1268,9 +1268,9 @@ static std::string convert_ulonglong_to_string(MET_ULONG_LONG_TYPE val)
 //
 bool MET_Write(std::ostream &fp,
                std::vector<MET_FieldRecordType *> * fields,
-               char _MET_SeperatorChar)
+               char _met_SeperatorChar)
 {
-  MET_SeperatorChar = _MET_SeperatorChar;
+  MET_SeperatorChar = _met_SeperatorChar;
 
   int j;
   std::vector<MET_FieldRecordType *>::iterator fieldIter;

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaVesselTube.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaVesselTube.cxx
@@ -57,8 +57,8 @@ MetaVesselTube(const char *_headerName)
 
 
 MetaVesselTube::
-MetaVesselTube(const MetaVesselTube *_VesselTube)
-:MetaTube(_VesselTube)
+MetaVesselTube(const MetaVesselTube *_vesselTube)
+:MetaTube(_vesselTube)
 {
   if(META_DEBUG)
     {


### PR DESCRIPTION
Update to MetaIO tag f473b7b86a15dc2f3578f1e82b5544ef7776e2e7
from May 11, 2020.

ENH: Parse() should handle char *argv[] as const (#91)