### PR TITLE
STYLE: Remove "include guards" from cxx files

### DIFF
--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkSpatialObjectProperty_cxx
-#define itkSpatialObjectProperty_cxx
 
 #include "itkSpatialObjectProperty.h"
 
@@ -199,5 +197,3 @@ SpatialObjectProperty ::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "StringDictionary size: " << m_StringDictionary.size() << std::endl;
 }
 } // end of namespace itk
-
-#endif // __SpatialObjectProperty_hxx

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkGDCMSeriesFileNames_h
-#define _itkGDCMSeriesFileNames_h
 
 #include "itkGDCMSeriesFileNames.h"
 #include "itksys/SystemTools.hxx"
@@ -301,5 +299,3 @@ GDCMSeriesFileNames::SetUseSeriesDetails(bool useSeriesDetails)
   m_SerieHelper->CreateDefaultUniqueSeriesIdentifier();
 }
 } // namespace itk
-
-#endif

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -15,9 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkArchetypeSeriesFileNames_h
-#define _itkArchetypeSeriesFileNames_h
-
 
 #include "itkArchetypeSeriesFileNames.h"
 #include "itkRegularExpressionSeriesFileNames.h"
@@ -235,5 +232,3 @@ ArchetypeSeriesFileNames ::PrintSelf(std::ostream & os, Indent indent) const
   }
 }
 } // namespace itk
-
-#endif

--- a/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkNumericSeriesFileNames_h
-#define _itkNumericSeriesFileNames_h
 
 #include "itkNumericSeriesFileNames.h"
 #include <cstdio>
@@ -91,5 +89,3 @@ NumericSeriesFileNames ::PrintSelf(std::ostream & os, Indent indent) const
   }
 }
 } // namespace itk
-
-#endif

--- a/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
@@ -15,9 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkRegularExpressionSeriesFileNames_cxx
-#define _itkRegularExpressionSeriesFileNames_cxx
-
 
 #include <algorithm>
 
@@ -128,5 +125,3 @@ RegularExpressionSeriesFileNames ::PrintSelf(std::ostream & os, Indent indent) c
   }
 }
 } // namespace itk
-
-#endif

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkPolygonGroupSpatialObjectXMLFile_hxx
-#define _itkPolygonGroupSpatialObjectXMLFile_hxx
 
 #include "itkPolygonGroupSpatialObjectXMLFile.h"
 #include "itksys/SystemTools.hxx"
@@ -270,5 +268,3 @@ PolygonGroupSpatialObjectXMLFileWriter::WriteFile()
   return 0;
 }
 } // namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkConjugateGradientOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkConjugateGradientOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkConjugateGradientOptimizer_hxx
-#define _itkConjugateGradientOptimizer_hxx
 
 #include "itkConjugateGradientOptimizer.h"
 
@@ -159,5 +157,3 @@ ConjugateGradientOptimizer ::GetCurrentIteration() const
   return m_VnlOptimizer->get_num_iterations();
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkCumulativeGaussianCostFunction_cxx
-#define _itkCumulativeGaussianCostFunction_cxx
 
 #include "itkCumulativeGaussianCostFunction.h"
 #include "itkMath.h"
@@ -210,4 +208,3 @@ CumulativeGaussianCostFunction ::PrintSelf(std::ostream & os, Indent indent) con
   os << indent << "Range Dimension = " << m_RangeDimension << std::endl;
 }
 } // end namespace itk
-#endif

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkCumulativeGaussianOptimizer_cxx
-#define _itkCumulativeGaussianOptimizer_cxx
 
 #include "itkCumulativeGaussianOptimizer.h"
 #include "itkMath.h"
@@ -408,5 +406,3 @@ CumulativeGaussianOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
   }
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkFRPROptimizer_cxx
-#define _itkFRPROptimizer_cxx
 
 #include "itkFRPROptimizer.h"
 
@@ -249,4 +247,3 @@ operator<<(std::ostream & out, const FRPROptimizerEnums::Optimization value)
 }
 
 } // end of namespace itk
-#endif

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkGradientDescentOptimizer_hxx
-#define _itkGradientDescentOptimizer_hxx
 
 #include "itkGradientDescentOptimizer.h"
 
@@ -202,5 +200,3 @@ operator<<(std::ostream & out, const GradientDescentOptimizerEnums::StopConditio
   }();
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkLBFGSOptimizer_hxx
-#define _itkLBFGSOptimizer_hxx
 
 #include "itkLBFGSOptimizer.h"
 #include "itkMath.h"
@@ -322,5 +320,3 @@ LBFGSOptimizer::GetStopConditionDescription() const
   }
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkLevenbergMarquardtOptimizer_hxx
-#define _itkLevenbergMarquardtOptimizer_hxx
 
 #include "itkLevenbergMarquardtOptimizer.h"
 
@@ -222,5 +220,3 @@ LevenbergMarquardtOptimizer ::GetStopConditionDescription() const
   return reason.str();
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkMultipleValuedNonLinearOptimizer_hxx
-#define _itkMultipleValuedNonLinearOptimizer_hxx
 
 #include "itkMultipleValuedNonLinearOptimizer.h"
 
@@ -65,5 +63,3 @@ MultipleValuedNonLinearOptimizer ::PrintSelf(std::ostream & os, Indent indent) c
   }
 }
 } // namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkMultipleValuedNonLinearVnlOptimizer_hxx
-#define _itkMultipleValuedNonLinearVnlOptimizer_hxx
 
 #include "itkMultipleValuedNonLinearVnlOptimizer.h"
 
@@ -139,5 +137,3 @@ MultipleValuedNonLinearVnlOptimizer ::PrintSelf(std::ostream & os, Indent indent
   os << "Cost Function adaptor" << m_CostFunctionAdaptor << std::endl;
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkOnePlusOneEvolutionaryOptimizer_cxx
-#define _itkOnePlusOneEvolutionaryOptimizer_cxx
 
 #include "itkOnePlusOneEvolutionaryOptimizer.h"
 #include "vnl/vnl_matrix.h"
@@ -323,4 +321,3 @@ OnePlusOneEvolutionaryOptimizer ::PrintSelf(std::ostream & os, Indent indent) co
   os << indent << "MetricWorstPossibleValue " << GetMetricWorstPossibleValue() << std::endl;
 }
 } // end of namespace itk
-#endif

--- a/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkOptimizer_hxx
-#define _itkOptimizer_hxx
 
 #include "itkOptimizer.h"
 
@@ -107,5 +105,3 @@ Optimizer ::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "StopConditionDescription: " << this->GetStopConditionDescription() << std::endl;
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkPowellOptimizer_cxx
-#define _itkPowellOptimizer_cxx
 
 #include "itkPowellOptimizer.h"
 #include "itkMath.h"
@@ -561,4 +559,3 @@ PowellOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Stop              " << m_Stop << std::endl;
 }
 } // end of namespace itk
-#endif

--- a/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkQuaternionRigidTransformGradientDescentOptimizer_hxx
-#define _itkQuaternionRigidTransformGradientDescentOptimizer_hxx
 
 #include "itkQuaternionRigidTransformGradientDescentOptimizer.h"
 #include "vnl/vnl_quaternion.h"
@@ -78,5 +76,3 @@ QuaternionRigidTransformGradientDescentOptimizer ::AdvanceOneStep()
   this->SetCurrentPosition(newPosition);
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkRegularStepGradientDescentBaseOptimizer_hxx
-#define _itkRegularStepGradientDescentBaseOptimizer_hxx
 
 #include "itkRegularStepGradientDescentBaseOptimizer.h"
 
@@ -305,5 +303,3 @@ operator<<(std::ostream & out, const RegularStepGradientDescentBaseOptimizerEnum
   }();
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkRegularStepGradientDescentOptimizer_hxx
-#define _itkRegularStepGradientDescentOptimizer_hxx
 
 #include "itkRegularStepGradientDescentOptimizer.h"
 
@@ -46,5 +44,3 @@ RegularStepGradientDescentOptimizer ::StepAlongGradient(double factor, const Der
   this->SetCurrentPosition(newPosition);
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkSingleValuedNonLinearOptimizer_hxx
-#define _itkSingleValuedNonLinearOptimizer_hxx
 
 #include "itkSingleValuedNonLinearOptimizer.h"
 
@@ -84,5 +82,3 @@ SingleValuedNonLinearOptimizer ::PrintSelf(std::ostream & os, Indent indent) con
   }
 }
 } // namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkSingleValuedNonLinearVnlOptimizer_hxx
-#define _itkSingleValuedNonLinearVnlOptimizer_hxx
 
 #include "itkSingleValuedNonLinearVnlOptimizer.h"
 
@@ -108,5 +106,3 @@ SingleValuedNonLinearVnlOptimizer ::PrintSelf(std::ostream & os, Indent indent) 
   os << "Cost Function adaptor" << m_CostFunctionAdaptor << std::endl;
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkVersorRigid3DTransformOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkVersorRigid3DTransformOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkVersorRigid3DTransformOptimizer_hxx
-#define _itkVersorRigid3DTransformOptimizer_hxx
 
 #include "itkVersorRigid3DTransformOptimizer.h"
 
@@ -83,5 +81,3 @@ VersorRigid3DTransformOptimizer ::StepAlongGradient(double factor, const Derivat
   this->SetCurrentPosition(newParameters);
 }
 } // end namespace itk
-
-#endif

--- a/Modules/Numerics/Optimizers/src/itkVersorTransformOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkVersorTransformOptimizer.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef _itkVersorTransformOptimizer_hxx
-#define _itkVersorTransformOptimizer_hxx
 
 #include "itkVersorTransformOptimizer.h"
 
@@ -84,5 +82,3 @@ VersorTransformOptimizer ::StepAlongGradient(double factor, const DerivativeType
   this->SetCurrentPosition(newParameters);
 }
 } // end namespace itk
-
-#endif


### PR DESCRIPTION
Include guards (like `itkSomeFileName_h`) are specifically intended to
avoid problems with double inclusion of header files, so they should
only be used in *.h and *.hxx files.

Corresponding elastix pull request:
https://github.com/SuperElastix/elastix/pull/345