### PR TITLE
ENH: Improve TopHatImageFilter classes coverage

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
+++ b/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
@@ -255,12 +255,12 @@ itk_add_test(NAME itkBlackTopHatImageFilterTest
       COMMAND ITKMathematicalMorphologyTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/itkBlackTopHatImageFilterTest.png}
               ${ITK_TEST_OUTPUT_DIR}/itkBlackTopHatImageFilterTest.png
-    itkTopHatImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/itkBlackTopHatImageFilterTest.png 0 3)
+    itkTopHatImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/itkBlackTopHatImageFilterTest.png 0 3 1 1 0)
 itk_add_test(NAME itkWhiteTopHatImageFilterTest
       COMMAND ITKMathematicalMorphologyTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/itkWhiteTopHatImageFilterTest.png}
               ${ITK_TEST_OUTPUT_DIR}/itkWhiteTopHatImageFilterTest.png
-    itkTopHatImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/itkWhiteTopHatImageFilterTest.png 1 3)
+    itkTopHatImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cthead1.png} ${ITK_TEST_OUTPUT_DIR}/itkWhiteTopHatImageFilterTest.png 1 3 1 1 0)
 itk_add_test(NAME itkGrayscaleMorphologicalClosingImageFilterTest2
       COMMAND ITKMathematicalMorphologyTestDriver
     --compare ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2Basic.png

--- a/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
@@ -24,14 +24,68 @@
 #include "itkImageFileWriter.h"
 #include "itkTestingMacros.h"
 
+
+template <typename TKernelImageFilter>
+int
+itkTopHatImageFilterTestHelper(TKernelImageFilter *                    filter,
+                               typename TKernelImageFilter::KernelType ball,
+                               const bool                              safeBorder,
+                               const int                               algorithm,
+                               const bool                              forceAlgorithm,
+                               const char *                            inputFileName,
+                               const char *                            outputFileName)
+{
+  // Declare the reader and writer
+  using ReaderType = itk::ImageFileReader<typename TKernelImageFilter::InputImageType>;
+  typename ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFileName);
+
+  itk::SimpleFilterWatcher watcher(filter, "filter");
+
+  ITK_TEST_SET_GET_BOOLEAN(filter, SafeBorder, safeBorder);
+
+  filter->SetAlgorithm(algorithm);
+  ITK_TEST_SET_GET_VALUE(algorithm, filter->GetAlgorithm());
+
+  ITK_TEST_SET_GET_BOOLEAN(filter, ForceAlgorithm, forceAlgorithm);
+
+  // Connect the structuring element
+  filter->SetKernel(ball);
+
+  // Connect the pipeline
+  filter->SetInput(reader->GetOutput());
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
+
+  // Write output
+  using WriterType = itk::ImageFileWriter<typename TKernelImageFilter::OutputImageType>;
+  typename WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  std::cout << "Test finished" << std::endl;
+  return EXIT_SUCCESS;
+}
+
+
 int
 itkTopHatImageFilterTest(int argc, char * argv[])
 {
-  if (argc < 5)
+  if (argc != 8)
   {
     std::cerr << "Missing arguments." << std::endl;
     std::cerr << "Usage: " << std::endl;
-    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImage outputImage 0/1(Black/White) radius" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage"
+              << " outputImage"
+              << " 0/1(Black/White)"
+              << " radius"
+              << " safeBorder"
+              << " algorithm"
+              << " forceAlgorithm" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -44,25 +98,11 @@ itkTopHatImageFilterTest(int argc, char * argv[])
   // Declare the types of the images
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the reader and writer
-  using ReaderType = itk::ImageFileReader<ImageType>;
-  using WriterType = itk::ImageFileWriter<ImageType>;
-
-
   // Declare the type for the structuring element
   using KernelType = itk::BinaryBallStructuringElement<PixelType, Dimension>;
 
-  // Declare the type for the morphology Filter
-  using BlackFilterType = itk::BlackTopHatImageFilter<ImageType, ImageType, KernelType>;
-
-  using WhiteFilterType = itk::WhiteTopHatImageFilter<ImageType, ImageType, KernelType>;
-
-  // Create the reader and writer
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
-
-  reader->SetFileName(argv[1]);
-  writer->SetFileName(argv[2]);
+  const char * inputFileName = argv[1];
+  const char * outputFileName = argv[2];
 
   // Create the structuring element
   KernelType           ball;
@@ -72,56 +112,45 @@ itkTopHatImageFilterTest(int argc, char * argv[])
   ball.SetRadius(ballSize);
   ball.CreateStructuringElement();
 
+  auto safeBorder = static_cast<bool>(std::stoi(argv[5]));
+  int  algorithm;
+  auto forceAlgorithm = static_cast<bool>(std::stoi(argv[7]));
+
   switch (std::stoi(argv[3]))
   {
     case 0:
     {
       // Create the filter
+      using BlackFilterType = itk::BlackTopHatImageFilter<ImageType, ImageType, KernelType>;
       BlackFilterType::Pointer filter = BlackFilterType::New();
-      itk::SimpleFilterWatcher watcher(filter, "filter");
 
-      // Connect the structuring element
-      filter->SetKernel(ball);
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BlackTopHatImageFilter, KernelImageFilter);
 
-      // Connect the pipeline
-      filter->SetInput(reader->GetOutput());
-      filter->Update();
-      writer->SetInput(filter->GetOutput());
+
+      algorithm = static_cast<BlackFilterType::AlgorithmType>(std::stoi(argv[6]));
+      return itkTopHatImageFilterTestHelper<BlackFilterType>(
+        filter, ball, safeBorder, algorithm, forceAlgorithm, inputFileName, outputFileName);
 
       break;
     }
     case 1:
     {
       // Create the filter
+      using WhiteFilterType = itk::WhiteTopHatImageFilter<ImageType, ImageType, KernelType>;
       WhiteFilterType::Pointer filter = WhiteFilterType::New();
-      itk::SimpleFilterWatcher watcher(filter, "filter");
 
-      // Connect the structuring element
-      filter->SetKernel(ball);
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, WhiteTopHatImageFilter, KernelImageFilter);
 
-      // Connect the pipeline
-      filter->SetInput(reader->GetOutput());
-      filter->Update();
-      writer->SetInput(filter->GetOutput());
+
+      algorithm = static_cast<WhiteFilterType::AlgorithmType>(std::stoi(argv[6]));
+      return itkTopHatImageFilterTestHelper<WhiteFilterType>(
+        filter, ball, safeBorder, algorithm, forceAlgorithm, inputFileName, outputFileName);
 
       break;
     }
     default:
+      std::cerr << "Test failed!" << std::endl;
       std::cerr << "Invalid filter selector: " << std::stoi(argv[3]) << std::endl;
       return EXIT_FAILURE;
   }
-  // Execute the filter
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during pipeline Update\n" << e;
-    return EXIT_FAILURE;
-  }
-
-  // All objects should be automatically destroyed at this point
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve `itk::BlackTopHatImageFilter` and `itk::WhiteTopHatImageFilter`
classes coverage:

- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Use the `ITK_TRY_EXPECT_NO_EXCEPTION` macro when updating the filters.
- Exercise the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Refactor the test to reduce boilerplate code.
- Add arguments to the test to improve the class testing of the additional
  ivars.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)