### PR TITLE
ENH: Improve the DTI module classes coverage

### DIFF
--- a/Modules/Filtering/DiffusionTensorImage/test/CMakeLists.txt
+++ b/Modules/Filtering/DiffusionTensorImage/test/CMakeLists.txt
@@ -11,7 +11,7 @@ CreateTestDriver(ITKDiffusionTensorImage  "${ITKDiffusionTensorImage-Test_LIBRAR
 itk_add_test(NAME itkDiffusionTensor3DTest
       COMMAND ITKDiffusionTensorImageTestDriver itkDiffusionTensor3DTest)
 itk_add_test(NAME itkDiffusionTensor3DReconstructionImageFilterTest
-      COMMAND ITKDiffusionTensorImageTestDriver itkDiffusionTensor3DReconstructionImageFilterTest)
+      COMMAND ITKDiffusionTensorImageTestDriver itkDiffusionTensor3DReconstructionImageFilterTest 1.0)
 itk_add_test(NAME itkTensorRelativeAnisotropyImageFilterTest
       COMMAND ITKDiffusionTensorImageTestDriver itkTensorRelativeAnisotropyImageFilterTest)
 itk_add_test(NAME itkTensorFractionalAnisotropyImageFilterTest

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
@@ -18,11 +18,21 @@
 #include "itkDiffusionTensor3DReconstructionImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 #include <iostream>
 
 int
-itkDiffusionTensor3DReconstructionImageFilterTest(int, char *[])
+itkDiffusionTensor3DReconstructionImageFilterTest(int argc, char * argv[])
 {
+  // Check parameters
+  if (argc != 2)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " bValue" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   using ReferencePixelType = short int;
   using GradientPixelType = short int;
   using TensorPrecisionType = double;
@@ -36,6 +46,17 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int, char *[])
     using GradientImageType = TensorReconstructionImageFilterType::GradientImageType;
     TensorReconstructionImageFilterType::Pointer tensorReconstructionFilter =
       TensorReconstructionImageFilterType::New();
+
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(
+      tensorReconstructionFilter, DiffusionTensor3DReconstructionImageFilter, ImageToImageFilter);
+
+    auto threshold = itk::NumericTraits<TensorReconstructionImageFilterType::ReferencePixelType>::min();
+    tensorReconstructionFilter->SetThreshold(threshold);
+    ITK_TEST_SET_GET_VALUE(threshold, tensorReconstructionFilter->GetThreshold());
+
+    auto bValue = static_cast<TensorPrecisionType>(std::stod(argv[1]));
+    tensorReconstructionFilter->SetBValue(bValue);
+    ITK_TEST_SET_GET_VALUE(bValue, tensorReconstructionFilter->GetBValue());
 
     // Create a reference image
     //
@@ -119,6 +140,8 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int, char *[])
       tensorReconstructionFilter->SetMaskSpatialObject(maskSpatialObject);
     }
     tensorReconstructionFilter->SetReferenceImage(referenceImage);
+    ITK_TEST_SET_GET_VALUE(referenceImage, tensorReconstructionFilter->GetReferenceImage());
+
     // TODO: remove this when netlib is made thread safe
     tensorReconstructionFilter->SetNumberOfWorkUnits(1);
 
@@ -201,5 +224,7 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int, char *[])
               << std::endl;
   }
 
+
+  std::cout << "Test finished" << std::endl;
   return result;
 }

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkHessianRecursiveGaussianImageFilter.h"
 #include "itkTensorFractionalAnisotropyImageFilter.h"
 #include "itkDiffusionTensor3D.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -122,6 +123,9 @@ itkTensorFractionalAnisotropyImageFilterTest(int, char *[])
 
   FAFilterType::Pointer fractionalAnisotropyFilter = FAFilterType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
+    fractionalAnisotropyFilter, TensorFractionalAnisotropyImageFilter, UnaryFunctorImageFilter);
+
   fractionalAnisotropyFilter->SetInput(filter->GetOutput());
 
   // Execute the filter
@@ -150,6 +154,6 @@ itkTensorFractionalAnisotropyImageFilterTest(int, char *[])
   }
 
 
-  // All objects should be automatically destroyed at this point
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkHessianRecursiveGaussianImageFilter.h"
 #include "itkTensorRelativeAnisotropyImageFilter.h"
 #include "itkDiffusionTensor3D.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -122,6 +123,9 @@ itkTensorRelativeAnisotropyImageFilterTest(int, char *[])
 
   FAFilterType::Pointer relativeAnisotropyFilter = FAFilterType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
+    relativeAnisotropyFilter, TensorRelativeAnisotropyImageFilter, UnaryFunctorImageFilter);
+
   relativeAnisotropyFilter->SetInput(filter->GetOutput());
 
   // Execute the filter
@@ -150,6 +154,6 @@ itkTensorRelativeAnisotropyImageFilterTest(int, char *[])
   }
 
 
-  // All objects should be automatically destroyed at this point
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve the DTI module classes coverage
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Increase the ability of the testing for the
  `itk::DiffusionTensor3DReconstructionImageFilterTest` class by adding an
  input argument to the test.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)