### PR TITLE
COMP: fix errors and warnings in OpenCV bridge

### DIFF
--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.h
@@ -27,7 +27,7 @@
 #include "opencv2/core/version.hpp"
 #if !defined(CV_VERSION_EPOCH)
 // OpenCV 3+
-#  include "opencv2/core.hpp"
+#  include "opencv2/imgproc.hpp"
 #  include "opencv2/imgproc/types_c.h"   // CV_RGB2BGR, CV_BGR2GRAY, ...
 #  include "opencv2/imgproc/imgproc_c.h" // cvCvtColor
 #else
@@ -92,7 +92,7 @@ private:
     4) Copy the buffer and convert the pixels if necessary */
   template <typename TOutputImageType, typename TPixel>
   static void
-  ITKConvertIplImageBuffer(const IplImage * in, TOutputImageType * out, int iDepth)
+  ITKConvertIplImageBuffer(const IplImage * in, TOutputImageType * out, unsigned int iDepth)
   {
     // Typedefs
     using ImageType = TOutputImageType;
@@ -141,7 +141,7 @@ private:
     }
 
     ITKConvertImageBuffer<TOutputImageType, TPixel>(
-      current->imageData, out, iDepth, current->nChannels, current->width, current->height, current->widthStep);
+      current->imageData, out, current->nChannels, current->width, current->height, current->widthStep);
 
     if (freeCurrent)
     {
@@ -151,7 +151,7 @@ private:
 
   template <typename TOutputImageType, typename TPixel>
   static void
-  ITKConvertMatImageBuffer(const Mat & in, TOutputImageType * out)
+  ITKConvertMatImageBuffer(const cv::Mat & in, TOutputImageType * out)
   {
     using namespace cv;
 
@@ -198,13 +198,8 @@ private:
       current = in;
     }
 
-    ITKConvertImageBuffer<TOutputImageType, TPixel>(reinterpret_cast<char *>(current.ptr()),
-                                                    out,
-                                                    iDepth,
-                                                    current.channels(),
-                                                    current.cols,
-                                                    current.rows,
-                                                    current.step);
+    ITKConvertImageBuffer<TOutputImageType, TPixel>(
+      reinterpret_cast<char *>(current.ptr()), out, current.channels(), current.cols, current.rows, current.step);
   }
 
   template <typename InputPixelType, typename OutputPixelType>
@@ -228,7 +223,6 @@ private:
   static void
   ITKConvertImageBuffer(const char *       in,
                         TOutputImageType * out,
-                        int                iDepth,
                         unsigned int       inChannels,
                         int                imgWidth,
                         int                imgHeight,

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
@@ -195,7 +195,7 @@ itkOpenCVImageBridgeTestTemplatedScalar(char * argv)
   cv::Mat outMat = itk::OpenCVImageBridge::ITKImageToCVMat<ImageType>(baselineImage);
 
   // check results of itk::Image -> IplImage
-  IplImage outMatAsIpl = outMat;
+  IplImage outMatAsIpl = cvIplImage(outMat);
   double   itkMatDiff = cvNorm(&outMatAsIpl, dataConvertedInIpl);
   if (itkMatDiff != 0.0)
   {

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -237,7 +237,7 @@ itkOpenCVImageBridgeTestTemplatedRGB(char * argv0, char * argv1)
   cv::Mat outMat = itk::OpenCVImageBridge::ITKImageToCVMat<ImageType>(baselineImage);
 
   // check results of itk::Image -> IplImage
-  IplImage outMatAsIpl = outMat;
+  IplImage outMatAsIpl = cvIplImage(outMat);
   double   itkMatDiff = cvNorm(&outMatAsIpl, dataConvertedInIpl);
   if (itkMatDiff != 0.0)
   {

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVTestHelper.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVTestHelper.cxx
@@ -40,7 +40,7 @@ cvLoadImage(const char * filename, int iscolor)
                                          { CV_64F, IPL_DEPTH_64F } };
   cv::Mat            mat = cv::imread(filename, iscolor);
   IplImage *         ipl = cvCreateImage(cvSize(mat.cols, mat.rows), matDepthToIplDepth[mat.depth()], mat.channels());
-  IplImage           iplTemp = mat;
+  IplImage           iplTemp = cvIplImage(mat);
   cvCopy(&iplTemp, ipl);
   return ipl;
 }


### PR DESCRIPTION
This fixes Issue #1929 as well as compile warnings introduced in the update (unused method parameter and signed/unsigned comparison)

In addition, this fixes the tests' compile errors due tu deprecated assignment of cv::Mat to IplImage

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.
