### PR TITLE
BUG: Fix Segfault in Delaunay Filter

### DIFF
--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.hxx
@@ -158,14 +158,15 @@ DelaunayConformingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Process()
     const auto il_id = qe->GetLeft();  // Input Left ID
     const auto ir_id = qe->GetRight(); // Input Right ID
     qe = m_FlipEdge->Evaluate(qe);
-    const auto ol_id = qe->GetLeft();  // Output Left ID
-    const auto or_id = qe->GetRight(); // Output Right ID
-
-    this->ReassignCellData(il_id, ol_id);
-    this->ReassignCellData(ir_id, or_id);
 
     if (qe != nullptr)
     {
+      const auto ol_id = qe->GetLeft();  // Output Left ID
+      const auto or_id = qe->GetRight(); // Output Right ID
+
+      this->ReassignCellData(il_id, ol_id);
+      this->ReassignCellData(ir_id, or_id);
+
       ++this->m_NumberOfEdgeFlips;
       list_qe[4] = qe;
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/itk-module.cmake
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/itk-module.cmake
@@ -15,6 +15,7 @@ itk_module(ITKQuadEdgeMeshFiltering
   TEST_DEPENDS
     ITKTestKernel
     ITKIOMesh
+    ITKStatistics
   DESCRIPTION
     "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
@@ -83,7 +83,7 @@ endforeach()
 
 itk_add_test(NAME itkDelaunayConformingQuadEdgeMeshFilterTest
       COMMAND ITKQuadEdgeMeshFilteringTestDriver
-          itkDelaunayConformingQuadEdgeMeshFilterTest DATA{${INPUTDATA}/mushroom.vtk} ${TEMP}/mushrom_delaunay.vtk)
+          itkDelaunayConformingQuadEdgeMeshFilterTest DATA{${INPUTDATA}/mushroom.vtk} ${TEMP}/mushroom_delaunay.vtk)
 itk_add_test(NAME itkCleanQuadEdgeMeshFilterTest
       COMMAND ITKQuadEdgeMeshFilteringTestDriver
           itkCleanQuadEdgeMeshFilterTest


### PR DESCRIPTION
In the event that the Delaunay filter attempts to flip a non-internal
edge (such as along the boundary of an open mesh), the EulerOperator
returns a nullptr.  Previously, this filter was not properly checking
whether the returned edge was nullptr when attempting to reassign cell
data, causing a segfault.  Although the test mesh (mushroom.vtk) is
open and contains a boundary edge, these edges were apparently not being
added to the priority queue, presumably due to the regularity of the
cells, and therefore this case was not triggered in the testing suite.

In this patch, the test is modified by adding a small amount of noise
to the mesh vertices, causing boundary edges to be added to the priority
queue and triggering the failure.  Second, this patch only attempts to
reassign cell data if the Euler operator does not return a nullptr,
thus preventing the segfault.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
