### PR TITLE
STYLE: Correct doc for ReadImageInformation

### DIFF
--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -130,7 +130,7 @@ public:
   bool
   CanReadFile(const char *) override;
 
-  /** Set the spacing and dimension information for the current filename. */
+  /** Read the spacing and dimension information for the current filename. */
   void
   ReadImageInformation() override;
 


### PR DESCRIPTION
Correct the doc string for ReadImageInformation() in Modules/IO/GDCM/include/itkGDCMImageIO.h.