### PR TITLE
COMP: Remove unnecessary inherited member re-definitions

### DIFF
--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
@@ -140,16 +140,6 @@ public:
   itkGetConstReferenceMacro(ApplyUpdateTime, TimeProbe);
   itkGetConstReferenceMacro(SmoothFieldTime, TimeProbe);
 
-  /** Set/Get the maximum error allowed in the solution.  This may not be
-      defined for all solvers and its meaning may change with the application. */
-  itkSetMacro(MaximumRMSError, double);
-  itkGetConstReferenceMacro(MaximumRMSError, double);
-
-  /** Set/Get the root mean squared change of the previous iteration. May not
-      be used by all solvers. */
-  itkSetMacro(RMSChange, double);
-  itkGetConstReferenceMacro(RMSChange, double);
-
 protected:
   GPUFiniteDifferenceImageFilter();
   ~GPUFiniteDifferenceImageFilter() override;
@@ -262,21 +252,6 @@ protected:
   void
   PostProcessOutput() override
   {}
-
-  /** The maximum number of iterations this filter will run */
-
-  // unsigned int m_NumberOfIterations;
-
-  /** A counter for keeping track of the number of elapsed
-      iterations during filtering. */
-  // unsigned int m_ElapsedIterations;
-
-  /** Indicates whether the filter automatically resets to UNINITIALIZED state
-      after completing, or whether filter must be manually reset */
-  bool m_ManualReinitialization;
-
-  double m_RMSChange;
-  double m_MaximumRMSError;
 
   /** Timers for statistics */
   TimeProbe m_InitTime, m_ComputeUpdateTime, m_ApplyUpdateTime, m_SmoothFieldTime;

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -29,13 +29,8 @@ template <typename TInputImage, typename TOutputImage, typename TParentImageFilt
 GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::GPUFiniteDifferenceImageFilter()
 {
   m_UseImageSpacing = false;
-  this->m_ElapsedIterations = 0;
   m_DifferenceFunction = nullptr;
-  this->m_NumberOfIterations = NumericTraits<unsigned int>::max();
-  m_MaximumRMSError = 0.0;
-  m_RMSChange = 0.0;
   m_State = GPUFiniteDifferenceFilterEnum::UNINITIALIZED;
-  m_ManualReinitialization = false;
   this->InPlaceOff();
 }
 
@@ -110,7 +105,7 @@ GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::G
     }
   }
 
-  if (m_ManualReinitialization == false)
+  if (this->GetManualReinitialization() == false)
   {
     this->SetStateToUninitialized(); // Reset the state once execution is
                                      // completed
@@ -300,14 +295,10 @@ GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::P
                                                                                          Indent         indent) const
 {
   GPUSuperclass::PrintSelf(os, indent);
+  CPUSuperclass::PrintSelf(os, indent);
   /*
-    os << indent << "ElapsedIterations: " << this->m_ElapsedIterations << std::endl;
     os << indent << "UseImageSpacing: " << ( m_UseImageSpacing ? "On" : "Off" ) << std::endl;
     os << indent << "State: " << m_State << std::endl;
-    os << indent << "MaximumRMSError: " << m_MaximumRMSError << std::endl;
-    os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
-    os << indent << "ManualReinitialization: " << m_ManualReinitialization << std::endl;
-    os << indent << "RMSChange: " << m_RMSChange << std::endl;
     os << std::endl;
     if ( m_DifferenceFunction )
       {


### PR DESCRIPTION
Remove unnecessary inherited member re-definitions.

Add the missing call to its CPU superclass `PrintSelf` method.

Fixes
```
/Users/builder/externalModules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h:145:3:
warning: 'SetMaximumRMSError' overrides a member function but is not
marked 'override' [-Winconsistent-missing-override]

/Users/builder/externalModules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h:146:3:
warning: 'GetMaximumRMSError' overrides a member function but is not
marked 'override' [-Winconsistent-missing-override]
```
and
```
/Users/builder/externalModules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h:150:3:
warning: 'SetRMSChange' overrides a member function but is not marked
'override' [-Winconsistent-missing-override]

/Users/builder/externalModules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h:151:3:
warning: 'GetRMSChange' overrides a member function but is not marked
'override' [-Winconsistent-missing-override]
```

reported here:
https://open.cdash.org/viewBuildError.php?type=1&buildid=6738417

Take advantage of the commit to clean up additional inherited member
unnecessary re-definitions (e.g. `m_ManualReinitialization`).

Remove commented statements in the class header.

Rely on the parent class initialization for the inherited ivars (the
initialization values in the current class were no different from the
parent's).

Add the missing call to its CPU superclass `PrintSelf` method.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)