### PR TITLE
COMP: Fix warning -Wdeprecated-copy in itkQuadEdgeMeshBaseIterator

### DIFF
--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -89,6 +89,8 @@ public:
     , m_Start(start)
   {}
 
+  QuadEdgeMeshBaseIterator(const QuadEdgeMeshBaseIterator & other) = default;
+
   virtual ~QuadEdgeMeshBaseIterator() = default;
 
   Self &
@@ -254,6 +256,8 @@ public:
     : Superclass(e, op, start)
   {}
 
+  QuadEdgeMeshIterator(const QuadEdgeMeshIterator & other) = default;
+
   ~QuadEdgeMeshIterator() override = default;
 
   QuadEdgeType *
@@ -291,6 +295,9 @@ public:
                            bool           start = true)
     : Superclass(e, op, start)
   {}
+
+  QuadEdgeMeshIteratorGeom(const QuadEdgeMeshIteratorGeom & other) = default;
+
   OriginRefType operator*() { return (this->m_Iterator->GetOrigin()); }
 };
 
@@ -317,6 +324,8 @@ public:
                             bool                 start = true)
     : Superclass(const_cast<QuadEdgeType *>(e), op, start)
   {}
+
+  QuadEdgeMeshConstIterator(const QuadEdgeMeshConstIterator & other) = default;
 
   ~QuadEdgeMeshConstIterator() override = default;
 
@@ -362,6 +371,8 @@ public:
                                 bool                 start = true)
     : Superclass(e, op, start)
   {}
+
+  QuadEdgeMeshConstIteratorGeom(const QuadEdgeMeshConstIteratorGeom & other) = default;
 
   ~QuadEdgeMeshConstIteratorGeom() override = default;
 


### PR DESCRIPTION
C++17 related warning.
Solved adding a default copy constructor.

```
Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h:304:7: warning: implicitly-declared ‘constexpr itk::QuadEdgeMeshBaseIterator<itk::GeometricalQuadEdge<long unsigned int, long unsigned int, bool, bool, true> >::QuadEdgeMeshBaseIterator(const itk::QuadEdgeMeshBaseIterator<itk::GeometricalQuadEdge<long unsigned int, long unsigned int, bool, bool, true> >&)’ is deprecated [-Wdeprecated-copy]
  304 | class QuadEdgeMeshConstIterator : public QuadEdgeMeshBaseIterator<TQuadEdge>
```

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
