### PR TITLE
COMP: Avoid Dimension < 3 in FrustumSpatialFunction

### DIFF
--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
@@ -34,6 +34,8 @@ FrustumSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position)
 {
   using PointType = InputType;
   using VectorType = typename PointType::VectorType;
+  static_assert(VDimension > 2, "VDimension must be greater than 2");
+  static_assert(PointType::PointDimension > 2, "PointDimension of TInput must be greater than 2");
 
   VectorType   relativePosition = position - m_Apex;
   const double distanceToApex = relativePosition.GetNorm();

--- a/Modules/Nonunit/IntegratedTest/test/itkCommonPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkCommonPrintTest.cxx
@@ -229,8 +229,8 @@ itkCommonPrintTest(int, char *[])
     itk::FiniteCylinderSpatialFunction<3, Point3DType>::New();
   std::cout << "------------FiniteCylinderSpatialFunction" << FiniteCylinderSpatialFunctionObj;
 
-  itk::FrustumSpatialFunction<2, PointType>::Pointer FrustumSpatialFunctionObj =
-    itk::FrustumSpatialFunction<2, PointType>::New();
+  itk::FrustumSpatialFunction<3, Point3DType>::Pointer FrustumSpatialFunctionObj =
+    itk::FrustumSpatialFunction<3, Point3DType>::New();
   std::cout << "------------FrustumSpatialFunction" << FrustumSpatialFunctionObj;
 
   itk::GaussianKernelFunction<double>::Pointer GaussianKernelFunctionObj = itk::GaussianKernelFunction<double>::New();


### PR DESCRIPTION
`FrustumSpatialFunction` deals with a pyramid and doesn't really accept `VDimension < 3`.
However, it was used in itkCommonPrintTest with `VDimension = 2`,
raising a correct `-Warray-bounds` warning.

This fix:
- Add a static_assert to the Evaluate function.
- Change the print test to use `VDimension = 3`

Fix warning:

```
Building CXX object Modules/Nonunit/IntegratedTest/t...Files/ITKIntegratedTestTestDriver.dir/itkCommonPrintTest.cxx.o
In file included from Modules/Core/Common/include/itkFrustumSpatialFunction.h:147,
                 from Modules/Nonunit/IntegratedTest/test/itkCommonPrintTest.cxx:43:
Modules/Core/Common/include/itkFrustumSpatialFunction.hxx: In member function ‘itk::FrustumSpatialFunction<VDimension, TInput>::OutputType itk::FrustumSpatialFunction<VDimension, TInput>::Evaluate(const InputType&) const [with unsigned int VDimension = 3; TInput = itk::Point<float, 2>]’:
Modules/Core/Common/include/itkFrustumSpatialFunction.hxx:89:18: warning: array subscript 2 is outside array bounds of ‘VectorType [1]’ {aka ‘itk::Vector<float, 2> [1]’} [-Warray-bounds]
   89 |     const double dz = relativePosition[2];
      |                  ^~
Modules/Core/Common/include/itkFrustumSpatialFunction.hxx:38:16: note: while referencing ‘relativePosition’
   38 |   VectorType   relativePosition = position - m_Apex;
      |                ^~~~~~~~~~~~~~~~
Modules/Core/Common/include/itkFrustumSpatialFunction.hxx:62:18: warning: array subscript 2 is outside array bounds of ‘VectorType [1]’ {aka ‘itk::Vector<float, 2> [1]’} [-Warray-bounds]
   62 |     const double dz = relativePosition[2];
      |                  ^~
Modules/Core/Common/include/itkFrustumSpatialFunction.hxx:38:16: note: while referencing ‘relativePosition’
   38 |   VectorType   relativePosition = position - m_Apex;
```