### PR TITLE
BUG: Accept TemplateTypeError with fallback_only=True (python)

### DIFF
--- a/Wrapping/Generators/Python/itkExtras.py
+++ b/Wrapping/Generators/Python/itkExtras.py
@@ -660,6 +660,7 @@ def imwrite(image_or_filter, filename, compression=False):
     auto_pipeline.current = tmp_auto_pipeline
     writer.Update()
 
+
 def imread(filename, pixel_type=None, fallback_only=False):
     """Read an image from a file or series of files and return an itk.Image.
 
@@ -675,23 +676,24 @@ def imread(filename, pixel_type=None, fallback_only=False):
     wrapped).
     """
     import itk
-    if fallback_only == True:
+    import itkTemplate
+    if fallback_only:
         if pixel_type is None:
             raise Exception("pixel_type must be set when using the fallback_only option")
         try:
             return imread(filename)
-        except KeyError:
+        except (KeyError, itkTemplate.TemplateTypeError):
             pass
     if type(filename) in [list, tuple]:
-        TemplateReaderType=itk.ImageSeriesReader
+        TemplateReaderType = itk.ImageSeriesReader
         io_filename=filename[0]
-        increase_dimension=True
-        kwargs={'FileNames':filename}
+        increase_dimension = True
+        kwargs = {'FileNames': filename}
     else:
-        TemplateReaderType=itk.ImageFileReader
+        TemplateReaderType = itk.ImageFileReader
         io_filename=filename
         increase_dimension=False
-        kwargs={'FileName':filename}
+        kwargs = {'FileName': filename}
     if pixel_type:
         imageIO = itk.ImageIOFactory.CreateImageIO(io_filename, itk.CommonEnums.IOFileMode_ReadMode)
         if not imageIO:
@@ -708,6 +710,7 @@ def imread(filename, pixel_type=None, fallback_only=False):
         reader = TemplateReaderType.New(**kwargs)
     reader.Update()
     return reader.GetOutput()
+
 
 def meshwrite(mesh, filename, compression=False):
     """Write a mesh to a file.
@@ -726,6 +729,7 @@ def meshwrite(mesh, filename, compression=False):
     auto_pipeline.current = tmp_auto_pipeline
     writer.Update()
 
+
 def meshread(filename, pixel_type=None, fallback_only=False):
     """Read a mesh from a file and return an itk.Mesh.
 
@@ -740,17 +744,18 @@ def meshread(filename, pixel_type=None, fallback_only=False):
     wrapped).
     """
     import itk
-    if fallback_only == True:
+    import itkTemplate
+    if fallback_only:
         if pixel_type is None:
             raise Exception("pixel_type must be set when using the fallback_only option")
         try:
             return meshread(filename)
-        except KeyError:
+        except (KeyError, itkTemplate.TemplateTypeError):
             pass
-    TemplateReaderType=itk.MeshFileReader
-    io_filename=filename
-    increase_dimension=False
-    kwargs={'FileName':filename}
+    TemplateReaderType = itk.MeshFileReader
+    io_filename = filename
+    increase_dimension = False
+    kwargs = {'FileName': filename}
     if pixel_type:
         meshIO = itk.MeshIOFactory.CreateMeshIO(io_filename, itk.CommonEnums.IOFileMode_ReadMode)
         if not meshIO:
@@ -767,6 +772,7 @@ def meshread(filename, pixel_type=None, fallback_only=False):
         reader = TemplateReaderType.New(**kwargs)
     reader.Update()
     return reader.GetOutput()
+
 
 def search(s, case_sensitive=False):  # , fuzzy=True):
     """Search for a class name in the itk module.

--- a/Wrapping/Generators/Python/itkTemplate.py
+++ b/Wrapping/Generators/Python/itkTemplate.py
@@ -65,7 +65,7 @@ class TemplateTypeError(TypeError):
         extra_eg = ""
         if template_type in [itk.ImageFileReader, itk.ImageSeriesReader,
                 itk.MeshFileReader]:
-            extra_eg="""
+            extra_eg = """
 
 or
 


### PR DESCRIPTION
If the pixel type is not supported the error is of type TemplateTypeError, and we should accept it when fallback_only is True

Closes #1835 