### PR TITLE
COMP: Fix arithmetic overflow MersenneTwisterRandomVariateGenerator

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -364,7 +364,7 @@ MersenneTwisterRandomVariateGenerator::reload()
   // matthew dot bellew at home dot com
 
   // get rid of VS warning
-  auto index = static_cast<int>(M - MersenneTwisterRandomVariateGenerator::StateVectorLength);
+  constexpr auto index = int{ M } - int{ MersenneTwisterRandomVariateGenerator::StateVectorLength };
 
   IntegerType * p = state;
   int           i;


### PR DESCRIPTION
Fixed Visual Studio 2019 Code Analysis (C++ Core Guidelines) warning
C26454 in `MersenneTwisterRandomVariateGenerator::reload()`, saying:

> Arithmetic overflow: '-' operation produces a negative unsigned result
> at compile time (io.5).

Declared the `index` variable `constexpr`.
