### PR TITLE
BUG: fix Statistics::Histogram::Mean calculation

### DIFF
--- a/Modules/Filtering/Thresholding/test/CMakeLists.txt
+++ b/Modules/Filtering/Thresholding/test/CMakeLists.txt
@@ -121,7 +121,7 @@ itk_add_test(NAME itkIsoDataThresholdImageFilterTestNoAutoMinMax
       COMMAND ITKThresholdingTestDriver
     --compare-MD5 DATA{Baseline/itkIsoDataThresholdImageFilterTestNoAutoMinMax.png}
               9f844fd120ff49a7812e329a1b0216d8
-    itkIsoDataThresholdImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/itkIsoDataThresholdImageFilterTestNoAutoMinMax.png 32 0 1)
+    itkIsoDataThresholdImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/itkIsoDataThresholdImageFilterTestNoAutoMinMax.png 32 0 1023)
 
 itk_add_test(NAME itkIsoDataMaskedThresholdImageFilterTest
       COMMAND ITKThresholdingTestDriver

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -645,11 +645,12 @@ double
 Histogram<TMeasurement, TFrequencyContainer>::Mean(unsigned int dimension) const
 {
   const unsigned int size = this->GetSize(dimension);
-  auto               totalFrequency = double(this->GetTotalFrequency());
+  double             totalFrequency = this->GetTotalFrequency();
   double             sum = 0;
   for (unsigned int i = 0; i < size; i++)
   {
-    sum += this->GetFrequency(i, dimension);
+    double frequency = this->GetFrequency(i, dimension);
+    sum += frequency * this->GetMeasurement(i, dimension);
   }
   return sum / totalFrequency;
 }


### PR DESCRIPTION
This method was introduced by fb95a5e613362e956788ab0cdb444cc8e7f6a211,
but it never worked properly, always returning 1.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

