### PR TITLE
ENH: accommodate dask_loads for default serializers of dask

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
@@ -17,6 +17,22 @@ try:
 
 except ImportError:
   HAVE_NUMPY = False
+try:
+    import numpy as np
+    from distributed.protocol import dask_serialize, dask_deserialize
+    from typing import Dict, List, Tuple
+except ImportError:
+    pass
+else:
+    @dask_serialize.register(NDArrayITKBase)
+    def serialize(ndarray_itk_base: NDArrayITKBase) -> Tuple[Dict, List[bytes]]:
+        dumps = dask_serialize.dispatch(np.ndarray)
+        return dumps(ndarray_itk_base)
+
+    @dask_deserialize.register(NDArrayITKBase)
+    def deserialize(header: Dict, frames: List[bytes]) -> NDArrayITKBase:
+        loads = dask_deserialize.dispatch(np.ndarray)
+        return NDArrayITKBase(loads(header, frames))
 
 def _get_numpy_pixelid(itk_Image_type):
     """Returns a ITK PixelID given a numpy array."""

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -28,6 +28,45 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
 
     def setUp(self):
         pass
+    def test_NDArrayITKBase_pickle(self):
+        """
+        Test the serialization of itk.NDArrayITKBase
+        """
+        Dimension             = 3
+        ScalarImageType       = itk.Image[itk.UC, Dimension]
+        RegionType            = itk.ImageRegion[Dimension]
+
+        region                = RegionType()
+        region.SetSize(0, 6);
+        region.SetSize(1, 6);
+        region.SetSize(2, 6);
+
+        scalarImage           = ScalarImageType.New()
+        scalarImage.SetRegions(region);
+        scalarImage.Allocate(True);
+        scalarImage.SetPixel([0, 0, 0], 5)
+        scalarImage.SetPixel([0, 0, 1], 3)
+        scalarImage.SetPixel([5, 5, 5], 8)
+        ndarray_itk_base      = itk.array_view_from_image(scalarImage)
+
+        import pickle
+
+        ## test serialization of itk ndarrary itk base
+        pickled = pickle.dumps(ndarray_itk_base)
+        reloaded = pickle.loads(pickled)
+        equal = (reloaded == ndarray_itk_base).all()
+        assert equal, 'Different results before and after pickle'
+
+        try:
+            import dask
+            from distributed.protocol.serialize import dask_dumps, dask_loads
+        except ImportError:
+            pass
+        else:
+            header, frames = dask_dumps(ndarray_itk_base)
+            recon_obj = dask_loads(header, frames)
+            equal = (recon_obj == ndarray_itk_base).all()
+            assert equal, 'Different results before and after pickle'
 
     def test_NumPyBridge_itkScalarImage(self):
         "Try to convert all pixel types to NumPy array view"


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

Dask loads method may complain TypeError: No dispatch for <class 'itkPyBufferPython.NDArrayITKBase'> due to the missing of a deserialization method for NDArrayITKBase. This commit tries to solve this issue by registering a deserialization method in dask for NDArrayITKBase. 

Correspondingly, the test case verifies the pickling and unpickling of a NDArrayITKBase instance.

<!-- **Thanks for contributing to ITK!** -->
