### PR TITLE
ENH: Improve `itk::DCMTKSeriesFileNames` class coverage

### DIFF
--- a/Modules/IO/DCMTK/test/CMakeLists.txt
+++ b/Modules/IO/DCMTK/test/CMakeLists.txt
@@ -45,12 +45,12 @@ itk_add_test(NAME itkDCMTKImageIOTest4 COMMAND ITKIODCMTKTestDriver
 itk_add_test(NAME itkDCMTKSeriesReadImageWrite
   COMMAND ITKIODCMTKTestDriver itkDCMTKSeriesReadImageWrite
   DATA{${ITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm}
-  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesReadImageWrite.vtk)
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesReadImageWrite.vtk 0 0 0)
 
 itk_add_test(NAME itkDCMTKDirCosinesTest
   COMMAND ITKIODCMTKTestDriver itkDCMTKSeriesReadImageWrite
   DATA{${ITK_DATA_ROOT}/Input/DicomDirectionsTest/,REGEX:1020_[0-9]+.dcm}
-  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesReadImageWrite.vtk)
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesReadImageWrite.vtk 0 0 0)
 
 set_property(TEST itkDCMTKSeriesReadImageWrite APPEND PROPERTY DEPENDS ITKData)
 
@@ -67,7 +67,7 @@ itk_add_test(NAME itkDCMTKSeriesImageOrientationWrite1
   ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesImageOrientationWrite1.mha
   itkDCMTKSeriesReadImageWrite
   DATA{${ITK_DATA_ROOT}/Input/DicomImageOrientationTest/,REGEX:ImageOrientation.[0-9]+.dcm}
-  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesImageOrientationWrite1.mha)
+  ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesImageOrientationWrite1.mha 0 0 0)
 
 itk_add_test(NAME itkDCMTKImageIOOrthoDirTest
   COMMAND ITKIODCMTKTestDriver itkDCMTKImageIOOrthoDirTest

--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
@@ -28,13 +28,20 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkDCMTKImageIO.h"
 #include "itkDCMTKSeriesFileNames.h"
+#include "itkTestingMacros.h"
 
 int
 itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
 {
-  if (argc < 3)
+  if (argc != 6)
   {
-    std::cerr << "Usage: " << argv[0] << " DicomDirectory  outputFile" << std::endl;
+    std::cerr << "Missing arguments." << std::endl;
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " DicomDirectory "
+              << " outputFile"
+              << " recursive"
+              << " loadSequences"
+              << " loadPrivateTags" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -46,7 +53,19 @@ itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
   ImageIOType::Pointer     dcmtkIO = ImageIOType::New();
   SeriesFileNames::Pointer it = SeriesFileNames::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(it, DCMTKSeriesFileNames, ProcessObject);
+
+
   it->SetInputDirectory(argv[1]);
+
+  auto recursive = static_cast<bool>(std::stoi(argv[3]);
+  ITK_TEST_SET_GET_BOOLEAN(it, Recursive, recursive);
+
+  auto loadSequences = static_cast<bool>(std::stoi(argv[4]);
+  ITK_TEST_SET_GET_BOOLEAN(it, LoadSequences, loadSequences);
+
+  auto loadPrivateTags = static_cast<bool>(std::stoi(argv[5]);
+  ITK_TEST_SET_GET_BOOLEAN(it, LoadPrivateTags, loadPrivateTags);
 
   ReaderType::Pointer reader = ReaderType::New();
 
@@ -62,17 +81,8 @@ itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
   reader->SetFileNames(fileNames);
   reader->SetImageIO(dcmtkIO);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown while writing the image" << std::endl;
-    std::cerr << excp << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
-    return EXIT_FAILURE;
-  }
 
   using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
@@ -80,16 +90,9 @@ itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown while writing the image" << std::endl;
-    std::cerr << excp << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve `itk::DCMTKSeriesFileNames` class coverage:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Use the `ITK_TRY_EXPECT_NO_EXCEPTION` macro when updating the filters.
- Exercise the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Add arguments to the test to improve the class testing of the additional
  ivars.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
