### PR TITLE
BUG: MinPriorityQueueElementWrapper constructor needs ZeroValue()

### DIFF
--- a/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
@@ -91,9 +91,7 @@ const TElementIdentifier ElementWrapperPointerInterface<TElement, TElementIdenti
 // -----------------------------------------------------------------------------
 template <typename TElement, typename TElementPriority, typename TElementIdentifier>
 MinPriorityQueueElementWrapper<TElement, TElementPriority, TElementIdentifier>::MinPriorityQueueElementWrapper()
-  : m_Element(NumericTraits<TElement>::ZeroValue())
-  , m_Priority(NumericTraits<TElementPriority>::ZeroValue())
-  , m_Location(Superclass::m_ElementNotFound)
+  : m_Location(Superclass::m_ElementNotFound)
 {}
 // -----------------------------------------------------------------------------
 

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
@@ -91,8 +91,8 @@ const TElementIdentifier ElementWrapperPointerInterface<TElement, TElementIdenti
 // -----------------------------------------------------------------------------
 template <typename TElement, typename TElementPriority, typename TElementIdentifier>
 MinPriorityQueueElementWrapper<TElement, TElementPriority, TElementIdentifier>::MinPriorityQueueElementWrapper()
-  : m_Element(0)
-  , m_Priority(0)
+  : m_Element(NumericTraits<TElement>::ZeroValue())
+  , m_Priority(NumericTraits<TElementPriority>::ZeroValue())
   , m_Location(Superclass::m_ElementNotFound)
 {}
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
For some types, 0 won't do in the constructor. Instead we need, e.g., NumericTraits<TElement>::ZeroValue(). This will help Seg3D to compile.