### PR TITLE
BUG: Simplify itk.BlockMatchingImageFilter feature points PointSet ma…

### DIFF
--- a/Modules/Core/Common/wrapping/itkPointSet.wrap
+++ b/Modules/Core/Common/wrapping/itkPointSet.wrap
@@ -17,9 +17,6 @@ itk_wrap_class("itk::PointSet" POINTER)
       "${ITKT_UI},${d},itk::DefaultStaticMeshTraits<${ITKT_UI},${d},${d},${ITKT_F},${ITKT_F},${ITKT_UI} >")
   endforeach()
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    # Also wrap the point set type needed for the kernel transforms,
-    # which may be a bug in ITK but they're needed currently.
-    itk_wrap_template("M${ITKM_D}${d}${d}STM${ITKM_D}${d}${d}${d}${d}${ITKM_F}${ITKM_F}M${ITKM_D}${d}${d}"
-      "itk::Matrix <${ITKT_D},${d},${d}>,${d},itk::DefaultStaticMeshTraits< itk::Matrix <${ITKT_D},${d},${d}>,${d},${d},${ITKT_F},${ITKT_F},itk::Matrix <${ITKT_D},${d},${d}> >")
+    itk_wrap_template("M${ITKM_D}${d}${d}" "itk::Matrix <${ITKT_D},${d},${d}>,${d}")
   endforeach()
 itk_end_wrap_class()

--- a/Modules/Registration/Common/wrapping/itkBlockMatchingImageFilter.wrap
+++ b/Modules/Registration/Common/wrapping/itkBlockMatchingImageFilter.wrap
@@ -6,10 +6,8 @@ if(has_d_3)
   itk_end_wrap_class()
 
   itk_wrap_class("itk::PointSet" POINTER)
-    itk_wrap_template("VF33DTVF333FFVF3"
-      "itk::Vector< float, 3 >, 3, itk::DefaultStaticMeshTraits< itk::Vector< float, 3 >, 3, 3, float, float, itk::Vector< float, 3 > >")
-    itk_wrap_template("D3DTD33FFD"
-      "double, 3, itk::DefaultStaticMeshTraits< double, 3, 3, float, float, double >")
+    itk_wrap_template("VF33" "itk::Vector< float, 3 >, 3")
+    itk_wrap_template("D3" "double, 3")
   itk_end_wrap_class()
 
 endif()


### PR DESCRIPTION
…ngling

Simplify the Python wrapping name mangling to remove the
DefaultStaticMeshTraits, standard with itk 5 mesh wrapping.
