### PR TITLE
ENH: Improve coverage for `SpatialObjects` module classes.

### DIFF
--- a/Modules/Core/SpatialObjects/test/itkArrowSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkArrowSpatialObjectTest.cxx
@@ -16,12 +16,9 @@
  *
  *=========================================================================*/
 
-/**
- * This is a test file for the itkArrowSpatialObject class.
- */
-
 #include "itkArrowSpatialObject.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkArrowSpatialObjectTest(int, char *[])
@@ -29,6 +26,9 @@ itkArrowSpatialObjectTest(int, char *[])
   using ArrowType = itk::ArrowSpatialObject<3>;
 
   ArrowType::Pointer myArrow = ArrowType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(myArrow, ArrowSpatialObject, SpatialObject);
+
 
   // Testing the position
   std::cout << "Testing position : ";
@@ -38,24 +38,14 @@ itkArrowSpatialObjectTest(int, char *[])
   pnt[2] = 0;
   myArrow->SetPositionInObjectSpace(pnt);
   myArrow->Update();
-  if (itk::Math::NotExactlyEquals(myArrow->GetPositionInObjectSpace()[1], 1))
-  {
-    std::cout << "[FAILURE]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "[PASSED]" << std::endl;
+
+  ITK_TEST_SET_GET_VALUE(pnt, myArrow->GetPositionInObjectSpace());
 
   // Testing the length
   std::cout << "Testing length : ";
-  myArrow->SetLengthInObjectSpace(2);
-  myArrow->Update();
-  if (itk::Math::NotExactlyEquals(myArrow->GetLengthInObjectSpace(), 2))
-  {
-    std::cout << "[FAILURE]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "[PASSED]" << std::endl;
-
+  double length = 2;
+  myArrow->SetLengthInObjectSpace(length);
+  ITK_TEST_SET_GET_VALUE(length, myArrow->GetLengthInObjectSpace());
 
   // Testing the direction of the arrow
   std::cout << "Testing direction : ";
@@ -67,14 +57,7 @@ itkArrowSpatialObjectTest(int, char *[])
   myArrow->SetDirectionInObjectSpace(direction);
   myArrow->Update();
 
-  if (itk::Math::NotExactlyEquals(myArrow->GetDirectionInObjectSpace()[0], 0) ||
-      itk::Math::NotExactlyEquals(myArrow->GetDirectionInObjectSpace()[1], 1) ||
-      itk::Math::NotExactlyEquals(myArrow->GetDirectionInObjectSpace()[2], 0))
-  {
-    std::cout << "[FAILURE]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "[PASSED]" << std::endl;
+  ITK_TEST_SET_GET_VALUE(direction, myArrow->GetDirectionInObjectSpace());
 
   // Point consistency
   std::cout << "Is Inside (Inside): ";
@@ -118,10 +101,10 @@ itkArrowSpatialObjectTest(int, char *[])
   std::cout << "Testing 2D Arrow:";
   using Arrow2DType = itk::ArrowSpatialObject<2>;
   Arrow2DType::Pointer myArrow2D = Arrow2DType::New();
-  myArrow2D->Print(std::cout);
 
-  std::cout << "[PASSED]" << std::endl;
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(myArrow2D, ArrowSpatialObject, SpatialObject);
 
-  std::cout << "Test: [DONE]" << std::endl;
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
@@ -16,12 +16,9 @@
  *
  *=========================================================================*/
 
-/**
- * This is a test file for the itkBlobSpatialObject class.
- */
-
 #include "itkBlobSpatialObject.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkBlobSpatialObjectTest(int, char *[])
@@ -63,14 +60,14 @@ itkBlobSpatialObjectTest(int, char *[])
 
   // Create a Blob Spatial Object
   BlobPointer blob = BlobType::New();
-  blob->Print(std::cout);
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(blob, BlobSpatialObject, PointBasedSpatialObject);
+
 
   blob->GetProperty().SetName("Blob 1");
   blob->SetId(1);
   blob->SetPoints(list);
   blob->Update();
-
-  blob->Print(std::cout);
 
   // Number of points
   std::cout << "Testing Consistency: " << std::endl;
@@ -198,5 +195,6 @@ itkBlobSpatialObjectTest(int, char *[])
   std::cout << "[PASSED]" << std::endl;
 
 
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
@@ -41,8 +41,14 @@ itkBoxSpatialObjectTest(int argc, char * argv[])
   using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<SceneType, OutputImageType>;
 
   SceneType::Pointer scene = SceneType::New();
-  BoxType::Pointer   box1 = BoxType::New();
-  box1->Print(std::cout);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(scene, GroupSpatialObject, SpatialObject);
+
+
+  BoxType::Pointer box1 = BoxType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(box1, BoxSpatialObject, SpatialObject);
+
+
   BoxType::Pointer box2 = BoxType::New();
   box1->SetId(1);
 
@@ -56,21 +62,25 @@ itkBoxSpatialObjectTest(int argc, char * argv[])
   boxsize1[0] = 30;
   boxsize1[1] = 30;
   box1->SetSizeInObjectSpace(boxsize1);
+  ITK_TEST_SET_GET_VALUE(boxsize1, box1->GetSizeInObjectSpace());
+
   boxsize2[0] = 30;
   boxsize2[1] = 30;
   box2->SetSizeInObjectSpace(boxsize2);
 
   BoxType::TransformType::OffsetType offset1;
-  BoxType::TransformType::OffsetType offset2;
 
   offset1[0] = 29.0;
   offset1[1] = 29.0;
   box1->GetModifiableObjectToParentTransform()->SetOffset(offset1);
   box1->Update();
 
-  offset2[0] = 50.0;
-  offset2[1] = 50.0;
-  box2->SetPositionInObjectSpace(offset2);
+  BoxType::PointType point1;
+  point1[0] = 50.0;
+  point1[1] = 50.0;
+  box2->SetPositionInObjectSpace(point1);
+  ITK_TEST_SET_GET_VALUE(point1, box2->GetPositionInObjectSpace());
+
   box2->Update();
 
   scene->Update();
@@ -149,16 +159,10 @@ itkBoxSpatialObjectTest(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName(outputFilename);
   writer->SetInput(imageFilter->GetOutput());
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return EXIT_FAILURE;
-  }
-  box1->Print(std::cout);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkCastSpatialObjectFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkCastSpatialObjectFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkGroupSpatialObject.h"
 #include "itkTubeSpatialObject.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkCastSpatialObjectFilterTest(int, char *[])
@@ -59,7 +60,13 @@ itkCastSpatialObjectFilterTest(int, char *[])
   using CastType = itk::CastSpatialObjectFilter<3>;
   using TubeListType = std::list<TubeType::Pointer>;
   CastType::Pointer caster = CastType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(caster, CastSpatialObjectFilter, Object);
+
+
   caster->SetInput(group);
+  ITK_TEST_SET_GET_VALUE(group, caster->GetInput());
+
   std::unique_ptr<TubeListType> tList(caster->GetTubes());
 
   TubeType::Pointer tListTube = (*tList).begin()->GetPointer();
@@ -103,8 +110,6 @@ itkCastSpatialObjectFilterTest(int, char *[])
   }
 
 
-  std::cout << "TEST: [DONE]" << std::endl;
-
-
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
@@ -29,6 +29,8 @@ itkContourSpatialObjectPointTest(int, char *[])
 
   ContourSpatialObjectPoint2DType contourSpatialObjectPoint2D;
 
+  contourSpatialObjectPoint2D.Print(std::cout);
+
   constexpr double                           pickedPointX = 4.35;
   constexpr double                           pickedPointY = 7.56;
   ContourSpatialObjectPoint2DType::PointType pickedPoint2D;
@@ -130,50 +132,50 @@ itkContourSpatialObjectPointTest(int, char *[])
 
   // Test Copy and Assignment for ContourSpatialObjectPoint3DType
   {
-    ContourSpatialObjectPoint3DType p_original;
+    ContourSpatialObjectPoint3DType pOriginal;
 
     // itk::SpatialObjectPoint
-    p_original.SetId(250);
-    p_original.SetColor(0.5, 0.4, 0.3, 0.2);
-    p_original.SetPositionInObjectSpace(42, 41, 43);
+    pOriginal.SetId(250);
+    pOriginal.SetColor(0.5, 0.4, 0.3, 0.2);
+    pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::ContourSpatialObjectPoint
     ContourSpatialObjectPoint3DType::CovariantVectorType normal;
     normal.Fill(276);
-    p_original.SetNormalInObjectSpace(normal);
+    pOriginal.SetNormalInObjectSpace(normal);
     ContourSpatialObjectPoint3DType::PointType picked;
     picked.Fill(277);
-    p_original.SetPickedPointInObjectSpace(picked);
+    pOriginal.SetPickedPointInObjectSpace(picked);
 
     // Copy
-    ContourSpatialObjectPoint3DType p_copy(p_original);
+    ContourSpatialObjectPoint3DType pCopy(pOriginal);
     // Assign
-    ContourSpatialObjectPoint3DType p_assign = p_original;
+    ContourSpatialObjectPoint3DType pAssign = pOriginal;
 
-    std::vector<ContourSpatialObjectPoint3DType> point_vector;
-    point_vector.push_back(p_copy);
-    point_vector.push_back(p_assign);
+    std::vector<ContourSpatialObjectPoint3DType> pointVector;
+    pointVector.push_back(pCopy);
+    pointVector.push_back(pAssign);
 
-    for (const auto & pv : point_vector)
+    for (const auto & pv : pointVector)
     {
       // itk::SpatialObjectPoint
-      ITK_TEST_EXPECT_EQUAL(p_original.GetId(), pv.GetId());
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRed(), pv.GetRed()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetGreen(), pv.GetGreen()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBlue(), pv.GetBlue()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha(), pv.GetAlpha()));
+      ITK_TEST_EXPECT_EQUAL(pOriginal.GetId(), pv.GetId());
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRed(), pv.GetRed()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetGreen(), pv.GetGreen()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetBlue(), pv.GetBlue()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha(), pv.GetAlpha()));
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
       }
       // itk::ContourSpatialObjectPoint
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetNormalInObjectSpace()[j], pv.GetNormalInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetNormalInObjectSpace()[j], pv.GetNormalInObjectSpace()[j]));
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetPickedPointInObjectSpace()[j], pv.GetPickedPointInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetPickedPointInObjectSpace()[j], pv.GetPickedPointInObjectSpace()[j]));
       }
     }
   }
@@ -233,6 +235,7 @@ itkContourSpatialObjectPointTest(int, char *[])
 
   ITK_TEST_SET_GET_VALUE(pickedPoint4D, contourSpatialObjectPoint4DAlt.GetPickedPointInObjectSpace());
   ITK_TEST_SET_GET_VALUE(normal4D, contourSpatialObjectPoint4DAlt.GetNormalInObjectSpace());
+
 
   std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectTest.cxx
@@ -18,6 +18,7 @@
 #include "itkContourSpatialObject.h"
 #include <iostream>
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 /**
  * This is a test for itkContourSpatialObject.  It runs all methods and checks
@@ -62,6 +63,12 @@ itkContourSpatialObjectTest(int, char *[])
 
   SpatialObjectType::Pointer contour = SpatialObjectType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(contour, ContourSpatialObject, PointBasedSpatialObject);
+
+
+  auto interpolationFactor = 2u;
+  contour->SetInterpolationFactor(interpolationFactor);
+  ITK_TEST_SET_GET_VALUE(interpolationFactor, contour->GetInterpolationFactor());
 
   //
   // Test Control Points (SetControlPoints, GetControlPoints,
@@ -128,21 +135,14 @@ itkContourSpatialObjectTest(int, char *[])
   //
 
   // first set to not closed and test
-  contour->SetIsClosed(false);
-  if (contour->GetIsClosed())
-  {
-    std::cout << "[FAILED] Did not set/retrieve closed property correctly" << std::endl;
-    return EXIT_FAILURE;
-  }
+  auto isClosed = false;
+  contour->SetIsClosed(isClosed);
+  ITK_TEST_SET_GET_BOOLEAN(contour, IsClosed, isClosed);
 
   // then set it to closed and test
+  isClosed = true;
   contour->SetIsClosed(true);
-  if (!contour->GetIsClosed())
-  {
-    std::cout << "[FAILED] Did not set/retrieve closed property correctly" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "[PASSED] Set/GetClosed" << std::endl;
+  ITK_TEST_SET_GET_BOOLEAN(contour, IsClosed, isClosed);
 
 
   //
@@ -310,8 +310,7 @@ itkContourSpatialObjectTest(int, char *[])
     std::cout << "STREAMED ENUM VALUE ContourSpatialObjectEnums::InterpolationMethod: " << ee << std::endl;
   }
 
-  //
-  // All tests executed successfully
-  //
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -54,6 +54,10 @@ itkDTITubeSpatialObjectTest(int, char *[])
   std::cout << "Testing SpatialObject:" << std::endl << std::endl;
 
   TubePointer tube1 = TubeType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(tube1, DTITubeSpatialObject, TubeSpatialObject);
+
+
   tube1->GetProperty().SetName("Tube 1");
   tube1->SetId(1);
 
@@ -507,95 +511,97 @@ itkDTITubeSpatialObjectTest(int, char *[])
 
   // Test Copy and Assignment for TubePointType
   {
-    TubePointType p_original;
+    TubePointType pOriginal;
 
     // itk::SpatialObjectPoint
-    p_original.SetId(250);
-    p_original.SetColor(0.5, 0.4, 0.3, 0.2);
-    p_original.SetPositionInObjectSpace(42, 41, 43);
+    pOriginal.SetId(250);
+    pOriginal.SetColor(0.5, 0.4, 0.3, 0.2);
+    pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::TubeSpatialObjectPoint
     TubePointType::VectorType tangent;
     tangent.Fill(1);
-    p_original.SetTangentInObjectSpace(tangent);
+    pOriginal.SetTangentInObjectSpace(tangent);
     TubePointType::CovariantVectorType normal1;
     normal1.Fill(2);
-    p_original.SetNormal1InObjectSpace(normal1);
+    pOriginal.SetNormal1InObjectSpace(normal1);
     TubePointType::CovariantVectorType normal2;
     normal2.Fill(3);
-    p_original.SetNormal2InObjectSpace(normal2);
-    p_original.SetRadiusInObjectSpace(1.0);
-    p_original.SetMedialness(2.0);
-    p_original.SetRidgeness(3.0);
-    p_original.SetBranchness(4.0);
-    p_original.SetCurvature(5.0);
-    p_original.SetLevelness(6.0);
-    p_original.SetRoundness(7.0);
-    p_original.SetIntensity(8.0);
-    p_original.SetAlpha1(9.0);
-    p_original.SetAlpha2(10.0);
-    p_original.SetAlpha3(11.0);
+    pOriginal.SetNormal2InObjectSpace(normal2);
+    pOriginal.SetRadiusInObjectSpace(1.0);
+    pOriginal.SetMedialness(2.0);
+    pOriginal.SetRidgeness(3.0);
+    pOriginal.SetBranchness(4.0);
+    pOriginal.SetCurvature(5.0);
+    pOriginal.SetLevelness(6.0);
+    pOriginal.SetRoundness(7.0);
+    pOriginal.SetIntensity(8.0);
+    pOriginal.SetAlpha1(9.0);
+    pOriginal.SetAlpha2(10.0);
+    pOriginal.SetAlpha3(11.0);
 
     // itk::DTITubeSpatialObjectTest.cxx
     itk::DiffusionTensor3D<float> tensor;
     tensor.Fill(0);
-    p_original.SetTensorMatrix(tensor);
+    pOriginal.SetTensorMatrix(tensor);
 
     // Copy
-    TubePointType p_copy(p_original);
+    TubePointType pCopy(pOriginal);
     // Assign
-    TubePointType p_assign = p_original;
+    TubePointType pAssign = pOriginal;
 
-    std::vector<TubePointType> point_vector;
-    point_vector.push_back(p_copy);
-    point_vector.push_back(p_assign);
+    std::vector<TubePointType> pointVector;
+    pointVector.push_back(pCopy);
+    pointVector.push_back(pAssign);
 
-    for (const auto & pv : point_vector)
+    for (const auto & pv : pointVector)
     {
       // itk::SpatialObjectPoint
-      ITK_TEST_EXPECT_EQUAL(p_original.GetId(), pv.GetId());
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRed(), pv.GetRed()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetGreen(), pv.GetGreen()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBlue(), pv.GetBlue()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha(), pv.GetAlpha()));
+      ITK_TEST_EXPECT_EQUAL(pOriginal.GetId(), pv.GetId());
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRed(), pv.GetRed()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetGreen(), pv.GetGreen()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetBlue(), pv.GetBlue()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha(), pv.GetAlpha()));
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
       }
       // itk::TubeSpatialObjectPoint
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetTangentInObjectSpace()[j], pv.GetTangentInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetTangentInObjectSpace()[j], pv.GetTangentInObjectSpace()[j]));
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetNormal1InObjectSpace()[j], pv.GetNormal1InObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetNormal1InObjectSpace()[j], pv.GetNormal1InObjectSpace()[j]));
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetNormal2InObjectSpace()[j], pv.GetNormal2InObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetNormal2InObjectSpace()[j], pv.GetNormal2InObjectSpace()[j]));
       }
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRadiusInObjectSpace(), pv.GetRadiusInObjectSpace()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetMedialness(), pv.GetMedialness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRidgeness(), pv.GetRidgeness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBranchness(), pv.GetBranchness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetCurvature(), pv.GetCurvature()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetLevelness(), pv.GetLevelness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRoundness(), pv.GetRoundness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetIntensity(), pv.GetIntensity()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha1(), pv.GetAlpha1()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha2(), pv.GetAlpha2()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha3(), pv.GetAlpha3()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRadiusInObjectSpace(), pv.GetRadiusInObjectSpace()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetMedialness(), pv.GetMedialness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRidgeness(), pv.GetRidgeness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetBranchness(), pv.GetBranchness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetCurvature(), pv.GetCurvature()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetLevelness(), pv.GetLevelness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRoundness(), pv.GetRoundness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetIntensity(), pv.GetIntensity()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha1(), pv.GetAlpha1()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha2(), pv.GetAlpha2()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha3(), pv.GetAlpha3()));
 
       // itk::DTITubeSpatialObjectPoint
-      const auto p_original_tensor = p_original.GetTensorMatrix();
+      const auto pOriginal_tensor = pOriginal.GetTensorMatrix();
       const auto pv_tensor = pv.GetTensorMatrix();
       for (size_t j = 0; j < 6; ++j)
       {
-        ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original_tensor[j], pv_tensor[j]));
+        ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal_tensor[j], pv_tensor[j]));
       }
     }
 
     std::cout << "[DONE]" << std::endl;
   }
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
@@ -16,12 +16,9 @@
  *
  *=========================================================================*/
 
-/**
- * This is a test file for the itkEllipseSpatialObject class.
- */
-
 #include "itkEllipseSpatialObject.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkEllipseSpatialObjectTest(int, char *[])
@@ -29,8 +26,9 @@ itkEllipseSpatialObjectTest(int, char *[])
   using EllipseType = itk::EllipseSpatialObject<4>;
 
   EllipseType::Pointer myEllipse = EllipseType::New();
-  std::cout << "Testing Print after construction" << std::endl;
-  myEllipse->Print(std::cout);
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(myEllipse, EllipseSpatialObject, SpatialObject);
+
 
   EllipseType::ArrayType radii;
 
@@ -43,31 +41,14 @@ itkEllipseSpatialObjectTest(int, char *[])
 
   myEllipse->SetRadiusInObjectSpace(radii);
   myEllipse->Update();
-  EllipseType::ArrayType radii2 = myEllipse->GetRadiusInObjectSpace();
-  for (unsigned int i = 0; i < 4; i++)
-  {
-    if (itk::Math::NotExactlyEquals(radii2[i], i))
-    {
-      std::cout << "[FAILURE]" << std::endl;
-      return EXIT_FAILURE;
-    }
-  }
-  std::cout << "[PASSED]" << std::endl;
 
-  myEllipse->SetRadiusInObjectSpace(3);
+  ITK_TEST_SET_GET_VALUE(radii, myEllipse->GetRadiusInObjectSpace());
+
+  EllipseType::ArrayType objectSpaceRadius = 3;
+  myEllipse->SetRadiusInObjectSpace(objectSpaceRadius);
   myEllipse->Update();
-  EllipseType::ArrayType radii3 = myEllipse->GetRadiusInObjectSpace();
-  std::cout << "Testing Global radii : ";
-  for (unsigned int i = 0; i < 4; i++)
-  {
-    if (itk::Math::NotExactlyEquals(radii3[i], 3))
-    {
-      std::cout << "[FAILURE]" << std::endl;
-      return EXIT_FAILURE;
-    }
-  }
 
-  std::cout << "[PASSED]" << std::endl;
+  ITK_TEST_SET_GET_VALUE(objectSpaceRadius, myEllipse->GetRadiusInObjectSpace());
 
   // Point consistency
   std::cout << "Is Inside: ";
@@ -144,9 +125,8 @@ itkEllipseSpatialObjectTest(int, char *[])
       return EXIT_FAILURE;
     }
   }
-  std::cout << "Testing Print after use" << std::endl;
-  myEllipse->Print(std::cout);
 
-  std::cout << "[PASSED]" << std::endl;
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
@@ -16,12 +16,9 @@
  *
  *=========================================================================*/
 
-/**
- * This is a test file for the itkGaussianSpatialObject class.
- */
-
 #include "itkGaussianSpatialObject.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkGaussianSpatialObjectTest(int, char *[])
@@ -29,37 +26,20 @@ itkGaussianSpatialObjectTest(int, char *[])
   using GaussianType = itk::GaussianSpatialObject<4>;
 
   GaussianType::Pointer myGaussian = GaussianType::New();
-  myGaussian->Print(std::cout);
 
-  myGaussian->SetMaximum(2);
-  GaussianType::ScalarType maximum = myGaussian->GetMaximum();
-  std::cout << "Testing Maximum: ";
-  if (itk::Math::NotExactlyEquals(maximum, 2))
-  {
-    std::cout << "[FAILURE]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "[PASSED]" << std::endl;
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(myGaussian, GaussianSpatialObject, SpatialObject);
 
-  myGaussian->SetRadiusInObjectSpace(3);
-  GaussianType::ScalarType radius = myGaussian->GetRadiusInObjectSpace();
-  std::cout << "Testing Radius: ";
-  if (itk::Math::NotExactlyEquals(radius, 3))
-  {
-    std::cout << "[FAILURE]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "[PASSED]" << std::endl;
+  GaussianType::ScalarType maximum = 2;
+  myGaussian->SetMaximum(maximum);
+  ITK_TEST_SET_GET_VALUE(maximum, myGaussian->GetMaximum());
 
-  myGaussian->SetSigmaInObjectSpace(1.5);
-  GaussianType::ScalarType sigma = myGaussian->GetSigmaInObjectSpace();
-  std::cout << "Testing Sigma: ";
-  if (sigma != 1.5)
-  {
-    std::cout << "[FAILURE]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "[PASSED]" << std::endl;
+  GaussianType::ScalarType radius = 3;
+  myGaussian->SetRadiusInObjectSpace(radius);
+  ITK_TEST_SET_GET_VALUE(radius, myGaussian->GetRadiusInObjectSpace());
+
+  GaussianType::ScalarType sigma = 1.5;
+  myGaussian->SetSigmaInObjectSpace(sigma);
+  ITK_TEST_SET_GET_VALUE(sigma, myGaussian->GetSigmaInObjectSpace());
 
   // Point consistency
 
@@ -164,8 +144,7 @@ itkGaussianSpatialObjectTest(int, char *[])
     }
   }
 
-  myGaussian->Print(std::cout);
 
-  std::cout << "[PASSED]" << std::endl;
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
@@ -28,6 +28,7 @@
 #include "itkImageRegionIterator.h"
 
 #include "itkImageMaskSpatialObject.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -68,7 +69,9 @@ itkImageMaskSpatialObjectTest(int, char *[])
   }
 
   ImageMaskSpatialObject::Pointer maskSO = ImageMaskSpatialObject::New();
-  maskSO->Print(std::cout);
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(maskSO, ImageMaskSpatialObject, ImageSpatialObject);
+
 
   maskSO->SetImage(image);
   maskSO->Update();
@@ -92,7 +95,7 @@ itkImageMaskSpatialObjectTest(int, char *[])
     ++itr;
   }
 
-  maskSO->Print(std::cout);
 
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -217,5 +217,8 @@ itkImageMaskSpatialObjectTest2(int, char *[])
       }
     }
   }
+
+
+  std::cout << "Test finished" << std::endl;
   return retval;
 }

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -116,5 +116,7 @@ itkImageMaskSpatialObjectTest3(int, char *[])
     }
   }
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
@@ -298,5 +298,7 @@ itkImageMaskSpatialObjectTest4(int, char *[])
     return EXIT_FAILURE;
   }
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -29,6 +29,7 @@
 
 #include "itkImageSpatialObject.h"
 #include "itkLinearInterpolateImageFunction.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -68,7 +69,9 @@ itkImageSpatialObjectTest(int, char *[])
   it.GoToBegin();
 
   ImageSpatialObject::Pointer imageSO = ImageSpatialObject::New();
-  imageSO->Print(std::cout);
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(imageSO, ImageSpatialObject, SpatialObject);
+
 
   imageSO->SetImage(image);
   imageSO->Update();
@@ -149,16 +152,12 @@ itkImageSpatialObjectTest(int, char *[])
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType>;
   InterpolatorType::Pointer interpolator = InterpolatorType::New();
   imageSO->SetInterpolator(interpolator);
+  ITK_TEST_SET_GET_VALUE(interpolator, imageSO->GetInterpolator());
+
   expectedValue = 566.1;
 
-  try
-  {
-    imageSO->ValueAtInWorldSpace(q, returnedValue);
-  }
-  catch (itk::ExceptionObject &)
-  {
-    throw;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(imageSO->ValueAtInWorldSpace(q, returnedValue));
+
 
   std::cout << "ValueAt() with interpolator...";
   if (std::fabs(returnedValue - expectedValue) > 0.001)
@@ -190,7 +189,7 @@ itkImageSpatialObjectTest(int, char *[])
     std::cout << "[PASSED]" << std::endl;
   }
 
-  imageSO->Print(std::cout);
 
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
@@ -16,12 +16,9 @@
  *
  *=========================================================================*/
 
-/**
- * This is a test file for the itkLandmarkSpatialObject class.
- */
-
 #include "itkLandmarkSpatialObject.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkLandmarkSpatialObjectTest(int, char *[])
@@ -56,7 +53,8 @@ itkLandmarkSpatialObjectTest(int, char *[])
 
   // Create a Landmark Spatial Object
   LandmarkPointer landmark = LandmarkType::New();
-  landmark->Print(std::cout);
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(landmark, LandmarkSpatialObject, PointBasedSpatialObject);
 
   landmark->GetProperty().SetName("Landmark 1");
   landmark->SetId(1);
@@ -187,7 +185,7 @@ itkLandmarkSpatialObjectTest(int, char *[])
   }
   std::cout << "[PASSED]" << std::endl;
 
-  std::cout << "[DONE]" << std::endl;
 
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -16,10 +16,6 @@
  *
  *=========================================================================*/
 
-/**
- * This is a test file for the itkLineSpatialObject class.
- */
-
 #include "itkTestingMacros.h"
 #include "itkLineSpatialObject.h"
 #include "itkMath.h"
@@ -60,17 +56,21 @@ itkLineSpatialObjectTest(int, char *[])
   p.Print(std::cout);
 
   // Create a Line Spatial Object
-  LinePointer Line = LineType::New();
-  Line->GetProperty().SetName("Line 1");
-  Line->SetId(1);
-  Line->SetPoints(list);
-  Line->Update();
+  LinePointer line = LineType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(line, LineSpatialObject, PointBasedSpatialObject);
+
+
+  line->GetProperty().SetName("Line 1");
+  line->SetId(1);
+  line->SetPoints(list);
+  line->Update();
 
   // Number of points
   std::cout << "Testing Consistency: " << std::endl;
   std::cout << "Number of Points: ";
 
-  if (Line->GetPoints().size() != 10)
+  if (line->GetPoints().size() != 10)
   {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -84,10 +84,10 @@ itkLineSpatialObjectTest(int, char *[])
   // Point consistency
   std::cout << "Point consistency: ";
 
-  LineType::LinePointListType::const_iterator it = Line->GetPoints().begin();
+  LineType::LinePointListType::const_iterator it = line->GetPoints().begin();
 
   i = 0;
-  while (it != Line->GetPoints().end())
+  while (it != line->GetPoints().end())
   {
     for (unsigned int d = 0; d < 3; d++)
     {
@@ -126,13 +126,13 @@ itkLineSpatialObjectTest(int, char *[])
   out[1] = 0;
   out[2] = 0;
 
-  if (!Line->IsInsideInWorldSpace(in))
+  if (!line->IsInsideInWorldSpace(in))
   {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
 
-  if (Line->IsInsideInWorldSpace(out))
+  if (line->IsInsideInWorldSpace(out))
   {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -141,7 +141,7 @@ itkLineSpatialObjectTest(int, char *[])
 
   // Testing IsEvaluableAt()
   std::cout << "IsEvaluableAt: ";
-  if (!Line->IsEvaluableAtInWorldSpace(in) || Line->IsEvaluableAtInWorldSpace(out))
+  if (!line->IsEvaluableAtInWorldSpace(in) || line->IsEvaluableAtInWorldSpace(out))
   {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -153,7 +153,7 @@ itkLineSpatialObjectTest(int, char *[])
   std::cout << "ValueAt: ";
 
   double value;
-  if (!Line->ValueAtInWorldSpace(in, value))
+  if (!line->ValueAtInWorldSpace(in, value))
   {
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -168,48 +168,50 @@ itkLineSpatialObjectTest(int, char *[])
 
   // Test Copy and Assignment for LinePointType
   {
-    LinePointType p_original;
+    LinePointType pOriginal;
 
     // itk::SpatialObjectPoint
-    p_original.SetId(250);
-    p_original.SetColor(0.5, 0.4, 0.3, 0.2);
-    p_original.SetPositionInObjectSpace(42, 41, 43);
+    pOriginal.SetId(250);
+    pOriginal.SetColor(0.5, 0.4, 0.3, 0.2);
+    pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::LineSpatialObjectPoint
     VectorType normal;
     normal.Fill(276);
-    p_original.SetNormalInObjectSpace(normal, 0);
+    pOriginal.SetNormalInObjectSpace(normal, 0);
 
     // Copy
-    LinePointType p_copy(p_original);
+    LinePointType pCopy(pOriginal);
     // Assign
-    LinePointType p_assign = p_original;
+    LinePointType pAssign = pOriginal;
 
-    std::vector<LinePointType> point_vector;
-    point_vector.push_back(p_copy);
-    point_vector.push_back(p_assign);
+    std::vector<LinePointType> pointVector;
+    pointVector.push_back(pCopy);
+    pointVector.push_back(pAssign);
 
-    for (const auto & pv : point_vector)
+    for (const auto & pv : pointVector)
     {
       // itk::SpatialObjectPoint
-      ITK_TEST_EXPECT_EQUAL(p_original.GetId(), pv.GetId());
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRed(), pv.GetRed()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetGreen(), pv.GetGreen()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBlue(), pv.GetBlue()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha(), pv.GetAlpha()));
+      ITK_TEST_EXPECT_EQUAL(pOriginal.GetId(), pv.GetId());
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRed(), pv.GetRed()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetGreen(), pv.GetGreen()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetBlue(), pv.GetBlue()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha(), pv.GetAlpha()));
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
       }
       // itk::LineSpatialObjectPoint
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetNormalInObjectSpace(0)[j], pv.GetNormalInObjectSpace(0)[j]));
+          itk::Math::AlmostEquals(pOriginal.GetNormalInObjectSpace(0)[j], pv.GetNormalInObjectSpace(0)[j]));
       }
     }
   }
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
@@ -20,6 +20,7 @@
 #include "itkMeshSpatialObject.h"
 #include "itkTetrahedronCell.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkMeshSpatialObjectTest(int, char *[])
@@ -56,19 +57,15 @@ itkMeshSpatialObjectTest(int, char *[])
   // Create the mesh Spatial Object
 
   MeshSpatialObjectType::Pointer meshSO = MeshSpatialObjectType::New();
-  meshSO->Print(std::cout);
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(meshSO, MeshSpatialObject, SpatialObject);
+
 
   meshSO->SetMesh(mesh);
+  ITK_TEST_SET_GET_VALUE(mesh, meshSO->GetMesh());
+
   meshSO->Update();
 
-  std::cout << "Testing GetMesh(): ";
-
-  if (mesh != meshSO->GetMesh())
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "[PASSED]" << std::endl;
 
   std::cout << "Testing Bounding Box: ";
 
@@ -186,7 +183,7 @@ itkMeshSpatialObjectTest(int, char *[])
   meshSO->Print(std::cout);
   std::cout << "[PASSED]" << std::endl;
 
-  std::cout << "[TEST DONE]" << std::endl;
 
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkGroupSpatialObject.h"
 #include <iostream>
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 /**
  * This is a test file for the itkMetaArrowConverter class.
@@ -35,16 +36,16 @@
  *        Only the ParentID can be properly converted.
  */
 int
-itkMetaArrowConverterTest(int ac, char * av[])
+itkMetaArrowConverterTest(int argc, char * argv[])
 {
-
-  // check number of arguments
-  if (ac != 2)
+  // Check parameters
+  if (argc != 2)
   {
-    std::cout << "Must specify output path as argument" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " OutputFileName" << std::endl;
     return EXIT_FAILURE;
   }
-
 
   // type alias
   constexpr unsigned int Dimensions = 3;
@@ -55,6 +56,7 @@ itkMetaArrowConverterTest(int ac, char * av[])
   // instantiate new converter and object
   ConverterType::Pointer converter = ConverterType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(converter, MetaArrowConverter, MetaConverterBase);
 
   //
   // create the test data
@@ -290,7 +292,7 @@ itkMetaArrowConverterTest(int ac, char * av[])
   //
   // test writing
   //
-  if (!converter->WriteMeta(itkArrow, av[1]))
+  if (!converter->WriteMeta(itkArrow, argv[1]))
   {
     std::cout << "Didn't write properly [FAILED]" << std::endl;
     return EXIT_FAILURE;
@@ -300,7 +302,7 @@ itkMetaArrowConverterTest(int ac, char * av[])
   //
   // test reading
   //
-  SpatialObjectType::Pointer reLoad = dynamic_cast<SpatialObjectType *>(converter->ReadMeta(av[1]).GetPointer());
+  SpatialObjectType::Pointer reLoad = dynamic_cast<SpatialObjectType *>(converter->ReadMeta(argv[1]).GetPointer());
 
   // check length
   if (std::fabs(reLoad->GetLengthInWorldSpace() - length) > precisionLimit)
@@ -361,6 +363,7 @@ itkMetaArrowConverterTest(int ac, char * av[])
   }
   std::cout << "[PASSED]  Reading: direction" << std::endl;
 
-  // All tests executed successfully
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkMetaGaussianConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaGaussianConverterTest.cxx
@@ -44,6 +44,7 @@ itkMetaGaussianConverterTest(int argc, char * argv[])
   // Check number of arguments
   if (argc != 2)
   {
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " output" << std::endl;
     return EXIT_FAILURE;
   }
@@ -58,6 +59,9 @@ itkMetaGaussianConverterTest(int argc, char * argv[])
 
   // Instantiate new converter object
   ConverterType::Pointer converter = ConverterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(converter, MetaGaussianConverter, MetaConverterBase);
+
 
   // Set up a Gaussian spatial object
   SpatialObjectType::Pointer GaussianSpatialObj = SpatialObjectType::New();
@@ -297,8 +301,6 @@ itkMetaGaussianConverterTest(int argc, char * argv[])
   std::cout << "[PASSED] Reading: parent id: " << reLoad->GetParentId() << std::endl;
 
 
-  // All tests executed successfully
-  std::cout << "Test succeeded." << std::endl;
-
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "itkMetaSceneConverter.h"
+#include "itkTestingMacros.h"
 
 /**
  *\class MetaDummy
@@ -239,6 +240,10 @@ itkNewMetaObjectTypeTest(int, char *[])
   DummyConverterType::Pointer dummyConverter(DummyConverterType::New());
 
   MetaSceneConverterType::Pointer converter = MetaSceneConverterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(converter, MetaSceneConverter, Object);
+
+
   converter->RegisterMetaConverter("Dummy", "DummySpatialObject", dummyConverter);
 
   MetaScene * metaScene = converter->CreateMetaScene(group);
@@ -294,5 +299,8 @@ itkNewMetaObjectTypeTest(int, char *[])
   }
   delete mySceneChildren;
   delete metaScene;
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkPolygonSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkPolygonSpatialObjectTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkPolygonSpatialObject.h"
+#include "itkTestingMacros.h"
 #include <iostream>
 
 int
@@ -28,6 +29,9 @@ itkPolygonSpatialObjectTest(int, char *[])
   //
   // create rectangle
   PolygonType::Pointer rectangle = PolygonType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(rectangle, PolygonSpatialObject, PointBasedSpatialObject);
+
 
   double                 d1[3] = { 0.0, 0.0, 0.0 };
   PolygonType::PointType p1(d1);
@@ -50,11 +54,18 @@ itkPolygonSpatialObjectTest(int, char *[])
   pPoint.SetPositionInObjectSpace(p4);
   pList.push_back(pPoint);
   rectangle->SetPoints(pList);
-  rectangle->SetThicknessInObjectSpace(10);
-  rectangle->SetIsClosed(true);
+
+  double objectSpaceThickness = 10;
+  rectangle->SetThicknessInObjectSpace(objectSpaceThickness);
+  ITK_TEST_SET_GET_VALUE(objectSpaceThickness, rectangle->GetThicknessInObjectSpace());
+
+  bool isClosed = true;
+  rectangle->SetIsClosed(isClosed);
+  ITK_TEST_SET_GET_BOOLEAN(rectangle, IsClosed, isClosed);
+
+
   rectangle->Update();
 
-  rectangle->Print(std::cout);
   for (unsigned int i = 0; i < rectangle->GetNumberOfPoints(); ++i)
   {
     std::cout << i << " : ";
@@ -151,5 +162,7 @@ itkPolygonSpatialObjectTest(int, char *[])
     std::cout << "[Passed]" << std::endl;
   }
 
+
+  std::cout << "Test finished" << std::endl;
   return failed ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -21,6 +21,7 @@
 #include "itkGroupSpatialObject.h"
 #include "itkDTITubeSpatialObject.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkSpatialObjectDuplicatorTest(int, char *[])
@@ -33,10 +34,11 @@ itkSpatialObjectDuplicatorTest(int, char *[])
   using DuplicatorType = itk::SpatialObjectDuplicator<EllipseType>;
   DuplicatorType::Pointer duplicator = DuplicatorType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(duplicator, SpatialObjectDuplicator, Object);
+
 
   duplicator->SetInput(ellipse);
   duplicator->Update();
-  duplicator->Print(std::cout);
 
   EllipseType::Pointer ellipse_copy = duplicator->GetOutput();
 
@@ -52,9 +54,9 @@ itkSpatialObjectDuplicatorTest(int, char *[])
   DuplicatorGroupType::Pointer duplicatorGroup = DuplicatorGroupType::New();
   duplicatorGroup->SetInput(group);
   duplicatorGroup->Update();
-  GroupType::Pointer group_copy = duplicatorGroup->GetOutput();
+  GroupType::Pointer groupCopy = duplicatorGroup->GetOutput();
 
-  GroupType::ChildrenListType * children = group_copy->GetChildren();
+  GroupType::ChildrenListType * children = groupCopy->GetChildren();
 
   EllipseType::Pointer ellipse_copy2 = static_cast<EllipseType *>((*(children->begin())).GetPointer());
   std::cout << ellipse_copy2->GetRadiusInObjectSpace() << std::endl;
@@ -236,8 +238,6 @@ itkSpatialObjectDuplicatorTest(int, char *[])
   }
 
 
-  std::cout << "TEST: [DONE]" << std::endl;
-
-
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkEllipseSpatialObject.h"
 #include "itkSpatialObjectToImageFilter.h"
 #include "itkCommand.h"
+#include "itkTestingMacros.h"
 
 class ShowProgressObject
 {
@@ -51,31 +52,43 @@ itkSpatialObjectToImageFilterTest(int, char *[])
 
   using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
   SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(imageFilter, SpatialObjectToImageFilter, ImageSource);
+
+
   imageFilter->SetInput(ellipse);
-  imageFilter->SetInsideValue(2);
-  imageFilter->GetInsideValue();
+
+  SpatialObjectToImageFilterType::ValueType insideValue = 2;
+  imageFilter->SetInsideValue(insideValue);
+  ITK_TEST_SET_GET_VALUE(insideValue, imageFilter->GetInsideValue());
+
+  SpatialObjectToImageFilterType::ValueType outsideValue = 0;
   imageFilter->SetOutsideValue(0);
-  imageFilter->GetOutsideValue();
-  imageFilter->SetChildrenDepth(1);
-  imageFilter->GetChildrenDepth();
+  ITK_TEST_SET_GET_VALUE(outsideValue, imageFilter->GetOutsideValue());
+
+  unsigned int childrenDepth = 1;
+  imageFilter->SetChildrenDepth(childrenDepth);
+  ITK_TEST_SET_GET_VALUE(childrenDepth, imageFilter->GetChildrenDepth());
+
   ImageType::SizeType size;
   size[0] = 50;
   size[1] = 50;
   imageFilter->SetSize(size);
+  ITK_TEST_SET_GET_VALUE(size, imageFilter->GetSize());
 
   // Testing spacing
   std::cout << "Testing Spacing: ";
 
-  float  spacing_float[2];
-  double spacing_double[2];
+  float  spacingFloat[2];
+  double spacingDouble[2];
 
   for (unsigned int i = 0; i < 2; i++)
   {
-    spacing_float[i] = 1.0;
-    spacing_double[i] = 1.0;
+    spacingFloat[i] = 1.0;
+    spacingDouble[i] = 1.0;
   }
-  imageFilter->SetSpacing(spacing_float);
-  imageFilter->SetSpacing(spacing_double);
+  imageFilter->SetSpacing(spacingFloat);
+  imageFilter->SetSpacing(spacingDouble);
   const double * spacing_result = imageFilter->GetSpacing();
 
   for (unsigned int i = 0; i < 2; i++)
@@ -92,16 +105,16 @@ itkSpatialObjectToImageFilterTest(int, char *[])
   // Testing Origin
   std::cout << "Testing Origin: ";
 
-  float  origin_float[2];
-  double origin_double[2];
+  float  originFloat[2];
+  double originDouble[2];
 
   for (unsigned int i = 0; i < 2; i++)
   {
-    origin_float[i] = 0.0;
-    origin_double[i] = 0.0;
+    originFloat[i] = 0.0;
+    originDouble[i] = 0.0;
   }
-  imageFilter->SetOrigin(origin_float);
-  imageFilter->SetOrigin(origin_double);
+  imageFilter->SetOrigin(originFloat);
+  imageFilter->SetOrigin(originDouble);
   const double * origin_result = imageFilter->GetOrigin();
 
   for (unsigned int i = 0; i < 2; i++)
@@ -152,7 +165,10 @@ itkSpatialObjectToImageFilterTest(int, char *[])
   std::cout << "[PASSED]" << std::endl;
 
   // Test the UseObjectValue
-  imageFilter->SetUseObjectValue(true);
+  bool useObjectValue = true;
+  imageFilter->SetUseObjectValue(useObjectValue);
+  ITK_TEST_SET_GET_BOOLEAN(imageFilter, UseObjectValue, useObjectValue);
+
   imageFilter->Update();
 
   std::cout << "Testing SetUseObjectValue: ";
@@ -174,8 +190,6 @@ itkSpatialObjectToImageFilterTest(int, char *[])
   }
 
 
-  std::cout << "[PASSED]" << std::endl;
-  std::cout << "Test [DONE]" << std::endl;
-
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -21,6 +21,7 @@
 #include "itkSpatialObjectToImageFilter.h"
 #include "itkEllipseSpatialObject.h"
 #include "itkImageSliceIteratorWithIndex.h"
+#include "itkTestingMacros.h"
 
 int
 itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
@@ -64,8 +65,17 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
 
   using CalculatorType = itk::SpatialObjectToImageStatisticsCalculator<ImageType, EllipseType>;
   CalculatorType::Pointer calculator = CalculatorType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(calculator, SpatialObjectToImageStatisticsCalculator, Object);
+
+
   calculator->SetImage(image);
   calculator->SetSpatialObject(ellipse);
+
+  unsigned int sampleDirection = CalculatorType::SampleDimension - 1;
+  calculator->SetSampleDirection(sampleDirection);
+  ITK_TEST_SET_GET_VALUE(sampleDirection, calculator->GetSampleDirection());
+
   calculator->Update();
 
   std::cout << " --- Ellipse and Image perfectly aligned --- " << std::endl;
@@ -214,6 +224,7 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
     return EXIT_FAILURE;
   }
 
-  std::cout << " [PASSED]" << std::endl;
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToPointSetFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToPointSetFilterTest.cxx
@@ -53,6 +53,7 @@ itkSpatialObjectToPointSetFilterTest(int, char *[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(pointSetFilter, SpatialObjectToPointSetFilter, MeshSource);
 
+
   unsigned int childrenDepth = 0;
   pointSetFilter->SetChildrenDepth(childrenDepth);
   ITK_TEST_SET_GET_VALUE(childrenDepth, pointSetFilter->GetChildrenDepth());
@@ -198,7 +199,6 @@ itkSpatialObjectToPointSetFilterTest(int, char *[])
   std::cout << "[PASSED]" << std::endl;
 
 
-  std::cout << "[PASSED]" << std::endl;
-
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -17,10 +17,6 @@
  *=========================================================================*/
 // Disable warning for long symbol names in this file only
 
-/**
- * This is a test file for the itkSurfaceSpatialObject class.
- */
-
 #include "itkTestingMacros.h"
 #include "itkSurfaceSpatialObject.h"
 #include "itkMath.h"
@@ -160,48 +156,49 @@ itkSurfaceSpatialObjectTest(int, char *[])
 
   // Test Copy and Assignment for SurfacePointType
   {
-    SurfacePointType p_original;
+    SurfacePointType pOriginal;
 
     // itk::SpatialObjectPoint
-    p_original.SetId(250);
-    p_original.SetColor(0.5, 0.4, 0.3, 0.2);
-    p_original.SetPositionInObjectSpace(42, 41, 43);
+    pOriginal.SetId(250);
+    pOriginal.SetColor(0.5, 0.4, 0.3, 0.2);
+    pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::SurfaceSpatialObjectPoint
     VectorType normal;
     normal.Fill(276);
-    p_original.SetNormalInObjectSpace(normal);
+    pOriginal.SetNormalInObjectSpace(normal);
 
     // Copy
-    SurfacePointType p_copy(p_original);
+    SurfacePointType pCopy(pOriginal);
     // Assign
-    SurfacePointType p_assign = p_original;
+    SurfacePointType pAssign = pOriginal;
 
-    std::vector<SurfacePointType> point_vector;
-    point_vector.push_back(p_copy);
-    point_vector.push_back(p_assign);
+    std::vector<SurfacePointType> pointVector;
+    pointVector.push_back(pCopy);
+    pointVector.push_back(pAssign);
 
-    for (const auto & pv : point_vector)
+    for (const auto & pv : pointVector)
     {
       // itk::SpatialObjectPoint
-      ITK_TEST_EXPECT_EQUAL(p_original.GetId(), pv.GetId());
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRed(), pv.GetRed()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetGreen(), pv.GetGreen()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBlue(), pv.GetBlue()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha(), pv.GetAlpha()));
+      ITK_TEST_EXPECT_EQUAL(pOriginal.GetId(), pv.GetId());
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRed(), pv.GetRed()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetGreen(), pv.GetGreen()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetBlue(), pv.GetBlue()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha(), pv.GetAlpha()));
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
       }
       // itk::SurfaceSpatialObjectPoint
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetNormalInObjectSpace()[j], pv.GetNormalInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetNormalInObjectSpace()[j], pv.GetNormalInObjectSpace()[j]));
       }
     }
   }
 
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -24,6 +24,7 @@
 #include "itkTestingMacros.h"
 #include "itkTubeSpatialObject.h"
 #include "itkGroupSpatialObject.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -54,6 +55,10 @@ itkTubeSpatialObjectTest(int, char *[])
   std::cout << "Testing SpatialObject:" << std::endl << std::endl;
 
   TubePointer tube1 = TubeType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(tube1, TubeSpatialObject, PointBasedSpatialObject);
+
+
   tube1->GetProperty().SetName("Tube 1");
   tube1->SetId(1);
 
@@ -507,82 +512,84 @@ itkTubeSpatialObjectTest(int, char *[])
 
   // Test Copy and Assignment for TubePointType
   {
-    TubePointType p_original;
+    TubePointType pOriginal;
 
     // itk::SpatialObjectPoint
-    p_original.SetId(250);
-    p_original.SetColor(0.5, 0.4, 0.3, 0.2);
-    p_original.SetPositionInObjectSpace(42, 41, 43);
+    pOriginal.SetId(250);
+    pOriginal.SetColor(0.5, 0.4, 0.3, 0.2);
+    pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
     // itk::TubeSpatialObjectPoint
     TubePointType::VectorType tangent;
+
     tangent.Fill(1);
-    p_original.SetTangentInObjectSpace(tangent);
+    pOriginal.SetTangentInObjectSpace(tangent);
     TubePointType::CovariantVectorType normal1;
     normal1.Fill(2);
-    p_original.SetNormal1InObjectSpace(normal1);
+    pOriginal.SetNormal1InObjectSpace(normal1);
     TubePointType::CovariantVectorType normal2;
     normal2.Fill(3);
-    p_original.SetNormal2InObjectSpace(normal2);
-    p_original.SetRadiusInObjectSpace(1.0);
-    p_original.SetMedialness(2.0);
-    p_original.SetRidgeness(3.0);
-    p_original.SetBranchness(4.0);
-    p_original.SetCurvature(5.0);
-    p_original.SetLevelness(6.0);
-    p_original.SetRoundness(7.0);
-    p_original.SetIntensity(8.0);
-    p_original.SetAlpha1(9.0);
-    p_original.SetAlpha2(10.0);
-    p_original.SetAlpha3(11.0);
+    pOriginal.SetNormal2InObjectSpace(normal2);
+    pOriginal.SetRadiusInObjectSpace(1.0);
+    pOriginal.SetMedialness(2.0);
+    pOriginal.SetRidgeness(3.0);
+    pOriginal.SetBranchness(4.0);
+    pOriginal.SetCurvature(5.0);
+    pOriginal.SetLevelness(6.0);
+    pOriginal.SetRoundness(7.0);
+    pOriginal.SetIntensity(8.0);
+    pOriginal.SetAlpha1(9.0);
+    pOriginal.SetAlpha2(10.0);
+    pOriginal.SetAlpha3(11.0);
 
     // Copy
-    TubePointType p_copy(p_original);
+    TubePointType pCopy(pOriginal);
     // Assign
-    TubePointType p_assign = p_original;
+    TubePointType pAssign = pOriginal;
 
-    std::vector<TubePointType> point_vector;
-    point_vector.push_back(p_copy);
-    point_vector.push_back(p_assign);
+    std::vector<TubePointType> pointVector;
+    pointVector.push_back(pCopy);
+    pointVector.push_back(pAssign);
 
-    for (const auto & pv : point_vector)
+    for (const auto & pv : pointVector)
     {
       // itk::SpatialObjectPoint
-      ITK_TEST_EXPECT_EQUAL(p_original.GetId(), pv.GetId());
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRed(), pv.GetRed()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetGreen(), pv.GetGreen()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBlue(), pv.GetBlue()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha(), pv.GetAlpha()));
+      ITK_TEST_EXPECT_EQUAL(pOriginal.GetId(), pv.GetId());
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRed(), pv.GetRed()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetGreen(), pv.GetGreen()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetBlue(), pv.GetBlue()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha(), pv.GetAlpha()));
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetPositionInObjectSpace()[j], pv.GetPositionInObjectSpace()[j]));
       }
       // itk::TubeSpatialObjectPoint
       for (size_t j = 0; j < 3; ++j)
       {
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetTangentInObjectSpace()[j], pv.GetTangentInObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetTangentInObjectSpace()[j], pv.GetTangentInObjectSpace()[j]));
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetNormal1InObjectSpace()[j], pv.GetNormal1InObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetNormal1InObjectSpace()[j], pv.GetNormal1InObjectSpace()[j]));
         ITK_TEST_EXPECT_TRUE(
-          itk::Math::AlmostEquals(p_original.GetNormal2InObjectSpace()[j], pv.GetNormal2InObjectSpace()[j]));
+          itk::Math::AlmostEquals(pOriginal.GetNormal2InObjectSpace()[j], pv.GetNormal2InObjectSpace()[j]));
       }
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRadiusInObjectSpace(), pv.GetRadiusInObjectSpace()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetMedialness(), pv.GetMedialness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRidgeness(), pv.GetRidgeness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetBranchness(), pv.GetBranchness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetCurvature(), pv.GetCurvature()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetLevelness(), pv.GetLevelness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetRoundness(), pv.GetRoundness()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetIntensity(), pv.GetIntensity()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha1(), pv.GetAlpha1()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha2(), pv.GetAlpha2()));
-      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(p_original.GetAlpha3(), pv.GetAlpha3()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRadiusInObjectSpace(), pv.GetRadiusInObjectSpace()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetMedialness(), pv.GetMedialness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRidgeness(), pv.GetRidgeness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetBranchness(), pv.GetBranchness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetCurvature(), pv.GetCurvature()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetLevelness(), pv.GetLevelness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetRoundness(), pv.GetRoundness()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetIntensity(), pv.GetIntensity()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha1(), pv.GetAlpha1()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha2(), pv.GetAlpha2()));
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetAlpha3(), pv.GetAlpha3()));
     }
 
     std::cout << "[DONE]" << std::endl;
   }
 
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve coverage for `SpatialObjects` module classes:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Make the calls to the Get methods be quantitative where they were just
  being called without being compared to the expected value.
- Remove explicit calls to the `Print` method and rely on the basic method
  exercising macro call.
- Use the C++ ITK style in variable naming.
- Improve slightly the test style to make them more consistent (e.g.
  input argument checking or test finishing message).
- Remove unnecessary comment in files about their purpose.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)