### PR TITLE
ENH: Use strongly typed enums for the `Algorithm` type in math morphology

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/CMakeLists.txt
+++ b/Modules/Filtering/MathematicalMorphology/CMakeLists.txt
@@ -1,2 +1,3 @@
 project(ITKMathematicalMorphology)
+set(ITKMathematicalMorphology_LIBRARIES ITKMathematicalMorphology)
 itk_module_impl()

--- a/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.h
@@ -19,6 +19,7 @@
 #define itkBlackTopHatImageFilter_h
 
 #include "itkKernelImageFilter.h"
+#include "itkMathematicalMorphologyEnums.h"
 
 namespace itk
 {
@@ -69,6 +70,19 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
+  using AlgorithmEnum = MathematicalMorphologyEnums::Algorithm;
+
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Backwards compatibility for enum values */
+  using AlgorithmType = AlgorithmEnum;
+  // We need to expose the enum values at the class level
+  // for backwards compatibility
+  static constexpr AlgorithmType BASIC = AlgorithmEnum::BASIC;
+  static constexpr AlgorithmType HISTO = AlgorithmEnum::HISTO;
+  static constexpr AlgorithmType ANCHOR = AlgorithmEnum::ANCHOR;
+  static constexpr AlgorithmType VHGW = AlgorithmEnum::VHGW;
+#endif
+
   /** Standard New method. */
   itkNewMacro(Self);
 
@@ -81,18 +95,9 @@ public:
   itkGetConstReferenceMacro(SafeBorder, bool);
   itkBooleanMacro(SafeBorder);
 
-  /** define values used to determine which algorithm to use */
-  enum AlgorithmType
-  {
-    BASIC = 0,
-    HISTO = 1,
-    ANCHOR = 2,
-    VHGW = 3
-  };
-
   /** Set/Get the backend filter class. */
-  itkSetMacro(Algorithm, int);
-  itkGetConstMacro(Algorithm, int);
+  itkSetMacro(Algorithm, AlgorithmEnum);
+  itkGetConstMacro(Algorithm, AlgorithmEnum);
 
   itkSetMacro(ForceAlgorithm, bool);
   itkGetConstReferenceMacro(ForceAlgorithm, bool);
@@ -110,7 +115,7 @@ protected:
 private:
   bool m_SafeBorder;
 
-  int m_Algorithm;
+  AlgorithmEnum m_Algorithm;
 
   bool m_ForceAlgorithm;
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.hxx
@@ -30,7 +30,7 @@ template <typename TInputImage, typename TOutputImage, typename TKernel>
 BlackTopHatImageFilter<TInputImage, TOutputImage, TKernel>::BlackTopHatImageFilter()
 {
   m_SafeBorder = true;
-  m_Algorithm = HISTO;
+  m_Algorithm = AlgorithmEnum::HISTO;
   m_ForceAlgorithm = false;
 }
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.h
@@ -19,6 +19,7 @@
 #define itkGrayscaleDilateImageFilter_h
 
 #include "itkKernelImageFilter.h"
+#include "itkMathematicalMorphologyEnums.h"
 #include "itkMovingHistogramDilateImageFilter.h"
 #include "itkBasicDilateImageFilter.h"
 #include "itkAnchorDilateImageFilter.h"
@@ -99,6 +100,19 @@ public:
   //   using KernelSuperclass = typename KernelType::Superclass;
   //   using KernelSuperclass = Neighborhood< typename KernelType::PixelType, ImageDimension >;
 
+  using AlgorithmEnum = MathematicalMorphologyEnums::Algorithm;
+
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Backwards compatibility for enum values */
+  using AlgorithmType = AlgorithmEnum;
+  // We need to expose the enum values at the class level
+  // for backwards compatibility
+  static constexpr AlgorithmType BASIC = AlgorithmEnum::BASIC;
+  static constexpr AlgorithmType HISTO = AlgorithmEnum::HISTO;
+  static constexpr AlgorithmType ANCHOR = AlgorithmType::ANCHOR;
+  static constexpr AlgorithmType VHGW = AlgorithmEnum::VHGW;
+#endif
+
   /** Set kernel (structuring element). */
   void
   SetKernel(const KernelType & kernel) override;
@@ -111,22 +125,12 @@ public:
 
   /** Set/Get the backend filter class. */
   void
-  SetAlgorithm(int algo);
-
-  itkGetConstMacro(Algorithm, int);
+  SetAlgorithm(AlgorithmEnum algo);
+  itkGetConstMacro(Algorithm, AlgorithmEnum);
 
   /** GrayscaleDilateImageFilter need to set its internal filters as modified */
   void
   Modified() const override;
-
-  /** define values used to determine which algorithm to use */
-  enum AlgorithmType
-  {
-    BASIC = 0,
-    HISTO = 1,
-    ANCHOR = 2,
-    VHGW = 3
-  };
 
   void
   SetNumberOfWorkUnits(ThreadIdType nb) override;
@@ -153,7 +157,7 @@ private:
   typename VHGWFilterType::Pointer m_VHGWFilter;
 
   // and the name of the filter
-  int m_Algorithm;
+  AlgorithmEnum m_Algorithm;
 
   // the boundary condition need to be stored here
   DefaultBoundaryConditionType m_BoundaryCondition;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.hxx
@@ -32,7 +32,7 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::GrayscaleDilateI
   m_HistogramFilter = HistogramFilterType::New();
   m_AnchorFilter = AnchorFilterType::New();
   m_VHGWFilter = VHGWFilterType::New();
-  m_Algorithm = HISTO;
+  m_Algorithm = AlgorithmEnum::HISTO;
 
   this->SetBoundary(NumericTraits<PixelType>::NonpositiveMin());
 }
@@ -57,13 +57,13 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::SetKernel(const 
   if (flatKernel != nullptr && flatKernel->GetDecomposable())
   {
     m_AnchorFilter->SetKernel(*flatKernel);
-    m_Algorithm = ANCHOR;
+    m_Algorithm = AlgorithmEnum::ANCHOR;
   }
   else if (m_HistogramFilter->GetUseVectorBasedAlgorithm())
   {
     // histogram based filter is as least as good as the basic one, so always
     // use it
-    m_Algorithm = HISTO;
+    m_Algorithm = AlgorithmEnum::HISTO;
     m_HistogramFilter->SetKernel(kernel);
   }
   else
@@ -80,11 +80,11 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::SetKernel(const 
         (ImageDimension == 3 && this->GetKernel().Size() < m_HistogramFilter->GetPixelsPerTranslation() * 4.5))
     {
       m_BasicFilter->SetKernel(kernel);
-      m_Algorithm = BASIC;
+      m_Algorithm = AlgorithmEnum::BASIC;
     }
     else
     {
-      m_Algorithm = HISTO;
+      m_Algorithm = AlgorithmEnum::HISTO;
     }
   }
 
@@ -105,25 +105,25 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::SetBoundary(cons
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 void
-GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(int algo)
+GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(AlgorithmEnum algo)
 {
   const auto * flatKernel = dynamic_cast<const FlatKernelType *>(&this->GetKernel());
 
   if (m_Algorithm != algo)
   {
-    if (algo == BASIC)
+    if (algo == AlgorithmEnum::BASIC)
     {
       m_BasicFilter->SetKernel(this->GetKernel());
     }
-    else if (algo == HISTO)
+    else if (algo == AlgorithmEnum::HISTO)
     {
       m_HistogramFilter->SetKernel(this->GetKernel());
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == ANCHOR)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::ANCHOR)
     {
       m_AnchorFilter->SetKernel(*flatKernel);
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == VHGW)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::VHGW)
     {
       m_VHGWFilter->SetKernel(*flatKernel);
     }
@@ -150,7 +150,7 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   this->AllocateOutputs();
 
   // Delegate to the appropriate dilation filter
-  if (m_Algorithm == BASIC)
+  if (m_Algorithm == AlgorithmEnum::BASIC)
   {
     itkDebugMacro("Running BasicDilateImageFilter");
     m_BasicFilter->SetInput(this->GetInput());
@@ -160,7 +160,7 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
     m_BasicFilter->Update();
     this->GraftOutput(m_BasicFilter->GetOutput());
   }
-  else if (m_Algorithm == HISTO)
+  else if (m_Algorithm == AlgorithmEnum::HISTO)
   {
     itkDebugMacro("Running MovingHistogramDilateImageFilter");
     m_HistogramFilter->SetInput(this->GetInput());
@@ -170,7 +170,7 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
     m_HistogramFilter->Update();
     this->GraftOutput(m_HistogramFilter->GetOutput());
   }
-  else if (m_Algorithm == ANCHOR)
+  else if (m_Algorithm == AlgorithmEnum::ANCHOR)
   {
     itkDebugMacro("Running AnchorDilateImageFilter");
     m_AnchorFilter->SetInput(this->GetInput());
@@ -184,7 +184,7 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
     cast->Update();
     this->GraftOutput(cast->GetOutput());
   }
-  else if (m_Algorithm == VHGW)
+  else if (m_Algorithm == AlgorithmEnum::VHGW)
   {
     itkDebugMacro("Running VanHerkGilWermanDilateImageFilter");
     m_VHGWFilter->SetInput(this->GetInput());

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.h
@@ -19,6 +19,7 @@
 #define itkGrayscaleErodeImageFilter_h
 
 #include "itkKernelImageFilter.h"
+#include "itkMathematicalMorphologyEnums.h"
 #include "itkMovingHistogramErodeImageFilter.h"
 #include "itkBasicErodeImageFilter.h"
 #include "itkAnchorErodeImageFilter.h"
@@ -80,15 +81,6 @@ public:
   using OffsetType = typename TInputImage::OffsetType;
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;
 
-  /** define values used to determine which algorithm to use */
-  enum AlgorithmType
-  {
-    BASIC = 0,
-    HISTO = 1,
-    ANCHOR = 2,
-    VHGW = 3
-  };
-
   using HistogramFilterType = MovingHistogramErodeImageFilter<TInputImage, TOutputImage, TKernel>;
   using BasicFilterType = BasicErodeImageFilter<TInputImage, TOutputImage, TKernel>;
 
@@ -108,6 +100,19 @@ public:
   //   using KernelSuperclass = typename KernelType::Superclass;
   //   using KernelSuperclass = Neighborhood< typename KernelType::PixelType, ImageDimension >;
 
+  using AlgorithmEnum = MathematicalMorphologyEnums::Algorithm;
+
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Backwards compatibility for enum values */
+  using AlgorithmType = AlgorithmEnum;
+  // We need to expose the enum values at the class level
+  // for backwards compatibility
+  static constexpr AlgorithmType BASIC = AlgorithmType::BASIC;
+  static constexpr AlgorithmType HISTO = AlgorithmType::HISTO;
+  static constexpr AlgorithmType ANCHOR = AlgorithmType::ANCHOR;
+  static constexpr AlgorithmType VHGW = AlgorithmType::VHGW;
+#endif
+
   /** Set kernel (structuring element). */
   void
   SetKernel(const KernelType & kernel) override;
@@ -120,9 +125,8 @@ public:
 
   /** Set/Get the backend filter class. */
   void
-  SetAlgorithm(int algo);
-
-  itkGetConstMacro(Algorithm, int);
+  SetAlgorithm(AlgorithmEnum algo);
+  itkGetConstMacro(Algorithm, AlgorithmEnum);
 
   /** GrayscaleErodeImageFilter need to set its internal filters as modified */
   void
@@ -153,7 +157,7 @@ private:
   typename VHGWFilterType::Pointer m_VHGWFilter;
 
   // and the name of the filter
-  int m_Algorithm;
+  AlgorithmEnum m_Algorithm;
 
   // the boundary condition need to be stored here
   DefaultBoundaryConditionType m_BoundaryCondition;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.hxx
@@ -32,7 +32,7 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::GrayscaleErodeIma
   m_HistogramFilter = HistogramFilterType::New();
   m_AnchorFilter = AnchorFilterType::New();
   m_VHGWFilter = VHGWFilterType::New();
-  m_Algorithm = HISTO;
+  m_Algorithm = AlgorithmEnum::HISTO;
 
   this->SetBoundary(NumericTraits<PixelType>::max());
 }
@@ -57,13 +57,13 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::SetKernel(const K
   if (flatKernel != nullptr && flatKernel->GetDecomposable())
   {
     m_AnchorFilter->SetKernel(*flatKernel);
-    m_Algorithm = ANCHOR;
+    m_Algorithm = AlgorithmEnum::ANCHOR;
   }
   else if (m_HistogramFilter->GetUseVectorBasedAlgorithm())
   {
     // histogram based filter is as least as good as the basic one, so always
     // use it
-    m_Algorithm = HISTO;
+    m_Algorithm = AlgorithmEnum::HISTO;
     m_HistogramFilter->SetKernel(kernel);
   }
   else
@@ -80,11 +80,11 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::SetKernel(const K
         (ImageDimension == 3 && this->GetKernel().Size() < m_HistogramFilter->GetPixelsPerTranslation() * 4.5))
     {
       m_BasicFilter->SetKernel(kernel);
-      m_Algorithm = BASIC;
+      m_Algorithm = AlgorithmEnum::BASIC;
     }
     else
     {
-      m_Algorithm = HISTO;
+      m_Algorithm = AlgorithmEnum::HISTO;
     }
   }
 
@@ -105,25 +105,25 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::SetBoundary(const
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 void
-GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(int algo)
+GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(AlgorithmEnum algo)
 {
   const auto * flatKernel = dynamic_cast<const FlatKernelType *>(&this->GetKernel());
 
   if (m_Algorithm != algo)
   {
-    if (algo == BASIC)
+    if (algo == AlgorithmEnum::BASIC)
     {
       m_BasicFilter->SetKernel(this->GetKernel());
     }
-    else if (algo == HISTO)
+    else if (algo == AlgorithmEnum::HISTO)
     {
       m_HistogramFilter->SetKernel(this->GetKernel());
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == ANCHOR)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::ANCHOR)
     {
       m_AnchorFilter->SetKernel(*flatKernel);
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == VHGW)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::VHGW)
     {
       m_VHGWFilter->SetKernel(*flatKernel);
     }
@@ -150,7 +150,7 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   this->AllocateOutputs();
 
   // Delegate to the appropriate erosion filter
-  if (m_Algorithm == BASIC)
+  if (m_Algorithm == AlgorithmEnum::BASIC)
   {
     itkDebugMacro("Running BasicErodeImageFilter");
     m_BasicFilter->SetInput(this->GetInput());
@@ -160,7 +160,7 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
     m_BasicFilter->Update();
     this->GraftOutput(m_BasicFilter->GetOutput());
   }
-  else if (m_Algorithm == HISTO)
+  else if (m_Algorithm == AlgorithmEnum::HISTO)
   {
     itkDebugMacro("Running MovingHistogramErodeImageFilter");
     m_HistogramFilter->SetInput(this->GetInput());
@@ -170,7 +170,7 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
     m_HistogramFilter->Update();
     this->GraftOutput(m_HistogramFilter->GetOutput());
   }
-  else if (m_Algorithm == ANCHOR)
+  else if (m_Algorithm == AlgorithmEnum::ANCHOR)
   {
     itkDebugMacro("Running AnchorErodeImageFilter");
     m_AnchorFilter->SetInput(this->GetInput());
@@ -184,7 +184,7 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
     cast->Update();
     this->GraftOutput(cast->GetOutput());
   }
-  else if (m_Algorithm == VHGW)
+  else if (m_Algorithm == AlgorithmEnum::VHGW)
   {
     itkDebugMacro("Running VanHerkGilWermanErodeImageFilter");
     m_VHGWFilter->SetInput(this->GetInput());

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
@@ -19,6 +19,7 @@
 #define itkGrayscaleMorphologicalClosingImageFilter_h
 
 #include "itkKernelImageFilter.h"
+#include "itkMathematicalMorphologyEnums.h"
 #include "itkMovingHistogramErodeImageFilter.h"
 #include "itkMovingHistogramDilateImageFilter.h"
 #include "itkBasicErodeImageFilter.h"
@@ -69,15 +70,6 @@ public:
   /** Image related type alias. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
-  /** define values used to determine which algorithm to use */
-  enum AlgorithmType
-  {
-    BASIC = 0,
-    HISTO = 1,
-    ANCHOR = 2,
-    VHGW = 3
-  };
-
   /** Image related type alias. */
   using InputImageType = TInputImage;
   using OutputImageType = TOutputImage;
@@ -103,14 +95,27 @@ public:
   //   using KernelSuperclass = typename KernelType::Superclass;
   //   using KernelSuperclass = Neighborhood< typename KernelType::PixelType, ImageDimension >;
 
+  using AlgorithmEnum = MathematicalMorphologyEnums::Algorithm;
+
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Backwards compatibility for enum values */
+  using AlgorithmType = AlgorithmEnum;
+  // We need to expose the enum values at the class level
+  // for backwards compatibility
+  static constexpr AlgorithmType BASIC = AlgorithmEnum::BASIC;
+  static constexpr AlgorithmType HISTO = AlgorithmEnum::HISTO;
+  static constexpr AlgorithmType ANCHOR = AlgorithmEnum::ANCHOR;
+  static constexpr AlgorithmType VHGW = AlgorithmEnum::VHGW;
+#endif
+
   /** Set kernel (structuring element). */
   void
   SetKernel(const KernelType & kernel) override;
 
   /** Set/Get the backend filter class. */
   void
-  SetAlgorithm(int algo);
-  itkGetConstMacro(Algorithm, int);
+  SetAlgorithm(AlgorithmEnum algo);
+  itkGetConstMacro(Algorithm, AlgorithmEnum);
 
   /** GrayscaleMorphologicalClosingImageFilter need to set its internal filters
     as modified */
@@ -149,7 +154,7 @@ private:
   typename AnchorFilterType::Pointer m_AnchorFilter;
 
   // and the name of the filter
-  int m_Algorithm;
+  AlgorithmEnum m_Algorithm;
 
   bool m_SafeBorder;
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.hxx
@@ -37,7 +37,7 @@ GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Gr
   m_VanHerkGilWermanDilateFilter = VanHerkGilWermanDilateFilterType::New();
   m_VanHerkGilWermanErodeFilter = VanHerkGilWermanErodeFilterType::New();
   m_AnchorFilter = AnchorFilterType::New();
-  m_Algorithm = HISTO;
+  m_Algorithm = AlgorithmEnum::HISTO;
   m_SafeBorder = true;
 }
 
@@ -50,13 +50,13 @@ GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Se
   if (flatKernel != nullptr && flatKernel->GetDecomposable())
   {
     m_AnchorFilter->SetKernel(*flatKernel);
-    m_Algorithm = ANCHOR;
+    m_Algorithm = AlgorithmEnum::ANCHOR;
   }
   else if (m_HistogramErodeFilter->GetUseVectorBasedAlgorithm())
   {
     // histogram based filter is as least as good as the basic one, so always
     // use it
-    m_Algorithm = HISTO;
+    m_Algorithm = AlgorithmEnum::HISTO;
     m_HistogramErodeFilter->SetKernel(kernel);
     m_HistogramDilateFilter->SetKernel(kernel);
   }
@@ -74,12 +74,12 @@ GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Se
     {
       m_BasicErodeFilter->SetKernel(kernel);
       m_BasicDilateFilter->SetKernel(kernel);
-      m_Algorithm = BASIC;
+      m_Algorithm = AlgorithmEnum::BASIC;
     }
     else
     {
       m_HistogramDilateFilter->SetKernel(kernel);
-      m_Algorithm = HISTO;
+      m_Algorithm = AlgorithmEnum::HISTO;
     }
   }
 
@@ -88,27 +88,27 @@ GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Se
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 void
-GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(int algo)
+GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(AlgorithmEnum algo)
 {
   const auto * flatKernel = dynamic_cast<const FlatKernelType *>(&this->GetKernel());
 
   if (m_Algorithm != algo)
   {
-    if (algo == BASIC)
+    if (algo == AlgorithmEnum::BASIC)
     {
       m_BasicErodeFilter->SetKernel(this->GetKernel());
       m_BasicDilateFilter->SetKernel(this->GetKernel());
     }
-    else if (algo == HISTO)
+    else if (algo == AlgorithmEnum::HISTO)
     {
       m_HistogramErodeFilter->SetKernel(this->GetKernel());
       m_HistogramDilateFilter->SetKernel(this->GetKernel());
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == ANCHOR)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::ANCHOR)
     {
       m_AnchorFilter->SetKernel(*flatKernel);
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == VHGW)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::VHGW)
     {
       m_VanHerkGilWermanDilateFilter->SetKernel(*flatKernel);
       m_VanHerkGilWermanErodeFilter->SetKernel(*flatKernel);
@@ -136,7 +136,7 @@ GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Ge
   this->AllocateOutputs();
 
   // Delegate to a dilate filter.
-  if (m_Algorithm == BASIC)
+  if (m_Algorithm == AlgorithmEnum::BASIC)
   {
     // Use itk::BasicErodeImageFilter
     if (m_SafeBorder)
@@ -179,7 +179,7 @@ GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Ge
       this->GraftOutput(m_BasicErodeFilter->GetOutput());
     }
   }
-  else if (m_Algorithm == HISTO)
+  else if (m_Algorithm == AlgorithmEnum::HISTO)
   {
     // Use itk::MovingHistogramErodeImageFilter
     if (m_SafeBorder)
@@ -222,7 +222,7 @@ GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Ge
       this->GraftOutput(m_HistogramErodeFilter->GetOutput());
     }
   }
-  else if (m_Algorithm == VHGW)
+  else if (m_Algorithm == AlgorithmEnum::VHGW)
   {
     // Use itk::VanHerkGilWermanErodeImageFilter
     if (m_SafeBorder)
@@ -265,7 +265,7 @@ GrayscaleMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Ge
       this->GraftOutput(m_VanHerkGilWermanErodeFilter->GetOutput());
     }
   }
-  else if (m_Algorithm == ANCHOR)
+  else if (m_Algorithm == AlgorithmEnum::ANCHOR)
   {
     // Use itk::AnchorErodeImageFilter
     if (m_SafeBorder)

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
@@ -19,6 +19,7 @@
 #define itkGrayscaleMorphologicalOpeningImageFilter_h
 
 #include "itkKernelImageFilter.h"
+#include "itkMathematicalMorphologyEnums.h"
 #include "itkMovingHistogramDilateImageFilter.h"
 #include "itkMovingHistogramErodeImageFilter.h"
 #include "itkBasicDilateImageFilter.h"
@@ -93,29 +94,32 @@ public:
   //   using KernelSuperclass = typename KernelType::Superclass;
   //   using KernelSuperclass = Neighborhood< typename KernelType::PixelType, ImageDimension >;
 
+  using AlgorithmEnum = MathematicalMorphologyEnums::Algorithm;
+
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Backwards compatibility for enum values */
+  using AlgorithmType = AlgorithmEnum;
+  // We need to expose the enum values at the class level
+  // for backwards compatibility
+  static constexpr AlgorithmType BASIC = AlgorithmEnum::BASIC;
+  static constexpr AlgorithmType HISTO = AlgorithmEnum::HISTO;
+  static constexpr AlgorithmType ANCHOR = AlgorithmEnum::ANCHOR;
+  static constexpr AlgorithmType VHGW = AlgorithmEnum::VHGW;
+#endif
+
   /** Set kernel (structuring element). */
   void
   SetKernel(const KernelType & kernel) override;
 
   /** Set/Get the backend filter class. */
   void
-  SetAlgorithm(int algo);
-
-  itkGetConstMacro(Algorithm, int);
+  SetAlgorithm(AlgorithmEnum algo);
+  itkGetConstMacro(Algorithm, AlgorithmEnum);
 
   /** GrayscaleMorphologicalOpeningImageFilter need to set its internal filters
     as modified */
   void
   Modified() const override;
-
-  /** define values used to determine which algorithm to use */
-  enum AlgorithmType
-  {
-    BASIC = 0,
-    HISTO = 1,
-    ANCHOR = 2,
-    VHGW = 3
-  };
 
   /** A safe border is added to input image to avoid borders effects
    * and remove it once the closing is done */
@@ -149,7 +153,7 @@ private:
   typename AnchorFilterType::Pointer m_AnchorFilter;
 
   // and the name of the filter
-  int m_Algorithm;
+  AlgorithmEnum m_Algorithm;
 
   bool m_SafeBorder{ true };
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.hxx
@@ -36,7 +36,7 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Gr
   , m_VanHerkGilWermanDilateFilter(VanHerkGilWermanDilateFilterType::New())
   , m_VanHerkGilWermanErodeFilter(VanHerkGilWermanErodeFilterType::New())
   , m_AnchorFilter(AnchorFilterType::New())
-  , m_Algorithm(HISTO)
+  , m_Algorithm(AlgorithmEnum::HISTO)
 
 {}
 
@@ -49,13 +49,13 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Se
   if (flatKernel != nullptr && flatKernel->GetDecomposable())
   {
     m_AnchorFilter->SetKernel(*flatKernel);
-    m_Algorithm = ANCHOR;
+    m_Algorithm = AlgorithmEnum::ANCHOR;
   }
   else if (m_HistogramDilateFilter->GetUseVectorBasedAlgorithm())
   {
     // histogram based filter is as least as good as the basic one, so always
     // use it
-    m_Algorithm = HISTO;
+    m_Algorithm = AlgorithmEnum::HISTO;
     m_HistogramDilateFilter->SetKernel(kernel);
     m_HistogramErodeFilter->SetKernel(kernel);
   }
@@ -73,12 +73,12 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Se
     {
       m_BasicDilateFilter->SetKernel(kernel);
       m_BasicErodeFilter->SetKernel(kernel);
-      m_Algorithm = BASIC;
+      m_Algorithm = AlgorithmEnum::BASIC;
     }
     else
     {
       m_HistogramErodeFilter->SetKernel(kernel);
-      m_Algorithm = HISTO;
+      m_Algorithm = AlgorithmEnum::HISTO;
     }
   }
 
@@ -87,27 +87,27 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Se
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 void
-GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(int algo)
+GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(AlgorithmEnum algo)
 {
   const auto * flatKernel = dynamic_cast<const FlatKernelType *>(&this->GetKernel());
 
   if (m_Algorithm != algo)
   {
-    if (algo == BASIC)
+    if (algo == AlgorithmEnum::BASIC)
     {
       m_BasicDilateFilter->SetKernel(this->GetKernel());
       m_BasicErodeFilter->SetKernel(this->GetKernel());
     }
-    else if (algo == HISTO)
+    else if (algo == AlgorithmEnum::HISTO)
     {
       m_HistogramDilateFilter->SetKernel(this->GetKernel());
       m_HistogramErodeFilter->SetKernel(this->GetKernel());
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == ANCHOR)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::ANCHOR)
     {
       m_AnchorFilter->SetKernel(*flatKernel);
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == VHGW)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::VHGW)
     {
       m_VanHerkGilWermanDilateFilter->SetKernel(*flatKernel);
       m_VanHerkGilWermanErodeFilter->SetKernel(*flatKernel);
@@ -135,7 +135,7 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Ge
   this->AllocateOutputs();
 
   // Delegate to a dilate filter.
-  if (m_Algorithm == BASIC)
+  if (m_Algorithm == AlgorithmEnum::BASIC)
   {
     // Use itk::BasicDilateImageFilter
     if (m_SafeBorder)
@@ -178,7 +178,7 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Ge
       this->GraftOutput(m_BasicDilateFilter->GetOutput());
     }
   }
-  else if (m_Algorithm == HISTO)
+  else if (m_Algorithm == AlgorithmEnum::HISTO)
   {
     // Use itk::MovingHistogramDilateImageFilter
     if (m_SafeBorder)
@@ -221,7 +221,7 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Ge
       this->GraftOutput(m_HistogramDilateFilter->GetOutput());
     }
   }
-  else if (m_Algorithm == VHGW)
+  else if (m_Algorithm == AlgorithmEnum::VHGW)
   {
     // Use itk::VanHerkGilWermanDilateImageFilter
     if (m_SafeBorder)
@@ -270,7 +270,7 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Ge
       this->GraftOutput(cast->GetOutput());
     }
   }
-  else if (m_Algorithm == ANCHOR)
+  else if (m_Algorithm == AlgorithmEnum::ANCHOR)
   {
     // Use itk::AnchorDilateImageFilter
     if (m_SafeBorder)

--- a/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h
@@ -1,0 +1,56 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkMathematicalMorphologyEnums_h
+#define itkMathematicalMorphologyEnums_h
+
+#include <iostream>
+#include "ITKMathematicalMorphologyExport.h"
+
+
+namespace itk
+{
+
+/**
+ * \class MathematicalMorphologyEnums
+ * \brief Mathematical Morphology enum classes.
+ * \ingroup ITKMathematicalMorphology
+ */
+
+class MathematicalMorphologyEnums
+{
+public:
+  /**\class AlgorithmType
+   * \brief Algorithm or implementation used in the dilation/erosion operations.
+   * \ingroup ITKMathematicalMorphology
+   */
+  enum class Algorithm : uint8_t
+  {
+    BASIC = 0,
+    HISTO = 1,
+    ANCHOR = 2,
+    VHGW = 3
+  };
+};
+
+/** Define how to print enumeration values. */
+extern ITKMathematicalMorphology_EXPORT std::ostream &
+                                        operator<<(std::ostream & out, const MathematicalMorphologyEnums::Algorithm value);
+
+} // end namespace itk
+
+#endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.h
@@ -19,6 +19,7 @@
 #define itkMorphologicalGradientImageFilter_h
 
 #include "itkKernelImageFilter.h"
+#include "itkMathematicalMorphologyEnums.h"
 #include "itkMovingHistogramMorphologicalGradientImageFilter.h"
 #include "itkBasicDilateImageFilter.h"
 #include "itkBasicErodeImageFilter.h"
@@ -92,29 +93,32 @@ public:
   //   using KernelSuperclass = typename KernelType::Superclass;
   //   using KernelSuperclass = Neighborhood< typename KernelType::PixelType, ImageDimension >;
 
+  using AlgorithmEnum = MathematicalMorphologyEnums::Algorithm;
+
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Backwards compatibility for enum values */
+  using AlgorithmType = AlgorithmEnum;
+  // We need to expose the enum values at the class level
+  // for backwards compatibility
+  static constexpr AlgorithmType BASIC = AlgorithmEnum::BASIC;
+  static constexpr AlgorithmType HISTO = AlgorithmEnum::HISTO;
+  static constexpr AlgorithmType ANCHOR = AlgorithmEnum::ANCHOR;
+  static constexpr AlgorithmType VHGW = AlgorithmEnum::VHGW;
+#endif
+
   /** Set kernel (structuring element). */
   void
   SetKernel(const KernelType & kernel) override;
 
   /** Set/Get the backend filter class. */
   void
-  SetAlgorithm(int algo);
-
-  itkGetConstMacro(Algorithm, int);
+  SetAlgorithm(AlgorithmEnum algo);
+  itkGetConstMacro(Algorithm, AlgorithmEnum);
 
   /** MorphologicalGradientImageFilter need to set its internal filters as
     modified */
   void
   Modified() const override;
-
-  /** define values used to determine which algorithm to use */
-  enum AlgorithmType
-  {
-    BASIC = 0,
-    HISTO = 1,
-    ANCHOR = 2,
-    VHGW = 3
-  };
 
 protected:
   MorphologicalGradientImageFilter();
@@ -142,7 +146,7 @@ private:
   typename VHGWErodeFilterType::Pointer m_VanHerkGilWermanErodeFilter;
 
   // and the name of the filter
-  int m_Algorithm;
+  AlgorithmEnum m_Algorithm;
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.hxx
@@ -35,7 +35,7 @@ MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::Morphologi
   m_AnchorErodeFilter = AnchorErodeFilterType::New();
   m_VanHerkGilWermanDilateFilter = VHGWDilateFilterType::New();
   m_VanHerkGilWermanErodeFilter = VHGWErodeFilterType::New();
-  m_Algorithm = HISTO;
+  m_Algorithm = AlgorithmEnum::HISTO;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
@@ -48,13 +48,13 @@ MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::SetKernel(
   {
     m_AnchorDilateFilter->SetKernel(*flatKernel);
     m_AnchorErodeFilter->SetKernel(*flatKernel);
-    m_Algorithm = ANCHOR;
+    m_Algorithm = AlgorithmEnum::ANCHOR;
   }
   else if (m_HistogramFilter->GetUseVectorBasedAlgorithm())
   {
     // histogram based filter is as least as good as the basic one, so always
     // use it
-    m_Algorithm = HISTO;
+    m_Algorithm = AlgorithmEnum::HISTO;
     m_HistogramFilter->SetKernel(kernel);
   }
   else
@@ -71,11 +71,11 @@ MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::SetKernel(
     {
       m_BasicDilateFilter->SetKernel(kernel);
       m_BasicErodeFilter->SetKernel(kernel);
-      m_Algorithm = BASIC;
+      m_Algorithm = AlgorithmEnum::BASIC;
     }
     else
     {
-      m_Algorithm = HISTO;
+      m_Algorithm = AlgorithmEnum::HISTO;
     }
   }
 
@@ -84,27 +84,27 @@ MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::SetKernel(
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 void
-MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(int algo)
+MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::SetAlgorithm(AlgorithmEnum algo)
 {
   const auto * flatKernel = dynamic_cast<const FlatKernelType *>(&this->GetKernel());
 
   if (m_Algorithm != algo)
   {
-    if (algo == BASIC)
+    if (algo == AlgorithmEnum::BASIC)
     {
       m_BasicDilateFilter->SetKernel(this->GetKernel());
       m_BasicErodeFilter->SetKernel(this->GetKernel());
     }
-    else if (algo == HISTO)
+    else if (algo == AlgorithmEnum::HISTO)
     {
       m_HistogramFilter->SetKernel(this->GetKernel());
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == ANCHOR)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::ANCHOR)
     {
       m_AnchorDilateFilter->SetKernel(*flatKernel);
       m_AnchorErodeFilter->SetKernel(*flatKernel);
     }
-    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == VHGW)
+    else if (flatKernel != nullptr && flatKernel->GetDecomposable() && algo == AlgorithmEnum::VHGW)
     {
       m_VanHerkGilWermanDilateFilter->SetKernel(*flatKernel);
       m_VanHerkGilWermanErodeFilter->SetKernel(*flatKernel);
@@ -132,7 +132,7 @@ MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::GenerateDa
   this->AllocateOutputs();
 
   // Delegate to a dilate filter.
-  if (m_Algorithm == BASIC)
+  if (m_Algorithm == AlgorithmEnum::BASIC)
   {
     // Use itk::BasicDilateImageFilter
     m_BasicDilateFilter->SetInput(this->GetInput());
@@ -150,7 +150,7 @@ MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::GenerateDa
     sub->Update();
     this->GraftOutput(sub->GetOutput());
   }
-  else if (m_Algorithm == HISTO)
+  else if (m_Algorithm == AlgorithmEnum::HISTO)
   {
     // Use itk::MovingHistogramDilateImageFilter
     m_HistogramFilter->SetInput(this->GetInput());
@@ -160,7 +160,7 @@ MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::GenerateDa
     m_HistogramFilter->Update();
     this->GraftOutput(m_HistogramFilter->GetOutput());
   }
-  else if (m_Algorithm == ANCHOR)
+  else if (m_Algorithm == AlgorithmEnum::ANCHOR)
   {
     // Use itk::AnchorDilateImageFilter
     m_AnchorDilateFilter->SetInput(this->GetInput());
@@ -178,7 +178,7 @@ MorphologicalGradientImageFilter<TInputImage, TOutputImage, TKernel>::GenerateDa
     sub->Update();
     this->GraftOutput(sub->GetOutput());
   }
-  else if (m_Algorithm == VHGW)
+  else if (m_Algorithm == AlgorithmEnum::VHGW)
   {
     // Use itk::VanHerkGilWermanDilateImageFilter
     m_VanHerkGilWermanDilateFilter->SetInput(this->GetInput());

--- a/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.h
@@ -19,9 +19,12 @@
 #define itkWhiteTopHatImageFilter_h
 
 #include "itkKernelImageFilter.h"
+#include "itkMathematicalMorphologyEnums.h"
+
 
 namespace itk
 {
+
 /** \class WhiteTopHatImageFilter
  * \brief White top hat extracts local maxima that are larger than the structuring element
  *
@@ -65,6 +68,19 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
+  using AlgorithmEnum = MathematicalMorphologyEnums::Algorithm;
+
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Backwards compatibility for enum values */
+  using AlgorithmType = AlgorithmEnum;
+  // We need to expose the enum values at the class level
+  // for backwards compatibility
+  static constexpr AlgorithmType BASIC = AlgorithmEnum::BASIC;
+  static constexpr AlgorithmType HISTO = AlgorithmEnum::HISTO;
+  static constexpr AlgorithmType ANCHOR = AlgorithmEnum::ANCHOR;
+  static constexpr AlgorithmType VHGW = AlgorithmEnum::VHGW;
+#endif
+
   /** Standard New method. */
   itkNewMacro(Self);
 
@@ -77,18 +93,9 @@ public:
   itkGetConstReferenceMacro(SafeBorder, bool);
   itkBooleanMacro(SafeBorder);
 
-  /** define values used to determine which algorithm to use */
-  enum AlgorithmType
-  {
-    BASIC = 0,
-    HISTO = 1,
-    ANCHOR = 2,
-    VHGW = 3
-  };
-
   /** Set/Get the backend filter class. */
-  itkSetMacro(Algorithm, int);
-  itkGetConstMacro(Algorithm, int);
+  itkSetMacro(Algorithm, AlgorithmEnum);
+  itkGetConstMacro(Algorithm, AlgorithmEnum);
 
   itkSetMacro(ForceAlgorithm, bool);
   itkGetConstReferenceMacro(ForceAlgorithm, bool);
@@ -106,7 +113,7 @@ protected:
 private:
   bool m_SafeBorder;
 
-  int m_Algorithm;
+  AlgorithmEnum m_Algorithm;
 
   bool m_ForceAlgorithm;
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.hxx
@@ -30,7 +30,7 @@ template <typename TInputImage, typename TOutputImage, typename TKernel>
 WhiteTopHatImageFilter<TInputImage, TOutputImage, TKernel>::WhiteTopHatImageFilter()
 {
   m_SafeBorder = true;
-  m_Algorithm = HISTO;
+  m_Algorithm = AlgorithmEnum::HISTO;
   m_ForceAlgorithm = false;
 }
 

--- a/Modules/Filtering/MathematicalMorphology/itk-module.cmake
+++ b/Modules/Filtering/MathematicalMorphology/itk-module.cmake
@@ -4,6 +4,7 @@ dilation, opening and closing filters, you will find here geodesic operations,
 maxima and minima filters, and reconstruction filters.")
 
 itk_module(ITKMathematicalMorphology
+  ENABLE_SHARED
   DEPENDS
     ITKImageIntensity
   COMPILE_DEPENDS

--- a/Modules/Filtering/MathematicalMorphology/src/CMakeLists.txt
+++ b/Modules/Filtering/MathematicalMorphology/src/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(ITKMathematicalMorphology_SRCS
+  itkMathematicalMorphologyEnums.cxx
+)
+
+itk_module_add_library(ITKMathematicalMorphology ${ITKMathematicalMorphology_SRCS})

--- a/Modules/Filtering/MathematicalMorphology/src/itkMathematicalMorphologyEnums.cxx
+++ b/Modules/Filtering/MathematicalMorphology/src/itkMathematicalMorphologyEnums.cxx
@@ -1,0 +1,44 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkMathematicalMorphologyEnums.h"
+
+namespace itk
+{
+
+std::ostream &
+operator<<(std::ostream & out, const MathematicalMorphologyEnums::Algorithm value)
+{
+  return out << [value] {
+    switch (value)
+    {
+      case MathematicalMorphologyEnums::Algorithm::BASIC:
+        return "itk::MathematicalMorphologyEnums::Algorithm::BASIC";
+      case MathematicalMorphologyEnums::Algorithm::HISTO:
+        return "itk::MathematicalMorphologyEnums::Algorithm::HISTO";
+      case MathematicalMorphologyEnums::Algorithm::ANCHOR:
+        return "itk::MathematicalMorphologyEnums::Algorithm::ANCHOR";
+      case MathematicalMorphologyEnums::Algorithm::VHGW:
+        return "itk::MathematicalMorphologyEnums::Algorithm::VHGW";
+      default:
+        return "INVALID VALUE FOR itk::MathematicalMorphologyEnums::Algorithm";
+    }
+  }();
+}
+
+} // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
@@ -62,7 +62,7 @@ itkGrayscaleDilateImageFilterTest(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
-  if (filter->GetAlgorithm() != FilterType::HISTO)
+  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
   {
     std::cerr << "Wrong default algorithm." << std::endl;
     return EXIT_FAILURE;
@@ -76,19 +76,19 @@ itkGrayscaleDilateImageFilterTest(int ac, char * av[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
-    filter->SetAlgorithm(FilterType::BASIC);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
     writer->SetFileName(av[2]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::HISTO);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
     writer->SetFileName(av[3]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::ANCHOR);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
     writer->SetFileName(av[4]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::VHGW);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
     writer->SetFileName(av[5]);
     writer->Update();
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
@@ -62,7 +62,7 @@ itkGrayscaleErodeImageFilterTest(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
-  if (filter->GetAlgorithm() != FilterType::HISTO)
+  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
   {
     std::cerr << "Wrong default algorithm." << std::endl;
     return EXIT_FAILURE;
@@ -76,19 +76,19 @@ itkGrayscaleErodeImageFilterTest(int ac, char * av[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
-    filter->SetAlgorithm(FilterType::BASIC);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
     writer->SetFileName(av[2]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::HISTO);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
     writer->SetFileName(av[3]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::ANCHOR);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
     writer->SetFileName(av[4]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::VHGW);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
     writer->SetFileName(av[5]);
     writer->Update();
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
@@ -62,7 +62,7 @@ itkGrayscaleMorphologicalClosingImageFilterTest2(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
-  if (filter->GetAlgorithm() != FilterType::HISTO)
+  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
   {
     std::cerr << "Wrong default algorithm." << std::endl;
     return EXIT_FAILURE;
@@ -83,19 +83,19 @@ itkGrayscaleMorphologicalClosingImageFilterTest2(int ac, char * av[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
-    filter->SetAlgorithm(FilterType::BASIC);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
     writer->SetFileName(av[2]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::HISTO);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
     writer->SetFileName(av[3]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::ANCHOR);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
     writer->SetFileName(av[4]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::VHGW);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
     writer->SetFileName(av[5]);
     writer->Update();
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
@@ -62,7 +62,7 @@ itkMapGrayscaleDilateImageFilterTest(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
-  if (filter->GetAlgorithm() != FilterType::HISTO)
+  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
   {
     std::cerr << "Wrong default algorithm." << std::endl;
     return EXIT_FAILURE;
@@ -76,19 +76,19 @@ itkMapGrayscaleDilateImageFilterTest(int ac, char * av[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
-    filter->SetAlgorithm(FilterType::BASIC);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
     writer->SetFileName(av[2]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::HISTO);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
     writer->SetFileName(av[3]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::ANCHOR);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
     writer->SetFileName(av[4]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::VHGW);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
     writer->SetFileName(av[5]);
     writer->Update();
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
@@ -62,7 +62,7 @@ itkMapGrayscaleErodeImageFilterTest(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
-  if (filter->GetAlgorithm() != FilterType::HISTO)
+  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
   {
     std::cerr << "Wrong default algorithm." << std::endl;
     return EXIT_FAILURE;
@@ -76,19 +76,19 @@ itkMapGrayscaleErodeImageFilterTest(int ac, char * av[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
-    filter->SetAlgorithm(FilterType::BASIC);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
     writer->SetFileName(av[2]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::HISTO);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
     writer->SetFileName(av[3]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::ANCHOR);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
     writer->SetFileName(av[4]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::VHGW);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
     writer->SetFileName(av[5]);
     writer->Update();
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
@@ -62,7 +62,7 @@ itkMapGrayscaleMorphologicalClosingImageFilterTest(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
-  if (filter->GetAlgorithm() != FilterType::HISTO)
+  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
   {
     std::cerr << "Wrong default algorithm." << std::endl;
     return EXIT_FAILURE;
@@ -83,19 +83,19 @@ itkMapGrayscaleMorphologicalClosingImageFilterTest(int ac, char * av[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
-    filter->SetAlgorithm(FilterType::BASIC);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
     writer->SetFileName(av[2]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::HISTO);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
     writer->SetFileName(av[3]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::ANCHOR);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
     writer->SetFileName(av[4]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::VHGW);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
     writer->SetFileName(av[5]);
     writer->Update();
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
@@ -62,7 +62,7 @@ itkMapGrayscaleMorphologicalOpeningImageFilterTest(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
-  if (filter->GetAlgorithm() != FilterType::HISTO)
+  if (filter->GetAlgorithm() != FilterType::AlgorithmEnum::HISTO)
   {
     std::cerr << "Wrong default algorithm." << std::endl;
     return EXIT_FAILURE;
@@ -83,19 +83,19 @@ itkMapGrayscaleMorphologicalOpeningImageFilterTest(int ac, char * av[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
-    filter->SetAlgorithm(FilterType::BASIC);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
     writer->SetFileName(av[2]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::HISTO);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
     writer->SetFileName(av[3]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::ANCHOR);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
     writer->SetFileName(av[4]);
     writer->Update();
 
-    filter->SetAlgorithm(FilterType::VHGW);
+    filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
     writer->SetFileName(av[5]);
     writer->Update();
   }

--- a/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest2.cxx
@@ -53,7 +53,7 @@ itkMorphologicalGradientImageFilterTest2(int argc, char * argv[])
   gradient->SetKernel(structuringElement);
   itk::SimpleFilterWatcher watcher(gradient);
 
-  const int algorithmType = gradient->GetAlgorithm();
+  const GradientType::AlgorithmEnum algorithmType = gradient->GetAlgorithm();
   std::cout << "algorithmType : " << algorithmType << std::endl;
 
   using WriterType = itk::ImageFileWriter<IType>;
@@ -75,9 +75,9 @@ itkMorphologicalGradientImageFilterTest2(int argc, char * argv[])
   try
   {
     structuringElement.SetRadius(4);
-    gradient->SetAlgorithm(0);
+    gradient->SetAlgorithm(GradientType::AlgorithmEnum::BASIC);
     gradient->Update();
-    const int algorithmType1 = gradient->GetAlgorithm();
+    const GradientType::AlgorithmEnum algorithmType1 = gradient->GetAlgorithm();
     std::cout << "algorithmType1 : " << algorithmType1 << std::endl;
   }
   catch (const itk::ExceptionObject & e)
@@ -96,14 +96,14 @@ itkMorphologicalGradientImageFilterTest2(int argc, char * argv[])
     Gradient1Type::Pointer gradient1 = Gradient1Type::New();
     gradient1->SetInput(reader->GetOutput());
     gradient1->SetKernel(structuringElement2);
-    gradient1->SetAlgorithm(3);
+    gradient1->SetAlgorithm(GradientType::AlgorithmEnum::VHGW);
     gradient1->Update();
-    const int algorithmType2 = gradient1->GetAlgorithm();
+    const GradientType::AlgorithmEnum algorithmType2 = gradient1->GetAlgorithm();
     std::cout << "algorithmType : " << algorithmType2 << std::endl;
 
-    gradient1->SetAlgorithm(2);
+    gradient1->SetAlgorithm(GradientType::AlgorithmEnum::ANCHOR);
     gradient1->Update();
-    const int algorithmType3 = gradient1->GetAlgorithm();
+    const GradientType::AlgorithmEnum algorithmType3 = gradient1->GetAlgorithm();
     std::cout << "algorithmType : " << algorithmType3 << std::endl;
   }
   catch (const itk::ExceptionObject & e)

--- a/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkBlackTopHatImageFilter.h"
 #include "itkWhiteTopHatImageFilter.h"
+#include "itkMathematicalMorphologyEnums.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkImageFileReader.h"
@@ -27,13 +28,13 @@
 
 template <typename TKernelImageFilter>
 int
-itkTopHatImageFilterTestHelper(TKernelImageFilter *                    filter,
-                               typename TKernelImageFilter::KernelType ball,
-                               const bool                              safeBorder,
-                               const int                               algorithm,
-                               const bool                              forceAlgorithm,
-                               const char *                            inputFileName,
-                               const char *                            outputFileName)
+itkTopHatImageFilterTestHelper(TKernelImageFilter *                              filter,
+                               typename TKernelImageFilter::KernelType           ball,
+                               const bool                                        safeBorder,
+                               const itk::MathematicalMorphologyEnums::Algorithm algorithm,
+                               const bool                                        forceAlgorithm,
+                               const char *                                      inputFileName,
+                               const char *                                      outputFileName)
 {
   // Declare the reader and writer
   using ReaderType = itk::ImageFileReader<typename TKernelImageFilter::InputImageType>;
@@ -112,9 +113,9 @@ itkTopHatImageFilterTest(int argc, char * argv[])
   ball.SetRadius(ballSize);
   ball.CreateStructuringElement();
 
-  auto safeBorder = static_cast<bool>(std::stoi(argv[5]));
-  int  algorithm;
-  auto forceAlgorithm = static_cast<bool>(std::stoi(argv[7]));
+  auto                                        safeBorder = static_cast<bool>(std::stoi(argv[5]));
+  itk::MathematicalMorphologyEnums::Algorithm algorithm;
+  auto                                        forceAlgorithm = static_cast<bool>(std::stoi(argv[7]));
 
   switch (std::stoi(argv[3]))
   {
@@ -127,7 +128,7 @@ itkTopHatImageFilterTest(int argc, char * argv[])
       ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BlackTopHatImageFilter, KernelImageFilter);
 
 
-      algorithm = static_cast<BlackFilterType::AlgorithmType>(std::stoi(argv[6]));
+      algorithm = static_cast<BlackFilterType::AlgorithmEnum>(std::stoi(argv[6]));
       return itkTopHatImageFilterTestHelper<BlackFilterType>(
         filter, ball, safeBorder, algorithm, forceAlgorithm, inputFileName, outputFileName);
 
@@ -142,7 +143,7 @@ itkTopHatImageFilterTest(int argc, char * argv[])
       ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, WhiteTopHatImageFilter, KernelImageFilter);
 
 
-      algorithm = static_cast<WhiteFilterType::AlgorithmType>(std::stoi(argv[6]));
+      algorithm = static_cast<WhiteFilterType::AlgorithmEnum>(std::stoi(argv[6]));
       return itkTopHatImageFilterTestHelper<WhiteFilterType>(
         filter, ball, safeBorder, algorithm, forceAlgorithm, inputFileName, outputFileName);
 

--- a/Modules/Filtering/MathematicalMorphology/wrapping/itkMathematicalMorphologyEnums.wrap
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/itkMathematicalMorphologyEnums.wrap
@@ -1,0 +1,1 @@
+itk_wrap_simple_class("itk::MathematicalMorphologyEnums")


### PR DESCRIPTION
Use strongly typed enums for the `Algorithm` type in math morphology.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5