### PR TITLE
ENH: Add torch.Tensor input/output support for ITK filters

### DIFF
--- a/Wrapping/Generators/Python/itkHelpers.py
+++ b/Wrapping/Generators/Python/itkHelpers.py
@@ -25,6 +25,12 @@ try:
     _HAVE_XARRAY = True
 except ImportError:
     pass
+_HAVE_TORCH = False
+try:
+    import torch
+    _HAVE_TORCH = True
+except ImportError:
+    pass
 
 def camel_to_snake_case(name):
     snake = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
@@ -49,12 +55,17 @@ def accept_numpy_array_like_xarray(image_filter):
     def image_filter_wrapper(*args, **kwargs):
         have_array_input = False
         have_xarray_input = False
+        have_torch_input = False
 
         args_list = list(args)
         for index, arg in enumerate(args):
             if _HAVE_XARRAY and isinstance(arg, xr.DataArray):
                     have_xarray_input = True
                     image = itk.image_from_xarray(arg)
+                    args_list[index] = image
+            elif _HAVE_TORCH and isinstance(arg, torch.Tensor):
+                    have_torch_input = True
+                    image = itk.image_view_from_array(np.asarray(arg))
                     args_list[index] = image
             elif not isinstance(arg, itk.Object) and is_arraylike(arg):
                 have_array_input = True
@@ -69,13 +80,17 @@ def accept_numpy_array_like_xarray(image_filter):
                     have_xarray_input = True
                     image = itk.image_from_xarray(value)
                     kwargs[key] = image
+                elif _HAVE_TORCH and isinstance(value, torch.Tensor):
+                    have_torch_input = True
+                    image = itk.image_view_from_array(np.asarray(value))
+                    kwargs[key] = image
                 elif not isinstance(value, itk.Object) and is_arraylike(value):
                     have_array_input = True
                     array = np.asarray(value)
                     image = itk.image_view_from_array(array)
                     kwargs[key] = image
 
-        if have_xarray_input or have_array_input:
+        if have_xarray_input or have_torch_input or have_array_input:
             # Convert output itk.Image's to numpy.ndarray's
             output = image_filter(*tuple(args_list), **kwargs)
             if isinstance(output, tuple):
@@ -85,6 +100,10 @@ def accept_numpy_array_like_xarray(image_filter):
                         if have_xarray_input:
                             data_array = itk.xarray_from_image(value)
                             output_list[index] = data_array
+                        elif have_torch_input:
+                            data_array = itk.array_view_from_image(value)
+                            torch_tensor = torch.from_numpy(data_array)
+                            output_list[index] = torch_tensor
                         else:
                             array = itk.array_view_from_image(value)
                             output_list[index] = array
@@ -93,6 +112,9 @@ def accept_numpy_array_like_xarray(image_filter):
                 if isinstance(output, itk.Image):
                     if have_xarray_input:
                         output = itk.xarray_from_image(output)
+                    elif have_torch_input:
+                        output = itk.array_view_from_image(output)
+                        output = torch.from_numpy(output)
                     else:
                         output = itk.array_view_from_image(output)
                 return output


### PR DESCRIPTION
Example:

  In [1]: import itk

  In [2]: import torch

  In [3]: import numpy as np

  In [4]: a = np.random.rand(50,50)

  In [5]: t = torch.from_numpy(a)

  In [6]: r = itk.median_image_filter(t)

  In [7]: r
  Out[7]:
  tensor([[0.8428, 0.3881, 0.3881,  ..., 0.3222, 0.3953, 0.3408],
	  [0.7785, 0.3881, 0.1350,  ..., 0.3953, 0.4557, 0.5307],
	  [0.4023, 0.4023, 0.3787,  ..., 0.4440, 0.5307, 0.6666],
	  ...,
	  [0.4938, 0.4938, 0.6298,  ..., 0.4480, 0.1807, 0.1341],
	  [0.3539, 0.4938, 0.7471,  ..., 0.4480, 0.1618, 0.1341],
	  [0.3539, 0.3539, 0.6298,  ..., 0.1618, 0.1618, 0.1618]],
	 dtype=torch.float64)

Suggested-by: Stephen R. Aylward <stephen.aylward@kitware.com>
