### PR TITLE
ENH: Prevent segfault by failing fast in itkGDCMImageIO

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -477,7 +477,10 @@ GDCMImageIO::InternalReadImageInformation()
     outputpt = r.ComputeInterceptSlopePixelType();
   }
 
-  itkAssertInDebugAndIgnoreInReleaseMacro(pixeltype <= outputpt);
+  if (pixeltype > outputpt)
+  {
+    itkAssertInDebugOrThrowInReleaseMacro("Pixel type larger than output type")
+  }
 
   m_ComponentType = IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   switch (outputpt)


### PR DESCRIPTION
In InternalReadImageInformation:

When pixel type is larger than the output type, it is likely
something wrong in the dataset currently being read.

An example is if the following two headers are "out-of-sync"
(0028,0100) BitsAllocated
(0028,0101) BitsStored

Instead of ignoring this sanity check in release-mode,
it is better to throw an exception. That way, the caller
can handle the error instead of seeing the application crash.

Please note the following warning in
Documentation/ReleaseNotes/3.14.md

"when using itkAssertInDebugOrThrowInReleaseMacro do not
terminate with a ;"

Signed-off-by: Niklas Johansson <raphexion@gmail.com>
