### PR TITLE
ENH: Add image.astype(pixel_type) for casting

### DIFF
--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -419,6 +419,22 @@ str = str
                     # CovariantVector, etc.
                     return itk.template(first_template_arg)[1][0].dtype
 
+            def astype(self, pixel_type):
+                """Cast the image to the provided itk pixel type or equivalent NumPy dtype."""
+                import itk
+                import numpy as np
+                import itkTypes
+
+                # numpy dtype
+                if type(pixel_type) is type:
+                    pixel_type = itkTypes.itkCType.GetCTypeForDType(pixel_type)
+                current_pixel_type = itk.template(self)[1][0]
+                if current_pixel_type is pixel_type:
+                    return self
+                OutputImageType = itk.Image[pixel_type, self.GetImageDimension()]
+                cast = itk.cast_image_filter(self, ttype=(type(self), OutputImageType))
+                return cast
+
             def SetDirection(self, direction):
                 import itkHelpers
                 if itkHelpers.is_arraylike(direction):

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -119,7 +119,6 @@ s = itk.region(reader.GetOutput())
 assert s.GetIndex()[0] == s.GetIndex()[1] == 0
 assert s.GetSize()[0] == s.GetSize()[1] == 256
 
-
 # test range
 assert itk.range(reader) == (0, 255)
 assert itk.range(reader.GetOutput()) == (0, 255)
@@ -328,6 +327,18 @@ try:
     assert arr2[0,0] == 2
     # and make sure that the matrix hasn't changed.
     assert m_itk(0,0) == 1
+
+    # test .astype
+    image = itk.imread(filename, itk.UC)
+    cast = image.astype(PixelType)
+    assert cast == image
+    cast = image.astype(itk.F)
+    assert cast.dtype == np.float32
+    cast = image.astype(itk.SS)
+    assert cast.dtype == np.int16
+    cast = image.astype(np.float32)
+    assert cast.dtype == np.float32
+
 except ImportError:
     print("NumPy not imported. Skipping BridgeNumPy tests")
     # Numpy is not available, do not run the Bridge NumPy tests

--- a/Wrapping/Generators/Python/itkTypes.py
+++ b/Wrapping/Generators/Python/itkTypes.py
@@ -24,18 +24,21 @@ except ImportError:
   HAVE_NUMPY = False
 
 class itkCType:
-    __cTypes__ = {}
+    __c_types__ = {}
+    __c_types_for_dtype__ = {}
 
     def __init__(self, name, short_name, np_dtype=None):
         self.name = name
         self.short_name = short_name
         self.dtype = np_dtype
 
-        itkCType.__cTypes__[self.name] = self
+        itkCType.__c_types__[self.name] = self
+        if np_dtype:
+            itkCType.__c_types_for_dtype__[np_dtype] = self
 
     def __del__(self):
         try:
-            del itkCType.__cTypes__[self.name]
+            del itkCType.__c_types__[self.name]
         except:
             pass
 
@@ -43,6 +46,7 @@ class itkCType:
         return "<itkCType %s>" % self.name
 
     def GetCType(name):
+        """Get the type corresponding to the provided C primitive type name."""
         aliases = {'short': 'signed short',
             'int': 'signed int',
             'long': 'signed long',
@@ -50,10 +54,18 @@ class itkCType:
         if name in aliases:
             name = aliases[name]
         try:
-            return(itkCType.__cTypes__[name])
+            return itkCType.__c_types__[name]
         except KeyError:
-            return(None)
+            return None
     GetCType = staticmethod(GetCType)
+
+    def GetCTypeForDType(np_dtype):
+        """Get the type corresponding to the provided numpy.dtype."""
+        try:
+            return itkCType.__c_types_for_dtype__[np_dtype]
+        except KeyError:
+            return None
+    GetCTypeForDType = staticmethod(GetCTypeForDType)
 
 
 if HAVE_NUMPY:


### PR DESCRIPTION
Similar to the numpy.ndarray.astype, supporting itk PixelType's and
numpy dtype's.

More convenient than itk.cast_image_filter, similar to
numpy.ndarray.astype. itk.Image PixelType's are supported along with
scalar numpy dtype's. itkType.itkCType.GetCTypeForDType is added to
support conversion.