### PR TITLE
COMP: variable is uninitialized when passed as a const reference

### DIFF
--- a/Modules/Core/Common/include/itkImage.hxx
+++ b/Modules/Core/Common/include/itkImage.hxx
@@ -148,7 +148,7 @@ Image<TPixel, VImageDimension>::GetNumberOfComponentsPerPixel() const
 {
   // use the GetLength() method which works with variable length arrays,
   // to make it work with as much pixel types as possible
-  PixelType p;
+  const PixelType p{};
   return NumericTraits<PixelType>::GetLength(p);
 }
 


### PR DESCRIPTION
Trying to fix the [warning](https://open.cdash.org/viewBuildError.php?type=1&buildid=6756465):
```text
In file included from /Users/builder/externalModules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx:22:
In file included from /Users/builder/externalModules/Core/Common/include/itkImage.h:346:
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkImage.hxx:152:46: warning: variable 'p' is uninitialized when passed as a const reference argument here [-Wuninitialized-const-reference]
  return NumericTraits<PixelType>::GetLength(p);
                                             ^
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkImage.h:322:3: note: in instantiation of member function 'itk::Image<double, 2>::GetNumberOfComponentsPerPixel' requested here
  Image();
  ^
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkImage.h:99:15: note: in instantiation of member function 'itk::Image<double, 2>::Image' requested here
  itkNewMacro(Self);
              ^
[CTest: warning matched] /Users/builder/externalModules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx:57:30: note: in instantiation of member function 'itk::Image<double, 2>::New' requested here
  const auto image = TImage::New();
                             ^
[CTest: warning matched] /Users/builder/externalModules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx:101:3: note: in instantiation of function template specialization '(anonymous namespace)::Expect_EvaluateAtIndex_returns_zero_when_all_pixels_are_zero<itk::Image<double, 2>>' requested here
  Expect_EvaluateAtIndex_returns_zero_when_all_pixels_are_zero<itk::Image<double, 2>>(itk::Size<2>{ { 2, 3 } });
  ^
```
