### PR TITLE
COMP: Fix missing initialization braces warnings

### DIFF
--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
@@ -118,21 +118,21 @@ TEST_F(PasteFixture, ConstantPaste)
   auto inputImage = Utils::CreateImage(100);
 
   filter->SetDestinationImage(inputImage);
-  filter->SetDestinationIndex({ 11, 13 });
+  filter->SetDestinationIndex({ { 11, 13 } });
 
   constexpr int constantValue = -97;
   filter->SetConstant(constantValue);
-  filter->SetSourceRegion(Utils::SizeType{ 3, 3 });
+  filter->SetSourceRegion(Utils::SizeType{ { 3, 3 } });
 
   filter->SetNumberOfWorkUnits(1);
   filter->UpdateLargestPossibleRegion();
 
   auto outputImage = filter->GetOutput();
-  EXPECT_EQ(0, outputImage->GetPixel({ 10, 13 }));
-  EXPECT_EQ(0, outputImage->GetPixel({ 11, 12 }));
+  EXPECT_EQ(0, outputImage->GetPixel({ { 10, 13 } }));
+  EXPECT_EQ(0, outputImage->GetPixel({ { 11, 12 } }));
 
-  EXPECT_EQ(constantValue, outputImage->GetPixel({ 11, 13 }));
-  EXPECT_EQ(constantValue, outputImage->GetPixel({ 13, 15 }));
+  EXPECT_EQ(constantValue, outputImage->GetPixel({ { 11, 13 } }));
+  EXPECT_EQ(constantValue, outputImage->GetPixel({ { 13, 15 } }));
 
   EXPECT_EQ("e73092e3e58f66f13d32a5aca97ca1d9", MD5Hash(filter->GetOutput()));
 
@@ -141,22 +141,22 @@ TEST_F(PasteFixture, ConstantPaste)
   EXPECT_EQ("e73092e3e58f66f13d32a5aca97ca1d9", MD5Hash(filter->GetOutput()));
 
 
-  filter->SetSourceRegion(Utils::SizeType{ 2, 1 });
+  filter->SetSourceRegion(Utils::SizeType{ { 2, 1 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("47e4689dc4a86bc6da9eeb9ce0326fa7", MD5Hash(filter->GetOutput()));
 
 
-  filter->SetSourceRegion(Utils::SizeType{ 1, 5 });
+  filter->SetSourceRegion(Utils::SizeType{ { 1, 5 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("2bd084a4aa4696409b6019438ef1313f", MD5Hash(filter->GetOutput()));
 
 
-  filter->SetSourceRegion(Utils::SizeType{ 1, 3 });
+  filter->SetSourceRegion(Utils::SizeType{ { 1, 3 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("07f0acc6e11ac92b5ea5dfd8ae3f9209", MD5Hash(filter->GetOutput()));
 
 
-  filter->SetSourceRegion(Utils::SizeType{ 1, 1 });
+  filter->SetSourceRegion(Utils::SizeType{ { 1, 1 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("2a9bfc9d4548a986f52fb3ba2ae07de2", MD5Hash(filter->GetOutput()));
 }
@@ -179,49 +179,48 @@ TEST_F(PasteFixture, ConstantPaste3_2)
 
   filter->SetDestinationImage(inputImage);
 
-  filter->SetDestinationIndex({ 11, 13, 17 });
-  filter->SetDestinationSkipAxes(SkipType({ true, false, false }));
-  filter->SetSourceRegion(Utils::SourceSizeType{ 5, 6 });
+  filter->SetDestinationIndex({ { 11, 13, 17 } });
+  filter->SetDestinationSkipAxes(SkipType{ { { true, false, false } } });
+  filter->SetSourceRegion(Utils::SourceSizeType{ { 5, 6 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("dfdbfe702adeccece580c5e0795d8f0a", MD5Hash(filter->GetOutput()));
 
-  EXPECT_EQ(0, filter->GetOutput()->GetPixel({ 0, 0, 0 }));
+  EXPECT_EQ(0, filter->GetOutput()->GetPixel({ { 0, 0, 0 } }));
 
 
-  filter->SetDestinationIndex({ 11, 13, 17 });
-  filter->SetDestinationSkipAxes(SkipType({ false, false, true }));
-  filter->SetSourceRegion(Utils::SourceSizeType{ 5, 6 });
+  filter->SetDestinationIndex({ { 11, 13, 17 } });
+  filter->SetDestinationSkipAxes(SkipType{ { { false, false, true } } });
+  filter->SetSourceRegion(Utils::SourceSizeType{ { 5, 6 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("7bca1328ead4ab2c6b89e1cdd1e3fdad", MD5Hash(filter->GetOutput()));
 
-  filter->SetDestinationIndex({ 11, 13, 17 });
-  filter->SetDestinationSkipAxes(SkipType({ false, false, true }));
-  filter->SetSourceRegion(Utils::SourceSizeType{ 5, 6 });
+  filter->SetDestinationIndex({ { 11, 13, 17 } });
+  filter->SetDestinationSkipAxes(SkipType{ { { false, false, true } } });
+  filter->SetSourceRegion(Utils::SourceSizeType{ { 5, 6 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("7bca1328ead4ab2c6b89e1cdd1e3fdad", MD5Hash(filter->GetOutput()));
 
 
-  filter->SetDestinationIndex({ 11, 13, 17 });
-  filter->SetDestinationSkipAxes(SkipType({ true, false, false }));
-  filter->SetSourceRegion(Utils::SourceSizeType{ 1, 1 });
+  filter->SetDestinationIndex({ { 11, 13, 17 } });
+  filter->SetDestinationSkipAxes(SkipType{ { { true, false, false } } });
+  filter->SetSourceRegion(Utils::SourceSizeType{ { 1, 1 } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("2e40b486120da8d8a225d9ab505bc580", MD5Hash(filter->GetOutput()));
 
 
-  filter->SetDestinationIndex({ 11, 13, 17 });
-  filter->SetSourceRegion(Utils::SourceSizeType{ 1, 1 });
-  filter->SetDestinationSkipAxes(SkipType({ true, true, true }));
+  filter->SetDestinationIndex({ { 11, 13, 17 } });
+  filter->SetSourceRegion(Utils::SourceSizeType{ { 1, 1 } });
+  filter->SetDestinationSkipAxes(SkipType{ { { true, true, true } } });
   EXPECT_THROW(filter->VerifyPreconditions(), itk::ExceptionObject);
 
 
-  filter->SetDestinationSkipAxes(SkipType({ false, true, true }));
+  filter->SetDestinationSkipAxes(SkipType{ { { false, true, true } } });
   EXPECT_THROW(filter->VerifyPreconditions(), itk::ExceptionObject);
 
 
-  filter->SetDestinationSkipAxes(SkipType({ true, true, false }));
+  filter->SetDestinationSkipAxes(SkipType{ { { true, true, false } } });
   EXPECT_THROW(filter->VerifyPreconditions(), itk::ExceptionObject);
 }
-
 TEST_F(PasteFixture, InPlace)
 {
   // test case were source and destination are the same image.
@@ -232,14 +231,14 @@ TEST_F(PasteFixture, InPlace)
 
 
   constexpr int constantValue = 99;
-  inputImage->SetPixel(Utils::IndexType{ 1, 1 }, constantValue);
+  inputImage->SetPixel(Utils::IndexType{ { 1, 1 } }, constantValue);
 
   filter->SetDestinationImage(inputImage);
   filter->SetSourceImage(inputImage);
   filter->InPlaceOn();
 
-  filter->SetSourceRegion(Utils::SourceSizeType{ 2, 2 });
-  filter->SetDestinationIndex({ 5, 5 });
+  filter->SetSourceRegion(Utils::SourceSizeType{ { 2, 2 } });
+  filter->SetDestinationIndex({ { 5, 5 } });
 
   EXPECT_FALSE(filter->CanRunInPlace());
 
@@ -247,19 +246,19 @@ TEST_F(PasteFixture, InPlace)
 
   auto outputImage = filter->GetOutput();
 
-  EXPECT_EQ(constantValue, outputImage->GetPixel(Utils::IndexType{ 1, 1 }));
-  EXPECT_EQ(constantValue, outputImage->GetPixel(Utils::IndexType{ 6, 6 }));
+  EXPECT_EQ(constantValue, outputImage->GetPixel(Utils::IndexType{ { 1, 1 } }));
+  EXPECT_EQ(constantValue, outputImage->GetPixel(Utils::IndexType{ { 6, 6 } }));
 
   EXPECT_EQ("0daa5bf5670eb8df504b63ddcf51d81e", MD5Hash(outputImage));
   ASSERT_NE(nullptr, inputImage->GetBufferPointer());
 
   auto sourceImage = Utils::CreateSourceImage(5);
-  sourceImage->SetPixel(Utils::IndexType{ 1, 3 }, constantValue);
+  sourceImage->SetPixel(Utils::IndexType{ { 1, 3 } }, constantValue);
   filter->SetSourceImage(sourceImage);
 
 
   filter->SetSourceRegion(sourceImage->GetLargestPossibleRegion().GetSize());
-  filter->SetDestinationIndex({ 3, 3 });
+  filter->SetDestinationIndex({ { 3, 3 } });
 
   EXPECT_TRUE(filter->CanRunInPlace());
 
@@ -268,8 +267,8 @@ TEST_F(PasteFixture, InPlace)
   outputImage = filter->GetOutput();
 
   EXPECT_EQ(nullptr, inputImage->GetBufferPointer());
-  EXPECT_EQ(constantValue, outputImage->GetPixel(Utils::IndexType{ 4, 6 }));
-  EXPECT_EQ(0, outputImage->GetPixel(Utils::IndexType{ 1, 3 }));
+  EXPECT_EQ(constantValue, outputImage->GetPixel(Utils::IndexType{ { 4, 6 } }));
+  EXPECT_EQ(0, outputImage->GetPixel(Utils::IndexType{ { 1, 3 } }));
   EXPECT_EQ("31625a3e3a34a5df00a719861d3a89da", MD5Hash(outputImage));
 }
 
@@ -294,22 +293,22 @@ TEST_F(PasteFixture, Paste3_2)
 
   filter->SetNumberOfWorkUnits(25);
 
-  filter->SetDestinationIndex({ 11, 13, 17 });
+  filter->SetDestinationIndex({ { 11, 13, 17 } });
   filter->SetSourceRegion(sourceImage->GetLargestPossibleRegion());
 
-  filter->SetDestinationSkipAxes(SkipType({ true, false, false }));
+  filter->SetDestinationSkipAxes(SkipType{ { { true, false, false } } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("753e433a43ab8fcf3d2ef0f8c78aef35", MD5Hash(filter->GetOutput()));
-  EXPECT_EQ(0, filter->GetOutput()->GetPixel({ 12, 13, 17 }));
+  EXPECT_EQ(0, filter->GetOutput()->GetPixel({ { 12, 13, 17 } }));
 
-  filter->SetDestinationSkipAxes(SkipType({ false, true, false }));
+  filter->SetDestinationSkipAxes(SkipType{ { { false, true, false } } });
   filter->UpdateLargestPossibleRegion();
-  EXPECT_EQ(0, filter->GetOutput()->GetPixel({ 11, 14, 17 }));
+  EXPECT_EQ(0, filter->GetOutput()->GetPixel({ { 11, 14, 17 } }));
   EXPECT_EQ("44bd0a10b89c58fd306beee6148fdb4d", MD5Hash(filter->GetOutput()));
 
 
-  filter->SetDestinationSkipAxes(SkipType({ false, false, true }));
+  filter->SetDestinationSkipAxes(SkipType{ { { false, false, true } } });
   filter->UpdateLargestPossibleRegion();
   EXPECT_EQ("ce630d54304b6eba8cd73ec9617d2cf4", MD5Hash(filter->GetOutput()));
-  EXPECT_EQ(0, filter->GetOutput()->GetPixel({ 11, 13, 18 }));
+  EXPECT_EQ(0, filter->GetOutput()->GetPixel({ { 11, 13, 18 } }));
 }


### PR DESCRIPTION
Fix missing initialization braces warnings.

Fixes:
```
[CTest: warning matched]
/Users/builder/externalModules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx:121:33:
warning: suggest braces around initialization of subobject
[-Wmissing-braces]
  filter->SetDestinationIndex({ 11, 13 });
                                ^~~~~~
				{     }
```

and warnings of the same kind reported at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=6799229

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)