### PR TITLE
COMP: Fix SW Guide examples multi-line comment warnings

### DIFF
--- a/Examples/Segmentation/GeodesicActiveContourImageFilter.cxx
+++ b/Examples/Segmentation/GeodesicActiveContourImageFilter.cxx
@@ -544,11 +544,12 @@ main(int argc, char * argv[])
   //  \hline
   //  Structure    & Seed Index &  Distance   &   $\sigma$  &
   //  $\alpha$     &  $\beta$   & Propag. & Output Image \\  \hline
-  //  Left Ventricle  & $(81,114)$ & 5.0 & 1.0 & -0.5 & 3.0  &  2.0 & First \\
-  //  \hline Right Ventricle & $(99,114)$ & 5.0 & 1.0 & -0.5 & 3.0  &  2.0 &
-  //  Second  \\  \hline White matter    & $(56, 92)$ & 5.0 & 1.0 & -0.3 & 2.0
-  //  & 10.0 & Third   \\  \hline Gray matter     & $(40, 90)$ & 5.0 & 0.5 &
-  //  -0.3 & 2.0  & 10.0 & Fourth  \\  \hline \end{tabular} \end{center}
+  //  Left Ventricle  & $(81,114)$ & 5.0 & 1.0 & -0.5 & 3.0  &  2.0 &
+  //  First  \\  \hline  Right Ventricle & $(99,114)$ & 5.0 & 1.0 & -0.5 &
+  //  3.0  &  2.0 & Second  \\  \hline White matter    & $(56, 92)$ & 5.0 &
+  //  1.0 & -0.3 & 2.0 & 10.0 & Third   \\  \hline Gray matter     &
+  //  $(40, 90)$ & 5.0 & 0.5 & -0.3 & 2.0  & 10.0 & Fourth  \\  \hline
+  //  \end{tabular} \end{center}
   //  \itkcaption[GeodesicActiveContour segmentation example
   //  parameters]{Parameters used for segmenting some brain structures shown
   //  in Figure~\ref{fig:GeodesicActiveContourImageFilterOutput2} using the

--- a/Examples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx
@@ -1027,8 +1027,9 @@ main(int argc, char * argv[])
   //  \includegraphics[width=0.10\textwidth]{CorpusCallosumModePlus1} \\ mode
   //  2: & \includegraphics[width=0.10\textwidth]{CorpusCallosumModeMinus2} &
   //  \includegraphics[width=0.10\textwidth]{CorpusCallosumMeanShape} &
-  //  \includegraphics[width=0.10\textwidth]{CorpusCallosumModePlus2} \\
-  //  \end{tabular} \itkcaption[Corpus callosum PCA modes]{First three PCA
+  //  \includegraphics[width=0.10\textwidth]{CorpusCallosumModePlus2}
+  //  \\ \end{tabular}
+  //  \itkcaption[Corpus callosum PCA modes]{First three PCA
   //  modes of a low-resolution
   //  ($58 \times 31$ pixels, $2 \times 2$ mm spacing) corpus callosum model
   //  used in the shape guided geodesic active contours example.}

--- a/Examples/Segmentation/IsolatedConnectedImageFilter.cxx
+++ b/Examples/Segmentation/IsolatedConnectedImageFilter.cxx
@@ -265,8 +265,9 @@ main(int argc, char * argv[])
   //  \begin{center}
   //  \begin{tabular}{|l|c|c|c|c|}
   //  \hline
-  //  Adjacent Structures & Seed1 & Seed2 & Lower & Isolated value found \\
-  //  \hline Gray matter vs White matter & $(61,140)$ & $(63,43)$ & $150$ &
+  //  Adjacent Structures & Seed1 & Seed2 & Lower &
+  //  Isolated value found \\ \hline
+  //  Gray matter vs White matter & $(61,140)$ & $(63,43)$ & $150$ &
   //  $183.31$  \\ \hline \end{tabular} \end{center}
   //  \itkcaption[IsolatedConnectedImageFilter example parameters]{Parameters
   //  used for separating white matter from gray matter in

--- a/Examples/Segmentation/VectorConfidenceConnected.cxx
+++ b/Examples/Segmentation/VectorConfidenceConnected.cxx
@@ -273,8 +273,9 @@ main(int argc, char * argv[])
   //  \begin{center}
   //  \begin{tabular}{|l|c|c|c|c|}
   //  \hline
-  //  Structure & Seed Index & Multiplier & Iterations & Output Image \\
-  //  \hline Rectum & $(70,120)$ & 7 & 1 & Second from left in Figure
+  //  Structure & Seed Index & Multiplier & Iterations
+  //  & Output Image \\ \hline
+  //  Rectum & $(70,120)$ & 7 & 1 & Second from left in Figure
   //  \ref{fig:VectorConfidenceConnectedOutput} \\ \hline Rectum & $(23, 93)$
   //  & 7 & 1 & Third  from left in Figure
   //  \ref{fig:VectorConfidenceConnectedOutput} \\ \hline Vitreo & $(66, 66)$


### PR DESCRIPTION
Fix SW Guide examples multi-line comment warnings.

Fixes:
```
[CTest: warning matched]
/home/kitware/Dashboards/TestsExamples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx:1030:3:
warning: multi-line comment [-Wcomment]
   //  \includegraphics[width=0.10\textwidth]{CorpusCallosumModePlus2} \\
      ^
```
and
```
[CTest: warning matched]
/home/kitware/Dashboards/TestsExamples/Segmentation/IsolatedConnectedImageFilter.cxx:268:3:
warning: multi-line comment [-Wcomment]
   //  Adjacent Structures & Seed1 & Seed2 & Lower & Isolated value found
   //  \\
      ^
```
and
```
[CTest: warning matched]
/home/kitware/Dashboards/TestsExamples/Segmentation/VectorConfidenceConnected.cxx:276:3:
warning: multi-line comment [-Wcomment]
   //  Structure & Seed Index & Multiplier & Iterations & Output Image \\
      ^
```
and
```
[CTest: warning matched]
/home/kitware/Dashboards/TestsExamples/Segmentation/GeodesicActiveContourImageFilter.cxx:547:3:
warning: multi-line comment [-Wcomment]
   //  Left Ventricle  & $(81,114)$ & 5.0 & 1.0 & -0.5 & 3.0  &  2.0 &
   //  First \\
      ^
```

raised for example at:
https://open.cdash.org/viewBuildError.php?type=1&onlydeltap&buildid=6687599


## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)