### PR TITLE
COMP: Remove dynamic exception specifications in tests

### DIFF
--- a/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
@@ -96,7 +96,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     m_Parameters.SetSize(SpaceDimension);
   }
@@ -210,7 +210,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     m_Parameters.SetSize(SpaceDimension);
   }

--- a/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
@@ -63,7 +63,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkExhaustiveOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkExhaustiveOptimizerv4Test.cxx
@@ -98,7 +98,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     m_Parameters.SetSize(SpaceDimension);
   }

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
@@ -65,7 +65,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
@@ -94,7 +94,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
@@ -64,7 +64,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test2.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test2.cxx
@@ -59,7 +59,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
@@ -101,7 +101,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     m_Parameters.SetSize(SpaceDimension);
   }

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
@@ -71,7 +71,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     m_Parameters.SetSize(SpaceDimension);
   }

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
@@ -102,7 +102,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     m_Parameters.SetSize(SpaceDimension);
   }

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -65,7 +65,7 @@ public:
   MultiGradientOptimizerv4TestMetric() = default;
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void
@@ -178,7 +178,7 @@ public:
   MultiGradientOptimizerv4TestMetric2() = default;
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
@@ -61,7 +61,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkObjectToObjectMetricBaseTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkObjectToObjectMetricBaseTest.cxx
@@ -97,7 +97,7 @@ public:
   {}
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() throw() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx
@@ -92,7 +92,7 @@ public:
   {}
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
@@ -93,7 +93,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     m_Parameters.SetSize(SpaceDimension);
   }

--- a/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
@@ -88,7 +88,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     m_Parameters.SetSize(SpaceDimension);
   }

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
@@ -89,7 +89,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
@@ -83,7 +83,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   ParametersType m_Parameters;

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
@@ -83,7 +83,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   ParametersType m_Parameters;

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
@@ -83,7 +83,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   ParametersType m_Parameters;

--- a/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
@@ -64,7 +64,7 @@ public:
   }
 
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {}
 
   void

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -236,7 +236,7 @@ public:
 
   /** Override PropagateRequestedRegion for debug output */
   void
-  PropagateRequestedRegion() throw(itk::InvalidRequestedRegionError) override
+  PropagateRequestedRegion() override
   {
     Superclass::PropagateRequestedRegion();
   }


### PR DESCRIPTION
```
Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx:95:16:
error: ISO C++17 does not allow dynamic exception specifications
   95 |   Initialize() throw(itk::ExceptionObject) override
```
