### PR TITLE
COMP: Override inherited methods in `itkGPUFiniteDifferenceImageFilter`

### DIFF
--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
@@ -140,15 +140,38 @@ public:
   itkGetConstReferenceMacro(ApplyUpdateTime, TimeProbe);
   itkGetConstReferenceMacro(SmoothFieldTime, TimeProbe);
 
-  /** Set/Get the maximum error allowed in the solution.  This may not be
+  /** Set the maximum error allowed in the solution. This may not be
       defined for all solvers and its meaning may change with the application. */
-  itkSetMacro(MaximumRMSError, double);
-  itkGetConstReferenceMacro(MaximumRMSError, double);
+  void
+  SetMaximumRMSError(double maximumRMSError) override
+  {
+    this->m_MaximumRMSError = maximumRMSError;
+  }
 
-  /** Set/Get the root mean squared change of the previous iteration. May not
+  /** Get the maximum error allowed in the solution. This may not be
+      defined for all solvers and its meaning may change with the application. */
+  const double &
+  GetMaximumRMSError() const override
+  {
+    return this->m_MaximumRMSError;
+  }
+
+  /** Set the root mean squared change of the previous iteration. May not
       be used by all solvers. */
-  itkSetMacro(RMSChange, double);
-  itkGetConstReferenceMacro(RMSChange, double);
+  void
+  SetRMSChange(double RMSChange) override
+  {
+    this->m_RMSChange = RMSChange;
+  }
+
+  /** Get the root mean squared change of the previous iteration. May not
+      be used by all solvers. */
+  const double &
+  GetRMSChange() const override
+  {
+    return this->m_RMSChange;
+  }
+
 
 protected:
   GPUFiniteDifferenceImageFilter();


### PR DESCRIPTION
Mark inherited methods in `itkGPUFiniteDifferenceImageFilter` with the
`override` specifier.

Fixes
```
/Users/builder/externalModules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h:145:3:
warning: 'SetMaximumRMSError' overrides a member function but is not
marked 'override' [-Winconsistent-missing-override]

/Users/builder/externalModules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h:146:3:
warning: 'GetMaximumRMSError' overrides a member function but is not
marked 'override' [-Winconsistent-missing-override]

```
and
```
/Users/builder/externalModules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h:150:3:
warning: 'SetRMSChange' overrides a member function but is not marked
'override' [-Winconsistent-missing-override]

/Users/builder/externalModules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h:151:3:
warning: 'GetRMSChange' overrides a member function but is not marked
'override' [-Winconsistent-missing-override]
```

reported here:
https://open.cdash.org/viewBuildError.php?type=1&buildid=6738417

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
