### PR TITLE
COMP: Add lxml to macOS CI environment

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -29,6 +29,7 @@ jobs:
         sudo python3 -m pip install ninja
         sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install scikit-ci-addons
+        sudo python3 -m pip install lxml
       displayName: Install dependencies
 
     - bash: |

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -29,6 +29,7 @@ jobs:
         sudo pip3 install ninja numpy
         sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install scikit-ci-addons
+        sudo python3 -m pip install lxml
       displayName: 'Install dependencies'
 
     - bash: |


### PR DESCRIPTION
To address recent failures:

  Traceback (most recent call last):
    File "/usr/local/lib/python3.8/site-packages/anyci/ctest_junit_formatter.py", line 4, in <module>
      from lxml import etree
  ModuleNotFoundError: No module named 'lxml'
