### PR TITLE
DOC: Add Doxygen links from iterators to ShapedImageNeighborhoodRange

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -40,6 +40,7 @@ namespace itk
  * \ingroup ImageIterators
  *
  * \sa Neighborhood \sa ImageIterator \sa NeighborhoodIterator
+ * \sa ShapedImageNeighborhoodRange
  * \ingroup ITKCommon
  *
  * \sphinx

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -65,6 +65,7 @@ namespace itk
  * \sa NeighborhoodIterator \sa PathConstIterator  \sa PathIterator
  * \sa ShapedNeighborhoodIterator  \sa SliceIterator
  * \sa ImageConstIteratorWithIndex
+ * \sa ShapedImageNeighborhoodRange
  * \ingroup ITKCommon
  */
 template <typename TImage, typename TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TImage>>

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -198,6 +198,7 @@ std::cout << *iterator[c]              << std::endl;
  * \sa NeighborhoodIterator \sa PathConstIterator  \sa PathIterator
  * \sa ShapedNeighborhoodIterator  \sa SliceIterator
  * \sa ImageConstIteratorWithIndex
+ * \sa ShapedImageNeighborhoodRange
  *
  * \ingroup Operators
  * \ingroup ITKCommon

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -140,6 +140,7 @@ namespace itk
  * \sa NeighborhoodIterator \sa PathConstIterator  \sa PathIterator
  * \sa ShapedNeighborhoodIterator  \sa SliceIterator
  * \sa ImageConstIteratorWithIndex
+ * \sa ShapedImageNeighborhoodRange
  * \ingroup ITKCommon
  *
  * \sphinx


### PR DESCRIPTION
Follow-up to pull request #2051, "DOC: Link region iterators to
ImageRegionRange, ImageRegionIndexRange".
