### PR TITLE
BUG: Fix additional segmentation faults with empty Composite - For Release

### DIFF
--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -72,14 +72,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformPoint(const Inpu
 {
 
   /* Apply in reverse queue order.  */
-  typename TransformQueueType::const_iterator       it(this->m_TransformQueue.end());
-  const typename TransformQueueType::const_iterator beginit(this->m_TransformQueue.begin());
-  OutputPointType                                   outputPoint(inputPoint);
-  do
+  OutputPointType outputPoint(inputPoint);
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != beginit);
+  }
   return outputPoint;
 }
 
@@ -90,15 +87,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 {
   OutputVectorType outputVector(inputVector);
 
-  typename TransformQueueType::const_iterator it;
-  /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
 
-  do
+  /* Apply in reverse queue order.  */
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformVector(outputVector);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -112,16 +106,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
   OutputVectorType outputVector(inputVector);
   OutputPointType  outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformVector(outputVector, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -135,16 +125,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
   OutputVnlVectorType outputVector(inputVector);
   OutputPointType     outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformVector(outputVector, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -156,15 +142,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 {
   OutputVnlVectorType outputVector(inputVector);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformVector(outputVector);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -176,15 +158,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 {
   OutputVectorPixelType outputVector(inputVector);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformVector(outputVector);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -198,16 +176,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
   OutputVectorPixelType outputVector(inputVector);
   OutputPointType       outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformVector(outputVector, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -220,15 +194,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
 {
   OutputCovariantVectorType outputVector(inputVector);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformCovariantVector(outputVector);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -243,16 +213,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
   OutputCovariantVectorType outputVector(inputVector);
   OutputPointType           outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformCovariantVector(outputVector, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -265,15 +231,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
 {
   OutputVectorPixelType outputVector(inputVector);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformCovariantVector(outputVector);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -288,16 +250,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
   OutputVectorPixelType outputVector(inputVector);
   OutputPointType       outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputVector = (*it)->TransformCovariantVector(outputVector, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputVector;
 }
@@ -312,16 +270,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3
   OutputDiffusionTensor3DType outputTensor(inputTensor);
   OutputPointType             outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputTensor = (*it)->TransformDiffusionTensor3D(outputTensor, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputTensor;
 }
@@ -336,16 +290,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3
   OutputVectorPixelType outputTensor(inputTensor);
   OutputPointType       outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputTensor = (*it)->TransformDiffusionTensor3D(outputTensor, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputTensor;
 }
@@ -358,15 +308,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3
 {
   OutputDiffusionTensor3DType outputTensor(inputTensor);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputTensor = (*it)->TransformDiffusionTensor3D(outputTensor);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputTensor;
 }
@@ -379,15 +325,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3
 {
   OutputVectorPixelType outputTensor(inputTensor);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputTensor = (*it)->TransformDiffusionTensor3D(outputTensor);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputTensor;
 }
@@ -402,16 +344,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondR
   OutputSymmetricSecondRankTensorType outputTensor(inputTensor);
   OutputPointType                     outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputTensor = (*it)->TransformSymmetricSecondRankTensor(outputTensor, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputTensor;
 }
@@ -426,16 +364,12 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondR
   OutputVectorPixelType outputTensor(inputTensor);
   OutputPointType       outputPoint(inputPoint);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputTensor = (*it)->TransformSymmetricSecondRankTensor(outputTensor, outputPoint);
     outputPoint = (*it)->TransformPoint(outputPoint);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputTensor;
 }
@@ -448,15 +382,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondR
 {
   OutputSymmetricSecondRankTensorType outputTensor(inputTensor);
 
-  typename TransformQueueType::const_iterator it;
   /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
-
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputTensor = (*it)->TransformSymmetricSecondRankTensor(outputTensor);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputTensor;
 }
@@ -469,15 +399,11 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondR
 {
   OutputVectorPixelType outputTensor(inputTensor);
 
-  typename TransformQueueType::const_iterator it;
-  /* Apply in reverse queue order.  */
-  it = this->m_TransformQueue.end();
 
-  do
+  for (auto it = this->m_TransformQueue.rbegin(); it != this->m_TransformQueue.rend(); ++it)
   {
-    it--;
     outputTensor = (*it)->TransformSymmetricSecondRankTensor(outputTensor);
-  } while (it != this->m_TransformQueue.begin());
+  }
 
   return outputTensor;
 }
@@ -702,17 +628,13 @@ CompositeTransform<TParametersValueType, NDimensions>::GetParameters() const
 
     NumberOfParametersType offset = NumericTraits<NumberOfParametersType>::ZeroValue();
 
-    auto it = transforms.end();
-
-    do
+    for (auto it = transforms.rbegin(); it != transforms.rend(); ++it)
     {
-      it--;
       const ParametersType & subParameters = (*it)->GetParameters();
       /* use vnl_vector data_block() to get data ptr */
       std::copy_n(subParameters.data_block(), subParameters.Size(), &(this->m_Parameters.data_block())[offset]);
       offset += subParameters.Size();
-
-    } while (it != transforms.begin());
+    }
   }
 
   return this->m_Parameters;

--- a/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
@@ -131,7 +131,9 @@ itkCompositeTransformTest(int, char *[])
   ITK_TEST_EXPECT_EQUAL(compositeTransform->GetFixedParameters().Size(), 0u);
 
   {
-    CompositeType::InputPointType  inputPoint({ 1.1, 2.2 });
+    CompositeType::InputPointType inputPoint;
+    inputPoint[0] = 1.1;
+    inputPoint[1] = 2.2;
     CompositeType::InputVectorType inputVector;
     inputVector[0] = 9.1;
     inputVector[1] = 8.2;

--- a/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
@@ -127,6 +127,33 @@ itkCompositeTransformTest(int, char *[])
   ITK_TEST_EXPECT_EQUAL(compositeTransform->GetNumberOfTransforms(), 0u);
   ITK_TEST_EXPECT_EQUAL(compositeTransform->GetNumberOfParameters(), 0u);
   ITK_TEST_EXPECT_EQUAL(compositeTransform->GetNumberOfFixedParameters(), 0u);
+  ITK_TEST_EXPECT_EQUAL(compositeTransform->GetParameters().Size(), 0u);
+  ITK_TEST_EXPECT_EQUAL(compositeTransform->GetFixedParameters().Size(), 0u);
+
+  {
+    CompositeType::InputPointType  inputPoint({ 1.1, 2.2 });
+    CompositeType::InputVectorType inputVector;
+    inputVector[0] = 9.1;
+    inputVector[1] = 8.2;
+
+    if (!testPoint(inputPoint, compositeTransform->TransformPoint(inputPoint)))
+    {
+      std::cout << "Failed transforming point with empty transform." << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    if (!testVectorArray(inputVector, compositeTransform->TransformVector(inputVector)))
+    {
+      std::cout << "Failed transforming vector with empty transform." << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    if (!testVectorArray(inputVector, compositeTransform->TransformVector(inputVector, inputPoint)))
+    {
+      std::cout << "Failed transforming vector with empty transform." << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
 
 
   /* Add an affine transform */


### PR DESCRIPTION
When the CompositeTransform contains no transform is should behave
like an identity transform. This patches address loop iteration issues
that would cause a segmentation fault due to invalid indexing of
transforms when there composite was empty.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
