### PR TITLE
BUG: Centos internal lib64 lib path

### DIFF
--- a/CMake/itkExternal_FFTW.cmake
+++ b/CMake/itkExternal_FFTW.cmake
@@ -158,9 +158,9 @@ if(NOT ITK_USE_SYSTEM_FFTW)
     endif()
 
     #
-    # copy libraries into install tree
+    # copy libraries into install tree, NOTE: DESTINATION MUST EXACTLY MATCH values from main CMakeLists.txt for FFTW_LIBDIR
     install(CODE
-      "file(GLOB FFTW_LIBS ${FFTW_STAGED_INSTALL_PREFIX}/lib/*fftw3*)
+      "file(GLOB FFTW_LIBS ${FFTW_STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/*fftw3*)
 file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/lib/ITK-${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}\"
 TYPE FILE FILES \${FFTW_LIBS})"
       COMPONENT Development)


### PR DESCRIPTION
On Centos 7.5 the internal CMAKE_INSTALL_LIBDIR
is 'lib64' instead of 'lib'.  Ensure that the
internal glob for installing the shared
libraries uses the platform specific
CMAKE_INSTALL_LIBDIR for installing the
shared libraries.