### PR TITLE
BUG: MinPriorityQueueElementWrapper constructor doesn't work

### DIFF
--- a/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
@@ -91,9 +91,7 @@ const TElementIdentifier ElementWrapperPointerInterface<TElement, TElementIdenti
 // -----------------------------------------------------------------------------
 template <typename TElement, typename TElementPriority, typename TElementIdentifier>
 MinPriorityQueueElementWrapper<TElement, TElementPriority, TElementIdentifier>::MinPriorityQueueElementWrapper()
-  : m_Element(NumericTraits<TElement>::ZeroValue())
-  , m_Priority(NumericTraits<TElementPriority>::ZeroValue())
-  , m_Location(Superclass::m_ElementNotFound)
+  : m_Location(Superclass::m_ElementNotFound)
 {}
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
The default constructor of MinPriorityQueueElementWrapper cannot use `0` or `itk::NumericTraits<TElement>::ZeroValue()` for `TElement == itk::Index<2>` on some configurations.
Closes #2017.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

