### PR TITLE
ENH: Update remote modules

### DIFF
--- a/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
+++ b/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(AnalyzeObjectLabelMap
   "AnalyzeObjectLabelMap plugin for ITK. From Insight Journal article with handle: https://hdl.handle.net/1926/593"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/itkAnalyzeObjectMap.git
-  GIT_TAG 9ab8ca515b404e4f1fa3b0cbdf363e3b17274322
+  GIT_TAG c581299e71f01de7cba9aec5530accd3e6c8aee0
   )

--- a/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
+++ b/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
@@ -64,5 +64,5 @@ itk_fetch_module(AnisotropicDiffusionLBR
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKAnisotropicDiffusionLBR.git
-  GIT_TAG 6e90e9d4f2f5d52042e56395cf55ed27b87b5465
+  GIT_TAG 2bc79a84a20b3229e1a802e554a57b4fed6911b2
   )

--- a/Modules/Remote/BSplineGradient.remote.cmake
+++ b/Modules/Remote/BSplineGradient.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(BSplineGradient
   "Approximate an image's gradient from a b-spline fit to its intensity."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBSplineGradient.git
-  GIT_TAG f2eccd4995912cda0132d0fd12e65bf46bed5f1a
+  GIT_TAG 024bfed87a31f8c9d841032f11982f53554614f2
 )

--- a/Modules/Remote/BioCell.remote.cmake
+++ b/Modules/Remote/BioCell.remote.cmake
@@ -48,5 +48,5 @@ It also has classes to represent a cell genome,
 whose expression is modeled by differential equations."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBioCell.git
-  GIT_TAG 1d394ab80f94bfaea32dd9806f8806ce7101e683
+  GIT_TAG ed4237f50d846ef120184c0298c983171496bd42
   )

--- a/Modules/Remote/BoneEnhancement.remote.cmake
+++ b/Modules/Remote/BoneEnhancement.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(BoneEnhancement
   "Various filters for enhancing cortical bones in quantitative computed tomography."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBoneEnhancement.git
-  GIT_TAG b29ba808b0468762769d5e32bbc7a97745478df2
+  GIT_TAG 1acf2c4ddf96523ec5a251ffdb0fcc2a48101a27
 )

--- a/Modules/Remote/Cuberille.remote.cmake
+++ b/Modules/Remote/Cuberille.remote.cmake
@@ -64,5 +64,5 @@ http://www.insight-journal.org/browse/publication/213
 "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKCuberille.git
-  GIT_TAG 305e3f3011b394d6998a23e7eff378d9701569ea
+  GIT_TAG ba030a7e2de493a932e33cc7b3ec0fdf6b072968
   )

--- a/Modules/Remote/GenericLabelInterpolator.remote.cmake
+++ b/Modules/Remote/GenericLabelInterpolator.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(GenericLabelInterpolator
   "A generic interpolator for multi-label images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKGenericLabelInterpolator.git
-  GIT_TAG 11616d3bb65c942d405437d0322473797155215c
+  GIT_TAG a02cbeaf28cb3d28ac66b9ac651073530eb6ab78
   )

--- a/Modules/Remote/HigherOrderAccurateGradient.remote.cmake
+++ b/Modules/Remote/HigherOrderAccurateGradient.remote.cmake
@@ -51,5 +51,5 @@ itk_fetch_module(HigherOrderAccurateGradient
   https://hdl.handle.net/10380/3231"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKHigherOrderAccurateGradient.git
-  GIT_TAG d3d205022f8c15f9de709c01b27949538f0ac411
+  GIT_TAG 129e28000bcb8abcc10767f8f8062261f1e9e327
   )

--- a/Modules/Remote/IOScanco.remote.cmake
+++ b/Modules/Remote/IOScanco.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(IOScanco
   "An ITK module to read and write Scanco microCT .isq files."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/ITKIOScanco.git
-  GIT_TAG 5ca9656e823aa33fc00b7b18cdd6acd8c01e791d
+  GIT_TAG c452b8c09e259b269fa01ccce52e50210afb2631
 )

--- a/Modules/Remote/MGHIO.remote.cmake
+++ b/Modules/Remote/MGHIO.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(MGHIO
   "MGHIO ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/Slicer/itkMGHImageIO.git
-  GIT_TAG fb551cd1a586e96c20b81041bcb7ffbf492a41b6
+  GIT_TAG 311277df797fec7124a15d78f0d54592bd904c53
   )

--- a/Modules/Remote/MinimalPathExtraction.remote.cmake
+++ b/Modules/Remote/MinimalPathExtraction.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(MinimalPathExtraction
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git
-  GIT_TAG fbeaa4682397a4013da580e5c513d5df9fe86ee1
+  GIT_TAG 7e693358a018957e14257df9ddbe93942c9b8664
   )

--- a/Modules/Remote/Montage.remote.cmake
+++ b/Modules/Remote/Montage.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(Montage
 "Reconstruction of 3D volumetric dataset from a collection of 2D slices"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMontage.git
-  GIT_TAG e9467e9177ed4f20200ee12f407a025503416c13
+  GIT_TAG 8ee6eb49da613f55a08efcc95cd3c27cbfdbd95a
   )

--- a/Modules/Remote/MultipleImageIterator.remote.cmake
+++ b/Modules/Remote/MultipleImageIterator.remote.cmake
@@ -57,5 +57,5 @@ Schaerer J. \"A MultipleImageIterator for iterating over multiple images simulta
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/KitwareMedical/MultipleImageIterator.git
-  GIT_TAG 3b71d6e8611cf01e4f59df2e5f94854c9a42fbf2
+  GIT_TAG 8a2595b490be876007f7bc2491bd8b4914b8be8e
   )

--- a/Modules/Remote/PerformanceBenchmarking.remote.cmake
+++ b/Modules/Remote/PerformanceBenchmarking.remote.cmake
@@ -59,5 +59,5 @@ For more information, see::
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKPerformanceBenchmarking.git
-  GIT_TAG 1518a33cd99bb3d3b8d36f19741af68a38299bfa
+  GIT_TAG 322b59ee3b074fabc8d9816bac3a0e6e2f91cc17
   )

--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -38,8 +38,8 @@
 #       Code style enforced by clang-format on 2020-02-19, and clang-tidy modernizations completed
 
 itk_fetch_module(RTK
-    "Reconstruction Toolkit (RTK) http://www.openrtk.org/"
+  "Reconstruction Toolkit (RTK) http://www.openrtk.org/"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/SimonRit/RTK.git
-  GIT_TAG "f43ecb2a8c4438cc7abb47f371e4981f0f07b67e"
+  GIT_TAG 34b953f2308e281e87a2c82bb264574376f5b0fd
 )

--- a/Modules/Remote/SCIFIO.remote.cmake
+++ b/Modules/Remote/SCIFIO.remote.cmake
@@ -45,5 +45,5 @@ itk_fetch_module(SCIFIO
   "SCIFIO (Bioformats) ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/scifio/scifio-imageio.git
-  GIT_TAG 8811bce697efe0f3012b1f569e8603990cab1209
+  GIT_TAG c124b2b3354fb7b5644fa48df0bcde70eb78d974
   )

--- a/Modules/Remote/SimpleITKFilters.remote.cmake
+++ b/Modules/Remote/SimpleITKFilters.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(SimpleITKFilters
   contains a discrete hessian, and a composite filter to compute objectness."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKSimpleITKFilters.git
-  GIT_TAG c8c42430626f0123e7ec401c17c72c7d5ce82669
+  GIT_TAG 043d96d61aa3fafe16033de142932862104fa043
   )

--- a/Modules/Remote/SphinxExamples.remote.cmake
+++ b/Modules/Remote/SphinxExamples.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(SphinxExamples
   "This module builds the examples found at https://itk.org/ITKExamples/"
   MODULE_COMPLIANCE_LEVEL 5
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKExamples.git
-  GIT_TAG 0db19e7adcf228389d83bf7cf6da683def62810c
+  GIT_TAG de13e14d5e89efbafec7d5f6b4b8b87f9c19c42c
   )

--- a/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
+++ b/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
@@ -51,5 +51,5 @@ See the following Insight Journal's publication:
   https://hdl.handle.net/10380/3307"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/itkSubdivisionQuadEdgeMeshFilter
-  GIT_TAG 407179c85bdd425f19fb347ee83e282c65b54f9f
+  GIT_TAG 66c687869ad64b4edfab1e7cadc53d15be83eee2
   )

--- a/Modules/Remote/TextureFeatures.remote.cmake
+++ b/Modules/Remote/TextureFeatures.remote.cmake
@@ -57,5 +57,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTextureFeatures.git
-  GIT_TAG 2b831c41f38b1dea57efed638122c5e74f910450
+  GIT_TAG e5607af8b3c610600e28b84a8d84407655af5e2b
   )

--- a/Modules/Remote/TotalVariation.remote.cmake
+++ b/Modules/Remote/TotalVariation.remote.cmake
@@ -51,5 +51,5 @@ https://github.com/albarji/proxTV
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
-  GIT_TAG d44a4e5518f30b28bd913503f75bdf75ae9fb9db
+  GIT_TAG 2a295a5775e5ca4affc93647cb5ead4e0f62c181
 )

--- a/Modules/Remote/TubeTK.remote.cmake
+++ b/Modules/Remote/TubeTK.remote.cmake
@@ -45,9 +45,8 @@
 #--
 # Contact: Stephen Aylward <stephen.aylward@kitware.com>
 itk_fetch_module(TubeTK
- "http://www.tubetk.org
-"
+  "http://www.tubetk.org"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTubeTK.git
-  GIT_TAG "35126d4d091c2b17d772461f4bae0bdd1c04f9ac"
+  GIT_TAG 9cf631852ce8b07cdf736f7873abe8e300077fa6
   )

--- a/Modules/Remote/TwoProjectionRegistration.remote.cmake
+++ b/Modules/Remote/TwoProjectionRegistration.remote.cmake
@@ -62,5 +62,5 @@ Wu, J. \"ITK-Based Implementation of Two-Projection 2D/3D Registration Method wi
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTwoProjectionRegistration.git
-  GIT_TAG df2d0c2beeb0439eafcc002caa60e50d5314cedc
+  GIT_TAG 439ef9f41fc09960641fa48ec7237cb4889847c7
   )


### PR DESCRIPTION
Update remote modules.

Used the `/Utilities/Maintenance/UpdateRemoteModules.sh` script to update
the modules.

Manually remove the double quotes for the commit hash before update for
the the `RTK` and `TubeTK` modules to allow the script to work as
expected.

Take advantage of the commit to do minor manual editions on the `RTK` and
`TubeTK` remote files concerning the style.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)