### PR TITLE
DOC: Fix typos in DTI module's anisotropy image filter classes

### DIFF
--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
@@ -57,7 +57,7 @@ public:
 /** \class TensorFractionalAnisotropyImageFilter
  * \brief Computes the Fractional Anisotropy for every pixel of a input tensor image.
  *
- * TensorFractionalAnisotropyImageFilter applies pixel-wise the invokation for
+ * TensorFractionalAnisotropyImageFilter applies pixel-wise the invocation for
  * computing the fractional anisotropy of every pixel. The pixel type of the
  * input image is expected to implement a method GetFractionalAnisotropy(), and
  * to specify its return type as  RealValueType.

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
@@ -57,7 +57,7 @@ public:
 /** \class TensorRelativeAnisotropyImageFilter
  * \brief Computes the Relative Anisotropy for every pixel of a input tensor image.
  *
- * TensorRelativeAnisotropyImageFilter applies pixel-wise the invokation for
+ * TensorRelativeAnisotropyImageFilter applies pixel-wise the invocation for
  * computing the relative anisotropy of every pixel. The pixel type of the
  * input image is expected to implement a method GetRelativeAnisotropy(), and
  * to specify its return type as  RealValueType.


### PR DESCRIPTION
Fix typos in DTI module's anisotropy image filter classes.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
