### PR TITLE
ENH: progress reporting does not stall with PoolMultiThreader

### DIFF
--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -226,9 +226,6 @@ ImageSource<TOutputImage>::GenerateData()
   }
   else
   {
-    // give process object if progress reporting is to occur from the threader
-    Self * processObjectForThreader = this->GetThreaderUpdateProgress() ? this : nullptr;
-
     this->GetMultiThreader()->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
     this->GetMultiThreader()->SetUpdateProgress(this->GetThreaderUpdateProgress());
     this->GetMultiThreader()->template ParallelizeImageRegion<OutputImageDimension>(
@@ -236,7 +233,7 @@ ImageSource<TOutputImage>::GenerateData()
       [this](const OutputImageRegionType & outputRegionForThread) {
         this->DynamicThreadedGenerateData(outputRegionForThread);
       },
-      processObjectForThreader);
+      this);
   }
 
   // Call a method that can be overridden by a subclass to perform

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -472,6 +472,10 @@ MultiThreaderBase ::ParallelizeArray(SizeValueType             firstIndex,
   // This implementation simply delegates parallelization to the old interface
   // SetSingleMethod+SingleMethodExecute. This method is meant to be overloaded!
 
+  if (!this->GetUpdateProgress())
+  {
+    filter = nullptr;
+  }
   // Upon destruction, progress will be set to 1.0
   ProgressReporter progress(filter, 0, 1);
 
@@ -532,6 +536,10 @@ MultiThreaderBase ::ParallelizeImageRegion(unsigned int                         
 {
   // This implementation simply delegates parallelization to the old interface
   // SetSingleMethod+SingleMethodExecute. This method is meant to be overloaded!
+  if (!this->GetUpdateProgress())
+  {
+    filter = nullptr;
+  }
   ProgressReporter progress(filter, 0, 1);
 
   SizeValueType pixelCount = 1;

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -123,7 +123,10 @@ TBBMultiThreader ::ParallelizeArray(SizeValueType             firstIndex,
                                     ArrayThreadingFunctorType aFunc,
                                     ProcessObject *           filter)
 {
-
+  if (!this->GetUpdateProgress())
+  {
+    filter = nullptr;
+  }
   ProgressReporter progressStartEnd(filter, 0, 1);
 
   if (firstIndex + 1 < lastIndexPlus1)
@@ -243,6 +246,10 @@ TBBMultiThreader ::ParallelizeImageRegion(unsigned int         dimension,
                                           ThreadingFunctorType funcP,
                                           ProcessObject *      filter)
 {
+  if (!this->GetUpdateProgress())
+  {
+    filter = nullptr;
+  }
   ProgressReporter progressStartEnd(filter, 0, 1);
 
   if (m_NumberOfWorkUnits == 1)


### PR DESCRIPTION
Implementing the suggestion made in [a forum post](https://discourse.itk.org/t/no-progress-reporting-in-itk5/2630/33?u=dzenanz). Related to #1673.
## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)