### PR TITLE
COMP: Fix `itk::ContourSpatialObject` ivar initialization value type

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -48,7 +48,7 @@ ContourSpatialObject<TDimension>::Clear()
   m_ControlPoints.clear();
 
   m_InterpolationMethod = InterpolationMethodEnum::NO_INTERPOLATION;
-  m_InterpolationFactor = 2.0;
+  m_InterpolationFactor = 2;
 
   m_IsClosed = false;
 


### PR DESCRIPTION
Fix `itk::ContourSpatialObject` ivar initialization value type: avoid
unnecessary casting from `float`/`double` to `unsigned int`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)