### PR TITLE
BUG: Add missing enumerate with multi-ndarray-output itk filters

### DIFF
--- a/Wrapping/Generators/Python/itkHelpers.py
+++ b/Wrapping/Generators/Python/itkHelpers.py
@@ -98,7 +98,7 @@ def accept_numpy_array_like_xarray(image_filter):
             output = image_filter(*tuple(args_list), **kwargs)
             if isinstance(output, tuple):
                 output_list = list(output)
-                for index, value in output_list:
+                for index, value in enumerate(output_list):
                     if isinstance(value, itk.Image):
                         if have_xarray_input:
                             data_array = itk.xarray_from_image(value)


### PR DESCRIPTION
Required for returning the (registered_image, transform_parameters)
output when ndarray's is passed for the fixed and moving image in
itk-elastix.