### PR TITLE
ENH: Add the `PrintSelf` method to `itk::SpatialFunctionImageEvaluatorFilter`

### DIFF
--- a/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.h
+++ b/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.h
@@ -96,6 +96,9 @@ protected:
   void
   GenerateData() override;
 
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+
 private:
   /** The function that will be evaluated over the image */
   FunctionType * m_PixelFunction;

--- a/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
+++ b/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
@@ -69,6 +69,17 @@ SpatialFunctionImageEvaluatorFilter<TSpatialFunction, TInputImage, TOutputImage>
 
   itkDebugMacro(<< "SpatialFunctionImageEvaluatorFilter::GenerateData() finished");
 }
+
+template <typename TSpatialFunction, typename TInputImage, typename TOutputImage>
+void
+SpatialFunctionImageEvaluatorFilter<TSpatialFunction, TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
+                                                                                            Indent         indent) const
+{
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "PixelFunction: " << m_PixelFunction << std::endl;
+}
+
 } // namespace itk
 
 #endif


### PR DESCRIPTION
Add the `PrintSelf` method to the `itk::SpatialFunctionImageEvaluatorFilter`
class.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)