### PR TITLE
COMP: Fix const-correctness of iterators in multiple classes

### DIFF
--- a/Modules/Core/Common/include/itkConstSliceIterator.h
+++ b/Modules/Core/Common/include/itkConstSliceIterator.h
@@ -108,7 +108,7 @@ public:
   /** Returns the logical && of the boolean == of two slice iterator positions,
    * stride, and start locations. */
   bool
-  operator==(const ConstSliceIterator & orig)
+  operator==(const ConstSliceIterator & orig) const
   {
     return orig.m_Pos == this->m_Pos && orig.m_Slice.stride() == this->m_Slice.stride() &&
            orig.m_Slice.start() == this->m_Slice.start();
@@ -116,7 +116,7 @@ public:
 
   /** Returns the logical inverse of the boolean == of two slice iterators. */
   bool
-  operator!=(const ConstSliceIterator & orig)
+  operator!=(const ConstSliceIterator & orig) const
   {
     return !operator==(orig);
   }
@@ -125,7 +125,7 @@ public:
    * is only true if the slice iterators have the same stride and
    * start location. */
   bool
-  operator<(const ConstSliceIterator & orig)
+  operator<(const ConstSliceIterator & orig) const
   {
     return this->m_Pos < orig.m_Pos && this->m_Slice.stride() == orig.m_Slice.stride() &&
            this->m_Slice.start() == orig.m_Slice.start();

--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -73,7 +73,7 @@ public:
 
   /** Equivalence operator. */
   virtual bool
-  operator==(const ExceptionObject & orig);
+  operator==(const ExceptionObject & orig) const;
 
   virtual const char *
   GetNameOfClass() const

--- a/Modules/Core/Common/include/itkSliceIterator.h
+++ b/Modules/Core/Common/include/itkSliceIterator.h
@@ -104,7 +104,7 @@ public:
   /** Returns the logical && of the boolean == of two slice iterator positions,
    * stride, and start locations. */
   bool
-  operator==(const SliceIterator & orig)
+  operator==(const SliceIterator & orig) const
   {
     return orig.m_Pos == this->m_Pos && orig.m_Slice.stride() == this->m_Slice.stride() &&
            orig.m_Slice.start() == this->m_Slice.start();

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -193,7 +193,7 @@ ExceptionObject::operator=(const ExceptionObject & orig) noexcept
 }
 
 bool
-ExceptionObject::operator==(const ExceptionObject & orig)
+ExceptionObject::operator==(const ExceptionObject & orig) const
 {
   // operator== is reimplemented, but it still behaves like the previous
   // version, from ITK 3.6.0.

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -171,7 +171,7 @@ public:
 
   // Iteration methods.
   bool
-  operator==(Self & r)
+  operator==(Self & r) const
   {
     return (m_Start == r.m_Start);
   }
@@ -183,7 +183,7 @@ public:
   }
 
   bool
-  operator!=(Self & r)
+  operator!=(Self & r) const
   {
     return (!(this->operator==(r)));
   }

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -402,13 +402,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (m_Id != it.m_Id);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (m_Id == it.m_Id);
     }

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
@@ -195,13 +195,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (m_Iter != it.m_Iter);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (m_Iter == it.m_Iter);
     }

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
@@ -209,13 +209,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (m_MeasurementVectorCache[0] != it.m_MeasurementVectorCache[0]);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (m_MeasurementVectorCache[0] == it.m_MeasurementVectorCache[0]);
     }

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
@@ -234,13 +234,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (m_InstanceIdentifier != it.m_InstanceIdentifier);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (m_InstanceIdentifier == it.m_InstanceIdentifier);
     }

--- a/Modules/Numerics/Statistics/include/itkListSample.h
+++ b/Modules/Numerics/Statistics/include/itkListSample.h
@@ -183,13 +183,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (m_Iter != it.m_Iter);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (m_Iter == it.m_Iter);
     }

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.h
@@ -176,13 +176,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (m_InstanceIdentifier != it.m_InstanceIdentifier);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (m_InstanceIdentifier == it.m_InstanceIdentifier);
     }

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
@@ -160,13 +160,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (m_Iter != it.m_Iter);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (m_Iter == it.m_Iter);
     }

--- a/Modules/Numerics/Statistics/include/itkSubsample.h
+++ b/Modules/Numerics/Statistics/include/itkSubsample.h
@@ -174,13 +174,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (m_Iter != it.m_Iter);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (m_Iter == it.m_Iter);
     }

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
@@ -153,13 +153,13 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it)
+    operator!=(const ConstIterator & it) const
     {
       return (this->m_Iter != it.m_Iter);
     }
 
     bool
-    operator==(const ConstIterator & it)
+    operator==(const ConstIterator & it) const
     {
       return (this->m_Iter == it.m_Iter);
     }


### PR DESCRIPTION
Fix ambiguous overloaded operator != triggered in Apple Clang 12.
Reported here: https://discourse.itk.org/t/c-20-comparison-operators/3506

```
ITK-5.1/itkImageToHistogramFilter.hxx:294:18: error: use of overloaded operator '!=' is ambiguous (with operand types 'HistogramIterator' (aka 'itk::Statistics::Histogram<double, itk::Statistics::DenseFrequencyContainer2>::ConstIterator') and 'HistogramIterator')
      while (hit != end)
             ~~~ ^  ~~~
vcpkg_installed/x64-osx-asan/include/ITK-5.1/itkHistogram.h:405:5: note: candidate function
    operator!=(const ConstIterator & it)
    ^
vcpkg_installed/x64-osx-asan/include/ITK-5.1/itkHistogram.h:411:5: note: candidate function
    operator==(const ConstIterator & it)
```

## PR Checklist
- [ x ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ x ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-

