### PR TITLE
STYLE: Use C++11 override and `= default` in itkWin32OutputWindow.h

### DIFF
--- a/Modules/Core/Common/include/itkWin32OutputWindow.h
+++ b/Modules/Core/Common/include/itkWin32OutputWindow.h
@@ -69,15 +69,15 @@ public:
 
   /** Put the text into the display window.
    * Each new line is converted to a carriage return, new line. */
-  virtual void
-  DisplayText(const char *);
+  void
+  DisplayText(const char *) override;
 
   static LRESULT APIENTRY
                  WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 protected:
-  Win32OutputWindow() {}
-  virtual ~Win32OutputWindow();
+  Win32OutputWindow() = default;
+  ~Win32OutputWindow() override;
 
   void
   PromptText(const char * text);


### PR DESCRIPTION
Fixed two Clang-Tidy (LLVM 11.0) warnings:

> 'DisplayText' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]

> use '= default' to define a trivial default constructor [modernize-use-equals-default]