### PR TITLE
STYLE:  Missed conversions for new macro name

### DIFF
--- a/Examples/Filtering/CompositeFilterExample.cxx
+++ b/Examples/Filtering/CompositeFilterExample.cxx
@@ -63,7 +63,7 @@ template <typename TImage>
 class CompositeExampleImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CompositeExampleImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(CompositeExampleImageFilter);
 
   //  Software Guide : EndCodeSnippet
 

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -31,7 +31,7 @@ namespace itk
 class ExceptionObject::ExceptionData : public ReferenceCounterInterface
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ExceptionData);
+  ITK_DISALLOW_COPY_AND_MOVE(ExceptionData);
 
 protected:
   // Constructor. Might throw an exception.
@@ -79,7 +79,7 @@ class ExceptionObject::ReferenceCountedExceptionData
   , public LightObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ReferenceCountedExceptionData);
+  ITK_DISALLOW_COPY_AND_MOVE(ReferenceCountedExceptionData);
 
   using Self = ReferenceCountedExceptionData;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
@@ -41,7 +41,7 @@ public:
   class TestDomainThreader : public itk::DomainThreader<itk::ThreadedIndexedContainerPartitioner, Self>
   {
   public:
-    ITK_DISALLOW_COPY_AND_ASSIGN(TestDomainThreader);
+    ITK_DISALLOW_COPY_AND_MOVE(TestDomainThreader);
 
     using Self = TestDomainThreader;
     using Superclass = itk::DomainThreader<itk::ThreadedIndexedContainerPartitioner, Self>;

--- a/Modules/Core/Common/test/itkDataObjectTest.cxx
+++ b/Modules/Core/Common/test/itkDataObjectTest.cxx
@@ -25,7 +25,7 @@ namespace itk
 class DataObjectTestHelper : public DataObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DataObjectTestHelper);
+  ITK_DISALLOW_COPY_AND_MOVE(DataObjectTestHelper);
 
   /** Standard type alias. */
   using Self = DataObjectTestHelper;

--- a/Modules/Core/Common/test/itkFactoryTestLib.cxx
+++ b/Modules/Core/Common/test/itkFactoryTestLib.cxx
@@ -26,7 +26,7 @@ template <typename TElementIdentifier, typename TElement>
 class TestImportImageContainer : public itk::ImportImageContainer<TElementIdentifier, TElement>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TestImportImageContainer);
+  ITK_DISALLOW_COPY_AND_MOVE(TestImportImageContainer);
 
   /** Standard class type aliases.   */
   using Self = TestImportImageContainer;
@@ -137,7 +137,7 @@ private:
 class ImportImageContainerFactory : public itk::ObjectFactoryBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImportImageContainerFactory);
+  ITK_DISALLOW_COPY_AND_MOVE(ImportImageContainerFactory);
 
   using Self = ImportImageContainerFactory;
   using Superclass = itk::ObjectFactoryBase;

--- a/Modules/Core/Common/test/itkFilterDispatchTest.cxx
+++ b/Modules/Core/Common/test/itkFilterDispatchTest.cxx
@@ -48,7 +48,7 @@ template <typename TInputImage, typename TOutputImage>
 class ExampleImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ExampleImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ExampleImageFilter);
 
   /**
    * Standard "Self" type alias.

--- a/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
@@ -46,7 +46,7 @@ private:
   static std::size_t m_Count;
 
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ObjectCounter);
+  ITK_DISALLOW_COPY_AND_MOVE(ObjectCounter);
 
   ObjectCounter() ITK_NOEXCEPT { ++m_Count; }
 

--- a/Modules/Core/Common/test/itkObjectFactoryTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest.cxx
@@ -33,7 +33,7 @@ template <typename TPixel, unsigned int VImageDimension = 2>
 class TestImage : public itk::Image<TPixel, VImageDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TestImage);
+  ITK_DISALLOW_COPY_AND_MOVE(TestImage);
 
   /** Standard class type aliases.   */
   using Self = TestImage;
@@ -56,7 +56,7 @@ template <typename TPixel, unsigned int VImageDimension = 3>
 class TestImage2 : public itk::Image<TPixel, VImageDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TestImage2);
+  ITK_DISALLOW_COPY_AND_MOVE(TestImage2);
 
   /** Standard class type aliases.   */
   using Self = TestImage2;
@@ -78,7 +78,7 @@ public:
 class TestFactory : public itk::ObjectFactoryBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TestFactory);
+  ITK_DISALLOW_COPY_AND_MOVE(TestFactory);
 
   using Self = TestFactory;
   using Superclass = itk::ObjectFactoryBase;

--- a/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
@@ -34,7 +34,7 @@ protected:
 class TestFactory3 : public itk::ObjectFactoryBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TestFactory3);
+  ITK_DISALLOW_COPY_AND_MOVE(TestFactory3);
 
   using Self = TestFactory3;
   using Superclass = itk::ObjectFactoryBase;

--- a/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
+++ b/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
@@ -62,7 +62,7 @@ class TanHelperImageFilter
       Function::TanHelper<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TanHelperImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(TanHelperImageFilter);
 
   /** Standard class type aliases. */
   using Self = TanHelperImageFilter;

--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -29,7 +29,7 @@ namespace
 class Derived1 : public itk::Object
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(Derived1);
+  ITK_DISALLOW_COPY_AND_MOVE(Derived1);
 
   /** Standard class type aliases. */
   using Self = Derived1;
@@ -67,7 +67,7 @@ protected:
 class Derived2 : public itk::Object
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(Derived2);
+  ITK_DISALLOW_COPY_AND_MOVE(Derived2);
 
   /** Standard class type aliases. */
   using Self = Derived2;

--- a/Modules/Core/Common/test/itkThreadedIndexedContainerPartitionerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIndexedContainerPartitionerTest.cxx
@@ -26,7 +26,7 @@ public:
   class TestDomainThreader : public itk::DomainThreader<itk::ThreadedIndexedContainerPartitioner, Self>
   {
   public:
-    ITK_DISALLOW_COPY_AND_ASSIGN(TestDomainThreader);
+    ITK_DISALLOW_COPY_AND_MOVE(TestDomainThreader);
 
     using Self = TestDomainThreader;
     using Superclass = itk::DomainThreader<itk::ThreadedIndexedContainerPartitioner, Self>;

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest.cxx
@@ -31,7 +31,7 @@ public:
   class TestDomainThreader : public itk::DomainThreader<ThreadedPartitionerType, Self>
   {
   public:
-    ITK_DISALLOW_COPY_AND_ASSIGN(TestDomainThreader);
+    ITK_DISALLOW_COPY_AND_MOVE(TestDomainThreader);
 
     using Self = TestDomainThreader;
     using Superclass = itk::DomainThreader<ThreadedPartitionerType, Self>;

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest2.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest2.cxx
@@ -34,7 +34,7 @@ public:
   class TestDomainThreader : public itk::DomainThreader<ThreadedPartitionerType, Self>
   {
   public:
-    ITK_DISALLOW_COPY_AND_ASSIGN(TestDomainThreader);
+    ITK_DISALLOW_COPY_AND_MOVE(TestDomainThreader);
 
     using Self = TestDomainThreader;
     using Superclass = itk::DomainThreader<ThreadedPartitionerType, Self>;

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest3.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerTest3.cxx
@@ -34,7 +34,7 @@ public:
   class TestDomainThreader : public itk::DomainThreader<ThreadedPartitionerType, Self>
   {
   public:
-    ITK_DISALLOW_COPY_AND_ASSIGN(TestDomainThreader);
+    ITK_DISALLOW_COPY_AND_MOVE(TestDomainThreader);
 
     using Self = TestDomainThreader;
     using Superclass = itk::DomainThreader<ThreadedPartitionerType, Self>;

--- a/Modules/Core/Mesh/test/itkMeshSourceGraftOutputTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshSourceGraftOutputTest.cxx
@@ -27,7 +27,7 @@ template <typename TInputMesh, typename TOutputMesh, typename TTransform>
 class MeshSourceGraftOutputFilter : public MeshToMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MeshSourceGraftOutputFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MeshSourceGraftOutputFilter);
 
   /** Standard class type aliases. */
   using Self = MeshSourceGraftOutputFilter;

--- a/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
@@ -89,7 +89,7 @@ template <unsigned int TDimension = 3>
 class DummySpatialObject : public SpatialObject<TDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DummySpatialObject);
+  ITK_DISALLOW_COPY_AND_MOVE(DummySpatialObject);
 
   using Self = DummySpatialObject;
   using Superclass = SpatialObject<TDimension>;
@@ -134,7 +134,7 @@ template <unsigned int NDimensions = 3>
 class MetaDummyConverter : public MetaConverterBase<NDimensions>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MetaDummyConverter);
+  ITK_DISALLOW_COPY_AND_MOVE(MetaDummyConverter);
 
   /** Standard class type aliases */
   using Self = MetaDummyConverter;

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -75,7 +75,7 @@ template <class TScalar = double, unsigned int NDimensions = itkMultiTransformTe
 class MultiTransformTestTransform : public itk::MultiTransform<TScalar, NDimensions>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MultiTransformTestTransform);
+  ITK_DISALLOW_COPY_AND_MOVE(MultiTransformTestTransform);
 
   /** Standard class type aliases. */
   using Self = MultiTransformTestTransform;

--- a/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowTest.cxx
@@ -52,7 +52,7 @@ template <typename TImageType>
 class DummyFunction : public FiniteDifferenceFunction<TImageType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DummyFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(DummyFunction);
 
   using Self = DummyFunction;
   using Superclass = FiniteDifferenceFunction<TImageType>;

--- a/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
@@ -31,7 +31,7 @@ template <typename TOutputImage>
 class ExampleImageSource : public GaussianImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ExampleImageSource);
+  ITK_DISALLOW_COPY_AND_MOVE(ExampleImageSource);
 
   /** Standard type alias. */
   using Self = ExampleImageSource;

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
@@ -24,7 +24,7 @@ template <typename TInput, typename TOutput>
 class FastMarchingBaseTestHelper : public FastMarchingBase<TInput, TOutput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingBaseTestHelper);
+  ITK_DISALLOW_COPY_AND_MOVE(FastMarchingBaseTestHelper);
 
   using Self = FastMarchingBaseTestHelper;
   using Superclass = FastMarchingBase<TInput, TOutput>;

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingStoppingCriterionBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingStoppingCriterionBaseTest.cxx
@@ -24,7 +24,7 @@ template <typename TInput, typename TOutput>
 class FastMarchingStoppingCriterionBaseHelperTest : public FastMarchingStoppingCriterionBase<TInput, TOutput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingStoppingCriterionBaseHelperTest);
+  ITK_DISALLOW_COPY_AND_MOVE(FastMarchingStoppingCriterionBaseHelperTest);
 
   using Self = FastMarchingStoppingCriterionBaseHelperTest;
   using Superclass = FastMarchingStoppingCriterionBase<TInput, TOutput>;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -27,7 +27,7 @@
 class ProjectTransform : public itk::Transform<double, 3, 2>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ProjectTransform);
+  ITK_DISALLOW_COPY_AND_MOVE(ProjectTransform);
 
   using Self = ProjectTransform;
   using Superclass = itk::Transform<double, 3, 2>;

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -43,7 +43,7 @@ template <class TOutputImage>
 class DemoImageSource : public GenerateImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DemoImageSource);
+  ITK_DISALLOW_COPY_AND_MOVE(DemoImageSource);
 
   /** Standard class type aliases. */
   using Self = DemoImageSource;

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -37,7 +37,7 @@ template <class TOutputImage>
 class ConstantImageSource : public GenerateImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConstantImageSource);
+  ITK_DISALLOW_COPY_AND_MOVE(ConstantImageSource);
 
   /** Standard class type aliases. */
   using Self = ConstantImageSource;

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -30,7 +30,7 @@ class TestImageFunction
   : public ImageFunction<TInputImage, typename NumericTraits<typename TInputImage::PixelType>::RealType, TCoordRep>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TestImageFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(TestImageFunction);
 
   /** Standard class type aliases. */
   using Self = TestImageFunction;

--- a/Modules/Nonunit/Review/test/itkRegionBasedLevelSetFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRegionBasedLevelSetFunctionTest.cxx
@@ -27,7 +27,7 @@ template <typename TInput,   // LevelSetImageType
 class RegionBasedLevelSetFunctionTestHelper : public RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RegionBasedLevelSetFunctionTestHelper);
+  ITK_DISALLOW_COPY_AND_MOVE(RegionBasedLevelSetFunctionTestHelper);
 
   /** Standard class type aliases. */
   using Self = RegionBasedLevelSetFunctionTestHelper;

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest1.cxx
@@ -28,7 +28,7 @@ class ScalarChanAndVeseLevelSetFunctionTestHelper
   : public ScalarChanAndVeseLevelSetFunction<TInput, TFeature, TSharedData>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ScalarChanAndVeseLevelSetFunctionTestHelper);
+  ITK_DISALLOW_COPY_AND_MOVE(ScalarChanAndVeseLevelSetFunctionTestHelper);
 
   /** Standard class type aliases. */
   using Self = ScalarChanAndVeseLevelSetFunctionTestHelper;

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest2.cxx
@@ -28,7 +28,7 @@ class ScalarChanAndVeseLevelSetFunctionTest2Helper
   : public ScalarChanAndVeseLevelSetFunction<TInput, TFeature, TSharedData>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ScalarChanAndVeseLevelSetFunctionTest2Helper);
+  ITK_DISALLOW_COPY_AND_MOVE(ScalarChanAndVeseLevelSetFunctionTest2Helper);
 
   /** Standard class type aliases. */
   using Self = ScalarChanAndVeseLevelSetFunctionTest2Helper;

--- a/Modules/Nonunit/Review/test/itkScalarRegionBasedLevelSetFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarRegionBasedLevelSetFunctionTest.cxx
@@ -28,7 +28,7 @@ class ScalarRegionBasedLevelSetFunctionTestHelper
   : public ScalarRegionBasedLevelSetFunction<TInput, TFeature, TSharedData>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ScalarRegionBasedLevelSetFunctionTestHelper);
+  ITK_DISALLOW_COPY_AND_MOVE(ScalarRegionBasedLevelSetFunctionTestHelper);
 
   /** Standard class type aliases. */
   using Self = ScalarRegionBasedLevelSetFunctionTestHelper;

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
@@ -24,7 +24,7 @@ template <typename TFixedObject, typename TMovingObject>
 class GradientDescentOptimizerBasev4TestMetric : public itk::ObjectToObjectMetricBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GradientDescentOptimizerBasev4TestMetric);
+  ITK_DISALLOW_COPY_AND_MOVE(GradientDescentOptimizerBasev4TestMetric);
 
   /** Standard class type aliases. */
   using Self = GradientDescentOptimizerBasev4TestMetric;
@@ -116,7 +116,7 @@ private:
 class GradientDescentOptimizerBasev4TestOptimizer : public itk::GradientDescentOptimizerBasev4
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GradientDescentOptimizerBasev4TestOptimizer);
+  ITK_DISALLOW_COPY_AND_MOVE(GradientDescentOptimizerBasev4TestOptimizer);
 
   /** Standard "Self" type alias. */
   using Self = GradientDescentOptimizerBasev4TestOptimizer;

--- a/Modules/Numerics/Optimizersv4/test/itkOptimizerParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkOptimizerParameterScalesEstimatorTest.cxx
@@ -24,7 +24,7 @@
 class OptimizerParameterScalesEstimatorTest : public itk::OptimizerParameterScalesEstimator
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(OptimizerParameterScalesEstimatorTest);
+  ITK_DISALLOW_COPY_AND_MOVE(OptimizerParameterScalesEstimatorTest);
 
   /** Standard class type aliases. */
   using Self = OptimizerParameterScalesEstimatorTest;

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
@@ -128,7 +128,7 @@ template <typename TMetric>
 class RegistrationParameterScalesEstimatorTest : public itk::RegistrationParameterScalesEstimator<TMetric>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RegistrationParameterScalesEstimatorTest);
+  ITK_DISALLOW_COPY_AND_MOVE(RegistrationParameterScalesEstimatorTest);
 
   /** Standard class type aliases. */
   using Self = RegistrationParameterScalesEstimatorTest;

--- a/Modules/Numerics/Statistics/test/itkSampleToSubsampleFilterTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToSubsampleFilterTest1.cxx
@@ -31,7 +31,7 @@ template <typename TSample>
 class SubsamplerTester : public SampleToSubsampleFilter<TSample>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SubsamplerTester);
+  ITK_DISALLOW_COPY_AND_MOVE(SubsamplerTester);
 
   /** Standard class type aliases. */
   using Self = SubsamplerTester;

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -108,7 +108,7 @@ template <typename TFixedImage, typename TMovingImage, typename TVirtualImage>
 class ImageToImageMetricv4TestMetric : public itk::ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImageToImageMetricv4TestMetric);
+  ITK_DISALLOW_COPY_AND_MOVE(ImageToImageMetricv4TestMetric);
 
   /** Standard class type aliases. */
   using Self = ImageToImageMetricv4TestMetric;

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -69,7 +69,7 @@ class VanilaImageToImageMetricv4GetValueAndDerivativeThreader
   : public ImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner, TImageToImageMetric>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VanilaImageToImageMetricv4GetValueAndDerivativeThreader);
+  ITK_DISALLOW_COPY_AND_MOVE(VanilaImageToImageMetricv4GetValueAndDerivativeThreader);
 
   /** Standard class type aliases. */
   using Self = VanilaImageToImageMetricv4GetValueAndDerivativeThreader;
@@ -131,7 +131,7 @@ template <typename TFixedImage, typename TMovingImage, typename TVirtualImage = 
 class VanillaImageToImageMetricv4 : public ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VanillaImageToImageMetricv4);
+  ITK_DISALLOW_COPY_AND_MOVE(VanillaImageToImageMetricv4);
 
   /** Standard class type aliases. */
   using Self = VanillaImageToImageMetricv4;

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -145,7 +145,7 @@ private:
 class MorphFilter : public ::itk::DenseFiniteDifferenceImageFilter<::itk::Image<float, 2>, ::itk::Image<float, 2>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MorphFilter);
 
   using Self = MorphFilter;
 

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -155,7 +155,7 @@ private:
 class MorphFilter : public ::itk::ParallelSparseFieldLevelSetImageFilter<::itk::Image<float, 3>, ::itk::Image<float, 3>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MorphFilter);
 
   using Self = MorphFilter;
 

--- a/Utilities/Doxygen/doxygen.config.in
+++ b/Utilities/Doxygen/doxygen.config.in
@@ -2199,6 +2199,7 @@ PREDEFINED             = "itkNotUsed(x)=" \
                          "ITK_OVERRIDE= override " \
                          "ITK_NULLPTR=  nullptr " \
                          "ITK_NOEXCEPT= noexcept " \
+                         "ITK_DISALLOW_COPY_AND_MOVE(type)=" \
                          "ITK_DISALLOW_COPY_AND_ASSIGN(type)=" \
                          "ITK_FORCE_EXPORT_MACRO(X)="
 

--- a/Utilities/ITKv5Preparation/Move_DISALLOW_COPY_to_public_section.cpp
+++ b/Utilities/ITKv5Preparation/Move_DISALLOW_COPY_to_public_section.cpp
@@ -2,7 +2,7 @@
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
 
-/* Script to move ITK_DISALLOW_COPY_AND_ASSIGN calls to the public section
+/* Script to move ITK_DISALLOW_COPY_AND_MOVE calls to the public section
  * of the classes.
  *
  * Initial version by Niels Dekker, LKEB, Leiden University Medical Center, 2018
@@ -167,7 +167,8 @@ namespace
           }
           else
           {
-            if (StringStartsWithPrefix(c_str, "ITK_DISALLOW_COPY_AND_ASSIGN("))
+            if (StringStartsWithPrefix(c_str, "ITK_DISALLOW_COPY_AND_MOVE(")
+                || StringStartsWithPrefix(c_str, "ITK_DISALLOW_COPY_AND_ASSIGN("))
             {
               ++statistics.numberOfDisallowMacroCalls;
 


### PR DESCRIPTION
Call ITK_DISALLOW_COPY_AND_MOVE, not ITK_DISALLOW_COPY_AND_ASSIGN
Some conversions were missed during initial update of macro name.
