### PR TITLE
Address Wdeprecated-copy warnings on gcc 9.3

### DIFF
--- a/Modules/Core/Common/include/itkMapContainer.h
+++ b/Modules/Core/Common/include/itkMapContainer.h
@@ -173,18 +173,9 @@ public:
     using reference = typename MapIterator::reference;
 
     Iterator() = default;
-    Iterator(const Iterator & i)
-      : m_Iter(i.m_Iter)
-    {}
     Iterator(const MapIterator & i)
       : m_Iter(i)
     {}
-    Iterator &
-    operator=(const Iterator & r)
-    {
-      m_Iter = r.m_Iter;
-      return *this;
-    }
 
     Iterator & operator*() { return *this; }
     Iterator * operator->() { return this; }
@@ -275,12 +266,6 @@ public:
     ConstIterator(const Iterator & r)
       : m_Iter(r.m_Iter)
     {}
-    ConstIterator &
-    operator=(const ConstIterator & r)
-    {
-      m_Iter = r.m_Iter;
-      return *this;
-    }
 
     ConstIterator & operator*() { return *this; }
     ConstIterator * operator->() { return this; }

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -192,10 +192,6 @@ public:
       : m_Pos(d)
       , m_Iter(i)
     {}
-    Iterator(const Iterator & r)
-      : m_Pos(r.m_Pos)
-      , m_Iter(r.m_Iter)
-    {}
     Iterator & operator*() { return *this; }
     Iterator * operator->() { return this; }
     Iterator &

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -14,6 +14,7 @@ itkFloodFilledSpatialFunctionTest.cxx
 itkFloodFillIteratorTest.cxx
 itkGaussianDerivativeOperatorTest.cxx
 itkMapContainerTest.cxx
+itkVectorContainerTest.cxx
 itkIteratorTests.cxx
 itkImageReverseIteratorTest.cxx
 itkImageComputeOffsetAndIndexTest.cxx
@@ -338,6 +339,7 @@ itk_add_test(NAME itkLoggerManagerTest COMMAND ITKCommon2TestDriver itkLoggerMan
 itk_add_test(NAME itkLoggerThreadWrapperTest COMMAND ITKCommon2TestDriver itkLoggerThreadWrapperTest ${TEMP}/test_LoggerThreadWrapper.txt)
 itk_add_test(NAME itkMatrixTest COMMAND ITKCommon2TestDriver itkMatrixTest)
 itk_add_test(NAME itkMapContainerTest COMMAND ITKCommon1TestDriver itkMapContainerTest)
+itk_add_test(NAME itkVectorContainerTest COMMAND ITKCommon1TestDriver itkVectorContainerTest)
 itk_add_test(NAME itkIteratorTests COMMAND ITKCommon1TestDriver itkIteratorTests)
 itk_add_test(NAME itkObjectFactoryTest COMMAND ITKCommon1TestDriver itkObjectFactoryTest)
 itk_add_test(NAME itkVectorTest COMMAND ITKCommon1TestDriver itkVectorTest)

--- a/Modules/Core/Common/test/itkVectorContainerTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerTest.cxx
@@ -16,50 +16,20 @@
  *
  *=========================================================================*/
 
+#include "itkVectorContainer.h"
 #include "itkTestingMacros.h"
-#include "itkMapContainer.h"
-#include "itkPoint.h"
 
-#include <iostream>
-
-/**
- * Some type alias to make things easier.
- */
-using PointType = itk::Point<float, 3>;
-using VectorType = itk::Vector<float, 3>;
-
-using ContainerType = itk::MapContainer<unsigned long, PointType>;
-using ContainerPointer = ContainerType::Pointer;
+using ContainerType = itk::VectorContainer<size_t, double>;
 
 int
-itkMapContainerTest(int, char *[])
+itkVectorContainerTest(int, char *[])
 {
 
-  /**
-   * Create the Container
-   */
-  ContainerPointer container = ContainerType::New();
-
-  PointType pointA;
-  PointType pointB;
-  PointType pointC;
-  PointType pointD;
-
-  VectorType displacement;
-
-  displacement[0] = 2;
-  displacement[1] = 5;
-  displacement[2] = 9;
-
-  pointA.Fill(0.0);
-  pointB = pointA + displacement;
-  pointC = pointB + displacement;
-  pointD = pointC + displacement;
-
-  container->SetElement(0, pointA);
-  container->SetElement(1, pointB);
-  container->SetElement(2, pointC);
-  container->SetElement(3, pointD);
+  auto container = ContainerType::New();
+  container->InsertElement(0, 9.2);
+  container->InsertElement(1, 4.7);
+  container->InsertElement(2, 1.1);
+  container->InsertElement(3, 4.9);
 
   // Iterator
   {
@@ -95,13 +65,6 @@ itkMapContainerTest(int, char *[])
       ++p_copy;
       ++p_assign;
     }
-  }
-
-  container->Initialize();
-  if (container->Size() != 0)
-  {
-    std::cerr << "Initialize() didn't get rid of elements" << std::endl;
-    return EXIT_FAILURE;
   }
 
   return EXIT_SUCCESS;

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
@@ -47,6 +47,9 @@ public:
    *  in the ContourSpatialObjectPoint */
   ContourSpatialObjectPoint();
 
+  /** Copy Constructor */
+  ContourSpatialObjectPoint(const ContourSpatialObjectPoint & other);
+
   /** Default destructor. */
   ~ContourSpatialObjectPoint() override = default;
 

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -73,10 +73,7 @@ ContourSpatialObjectPoint<TPointDimension>::operator=(const ContourSpatialObject
 {
   if (this != &rhs)
   {
-    this->m_Id = rhs.GetId();
-    this->m_PositionInObjectSpace = rhs.GetPositionInObjectSpace();
-    this->m_Color = rhs.GetColor();
-    this->m_SpatialObject = rhs.GetSpatialObject();
+    Superclass::operator=(rhs);
     this->m_NormalInObjectSpace = rhs.GetNormalInObjectSpace();
     this->m_PickedPointInObjectSpace = rhs.GetPickedPointInObjectSpace();
   }

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -22,11 +22,21 @@
 
 namespace itk
 {
+/** Constructor */
 template <unsigned int TPointDimension>
 ContourSpatialObjectPoint<TPointDimension>::ContourSpatialObjectPoint()
 {
   m_NormalInObjectSpace.Fill(0);
   m_PickedPointInObjectSpace.Fill(0);
+}
+
+/** Copy Constructor */
+template <unsigned int TPointDimension>
+ContourSpatialObjectPoint<TPointDimension>::ContourSpatialObjectPoint(const ContourSpatialObjectPoint & other)
+  : Superclass(other)
+{
+  this->m_NormalInObjectSpace = other.GetNormalInObjectSpace();
+  this->m_PickedPointInObjectSpace = other.GetPickedPointInObjectSpace();
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
@@ -61,7 +61,7 @@ class ITK_TEMPLATE_EXPORT DTITubeSpatialObjectPoint : public TubeSpatialObjectPo
 {
 public:
   using Self = DTITubeSpatialObjectPoint;
-  using Superclass = SpatialObjectPoint<TPointDimension>;
+  using Superclass = TubeSpatialObjectPoint<TPointDimension>;
   using PointType = Point<double, TPointDimension>;
   using VectorType = Vector<double, TPointDimension>;
   using CovariantVectorType = CovariantVector<double, TPointDimension>;
@@ -82,6 +82,9 @@ public:
   /** Constructor. This one defines the number of dimensions in the
    * DTITubeSpatialObjectPoint */
   DTITubeSpatialObjectPoint();
+
+  /** Copy Constructor */
+  DTITubeSpatialObjectPoint(const DTITubeSpatialObjectPoint & other);
 
   /** Default destructor. */
   ~DTITubeSpatialObjectPoint() override = default;

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -37,6 +37,25 @@ DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint()
   m_TensorMatrix[5] = 1;
 }
 
+/** Copy Constructor */
+template <unsigned int TPointDimension>
+DTITubeSpatialObjectPoint<TPointDimension>::DTITubeSpatialObjectPoint(const DTITubeSpatialObjectPoint & other)
+  : Superclass(other)
+{
+  m_Fields.clear();
+  const FieldListType & fields = other.GetFields();
+  auto                  it = fields.begin();
+  while (it != fields.end())
+  {
+    this->AddField((*it).first.c_str(), (*it).second);
+    it++;
+  }
+  for (unsigned int i = 0; i < 6; i++)
+  {
+    m_TensorMatrix[i] = other.m_TensorMatrix[i];
+  }
+}
+
 template <unsigned int TPointDimension>
 void
 DTITubeSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -184,26 +184,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::operator=(const DTITubeSpatialObject
 {
   if (this != &rhs)
   {
-    // Point
-    this->SetId(rhs.GetId());
-    this->SetPositionInObjectSpace(rhs.GetPositionInObjectSpace());
-    this->SetColor(rhs.GetColor());
-    this->SetSpatialObject(rhs.GetSpatialObject());
-
-    // Tube
-    this->SetRadiusInObjectSpace(rhs.GetRadiusInObjectSpace());
-    this->SetTangentInObjectSpace(rhs.GetTangentInObjectSpace());
-    this->SetNormal1InObjectSpace(rhs.GetNormal1InObjectSpace());
-    this->SetNormal2InObjectSpace(rhs.GetNormal2InObjectSpace());
-
-    this->SetRidgeness(rhs.GetRidgeness());
-    this->SetMedialness(rhs.GetMedialness());
-    this->SetBranchness(rhs.GetBranchness());
-    this->SetAlpha1(rhs.GetAlpha1());
-    this->SetAlpha2(rhs.GetAlpha2());
-    this->SetAlpha3(rhs.GetAlpha3());
-
-    // Class
+    Superclass::operator=(rhs);
     m_Fields.clear();
     const FieldListType & fields = rhs.GetFields();
     auto                  it = fields.begin();

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -52,6 +52,9 @@ public:
   /** Constructor */
   LineSpatialObjectPoint();
 
+  /** Copy Constructor */
+  LineSpatialObjectPoint(const LineSpatialObjectPoint & other);
+
   /** Destructor */
   ~LineSpatialObjectPoint() override = default;
 

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -82,10 +82,7 @@ LineSpatialObjectPoint<TPointDimension>::operator=(const LineSpatialObjectPoint 
 {
   if (this != &rhs)
   {
-    this->m_Id = rhs.m_Id;
-    this->m_Color = rhs.m_Color;
-    this->m_SpatialObject = rhs.m_SpatialObject;
-    this->m_PositionInObjectSpace = rhs.m_PositionInObjectSpace;
+    Superclass::operator=(rhs);
     this->m_NormalArrayInObjectSpace = rhs.m_NormalArrayInObjectSpace;
   }
   return *this;

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -36,6 +36,14 @@ LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint()
   }
 }
 
+/** Copy Constructor */
+template <unsigned int TPointDimension>
+LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint(const LineSpatialObjectPoint & other)
+  : Superclass(other)
+{
+  this->m_NormalArrayInObjectSpace = other.m_NormalArrayInObjectSpace;
+}
+
 /** Get the specified normal */
 template <unsigned int TPointDimension>
 const typename LineSpatialObjectPoint<TPointDimension>::CovariantVectorType &
@@ -72,13 +80,17 @@ template <unsigned int TPointDimension>
 typename LineSpatialObjectPoint<TPointDimension>::Self &
 LineSpatialObjectPoint<TPointDimension>::operator=(const LineSpatialObjectPoint & rhs)
 {
-  this->m_Id = rhs.m_Id;
-  this->m_Color = rhs.m_Color;
-  this->m_SpatialObject = rhs.m_SpatialObject;
-  this->m_PositionInObjectSpace = rhs.m_PositionInObjectSpace;
-  this->m_NormalArrayInObjectSpace = rhs.m_NormalArrayInObjectSpace;
+  if (this != &rhs)
+  {
+    this->m_Id = rhs.m_Id;
+    this->m_Color = rhs.m_Color;
+    this->m_SpatialObject = rhs.m_SpatialObject;
+    this->m_PositionInObjectSpace = rhs.m_PositionInObjectSpace;
+    this->m_NormalArrayInObjectSpace = rhs.m_NormalArrayInObjectSpace;
+  }
   return *this;
 }
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -47,6 +47,9 @@ public:
   /** Constructor. */
   SpatialObjectPoint();
 
+  /** Copy Constructor. */
+  SpatialObjectPoint(const SpatialObjectPoint & other);
+
   /** Default destructor. */
   virtual ~SpatialObjectPoint() = default;
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -38,6 +38,16 @@ SpatialObjectPoint<TPointDimension>::SpatialObjectPoint()
   m_SpatialObject = nullptr;
 }
 
+/** Copy Constructor */
+template <unsigned int TPointDimension>
+SpatialObjectPoint<TPointDimension>::SpatialObjectPoint(const SpatialObjectPoint & other)
+{
+  this->SetId(other.GetId());
+  this->SetPositionInObjectSpace(other.GetPositionInObjectSpace());
+  this->SetColor(other.GetColor());
+  this->SetSpatialObject(other.GetSpatialObject());
+}
+
 template <unsigned int TPointDimension>
 void
 SpatialObjectPoint<TPointDimension>::SetPositionInWorldSpace(const PointType & point)

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
@@ -48,6 +48,9 @@ public:
   /** Constructor */
   SurfaceSpatialObjectPoint();
 
+  /** Copy Constructor */
+  SurfaceSpatialObjectPoint(const SurfaceSpatialObjectPoint & other);
+
   /** Destructor */
   ~SurfaceSpatialObjectPoint() override = default;
 

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -71,10 +71,7 @@ SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObject
 {
   if (this != &rhs)
   {
-    this->m_Id = rhs.m_Id;
-    this->m_Color = rhs.m_Color;
-    this->m_SpatialObject = rhs.m_SpatialObject;
-    this->m_PositionInObjectSpace = rhs.m_PositionInObjectSpace;
+    Superclass::operator=(rhs);
     this->m_NormalInObjectSpace = rhs.m_NormalInObjectSpace;
   }
   return *this;

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -29,6 +29,14 @@ SurfaceSpatialObjectPoint<TPointDimension>::SurfaceSpatialObjectPoint()
   m_NormalInObjectSpace.Fill(0);
 }
 
+/** Copy Constructor */
+template <unsigned int TPointDimension>
+SurfaceSpatialObjectPoint<TPointDimension>::SurfaceSpatialObjectPoint(const SurfaceSpatialObjectPoint & other)
+  : Superclass(other)
+{
+  this->m_NormalInObjectSpace = other.m_NormalInObjectSpace;
+}
+
 /** Set the normal : N-D case */
 template <unsigned int TPointDimension>
 void
@@ -61,11 +69,14 @@ template <unsigned int TPointDimension>
 typename SurfaceSpatialObjectPoint<TPointDimension>::Self &
 SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObjectPoint & rhs)
 {
-  this->m_Id = rhs.m_Id;
-  this->m_Color = rhs.m_Color;
-  this->m_SpatialObject = rhs.m_SpatialObject;
-  this->m_PositionInObjectSpace = rhs.m_PositionInObjectSpace;
-  this->m_NormalInObjectSpace = rhs.m_NormalInObjectSpace;
+  if (this != &rhs)
+  {
+    this->m_Id = rhs.m_Id;
+    this->m_Color = rhs.m_Color;
+    this->m_SpatialObject = rhs.m_SpatialObject;
+    this->m_PositionInObjectSpace = rhs.m_PositionInObjectSpace;
+    this->m_NormalInObjectSpace = rhs.m_NormalInObjectSpace;
+  }
   return *this;
 }
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
@@ -49,6 +49,9 @@ public:
    * TubeSpatialObjectPoint */
   TubeSpatialObjectPoint();
 
+  /** Copy Constructor */
+  TubeSpatialObjectPoint(const TubeSpatialObjectPoint & other);
+
   /** Default destructor. */
   ~TubeSpatialObjectPoint() override = default;
 

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -43,6 +43,28 @@ TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint()
   m_Alpha3 = 0;
 }
 
+/** Copy Constructor */
+template <unsigned int TPointDimension>
+TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint(const TubeSpatialObjectPoint & other)
+  : Superclass(other)
+{
+  this->SetRadiusInObjectSpace(other.GetRadiusInObjectSpace());
+  this->SetTangentInObjectSpace(other.GetTangentInObjectSpace());
+  this->SetNormal1InObjectSpace(other.GetNormal1InObjectSpace());
+  this->SetNormal2InObjectSpace(other.GetNormal2InObjectSpace());
+
+  this->SetRidgeness(other.GetRidgeness());
+  this->SetMedialness(other.GetMedialness());
+  this->SetBranchness(other.GetBranchness());
+  this->SetCurvature(other.GetCurvature());
+  this->SetLevelness(other.GetLevelness());
+  this->SetRoundness(other.GetRoundness());
+  this->SetIntensity(other.GetIntensity());
+  this->SetAlpha1(other.GetAlpha1());
+  this->SetAlpha2(other.GetAlpha2());
+  this->SetAlpha3(other.GetAlpha3());
+}
+
 /** Get the radius */
 template <unsigned int TPointDimension>
 double

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -211,13 +211,8 @@ TubeSpatialObjectPoint<TPointDimension>::operator=(const TubeSpatialObjectPoint 
 {
   if (this != &rhs)
   {
-    // Superclass
-    this->SetId(rhs.GetId());
-    this->SetPositionInObjectSpace(rhs.GetPositionInObjectSpace());
-    this->SetColor(rhs.GetColor());
-    this->SetSpatialObject(rhs.GetSpatialObject());
+    Superclass::operator=(rhs);
 
-    // class
     this->SetRadiusInObjectSpace(rhs.GetRadiusInObjectSpace());
     this->SetTangentInObjectSpace(rhs.GetTangentInObjectSpace());
     this->SetNormal1InObjectSpace(rhs.GetNormal1InObjectSpace());

--- a/Modules/Core/SpatialObjects/test/CMakeLists.txt
+++ b/Modules/Core/SpatialObjects/test/CMakeLists.txt
@@ -16,6 +16,7 @@ itkSurfaceSpatialObjectTest.cxx
 itkMetaArrowConverterTest.cxx
 itkMetaGaussianConverterTest.cxx
 itkTubeSpatialObjectTest.cxx
+itkDTITubeSpatialObjectTest.cxx
 itkSpatialObjectToPointSetFilterTest.cxx
 itkSpatialObjectDuplicatorTest.cxx
 itkBoxSpatialObjectTest.cxx
@@ -63,6 +64,8 @@ itk_add_test(NAME itkMetaGaussianConverterTest
       COMMAND ITKSpatialObjectsTestDriver itkMetaGaussianConverterTest
               ${ITK_TEST_OUTPUT_DIR}/MetaGaussianConverterTest.mha)
 itk_add_test(NAME itkTubeSpatialObjectTest
+      COMMAND ITKSpatialObjectsTestDriver itkTubeSpatialObjectTest)
+itk_add_test(NAME itkDTITubeSpatialObjectTest
       COMMAND ITKSpatialObjectsTestDriver itkTubeSpatialObjectTest)
 itk_add_test(NAME itkSpatialObjectToPointSetFilterTest
       COMMAND ITKSpatialObjectsTestDriver itkSpatialObjectToPointSetFilterTest)

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
@@ -128,6 +128,56 @@ itkContourSpatialObjectPointTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(pickedPoint3D, contourSpatialObjectPoint3DAlt.GetPickedPointInObjectSpace());
   ITK_TEST_SET_GET_VALUE(normal3D, contourSpatialObjectPoint3DAlt.GetNormalInObjectSpace());
 
+  // Test Copy and Assignment for ContourSpatialObjectPoint3DType
+  {
+    ContourSpatialObjectPoint3DType p_original;
+
+    // itk::SpatialObjectPoint
+    p_original.SetId(250);
+    p_original.SetColor(0.5, 0.4, 0.3, 0.2);
+    p_original.SetPositionInObjectSpace(42, 41, 43);
+
+    // itk::ContourSpatialObjectPoint
+    ContourSpatialObjectPoint3DType::CovariantVectorType normal;
+    normal.Fill(276);
+    p_original.SetNormalInObjectSpace(normal);
+    ContourSpatialObjectPoint3DType::PointType picked;
+    picked.Fill(277);
+    p_original.SetPickedPointInObjectSpace(picked);
+
+    // Copy
+    ContourSpatialObjectPoint3DType p_copy(p_original);
+    // Assign
+    ContourSpatialObjectPoint3DType p_assign = p_original;
+
+    std::vector<ContourSpatialObjectPoint3DType> point_vector;
+    point_vector.push_back(p_copy);
+    point_vector.push_back(p_assign);
+
+    for (const auto & pv : point_vector)
+    {
+      // itk::SpatialObjectPoint
+      ITK_TEST_EXPECT_EQUAL(p_original.GetId(), pv.GetId());
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRed(), pv.GetRed()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetGreen(), pv.GetGreen()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBlue(), pv.GetBlue()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha(), pv.GetAlpha()));
+      for (size_t j = 0; j < 3; ++j)
+      {
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(p_original.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
+      }
+      // itk::ContourSpatialObjectPoint
+      for (size_t j = 0; j < 3; ++j)
+      {
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(p_original.GetNormalInObjectSpace()[j], pv.GetNormalInObjectSpace()[j]));
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(p_original.GetPickedPointInObjectSpace()[j], pv.GetPickedPointInObjectSpace()[j]));
+      }
+    }
+  }
+
   // Test for 4D
   //
   using ContourSpatialObjectPoint4DType = itk::ContourSpatialObjectPoint<4>;

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -16,23 +16,23 @@
  *
  *=========================================================================*/
 /*
- * itkTubeSpatialObject test file.
+ * itkDTITubeSpatialObject test file.
  * This test file test also the basic functions of the CompositeSpatialObject class,
  * like Add/RemoveChild(...), Get/SetChildren(...), etc...
  */
 
 #include "itkTestingMacros.h"
-#include "itkTubeSpatialObject.h"
+#include "itkDTITubeSpatialObject.h"
 #include "itkGroupSpatialObject.h"
 
 
 int
-itkTubeSpatialObjectTest(int, char *[])
+itkDTITubeSpatialObjectTest(int, char *[])
 {
   using ScalarType = double;
   using Vector = itk::Vector<ScalarType, 3>;
   using Point = itk::Point<ScalarType, 3>;
-  using TubeType = itk::TubeSpatialObject<3>;
+  using TubeType = itk::DTITubeSpatialObject<3>;
   using TubePointer = itk::SmartPointer<TubeType>;
   using GroupType = itk::GroupSpatialObject<3>;
   using GroupPointer = itk::SmartPointer<GroupType>;
@@ -536,6 +536,11 @@ itkTubeSpatialObjectTest(int, char *[])
     p_original.SetAlpha2(10.0);
     p_original.SetAlpha3(11.0);
 
+    // itk::DTITubeSpatialObjectTest.cxx
+    itk::DiffusionTensor3D<float> tensor;
+    tensor.Fill(0);
+    p_original.SetTensorMatrix(tensor);
+
     // Copy
     TubePointType p_copy(p_original);
     // Assign
@@ -579,6 +584,14 @@ itkTubeSpatialObjectTest(int, char *[])
       ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha1(), pv.GetAlpha1()));
       ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha2(), pv.GetAlpha2()));
       ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha3(), pv.GetAlpha3()));
+
+      // itk::DTITubeSpatialObjectPoint
+      const auto p_original_tensor = p_original.GetTensorMatrix();
+      const auto pv_tensor = pv.GetTensorMatrix();
+      for (size_t j = 0; j < 6; ++j)
+      {
+        ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original_tensor[j], pv_tensor[j]));
+      }
     }
 
     std::cout << "[DONE]" << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -20,6 +20,7 @@
  * This is a test file for the itkLineSpatialObject class.
  */
 
+#include "itkTestingMacros.h"
 #include "itkLineSpatialObject.h"
 #include "itkMath.h"
 
@@ -165,6 +166,50 @@ itkLineSpatialObjectTest(int, char *[])
   }
   std::cout << "[PASSED]" << std::endl;
 
+  // Test Copy and Assignment for LinePointType
+  {
+    LinePointType p_original;
+
+    // itk::SpatialObjectPoint
+    p_original.SetId(250);
+    p_original.SetColor(0.5, 0.4, 0.3, 0.2);
+    p_original.SetPositionInObjectSpace(42, 41, 43);
+
+    // itk::LineSpatialObjectPoint
+    VectorType normal;
+    normal.Fill(276);
+    p_original.SetNormalInObjectSpace(normal, 0);
+
+    // Copy
+    LinePointType p_copy(p_original);
+    // Assign
+    LinePointType p_assign = p_original;
+
+    std::vector<LinePointType> point_vector;
+    point_vector.push_back(p_copy);
+    point_vector.push_back(p_assign);
+
+    for (const auto & pv : point_vector)
+    {
+      // itk::SpatialObjectPoint
+      ITK_TEST_EXPECT_EQUAL(p_original.GetId(), pv.GetId());
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRed(), pv.GetRed()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetGreen(), pv.GetGreen()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBlue(), pv.GetBlue()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha(), pv.GetAlpha()));
+      for (size_t j = 0; j < 3; ++j)
+      {
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(p_original.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
+      }
+      // itk::LineSpatialObjectPoint
+      for (size_t j = 0; j < 3; ++j)
+      {
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(p_original.GetNormalInObjectSpace(0)[j], pv.GetNormalInObjectSpace(0)[j]));
+      }
+    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -21,6 +21,7 @@
  * This is a test file for the itkSurfaceSpatialObject class.
  */
 
+#include "itkTestingMacros.h"
 #include "itkSurfaceSpatialObject.h"
 #include "itkMath.h"
 
@@ -156,6 +157,51 @@ itkSurfaceSpatialObjectTest(int, char *[])
     return EXIT_FAILURE;
   }
   std::cout << "[PASSED]" << std::endl;
+
+  // Test Copy and Assignment for SurfacePointType
+  {
+    SurfacePointType p_original;
+
+    // itk::SpatialObjectPoint
+    p_original.SetId(250);
+    p_original.SetColor(0.5, 0.4, 0.3, 0.2);
+    p_original.SetPositionInObjectSpace(42, 41, 43);
+
+    // itk::SurfaceSpatialObjectPoint
+    VectorType normal;
+    normal.Fill(276);
+    p_original.SetNormalInObjectSpace(normal);
+
+    // Copy
+    SurfacePointType p_copy(p_original);
+    // Assign
+    SurfacePointType p_assign = p_original;
+
+    std::vector<SurfacePointType> point_vector;
+    point_vector.push_back(p_copy);
+    point_vector.push_back(p_assign);
+
+    for (const auto & pv : point_vector)
+    {
+      // itk::SpatialObjectPoint
+      ITK_TEST_EXPECT_EQUAL(p_original.GetId(), pv.GetId());
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRed(), pv.GetRed()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetGreen(), pv.GetGreen()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBlue(), pv.GetBlue()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha(), pv.GetAlpha()));
+      for (size_t j = 0; j < 3; ++j)
+      {
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(p_original.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
+      }
+      // itk::SurfaceSpatialObjectPoint
+      for (size_t j = 0; j < 3; ++j)
+      {
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(p_original.GetNormalInObjectSpace()[j], pv.GetNormalInObjectSpace()[j]));
+      }
+    }
+  }
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This addresses warnings in itk::MapContainer and
itk::VectorContainer regarding deprecation of implicitly defined
operator= (with explicitly defined copy constructor) or vice
versa.  This begins to address GitHub Issue #1302.  There
remain a number of warnings in SpatialObjects, so this patch
does not completely resolve the issue.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
