### PR TITLE
STYLE: Allow conversion from nullptr to WeakPointer, not from zero

### DIFF
--- a/Modules/Core/Common/include/itkWeakPointer.h
+++ b/Modules/Core/Common/include/itkWeakPointer.h
@@ -47,22 +47,20 @@ public:
   /** Extract information from template parameter. */
   using ObjectType = TObjectType;
 
-  /** Constructor.  */
-  WeakPointer() { m_Pointer = nullptr; }
+  /** Explicitly-defaulted default-constructor.
+   * \note The other five "special member functions" (copy-constructor,
+   * copy-assignment operator, move-constructor, move-assignment operator,
+   * and destructor) are defaulted implicitly, following the C++ "Rule of Zero".
+   */
+  WeakPointer() = default;
 
-  /** Copy constructor.  */
-  WeakPointer(const WeakPointer<ObjectType> & p) = default;
-
-  /** Move constructor */
-  WeakPointer(WeakPointer<ObjectType> && p) = default;
+  /** Constructor, converting from `nullptr`.  */
+  WeakPointer(std::nullptr_t) {}
 
   /** Constructor to pointer p.  */
   WeakPointer(ObjectType * p)
     : m_Pointer(p)
   {}
-
-  /** Destructor.  */
-  ~WeakPointer() = default;
 
   /** Overload operator ->.  */
   ObjectType * operator->() const { return m_Pointer; }
@@ -134,22 +132,6 @@ public:
     return (void *)m_Pointer >= (void *)r.m_Pointer;
   }
 
-  /** Overload operator assignment.  */
-  // cppcheck-suppress operatorEqVarError
-  WeakPointer &
-  operator=(const WeakPointer & r) = default;
-
-  WeakPointer &
-  operator=(WeakPointer && r) = default;
-
-  /** Overload operator assignment.  */
-  WeakPointer &
-  operator=(ObjectType * r)
-  {
-    m_Pointer = r;
-    return *this;
-  }
-
   /** Function to print object pointed to.  */
   ObjectType *
   Print(std::ostream & os) const
@@ -168,7 +150,7 @@ public:
 
 private:
   /** The pointer to the object referred to by this smart pointer. */
-  ObjectType * m_Pointer;
+  ObjectType * m_Pointer{ nullptr };
 };
 
 template <typename T>

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -621,6 +621,7 @@ set(ITKCommonGTests
       itkSizeGTest.cxx
       itkSmartPointerGTest.cxx
       itkVectorContainerGTest.cxx
+      itkWeakPointerGTest.cxx
       itkCommonTypeTraitsGTest.cxx
       itkMetaDataDictionaryGTest.cxx
 )

--- a/Modules/Core/Common/test/itkWeakPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkWeakPointerGTest.cxx
@@ -1,0 +1,68 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+
+#include "itkWeakPointer.h"
+#include "itkLightObject.h"
+
+#include <type_traits> // For is_default_constructible, is_copy_constructible, etc.
+
+namespace
+{
+using WeakPointerType = itk::WeakPointer<itk::LightObject>;
+
+template <typename T>
+constexpr bool
+AllSpecialMemberFunctionsNoThrow()
+{
+  return std::is_nothrow_default_constructible<T>::value && std::is_nothrow_copy_constructible<T>::value &&
+         std::is_nothrow_copy_assignable<T>::value && std::is_nothrow_move_constructible<T>::value &&
+         std::is_nothrow_move_assignable<T>::value && std::is_nothrow_destructible<T>::value;
+}
+
+} // namespace
+
+static_assert(AllSpecialMemberFunctionsNoThrow<WeakPointerType>(),
+              "All special member functions should be non-throwing.");
+
+
+TEST(WeakPointer, DefaultConstructedEqualsNullptr)
+{
+  ASSERT_EQ(WeakPointerType{}, nullptr);
+  ASSERT_TRUE(WeakPointerType{} == nullptr);
+  ASSERT_TRUE(nullptr == WeakPointerType{});
+}
+
+
+TEST(WeakPointer, ConvertedFromNullptrEqualsNullptr)
+{
+  ASSERT_EQ(WeakPointerType{ nullptr }, nullptr);
+  ASSERT_TRUE(WeakPointerType{ nullptr } == nullptr);
+  ASSERT_TRUE(nullptr == WeakPointerType{ nullptr });
+}
+
+
+TEST(WeakPointer, AssignedFromNullptrEqualsNullptr)
+{
+  WeakPointerType ptr;
+  ptr = nullptr;
+  ASSERT_EQ(ptr, nullptr);
+  ASSERT_TRUE(ptr == nullptr);
+  ASSERT_TRUE(nullptr == ptr);
+}


### PR DESCRIPTION
Small WeakPointer improvements:

- Defaulted default-constructor (allowing the compiler to consider it
"constexpr" and "noexcept")
- Removed the other user-defined special functions (Rule Of Zero)
- Removed redundant user-defined `operator=(ObjectType*)`
- Added converting constructor, WeakPointer(std::nullptr_t).

No longer allowed implicit conversion from the integer zero.

Included GoogleTest unit tests.