### PR TITLE
BUG: Fix Python Wrapping with MSVC and CMake >= 3.18, Closes #2049

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -234,7 +234,7 @@ macro(itk_wrap_module_python library_name)
   PyObject * sysModules = PyImport_GetModuleDict();\n")
   set(ITK_WRAP_PYTHON_CXX_FILES )
   if(MSVC)
-    get_filename_component(python_library_directory "${Python3_LIBRARY}" DIRECTORY)
+    get_filename_component(python_library_directory "${Python3_LIBRARIES}" DIRECTORY)
     # It should use the following code inside `itk_end_wrap_module_python` but
     # `target_link_directories()` was only added to CMake 3.13.
     # target_link_directories(${lib} PUBLIC ${python_library_directory})


### PR DESCRIPTION
Fix for ```LINK : fatal error LNK1104: cannot open file 'python38.lib'``` when using Python Wrapping with MSVC in VS2019 and CMake >=3.18.
Closes #2049  