### PR TITLE
DOC: Improve math morphology class documentation

### DIFF
--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
  * by the intensity value "SetForegroundValue()" (alias as SetDilateValue()) is considered
  * as foreground, and other intensity values are considered background.
  *
- * Gray scale images can be processed as binary images by selecting a
+ * Grayscale images can be processed as binary images by selecting a
  * "ForegroundValue" (alias "DilateValue").  Pixel values matching the dilate value are
  * considered the "foreground" and all other pixels are
  * "background". This is useful in processing segmented images where

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
  * by the intensity value "SetForegroundValue()" (alias as SetErodeValue()) is considered
  * as foreground, and other intensity values are considered background.
  *
- * Gray scale images can be processed as binary images by selecting a
+ * Grayscale images can be processed as binary images by selecting a
  * "ForegroundValue" (alias "ErodeValue").  Pixel values matching the erode value are
  * considered the "foreground" and all other pixels are
  * "background". This is useful in processing segmented images where

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  * for arbitrary size and shape". IEEE Transactions on Image
  * Processing. Vol. 9. No. 3. 2000. pp. 283-286.
  *
- * Gray scale images can be processed as binary images by selecting a
+ * Grayscale images can be processed as binary images by selecting a
  * "ForegroundValued" (which subclasses may alias as "DilateValue" or
  * "ErodeValue").  Pixel not matching the foreground value are
  * considered "background".  This is useful in processing segmented

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.h
@@ -24,7 +24,7 @@ namespace itk
 {
 /**
  * \class BasicDilateImageFilter
- * \brief gray scale dilation of an image
+ * \brief Grayscale dilation of an image.
  *
  * Dilate an image using grayscale morphology. Dilation takes the
  * maximum of all the pixels identified by the structuring element.

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 /** \class BasicErodeImageFilter
- * \brief gray scale erosion of an image
+ * \brief Grayscale erosion of an image.
  *
  * Erode an image using grayscale morphology. Erosion takes the
  * minimum of all the pixels identified by the structuring element.

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 /** \class GrayscaleFunctionDilateImageFilter
- * \brief gray scale function dilation of an image
+ * \brief Grayscale function dilation of an image.
  *
  * Dilate an image using functional grayscale morphology. Function
  * dilation takes the maximum of all the pixels identified by the
@@ -40,7 +40,7 @@ namespace itk
  *   - Evaluate() member function returns the maximum value among
  *     the image neighbors plus the kernel value where the kernel has
  *     elements > 0.
- *   - Replace the original value with the max value
+ *   - Replace the original value with the max value.
  *
  * \sa MorphologyImageFilter, GrayscaleDilateImageFilter, BinaryDilateImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 /** \class GrayscaleFunctionErodeImageFilter
- * \brief gray scale function erosion of an image
+ * \brief Grayscale function erosion of an image.
  *
  * Erode an image using functional grayscale morphology. Function
  * erosion takes the minimum of all the pixels identified by the

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 /** \class GrayscaleGeodesicDilateImageFilter
- * \brief geodesic gray scale dilation of an image
+ * \brief Geodesic grayscale dilation of an image.
  *
  * Geodesic dilation operates on a "marker" image and a "mask"
  * image. The marker image is dilated using an elementary structuring

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
@@ -34,10 +34,9 @@ namespace itk
 {
 /**
  * \class GrayscaleMorphologicalClosingImageFilter
- * \brief gray scale dilation of an image
+ * \brief Grayscale closing of an image.
  *
- * Erode an image using grayscale morphology. Dilation takes the
- * maximum of all the pixels identified by the structuring element.
+ * Close an image using grayscale morphology.
  *
  * The structuring element is assumed to be composed of binary
  * values (zero or one). Only elements of the structuring element

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
@@ -33,10 +33,9 @@ namespace itk
 {
 /**
  * \class GrayscaleMorphologicalOpeningImageFilter
- * \brief gray scale dilation of an image
+ * \brief Grayscale opening of an image.
  *
- * Dilate an image using grayscale morphology. Dilation takes the
- * maximum of all the pixels identified by the structuring element.
+ * Open an image using grayscale morphology.
  *
  * The structuring element is assumed to be composed of binary
  * values (zero or one). Only elements of the structuring element

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.h
@@ -34,10 +34,7 @@ namespace itk
 {
 /**
  * \class MorphologicalGradientImageFilter
- * \brief gray scale dilation of an image
- *
- * Dilate an image using grayscale morphology. Dilation takes the
- * maximum of all the pixels identified by the structuring element.
+ * \brief Compute the gradient of a grayscale image.
  *
  * The structuring element is assumed to be composed of binary
  * values (zero or one). Only elements of the structuring element

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramDilateImageFilter.h
@@ -25,7 +25,7 @@ namespace itk
 {
 /**
  * \class MovingHistogramDilateImageFilter
- * \brief gray scale dilation of an image
+ * \brief Grayscale dilation of an image.
  *
  * Dilate an image using grayscale morphology. Dilation takes the
  * maximum of all the pixels identified by the structuring element.

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramErodeImageFilter.h
@@ -24,7 +24,7 @@ namespace itk
 {
 /**
  * \class MovingHistogramErodeImageFilter
- * \brief gray scale erosion of an image
+ * \brief Grayscale erosion of an image.
  *
  * Erode an image using grayscale morphology. Erode takes the
  * minimum of all the pixels identified by the structuring element.


### PR DESCRIPTION
Improve documentation of classes in `BinaryMathematicalMorphology` and
`MathematicalMorphology` modules:
- Fix class brief descriptions to match the purpose of the filter.
- Remove wrong descriptions/descriptions corresponding to other filters.
- Fix spelling of `grayscale`.
- Capitalize the `\brief` description as a sentence and use punctuation.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)