### PR TITLE
ENH: Add Image dict and pixel set/get Python interfaces

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/test/CMakeLists.txt
+++ b/Modules/Bridge/NumPy/wrapping/test/CMakeLists.txt
@@ -14,6 +14,10 @@ if(_have_numpy_return_code EQUAL 0)
                       COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkPyBufferPipelineTest.py
                         DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
   )
+  itk_python_add_test(NAME itkImageMetaDataSetGetItem.py
+                        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkImageMetaDataSetGetItem.py
+                        DATA{${ITK_DATA_ROOT}/Input/dicom-sc_cs-1.dcm}
+  )
 endif()
 
 if(NOT WIN32)

--- a/Modules/Bridge/NumPy/wrapping/test/itkImageMetaDataSetGetItem.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkImageMetaDataSetGetItem.py
@@ -1,0 +1,64 @@
+#==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+import sys
+try:
+    import numpy as np
+except ImportError:
+    # We don't have numpy -- bail
+    sys.exit(0)
+from distutils.version import StrictVersion as VS
+if VS(np.__version__) < VS('1.15.0'):
+    print('NumPy 1.15.0 or greater is required')
+    sys.exit(0)
+
+import itk
+
+if len(sys.argv) < 2:
+    print('Usage: ' + sys.argv[0] + ' <input_image>')
+    sys.exit(1)
+filename = sys.argv[1]
+
+image = itk.imread(filename)
+
+meta_data = dict(image)
+assert meta_data['0008|0008'] == 'ORIGINAL\\PRIMARY\\AXIAL'
+assert meta_data['0008|0016'] == '1.2.840.10008.5.1.4.1.1.2'
+assert meta_data['0010|0010'] == 'LIVER DONOR PHANTOM 2                                           '
+assert np.allclose(meta_data['origin'], np.array([-836., -144., -122.]))
+assert np.allclose(meta_data['spacing'], np.array([1.      , 0.484375, 0.484375]))
+assert np.allclose(meta_data['direction'], np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]))
+
+assert image['0008|0008'] == 'ORIGINAL\\PRIMARY\\AXIAL'
+assert image['0008|0016'] == '1.2.840.10008.5.1.4.1.1.2'
+assert image['0010|0010'] == 'LIVER DONOR PHANTOM 2                                           '
+assert np.allclose(image['origin'], np.array([-836., -144., -122.]))
+assert np.allclose(image['spacing'], np.array([1.      , 0.484375, 0.484375]))
+assert np.allclose(image['direction'], np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]))
+
+new_origin = np.array([1.0, 5.0, 8.0])
+image['origin'] = new_origin
+assert np.allclose(image['origin'], new_origin)
+# NumPy indexing order is reverse of ITK
+assert np.allclose(np.array(image.GetOrigin()), np.array([8.0, 5.0, 1.0]))
+
+# __getitem__
+assert image[0,5,8] == -999
+# __setitem__
+image[0, 5, 8] = 123
+assert image[0,5,8] == 123


### PR DESCRIPTION
Provides a Python dictionary interface to image metadata, keys are
MetaDataDictionary entries along with 'origin', 'spacing', and
'direction' keys. The later reverse their order to be consistent with
the NumPy array index order resulting from array views of the image. The
entries can be accesses and set directly on the image, e.g.

  print(image['0008|0008'])
  image['origin'] = [4.0, 2.0, 2.0]

or a dictionary can be retrieved with:

  meta_dict = dict(image)

For example:

```
In [3]: dict(image)
Out[3]:
{'0008|0005': 'ISO IR 100',
 '0008|0008': 'ORIGINAL\\PRIMARY\\AXIAL',
 '0008|0016': '1.2.840.10008.5.1.4.1.1.2',
 '0008|0018': '1.3.12.2.1107.5.8.99.484849.834848.79844848.2001082217554549',
 '0008|0020': '20010822',
 '0008|0021': '20010822',
 '0008|0022': '20010822',
 '0008|0023': '20010822',
 '0008|0030': '093652.000000 ',
 '0008|0031': '093652.000000 ',
 '0008|0032': '094028.820000 ',
 '0008|0033': '094335.532000 ',
 '0008|0040': '0',
 '0008|0041': 'IMA SPI ',
 '0008|0050': '                ',
 '0008|0060': 'CT',
 '0008|0070': 'SIEMENS ',
 '0008|0080': 'UNC HOSPITALS - BODY C    ',
 '0008|0090': '',
 '0008|1010': 'bodyct          ',
 '0008|1090': 'SOMATOM PLUS 4            ',
 '0010|0010': 'LIVER DONOR PHANTOM 2                                           ',
 '0010|0020': '2                                                               ',
 '0010|0030': '',
 '0010|0040': 'M ',
 '0018|0010': 'NONE    ',
 '0018|0015': 'BODY',
 '0018|0020': 'RM',
 '0018|0050': '003.000000E+00',
 '0018|0060': '000120',
 '0018|0090': '000500',
 '0018|1000': '                     20380',
 '0018|1020': 'VC10C   ',
 '0018|1110': '001005',
 '0018|1111': '000570',
 '0018|1120': '000.000000E+00',
 '0018|1130': '001.270000E+02',
 '0018|1140': 'CW',
 '0018|1150': '750 ',
 '0018|1151': '170 ',
 '0018|1152': '128 ',
 '0018|1170': '20',
 '0018|1190': '001.200000E+00',
 '0018|1200': '20010817',
 '0018|1201': '072320.877000 ',
 '0018|1210': '59 .10.AB50     ',
 '0018|5100': 'HFS ',
 '0020|000d': '1.3.12.2.1107.5.8.99.484849.834848.79844848.2001082213291053',
 '0020|000e': '1.3.12.2.1107.5.1.1.20380.52.36.9.22.8.2001.3                  ',
 '0020|0010': '000001',
 '0020|0011': '000004',
 '0020|0012': '000003',
 '0020|0013': '000052',
 '0020|0030': '-01.217578E+02\\-1.437578E+02\\-8.360000E+02',
 '0020|0032': '-122\\-144\\-836',
 '0020|0035': '001.000000E+00\\00.000000E+00\\00.000000E+00\\00.000000E+00\\01.000000E+00\\00.000000E+00',
 '0020|0037': '1\\0\\0\\0\\1\\0 ',
 '0020|0050': '-08.360000E+02',
 '0020|0052': '1.3.12.2.1107.5.1.1.20380.52.36.9.22.8.2001                    ',
 '0020|0070': 'PLANAR  ',
 '0020|0080': '',
 '0020|1040': '',
 '0020|1041': '-836',
 '0020|3100': '',
 '0020|3401': '',
 '0020|3402': '',
 '0020|3403': '',
 '0020|3404': '',
 '0020|3405': '',
 '0020|3406': '',
 '0020|5000': '',
 '0020|5002': '',
 '0028|0002': '1',
 '0028|0004': 'MONOCHROME2 ',
 '0028|0005': '2',
 '0028|0010': '512',
 '0028|0011': '512',
 '0028|0030': '004.843750E-01\\04.843750E-01',
 '0028|0040': 'RECT',
 '0028|0050': '',
 '0028|0100': '16',
 '0028|0101': '12',
 '0028|0102': '11',
 '0028|0103': '0',
 '0028|0200': '32736',
 '0028|1050': '000070\\-0700',
 '0028|1051': '000422\\02000',
 '0028|1052': '-01.024000E+03',
 '0028|1053': '001.000000E+00',
 'origin': array([-836., -144., -122.]),
 'spacing': array([1.      , 0.484375, 0.484375]),
 'direction': array([[1., 0., 0.],
        [0., 1., 0.],
        [0., 0., 1.]])}
```

For non-string keys, they are passed to the NumPy array view so array views can be set and get with NumPy indexing syntax, e.g.

```
In [6]: image[0,:2,4] = [5,5]

In [7]: image[0,:4,4:6]
Out[7]:
NDArrayITKBase([[    5,  -997],
                [    5, -1003],
                [ -993,  -999],
                [ -996,  -994]], dtype=int16)
```

NumPy 1.15 or later is required to support the axis=None argument to
np.flip.