### PR TITLE
BUG: Fix fftw linkage issue with system fftw

### DIFF
--- a/CMake/itkExternal_FFTW.cmake
+++ b/CMake/itkExternal_FFTW.cmake
@@ -171,10 +171,6 @@ TYPE FILE FILES \${FFTW_LIBS})"
 file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/include/ITK-${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}\"
 TYPE FILE FILES \${FFTW_INC})"
       COMPONENT Development)
-
-   # This pollute the global namespace, but is needed for backward compatibility
-   include_directories(${FFTW_INCLUDE})
-   link_directories(${FFTW_LIBDIR})
 else()
   #Search the filesystem for compatible versions
   find_package( FFTW ) # Use local itk FindFFTW.config to set variables consistently both with/without USE_SYSTEM_FFTW

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,9 @@ mark_as_advanced(ITK_USE_SYSTEM_FFTW)
 
 if( ITK_USE_FFTWD OR ITK_USE_FFTWF )
   include(itkExternal_FFTW)
+  # This pollutes the global namespace, but is needed for backward compatibility
+  include_directories(${FFTW_INCLUDE})
+  link_directories(${FFTW_LIBDIR})
 endif()
 
 set(ITK_USE_64BITS_IDS_DEFAULT "OFF")


### PR DESCRIPTION
Resolves: #1930 for mac builds

The found fftw libraries locations were not pass
to ITK builds when using the system installed fftw.