### PR TITLE
ENH: Support additional pixel types in python wrapping for ShrinkImag…

### DIFF
--- a/Modules/Filtering/ImageGrid/wrapping/itkBinShrinkImageFilter.wrap
+++ b/Modules/Filtering/ImageGrid/wrapping/itkBinShrinkImageFilter.wrap
@@ -1,8 +1,7 @@
 itk_wrap_class("itk::BinShrinkImageFilter" POINTER)
   itk_wrap_image_filter("${WRAP_ITK_RGB}" 2)
   itk_wrap_image_filter("${WRAP_ITK_RGBA}" 2)
-# VS9 (2008) does not correctly implicitly cast itk::Vector for operator +=
-#  itk_wrap_image_filter("${WRAP_ITK_VECTOR}" 2)
+  itk_wrap_image_filter("${WRAP_ITK_VECTOR}" 2)
   itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2)
   itk_wrap_image_filter("${WRAP_ITK_COMPLEX_REAL}" 2)
 itk_end_wrap_class()

--- a/Modules/Filtering/ImageGrid/wrapping/itkShrinkImageFilter.wrap
+++ b/Modules/Filtering/ImageGrid/wrapping/itkShrinkImageFilter.wrap
@@ -1,3 +1,7 @@
 itk_wrap_class("itk::ShrinkImageFilter" POINTER)
+  itk_wrap_image_filter("${WRAP_ITK_RGB}" 2)
+  itk_wrap_image_filter("${WRAP_ITK_RGBA}" 2)
+  itk_wrap_image_filter("${WRAP_ITK_VECTOR}" 2)
   itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2)
+  itk_wrap_image_filter("${WRAP_ITK_COMPLEX_REAL}" 2)
 itk_end_wrap_class()


### PR DESCRIPTION
A change to `itkwidgets/widget_viewer.py` to use `ShrinkImageFilter` instead of `BinShrinkImageFilter` requires that the former support more pixel types in python than previously.  This pull request makes `ShrinkImageFilter` wrap all types that are already wrapped by `BinShrinkImageFilter`.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
