### PR TITLE
COMP: Do not reference FE_DIVBYZERO FE_INVALID with Emscripten

### DIFF
--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -136,7 +136,7 @@ void
 FloatingPointExceptions ::Enable()
 {
   itkInitGlobalsMacro(PimplGlobals);
-#if defined(ITK_HAS_FPE_CAPABILITY)
+#if defined(ITK_HAS_FPE_CAPABILITY) && !defined(__EMSCRIPTEN__)
   itk_feenableexcept(FE_DIVBYZERO);
   itk_feenableexcept(FE_INVALID);
 #  if defined(ITK_FPE_USE_SIGNAL_HANDLER)
@@ -158,7 +158,7 @@ void
 FloatingPointExceptions ::Disable()
 {
   itkInitGlobalsMacro(PimplGlobals);
-#if defined(ITK_HAS_FPE_CAPABILITY)
+#if defined(ITK_HAS_FPE_CAPABILITY) && !defined(__EMSCRIPTEN__)
   itk_fedisableexcept(FE_DIVBYZERO);
   itk_fedisableexcept(FE_INVALID);
   FloatingPointExceptions::m_PimplGlobals->m_Enabled = false;


### PR DESCRIPTION
With the Emscripten-upstream compiler:

  In file included from /ITK/Modules/Core/Common/src/itkFloatingPointExceptions.cxx:127:
  /ITK/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx:140:22: error: use of undeclared identifier 'FE_DIVBYZERO'
    itk_feenableexcept(FE_DIVBYZERO);
		       ^
  /ITK/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx:141:22: error: use of undeclared identifier 'FE_INVALID'
    itk_feenableexcept(FE_INVALID);
