### PR TITLE
ENH: Improve the `itk::VideoFileWriter` class coverage.

### DIFF
--- a/Modules/Video/IO/test/CMakeLists.txt
+++ b/Modules/Video/IO/test/CMakeLists.txt
@@ -21,6 +21,8 @@ itk_add_test(
       DATA{Input/frame3.jpg}
       DATA{Input/frame4.jpg}
       "${ITK_TEST_OUTPUT_DIR}/frame0.png,${ITK_TEST_OUTPUT_DIR}/frame1.png,${ITK_TEST_OUTPUT_DIR}/frame2.png,${ITK_TEST_OUTPUT_DIR}/frame3.png,${ITK_TEST_OUTPUT_DIR}/frame4.png"
+      24
+      MP42
     )
 
 

--- a/Modules/Video/IO/test/itkVideoFileReaderWriterTest.cxx
+++ b/Modules/Video/IO/test/itkVideoFileReaderWriterTest.cxx
@@ -26,9 +26,12 @@ int
 itkVideoFileReaderWriterTest(int argc, char * argv[])
 {
   // Check parameters
-  if (argc != 7)
+  if (argc != 9)
   {
-    std::cerr << "Usage: [Video Input] [Image Output]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " [Video Input] [Image Output] framesPerSecond fourCC"
+              << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -65,10 +68,21 @@ itkVideoFileReaderWriterTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(writer, VideoFileWriter, TemporalProcessObject);
 
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(argv[6]);
+  writer->SetFileName(std::string(argv[6]));
+  ITK_TEST_SET_GET_VALUE(std::string(argv[6]), writer->GetFileName());
+
+  auto framesPerSecond = static_cast<VideoWriterType::TemporalRatioType>(std::stod(argv[7]));
+  writer->SetFramesPerSecond(framesPerSecond);
+  ITK_TEST_SET_GET_VALUE(framesPerSecond, writer->GetFramesPerSecond());
+
+  auto fourCC = std::string(argv[8]);
+  writer->SetFourCC(fourCC);
+  ITK_TEST_SET_GET_VALUE(fourCC, writer->GetFourCC());
 
   // Call Update on the writer to process the entire video
-  writer->Update();
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve the `itk::VideoFileWriter` class coverage:
- Use the `ITK_TRY_EXPECT_NO_EXCEPTION` macro when updating the filters.
- Exercise the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Add arguments to the test to improve the class testing of the additional
  ivars.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)