### PR TITLE
STYLE: Remove space between class and member names in C++ source files

### DIFF
--- a/Examples/RegistrationITKv4/DeformableRegistration13.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration13.cxx
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
   }
 
   // For consistent results when regression testing.
-  itk::Statistics::MersenneTwisterRandomVariateGenerator ::GetInstance()
+  itk::Statistics::MersenneTwisterRandomVariateGenerator::GetInstance()
     ->SetSeed(121212);
 
   constexpr unsigned int ImageDimension = 2;

--- a/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
+++ b/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
@@ -43,10 +43,10 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   using SpatialObjectType = itk::SpatialObject<3>;
 
-  SpatialObjectType::Pointer object1 = SpatialObjectType ::New();
+  SpatialObjectType::Pointer object1 = SpatialObjectType::New();
   object1->GetProperty().SetName("First Object");
 
-  SpatialObjectType::Pointer object2 = SpatialObjectType ::New();
+  SpatialObjectType::Pointer object2 = SpatialObjectType::New();
   object2->GetProperty().SetName("Second Object");
   // Software Guide : EndCodeSnippet
 

--- a/Examples/SpatialObjects/SpatialObjectTransforms.cxx
+++ b/Examples/SpatialObjects/SpatialObjectTransforms.cxx
@@ -104,10 +104,10 @@ main(int, char *[])
   using SpatialObjectType = itk::SpatialObject<2>;
   using TransformType = SpatialObjectType::TransformType;
 
-  SpatialObjectType::Pointer object1 = SpatialObjectType ::New();
+  SpatialObjectType::Pointer object1 = SpatialObjectType::New();
   object1->GetProperty().SetName("First Object");
 
-  SpatialObjectType::Pointer object2 = SpatialObjectType ::New();
+  SpatialObjectType::Pointer object2 = SpatialObjectType::New();
   object2->GetProperty().SetName("Second Object");
   object1->AddChild(object2);
   // Software Guide : EndCodeSnippet

--- a/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
@@ -47,7 +47,7 @@ public:
   using VectorLengthType = unsigned int;
   using OffsetType = typename ImageType::OffsetType;
 
-  using NeighborhoodType = Neighborhood<InternalPixelType *, TImage ::ImageDimension>;
+  using NeighborhoodType = Neighborhood<InternalPixelType *, TImage::ImageDimension>;
 
   template <typename TOutput = ImageType>
   using ImageBoundaryConditionType = ImageBoundaryCondition<ImageType, TOutput>;

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -35,50 +35,50 @@ itkGetGlobalValueMacro(DataObject, bool, GlobalReleaseDataFlag, false);
 // after use by filter
 bool * DataObject::m_GlobalReleaseDataFlag;
 
-DataObjectError ::DataObjectError() noexcept
+DataObjectError::DataObjectError() noexcept
   : ExceptionObject()
 {}
 
-DataObjectError ::DataObjectError(const char * file, unsigned int lineNumber)
+DataObjectError::DataObjectError(const char * file, unsigned int lineNumber)
   : ExceptionObject(file, lineNumber)
 {}
 
-DataObjectError ::DataObjectError(const std::string & file, unsigned int lineNumber)
+DataObjectError::DataObjectError(const std::string & file, unsigned int lineNumber)
   : ExceptionObject(file, lineNumber)
 {}
 
-DataObjectError ::DataObjectError(const DataObjectError & orig) noexcept
+DataObjectError::DataObjectError(const DataObjectError & orig) noexcept
   : ExceptionObject(orig)
 {
   m_DataObject = orig.m_DataObject;
 }
 
 DataObjectError &
-DataObjectError ::operator=(const DataObjectError &) noexcept = default;
+DataObjectError::operator=(const DataObjectError &) noexcept = default;
 
 void
-DataObjectError ::SetDataObject(DataObject * dobj) noexcept
+DataObjectError::SetDataObject(DataObject * dobj) noexcept
 {
   m_DataObject = dobj;
 }
 
 #if !defined(ITK_LEGACY_REMOVE)
 DataObject *
-DataObjectError ::GetDataObject() noexcept
+DataObjectError::GetDataObject() noexcept
 {
   return m_DataObject;
 }
 #endif
 
 const DataObject *
-DataObjectError ::GetDataObject() const noexcept
+DataObjectError::GetDataObject() const noexcept
 {
   return m_DataObject;
 }
 
 
 void
-DataObjectError ::PrintSelf(std::ostream & os, Indent indent) const
+DataObjectError::PrintSelf(std::ostream & os, Indent indent) const
 {
   ExceptionObject::Print(os);
 
@@ -94,25 +94,25 @@ DataObjectError ::PrintSelf(std::ostream & os, Indent indent) const
   }
 }
 
-InvalidRequestedRegionError ::InvalidRequestedRegionError() noexcept
+InvalidRequestedRegionError::InvalidRequestedRegionError() noexcept
   : DataObjectError()
 {}
 
-InvalidRequestedRegionError ::InvalidRequestedRegionError(const char * file, unsigned int lineNumber)
+InvalidRequestedRegionError::InvalidRequestedRegionError(const char * file, unsigned int lineNumber)
   : DataObjectError(file, lineNumber)
 {}
 
-InvalidRequestedRegionError ::InvalidRequestedRegionError(const std::string & file, unsigned int lineNumber)
+InvalidRequestedRegionError::InvalidRequestedRegionError(const std::string & file, unsigned int lineNumber)
   : DataObjectError(file, lineNumber)
 {}
 
-InvalidRequestedRegionError ::InvalidRequestedRegionError(const InvalidRequestedRegionError &) noexcept = default;
+InvalidRequestedRegionError::InvalidRequestedRegionError(const InvalidRequestedRegionError &) noexcept = default;
 
 InvalidRequestedRegionError &
-InvalidRequestedRegionError ::operator=(const InvalidRequestedRegionError &) noexcept = default;
+InvalidRequestedRegionError::operator=(const InvalidRequestedRegionError &) noexcept = default;
 
 void
-InvalidRequestedRegionError ::PrintSelf(std::ostream & os, Indent indent) const
+InvalidRequestedRegionError::PrintSelf(std::ostream & os, Indent indent) const
 {
   DataObjectError::PrintSelf(os, indent);
 }
@@ -133,11 +133,11 @@ DataObject::DataObject()
 }
 
 //----------------------------------------------------------------------------
-DataObject ::~DataObject() = default;
+DataObject::~DataObject() = default;
 
 //----------------------------------------------------------------------------
 void
-DataObject ::Initialize()
+DataObject::Initialize()
 {
   // We don't modify ourselves because the "ReleaseData" methods depend upon
   // no modification when initialized.
@@ -146,7 +146,7 @@ DataObject ::Initialize()
 
 //----------------------------------------------------------------------------
 void
-DataObject ::SetGlobalReleaseDataFlag(bool val)
+DataObject::SetGlobalReleaseDataFlag(bool val)
 {
   itkInitGlobalsMacro(GlobalReleaseDataFlag);
   if (val == *m_GlobalReleaseDataFlag)
@@ -158,14 +158,14 @@ DataObject ::SetGlobalReleaseDataFlag(bool val)
 
 //----------------------------------------------------------------------------
 bool
-DataObject ::GetGlobalReleaseDataFlag()
+DataObject::GetGlobalReleaseDataFlag()
 {
   return *DataObject::GetGlobalReleaseDataFlagPointer();
 }
 
 //----------------------------------------------------------------------------
 void
-DataObject ::ReleaseData()
+DataObject::ReleaseData()
 {
   this->Initialize();
   m_DataReleased = true;
@@ -173,7 +173,7 @@ DataObject ::ReleaseData()
 
 //----------------------------------------------------------------------------
 bool
-DataObject ::ShouldIReleaseData() const
+DataObject::ShouldIReleaseData() const
 {
   return (GetGlobalReleaseDataFlag() || m_ReleaseDataFlag);
 }
@@ -182,7 +182,7 @@ DataObject ::ShouldIReleaseData() const
 // Set the process object that generates this data object.
 //
 void
-DataObject ::DisconnectPipeline()
+DataObject::DisconnectPipeline()
 {
   itkDebugMacro("disconnecting from the pipeline.");
 
@@ -204,7 +204,7 @@ DataObject ::DisconnectPipeline()
 }
 
 bool
-DataObject ::DisconnectSource(ProcessObject * arg, const DataObjectIdentifierType & name)
+DataObject::DisconnectSource(ProcessObject * arg, const DataObjectIdentifierType & name)
 {
   if (m_Source == arg && m_SourceOutputName == name)
   {
@@ -223,7 +223,7 @@ DataObject ::DisconnectSource(ProcessObject * arg, const DataObjectIdentifierTyp
 }
 
 bool
-DataObject ::ConnectSource(ProcessObject * arg, const DataObjectIdentifierType & name)
+DataObject::ConnectSource(ProcessObject * arg, const DataObjectIdentifierType & name)
 {
   if (m_Source != arg || m_SourceOutputName != name)
   {
@@ -245,21 +245,21 @@ DataObject ::ConnectSource(ProcessObject * arg, const DataObjectIdentifierType &
 //----------------------------------------------------------------------------
 
 SmartPointer<ProcessObject>
-DataObject ::GetSource() const
+DataObject::GetSource() const
 {
   itkDebugMacro("returning Source address " << m_Source.GetPointer());
   return m_Source.GetPointer();
 }
 
 const DataObject::DataObjectIdentifierType &
-DataObject ::GetSourceOutputName() const
+DataObject::GetSourceOutputName() const
 {
   itkDebugMacro("returning Source name " << m_SourceOutputName);
   return m_SourceOutputName;
 }
 
 DataObject::DataObjectPointerArraySizeType
-DataObject ::GetSourceOutputIndex() const
+DataObject::GetSourceOutputIndex() const
 {
   if (!m_Source)
   {
@@ -270,7 +270,7 @@ DataObject ::GetSourceOutputIndex() const
 
 //----------------------------------------------------------------------------
 void
-DataObject ::PrintSelf(std::ostream & os, Indent indent) const
+DataObject::PrintSelf(std::ostream & os, Indent indent) const
 {
   Object::PrintSelf(os, indent);
 
@@ -301,7 +301,7 @@ DataObject ::PrintSelf(std::ostream & os, Indent indent) const
 
 //----------------------------------------------------------------------------
 void
-DataObject ::Update()
+DataObject::Update()
 {
   this->UpdateOutputInformation();
   this->PropagateRequestedRegion();
@@ -309,7 +309,7 @@ DataObject ::Update()
 }
 
 void
-DataObject ::UpdateOutputInformation()
+DataObject::UpdateOutputInformation()
 {
 
   if (this->GetSource())
@@ -319,13 +319,13 @@ DataObject ::UpdateOutputInformation()
 }
 
 void
-DataObject ::ResetPipeline()
+DataObject::ResetPipeline()
 {
   this->PropagateResetPipeline();
 }
 
 void
-DataObject ::PropagateResetPipeline()
+DataObject::PropagateResetPipeline()
 {
   if (m_Source)
   {
@@ -335,7 +335,7 @@ DataObject ::PropagateResetPipeline()
 
 //----------------------------------------------------------------------------
 void
-DataObject ::PropagateRequestedRegion()
+DataObject::PropagateRequestedRegion()
 {
   // If we need to update due to PipelineMTime, or the fact that our
   // data was released, then propagate the update region to the source
@@ -364,7 +364,7 @@ DataObject ::PropagateRequestedRegion()
 
 //----------------------------------------------------------------------------
 void
-DataObject ::UpdateOutputData()
+DataObject::UpdateOutputData()
 {
   // If we need to update due to PipelineMTime, or the fact that our
   // data was released, then propagate the UpdateOutputData to the source
@@ -380,7 +380,7 @@ DataObject ::UpdateOutputData()
 
 //----------------------------------------------------------------------------
 void
-DataObject ::DataHasBeenGenerated()
+DataObject::DataHasBeenGenerated()
 {
   this->m_DataReleased = false;
   this->Modified();
@@ -389,7 +389,7 @@ DataObject ::DataHasBeenGenerated()
 
 //----------------------------------------------------------------------------
 ModifiedTimeType
-DataObject ::GetUpdateMTime() const
+DataObject::GetUpdateMTime() const
 {
   return m_UpdateMTime.GetMTime();
 }

--- a/Modules/Core/Common/src/itkEquivalencyTable.cxx
+++ b/Modules/Core/Common/src/itkEquivalencyTable.cxx
@@ -139,7 +139,7 @@ EquivalencyTable::RecursiveLookup(const unsigned long a) const
 }
 
 void
-EquivalencyTable ::PrintSelf(std::ostream & os, Indent indent) const
+EquivalencyTable::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/Core/Common/src/itkEventObject.cxx
+++ b/Modules/Core/Common/src/itkEventObject.cxx
@@ -20,7 +20,7 @@
 namespace itk
 {
 void
-EventObject ::Print(std::ostream & os) const
+EventObject::Print(std::ostream & os) const
 {
   Indent indent;
 
@@ -33,7 +33,7 @@ EventObject ::Print(std::ostream & os) const
  * Define a default print header for all objects.
  */
 void
-EventObject ::PrintHeader(std::ostream & os, Indent indent) const
+EventObject::PrintHeader(std::ostream & os, Indent indent) const
 {
   os << std::endl;
   os << indent << "itk::" << this->GetEventName() << " (" << this << ")\n";
@@ -43,13 +43,13 @@ EventObject ::PrintHeader(std::ostream & os, Indent indent) const
  * Define a default print trailer for all objects.
  */
 void
-EventObject ::PrintTrailer(std::ostream & os, Indent indent) const
+EventObject::PrintTrailer(std::ostream & os, Indent indent) const
 {
   os << indent << std::endl;
 }
 
 void
-EventObject ::PrintSelf(std::ostream &, Indent) const
+EventObject::PrintSelf(std::ostream &, Indent) const
 {}
 
 /**

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -297,7 +297,7 @@ ExceptionObject::what() const noexcept
 }
 
 void
-ExceptionObject ::Print(std::ostream & os) const
+ExceptionObject::Print(std::ostream & os) const
 {
   Indent indent;
 

--- a/Modules/Core/Common/src/itkFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkFileOutputWindow.cxx
@@ -22,7 +22,7 @@ namespace itk
 /**
  * Prompting off by default
  */
-FileOutputWindow ::FileOutputWindow()
+FileOutputWindow::FileOutputWindow()
 {
   m_Flush = false;
   m_Append = false;
@@ -37,7 +37,7 @@ FileOutputWindow ::~FileOutputWindow()
 }
 
 void
-FileOutputWindow ::PrintSelf(std::ostream & os, Indent indent) const
+FileOutputWindow::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -48,7 +48,7 @@ FileOutputWindow ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 void
-FileOutputWindow ::Initialize()
+FileOutputWindow::Initialize()
 {
   if (!m_Stream)
   {
@@ -71,7 +71,7 @@ FileOutputWindow ::Initialize()
  *
  */
 void
-FileOutputWindow ::DisplayText(const char * txt)
+FileOutputWindow::DisplayText(const char * txt)
 {
   if (!txt)
   {

--- a/Modules/Core/Common/src/itkFloatingPointExceptions.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions.cxx
@@ -40,7 +40,7 @@ struct ExceptionGlobals
 };
 
 void
-FloatingPointExceptions ::SetExceptionAction(FloatingPointExceptions::ExceptionActionEnum a)
+FloatingPointExceptions::SetExceptionAction(FloatingPointExceptions::ExceptionActionEnum a)
 {
   itkInitGlobalsMacro(PimplGlobals);
   FloatingPointExceptions::m_PimplGlobals->m_ExceptionAction = a;

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -133,7 +133,7 @@ namespace itk
 {
 
 void
-FloatingPointExceptions ::Enable()
+FloatingPointExceptions::Enable()
 {
   itkInitGlobalsMacro(PimplGlobals);
 #if defined(ITK_HAS_FPE_CAPABILITY) && !defined(__EMSCRIPTEN__)
@@ -155,7 +155,7 @@ FloatingPointExceptions ::Enable()
 }
 
 void
-FloatingPointExceptions ::Disable()
+FloatingPointExceptions::Disable()
 {
   itkInitGlobalsMacro(PimplGlobals);
 #if defined(ITK_HAS_FPE_CAPABILITY) && !defined(__EMSCRIPTEN__)
@@ -168,7 +168,7 @@ FloatingPointExceptions ::Disable()
 }
 
 bool
-FloatingPointExceptions ::HasFloatingPointExceptionsSupport()
+FloatingPointExceptions::HasFloatingPointExceptionsSupport()
 {
   itkInitGlobalsMacro(PimplGlobals);
 #if defined(ITK_HAS_FPE_CAPABILITY)

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_win.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_win.cxx
@@ -30,7 +30,7 @@ namespace itk
 #  include <cfloat>
 
 void
-FloatingPointExceptions ::Enable()
+FloatingPointExceptions::Enable()
 {
   itkInitGlobalsMacro(PimplGlobals);
   // enable floating point exceptions on MSVC
@@ -39,7 +39,7 @@ FloatingPointExceptions ::Enable()
 }
 
 void
-FloatingPointExceptions ::Disable()
+FloatingPointExceptions::Disable()
 {
   itkInitGlobalsMacro(PimplGlobals);
   // disable floating point exceptions on MSVC
@@ -48,7 +48,7 @@ FloatingPointExceptions ::Disable()
 }
 
 bool
-FloatingPointExceptions ::HasFloatingPointExceptionsSupport()
+FloatingPointExceptions::HasFloatingPointExceptionsSupport()
 {
   itkInitGlobalsMacro(PimplGlobals);
   return true;
@@ -59,21 +59,21 @@ FloatingPointExceptions ::HasFloatingPointExceptionsSupport()
 // MinGW has troubles include'ing float.h.
 
 void
-FloatingPointExceptions ::Enable()
+FloatingPointExceptions::Enable()
 {
   itkInitGlobalsMacro(PimplGlobals);
   itkFloatingPointExceptionsNotSupported();
 }
 
 void
-FloatingPointExceptions ::Disable()
+FloatingPointExceptions::Disable()
 {
   itkInitGlobalsMacro(PimplGlobals);
   itkFloatingPointExceptionsNotSupported();
 }
 
 bool
-FloatingPointExceptions ::HasFloatingPointExceptionsSupport()
+FloatingPointExceptions::HasFloatingPointExceptionsSupport()
 {
   itkInitGlobalsMacro(PimplGlobals);
   return false;

--- a/Modules/Core/Common/src/itkHexahedronCellTopology.cxx
+++ b/Modules/Core/Common/src/itkHexahedronCellTopology.cxx
@@ -31,7 +31,7 @@ const int HexahedronCellTopology ::m_Edges[12][2] = { { 0, 1 }, { 1, 2 }, { 3, 2
 const int HexahedronCellTopology ::m_Faces[6][4] = { { 0, 4, 7, 3 }, { 1, 2, 6, 5 }, { 0, 1, 5, 4 },
                                                      { 3, 7, 6, 2 }, { 0, 3, 2, 1 }, { 4, 5, 6, 7 } };
 
-HexahedronCellTopology ::HexahedronCellTopology() = default;
+HexahedronCellTopology::HexahedronCellTopology() = default;
 
 HexahedronCellTopology ::~HexahedronCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkImageIORegion.cxx
+++ b/Modules/Core/Common/src/itkImageIORegion.cxx
@@ -24,7 +24,7 @@ namespace itk
 
 ImageIORegion ::~ImageIORegion() = default;
 
-ImageIORegion ::ImageIORegion(unsigned int dimension)
+ImageIORegion::ImageIORegion(unsigned int dimension)
   : m_ImageDimension{ dimension }
   , m_Index(dimension)
   , m_Size(dimension)
@@ -62,20 +62,20 @@ operator<<(std::ostream & os, const ImageIORegion & region)
 
 /** Set the index defining the corner of the region. */
 void
-ImageIORegion ::SetIndex(const IndexType & index)
+ImageIORegion::SetIndex(const IndexType & index)
 {
   m_Index = index;
 }
 
 /** Get index defining the corner of the region. */
 const ImageIORegion::IndexType &
-ImageIORegion ::GetIndex() const
+ImageIORegion::GetIndex() const
 {
   return m_Index;
 }
 
 ImageIORegion::IndexType &
-ImageIORegion ::GetModifiableIndex()
+ImageIORegion::GetModifiableIndex()
 {
   return m_Index;
 }
@@ -84,38 +84,38 @@ ImageIORegion ::GetModifiableIndex()
 /** Set the size of the region. This plus the index determines the
  * rectangular shape, or extent, of the region. */
 void
-ImageIORegion ::SetSize(const SizeType & size)
+ImageIORegion::SetSize(const SizeType & size)
 {
   m_Size = size;
 }
 
 /** Get the size of the region. */
 const ImageIORegion::SizeType &
-ImageIORegion ::GetSize() const
+ImageIORegion::GetSize() const
 {
   return m_Size;
 }
 
 ImageIORegion::SizeType &
-ImageIORegion ::GetModifiableSize()
+ImageIORegion::GetModifiableSize()
 {
   return m_Size;
 }
 
 unsigned int
-ImageIORegion ::GetImageDimension() const
+ImageIORegion::GetImageDimension() const
 {
   return m_ImageDimension;
 }
 
 ImageIORegion::RegionType
-ImageIORegion ::GetRegionType() const
+ImageIORegion::GetRegionType() const
 {
   return Superclass::RegionEnum::ITK_STRUCTURED_REGION;
 }
 
 unsigned int
-ImageIORegion ::GetRegionDimension() const
+ImageIORegion::GetRegionDimension() const
 {
   unsigned int dim = 0;
 
@@ -130,7 +130,7 @@ ImageIORegion ::GetRegionDimension() const
 }
 
 ImageIORegion::SizeValueType
-ImageIORegion ::GetSize(unsigned long i) const
+ImageIORegion::GetSize(unsigned long i) const
 {
   if (i >= m_Size.size())
   {
@@ -140,7 +140,7 @@ ImageIORegion ::GetSize(unsigned long i) const
 }
 
 ImageIORegion::IndexValueType
-ImageIORegion ::GetIndex(unsigned long i) const
+ImageIORegion::GetIndex(unsigned long i) const
 {
   if (i >= m_Index.size())
   {
@@ -150,7 +150,7 @@ ImageIORegion ::GetIndex(unsigned long i) const
 }
 
 void
-ImageIORegion ::SetSize(const unsigned long i, SizeValueType size)
+ImageIORegion::SetSize(const unsigned long i, SizeValueType size)
 {
   if (i >= m_Size.size())
   {
@@ -160,7 +160,7 @@ ImageIORegion ::SetSize(const unsigned long i, SizeValueType size)
 }
 
 void
-ImageIORegion ::SetIndex(const unsigned long i, IndexValueType idx)
+ImageIORegion::SetIndex(const unsigned long i, IndexValueType idx)
 {
   if (i >= m_Index.size())
   {
@@ -170,7 +170,7 @@ ImageIORegion ::SetIndex(const unsigned long i, IndexValueType idx)
 }
 
 bool
-ImageIORegion ::IsInside(const IndexType & index) const
+ImageIORegion::IsInside(const IndexType & index) const
 {
   if (m_ImageDimension != index.size())
   {
@@ -192,7 +192,7 @@ ImageIORegion ::IsInside(const IndexType & index) const
 
 /** Test if a region (the argument) is completly inside of this region */
 bool
-ImageIORegion ::IsInside(const Self & region) const
+ImageIORegion::IsInside(const Self & region) const
 {
   IndexType beginCorner = region.GetIndex();
 
@@ -216,7 +216,7 @@ ImageIORegion ::IsInside(const Self & region) const
 /** Get the number of pixels contained in this region. This just
  * multiplies the size components. */
 ImageIORegion::SizeValueType
-ImageIORegion ::GetNumberOfPixels() const
+ImageIORegion::GetNumberOfPixels() const
 {
   size_t numPixels = 1;
 
@@ -242,7 +242,7 @@ ImageIORegion ::operator!=(const Self & region) const
 }
 
 void
-ImageIORegion ::PrintSelf(std::ostream & os, Indent indent) const
+ImageIORegion::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/Common/src/itkImageRegionSplitterBase.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterBase.cxx
@@ -22,10 +22,10 @@
 namespace itk
 {
 
-ImageRegionSplitterBase ::ImageRegionSplitterBase() = default;
+ImageRegionSplitterBase::ImageRegionSplitterBase() = default;
 
 void
-ImageRegionSplitterBase ::PrintSelf(std::ostream & os, Indent indent) const
+ImageRegionSplitterBase::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/Core/Common/src/itkImageRegionSplitterDirection.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterDirection.cxx
@@ -22,13 +22,13 @@
 namespace itk
 {
 
-ImageRegionSplitterDirection ::ImageRegionSplitterDirection()
+ImageRegionSplitterDirection::ImageRegionSplitterDirection()
 {
   this->m_Direction = 0;
 }
 
 void
-ImageRegionSplitterDirection ::PrintSelf(std::ostream & os, Indent indent) const
+ImageRegionSplitterDirection::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -36,10 +36,10 @@ ImageRegionSplitterDirection ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 unsigned int
-ImageRegionSplitterDirection ::GetNumberOfSplitsInternal(unsigned int         dim,
-                                                         const IndexValueType itkNotUsed(regionIndex)[],
-                                                         const SizeValueType  regionSize[],
-                                                         unsigned int         requestedNumber) const
+ImageRegionSplitterDirection::GetNumberOfSplitsInternal(unsigned int         dim,
+                                                        const IndexValueType itkNotUsed(regionIndex)[],
+                                                        const SizeValueType  regionSize[],
+                                                        unsigned int         requestedNumber) const
 {
   // split on the outermost dimension available
   int splitAxis = dim - 1;
@@ -62,11 +62,11 @@ ImageRegionSplitterDirection ::GetNumberOfSplitsInternal(unsigned int         di
 }
 
 unsigned int
-ImageRegionSplitterDirection ::GetSplitInternal(unsigned int   dim,
-                                                unsigned int   i,
-                                                unsigned int   numberOfPieces,
-                                                IndexValueType regionIndex[],
-                                                SizeValueType  regionSize[]) const
+ImageRegionSplitterDirection::GetSplitInternal(unsigned int   dim,
+                                               unsigned int   i,
+                                               unsigned int   numberOfPieces,
+                                               IndexValueType regionIndex[],
+                                               SizeValueType  regionSize[]) const
 {
   // split on the outermost dimension available
   // and avoid the current dimension

--- a/Modules/Core/Common/src/itkImageRegionSplitterMultidimensional.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterMultidimensional.cxx
@@ -24,19 +24,19 @@ namespace itk
 /**
  *
  */
-ImageRegionSplitterMultidimensional ::ImageRegionSplitterMultidimensional() = default;
+ImageRegionSplitterMultidimensional::ImageRegionSplitterMultidimensional() = default;
 
 void
-ImageRegionSplitterMultidimensional ::PrintSelf(std::ostream & os, Indent indent) const
+ImageRegionSplitterMultidimensional::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }
 
 unsigned int
-ImageRegionSplitterMultidimensional ::GetNumberOfSplitsInternal(unsigned int         dim,
-                                                                const IndexValueType regionIndex[],
-                                                                const SizeValueType  regionSize[],
-                                                                unsigned int         requestedNumber) const
+ImageRegionSplitterMultidimensional::GetNumberOfSplitsInternal(unsigned int         dim,
+                                                               const IndexValueType regionIndex[],
+                                                               const SizeValueType  regionSize[],
+                                                               unsigned int         requestedNumber) const
 {
   // number of splits in each dimension
   std::vector<unsigned int> splits(dim); // Note: stack allocation preferred
@@ -47,11 +47,11 @@ ImageRegionSplitterMultidimensional ::GetNumberOfSplitsInternal(unsigned int    
 }
 
 unsigned int
-ImageRegionSplitterMultidimensional ::GetSplitInternal(unsigned int   dim,
-                                                       unsigned int   splitI,
-                                                       unsigned int   numberOfPieces,
-                                                       IndexValueType regionIndex[],
-                                                       SizeValueType  regionSize[]) const
+ImageRegionSplitterMultidimensional::GetSplitInternal(unsigned int   dim,
+                                                      unsigned int   splitI,
+                                                      unsigned int   numberOfPieces,
+                                                      IndexValueType regionIndex[],
+                                                      SizeValueType  regionSize[]) const
 {
   // number of splits in each dimension
   std::vector<unsigned int> splits(dim); // Note: stack allocation preferred
@@ -107,11 +107,11 @@ ImageRegionSplitterMultidimensional ::GetSplitInternal(unsigned int   dim,
  * as "splits" and returns the total number of splitted regions
  */
 unsigned int
-ImageRegionSplitterMultidimensional ::ComputeSplits(unsigned int         dim,
-                                                    unsigned int         requestedNumber,
-                                                    const IndexValueType itkNotUsed(regionIndex)[],
-                                                    const SizeValueType  regionSize[],
-                                                    unsigned int         splits[])
+ImageRegionSplitterMultidimensional::ComputeSplits(unsigned int         dim,
+                                                   unsigned int         requestedNumber,
+                                                   const IndexValueType itkNotUsed(regionIndex)[],
+                                                   const SizeValueType  regionSize[],
+                                                   unsigned int         splits[])
 {
   // size of each splited region
   std::vector<double> splitRegionSize(dim); // Note: stack allocation preferred

--- a/Modules/Core/Common/src/itkImageRegionSplitterSlowDimension.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterSlowDimension.cxx
@@ -22,13 +22,13 @@
 namespace itk
 {
 
-ImageRegionSplitterSlowDimension ::ImageRegionSplitterSlowDimension() = default;
+ImageRegionSplitterSlowDimension::ImageRegionSplitterSlowDimension() = default;
 
 unsigned int
-ImageRegionSplitterSlowDimension ::GetNumberOfSplitsInternal(unsigned int         dim,
-                                                             const IndexValueType itkNotUsed(regionIndex)[],
-                                                             const SizeValueType  regionSize[],
-                                                             unsigned int         requestedNumber) const
+ImageRegionSplitterSlowDimension::GetNumberOfSplitsInternal(unsigned int         dim,
+                                                            const IndexValueType itkNotUsed(regionIndex)[],
+                                                            const SizeValueType  regionSize[],
+                                                            unsigned int         requestedNumber) const
 {
   // split on the outermost dimension available
   int splitAxis = dim - 1;
@@ -51,11 +51,11 @@ ImageRegionSplitterSlowDimension ::GetNumberOfSplitsInternal(unsigned int       
 }
 
 unsigned int
-ImageRegionSplitterSlowDimension ::GetSplitInternal(unsigned int   dim,
-                                                    unsigned int   i,
-                                                    unsigned int   numberOfPieces,
-                                                    IndexValueType regionIndex[],
-                                                    SizeValueType  regionSize[]) const
+ImageRegionSplitterSlowDimension::GetSplitInternal(unsigned int   dim,
+                                                   unsigned int   i,
+                                                   unsigned int   numberOfPieces,
+                                                   IndexValueType regionIndex[],
+                                                   SizeValueType  regionSize[]) const
 {
 
   // split on the outermost dimension available

--- a/Modules/Core/Common/src/itkImageToImageFilterCommon.cxx
+++ b/Modules/Core/Common/src/itkImageToImageFilterCommon.cxx
@@ -28,25 +28,25 @@ double globalDefaultDirectionTolerance = 1.0e-6;
 } // namespace
 
 void
-ImageToImageFilterCommon ::SetGlobalDefaultCoordinateTolerance(double tolerance)
+ImageToImageFilterCommon::SetGlobalDefaultCoordinateTolerance(double tolerance)
 {
   globalDefaultCoordinateTolerance = tolerance;
 }
 
 double
-ImageToImageFilterCommon ::GetGlobalDefaultCoordinateTolerance()
+ImageToImageFilterCommon::GetGlobalDefaultCoordinateTolerance()
 {
   return globalDefaultCoordinateTolerance;
 }
 
 void
-ImageToImageFilterCommon ::SetGlobalDefaultDirectionTolerance(double tolerance)
+ImageToImageFilterCommon::SetGlobalDefaultDirectionTolerance(double tolerance)
 {
   globalDefaultDirectionTolerance = tolerance;
 }
 
 double
-ImageToImageFilterCommon ::GetGlobalDefaultDirectionTolerance()
+ImageToImageFilterCommon::GetGlobalDefaultDirectionTolerance()
 {
   return globalDefaultDirectionTolerance;
 }

--- a/Modules/Core/Common/src/itkIndent.cxx
+++ b/Modules/Core/Common/src/itkIndent.cxx
@@ -48,7 +48,7 @@ Indent::New()
  * max of forty.
  */
 Indent
-Indent ::GetNextIndent() const
+Indent::GetNextIndent() const
 {
   int indent = m_Indent + ITK_STD_INDENT;
 

--- a/Modules/Core/Common/src/itkLightObject.cxx
+++ b/Modules/Core/Common/src/itkLightObject.cxx
@@ -78,7 +78,7 @@ LightObject::InternalClone() const
  * will not work with reference counting.
  */
 void
-LightObject ::Delete()
+LightObject::Delete()
 {
   this->UnRegister();
 }
@@ -119,7 +119,7 @@ LightObject ::operator delete[](void * m, size_t)
  * subclasses (any itk object).
  */
 void
-LightObject ::Print(std::ostream & os, Indent indent) const
+LightObject::Print(std::ostream & os, Indent indent) const
 {
   this->PrintHeader(os, indent);
   this->PrintSelf(os, indent.GetNextIndent());
@@ -131,14 +131,14 @@ LightObject ::Print(std::ostream & os, Indent indent) const
  * the debugger to break on error.
  */
 void
-LightObject ::BreakOnError()
+LightObject::BreakOnError()
 {}
 
 /**
  * Increase the reference count (mark as used by another object).
  */
 void
-LightObject ::Register() const
+LightObject::Register() const
 {
   ++m_ReferenceCount;
 }
@@ -147,7 +147,7 @@ LightObject ::Register() const
  * Decrease the reference count (release by another object).
  */
 void
-LightObject ::UnRegister() const noexcept
+LightObject::UnRegister() const noexcept
 {
   // As ReferenceCount gets unlocked, we may have a race condition
   // to delete the object.
@@ -162,7 +162,7 @@ LightObject ::UnRegister() const noexcept
  * Sets the reference count (use with care)
  */
 void
-LightObject ::SetReferenceCount(int ref)
+LightObject::SetReferenceCount(int ref)
 {
   m_ReferenceCount = ref;
 
@@ -202,7 +202,7 @@ LightObject ::~LightObject()
  * its superclasses.
  */
 void
-LightObject ::PrintSelf(std::ostream & os, Indent indent) const
+LightObject::PrintSelf(std::ostream & os, Indent indent) const
 {
 #ifdef GCC_USEDEMANGLE
   char const * mangledName = typeid(*this).name();
@@ -232,7 +232,7 @@ LightObject ::PrintSelf(std::ostream & os, Indent indent) const
  * Define a default print header for all objects.
  */
 void
-LightObject ::PrintHeader(std::ostream & os, Indent indent) const
+LightObject::PrintHeader(std::ostream & os, Indent indent) const
 {
   os << indent << this->GetNameOfClass() << " (" << this << ")\n";
 }
@@ -241,7 +241,7 @@ LightObject ::PrintHeader(std::ostream & os, Indent indent) const
  * Define a default print trailer for all objects.
  */
 void
-LightObject ::PrintTrailer(std::ostream & itkNotUsed(os), Indent itkNotUsed(indent)) const
+LightObject::PrintTrailer(std::ostream & itkNotUsed(os), Indent itkNotUsed(indent)) const
 {}
 
 std::ostream &

--- a/Modules/Core/Common/src/itkLightProcessObject.cxx
+++ b/Modules/Core/Common/src/itkLightProcessObject.cxx
@@ -22,7 +22,7 @@ namespace itk
 /**
  * Instantiate object with no start, end, or progress methods.
  */
-LightProcessObject ::LightProcessObject()
+LightProcessObject::LightProcessObject()
 {
   m_AbortGenerateData = false;
   m_Progress = 0.0f;
@@ -40,7 +40,7 @@ LightProcessObject ::~LightProcessObject() = default;
  * should range between (0,1).
  */
 void
-LightProcessObject ::UpdateProgress(float amount)
+LightProcessObject::UpdateProgress(float amount)
 {
   m_Progress = amount;
   this->InvokeEvent(ProgressEvent());
@@ -50,7 +50,7 @@ LightProcessObject ::UpdateProgress(float amount)
  *
  */
 void
-LightProcessObject ::PrintSelf(std::ostream & os, Indent indent) const
+LightProcessObject::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -62,7 +62,7 @@ LightProcessObject ::PrintSelf(std::ostream & os, Indent indent) const
  *
  */
 void
-LightProcessObject ::UpdateOutputData()
+LightProcessObject::UpdateOutputData()
 {
   this->InvokeEvent(StartEvent());
 

--- a/Modules/Core/Common/src/itkLoggerBase.cxx
+++ b/Modules/Core/Common/src/itkLoggerBase.cxx
@@ -63,7 +63,7 @@ LoggerBase::Flush()
 }
 
 std::string
-LoggerBase ::BuildFormattedEntry(PriorityLevelEnum level, std::string const & content)
+LoggerBase::BuildFormattedEntry(PriorityLevelEnum level, std::string const & content)
 {
   static std::string m_LevelString[] = { "(MUSTFLUSH) ", "(FATAL) ", "(CRITICAL) ", "(WARNING) ",
                                          "(INFO) ",      "(DEBUG) ", "(NOTSET) " };

--- a/Modules/Core/Common/src/itkMemoryProbe.cxx
+++ b/Modules/Core/Common/src/itkMemoryProbe.cxx
@@ -19,14 +19,14 @@
 
 namespace itk
 {
-MemoryProbe ::MemoryProbe()
+MemoryProbe::MemoryProbe()
   : ResourceProbe<MemoryProbe::MemoryLoadType, double>("Memory", "kB")
 {}
 
 MemoryProbe ::~MemoryProbe() = default;
 
 MemoryProbe::MemoryLoadType
-MemoryProbe ::GetInstantValue() const
+MemoryProbe::GetInstantValue() const
 {
   return static_cast<MemoryProbe::MemoryLoadType>(m_MemoryObserver.GetMemoryUsage());
 }

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -42,7 +42,7 @@ itkGetGlobalSimpleMacro(MersenneTwisterRandomVariateGenerator, MersenneTwisterGl
 MersenneTwisterGlobals * MersenneTwisterRandomVariateGenerator::m_PimplGlobals;
 
 MersenneTwisterRandomVariateGenerator::Pointer
-MersenneTwisterRandomVariateGenerator ::CreateInstance()
+MersenneTwisterRandomVariateGenerator::CreateInstance()
 {
   // Try the factory first
   MersenneTwisterRandomVariateGenerator::Pointer obj = ObjectFactory<Self>::Create();
@@ -58,7 +58,7 @@ MersenneTwisterRandomVariateGenerator ::CreateInstance()
 
 
 MersenneTwisterRandomVariateGenerator::Pointer
-MersenneTwisterRandomVariateGenerator ::New()
+MersenneTwisterRandomVariateGenerator::New()
 {
   MersenneTwisterRandomVariateGenerator::Pointer obj = MersenneTwisterRandomVariateGenerator::CreateInstance();
 
@@ -67,7 +67,7 @@ MersenneTwisterRandomVariateGenerator ::New()
 }
 
 MersenneTwisterRandomVariateGenerator::Pointer
-MersenneTwisterRandomVariateGenerator ::GetInstance()
+MersenneTwisterRandomVariateGenerator::GetInstance()
 {
   itkInitGlobalsMacro(PimplGlobals);
   std::lock_guard<std::recursive_mutex> mutexHolder(m_PimplGlobals->m_StaticInstanceLock);
@@ -81,7 +81,7 @@ MersenneTwisterRandomVariateGenerator ::GetInstance()
   return m_PimplGlobals->m_StaticInstance;
 }
 
-MersenneTwisterRandomVariateGenerator ::MersenneTwisterRandomVariateGenerator()
+MersenneTwisterRandomVariateGenerator::MersenneTwisterRandomVariateGenerator()
 {
   SetSeed(121212);
 }
@@ -118,7 +118,7 @@ MersenneTwisterRandomVariateGenerator ::hash(time_t t, clock_t c)
 }
 
 MersenneTwisterRandomVariateGenerator::IntegerType
-MersenneTwisterRandomVariateGenerator ::GetNextSeed()
+MersenneTwisterRandomVariateGenerator::GetNextSeed()
 {
   itkInitGlobalsMacro(PimplGlobals);
   IntegerType newSeed = GetInstance()->GetSeed();
@@ -129,7 +129,7 @@ MersenneTwisterRandomVariateGenerator ::GetNextSeed()
 }
 
 void
-MersenneTwisterRandomVariateGenerator ::PrintSelf(std::ostream & os, Indent indent) const
+MersenneTwisterRandomVariateGenerator::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/Common/src/itkMetaDataDictionary.cxx
+++ b/Modules/Core/Common/src/itkMetaDataDictionary.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-MetaDataDictionary ::MetaDataDictionary()
+MetaDataDictionary::MetaDataDictionary()
   : m_Dictionary(std::make_shared<MetaDataDictionaryMapType>())
 {}
 
@@ -27,7 +27,7 @@ MetaDataDictionary ::~MetaDataDictionary() = default;
 
 // NOTE: Desired behavior is to perform shallow copy, so m_Dictionary is shared
 //       as is thee default behavior for copy constructors.
-MetaDataDictionary ::MetaDataDictionary(const MetaDataDictionary &) = default;
+MetaDataDictionary::MetaDataDictionary(const MetaDataDictionary &) = default;
 
 MetaDataDictionary &
 MetaDataDictionary ::operator=(const MetaDataDictionary & old)
@@ -41,7 +41,7 @@ MetaDataDictionary ::operator=(const MetaDataDictionary & old)
 }
 
 void
-MetaDataDictionary ::Print(std::ostream & os) const
+MetaDataDictionary::Print(std::ostream & os) const
 {
   os << "Dictionary use_count: " << m_Dictionary.use_count() << std::endl;
   for (MetaDataDictionaryMapType::const_iterator it = m_Dictionary->begin(); it != m_Dictionary->end(); ++it)
@@ -70,7 +70,7 @@ const MetaDataObjectBase * MetaDataDictionary ::operator[](const std::string & k
 }
 
 const MetaDataObjectBase *
-MetaDataDictionary ::Get(const std::string & key) const
+MetaDataDictionary::Get(const std::string & key) const
 {
   if (!this->HasKey(key))
   {
@@ -82,20 +82,20 @@ MetaDataDictionary ::Get(const std::string & key) const
 }
 
 void
-MetaDataDictionary ::Set(const std::string & key, MetaDataObjectBase * object)
+MetaDataDictionary::Set(const std::string & key, MetaDataObjectBase * object)
 {
   MakeUnique();
   (*m_Dictionary)[key] = object;
 }
 
 bool
-MetaDataDictionary ::HasKey(const std::string & key) const
+MetaDataDictionary::HasKey(const std::string & key) const
 {
   return m_Dictionary->find(key) != m_Dictionary->end();
 }
 
 std::vector<std::string>
-MetaDataDictionary ::GetKeys() const
+MetaDataDictionary::GetKeys() const
 {
   using VectorType = std::vector<std::string>;
   VectorType ans;
@@ -109,53 +109,53 @@ MetaDataDictionary ::GetKeys() const
 }
 
 MetaDataDictionary::Iterator
-MetaDataDictionary ::Begin()
+MetaDataDictionary::Begin()
 {
   MakeUnique();
   return m_Dictionary->begin();
 }
 
 MetaDataDictionary::ConstIterator
-MetaDataDictionary ::Begin() const
+MetaDataDictionary::Begin() const
 {
   return m_Dictionary->begin();
 }
 
 MetaDataDictionary::Iterator
-MetaDataDictionary ::End()
+MetaDataDictionary::End()
 {
   MakeUnique();
   return m_Dictionary->end();
 }
 
 MetaDataDictionary::ConstIterator
-MetaDataDictionary ::End() const
+MetaDataDictionary::End() const
 {
   return m_Dictionary->end();
 }
 
 MetaDataDictionary::Iterator
-MetaDataDictionary ::Find(const std::string & key)
+MetaDataDictionary::Find(const std::string & key)
 {
   MakeUnique();
   return m_Dictionary->find(key);
 }
 
 MetaDataDictionary::ConstIterator
-MetaDataDictionary ::Find(const std::string & key) const
+MetaDataDictionary::Find(const std::string & key) const
 {
   return m_Dictionary->find(key);
 }
 
 void
-MetaDataDictionary ::Clear()
+MetaDataDictionary::Clear()
 {
   // Construct a new one instead of enforcing uniqueness then clearing
   this->m_Dictionary = std::make_shared<MetaDataDictionaryMapType>();
 }
 
 void
-MetaDataDictionary ::Swap(MetaDataDictionary & other)
+MetaDataDictionary::Swap(MetaDataDictionary & other)
 {
   using std::swap;
   swap(m_Dictionary, other.m_Dictionary);
@@ -163,7 +163,7 @@ MetaDataDictionary ::Swap(MetaDataDictionary & other)
 
 
 bool
-MetaDataDictionary ::MakeUnique()
+MetaDataDictionary::MakeUnique()
 {
   if (m_Dictionary.use_count() > 1)
   {
@@ -175,7 +175,7 @@ MetaDataDictionary ::MakeUnique()
 }
 
 bool
-MetaDataDictionary ::Erase(const std::string & key)
+MetaDataDictionary::Erase(const std::string & key)
 {
   auto                                      it = m_Dictionary->find(key);
   const MetaDataDictionaryMapType::iterator end = m_Dictionary->end();

--- a/Modules/Core/Common/src/itkMetaDataObjectBase.cxx
+++ b/Modules/Core/Common/src/itkMetaDataObjectBase.cxx
@@ -20,28 +20,28 @@
 namespace itk
 {
 
-MetaDataObjectBase ::MetaDataObjectBase() = default;
+MetaDataObjectBase::MetaDataObjectBase() = default;
 
 
 MetaDataObjectBase ::~MetaDataObjectBase() = default;
 
 
 const char *
-MetaDataObjectBase ::GetMetaDataObjectTypeName() const
+MetaDataObjectBase::GetMetaDataObjectTypeName() const
 {
   return typeid(itk::MetaDataObjectBase).name();
 }
 
 
 const std::type_info &
-MetaDataObjectBase ::GetMetaDataObjectTypeInfo() const
+MetaDataObjectBase::GetMetaDataObjectTypeInfo() const
 {
   return typeid(itk::MetaDataObjectBase);
 }
 
 
 void
-MetaDataObjectBase ::Print(std::ostream & os) const
+MetaDataObjectBase::Print(std::ostream & os) const
 {
   os << "[UNKNOWN_PRINT_CHARACTERISTICS]" << std::endl;
 }

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -125,7 +125,7 @@ MultiThreaderBase::SetGlobalDefaultThreader(ThreaderEnum threaderType)
 }
 
 MultiThreaderBase::ThreaderEnum
-MultiThreaderBase ::GetGlobalDefaultThreader()
+MultiThreaderBase::GetGlobalDefaultThreader()
 {
   // This method must be concurrent thread safe
   itkInitGlobalsMacro(PimplGlobals);
@@ -180,7 +180,7 @@ You should now use ITK_GLOBAL_DEFAULT_THREADER\
 }
 
 MultiThreaderBase::ThreaderEnum
-MultiThreaderBase ::ThreaderTypeFromString(std::string threaderString)
+MultiThreaderBase::ThreaderTypeFromString(std::string threaderString)
 {
   threaderString = itksys::SystemTools::UpperCase(threaderString);
   if (threaderString == "PLATFORM")
@@ -350,7 +350,7 @@ MultiThreaderBase::GetGlobalDefaultNumberOfThreads()
 }
 
 ThreadIdType
-MultiThreaderBase ::GetGlobalDefaultNumberOfThreadsByPlatform()
+MultiThreaderBase::GetGlobalDefaultNumberOfThreadsByPlatform()
 {
 #if defined(ITK_LEGACY_REMOVE)
   return std::thread::hardware_concurrency();
@@ -432,7 +432,7 @@ MultiThreaderBase::MultiThreaderBase()
 MultiThreaderBase::~MultiThreaderBase() = default;
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
-MultiThreaderBase ::SingleMethodProxy(void * arg)
+MultiThreaderBase::SingleMethodProxy(void * arg)
 {
   // grab the WorkUnitInfo originally prescribed
   auto * threadInfoStruct = static_cast<MultiThreaderBase::WorkUnitInfo *>(arg);
@@ -464,10 +464,10 @@ MultiThreaderBase ::SingleMethodProxy(void * arg)
 }
 
 void
-MultiThreaderBase ::ParallelizeArray(SizeValueType             firstIndex,
-                                     SizeValueType             lastIndexPlus1,
-                                     ArrayThreadingFunctorType aFunc,
-                                     ProcessObject *           filter)
+MultiThreaderBase::ParallelizeArray(SizeValueType             firstIndex,
+                                    SizeValueType             lastIndexPlus1,
+                                    ArrayThreadingFunctorType aFunc,
+                                    ProcessObject *           filter)
 {
   // This implementation simply delegates parallelization to the old interface
   // SetSingleMethod+SingleMethodExecute. This method is meant to be overloaded!
@@ -496,7 +496,7 @@ MultiThreaderBase ::ParallelizeArray(SizeValueType             firstIndex,
 }
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
-MultiThreaderBase ::ParallelizeArrayHelper(void * arg)
+MultiThreaderBase::ParallelizeArrayHelper(void * arg)
 {
   using ThreadInfo = MultiThreaderBase::WorkUnitInfo;
   auto *       threadInfo = static_cast<ThreadInfo *>(arg);
@@ -528,11 +528,11 @@ MultiThreaderBase ::ParallelizeArrayHelper(void * arg)
 
 
 void
-MultiThreaderBase ::ParallelizeImageRegion(unsigned int                            dimension,
-                                           const IndexValueType                    index[],
-                                           const SizeValueType                     size[],
-                                           MultiThreaderBase::ThreadingFunctorType funcP,
-                                           ProcessObject *                         filter)
+MultiThreaderBase::ParallelizeImageRegion(unsigned int                            dimension,
+                                          const IndexValueType                    index[],
+                                          const SizeValueType                     size[],
+                                          MultiThreaderBase::ThreadingFunctorType funcP,
+                                          ProcessObject *                         filter)
 {
   // This implementation simply delegates parallelization to the old interface
   // SetSingleMethod+SingleMethodExecute. This method is meant to be overloaded!
@@ -556,7 +556,7 @@ MultiThreaderBase ::ParallelizeImageRegion(unsigned int                         
 }
 
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
-MultiThreaderBase ::ParallelizeImageRegionHelper(void * arg)
+MultiThreaderBase::ParallelizeImageRegionHelper(void * arg)
 {
   using ThreadInfo = MultiThreaderBase::WorkUnitInfo;
   auto *       threadInfo = static_cast<ThreadInfo *>(arg);

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -313,7 +313,7 @@ Object::CreateAnother() const
  * Turn debugging output on.
  */
 void
-Object ::DebugOn() const
+Object::DebugOn() const
 {
   m_Debug = true;
 }
@@ -322,7 +322,7 @@ Object ::DebugOn() const
  * Turn debugging output off.
  */
 void
-Object ::DebugOff() const
+Object::DebugOff() const
 {
   m_Debug = false;
 }
@@ -331,7 +331,7 @@ Object ::DebugOff() const
  * Get the value of the debug flag.
  */
 bool
-Object ::GetDebug() const
+Object::GetDebug() const
 {
   return m_Debug;
 }
@@ -340,7 +340,7 @@ Object ::GetDebug() const
  * Set the value of the debug flag. A non-zero value turns debugging on.
  */
 void
-Object ::SetDebug(bool debugFlag) const
+Object::SetDebug(bool debugFlag) const
 {
   m_Debug = debugFlag;
 }
@@ -349,7 +349,7 @@ Object ::SetDebug(bool debugFlag) const
  * Return the modification for this object.
  */
 ModifiedTimeType
-Object ::GetMTime() const
+Object::GetMTime() const
 {
   return m_MTime.GetMTime();
 }
@@ -358,7 +358,7 @@ Object ::GetMTime() const
  * Return the modification for this object.
  */
 const TimeStamp &
-Object ::GetTimeStamp() const
+Object::GetTimeStamp() const
 {
   return m_MTime;
 }
@@ -366,7 +366,7 @@ Object ::GetTimeStamp() const
 /** Set the time stamp of this object. To be used very carefully !!!.
  * Most mortals will never need to call this method. */
 void
-Object ::SetTimeStamp(const TimeStamp & timeStamp)
+Object::SetTimeStamp(const TimeStamp & timeStamp)
 {
   this->m_MTime = timeStamp;
 }
@@ -375,7 +375,7 @@ Object ::SetTimeStamp(const TimeStamp & timeStamp)
  * Make sure this object's modified time is greater than all others.
  */
 void
-Object ::Modified() const
+Object::Modified() const
 {
   m_MTime.Modified();
   InvokeEvent(ModifiedEvent());
@@ -385,7 +385,7 @@ Object ::Modified() const
  * Increase the reference count (mark as used by another object).
  */
 void
-Object ::Register() const
+Object::Register() const
 {
   itkDebugMacro(<< "Registered, "
                 << "ReferenceCount = " << (m_ReferenceCount + 1));
@@ -398,7 +398,7 @@ Object ::Register() const
  * Decrease the reference count (release by another object).
  */
 void
-Object ::UnRegister() const noexcept
+Object::UnRegister() const noexcept
 {
   // call the parent
   itkDebugMacro(<< "UnRegistered, "
@@ -439,7 +439,7 @@ Object ::UnRegister() const noexcept
  * Sets the reference count (use with care)
  */
 void
-Object ::SetReferenceCount(int ref)
+Object::SetReferenceCount(int ref)
 {
   itkDebugMacro(<< "Reference Count set to " << ref);
 
@@ -467,7 +467,7 @@ Object ::SetReferenceCount(int ref)
  * Set the value of the global debug output control flag.
  */
 void
-Object ::SetGlobalWarningDisplay(bool val)
+Object::SetGlobalWarningDisplay(bool val)
 {
   itkInitGlobalsMacro(GlobalWarningDisplay);
   *m_GlobalWarningDisplay = val;
@@ -477,13 +477,13 @@ Object ::SetGlobalWarningDisplay(bool val)
  * Get the value of the global debug output control flag.
  */
 bool
-Object ::GetGlobalWarningDisplay()
+Object::GetGlobalWarningDisplay()
 {
   return *Object::GetGlobalWarningDisplayPointer();
 }
 
 unsigned long
-Object ::AddObserver(const EventObject & event, Command * cmd)
+Object::AddObserver(const EventObject & event, Command * cmd)
 {
   if (!this->m_SubjectImplementation)
   {
@@ -493,7 +493,7 @@ Object ::AddObserver(const EventObject & event, Command * cmd)
 }
 
 unsigned long
-Object ::AddObserver(const EventObject & event, Command * cmd) const
+Object::AddObserver(const EventObject & event, Command * cmd) const
 {
   if (!this->m_SubjectImplementation)
   {
@@ -513,7 +513,7 @@ Object::AddObserver(const EventObject & event, std::function<void(const EventObj
 
 
 Command *
-Object ::GetCommand(unsigned long tag)
+Object::GetCommand(unsigned long tag)
 {
   if (this->m_SubjectImplementation)
   {
@@ -523,7 +523,7 @@ Object ::GetCommand(unsigned long tag)
 }
 
 void
-Object ::RemoveObserver(unsigned long tag)
+Object::RemoveObserver(unsigned long tag)
 {
   if (this->m_SubjectImplementation)
   {
@@ -532,7 +532,7 @@ Object ::RemoveObserver(unsigned long tag)
 }
 
 void
-Object ::RemoveAllObservers()
+Object::RemoveAllObservers()
 {
   if (this->m_SubjectImplementation)
   {
@@ -541,7 +541,7 @@ Object ::RemoveAllObservers()
 }
 
 void
-Object ::InvokeEvent(const EventObject & event)
+Object::InvokeEvent(const EventObject & event)
 {
   if (this->m_SubjectImplementation)
   {
@@ -550,7 +550,7 @@ Object ::InvokeEvent(const EventObject & event)
 }
 
 void
-Object ::InvokeEvent(const EventObject & event) const
+Object::InvokeEvent(const EventObject & event) const
 {
   if (this->m_SubjectImplementation)
   {
@@ -559,7 +559,7 @@ Object ::InvokeEvent(const EventObject & event) const
 }
 
 bool
-Object ::HasObserver(const EventObject & event) const
+Object::HasObserver(const EventObject & event) const
 {
   if (this->m_SubjectImplementation)
   {
@@ -569,7 +569,7 @@ Object ::HasObserver(const EventObject & event) const
 }
 
 bool
-Object ::PrintObservers(std::ostream & os, Indent indent) const
+Object::PrintObservers(std::ostream & os, Indent indent) const
 {
   if (this->m_SubjectImplementation)
   {
@@ -582,7 +582,7 @@ Object ::PrintObservers(std::ostream & os, Indent indent) const
  * Create an object with Debug turned off and modified time initialized
  * to the most recently modified object.
  */
-Object ::Object()
+Object::Object()
   : LightObject()
   , m_ObjectName()
 {
@@ -601,7 +601,7 @@ Object ::~Object()
  * its superclasses.
  */
 void
-Object ::PrintSelf(std::ostream & os, Indent indent) const
+Object::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -616,7 +616,7 @@ Object ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 MetaDataDictionary &
-Object ::GetMetaDataDictionary()
+Object::GetMetaDataDictionary()
 {
   if (m_MetaDataDictionary == nullptr)
   {
@@ -626,7 +626,7 @@ Object ::GetMetaDataDictionary()
 }
 
 const MetaDataDictionary &
-Object ::GetMetaDataDictionary() const
+Object::GetMetaDataDictionary() const
 {
   if (m_MetaDataDictionary == nullptr)
   {
@@ -636,7 +636,7 @@ Object ::GetMetaDataDictionary() const
 }
 
 void
-Object ::SetMetaDataDictionary(const MetaDataDictionary & rhs)
+Object::SetMetaDataDictionary(const MetaDataDictionary & rhs)
 {
   if (m_MetaDataDictionary == nullptr)
   {
@@ -647,7 +647,7 @@ Object ::SetMetaDataDictionary(const MetaDataDictionary & rhs)
 }
 
 void
-Object ::SetMetaDataDictionary(MetaDataDictionary && rrhs)
+Object::SetMetaDataDictionary(MetaDataDictionary && rrhs)
 {
   if (m_MetaDataDictionary == nullptr)
   {

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -194,7 +194,7 @@ ObjectFactoryBase::GetStrictVersionChecking()
  * factories
  */
 LightObject::Pointer
-ObjectFactoryBase ::CreateInstance(const char * itkclassname)
+ObjectFactoryBase::CreateInstance(const char * itkclassname)
 {
   ObjectFactoryBase::Initialize();
 
@@ -211,7 +211,7 @@ ObjectFactoryBase ::CreateInstance(const char * itkclassname)
 }
 
 std::list<LightObject::Pointer>
-ObjectFactoryBase ::CreateAllInstance(const char * itkclassname)
+ObjectFactoryBase::CreateAllInstance(const char * itkclassname)
 {
   ObjectFactoryBase::Initialize();
 
@@ -228,7 +228,7 @@ ObjectFactoryBase ::CreateAllInstance(const char * itkclassname)
  * A one time initialization method.
  */
 void
-ObjectFactoryBase ::InitializeFactoryList()
+ObjectFactoryBase::InitializeFactoryList()
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -250,7 +250,7 @@ ObjectFactoryBase ::InitializeFactoryList()
  * A one time initialization method.
  */
 void
-ObjectFactoryBase ::Initialize()
+ObjectFactoryBase::Initialize()
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -270,7 +270,7 @@ ObjectFactoryBase ::Initialize()
  * the OpenGL factory, currently this is not done.
  */
 void
-ObjectFactoryBase ::RegisterInternal()
+ObjectFactoryBase::RegisterInternal()
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -290,7 +290,7 @@ ObjectFactoryBase ::RegisterInternal()
  * Load all libraries in ITK_AUTOLOAD_PATH
  */
 void
-ObjectFactoryBase ::LoadDynamicFactories()
+ObjectFactoryBase::LoadDynamicFactories()
 {
 #ifdef ITK_DYNAMIC_LOADING
   /**
@@ -423,7 +423,7 @@ NameIsSharedLibrary(const char * name)
  *
  */
 void
-ObjectFactoryBase ::LoadLibrariesInPath(const char * path)
+ObjectFactoryBase::LoadLibrariesInPath(const char * path)
 {
   Directory::Pointer dir = Directory::New();
 
@@ -500,7 +500,7 @@ ObjectFactoryBase ::LoadLibrariesInPath(const char * path)
  * Recheck the ITK_AUTOLOAD_PATH for new libraries
  */
 void
-ObjectFactoryBase ::ReHash()
+ObjectFactoryBase::ReHash()
 {
   ObjectFactoryBase::UnRegisterAllFactories();
   ObjectFactoryBase::Initialize();
@@ -531,7 +531,7 @@ ObjectFactoryBase ::~ObjectFactoryBase()
  * not to be used by loadable factories.
  */
 void
-ObjectFactoryBase ::RegisterFactoryInternal(ObjectFactoryBase * factory)
+ObjectFactoryBase::RegisterFactoryInternal(ObjectFactoryBase * factory)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -557,7 +557,7 @@ ObjectFactoryBase ::RegisterFactoryInternal(ObjectFactoryBase * factory)
  * Add a factory to the registered list
  */
 bool
-ObjectFactoryBase ::RegisterFactory(ObjectFactoryBase * factory, InsertionPositionEnum where, size_t position)
+ObjectFactoryBase::RegisterFactory(ObjectFactoryBase * factory, InsertionPositionEnum where, size_t position)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -653,7 +653,7 @@ ObjectFactoryBase ::RegisterFactory(ObjectFactoryBase * factory, InsertionPositi
  *
  */
 void
-ObjectFactoryBase ::PrintSelf(std::ostream & os, Indent indent) const
+ObjectFactoryBase::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -678,7 +678,7 @@ ObjectFactoryBase ::PrintSelf(std::ostream & os, Indent indent) const
  *
  */
 void
-ObjectFactoryBase ::DeleteNonInternalFactory(ObjectFactoryBase * factory)
+ObjectFactoryBase::DeleteNonInternalFactory(ObjectFactoryBase * factory)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -694,7 +694,7 @@ ObjectFactoryBase ::DeleteNonInternalFactory(ObjectFactoryBase * factory)
  *
  */
 void
-ObjectFactoryBase ::UnRegisterFactory(ObjectFactoryBase * factory)
+ObjectFactoryBase::UnRegisterFactory(ObjectFactoryBase * factory)
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -717,7 +717,7 @@ ObjectFactoryBase ::UnRegisterFactory(ObjectFactoryBase * factory)
  * unregister all factories and delete the m_RegisteredFactories list
  */
 void
-ObjectFactoryBase ::UnRegisterAllFactories()
+ObjectFactoryBase::UnRegisterAllFactories()
 {
   itkInitGlobalsMacro(PimplGlobals);
 
@@ -755,11 +755,11 @@ ObjectFactoryBase ::UnRegisterAllFactories()
  *
  */
 void
-ObjectFactoryBase ::RegisterOverride(const char *               classOverride,
-                                     const char *               subclass,
-                                     const char *               description,
-                                     bool                       enableFlag,
-                                     CreateObjectFunctionBase * createFunction)
+ObjectFactoryBase::RegisterOverride(const char *               classOverride,
+                                    const char *               subclass,
+                                    const char *               description,
+                                    bool                       enableFlag,
+                                    CreateObjectFunctionBase * createFunction)
 {
   ObjectFactoryBase::OverrideInformation info;
 
@@ -772,7 +772,7 @@ ObjectFactoryBase ::RegisterOverride(const char *               classOverride,
 }
 
 LightObject::Pointer
-ObjectFactoryBase ::CreateObject(const char * itkclassname)
+ObjectFactoryBase::CreateObject(const char * itkclassname)
 {
   auto start = m_OverrideMap->lower_bound(itkclassname);
   auto end = m_OverrideMap->upper_bound(itkclassname);
@@ -788,7 +788,7 @@ ObjectFactoryBase ::CreateObject(const char * itkclassname)
 }
 
 std::list<LightObject::Pointer>
-ObjectFactoryBase ::CreateAllObject(const char * itkclassname)
+ObjectFactoryBase::CreateAllObject(const char * itkclassname)
 {
   auto start = m_OverrideMap->lower_bound(itkclassname);
   auto end = m_OverrideMap->upper_bound(itkclassname);
@@ -809,7 +809,7 @@ ObjectFactoryBase ::CreateAllObject(const char * itkclassname)
  *
  */
 void
-ObjectFactoryBase ::SetEnableFlag(bool flag, const char * className, const char * subclassName)
+ObjectFactoryBase::SetEnableFlag(bool flag, const char * className, const char * subclassName)
 {
   auto start = m_OverrideMap->lower_bound(className);
   auto end = m_OverrideMap->upper_bound(className);
@@ -827,7 +827,7 @@ ObjectFactoryBase ::SetEnableFlag(bool flag, const char * className, const char 
  *
  */
 bool
-ObjectFactoryBase ::GetEnableFlag(const char * className, const char * subclassName)
+ObjectFactoryBase::GetEnableFlag(const char * className, const char * subclassName)
 {
   auto start = m_OverrideMap->lower_bound(className);
   auto end = m_OverrideMap->upper_bound(className);
@@ -846,7 +846,7 @@ ObjectFactoryBase ::GetEnableFlag(const char * className, const char * subclassN
  *
  */
 void
-ObjectFactoryBase ::Disable(const char * className)
+ObjectFactoryBase::Disable(const char * className)
 {
   auto start = m_OverrideMap->lower_bound(className);
   auto end = m_OverrideMap->upper_bound(className);
@@ -861,7 +861,7 @@ ObjectFactoryBase ::Disable(const char * className)
  *
  */
 void
-ObjectFactoryBase ::SynchronizeObjectFactoryBase(void * objectFactoryBasePrivate)
+ObjectFactoryBase::SynchronizeObjectFactoryBase(void * objectFactoryBasePrivate)
 {
   // We need to register the previously registered factories with the new pointer.
   // We keep track of the previoulsy registered factory in `previousObjectFactoryBasePrivate`
@@ -883,7 +883,7 @@ ObjectFactoryBase ::SynchronizeObjectFactoryBase(void * objectFactoryBasePrivate
  *
  */
 std::list<ObjectFactoryBase *>
-ObjectFactoryBase ::GetRegisteredFactories()
+ObjectFactoryBase::GetRegisteredFactories()
 {
   //  static SingletonIndex * singletonIndex = SingletonIndex::GetInstance();
   //  Unused(singletonIndex);
@@ -895,7 +895,7 @@ ObjectFactoryBase ::GetRegisteredFactories()
  * Return a list of classes that this factory overrides.
  */
 std::list<std::string>
-ObjectFactoryBase ::GetClassOverrideNames()
+ObjectFactoryBase::GetClassOverrideNames()
 {
   std::list<std::string> ret;
   for (auto & i : *m_OverrideMap)
@@ -909,7 +909,7 @@ ObjectFactoryBase ::GetClassOverrideNames()
  * Return a list of the names of classes that override classes.
  */
 std::list<std::string>
-ObjectFactoryBase ::GetClassOverrideWithNames()
+ObjectFactoryBase::GetClassOverrideWithNames()
 {
   std::list<std::string> ret;
   for (auto & i : *m_OverrideMap)
@@ -923,7 +923,7 @@ ObjectFactoryBase ::GetClassOverrideWithNames()
  * Return a list of descriptions for class overrides
  */
 std::list<std::string>
-ObjectFactoryBase ::GetClassOverrideDescriptions()
+ObjectFactoryBase::GetClassOverrideDescriptions()
 {
   std::list<std::string> ret;
   for (auto & i : *m_OverrideMap)
@@ -937,7 +937,7 @@ ObjectFactoryBase ::GetClassOverrideDescriptions()
  * Return a list of enable flags
  */
 std::list<bool>
-ObjectFactoryBase ::GetEnableFlags()
+ObjectFactoryBase::GetEnableFlags()
 {
   std::list<bool> ret;
   for (auto & i : *m_OverrideMap)
@@ -950,7 +950,7 @@ ObjectFactoryBase ::GetEnableFlags()
 /**
  * Return the path to a dynamically loaded factory. */
 const char *
-ObjectFactoryBase ::GetLibraryPath()
+ObjectFactoryBase::GetLibraryPath()
 {
   return m_LibraryPath.c_str();
 }

--- a/Modules/Core/Common/src/itkOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkOutputWindow.cxx
@@ -35,7 +35,7 @@ OutputWindow::Pointer OutputWindow::m_Instance = nullptr;
 /**
  * Prompting off by default
  */
-OutputWindow ::OutputWindow()
+OutputWindow::OutputWindow()
 {
   m_PromptUser = false;
 }
@@ -73,7 +73,7 @@ OutputWindowDisplayDebugText(const char * message)
 }
 
 void
-OutputWindow ::PrintSelf(std::ostream & os, Indent indent) const
+OutputWindow::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -86,7 +86,7 @@ OutputWindow ::PrintSelf(std::ostream & os, Indent indent) const
  * default implementation outputs to cerr only
  */
 void
-OutputWindow ::DisplayText(const char * txt)
+OutputWindow::DisplayText(const char * txt)
 {
   std::cerr << txt;
   if (m_PromptUser)
@@ -105,7 +105,7 @@ OutputWindow ::DisplayText(const char * txt)
  * Return the single instance of the OutputWindow
  */
 OutputWindow::Pointer
-OutputWindow ::GetInstance()
+OutputWindow::GetInstance()
 {
   if (!OutputWindow::m_Instance)
   {
@@ -126,7 +126,7 @@ OutputWindow ::GetInstance()
 }
 
 void
-OutputWindow ::SetInstance(OutputWindow * instance)
+OutputWindow::SetInstance(OutputWindow * instance)
 {
   if (OutputWindow::m_Instance == instance)
   {
@@ -139,7 +139,7 @@ OutputWindow ::SetInstance(OutputWindow * instance)
  * This just calls GetInstance
  */
 OutputWindow::Pointer
-OutputWindow ::New()
+OutputWindow::New()
 {
   return GetInstance();
 }

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
@@ -181,7 +181,7 @@ PlatformMultiThreader::TerminateThread(ThreadIdType WorkUnitID)
 #endif
 
 void
-PlatformMultiThreader ::SpawnWaitForSingleMethodThread(ThreadProcessIdType threadHandle)
+PlatformMultiThreader::SpawnWaitForSingleMethodThread(ThreadProcessIdType threadHandle)
 {
   // Using POSIX threads
   if (pthread_join(threadHandle, nullptr))
@@ -191,7 +191,7 @@ PlatformMultiThreader ::SpawnWaitForSingleMethodThread(ThreadProcessIdType threa
 }
 
 ThreadProcessIdType
-PlatformMultiThreader ::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * threadInfo)
+PlatformMultiThreader::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * threadInfo)
 {
   // Using POSIX threads
   pthread_attr_t attr;

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
@@ -78,14 +78,14 @@ PlatformMultiThreader::TerminateThread(ThreadIdType WorkUnitID)
 #endif
 
 void
-PlatformMultiThreader ::SpawnWaitForSingleMethodThread(ThreadProcessIdType itkNotUsed(threadHandle))
+PlatformMultiThreader::SpawnWaitForSingleMethodThread(ThreadProcessIdType itkNotUsed(threadHandle))
 {
   // No threading library specified.  Do nothing.  No joining or waiting
   // necessary.
 }
 
 ThreadProcessIdType
-PlatformMultiThreader ::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * itkNotUsed(threadInfo))
+PlatformMultiThreader::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * itkNotUsed(threadInfo))
 {
   // No threading library specified.  Do nothing.  The computation
   // will be run by the main execution thread.

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
@@ -165,7 +165,7 @@ PlatformMultiThreader::TerminateThread(ThreadIdType WorkUnitID)
 #endif
 
 void
-PlatformMultiThreader ::SpawnWaitForSingleMethodThread(ThreadProcessIdType threadHandle)
+PlatformMultiThreader::SpawnWaitForSingleMethodThread(ThreadProcessIdType threadHandle)
 {
   // Using _beginthreadex on a PC
   WaitForSingleObject(threadHandle, INFINITE);
@@ -173,7 +173,7 @@ PlatformMultiThreader ::SpawnWaitForSingleMethodThread(ThreadProcessIdType threa
 }
 
 ThreadProcessIdType
-PlatformMultiThreader ::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * threadInfo)
+PlatformMultiThreader::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * threadInfo)
 {
   // Using _beginthreadex on a PC
   DWORD  threadId;

--- a/Modules/Core/Common/src/itkPoolMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPoolMultiThreader.cxx
@@ -154,10 +154,10 @@ PoolMultiThreader::SingleMethodExecute()
 }
 
 void
-PoolMultiThreader ::ParallelizeArray(SizeValueType             firstIndex,
-                                     SizeValueType             lastIndexPlus1,
-                                     ArrayThreadingFunctorType aFunc,
-                                     ProcessObject *           filter)
+PoolMultiThreader::ParallelizeArray(SizeValueType             firstIndex,
+                                    SizeValueType             lastIndexPlus1,
+                                    ArrayThreadingFunctorType aFunc,
+                                    ProcessObject *           filter)
 {
   if (!this->GetUpdateProgress())
   {
@@ -224,11 +224,11 @@ PoolMultiThreader ::ParallelizeArray(SizeValueType             firstIndex,
 }
 
 void
-PoolMultiThreader ::ParallelizeImageRegion(unsigned int         dimension,
-                                           const IndexValueType index[],
-                                           const SizeValueType  size[],
-                                           ThreadingFunctorType funcP,
-                                           ProcessObject *      filter)
+PoolMultiThreader::ParallelizeImageRegion(unsigned int         dimension,
+                                          const IndexValueType index[],
+                                          const SizeValueType  size[],
+                                          ThreadingFunctorType funcP,
+                                          ProcessObject *      filter)
 {
   if (!this->GetUpdateProgress())
   {

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -48,7 +48,7 @@ constexpr char   globalIndexNames[ITK_GLOBAL_INDEX_NAMES_NUMBER][ITK_GLOBAL_INDE
 } // namespace
 
 
-ProcessObject ::ProcessObject()
+ProcessObject::ProcessObject()
   : m_Inputs()
   , m_Outputs()
   , m_CachedInputReleaseDataFlags()
@@ -76,7 +76,7 @@ ProcessObject ::ProcessObject()
 
 
 DataObject::Pointer
-ProcessObject ::MakeOutput(const DataObjectIdentifierType & name)
+ProcessObject::MakeOutput(const DataObjectIdentifierType & name)
 {
   /*
    * This is a default implementation to make sure we have something.
@@ -95,7 +95,7 @@ ProcessObject ::MakeOutput(const DataObjectIdentifierType & name)
 }
 
 
-DataObject::Pointer ProcessObject ::MakeOutput(DataObjectPointerArraySizeType)
+DataObject::Pointer ProcessObject::MakeOutput(DataObjectPointerArraySizeType)
 {
   return static_cast<DataObject *>(DataObject::New().GetPointer());
 }
@@ -127,7 +127,7 @@ ProcessObject ::~ProcessObject()
 
 
 void
-ProcessObject ::SetNumberOfIndexedInputs(DataObjectPointerArraySizeType num)
+ProcessObject::SetNumberOfIndexedInputs(DataObjectPointerArraySizeType num)
 {
   /*
    * Called by constructor to set up input array.
@@ -171,7 +171,7 @@ ProcessObject ::SetNumberOfIndexedInputs(DataObjectPointerArraySizeType num)
 
 
 ProcessObject::DataObjectPointerArraySizeType
-ProcessObject ::GetNumberOfValidRequiredInputs() const
+ProcessObject::GetNumberOfValidRequiredInputs() const
 {
   /*
    * Get the number of specified inputs
@@ -189,7 +189,7 @@ ProcessObject ::GetNumberOfValidRequiredInputs() const
 
 
 void
-ProcessObject ::AddInput(DataObject * input)
+ProcessObject::AddInput(DataObject * input)
 {
   /*
    * Adds an input to the first null position in the input list.
@@ -208,7 +208,7 @@ ProcessObject ::AddInput(DataObject * input)
 
 
 void
-ProcessObject ::RemoveInput(const DataObjectIdentifierType & key)
+ProcessObject::RemoveInput(const DataObjectIdentifierType & key)
 {
   /*
    * Remove an input.
@@ -247,7 +247,7 @@ ProcessObject ::RemoveInput(const DataObjectIdentifierType & key)
 
 
 void
-ProcessObject ::RemoveInput(DataObjectPointerArraySizeType idx)
+ProcessObject::RemoveInput(DataObjectPointerArraySizeType idx)
 {
   if (idx < this->GetNumberOfIndexedInputs())
   {
@@ -261,7 +261,7 @@ ProcessObject ::RemoveInput(DataObjectPointerArraySizeType idx)
 
 
 void
-ProcessObject ::SetInput(const DataObjectIdentifierType & key, DataObject * input)
+ProcessObject::SetInput(const DataObjectIdentifierType & key, DataObject * input)
 {
   if (key.empty())
   {
@@ -285,7 +285,7 @@ ProcessObject ::SetInput(const DataObjectIdentifierType & key, DataObject * inpu
 
 
 void
-ProcessObject ::SetNthInput(DataObjectPointerArraySizeType idx, DataObject * input)
+ProcessObject::SetNthInput(DataObjectPointerArraySizeType idx, DataObject * input)
 {
   /* Set an Input of this filter. This method
    * does Register()/UnRegister() manually to
@@ -305,7 +305,7 @@ ProcessObject ::SetNthInput(DataObjectPointerArraySizeType idx, DataObject * inp
 
 
 void
-ProcessObject ::PushBackInput(const DataObject * input)
+ProcessObject::PushBackInput(const DataObject * input)
 {
   /*
    * Model a queue on the input list by providing a push back
@@ -316,7 +316,7 @@ ProcessObject ::PushBackInput(const DataObject * input)
 
 
 void
-ProcessObject ::PopBackInput()
+ProcessObject::PopBackInput()
 {
   /*
    * Model a stack on the input list by providing a pop back
@@ -330,7 +330,7 @@ ProcessObject ::PopBackInput()
 
 
 void
-ProcessObject ::PushFrontInput(const DataObject * input)
+ProcessObject::PushFrontInput(const DataObject * input)
 {
   const DataObjectPointerArraySizeType nb = this->GetNumberOfIndexedInputs();
   for (DataObjectPointerArraySizeType i = nb; i > 0; i--)
@@ -342,7 +342,7 @@ ProcessObject ::PushFrontInput(const DataObject * input)
 
 
 void
-ProcessObject ::PopFrontInput()
+ProcessObject::PopFrontInput()
 {
   DataObjectPointerArraySizeType nb = this->GetNumberOfIndexedInputs();
   if (nb > 0)
@@ -357,7 +357,7 @@ ProcessObject ::PopFrontInput()
 
 
 void
-ProcessObject ::RemoveOutput(const DataObjectIdentifierType & key)
+ProcessObject::RemoveOutput(const DataObjectIdentifierType & key)
 {
   // if primary or required set to null
   if (key == m_IndexedOutputs[0]->first)
@@ -399,7 +399,7 @@ ProcessObject ::RemoveOutput(const DataObjectIdentifierType & key)
 
 
 void
-ProcessObject ::RemoveOutput(DataObjectPointerArraySizeType idx)
+ProcessObject::RemoveOutput(DataObjectPointerArraySizeType idx)
 {
   if (idx == this->GetNumberOfIndexedOutputs() - 1)
   {
@@ -414,7 +414,7 @@ ProcessObject ::RemoveOutput(DataObjectPointerArraySizeType idx)
 
 
 void
-ProcessObject ::SetOutput(const DataObjectIdentifierType & name, DataObject * output)
+ProcessObject::SetOutput(const DataObjectIdentifierType & name, DataObject * output)
 {
   /*
     Set an Output of this filter. This method
@@ -478,7 +478,7 @@ ProcessObject ::SetOutput(const DataObjectIdentifierType & name, DataObject * ou
 
 
 void
-ProcessObject ::SetNthOutput(DataObjectPointerArraySizeType idx, DataObject * output)
+ProcessObject::SetNthOutput(DataObjectPointerArraySizeType idx, DataObject * output)
 {
   if (idx >= this->GetNumberOfIndexedOutputs())
   {
@@ -489,7 +489,7 @@ ProcessObject ::SetNthOutput(DataObjectPointerArraySizeType idx, DataObject * ou
 
 
 void
-ProcessObject ::AddOutput(DataObject * output)
+ProcessObject::AddOutput(DataObject * output)
 {
   /*
    * Adds an output to the first null position in the output list.
@@ -509,7 +509,7 @@ ProcessObject ::AddOutput(DataObject * output)
 
 
 void
-ProcessObject ::SetNumberOfIndexedOutputs(DataObjectPointerArraySizeType num)
+ProcessObject::SetNumberOfIndexedOutputs(DataObjectPointerArraySizeType num)
 {
   /*
    * Called by constructor to set up output array.
@@ -560,7 +560,7 @@ ProcessObject ::SetNumberOfIndexedOutputs(DataObjectPointerArraySizeType num)
 
 
 DataObject *
-ProcessObject ::GetOutput(const DataObjectIdentifierType & key)
+ProcessObject::GetOutput(const DataObjectIdentifierType & key)
 {
   auto it = m_Outputs.find(key);
   if (it == m_Outputs.end())
@@ -572,7 +572,7 @@ ProcessObject ::GetOutput(const DataObjectIdentifierType & key)
 
 
 const DataObject *
-ProcessObject ::GetOutput(const DataObjectIdentifierType & key) const
+ProcessObject::GetOutput(const DataObjectIdentifierType & key) const
 {
   auto it = m_Outputs.find(key);
   if (it == m_Outputs.end())
@@ -584,28 +584,28 @@ ProcessObject ::GetOutput(const DataObjectIdentifierType & key) const
 
 
 DataObject *
-ProcessObject ::GetOutput(DataObjectPointerArraySizeType i)
+ProcessObject::GetOutput(DataObjectPointerArraySizeType i)
 {
   return m_IndexedOutputs[i]->second;
 }
 
 
 const DataObject *
-ProcessObject ::GetOutput(DataObjectPointerArraySizeType i) const
+ProcessObject::GetOutput(DataObjectPointerArraySizeType i) const
 {
   return m_IndexedOutputs[i]->second;
 }
 
 
 void
-ProcessObject ::SetPrimaryOutput(DataObject * object)
+ProcessObject::SetPrimaryOutput(DataObject * object)
 {
   this->SetOutput(m_IndexedOutputs[0]->first, object);
 }
 
 
 void
-ProcessObject ::SetPrimaryOutputName(const DataObjectIdentifierType & key)
+ProcessObject::SetPrimaryOutputName(const DataObjectIdentifierType & key)
 {
   if (key != this->m_IndexedOutputs[0]->first)
   {
@@ -626,7 +626,7 @@ ProcessObject ::SetPrimaryOutputName(const DataObjectIdentifierType & key)
 
 
 bool
-ProcessObject ::HasOutput(const DataObjectIdentifierType & key) const
+ProcessObject::HasOutput(const DataObjectIdentifierType & key) const
 {
   auto it = m_Outputs.find(key);
   return it != m_Outputs.end();
@@ -634,7 +634,7 @@ ProcessObject ::HasOutput(const DataObjectIdentifierType & key) const
 
 
 ProcessObject::NameArray
-ProcessObject ::GetOutputNames() const
+ProcessObject::GetOutputNames() const
 {
   NameArray res;
   res.reserve(m_Outputs.size());
@@ -664,7 +664,7 @@ ProcessObject ::GetOutputNames() const
 // }
 
 ProcessObject::DataObjectPointerArray
-ProcessObject ::GetOutputs()
+ProcessObject::GetOutputs()
 {
   DataObjectPointerArray res;
   res.reserve(m_Outputs.size());
@@ -681,7 +681,7 @@ ProcessObject ::GetOutputs()
 
 
 ProcessObject::DataObjectPointerArraySizeType
-ProcessObject ::GetNumberOfOutputs() const
+ProcessObject::GetNumberOfOutputs() const
 {
   // only include the primary if it's required or set
   if (m_IndexedOutputs[0]->second.IsNotNull())
@@ -693,7 +693,7 @@ ProcessObject ::GetNumberOfOutputs() const
 
 
 ProcessObject::DataObjectPointerArraySizeType
-ProcessObject ::GetNumberOfIndexedOutputs() const
+ProcessObject::GetNumberOfIndexedOutputs() const
 {
   // this first element should always contain the primary output's
   // name, if this is not true there is an internal logic error.
@@ -719,7 +719,7 @@ ProcessObject ::GetNumberOfIndexedOutputs() const
 // }
 
 ProcessObject::DataObjectPointerArray
-ProcessObject ::GetIndexedOutputs()
+ProcessObject::GetIndexedOutputs()
 {
   DataObjectPointerArray res(this->GetNumberOfIndexedOutputs());
   for (DataObjectPointerArraySizeType i = 0; i < this->GetNumberOfIndexedOutputs(); i++)
@@ -731,7 +731,7 @@ ProcessObject ::GetIndexedOutputs()
 
 
 DataObject *
-ProcessObject ::GetInput(const DataObjectIdentifierType & key)
+ProcessObject::GetInput(const DataObjectIdentifierType & key)
 {
   auto it = m_Inputs.find(key);
   if (it == m_Inputs.end())
@@ -743,7 +743,7 @@ ProcessObject ::GetInput(const DataObjectIdentifierType & key)
 
 
 const DataObject *
-ProcessObject ::GetInput(const DataObjectIdentifierType & key) const
+ProcessObject::GetInput(const DataObjectIdentifierType & key) const
 {
   auto it = m_Inputs.find(key);
   if (it == m_Inputs.end())
@@ -755,7 +755,7 @@ ProcessObject ::GetInput(const DataObjectIdentifierType & key) const
 
 
 void
-ProcessObject ::SetPrimaryInput(DataObject * object)
+ProcessObject::SetPrimaryInput(DataObject * object)
 {
   if (m_IndexedInputs[0]->second != object)
   {
@@ -766,7 +766,7 @@ ProcessObject ::SetPrimaryInput(DataObject * object)
 
 
 void
-ProcessObject ::SetPrimaryInputName(const DataObjectIdentifierType & key)
+ProcessObject::SetPrimaryInputName(const DataObjectIdentifierType & key)
 {
   this->RemoveRequiredInputName(m_IndexedInputs[0]->first);
   this->AddRequiredInputName(key, 0);
@@ -774,7 +774,7 @@ ProcessObject ::SetPrimaryInputName(const DataObjectIdentifierType & key)
 
 
 bool
-ProcessObject ::HasInput(const DataObjectIdentifierType & key) const
+ProcessObject::HasInput(const DataObjectIdentifierType & key) const
 {
   auto it = m_Inputs.find(key);
   return it != m_Inputs.end();
@@ -782,7 +782,7 @@ ProcessObject ::HasInput(const DataObjectIdentifierType & key) const
 
 
 ProcessObject::NameArray
-ProcessObject ::GetInputNames() const
+ProcessObject::GetInputNames() const
 {
   NameArray res;
   res.reserve(m_Inputs.size());
@@ -799,7 +799,7 @@ ProcessObject ::GetInputNames() const
 
 
 bool
-ProcessObject ::AddRequiredInputName(const DataObjectIdentifierType & name)
+ProcessObject::AddRequiredInputName(const DataObjectIdentifierType & name)
 {
   if (name.empty())
   {
@@ -823,7 +823,7 @@ ProcessObject ::AddRequiredInputName(const DataObjectIdentifierType & name)
 }
 
 void
-ProcessObject ::AddOptionalInputName(const DataObjectIdentifierType & name)
+ProcessObject::AddOptionalInputName(const DataObjectIdentifierType & name)
 {
 
   if (name.empty())
@@ -839,7 +839,7 @@ ProcessObject ::AddOptionalInputName(const DataObjectIdentifierType & name)
 
 
 bool
-ProcessObject ::AddRequiredInputName(const DataObjectIdentifierType & name, DataObjectPointerArraySizeType idx)
+ProcessObject::AddRequiredInputName(const DataObjectIdentifierType & name, DataObjectPointerArraySizeType idx)
 {
 
   if (name.empty())
@@ -865,7 +865,7 @@ ProcessObject ::AddRequiredInputName(const DataObjectIdentifierType & name, Data
 }
 
 void
-ProcessObject ::AddOptionalInputName(const DataObjectIdentifierType & name, DataObjectPointerArraySizeType idx)
+ProcessObject::AddOptionalInputName(const DataObjectIdentifierType & name, DataObjectPointerArraySizeType idx)
 {
 
   if (name.empty())
@@ -897,7 +897,7 @@ ProcessObject ::AddOptionalInputName(const DataObjectIdentifierType & name, Data
 
 
 bool
-ProcessObject ::RemoveRequiredInputName(const DataObjectIdentifierType & name)
+ProcessObject::RemoveRequiredInputName(const DataObjectIdentifierType & name)
 {
   if (m_RequiredInputNames.erase(name))
   {
@@ -913,14 +913,14 @@ ProcessObject ::RemoveRequiredInputName(const DataObjectIdentifierType & name)
 
 
 bool
-ProcessObject ::IsRequiredInputName(const DataObjectIdentifierType & name) const
+ProcessObject::IsRequiredInputName(const DataObjectIdentifierType & name) const
 {
   return m_RequiredInputNames.find(name) != m_RequiredInputNames.end();
 }
 
 
 void
-ProcessObject ::SetRequiredInputNames(const NameArray & names)
+ProcessObject::SetRequiredInputNames(const NameArray & names)
 {
   m_RequiredInputNames.clear();
   for (const auto & name : names)
@@ -932,7 +932,7 @@ ProcessObject ::SetRequiredInputNames(const NameArray & names)
 
 
 ProcessObject::NameArray
-ProcessObject ::GetRequiredInputNames() const
+ProcessObject::GetRequiredInputNames() const
 {
   NameArray res;
   res.reserve(m_RequiredInputNames.size());
@@ -957,7 +957,7 @@ ProcessObject ::GetRequiredInputNames() const
 // }
 
 ProcessObject::DataObjectPointerArray
-ProcessObject ::GetInputs()
+ProcessObject::GetInputs()
 {
   DataObjectPointerArray res;
   res.reserve(m_Inputs.size());
@@ -974,7 +974,7 @@ ProcessObject ::GetInputs()
 
 
 ProcessObject::DataObjectPointerArraySizeType
-ProcessObject ::GetNumberOfInputs() const
+ProcessObject::GetNumberOfInputs() const
 {
   // only include the primary if it's required or set
   if (m_IndexedInputs[0]->second.IsNotNull() || this->IsRequiredInputName(m_IndexedInputs[0]->first))
@@ -986,7 +986,7 @@ ProcessObject ::GetNumberOfInputs() const
 
 
 ProcessObject::DataObjectPointerArraySizeType
-ProcessObject ::GetNumberOfIndexedInputs() const
+ProcessObject::GetNumberOfIndexedInputs() const
 {
   // this first element should always contain the primary input's
   // name, if this is not true there is an internal logic error.
@@ -1012,7 +1012,7 @@ ProcessObject ::GetNumberOfIndexedInputs() const
 // }
 
 ProcessObject::DataObjectPointerArray
-ProcessObject ::GetIndexedInputs()
+ProcessObject::GetIndexedInputs()
 {
   DataObjectPointerArray res(this->GetNumberOfIndexedInputs());
   for (DataObjectPointerArraySizeType i = 0; i < this->GetNumberOfIndexedInputs(); i++)
@@ -1024,7 +1024,7 @@ ProcessObject ::GetIndexedInputs()
 
 
 ProcessObject::DataObjectIdentifierType
-ProcessObject ::MakeNameFromInputIndex(DataObjectPointerArraySizeType idx) const
+ProcessObject::MakeNameFromInputIndex(DataObjectPointerArraySizeType idx) const
 {
   if (idx == 0)
   {
@@ -1035,7 +1035,7 @@ ProcessObject ::MakeNameFromInputIndex(DataObjectPointerArraySizeType idx) const
 
 
 ProcessObject::DataObjectIdentifierType
-ProcessObject ::MakeNameFromOutputIndex(DataObjectPointerArraySizeType idx) const
+ProcessObject::MakeNameFromOutputIndex(DataObjectPointerArraySizeType idx) const
 {
   if (idx == 0)
   {
@@ -1046,7 +1046,7 @@ ProcessObject ::MakeNameFromOutputIndex(DataObjectPointerArraySizeType idx) cons
 
 
 ProcessObject::DataObjectIdentifierType
-ProcessObject ::MakeNameFromIndex(DataObjectPointerArraySizeType idx) const
+ProcessObject::MakeNameFromIndex(DataObjectPointerArraySizeType idx) const
 {
   if (idx < ITK_GLOBAL_INDEX_NAMES_NUMBER)
   {
@@ -1060,7 +1060,7 @@ ProcessObject ::MakeNameFromIndex(DataObjectPointerArraySizeType idx) const
 
 
 ProcessObject::DataObjectPointerArraySizeType
-ProcessObject ::MakeIndexFromInputName(const DataObjectIdentifierType & name) const
+ProcessObject::MakeIndexFromInputName(const DataObjectIdentifierType & name) const
 {
   if (name == m_IndexedInputs[0]->first)
   {
@@ -1072,7 +1072,7 @@ ProcessObject ::MakeIndexFromInputName(const DataObjectIdentifierType & name) co
 
 
 ProcessObject::DataObjectPointerArraySizeType
-ProcessObject ::MakeIndexFromOutputName(const DataObjectIdentifierType & name) const
+ProcessObject::MakeIndexFromOutputName(const DataObjectIdentifierType & name) const
 {
   if (name == this->m_IndexedOutputs[0]->first)
   {
@@ -1084,7 +1084,7 @@ ProcessObject ::MakeIndexFromOutputName(const DataObjectIdentifierType & name) c
 
 
 ProcessObject::DataObjectPointerArraySizeType
-ProcessObject ::MakeIndexFromName(const DataObjectIdentifierType & name) const
+ProcessObject::MakeIndexFromName(const DataObjectIdentifierType & name) const
 {
   DataObjectIdentifierType       baseName = "_";
   DataObjectPointerArraySizeType baseSize = baseName.size();
@@ -1106,7 +1106,7 @@ ProcessObject ::MakeIndexFromName(const DataObjectIdentifierType & name) const
 
 
 bool
-ProcessObject ::IsIndexedInputName(const DataObjectIdentifierType & name) const
+ProcessObject::IsIndexedInputName(const DataObjectIdentifierType & name) const
 {
   if (name == m_IndexedInputs[0]->first)
   {
@@ -1124,7 +1124,7 @@ ProcessObject ::IsIndexedInputName(const DataObjectIdentifierType & name) const
 
 
 bool
-ProcessObject ::IsIndexedOutputName(const DataObjectIdentifierType & name) const
+ProcessObject::IsIndexedOutputName(const DataObjectIdentifierType & name) const
 {
   if (name == m_IndexedOutputs[0]->first)
   {
@@ -1142,7 +1142,7 @@ ProcessObject ::IsIndexedOutputName(const DataObjectIdentifierType & name) const
 
 
 void
-ProcessObject ::UpdateProgress(float progress)
+ProcessObject::UpdateProgress(float progress)
 {
   // value is clamped between 0 and 1.
   m_Progress = progressFloatToFixed(progress);
@@ -1175,7 +1175,7 @@ ProcessObject::IncrementProgress(float increment)
 
 
 bool
-ProcessObject ::GetReleaseDataFlag() const
+ProcessObject::GetReleaseDataFlag() const
 {
   if (this->GetPrimaryOutput())
   {
@@ -1186,7 +1186,7 @@ ProcessObject ::GetReleaseDataFlag() const
 
 
 void
-ProcessObject ::SetReleaseDataFlag(bool val)
+ProcessObject::SetReleaseDataFlag(bool val)
 {
   for (auto & output : m_Outputs)
   {
@@ -1199,7 +1199,7 @@ ProcessObject ::SetReleaseDataFlag(bool val)
 
 
 void
-ProcessObject ::PrintSelf(std::ostream & os, Indent indent) const
+ProcessObject::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -1279,7 +1279,7 @@ ProcessObject ::PrintSelf(std::ostream & os, Indent indent) const
 
 
 void
-ProcessObject ::Update()
+ProcessObject::Update()
 {
   if (this->GetPrimaryOutput())
   {
@@ -1289,7 +1289,7 @@ ProcessObject ::Update()
 
 
 void
-ProcessObject ::ResetPipeline()
+ProcessObject::ResetPipeline()
 {
   if (this->GetPrimaryOutput())
   {
@@ -1304,7 +1304,7 @@ ProcessObject ::ResetPipeline()
 
 
 void
-ProcessObject ::PropagateResetPipeline()
+ProcessObject::PropagateResetPipeline()
 {
   //
   // Reset this object.
@@ -1327,7 +1327,7 @@ ProcessObject ::PropagateResetPipeline()
 
 
 void
-ProcessObject ::VerifyPreconditions() ITKv5_CONST
+ProcessObject::VerifyPreconditions() ITKv5_CONST
 {
   /**
    * Make sure that all the required named inputs are there and non null
@@ -1370,12 +1370,12 @@ ProcessObject ::VerifyPreconditions() ITKv5_CONST
 
 
 void
-ProcessObject ::VerifyInputInformation() ITKv5_CONST
+ProcessObject::VerifyInputInformation() ITKv5_CONST
 {}
 
 
 void
-ProcessObject ::UpdateOutputInformation()
+ProcessObject::UpdateOutputInformation()
 {
   /**
    * Watch out for loops in the pipeline
@@ -1486,7 +1486,7 @@ ProcessObject ::UpdateOutputInformation()
 
 
 void
-ProcessObject ::PropagateRequestedRegion(DataObject * output)
+ProcessObject::PropagateRequestedRegion(DataObject * output)
 {
   /**
    * check flag to avoid executing forever if there is a loop
@@ -1541,7 +1541,7 @@ ProcessObject ::PropagateRequestedRegion(DataObject * output)
 
 
 void
-ProcessObject ::GenerateInputRequestedRegion()
+ProcessObject::GenerateInputRequestedRegion()
 {
   /*
    * By default we require all the input to produce the output. This is
@@ -1559,7 +1559,7 @@ ProcessObject ::GenerateInputRequestedRegion()
 
 
 void
-ProcessObject ::GenerateOutputRequestedRegion(DataObject * output)
+ProcessObject::GenerateOutputRequestedRegion(DataObject * output)
 {
   /**
    * By default we set all the output requested regions to be the same.
@@ -1576,7 +1576,7 @@ ProcessObject ::GenerateOutputRequestedRegion(DataObject * output)
 
 
 void
-ProcessObject ::SetMultiThreader(MultiThreaderType * threader)
+ProcessObject::SetMultiThreader(MultiThreaderType * threader)
 {
   if (this->m_MultiThreader != threader)
   {
@@ -1605,7 +1605,7 @@ ProcessObject ::SetMultiThreader(MultiThreaderType * threader)
 
 
 void
-ProcessObject ::PrepareOutputs()
+ProcessObject::PrepareOutputs()
 {
   if (this->GetReleaseDataBeforeUpdateFlag())
   {
@@ -1621,7 +1621,7 @@ ProcessObject ::PrepareOutputs()
 
 
 void
-ProcessObject ::ReleaseInputs()
+ProcessObject::ReleaseInputs()
 {
   for (auto & input : m_Inputs)
   {
@@ -1637,7 +1637,7 @@ ProcessObject ::ReleaseInputs()
 
 
 void
-ProcessObject ::UpdateOutputData(DataObject * itkNotUsed(output))
+ProcessObject::UpdateOutputData(DataObject * itkNotUsed(output))
 {
   /**
    * prevent chasing our tail
@@ -1763,7 +1763,7 @@ ProcessObject ::UpdateOutputData(DataObject * itkNotUsed(output))
 
 
 void
-ProcessObject ::CacheInputReleaseDataFlags()
+ProcessObject::CacheInputReleaseDataFlags()
 {
   m_CachedInputReleaseDataFlags.clear();
   for (auto & input : m_Inputs)
@@ -1782,7 +1782,7 @@ ProcessObject ::CacheInputReleaseDataFlags()
 
 
 void
-ProcessObject ::RestoreInputReleaseDataFlags()
+ProcessObject::RestoreInputReleaseDataFlags()
 {
   for (auto & input : m_Inputs)
   {
@@ -1801,7 +1801,7 @@ ProcessObject::SetThreaderUpdateProgress(bool arg)
 }
 
 void
-ProcessObject ::GenerateOutputInformation()
+ProcessObject::GenerateOutputInformation()
 {
   /*
    * Default implementation - copy information from first input to all outputs
@@ -1823,7 +1823,7 @@ ProcessObject ::GenerateOutputInformation()
 
 
 void
-ProcessObject ::UpdateLargestPossibleRegion()
+ProcessObject::UpdateLargestPossibleRegion()
 {
   this->UpdateOutputInformation();
 
@@ -1836,7 +1836,7 @@ ProcessObject ::UpdateLargestPossibleRegion()
 
 
 void
-ProcessObject ::SetNumberOfRequiredInputs(DataObjectPointerArraySizeType nb)
+ProcessObject::SetNumberOfRequiredInputs(DataObjectPointerArraySizeType nb)
 {
   if (m_NumberOfRequiredInputs != nb)
   {

--- a/Modules/Core/Common/src/itkProgressAccumulator.cxx
+++ b/Modules/Core/Common/src/itkProgressAccumulator.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-ProgressAccumulator ::ProgressAccumulator()
+ProgressAccumulator::ProgressAccumulator()
 {
   m_MiniPipelineFilter = nullptr;
 
@@ -38,7 +38,7 @@ ProgressAccumulator ::~ProgressAccumulator()
 }
 
 void
-ProgressAccumulator ::RegisterInternalFilter(GenericFilterType * filter, float weight)
+ProgressAccumulator::RegisterInternalFilter(GenericFilterType * filter, float weight)
 {
   // Observe the filter
   unsigned long progressTag = filter->AddObserver(ProgressEvent(), m_CallbackCommand);
@@ -57,7 +57,7 @@ ProgressAccumulator ::RegisterInternalFilter(GenericFilterType * filter, float w
 }
 
 void
-ProgressAccumulator ::UnregisterAllFilters()
+ProgressAccumulator::UnregisterAllFilters()
 {
   // The filters should no longer be observing us
   FilterRecordVector::iterator it;
@@ -78,7 +78,7 @@ ProgressAccumulator ::UnregisterAllFilters()
 
 #if !defined(ITK_LEGACY_REMOVE)
 void
-ProgressAccumulator ::ResetProgress()
+ProgressAccumulator::ResetProgress()
 {
   // Reset the accumulated progress
   m_AccumulatedProgress = 0.0f;
@@ -95,14 +95,14 @@ ProgressAccumulator ::ResetProgress()
 
 #if !defined(ITK_LEGACY_REMOVE)
 void
-ProgressAccumulator ::ResetFilterProgressAndKeepAccumulatedProgress()
+ProgressAccumulator::ResetFilterProgressAndKeepAccumulatedProgress()
 {
   // Do nothing.  After all, this method is deprecated.
 }
 #endif
 
 void
-ProgressAccumulator ::ReportProgress(Object * who, const EventObject & event)
+ProgressAccumulator::ReportProgress(Object * who, const EventObject & event)
 {
   ProgressEvent pe;
   StartEvent    se;
@@ -161,7 +161,7 @@ ProgressAccumulator ::ReportProgress(Object * who, const EventObject & event)
 }
 
 void
-ProgressAccumulator ::PrintSelf(std::ostream & os, Indent indent) const
+ProgressAccumulator::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/Common/src/itkQuadraticTriangleCellTopology.cxx
+++ b/Modules/Core/Common/src/itkQuadraticTriangleCellTopology.cxx
@@ -24,7 +24,7 @@ namespace itk
  */
 const int QuadraticTriangleCellTopology ::m_Edges[3][3] = { { 0, 4, 1 }, { 1, 5, 2 }, { 2, 3, 0 } };
 
-QuadraticTriangleCellTopology ::QuadraticTriangleCellTopology() = default;
+QuadraticTriangleCellTopology::QuadraticTriangleCellTopology() = default;
 
 QuadraticTriangleCellTopology ::~QuadraticTriangleCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkQuadrilateralCellTopology.cxx
+++ b/Modules/Core/Common/src/itkQuadrilateralCellTopology.cxx
@@ -24,7 +24,7 @@ namespace itk
  */
 const int QuadrilateralCellTopology ::m_Edges[4][2] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 3, 0 } };
 
-QuadrilateralCellTopology ::QuadrilateralCellTopology() = default;
+QuadrilateralCellTopology::QuadrilateralCellTopology() = default;
 
 QuadrilateralCellTopology ::~QuadrilateralCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkRegion.cxx
+++ b/Modules/Core/Common/src/itkRegion.cxx
@@ -30,7 +30,7 @@
 namespace itk
 {
 void
-Region ::Print(std::ostream & os, Indent indent) const
+Region::Print(std::ostream & os, Indent indent) const
 {
   this->PrintHeader(os, indent);
   this->PrintSelf(os, indent.GetNextIndent());
@@ -38,16 +38,16 @@ Region ::Print(std::ostream & os, Indent indent) const
 }
 
 void
-Region ::PrintHeader(std::ostream & os, Indent indent) const
+Region::PrintHeader(std::ostream & os, Indent indent) const
 {
   os << indent << this->GetNameOfClass() << " (" << this << ")\n";
 }
 
 void
-Region ::PrintTrailer(std::ostream & itkNotUsed(os), Indent itkNotUsed(indent)) const
+Region::PrintTrailer(std::ostream & itkNotUsed(os), Indent itkNotUsed(indent)) const
 {}
 
 void
-Region ::PrintSelf(std::ostream &, Indent) const
+Region::PrintSelf(std::ostream &, Indent) const
 {}
 } // end namespace itk

--- a/Modules/Core/Common/src/itkSimpleFilterWatcher.cxx
+++ b/Modules/Core/Common/src/itkSimpleFilterWatcher.cxx
@@ -29,7 +29,7 @@
 
 namespace itk
 {
-SimpleFilterWatcher ::SimpleFilterWatcher(ProcessObject * o, const char * comment)
+SimpleFilterWatcher::SimpleFilterWatcher(ProcessObject * o, const char * comment)
 {
   // Initialize state
   m_Process = o;
@@ -46,13 +46,13 @@ SimpleFilterWatcher ::SimpleFilterWatcher(ProcessObject * o, const char * commen
   this->CreateCommands();
 }
 
-SimpleFilterWatcher ::SimpleFilterWatcher()
+SimpleFilterWatcher::SimpleFilterWatcher()
   : m_Comment("Not watching an object")
   , m_Process(nullptr)
 
 {}
 
-SimpleFilterWatcher ::SimpleFilterWatcher(const SimpleFilterWatcher & watch)
+SimpleFilterWatcher::SimpleFilterWatcher(const SimpleFilterWatcher & watch)
 {
   this->DeepCopy(watch);
 }
@@ -65,7 +65,7 @@ SimpleFilterWatcher ::operator=(const SimpleFilterWatcher & watch)
 }
 
 void
-SimpleFilterWatcher ::CreateCommands()
+SimpleFilterWatcher::CreateCommands()
 {
   // Create a series of commands
   m_StartFilterCommand = CommandType::New();
@@ -90,7 +90,7 @@ SimpleFilterWatcher ::CreateCommands()
 }
 
 void
-SimpleFilterWatcher ::DeepCopy(const SimpleFilterWatcher & watch)
+SimpleFilterWatcher::DeepCopy(const SimpleFilterWatcher & watch)
 {
   if (this != &watch)
   {
@@ -123,7 +123,7 @@ SimpleFilterWatcher ::DeepCopy(const SimpleFilterWatcher & watch)
 }
 
 void
-SimpleFilterWatcher ::RemoveObservers()
+SimpleFilterWatcher::RemoveObservers()
 {
   if (m_StartFilterCommand)
   {

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -81,7 +81,7 @@ GlobalSingletonIndexInitializer::SingletonIndex * GlobalSingletonIndexInitialize
 namespace itk
 {
 void *
-SingletonIndex ::GetGlobalInstancePrivate(const char * globalName)
+SingletonIndex::GetGlobalInstancePrivate(const char * globalName)
 {
   SingletonData::iterator it;
   it = m_GlobalObjects.find(globalName);
@@ -95,10 +95,10 @@ SingletonIndex ::GetGlobalInstancePrivate(const char * globalName)
 // If globalName is already registered remove it from map,
 // otherwise global is added to the singleton index under globalName
 bool
-SingletonIndex ::SetGlobalInstancePrivate(const char *                globalName,
-                                          void *                      global,
-                                          std::function<void(void *)> func,
-                                          std::function<void(void)>   deleteFunc)
+SingletonIndex::SetGlobalInstancePrivate(const char *                globalName,
+                                         void *                      global,
+                                         std::function<void(void *)> func,
+                                         std::function<void(void)>   deleteFunc)
 {
   m_GlobalObjects.erase(globalName);
   m_GlobalObjects.insert(std::make_pair(globalName, std::make_tuple(global, func, deleteFunc)));
@@ -106,7 +106,7 @@ SingletonIndex ::SetGlobalInstancePrivate(const char *                globalName
 }
 
 SingletonIndex *
-SingletonIndex ::GetInstance()
+SingletonIndex::GetInstance()
 {
   if (m_Instance == nullptr)
   {
@@ -116,7 +116,7 @@ SingletonIndex ::GetInstance()
 }
 
 void
-SingletonIndex ::SetInstance(Self * instance)
+SingletonIndex::SetInstance(Self * instance)
 {
   m_Instance = instance;
 }

--- a/Modules/Core/Common/src/itkSpatialOrientationAdapter.cxx
+++ b/Modules/Core/Common/src/itkSpatialOrientationAdapter.cxx
@@ -30,7 +30,7 @@
 namespace itk
 {
 SpatialOrientationAdapter::OrientationType
-SpatialOrientationAdapter ::FromDirectionCosines(const DirectionType & Dir)
+SpatialOrientationAdapter::FromDirectionCosines(const DirectionType & Dir)
 {
   int      axes[9] = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
   unsigned dominant_axis;
@@ -88,7 +88,7 @@ SpatialOrientationAdapter ::FromDirectionCosines(const DirectionType & Dir)
 }
 
 SpatialOrientationAdapter::DirectionType
-SpatialOrientationAdapter ::ToDirectionCosines(const OrientationType & Or)
+SpatialOrientationAdapter::ToDirectionCosines(const OrientationType & Or)
 {
   using CoordinateTerms = SpatialOrientation::CoordinateTerms;
 

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -118,10 +118,10 @@ TBBMultiThreader::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 void
-TBBMultiThreader ::ParallelizeArray(SizeValueType             firstIndex,
-                                    SizeValueType             lastIndexPlus1,
-                                    ArrayThreadingFunctorType aFunc,
-                                    ProcessObject *           filter)
+TBBMultiThreader::ParallelizeArray(SizeValueType             firstIndex,
+                                   SizeValueType             lastIndexPlus1,
+                                   ArrayThreadingFunctorType aFunc,
+                                   ProcessObject *           filter)
 {
   if (!this->GetUpdateProgress())
   {
@@ -240,11 +240,11 @@ struct TBBImageRegionSplitter : public itk::ImageIORegion
 namespace itk
 {
 void
-TBBMultiThreader ::ParallelizeImageRegion(unsigned int         dimension,
-                                          const IndexValueType index[],
-                                          const SizeValueType  size[],
-                                          ThreadingFunctorType funcP,
-                                          ProcessObject *      filter)
+TBBMultiThreader::ParallelizeImageRegion(unsigned int         dimension,
+                                         const IndexValueType index[],
+                                         const SizeValueType  size[],
+                                         ThreadingFunctorType funcP,
+                                         ProcessObject *      filter)
 {
   if (!this->GetUpdateProgress())
   {

--- a/Modules/Core/Common/src/itkTetrahedronCellTopology.cxx
+++ b/Modules/Core/Common/src/itkTetrahedronCellTopology.cxx
@@ -29,7 +29,7 @@ const int TetrahedronCellTopology ::m_Faces[4][3] = { { 0, 1, 3 }, { 1, 2, 3 }, 
  */
 const int TetrahedronCellTopology ::m_Edges[6][2] = { { 0, 1 }, { 1, 2 }, { 2, 0 }, { 0, 3 }, { 1, 3 }, { 2, 3 } };
 
-TetrahedronCellTopology ::TetrahedronCellTopology() = default;
+TetrahedronCellTopology::TetrahedronCellTopology() = default;
 
 TetrahedronCellTopology ::~TetrahedronCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkThreadLogger.cxx
+++ b/Modules/Core/Common/src/itkThreadLogger.cxx
@@ -22,7 +22,7 @@
 namespace itk
 {
 
-ThreadLogger ::ThreadLogger()
+ThreadLogger::ThreadLogger()
 {
   m_Delay = 300; // ms
   m_TerminationRequested = false;
@@ -39,7 +39,7 @@ ThreadLogger ::~ThreadLogger()
 }
 
 void
-ThreadLogger ::SetPriorityLevel(PriorityLevelEnum level)
+ThreadLogger::SetPriorityLevel(PriorityLevelEnum level)
 {
   this->m_Mutex.lock();
   this->m_OperationQ.push(SET_PRIORITY_LEVEL);
@@ -48,7 +48,7 @@ ThreadLogger ::SetPriorityLevel(PriorityLevelEnum level)
 }
 
 Logger::PriorityLevelEnum
-ThreadLogger ::GetPriorityLevel() const
+ThreadLogger::GetPriorityLevel() const
 {
   this->m_Mutex.lock();
   PriorityLevelEnum level = this->m_PriorityLevel;
@@ -57,7 +57,7 @@ ThreadLogger ::GetPriorityLevel() const
 }
 
 void
-ThreadLogger ::SetLevelForFlushing(PriorityLevelEnum level)
+ThreadLogger::SetLevelForFlushing(PriorityLevelEnum level)
 {
   this->m_Mutex.lock();
   this->m_LevelForFlushing = level;
@@ -67,7 +67,7 @@ ThreadLogger ::SetLevelForFlushing(PriorityLevelEnum level)
 }
 
 Logger::PriorityLevelEnum
-ThreadLogger ::GetLevelForFlushing() const
+ThreadLogger::GetLevelForFlushing() const
 {
   this->m_Mutex.lock();
   PriorityLevelEnum level = this->m_LevelForFlushing;
@@ -76,7 +76,7 @@ ThreadLogger ::GetLevelForFlushing() const
 }
 
 void
-ThreadLogger ::SetDelay(DelayType delay)
+ThreadLogger::SetDelay(DelayType delay)
 {
   this->m_Mutex.lock();
   this->m_Delay = delay;
@@ -84,7 +84,7 @@ ThreadLogger ::SetDelay(DelayType delay)
 }
 
 ThreadLogger::DelayType
-ThreadLogger ::GetDelay() const
+ThreadLogger::GetDelay() const
 {
   this->m_Mutex.lock();
   DelayType delay = this->m_Delay;
@@ -93,7 +93,7 @@ ThreadLogger ::GetDelay() const
 }
 
 void
-ThreadLogger ::AddLogOutput(OutputType * output)
+ThreadLogger::AddLogOutput(OutputType * output)
 {
   this->m_Mutex.lock();
   this->m_OperationQ.push(ADD_LOG_OUTPUT);
@@ -102,7 +102,7 @@ ThreadLogger ::AddLogOutput(OutputType * output)
 }
 
 void
-ThreadLogger ::Write(PriorityLevelEnum level, std::string const & content)
+ThreadLogger::Write(PriorityLevelEnum level, std::string const & content)
 {
   this->m_Mutex.lock();
   this->m_OperationQ.push(WRITE);
@@ -116,7 +116,7 @@ ThreadLogger ::Write(PriorityLevelEnum level, std::string const & content)
 }
 
 void
-ThreadLogger ::Flush()
+ThreadLogger::Flush()
 {
   this->m_Mutex.lock();
   this->m_OperationQ.push(FLUSH);
@@ -125,7 +125,7 @@ ThreadLogger ::Flush()
 }
 
 void
-ThreadLogger ::InternalFlush()
+ThreadLogger::InternalFlush()
 {
   this->m_Mutex.lock();
 
@@ -164,7 +164,7 @@ ThreadLogger ::InternalFlush()
 }
 
 void
-ThreadLogger ::ThreadFunction()
+ThreadLogger::ThreadFunction()
 {
   while (!m_TerminationRequested)
   {
@@ -205,7 +205,7 @@ ThreadLogger ::ThreadFunction()
 }
 
 void
-ThreadLogger ::PrintSelf(std::ostream & os, Indent indent) const
+ThreadLogger::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -52,14 +52,14 @@ struct ThreadPoolGlobals
 itkGetGlobalSimpleMacro(ThreadPool, ThreadPoolGlobals, PimplGlobals);
 
 ThreadPool::Pointer
-ThreadPool ::New()
+ThreadPool::New()
 {
   return Self::GetInstance();
 }
 
 
 ThreadPool::Pointer
-ThreadPool ::GetInstance()
+ThreadPool::GetInstance()
 {
   // This is called once, on-demand to ensure that m_PimplGlobals is
   // initialized.
@@ -83,20 +83,20 @@ ThreadPool ::GetInstance()
 }
 
 bool
-ThreadPool ::GetDoNotWaitForThreads()
+ThreadPool::GetDoNotWaitForThreads()
 {
   itkInitGlobalsMacro(PimplGlobals);
   return !m_PimplGlobals->m_WaitForThreads;
 }
 
 void
-ThreadPool ::SetDoNotWaitForThreads(bool doNotWaitForThreads)
+ThreadPool::SetDoNotWaitForThreads(bool doNotWaitForThreads)
 {
   itkInitGlobalsMacro(PimplGlobals);
   m_PimplGlobals->m_WaitForThreads = !doNotWaitForThreads;
 }
 
-ThreadPool ::ThreadPool()
+ThreadPool::ThreadPool()
 {
   m_PimplGlobals->m_ThreadPoolInstance = this;        // threads need this
   m_PimplGlobals->m_ThreadPoolInstance->UnRegister(); // Remove extra reference
@@ -109,7 +109,7 @@ ThreadPool ::ThreadPool()
 }
 
 void
-ThreadPool ::AddThreads(ThreadIdType count)
+ThreadPool::AddThreads(ThreadIdType count)
 {
   std::unique_lock<std::mutex> mutexHolder(m_PimplGlobals->m_Mutex);
   m_Threads.reserve(m_Threads.size() + count);
@@ -120,13 +120,13 @@ ThreadPool ::AddThreads(ThreadIdType count)
 }
 
 std::mutex &
-ThreadPool ::GetMutex()
+ThreadPool::GetMutex()
 {
   return m_PimplGlobals->m_Mutex;
 }
 
 int
-ThreadPool ::GetNumberOfCurrentlyIdleThreads() const
+ThreadPool::GetNumberOfCurrentlyIdleThreads() const
 {
   std::unique_lock<std::mutex> mutexHolder(m_PimplGlobals->m_Mutex);
   return int(m_Threads.size()) - int(m_WorkQueue.size()); // lousy approximation
@@ -156,7 +156,7 @@ ThreadPool ::~ThreadPool()
 
 
 void
-ThreadPool ::ThreadExecute()
+ThreadPool::ThreadExecute()
 {
   // plain pointer does not increase reference count
   ThreadPool * threadPool = m_PimplGlobals->m_ThreadPoolInstance.GetPointer();

--- a/Modules/Core/Common/src/itkThreadedIndexedContainerPartitioner.cxx
+++ b/Modules/Core/Common/src/itkThreadedIndexedContainerPartitioner.cxx
@@ -21,15 +21,15 @@
 namespace itk
 {
 
-ThreadedIndexedContainerPartitioner ::ThreadedIndexedContainerPartitioner() = default;
+ThreadedIndexedContainerPartitioner::ThreadedIndexedContainerPartitioner() = default;
 
 ThreadedIndexedContainerPartitioner ::~ThreadedIndexedContainerPartitioner() = default;
 
 ThreadIdType
-ThreadedIndexedContainerPartitioner ::PartitionDomain(const ThreadIdType threadId,
-                                                      const ThreadIdType requestedTotal,
-                                                      const DomainType & completeIndexRange,
-                                                      DomainType &       subIndexRange) const
+ThreadedIndexedContainerPartitioner::PartitionDomain(const ThreadIdType threadId,
+                                                     const ThreadIdType requestedTotal,
+                                                     const DomainType & completeIndexRange,
+                                                     DomainType &       subIndexRange) const
 {
   // completeIndexRange and subIndexRange are inclusive
 

--- a/Modules/Core/Common/src/itkTimeProbe.cxx
+++ b/Modules/Core/Common/src/itkTimeProbe.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-TimeProbe ::TimeProbe()
+TimeProbe::TimeProbe()
   : ResourceProbe<TimeStampType, TimeStampType>("Time", "s")
 {
   m_RealTimeClock = RealTimeClock::New();
@@ -28,7 +28,7 @@ TimeProbe ::TimeProbe()
 TimeProbe ::~TimeProbe() = default;
 
 TimeProbe::TimeStampType
-TimeProbe ::GetInstantValue() const
+TimeProbe::GetInstantValue() const
 {
   return m_RealTimeClock->GetTimeInSeconds();
 }

--- a/Modules/Core/Common/src/itkTimeProbesCollectorBase.cxx
+++ b/Modules/Core/Common/src/itkTimeProbesCollectorBase.cxx
@@ -20,7 +20,7 @@
 
 namespace itk
 {
-TimeProbesCollectorBase ::TimeProbesCollectorBase() = default;
+TimeProbesCollectorBase::TimeProbesCollectorBase() = default;
 
 TimeProbesCollectorBase ::~TimeProbesCollectorBase() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkTimeStamp.cxx
@@ -39,7 +39,7 @@ itkGetGlobalValueMacro(TimeStamp, TimeStamp::GlobalTimeStampType, GlobalTimeStam
  * Instance creation.
  */
 TimeStamp *
-TimeStamp ::New()
+TimeStamp::New()
 {
   return new Self;
 }
@@ -49,7 +49,7 @@ TimeStamp ::New()
  * Make sure the new time stamp is greater than all others so far.
  */
 void
-TimeStamp ::Modified()
+TimeStamp::Modified()
 {
   // This is called once, on-demand to ensure that m_GlobalTimeStamp is
   // initialized.

--- a/Modules/Core/Common/src/itkTriangleCellTopology.cxx
+++ b/Modules/Core/Common/src/itkTriangleCellTopology.cxx
@@ -24,7 +24,7 @@ namespace itk
  */
 const int TriangleCellTopology ::m_Edges[3][2] = { { 0, 1 }, { 1, 2 }, { 2, 0 } };
 
-TriangleCellTopology ::TriangleCellTopology() = default;
+TriangleCellTopology::TriangleCellTopology() = default;
 
 TriangleCellTopology ::~TriangleCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkWin32OutputWindow.cxx
+++ b/Modules/Core/Common/src/itkWin32OutputWindow.cxx
@@ -43,7 +43,7 @@ Win32OutputWindow ::~Win32OutputWindow()
 
 /** */
 LRESULT APIENTRY
-        Win32OutputWindow ::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+        Win32OutputWindow::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
   switch (message)
   {
@@ -77,7 +77,7 @@ LRESULT APIENTRY
 
 /** Display text in the window, and translate the \n to \r\n. */
 void
-Win32OutputWindow ::DisplayText(const char * text)
+Win32OutputWindow::DisplayText(const char * text)
 {
   if (!text)
   {
@@ -121,7 +121,7 @@ Win32OutputWindow ::DisplayText(const char * text)
 
 /** Add some text to the EDIT control. */
 void
-Win32OutputWindow ::AddText(const char * text)
+Win32OutputWindow::AddText(const char * text)
 {
   if (!Initialize() || (strlen(text) == 0))
   {
@@ -138,7 +138,7 @@ Win32OutputWindow ::AddText(const char * text)
 /** initialize the output window with an EDIT control and
  *  a container window. */
 int
-Win32OutputWindow ::Initialize()
+Win32OutputWindow::Initialize()
 {
   /** check to see if it is already initialized */
   if (Win32OutputWindow::m_OutputWindow)
@@ -219,7 +219,7 @@ Win32OutputWindow ::Initialize()
 
 /** Prompt some text */
 void
-Win32OutputWindow ::PromptText(const char * text)
+Win32OutputWindow::PromptText(const char * text)
 {
   std::ostringstream msg;
 

--- a/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
@@ -30,13 +30,13 @@ XMLFileOutputWindow ::XMLFileOutputWindow() = default;
 XMLFileOutputWindow ::~XMLFileOutputWindow() = default;
 
 void
-XMLFileOutputWindow ::PrintSelf(std::ostream & os, Indent indent) const
+XMLFileOutputWindow::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }
 
 void
-XMLFileOutputWindow ::Initialize()
+XMLFileOutputWindow::Initialize()
 {
   if (!m_Stream)
   {
@@ -56,13 +56,13 @@ XMLFileOutputWindow ::Initialize()
 }
 
 void
-XMLFileOutputWindow ::DisplayTag(const char * text)
+XMLFileOutputWindow::DisplayTag(const char * text)
 {
   Superclass::DisplayText(text);
 }
 
 void
-XMLFileOutputWindow ::DisplayXML(const char * tag, const char * text)
+XMLFileOutputWindow::DisplayXML(const char * tag, const char * text)
 {
   char * xmlText;
 
@@ -137,31 +137,31 @@ XMLFileOutputWindow ::DisplayXML(const char * tag, const char * text)
 }
 
 void
-XMLFileOutputWindow ::DisplayText(const char * text)
+XMLFileOutputWindow::DisplayText(const char * text)
 {
   this->DisplayXML("Text", text);
 }
 
 void
-XMLFileOutputWindow ::DisplayErrorText(const char * text)
+XMLFileOutputWindow::DisplayErrorText(const char * text)
 {
   this->DisplayXML("Error", text);
 }
 
 void
-XMLFileOutputWindow ::DisplayWarningText(const char * text)
+XMLFileOutputWindow::DisplayWarningText(const char * text)
 {
   this->DisplayXML("Warning", text);
 }
 
 void
-XMLFileOutputWindow ::DisplayGenericOutputText(const char * text)
+XMLFileOutputWindow::DisplayGenericOutputText(const char * text)
 {
   this->DisplayXML("GenericOutput", text);
 }
 
 void
-XMLFileOutputWindow ::DisplayDebugText(const char * text)
+XMLFileOutputWindow::DisplayDebugText(const char * text)
 {
   this->DisplayXML("Debug", text);
 }

--- a/Modules/Core/Common/test/ClientTestLibraryA.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryA.cxx
@@ -57,13 +57,13 @@ ITKObjectProducer ::ITKObjectProducer()
 }
 
 itk::Object *
-ITKObjectProducer ::EquivalencyTable()
+ITKObjectProducer::EquivalencyTable()
 {
   return m_EquivalencyTable.GetPointer();
 }
 
 itk::Object *
-ITKObjectProducer ::Image()
+ITKObjectProducer::Image()
 {
   return m_Image.GetPointer();
 }

--- a/Modules/Core/Common/test/ClientTestLibraryB.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryB.cxx
@@ -58,14 +58,14 @@ ITKObjectProducer ::ITKObjectProducer()
 
 
 itk::Object *
-ITKObjectProducer ::EquivalencyTable()
+ITKObjectProducer::EquivalencyTable()
 {
   return m_EquivalencyTable.GetPointer();
 }
 
 
 itk::Object *
-ITKObjectProducer ::Image()
+ITKObjectProducer::Image()
 {
   return m_Image.GetPointer();
 }

--- a/Modules/Core/Common/test/ClientTestLibraryC.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryC.cxx
@@ -57,13 +57,13 @@ ITKObjectProducer ::ITKObjectProducer()
 }
 
 itk::Object *
-ITKObjectProducer ::EquivalencyTable()
+ITKObjectProducer::EquivalencyTable()
 {
   return m_EquivalencyTable.GetPointer();
 }
 
 itk::Object *
-ITKObjectProducer ::Image()
+ITKObjectProducer::Image()
 {
   return m_Image.GetPointer();
 }

--- a/Modules/Core/Mesh/src/itkMeshRegion.cxx
+++ b/Modules/Core/Mesh/src/itkMeshRegion.cxx
@@ -22,7 +22,7 @@ namespace itk
 /**
  * Instantiate object.
  */
-MeshRegion ::MeshRegion()
+MeshRegion::MeshRegion()
 {
   m_NumberOfRegions = 0;
   m_Region = 0;

--- a/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
+++ b/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-SimplexMeshGeometry ::SimplexMeshGeometry()
+SimplexMeshGeometry::SimplexMeshGeometry()
 {
   double    c = 1.0 / 3.0;
   PointType p;
@@ -61,7 +61,7 @@ SimplexMeshGeometry ::~SimplexMeshGeometry()
 }
 
 void
-SimplexMeshGeometry ::ComputeGeometry()
+SimplexMeshGeometry::ComputeGeometry()
 {
   VectorType b, c, cXb, tmp;
 
@@ -140,7 +140,7 @@ SimplexMeshGeometry::CopyFrom(const SimplexMeshGeometry & input)
 }
 
 void
-SimplexMeshGeometry ::CopyNeigborSet(const NeighborSetType * nset)
+SimplexMeshGeometry::CopyNeigborSet(const NeighborSetType * nset)
 {
   delete this->neighborSet;
   if (nset)

--- a/Modules/Core/QuadEdgeMesh/src/itkQuadEdge.cxx
+++ b/Modules/Core/QuadEdgeMesh/src/itkQuadEdge.cxx
@@ -20,7 +20,7 @@
 namespace itk
 {
 // ---------------------------------------------------------------------
-QuadEdge ::QuadEdge()
+QuadEdge::QuadEdge()
 {
   this->m_Onext = this;
   this->m_Rot = nullptr;
@@ -35,7 +35,7 @@ QuadEdge ::~QuadEdge()
 
 // ---------------------------------------------------------------------
 QuadEdge *
-QuadEdge ::GetLnext()
+QuadEdge::GetLnext()
 {
 #ifdef NDEBUG
   return this->GetInvRot()->GetOnext()->GetRot();
@@ -64,7 +64,7 @@ QuadEdge ::GetLnext()
 
 // ---------------------------------------------------------------------
 const QuadEdge *
-QuadEdge ::GetLnext() const
+QuadEdge::GetLnext() const
 {
 #ifdef NDEBUG
   return this->GetInvRot()->GetOnext()->GetRot();
@@ -93,7 +93,7 @@ QuadEdge ::GetLnext() const
 
 // ---------------------------------------------------------------------
 QuadEdge *
-QuadEdge ::GetRnext()
+QuadEdge::GetRnext()
 {
 #ifdef NDEBUG
   return this->GetRot()->GetOnext()->GetInvRot();
@@ -122,7 +122,7 @@ QuadEdge ::GetRnext()
 
 // ---------------------------------------------------------------------
 const QuadEdge *
-QuadEdge ::GetRnext() const
+QuadEdge::GetRnext() const
 {
 #ifdef NDEBUG
   return this->GetRot()->GetOnext()->GetInvRot();
@@ -151,7 +151,7 @@ QuadEdge ::GetRnext() const
 
 // ---------------------------------------------------------------------
 QuadEdge *
-QuadEdge ::GetDnext()
+QuadEdge::GetDnext()
 {
 #ifdef NDEBUG
   return this->GetSym()->GetOnext()->GetSym();
@@ -180,7 +180,7 @@ QuadEdge ::GetDnext()
 
 // ---------------------------------------------------------------------
 const QuadEdge *
-QuadEdge ::GetDnext() const
+QuadEdge::GetDnext() const
 {
 #ifdef NDEBUG
   return this->GetSym()->GetOnext()->GetSym();
@@ -209,7 +209,7 @@ QuadEdge ::GetDnext() const
 
 // ---------------------------------------------------------------------
 QuadEdge *
-QuadEdge ::GetOprev()
+QuadEdge::GetOprev()
 {
 #ifdef NDEBUG
   return this->GetRot()->GetOnext()->GetRot();
@@ -238,7 +238,7 @@ QuadEdge ::GetOprev()
 
 // ---------------------------------------------------------------------
 const QuadEdge *
-QuadEdge ::GetOprev() const
+QuadEdge::GetOprev() const
 {
 #ifdef NDEBUG
   return this->GetRot()->GetOnext()->GetRot();
@@ -267,7 +267,7 @@ QuadEdge ::GetOprev() const
 
 // ---------------------------------------------------------------------
 QuadEdge *
-QuadEdge ::GetLprev()
+QuadEdge::GetLprev()
 {
 #ifdef NDEBUG
   return this->GetOnext()->GetSym();
@@ -290,7 +290,7 @@ QuadEdge ::GetLprev()
 
 // ---------------------------------------------------------------------
 const QuadEdge *
-QuadEdge ::GetLprev() const
+QuadEdge::GetLprev() const
 {
 #ifdef NDEBUG
   return this->GetOnext()->GetSym();
@@ -313,7 +313,7 @@ QuadEdge ::GetLprev() const
 
 // ---------------------------------------------------------------------
 QuadEdge *
-QuadEdge ::GetRprev()
+QuadEdge::GetRprev()
 {
 #ifdef NDEBUG
   return this->GetSym()->GetOnext();
@@ -336,7 +336,7 @@ QuadEdge ::GetRprev()
 
 // ---------------------------------------------------------------------
 const QuadEdge *
-QuadEdge ::GetRprev() const
+QuadEdge::GetRprev() const
 {
 #ifdef NDEBUG
   return this->GetSym()->GetOnext();
@@ -359,7 +359,7 @@ QuadEdge ::GetRprev() const
 
 // ---------------------------------------------------------------------
 QuadEdge *
-QuadEdge ::GetDprev()
+QuadEdge::GetDprev()
 {
 #ifdef NDEBUG
   return this->GetInvRot()->GetOnext()->GetInvRot();
@@ -388,7 +388,7 @@ QuadEdge ::GetDprev()
 
 // ---------------------------------------------------------------------
 const QuadEdge *
-QuadEdge ::GetDprev() const
+QuadEdge::GetDprev() const
 {
 #ifdef NDEBUG
   return this->GetInvRot()->GetOnext()->GetInvRot();
@@ -416,7 +416,7 @@ QuadEdge ::GetDprev() const
 }
 
 bool
-QuadEdge ::IsEdgeInOnextRing(Self * testEdge) const
+QuadEdge::IsEdgeInOnextRing(Self * testEdge) const
 {
   if (!this->IsIsolated())
   {
@@ -438,7 +438,7 @@ QuadEdge ::IsEdgeInOnextRing(Self * testEdge) const
 }
 
 bool
-QuadEdge ::IsLnextGivenSizeCyclic(const int size) const
+QuadEdge::IsLnextGivenSizeCyclic(const int size) const
 {
   const Self * iterated = this;
 
@@ -454,7 +454,7 @@ QuadEdge ::IsLnextGivenSizeCyclic(const int size) const
 }
 
 unsigned int
-QuadEdge ::GetOrder() const
+QuadEdge::GetOrder() const
 {
   if (!(this->IsIsolated()))
   {

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -22,13 +22,13 @@
 
 namespace itk
 {
-SpatialObjectProperty ::SpatialObjectProperty()
+SpatialObjectProperty::SpatialObjectProperty()
 {
   this->Clear();
 }
 
 void
-SpatialObjectProperty ::Clear()
+SpatialObjectProperty::Clear()
 {
   m_Color.SetRed(1);
   m_Color.SetGreen(1);
@@ -42,7 +42,7 @@ SpatialObjectProperty ::Clear()
 }
 
 void
-SpatialObjectProperty ::SetColor(double r, double g, double b)
+SpatialObjectProperty::SetColor(double r, double g, double b)
 {
   m_Color.SetRed(r);
   m_Color.SetGreen(g);
@@ -50,67 +50,67 @@ SpatialObjectProperty ::SetColor(double r, double g, double b)
 }
 
 void
-SpatialObjectProperty ::SetRed(double r)
+SpatialObjectProperty::SetRed(double r)
 {
   m_Color.SetRed(r);
 }
 
 double
-SpatialObjectProperty ::GetRed() const
+SpatialObjectProperty::GetRed() const
 {
   return m_Color.GetRed();
 }
 
 void
-SpatialObjectProperty ::SetGreen(double g)
+SpatialObjectProperty::SetGreen(double g)
 {
   m_Color.SetGreen(g);
 }
 
 double
-SpatialObjectProperty ::GetGreen() const
+SpatialObjectProperty::GetGreen() const
 {
   return m_Color.GetGreen();
 }
 
 void
-SpatialObjectProperty ::SetBlue(double b)
+SpatialObjectProperty::SetBlue(double b)
 {
   m_Color.SetBlue(b);
 }
 
 double
-SpatialObjectProperty ::GetBlue() const
+SpatialObjectProperty::GetBlue() const
 {
   return m_Color.GetBlue();
 }
 
 void
-SpatialObjectProperty ::SetAlpha(double a)
+SpatialObjectProperty::SetAlpha(double a)
 {
   m_Color.SetAlpha(a);
 }
 
 double
-SpatialObjectProperty ::GetAlpha() const
+SpatialObjectProperty::GetAlpha() const
 {
   return m_Color.GetAlpha();
 }
 
 void
-SpatialObjectProperty ::SetTagScalarValue(const std::string & tag, double value)
+SpatialObjectProperty::SetTagScalarValue(const std::string & tag, double value)
 {
   m_ScalarDictionary[tag] = value;
 }
 
 void
-SpatialObjectProperty ::SetTagStringValue(const std::string & tag, const std::string & value)
+SpatialObjectProperty::SetTagStringValue(const std::string & tag, const std::string & value)
 {
   m_StringDictionary[tag] = value;
 }
 
 bool
-SpatialObjectProperty ::GetTagScalarValue(const std::string & tag, double & value) const
+SpatialObjectProperty::GetTagScalarValue(const std::string & tag, double & value) const
 {
   auto it = m_ScalarDictionary.find(tag);
   if (it != m_ScalarDictionary.end())
@@ -125,7 +125,7 @@ SpatialObjectProperty ::GetTagScalarValue(const std::string & tag, double & valu
 }
 
 bool
-SpatialObjectProperty ::GetTagStringValue(const std::string & tag, std::string & value) const
+SpatialObjectProperty::GetTagStringValue(const std::string & tag, std::string & value) const
 {
   auto it = m_StringDictionary.find(tag);
   if (it != m_StringDictionary.end())
@@ -140,37 +140,37 @@ SpatialObjectProperty ::GetTagStringValue(const std::string & tag, std::string &
 }
 
 std::map<std::string, double> &
-SpatialObjectProperty ::GetTagScalarDictionary()
+SpatialObjectProperty::GetTagScalarDictionary()
 {
   return m_ScalarDictionary;
 }
 
 const std::map<std::string, double> &
-SpatialObjectProperty ::GetTagScalarDictionary() const
+SpatialObjectProperty::GetTagScalarDictionary() const
 {
   return m_ScalarDictionary;
 }
 
 std::map<std::string, std::string> &
-SpatialObjectProperty ::GetTagStringDictionary()
+SpatialObjectProperty::GetTagStringDictionary()
 {
   return m_StringDictionary;
 }
 
 const std::map<std::string, std::string> &
-SpatialObjectProperty ::GetTagStringDictionary() const
+SpatialObjectProperty::GetTagStringDictionary() const
 {
   return m_StringDictionary;
 }
 
 void
-SpatialObjectProperty ::SetTagScalarDictionary(const std::map<std::string, double> & dict)
+SpatialObjectProperty::SetTagScalarDictionary(const std::map<std::string, double> & dict)
 {
   m_ScalarDictionary = dict;
 }
 
 void
-SpatialObjectProperty ::SetTagStringDictionary(const std::map<std::string, std::string> & dict)
+SpatialObjectProperty::SetTagStringDictionary(const std::map<std::string, std::string> & dict)
 {
   m_StringDictionary = dict;
 }
@@ -190,7 +190,7 @@ SpatialObjectProperty ::operator=(const SpatialObjectProperty & rhs)
 }
 
 void
-SpatialObjectProperty ::PrintSelf(std::ostream & os, Indent indent) const
+SpatialObjectProperty::PrintSelf(std::ostream & os, Indent indent) const
 {
   os << indent << "Name: " << m_Name << std::endl;
   os << indent << "RGBA: " << m_Color.GetRed() << " " << m_Color.GetGreen() << " " << m_Color.GetBlue() << " "

--- a/Modules/Filtering/BiasCorrection/src/itkCacheableScalarFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCacheableScalarFunction.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-CacheableScalarFunction ::CacheableScalarFunction()
+CacheableScalarFunction::CacheableScalarFunction()
   : m_CacheTable(0)
 
 {}
@@ -27,7 +27,7 @@ CacheableScalarFunction ::CacheableScalarFunction()
 CacheableScalarFunction::~CacheableScalarFunction() = default;
 
 void
-CacheableScalarFunction ::CreateCache(double lowerBound, double upperBound, SizeValueType sampleSize)
+CacheableScalarFunction::CreateCache(double lowerBound, double upperBound, SizeValueType sampleSize)
 {
   m_NumberOfSamples = sampleSize;
   m_CacheLowerBound = lowerBound;

--- a/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
@@ -19,8 +19,8 @@
 
 namespace itk
 {
-CompositeValleyFunction ::CompositeValleyFunction(const MeasureArrayType & classMeans,
-                                                  const MeasureArrayType & classSigmas)
+CompositeValleyFunction::CompositeValleyFunction(const MeasureArrayType & classMeans,
+                                                 const MeasureArrayType & classSigmas)
 {
   const std::size_t length = classMeans.size();
 
@@ -51,7 +51,7 @@ CompositeValleyFunction ::CompositeValleyFunction(const MeasureArrayType & class
 CompositeValleyFunction::~CompositeValleyFunction() = default;
 
 void
-CompositeValleyFunction ::Initialize()
+CompositeValleyFunction::Initialize()
 {
   SizeValueType i, low, high;
 

--- a/Modules/Filtering/FFT/include/itkVnlFFTCommon.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlFFTCommon.hxx
@@ -25,7 +25,7 @@ namespace itk
 
 template <typename TSizeValue>
 bool
-VnlFFTCommon ::IsDimensionSizeLegal(TSizeValue n)
+VnlFFTCommon::IsDimensionSizeLegal(TSizeValue n)
 {
   int ifac = 2;
 

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -51,34 +51,34 @@ struct FFTWGlobalConfigurationGlobals
   std::mutex                       m_CreationLock;
 };
 
-WisdomFilenameGeneratorBase ::WisdomFilenameGeneratorBase() = default;
+WisdomFilenameGeneratorBase::WisdomFilenameGeneratorBase() = default;
 
 WisdomFilenameGeneratorBase ::~WisdomFilenameGeneratorBase() = default;
 
-ManualWisdomFilenameGenerator ::ManualWisdomFilenameGenerator(std::string wfn)
+ManualWisdomFilenameGenerator::ManualWisdomFilenameGenerator(std::string wfn)
   : m_WisdomFilename(std::move(wfn))
 {}
 
 void
-ManualWisdomFilenameGenerator ::SetWisdomFilename(const std::string & wfn)
+ManualWisdomFilenameGenerator::SetWisdomFilename(const std::string & wfn)
 {
   this->m_WisdomFilename = wfn;
 }
 
 std::string
-ManualWisdomFilenameGenerator ::GenerateWisdomFilename(const std::string &) const
+ManualWisdomFilenameGenerator::GenerateWisdomFilename(const std::string &) const
 {
   return this->m_WisdomFilename;
 }
 
 std::string
-SimpleWisdomFilenameGenerator ::GenerateWisdomFilename(const std::string & baseCacheDirectory) const
+SimpleWisdomFilenameGenerator::GenerateWisdomFilename(const std::string & baseCacheDirectory) const
 {
   return baseCacheDirectory + FFTWPathSep + ".itksimple.wisdom";
 }
 
 std::string
-HostnameWisdomFilenameGenerator ::GenerateWisdomFilename(const std::string & baseCacheDirectory) const
+HostnameWisdomFilenameGenerator::GenerateWisdomFilename(const std::string & baseCacheDirectory) const
 {
 
   itksys::SystemInformation hostInfo;
@@ -88,7 +88,7 @@ HostnameWisdomFilenameGenerator ::GenerateWisdomFilename(const std::string & bas
 }
 
 int
-FFTWGlobalConfiguration ::GetPlanRigorValue(const std::string & name)
+FFTWGlobalConfiguration::GetPlanRigorValue(const std::string & name)
 {
   if (name == "FFTW_ESTIMATE")
   {
@@ -110,7 +110,7 @@ FFTWGlobalConfiguration ::GetPlanRigorValue(const std::string & name)
 }
 
 std::string
-FFTWGlobalConfiguration ::GetPlanRigorName(const int & value)
+FFTWGlobalConfiguration::GetPlanRigorName(const int & value)
 {
   switch (value)
   {
@@ -143,7 +143,7 @@ itkGetGlobalSimpleMacro(FFTWGlobalConfiguration, FFTWGlobalConfigurationGlobals,
 FFTWGlobalConfigurationGlobals * FFTWGlobalConfiguration::m_PimplGlobals;
 
 FFTWGlobalConfiguration::Pointer
-FFTWGlobalConfiguration ::GetInstance()
+FFTWGlobalConfiguration::GetInstance()
 {
   itkInitGlobalsMacro(PimplGlobals);
   if (!m_PimplGlobals->m_Instance)
@@ -170,10 +170,10 @@ FFTWGlobalConfiguration ::GetInstance()
   return m_PimplGlobals->m_Instance;
 }
 
-HardwareWisdomFilenameGenerator ::HardwareWisdomFilenameGenerator() = default;
+HardwareWisdomFilenameGenerator::HardwareWisdomFilenameGenerator() = default;
 
 std::string
-HardwareWisdomFilenameGenerator ::GenerateWisdomFilename(const std::string & baseCacheDirectory) const
+HardwareWisdomFilenameGenerator::GenerateWisdomFilename(const std::string & baseCacheDirectory) const
 {
   // Now build the hardware string by system interogation
   itksys::SystemInformation hardwareInfo;
@@ -240,133 +240,133 @@ HardwareWisdomFilenameGenerator ::GenerateWisdomFilename(const std::string & bas
 
 
 void
-HardwareWisdomFilenameGenerator ::SetUseOSName(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseOSName(const bool flag)
 {
   this->m_UseOSName = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseOSRelease(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseOSRelease(const bool flag)
 {
   this->m_UseOSRelease = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseOSVersion(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseOSVersion(const bool flag)
 {
   this->m_UseOSVersion = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseOSPlatform(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseOSPlatform(const bool flag)
 {
   this->m_UseOSPlatform = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseOSBitSize(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseOSBitSize(const bool flag)
 {
   this->m_UseOSBitSize = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseNumberOfProcessors(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseNumberOfProcessors(const bool flag)
 {
   this->m_UseNumberOfProcessors = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseVendorString(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseVendorString(const bool flag)
 {
   this->m_UseVendorString = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseTypeID(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseTypeID(const bool flag)
 {
   this->m_UseTypeID = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseFamilyID(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseFamilyID(const bool flag)
 {
   this->m_UseFamilyID = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseModelID(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseModelID(const bool flag)
 {
   this->m_UseModelID = flag;
 }
 
 void
-HardwareWisdomFilenameGenerator ::SetUseSteppingCode(const bool flag)
+HardwareWisdomFilenameGenerator::SetUseSteppingCode(const bool flag)
 {
   this->m_UseSteppingCode = flag;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseOSName() const
+HardwareWisdomFilenameGenerator::GetUseOSName() const
 {
   return this->m_UseOSName;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseOSRelease() const
+HardwareWisdomFilenameGenerator::GetUseOSRelease() const
 {
   return this->m_UseOSRelease;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseOSVersion() const
+HardwareWisdomFilenameGenerator::GetUseOSVersion() const
 {
   return this->m_UseOSVersion;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseOSPlatform() const
+HardwareWisdomFilenameGenerator::GetUseOSPlatform() const
 {
   return this->m_UseOSPlatform;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseOSBitSize() const
+HardwareWisdomFilenameGenerator::GetUseOSBitSize() const
 {
   return this->m_UseOSBitSize;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseNumberOfProcessors() const
+HardwareWisdomFilenameGenerator::GetUseNumberOfProcessors() const
 {
   return this->m_UseNumberOfProcessors;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseVendorString() const
+HardwareWisdomFilenameGenerator::GetUseVendorString() const
 {
   return this->m_UseVendorString;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseTypeID() const
+HardwareWisdomFilenameGenerator::GetUseTypeID() const
 {
   return this->m_UseTypeID;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseFamilyID() const
+HardwareWisdomFilenameGenerator::GetUseFamilyID() const
 {
   return this->m_UseFamilyID;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseModelID() const
+HardwareWisdomFilenameGenerator::GetUseModelID() const
 {
   return this->m_UseModelID;
 }
 
 bool
-HardwareWisdomFilenameGenerator ::GetUseSteppingCode() const
+HardwareWisdomFilenameGenerator::GetUseSteppingCode() const
 {
   return this->m_UseSteppingCode;
 }
@@ -528,7 +528,7 @@ FFTWGlobalConfiguration ::~FFTWGlobalConfiguration()
 }
 
 void
-FFTWGlobalConfiguration ::SetWisdomFilenameGenerator(WisdomFilenameGeneratorBase * wfg)
+FFTWGlobalConfiguration::SetWisdomFilenameGenerator(WisdomFilenameGeneratorBase * wfg)
 {
   GetInstance()->m_WisdomFilenameGenerator = wfg;
   // Now we need to try to re-read the wisdom file
@@ -536,13 +536,13 @@ FFTWGlobalConfiguration ::SetWisdomFilenameGenerator(WisdomFilenameGeneratorBase
 }
 
 std::string
-FFTWGlobalConfiguration ::GetWisdomFileDefaultBaseName()
+FFTWGlobalConfiguration::GetWisdomFileDefaultBaseName()
 {
   return GetInstance()->m_WisdomFilenameGenerator->GenerateWisdomFilename(GetInstance()->m_WisdomCacheBase);
 }
 
 bool
-FFTWGlobalConfiguration ::ImportDefaultWisdomFile()
+FFTWGlobalConfiguration::ImportDefaultWisdomFile()
 {
   bool all_succeed = true;
 #  if defined(ITK_USE_FFTWF)
@@ -555,7 +555,7 @@ FFTWGlobalConfiguration ::ImportDefaultWisdomFile()
 }
 
 bool
-FFTWGlobalConfiguration ::ExportDefaultWisdomFile()
+FFTWGlobalConfiguration::ExportDefaultWisdomFile()
 {
   // import the wisdom files again to be sure to not erase the wisdom saved in another process
   bool all_succeed = true;
@@ -569,33 +569,33 @@ FFTWGlobalConfiguration ::ExportDefaultWisdomFile()
 }
 
 bool
-FFTWGlobalConfiguration ::ImportDefaultWisdomFileFloat()
+FFTWGlobalConfiguration::ImportDefaultWisdomFileFloat()
 {
   return ImportWisdomFileFloat(GetWisdomFileDefaultBaseName() + "f");
 }
 
 bool
-FFTWGlobalConfiguration ::ImportDefaultWisdomFileDouble()
+FFTWGlobalConfiguration::ImportDefaultWisdomFileDouble()
 {
   return ImportWisdomFileDouble(GetWisdomFileDefaultBaseName());
 }
 
 bool
-FFTWGlobalConfiguration ::ExportDefaultWisdomFileFloat()
+FFTWGlobalConfiguration::ExportDefaultWisdomFileFloat()
 {
   return ExportWisdomFileFloat(GetWisdomFileDefaultBaseName() + "f");
 }
 
 bool
-FFTWGlobalConfiguration ::ExportDefaultWisdomFileDouble()
+FFTWGlobalConfiguration::ExportDefaultWisdomFileDouble()
 {
   return ExportWisdomFileDouble(GetWisdomFileDefaultBaseName());
 }
 
 bool
-FFTWGlobalConfiguration ::ImportWisdomFileFloat(const std::string &
+FFTWGlobalConfiguration::ImportWisdomFileFloat(const std::string &
 #  if defined(ITK_USE_FFTWF) // Only define if ITK_USE_FFTWF, to avoid compiler warning
-                                                  path
+                                                 path
 #  endif
 )
 {
@@ -627,9 +627,9 @@ FFTWGlobalConfiguration ::ImportWisdomFileFloat(const std::string &
 }
 
 bool
-FFTWGlobalConfiguration ::ImportWisdomFileDouble(const std::string &
+FFTWGlobalConfiguration::ImportWisdomFileDouble(const std::string &
 #  if defined(ITK_USE_FFTWD) // Only define if ITK_USE_FFTWD, to avoid compiler warning
-                                                   path
+                                                  path
 #  endif
 )
 {
@@ -661,9 +661,9 @@ FFTWGlobalConfiguration ::ImportWisdomFileDouble(const std::string &
 }
 
 bool
-FFTWGlobalConfiguration ::ExportWisdomFileFloat(const std::string &
+FFTWGlobalConfiguration::ExportWisdomFileFloat(const std::string &
 #  if defined(ITK_USE_FFTWF) // Only define if ITK_USE_FFTWF, to avoid compiler warning
-                                                  path
+                                                 path
 #  endif
 )
 {
@@ -703,9 +703,9 @@ FFTWGlobalConfiguration ::ExportWisdomFileFloat(const std::string &
 }
 
 bool
-FFTWGlobalConfiguration ::ExportWisdomFileDouble(const std::string &
+FFTWGlobalConfiguration::ExportWisdomFileDouble(const std::string &
 #  if defined(ITK_USE_FFTWD) // Only define if ITK_USE_FFTWD, to avoid compiler warning
-                                                   path
+                                                  path
 #  endif
 )
 {
@@ -738,27 +738,27 @@ FFTWGlobalConfiguration ::ExportWisdomFileDouble(const std::string &
 }
 
 std::mutex &
-FFTWGlobalConfiguration ::GetLockMutex()
+FFTWGlobalConfiguration::GetLockMutex()
 {
   return GetInstance()->m_Lock;
 }
 
 void
-FFTWGlobalConfiguration ::SetNewWisdomAvailable(const bool & v)
+FFTWGlobalConfiguration::SetNewWisdomAvailable(const bool & v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   GetInstance()->m_NewWisdomAvailable = v;
 }
 
 bool
-FFTWGlobalConfiguration ::GetNewWisdomAvailable()
+FFTWGlobalConfiguration::GetNewWisdomAvailable()
 {
   itkInitGlobalsMacro(PimplGlobals);
   return GetInstance()->m_NewWisdomAvailable;
 }
 
 void
-FFTWGlobalConfiguration ::SetPlanRigor(const int & v)
+FFTWGlobalConfiguration::SetPlanRigor(const int & v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   // use that method to check the value
@@ -767,21 +767,21 @@ FFTWGlobalConfiguration ::SetPlanRigor(const int & v)
 }
 
 int
-FFTWGlobalConfiguration ::GetPlanRigor()
+FFTWGlobalConfiguration::GetPlanRigor()
 {
   itkInitGlobalsMacro(PimplGlobals);
   return GetInstance()->m_PlanRigor;
 }
 
 void
-FFTWGlobalConfiguration ::SetPlanRigor(const std::string & name)
+FFTWGlobalConfiguration::SetPlanRigor(const std::string & name)
 {
   itkInitGlobalsMacro(PimplGlobals);
   SetPlanRigor(GetPlanRigorValue(name));
 }
 
 void
-FFTWGlobalConfiguration ::SetReadWisdomCache(const bool & v)
+FFTWGlobalConfiguration::SetReadWisdomCache(const bool & v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   GetInstance()->m_ReadWisdomCache = v;
@@ -792,21 +792,21 @@ FFTWGlobalConfiguration ::SetReadWisdomCache(const bool & v)
 }
 
 bool
-FFTWGlobalConfiguration ::GetReadWisdomCache()
+FFTWGlobalConfiguration::GetReadWisdomCache()
 {
   itkInitGlobalsMacro(PimplGlobals);
   return GetInstance()->m_ReadWisdomCache;
 }
 
 void
-FFTWGlobalConfiguration ::SetWriteWisdomCache(const bool & v)
+FFTWGlobalConfiguration::SetWriteWisdomCache(const bool & v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   GetInstance()->m_WriteWisdomCache = v;
 }
 
 bool
-FFTWGlobalConfiguration ::GetWriteWisdomCache()
+FFTWGlobalConfiguration::GetWriteWisdomCache()
 {
   itkInitGlobalsMacro(PimplGlobals);
   return GetInstance()->m_WriteWisdomCache;
@@ -814,7 +814,7 @@ FFTWGlobalConfiguration ::GetWriteWisdomCache()
 
 
 void
-FFTWGlobalConfiguration ::SetWisdomCacheBase(const std::string & v)
+FFTWGlobalConfiguration::SetWisdomCacheBase(const std::string & v)
 {
   itkInitGlobalsMacro(PimplGlobals);
   GetInstance()->m_WisdomCacheBase = v;
@@ -823,7 +823,7 @@ FFTWGlobalConfiguration ::SetWisdomCacheBase(const std::string & v)
 }
 
 std::string
-FFTWGlobalConfiguration ::GetWisdomCacheBase()
+FFTWGlobalConfiguration::GetWisdomCacheBase()
 {
   itkInitGlobalsMacro(PimplGlobals);
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.h
@@ -55,7 +55,7 @@ namespace itk
 template <typename TLevelSet,
           typename TAuxValue,
           unsigned int VAuxDimension = 1,
-          typename TSpeedImage = Image<float, TLevelSet ::ImageDimension>>
+          typename TSpeedImage = Image<float, TLevelSet::ImageDimension>>
 class ITK_TEMPLATE_EXPORT FastMarchingExtensionImageFilter : public FastMarchingImageFilter<TLevelSet, TSpeedImage>
 {
 public:

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -132,7 +132,7 @@ extern ITKFastMarching_EXPORT std::ostream &
  * \ingroup LevelSetSegmentation
  * \ingroup ITKFastMarching
  */
-template <typename TLevelSet, typename TSpeedImage = Image<float, TLevelSet ::ImageDimension>>
+template <typename TLevelSet, typename TSpeedImage = Image<float, TLevelSet::ImageDimension>>
 class ITK_TEMPLATE_EXPORT FastMarchingImageFilter : public ImageToImageFilter<TSpeedImage, TLevelSet>
 {
 public:

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -57,7 +57,7 @@ namespace itk
  *
  * \ingroup ITKFastMarching
  */
-template <typename TLevelSet, typename TSpeedImage = Image<float, TLevelSet ::ImageDimension>>
+template <typename TLevelSet, typename TSpeedImage = Image<float, TLevelSet::ImageDimension>>
 class ITK_TEMPLATE_EXPORT FastMarchingUpwindGradientImageFilter : public FastMarchingImageFilter<TLevelSet, TSpeedImage>
 {
 public:

--- a/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.h
@@ -70,7 +70,7 @@ public:
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;
 
   /** Type to hold the number of checker boxes per dimension. */
-  using PatternArrayType = FixedArray<unsigned int, TImage ::ImageDimension>;
+  using PatternArrayType = FixedArray<unsigned int, TImage::ImageDimension>;
 
   /** Set the first operand for checker board. */
   void

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.h
@@ -93,7 +93,7 @@ public:
   using OutputPixelType = TPixel;
 
   /** Image dimension = 3. */
-  static constexpr unsigned int ImageDimension = InputImageType ::ImageDimension;
+  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
   static constexpr unsigned int InputPixelDimension = InputPixelType::Dimension;
 
   using EigenValueArrayType = FixedArray<double, Self::InputPixelDimension>;

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -76,7 +76,7 @@ public:
   using OutputImageRegionType = typename OutputImageType::RegionType;
 
   /** Image dimension */
-  static constexpr unsigned int ImageDimension = InputImageType ::ImageDimension;
+  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
   using EigenValueType = double;
   using EigenValueArrayType = itk::FixedArray<EigenValueType, Self::ImageDimension>;

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.h
@@ -109,7 +109,7 @@ public:
   using OutputRegionType = typename TOutputImage::RegionType;
 
   /** Image dimension. */
-  static constexpr unsigned int ImageDimension = InputImageType ::ImageDimension;
+  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
   /** Types for Scales image */
   using ScalesPixelType = float;

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.h
@@ -74,7 +74,7 @@ template <typename TInputImage,
           typename TOutputImage,
           typename TInputFilter =
             ImageToImageFilter<Image<typename TInputImage::PixelType, TInputImage::ImageDimension - 1>,
-                               Image<typename TOutputImage::PixelType, TOutputImage ::ImageDimension - 1>>,
+                               Image<typename TOutputImage::PixelType, TOutputImage::ImageDimension - 1>>,
           class TOutputFilter = typename TInputFilter::Superclass,
           class TInternalInputImage = typename TInputFilter::InputImageType,
           class TInternalOutputImage = typename TOutputFilter::OutputImageType>

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
@@ -50,7 +50,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 
-template <typename TImage, typename TLabelImage = Image<typename TImage::PixelType, TImage ::ImageDimension>>
+template <typename TImage, typename TLabelImage = Image<typename TImage::PixelType, TImage::ImageDimension>>
 class ITK_TEMPLATE_EXPORT ShapeLabelMapFilter : public InPlaceLabelMapFilter<TImage>
 {
 public:

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -40,7 +40,7 @@ namespace itk
  */
 template <typename TImage, typename TFeatureImage>
 class ITK_TEMPLATE_EXPORT StatisticsLabelMapFilter
-  : public ShapeLabelMapFilter<TImage, Image<typename TImage::PixelType, TImage ::ImageDimension>>
+  : public ShapeLabelMapFilter<TImage, Image<typename TImage::PixelType, TImage::ImageDimension>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(StatisticsLabelMapFilter);

--- a/Modules/Filtering/LabelMap/src/itkGeometryUtilities.cxx
+++ b/Modules/Filtering/LabelMap/src/itkGeometryUtilities.cxx
@@ -22,7 +22,7 @@ namespace itk
 {
 
 long
-GeometryUtilities ::Factorial(const long n)
+GeometryUtilities::Factorial(const long n)
 {
   if (n < 1)
   {
@@ -32,7 +32,7 @@ GeometryUtilities ::Factorial(const long n)
 }
 
 long
-GeometryUtilities ::DoubleFactorial(const long n)
+GeometryUtilities::DoubleFactorial(const long n)
 {
   if (n < 2)
   {
@@ -42,7 +42,7 @@ GeometryUtilities ::DoubleFactorial(const long n)
 }
 
 double
-GeometryUtilities ::GammaN2p1(const long n)
+GeometryUtilities::GammaN2p1(const long n)
 {
   const bool even = n % 2 == 0;
 
@@ -57,7 +57,7 @@ GeometryUtilities ::GammaN2p1(const long n)
 }
 
 double
-GeometryUtilities ::HyperSphereVolume(const int dim, const double radius)
+GeometryUtilities::HyperSphereVolume(const int dim, const double radius)
 {
   const auto dbldim = static_cast<double>(dim);
 
@@ -65,13 +65,13 @@ GeometryUtilities ::HyperSphereVolume(const int dim, const double radius)
 }
 
 double
-GeometryUtilities ::HyperSpherePerimeter(const int dim, const double radius)
+GeometryUtilities::HyperSpherePerimeter(const int dim, const double radius)
 {
   return dim * HyperSphereVolume(dim, radius) / radius;
 }
 
 double
-GeometryUtilities ::HyperSphereRadiusFromVolume(const int dim, const double volume)
+GeometryUtilities::HyperSphereRadiusFromVolume(const int dim, const double volume)
 {
   return std::pow(volume * GammaN2p1(dim) / std::pow(itk::Math::pi, dim * 0.5), 1.0 / dim);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramDilateImageFilter.h
@@ -46,7 +46,7 @@ class MovingHistogramDilateImageFilter
       TOutputImage,
       TKernel,
       typename Function::MorphologyHistogram<typename TInputImage::PixelType,
-                                             typename std::greater<typename TInputImage ::PixelType>>>
+                                             typename std::greater<typename TInputImage::PixelType>>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MovingHistogramDilateImageFilter);
@@ -58,7 +58,7 @@ public:
     TOutputImage,
     TKernel,
     typename Function::MorphologyHistogram<typename TInputImage::PixelType,
-                                           typename std::greater<typename TInputImage ::PixelType>>>;
+                                           typename std::greater<typename TInputImage::PixelType>>>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramErodeImageFilter.h
@@ -45,7 +45,7 @@ class MovingHistogramErodeImageFilter
       TOutputImage,
       TKernel,
       typename Function::MorphologyHistogram<typename TInputImage::PixelType,
-                                             typename std::less<typename TInputImage ::PixelType>>>
+                                             typename std::less<typename TInputImage::PixelType>>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MovingHistogramErodeImageFilter);
@@ -57,7 +57,7 @@ public:
     TOutputImage,
     TKernel,
     typename Function::MorphologyHistogram<typename TInputImage::PixelType,
-                                           typename std::less<typename TInputImage ::PixelType>>>;
+                                           typename std::less<typename TInputImage::PixelType>>>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
+++ b/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
@@ -20,7 +20,7 @@
 namespace itk
 {
 OrthogonallyCorrected2DParametricPath::OutputType
-OrthogonallyCorrected2DParametricPath ::Evaluate(const InputType & inputValue) const
+OrthogonallyCorrected2DParametricPath::Evaluate(const InputType & inputValue) const
 {
   InputType input = inputValue; // we may want to remap
                                 // the input
@@ -69,7 +69,7 @@ OrthogonallyCorrected2DParametricPath ::Evaluate(const InputType & inputValue) c
 }
 
 void
-OrthogonallyCorrected2DParametricPath ::SetOriginalPath(const OriginalPathType * originalPath)
+OrthogonallyCorrected2DParametricPath::SetOriginalPath(const OriginalPathType * originalPath)
 {
   itkDebugMacro("setting OriginalPath to " << originalPath);
   if (this->m_OriginalPath != originalPath)
@@ -84,7 +84,7 @@ OrthogonallyCorrected2DParametricPath ::SetOriginalPath(const OriginalPathType *
 /**
  * Constructor
  */
-OrthogonallyCorrected2DParametricPath ::OrthogonallyCorrected2DParametricPath()
+OrthogonallyCorrected2DParametricPath::OrthogonallyCorrected2DParametricPath()
 {
   m_OriginalPath = nullptr;
   m_OrthogonalCorrectionTable = OrthogonalCorrectionTableType::New();
@@ -94,7 +94,7 @@ OrthogonallyCorrected2DParametricPath ::OrthogonallyCorrected2DParametricPath()
  * Standard "PrintSelf" method
  */
 void
-OrthogonallyCorrected2DParametricPath ::PrintSelf(std::ostream & os, Indent indent) const
+OrthogonallyCorrected2DParametricPath::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Original Path:  " << m_OriginalPath << std::endl;

--- a/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
+++ b/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
@@ -35,7 +35,7 @@ CSVFileReaderBase::CSVFileReaderBase()
 }
 
 void
-CSVFileReaderBase ::PrintSelf(std::ostream & os, Indent indent) const
+CSVFileReaderBase::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "File Name: " << this->m_FileName << std::endl;
@@ -48,7 +48,7 @@ CSVFileReaderBase ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 void
-CSVFileReaderBase ::PrepareForParsing()
+CSVFileReaderBase::PrepareForParsing()
 {
   if (this->m_FileName.empty())
   {
@@ -70,7 +70,7 @@ CSVFileReaderBase ::PrepareForParsing()
 }
 
 void
-CSVFileReaderBase ::GetDataDimension(SizeValueType & rows, SizeValueType & cols)
+CSVFileReaderBase::GetDataDimension(SizeValueType & rows, SizeValueType & cols)
 {
 
   this->m_InputStream.seekg(0);
@@ -190,7 +190,7 @@ CSVFileReaderBase ::GetDataDimension(SizeValueType & rows, SizeValueType & cols)
 
 /** Function to get the next entry from the file. */
 void
-CSVFileReaderBase ::GetNextField(std::string & str)
+CSVFileReaderBase::GetNextField(std::string & str)
 {
   /** The process below is as follows: we check if this->m_Line is empty. If it is
    * then we have to get a new line. If not, we have to get the fields that

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -53,15 +53,15 @@ namespace itk
 {
 
 void
-DCMTKItem ::SetDcmItem(DcmItem * item)
+DCMTKItem::SetDcmItem(DcmItem * item)
 {
   this->m_DcmItem = item;
 }
 int
-DCMTKItem ::GetElementSQ(const unsigned short group,
-                         const unsigned short entry,
-                         DCMTKSequence &      sequence,
-                         const bool           throwException) const
+DCMTKItem::GetElementSQ(const unsigned short group,
+                        const unsigned short entry,
+                        DCMTKSequence &      sequence,
+                        const bool           throwException) const
 {
   DcmSequenceOfItems * seq;
   DcmTagKey            tagKey(group, entry);
@@ -76,10 +76,10 @@ DCMTKItem ::GetElementSQ(const unsigned short group,
 
 
 int
-DCMTKSequence ::GetStack(const unsigned short group,
-                         const unsigned short element,
-                         DcmStack &           resultStack,
-                         const bool           throwException) const
+DCMTKSequence::GetStack(const unsigned short group,
+                        const unsigned short element,
+                        DcmStack &           resultStack,
+                        const bool           throwException) const
 {
   DcmTagKey tagkey(group, element);
   if (this->m_DcmSequenceOfItems->search(tagkey, resultStack) != EC_Normal)
@@ -91,7 +91,7 @@ DCMTKSequence ::GetStack(const unsigned short group,
 
 
 void
-DCMTKSequence ::SetDcmSequenceOfItems(DcmSequenceOfItems * seq)
+DCMTKSequence::SetDcmSequenceOfItems(DcmSequenceOfItems * seq)
 {
   this->m_DcmSequenceOfItems = seq;
 }
@@ -103,7 +103,7 @@ DCMTKSequence ::card() const
 }
 
 int
-DCMTKSequence ::GetSequence(unsigned long index, DCMTKSequence & target, const bool throwException) const
+DCMTKSequence::GetSequence(unsigned long index, DCMTKSequence & target, const bool throwException) const
 {
   DcmItem * item = this->m_DcmSequenceOfItems->getItem(index);
   auto *    sequence = dynamic_cast<DcmSequenceOfItems *>(item);
@@ -116,10 +116,10 @@ DCMTKSequence ::GetSequence(unsigned long index, DCMTKSequence & target, const b
 }
 
 int
-DCMTKSequence ::GetElementCS(const unsigned short group,
-                             const unsigned short element,
-                             std::string &        target,
-                             const bool           throwException) const
+DCMTKSequence::GetElementCS(const unsigned short group,
+                            const unsigned short element,
+                            std::string &        target,
+                            const bool           throwException) const
 {
   DcmTagKey tagkey(group, element);
   DcmStack  resultStack;
@@ -146,10 +146,10 @@ DCMTKSequence ::GetElementCS(const unsigned short group,
 }
 
 int
-DCMTKSequence ::GetElementOB(const unsigned short group,
-                             const unsigned short element,
-                             std::string &        target,
-                             const bool           throwException) const
+DCMTKSequence::GetElementOB(const unsigned short group,
+                            const unsigned short element,
+                            std::string &        target,
+                            const bool           throwException) const
 {
   DcmTagKey tagkey(group, element);
   DcmStack  resultStack;
@@ -174,10 +174,10 @@ DCMTKSequence ::GetElementOB(const unsigned short group,
 }
 
 int
-DCMTKSequence ::GetElementCSorOB(const unsigned short group,
-                                 const unsigned short element,
-                                 std::string &        target,
-                                 const bool           throwException) const
+DCMTKSequence::GetElementCSorOB(const unsigned short group,
+                                const unsigned short element,
+                                std::string &        target,
+                                const bool           throwException) const
 {
   if (this->GetElementCS(group, element, target, false) == EXIT_SUCCESS)
   {
@@ -227,20 +227,20 @@ DCMTKSequence::GetElementFD(const unsigned short group,
 }
 
 int
-DCMTKSequence ::GetElementFD(const unsigned short group,
-                             const unsigned short element,
-                             double &             target,
-                             const bool           throwException) const
+DCMTKSequence::GetElementFD(const unsigned short group,
+                            const unsigned short element,
+                            double &             target,
+                            const bool           throwException) const
 {
   this->GetElementFD(group, element, 1, &target, throwException);
   return EXIT_SUCCESS;
 }
 
 int
-DCMTKSequence ::GetElementDS(const unsigned short group,
-                             const unsigned short element,
-                             std::string &        target,
-                             const bool           throwException) const
+DCMTKSequence::GetElementDS(const unsigned short group,
+                            const unsigned short element,
+                            std::string &        target,
+                            const bool           throwException) const
 {
   DcmStack resultStack;
   this->GetStack(group, element, resultStack);
@@ -265,10 +265,10 @@ DCMTKSequence ::GetElementDS(const unsigned short group,
 }
 
 int
-DCMTKSequence ::GetElementSQ(const unsigned short group,
-                             const unsigned short element,
-                             DCMTKSequence &      target,
-                             const bool           throwException) const
+DCMTKSequence::GetElementSQ(const unsigned short group,
+                            const unsigned short element,
+                            DCMTKSequence &      target,
+                            const bool           throwException) const
 {
   DcmTagKey tagkey(group, element);
   DcmStack  resultStack;
@@ -284,7 +284,7 @@ DCMTKSequence ::GetElementSQ(const unsigned short group,
 }
 
 int
-DCMTKSequence ::GetElementItem(unsigned short index, DCMTKItem & target, const bool throwException) const
+DCMTKSequence::GetElementItem(unsigned short index, DCMTKItem & target, const bool throwException) const
 {
   DcmItem * itemElement = this->m_DcmSequenceOfItems->getItem(index);
   if (itemElement == nullptr)
@@ -296,10 +296,10 @@ DCMTKSequence ::GetElementItem(unsigned short index, DCMTKItem & target, const b
 }
 
 int
-DCMTKSequence ::GetElementTM(const unsigned short group,
-                             const unsigned short element,
-                             std::string &        target,
-                             const bool           throwException) const
+DCMTKSequence::GetElementTM(const unsigned short group,
+                            const unsigned short element,
+                            std::string &        target,
+                            const bool           throwException) const
 {
   DcmTagKey tagkey(group, element);
   DcmStack  resultStack;
@@ -322,19 +322,19 @@ DCMTKFileReader ::~DCMTKFileReader()
 }
 
 void
-DCMTKFileReader ::SetFileName(const std::string & fileName)
+DCMTKFileReader::SetFileName(const std::string & fileName)
 {
   this->m_FileName = fileName;
 }
 
 const std::string &
-DCMTKFileReader ::GetFileName() const
+DCMTKFileReader::GetFileName() const
 {
   return this->m_FileName;
 }
 
 bool
-DCMTKFileReader ::CanReadFile(const std::string & filename)
+DCMTKFileReader::CanReadFile(const std::string & filename)
 {
   auto * MInfo = new DcmMetaInfo();
   if (!MInfo)
@@ -351,7 +351,7 @@ DCMTKFileReader ::CanReadFile(const std::string & filename)
 }
 
 bool
-DCMTKFileReader ::IsImageFile(const std::string & filename)
+DCMTKFileReader::IsImageFile(const std::string & filename)
 {
   if (!DCMTKFileReader::CanReadFile(filename))
   {
@@ -369,7 +369,7 @@ DCMTKFileReader ::IsImageFile(const std::string & filename)
 }
 
 void
-DCMTKFileReader ::LoadFile()
+DCMTKFileReader::LoadFile()
 {
   if (this->m_FileName.empty())
   {
@@ -408,10 +408,10 @@ DCMTKFileReader ::LoadFile()
 }
 
 int
-DCMTKFileReader ::GetElementLO(const unsigned short group,
-                               const unsigned short element,
-                               std::string &        target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementLO(const unsigned short group,
+                              const unsigned short element,
+                              std::string &        target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -440,10 +440,10 @@ DCMTKFileReader ::GetElementLO(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementLO(const unsigned short       group,
-                               const unsigned short       element,
-                               std::vector<std::string> & target,
-                               const bool                 throwException) const
+DCMTKFileReader::GetElementLO(const unsigned short       group,
+                              const unsigned short       element,
+                              std::vector<std::string> & target,
+                              const bool                 throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -474,10 +474,10 @@ DCMTKFileReader ::GetElementLO(const unsigned short       group,
 /** Get a DecimalString Item as a single string
  */
 int
-DCMTKFileReader ::GetElementDS(const unsigned short group,
-                               const unsigned short element,
-                               std::string &        target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementDS(const unsigned short group,
+                              const unsigned short element,
+                              std::string &        target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -506,11 +506,11 @@ DCMTKFileReader ::GetElementDS(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementFD(const unsigned short group,
-                               const unsigned short element,
-                               int                  count,
-                               double *             target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementFD(const unsigned short group,
+                              const unsigned short element,
+                              int                  count,
+                              double *             target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -547,19 +547,19 @@ DCMTKFileReader ::GetElementFD(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementFD(const unsigned short group,
-                               const unsigned short element,
-                               double &             target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementFD(const unsigned short group,
+                              const unsigned short element,
+                              double &             target,
+                              const bool           throwException) const
 {
   return this->GetElementFD(group, element, 1, &target, throwException);
 }
 
 int
-DCMTKFileReader ::GetElementFL(const unsigned short group,
-                               const unsigned short element,
-                               float &              target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementFL(const unsigned short group,
+                              const unsigned short element,
+                              float &              target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -581,10 +581,10 @@ DCMTKFileReader ::GetElementFL(const unsigned short group,
   return EXIT_SUCCESS;
 }
 int
-DCMTKFileReader ::GetElementFLorOB(const unsigned short group,
-                                   const unsigned short element,
-                                   float &              target,
-                                   const bool           throwException) const
+DCMTKFileReader::GetElementFLorOB(const unsigned short group,
+                                  const unsigned short element,
+                                  float &              target,
+                                  const bool           throwException) const
 {
   if (this->GetElementFL(group, element, target, false) == EXIT_SUCCESS)
   {
@@ -616,10 +616,10 @@ DCMTKFileReader ::GetElementFLorOB(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementUS(const unsigned short group,
-                               const unsigned short element,
-                               unsigned short &     target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementUS(const unsigned short group,
+                              const unsigned short element,
+                              unsigned short &     target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -641,10 +641,10 @@ DCMTKFileReader ::GetElementUS(const unsigned short group,
   return EXIT_SUCCESS;
 }
 int
-DCMTKFileReader ::GetElementUS(const unsigned short group,
-                               const unsigned short element,
-                               unsigned short *&    target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementUS(const unsigned short group,
+                              const unsigned short element,
+                              unsigned short *&    target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -668,10 +668,10 @@ DCMTKFileReader ::GetElementUS(const unsigned short group,
 /** Get a DecimalString Item as a single string
  */
 int
-DCMTKFileReader ::GetElementCS(const unsigned short group,
-                               const unsigned short element,
-                               std::string &        target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementCS(const unsigned short group,
+                              const unsigned short element,
+                              std::string &        target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -699,10 +699,10 @@ DCMTKFileReader ::GetElementCS(const unsigned short group,
   return EXIT_SUCCESS;
 }
 int
-DCMTKFileReader ::GetElementCSorOB(const unsigned short group,
-                                   const unsigned short element,
-                                   std::string &        target,
-                                   const bool           throwException) const
+DCMTKFileReader::GetElementCSorOB(const unsigned short group,
+                                  const unsigned short element,
+                                  std::string &        target,
+                                  const bool           throwException) const
 {
   if (this->GetElementCS(group, element, target, false) == EXIT_SUCCESS)
   {
@@ -717,10 +717,10 @@ DCMTKFileReader ::GetElementCSorOB(const unsigned short group,
 
 
 int
-DCMTKFileReader ::GetElementPN(const unsigned short group,
-                               const unsigned short element,
-                               std::string &        target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementPN(const unsigned short group,
+                              const unsigned short element,
+                              std::string &        target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -751,10 +751,10 @@ DCMTKFileReader ::GetElementPN(const unsigned short group,
 /** get an IS (Integer String Item
  */
 int
-DCMTKFileReader ::GetElementIS(const unsigned short group,
-                               const unsigned short element,
-                               ::itk::int32_t &     target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementIS(const unsigned short group,
+                              const unsigned short element,
+                              ::itk::int32_t &     target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -780,10 +780,10 @@ DCMTKFileReader ::GetElementIS(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementSL(const unsigned short group,
-                               const unsigned short element,
-                               ::itk::int32_t &     target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementSL(const unsigned short group,
+                              const unsigned short element,
+                              ::itk::int32_t &     target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -809,10 +809,10 @@ DCMTKFileReader ::GetElementSL(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementISorOB(const unsigned short group,
-                                   const unsigned short element,
-                                   ::itk::int32_t &     target,
-                                   const bool           throwException) const
+DCMTKFileReader::GetElementISorOB(const unsigned short group,
+                                  const unsigned short element,
+                                  ::itk::int32_t &     target,
+                                  const bool           throwException) const
 {
   if (this->GetElementIS(group, element, target, false) == EXIT_SUCCESS)
   {
@@ -846,10 +846,10 @@ DCMTKFileReader ::GetElementISorOB(const unsigned short group,
 /** get an OB OtherByte Item
  */
 int
-DCMTKFileReader ::GetElementOB(const unsigned short group,
-                               const unsigned short element,
-                               std::string &        target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementOB(const unsigned short group,
+                              const unsigned short element,
+                              std::string &        target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
   DcmElement * el;
@@ -876,10 +876,10 @@ DCMTKFileReader ::GetElementOB(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementSQ(const unsigned short group,
-                               unsigned short       entry,
-                               DCMTKSequence &      sequence,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementSQ(const unsigned short group,
+                              unsigned short       entry,
+                              DCMTKSequence &      sequence,
+                              const bool           throwException) const
 {
   DcmSequenceOfItems * seq;
   DcmTagKey            tagKey(group, entry);
@@ -893,10 +893,10 @@ DCMTKFileReader ::GetElementSQ(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementUI(const unsigned short group,
-                               unsigned short       entry,
-                               std::string &        target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementUI(const unsigned short group,
+                              unsigned short       entry,
+                              std::string &        target,
+                              const bool           throwException) const
 {
   DcmTagKey    tagKey(group, entry);
   DcmElement * el;
@@ -947,10 +947,10 @@ DCMTKFileReader::GetElementDA(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetElementTM(const unsigned short group,
-                               const unsigned short element,
-                               std::string &        target,
-                               const bool           throwException) const
+DCMTKFileReader::GetElementTM(const unsigned short group,
+                              const unsigned short element,
+                              std::string &        target,
+                              const bool           throwException) const
 {
 
   DcmTagKey    tagkey(group, element);
@@ -971,7 +971,7 @@ DCMTKFileReader ::GetElementTM(const unsigned short group,
 }
 
 int
-DCMTKFileReader ::GetDirCosArray(double * const dircos) const
+DCMTKFileReader::GetDirCosArray(double * const dircos) const
 {
   int           rval;
   DCMTKSequence planeSeq;
@@ -1029,7 +1029,7 @@ DCMTKFileReader ::GetDirCosArray(double * const dircos) const
 }
 
 int
-DCMTKFileReader ::GetDirCosines(vnl_vector<double> & dir1, vnl_vector<double> & dir2, vnl_vector<double> & dir3) const
+DCMTKFileReader::GetDirCosines(vnl_vector<double> & dir1, vnl_vector<double> & dir2, vnl_vector<double> & dir3) const
 {
   double dircos[6];
   int    rval = this->GetDirCosArray(dircos);
@@ -1047,7 +1047,7 @@ DCMTKFileReader ::GetDirCosines(vnl_vector<double> & dir1, vnl_vector<double> & 
 }
 
 int
-DCMTKFileReader ::GetSlopeIntercept(double & slope, double & intercept) const
+DCMTKFileReader::GetSlopeIntercept(double & slope, double & intercept) const
 {
   if (this->GetElementDS<double>(0x0028, 0x1053, 1, &slope, false) != EXIT_SUCCESS)
   {
@@ -1061,7 +1061,7 @@ DCMTKFileReader ::GetSlopeIntercept(double & slope, double & intercept) const
 }
 
 IOPixelEnum
-DCMTKFileReader ::GetImagePixelType() const
+DCMTKFileReader::GetImagePixelType() const
 {
   unsigned short SamplesPerPixel;
   if (this->GetElementUS(0x0028, 0x0100, SamplesPerPixel, false) != EXIT_SUCCESS)
@@ -1085,7 +1085,7 @@ DCMTKFileReader ::GetImagePixelType() const
 }
 
 IOComponentEnum
-DCMTKFileReader ::GetImageDataType() const
+DCMTKFileReader::GetImageDataType() const
 {
   unsigned short  IsSigned;
   unsigned short  BitsAllocated;
@@ -1159,7 +1159,7 @@ DCMTKFileReader ::GetImageDataType() const
 
 
 int
-DCMTKFileReader ::GetDimensions(unsigned short & rows, unsigned short & columns) const
+DCMTKFileReader::GetDimensions(unsigned short & rows, unsigned short & columns) const
 {
   if (this->GetElementUS(0x0028, 0x0010, rows, false) != EXIT_SUCCESS ||
       this->GetElementUS(0x0028, 0x0011, columns, false) != EXIT_SUCCESS)
@@ -1170,7 +1170,7 @@ DCMTKFileReader ::GetDimensions(unsigned short & rows, unsigned short & columns)
 }
 
 int
-DCMTKFileReader ::GetSpacing(double * const spacing) const
+DCMTKFileReader::GetSpacing(double * const spacing) const
 {
   double _spacing[3];
   //
@@ -1273,7 +1273,7 @@ DCMTKFileReader ::GetSpacing(double * const spacing) const
 }
 
 int
-DCMTKFileReader ::GetOrigin(double * const origin) const
+DCMTKFileReader::GetOrigin(double * const origin) const
 {
   int rval = EXIT_SUCCESS;
   // if the origin has yet to be cached
@@ -1323,7 +1323,7 @@ DCMTKFileReader ::GetOrigin(double * const origin) const
 }
 
 bool
-DCMTKFileReader ::HasPixelData() const
+DCMTKFileReader::HasPixelData() const
 {
   DcmTagKey tagkey(0x7fe0, 0x0010);
   DcmStack  resultStack;
@@ -1331,25 +1331,25 @@ DCMTKFileReader ::HasPixelData() const
 }
 
 int
-DCMTKFileReader ::GetFrameCount() const
+DCMTKFileReader::GetFrameCount() const
 {
   return this->m_FrameCount;
 }
 
 E_TransferSyntax
-DCMTKFileReader ::GetTransferSyntax() const
+DCMTKFileReader::GetTransferSyntax() const
 {
   return m_Xfer;
 }
 
 long
-DCMTKFileReader ::GetFileNumber() const
+DCMTKFileReader::GetFileNumber() const
 {
   return m_FileNumber;
 }
 
 void
-DCMTKFileReader ::AddDictEntry(DcmDictEntry * entry)
+DCMTKFileReader::AddDictEntry(DcmDictEntry * entry)
 {
   DcmDataDictionary & dict = dcmDataDict.wrlock();
   dict.addEntry(entry);

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -38,7 +38,7 @@ DCMTKSeriesFileNames ::DCMTKSeriesFileNames()
 DCMTKSeriesFileNames ::~DCMTKSeriesFileNames() = default;
 
 void
-DCMTKSeriesFileNames ::SetInputDirectory(const char * name)
+DCMTKSeriesFileNames::SetInputDirectory(const char * name)
 {
   if (!name)
   {
@@ -49,7 +49,7 @@ DCMTKSeriesFileNames ::SetInputDirectory(const char * name)
 }
 
 void
-DCMTKSeriesFileNames ::SetInputDirectory(std::string const & name)
+DCMTKSeriesFileNames::SetInputDirectory(std::string const & name)
 {
   if (name.empty())
   {
@@ -72,7 +72,7 @@ DCMTKSeriesFileNames ::SetInputDirectory(std::string const & name)
 }
 
 void
-DCMTKSeriesFileNames ::GetDicomData(const std::string & series, bool saveFileNames)
+DCMTKSeriesFileNames::GetDicomData(const std::string & series, bool saveFileNames)
 {
   if (saveFileNames)
   {
@@ -158,7 +158,7 @@ DCMTKSeriesFileNames ::GetDicomData(const std::string & series, bool saveFileNam
 }
 
 const DCMTKSeriesFileNames::FileNamesContainerType &
-DCMTKSeriesFileNames ::GetFileNames(const std::string series)
+DCMTKSeriesFileNames::GetFileNames(const std::string series)
 {
   this->GetDicomData(series, true);
   return m_InputFileNames;
@@ -173,7 +173,7 @@ DCMTKSeriesFileNames::GetSeriesUIDs()
 
 
 const DCMTKSeriesFileNames::FileNamesContainerType &
-DCMTKSeriesFileNames ::GetInputFileNames()
+DCMTKSeriesFileNames::GetInputFileNames()
 {
   // Do not specify any UID
   this->GetDicomData("", true);
@@ -181,13 +181,13 @@ DCMTKSeriesFileNames ::GetInputFileNames()
 }
 
 const DCMTKSeriesFileNames::FileNamesContainerType &
-DCMTKSeriesFileNames ::GetOutputFileNames()
+DCMTKSeriesFileNames::GetOutputFileNames()
 {
   return m_InputFileNames;
 }
 
 void
-DCMTKSeriesFileNames ::PrintSelf(std::ostream & os, Indent indent) const
+DCMTKSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -211,7 +211,7 @@ DCMTKSeriesFileNames ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 void
-DCMTKSeriesFileNames ::SetUseSeriesDetails(bool useSeriesDetails)
+DCMTKSeriesFileNames::SetUseSeriesDetails(bool useSeriesDetails)
 {
   m_UseSeriesDetails = useSeriesDetails;
   //  m_SerieHelper->SetUseSeriesDetails(m_UseSeriesDetails);

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -391,7 +391,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
   size_t sizeOfActualIORegion =
     m_ActualIORegion.GetNumberOfPixels() * (m_ImageIO->GetComponentSize() * m_ImageIO->GetNumberOfComponents());
 
-  IOComponentEnum ioType = ImageIOBase ::MapPixelType<typename ConvertPixelTraits::ComponentType>::CType;
+  IOComponentEnum ioType = ImageIOBase::MapPixelType<typename ConvertPixelTraits::ComponentType>::CType;
   if (m_ImageIO->GetComponentType() != ioType ||
       (m_ImageIO->GetNumberOfComponents() != ConvertPixelTraits::GetNumberOfComponents()))
   {

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -26,12 +26,12 @@
 
 namespace itk
 {
-ArchetypeSeriesFileNames ::ArchetypeSeriesFileNames()
+ArchetypeSeriesFileNames::ArchetypeSeriesFileNames()
   : m_Archetype("")
 {}
 
 void
-ArchetypeSeriesFileNames ::SetArchetype(const std::string & archetype)
+ArchetypeSeriesFileNames::SetArchetype(const std::string & archetype)
 {
   if (archetype != m_Archetype)
   {
@@ -42,7 +42,7 @@ ArchetypeSeriesFileNames ::SetArchetype(const std::string & archetype)
 }
 
 ArchetypeSeriesFileNames::VectorSizeType
-ArchetypeSeriesFileNames ::GetNumberOfGroupings()
+ArchetypeSeriesFileNames::GetNumberOfGroupings()
 {
   if (m_ScanTime < m_ArchetypeMTime)
   {
@@ -53,7 +53,7 @@ ArchetypeSeriesFileNames ::GetNumberOfGroupings()
 }
 
 const std::vector<std::string> &
-ArchetypeSeriesFileNames ::GetFileNames(VectorSizeType group)
+ArchetypeSeriesFileNames::GetFileNames(VectorSizeType group)
 {
   if (m_ScanTime < m_ArchetypeMTime)
   {
@@ -73,7 +73,7 @@ ArchetypeSeriesFileNames ::GetFileNames(VectorSizeType group)
 }
 
 void
-ArchetypeSeriesFileNames ::Scan()
+ArchetypeSeriesFileNames::Scan()
 {
   // For each group of contiguous numbers in m_Archetype, create a
   // regular expression that is identical to m_Archetype except that
@@ -212,7 +212,7 @@ ArchetypeSeriesFileNames ::Scan()
 }
 
 void
-ArchetypeSeriesFileNames ::PrintSelf(std::ostream & os, Indent indent) const
+ArchetypeSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/IO/ImageBase/src/itkIOCommon.cxx
+++ b/Modules/IO/ImageBase/src/itkIOCommon.cxx
@@ -50,7 +50,7 @@ const char * const ROI_PLANE = "ROI_PLANE";
 const char * const ROI_SCAN_ID = "ROI_SCAN_ID";
 
 std::string
-IOCommon ::AtomicPixelTypeToString(const AtomicPixelEnum pixelType)
+IOCommon::AtomicPixelTypeToString(const AtomicPixelEnum pixelType)
 {
   switch (pixelType)
   {
@@ -90,7 +90,7 @@ IOCommon ::AtomicPixelTypeToString(const AtomicPixelEnum pixelType)
 }
 
 unsigned int
-IOCommon ::ComputeSizeOfAtomicPixelType(const AtomicPixelEnum pixelType)
+IOCommon::ComputeSizeOfAtomicPixelType(const AtomicPixelEnum pixelType)
 {
   switch (pixelType)
   {

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -218,7 +218,7 @@ ImageIOBase::ComputeStrides()
 
 // Calculates the image size in PIXELS
 ImageIOBase::SizeType
-ImageIOBase ::GetImageSizeInPixels() const
+ImageIOBase::GetImageSizeInPixels() const
 {
   unsigned int i;
   SizeType     numPixels = 1;
@@ -232,37 +232,37 @@ ImageIOBase ::GetImageSizeInPixels() const
 }
 
 ImageIOBase::SizeType
-ImageIOBase ::GetImageSizeInComponents() const
+ImageIOBase::GetImageSizeInComponents() const
 {
   return (this->GetImageSizeInPixels() * m_NumberOfComponents);
 }
 
 ImageIOBase::SizeType
-ImageIOBase ::GetImageSizeInBytes() const
+ImageIOBase::GetImageSizeInBytes() const
 {
   return (this->GetImageSizeInComponents() * this->GetComponentSize());
 }
 
 ImageIOBase::SizeType
-ImageIOBase ::GetComponentStride() const
+ImageIOBase::GetComponentStride() const
 {
   return m_Strides[0];
 }
 
 ImageIOBase::SizeType
-ImageIOBase ::GetPixelStride() const
+ImageIOBase::GetPixelStride() const
 {
   return m_Strides[1];
 }
 
 ImageIOBase::SizeType
-ImageIOBase ::GetRowStride() const
+ImageIOBase::GetRowStride() const
 {
   return m_Strides[2];
 }
 
 ImageIOBase::SizeType
-ImageIOBase ::GetSliceStride() const
+ImageIOBase::GetSliceStride() const
 {
   return m_Strides[3];
 }
@@ -302,7 +302,7 @@ ImageIOBase::SetNumberOfDimensions(unsigned int dim)
 }
 
 bool
-ImageIOBase ::ReadBufferAsBinary(std::istream & is, void * buffer, ImageIOBase::SizeType num)
+ImageIOBase::ReadBufferAsBinary(std::istream & is, void * buffer, ImageIOBase::SizeType num)
 {
   const auto numberOfBytesToBeRead = Math::CastWithRangeCheck<std::streamsize>(num);
 
@@ -1079,7 +1079,7 @@ ImageIOBase::GetSplitRegionForWriting(unsigned int          ithPiece,
  * smaller than the LargestPossibleRegion and greater or equal to the
  * RequestedRegion */
 ImageIORegion
-ImageIOBase ::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requested) const
+ImageIOBase::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requested) const
 {
   //
   // The default implementations determines that the streamable region is
@@ -1136,7 +1136,7 @@ ImageIOBase ::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegio
  *  in the case the recipient image dimension is smaller than the dimension
  *  of the image in file. */
 std::vector<double>
-ImageIOBase ::GetDefaultDirection(unsigned int k) const
+ImageIOBase::GetDefaultDirection(unsigned int k) const
 {
   std::vector<double> axis;
   axis.resize(this->GetNumberOfDimensions());

--- a/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
@@ -23,12 +23,12 @@
 
 namespace itk
 {
-NumericSeriesFileNames ::NumericSeriesFileNames()
+NumericSeriesFileNames::NumericSeriesFileNames()
   : m_SeriesFormat("%d")
 {}
 
 const std::vector<std::string> &
-NumericSeriesFileNames ::GetFileNames()
+NumericSeriesFileNames::GetFileNames()
 {
   // validate the indices
   if (m_StartIndex > m_EndIndex)
@@ -76,7 +76,7 @@ NumericSeriesFileNames ::GetFileNames()
 }
 
 void
-NumericSeriesFileNames ::PrintSelf(std::ostream & os, Indent indent) const
+NumericSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
@@ -47,7 +47,7 @@ struct lt_pair_alphabetic_string_string
 namespace itk
 {
 const std::vector<std::string> &
-RegularExpressionSeriesFileNames ::GetFileNames()
+RegularExpressionSeriesFileNames::GetFileNames()
 {
   // Validate the ivars
   if (m_Directory.empty())
@@ -113,7 +113,7 @@ RegularExpressionSeriesFileNames ::GetFileNames()
 }
 
 void
-RegularExpressionSeriesFileNames ::PrintSelf(std::ostream & os, Indent indent) const
+RegularExpressionSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
@@ -33,7 +33,7 @@ StreamingImageIOBase::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 bool
-StreamingImageIOBase ::StreamReadBufferAsBinary(std::istream & file, void * _buffer)
+StreamingImageIOBase::StreamReadBufferAsBinary(std::istream & file, void * _buffer)
 {
   itkDebugMacro(<< "StreamingReadBufferAsBinary called");
 

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
@@ -24,7 +24,7 @@
 namespace itk
 {
 void
-BYUMeshIOFactory ::PrintSelf(std::ostream &, Indent) const
+BYUMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
 
@@ -38,14 +38,14 @@ BYUMeshIOFactory ::~BYUMeshIOFactory() = default;
 
 
 const char *
-BYUMeshIOFactory ::GetITKSourceVersion() const
+BYUMeshIOFactory::GetITKSourceVersion() const
 {
   return ITK_SOURCE_VERSION;
 }
 
 
 const char *
-BYUMeshIOFactory ::GetDescription() const
+BYUMeshIOFactory::GetDescription() const
 {
   return "BYU Mesh IO Factory, allows the loading of BYU mesh into insight";
 }

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -20,7 +20,7 @@
 
 namespace itk
 {
-MeshIOBase ::MeshIOBase()
+MeshIOBase::MeshIOBase()
   : m_NumberOfPoints(itk::NumericTraits<SizeValueType>::ZeroValue())
   , m_NumberOfCells(itk::NumericTraits<SizeValueType>::ZeroValue())
   , m_NumberOfPointPixels(itk::NumericTraits<SizeValueType>::ZeroValue())
@@ -30,31 +30,31 @@ MeshIOBase ::MeshIOBase()
 {}
 
 const MeshIOBase::ArrayOfExtensionsType &
-MeshIOBase ::GetSupportedReadExtensions() const
+MeshIOBase::GetSupportedReadExtensions() const
 {
   return this->m_SupportedReadExtensions;
 }
 
 const MeshIOBase::ArrayOfExtensionsType &
-MeshIOBase ::GetSupportedWriteExtensions() const
+MeshIOBase::GetSupportedWriteExtensions() const
 {
   return this->m_SupportedWriteExtensions;
 }
 
 void
-MeshIOBase ::AddSupportedReadExtension(const char * extension)
+MeshIOBase::AddSupportedReadExtension(const char * extension)
 {
   this->m_SupportedReadExtensions.push_back(extension);
 }
 
 void
-MeshIOBase ::AddSupportedWriteExtension(const char * extension)
+MeshIOBase::AddSupportedWriteExtension(const char * extension)
 {
   this->m_SupportedWriteExtensions.push_back(extension);
 }
 
 unsigned int
-MeshIOBase ::GetComponentSize(IOComponentEnum componentType) const
+MeshIOBase::GetComponentSize(IOComponentEnum componentType) const
 {
   switch (componentType)
   {
@@ -91,7 +91,7 @@ MeshIOBase ::GetComponentSize(IOComponentEnum componentType) const
 }
 
 std::string
-MeshIOBase ::GetFileTypeAsString(IOFileEnum t) const
+MeshIOBase::GetFileTypeAsString(IOFileEnum t) const
 {
   switch (t)
   {
@@ -125,7 +125,7 @@ MeshIOBase::GetByteOrderAsString(IOByteOrderEnum t) const
 }
 
 std::string
-MeshIOBase ::GetComponentTypeAsString(IOComponentEnum t) const
+MeshIOBase::GetComponentTypeAsString(IOComponentEnum t) const
 {
   switch (t)
   {
@@ -164,7 +164,7 @@ MeshIOBase ::GetComponentTypeAsString(IOComponentEnum t) const
 }
 
 std::string
-MeshIOBase ::GetPixelTypeAsString(IOPixelEnum t) const
+MeshIOBase::GetPixelTypeAsString(IOPixelEnum t) const
 {
   switch (t)
   {
@@ -207,7 +207,7 @@ MeshIOBase ::GetPixelTypeAsString(IOPixelEnum t) const
 }
 
 void
-MeshIOBase ::PrintSelf(std::ostream & os, Indent indent) const
+MeshIOBase::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
@@ -21,13 +21,13 @@
 namespace itk
 {
 
-MeshIOFactory ::MeshIOFactory() = default;
+MeshIOFactory::MeshIOFactory() = default;
 
 MeshIOFactory ::~MeshIOFactory() = default;
 
 
 MeshIOBase::Pointer
-MeshIOFactory ::CreateMeshIO(const char * path, IOFileModeEnum mode)
+MeshIOFactory::CreateMeshIO(const char * path, IOFileModeEnum mode)
 {
   std::list<MeshIOBase::Pointer> possibleMeshIO;
 

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIOFactory.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIOFactory.cxx
@@ -24,10 +24,10 @@
 namespace itk
 {
 void
-FreeSurferAsciiMeshIOFactory ::PrintSelf(std::ostream &, Indent) const
+FreeSurferAsciiMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
-FreeSurferAsciiMeshIOFactory ::FreeSurferAsciiMeshIOFactory()
+FreeSurferAsciiMeshIOFactory::FreeSurferAsciiMeshIOFactory()
 {
   this->RegisterOverride("itkMeshIOBase",
                          "itkFreeSurferAsciiMeshIO",
@@ -39,13 +39,13 @@ FreeSurferAsciiMeshIOFactory ::FreeSurferAsciiMeshIOFactory()
 FreeSurferAsciiMeshIOFactory ::~FreeSurferAsciiMeshIOFactory() = default;
 
 const char *
-FreeSurferAsciiMeshIOFactory ::GetITKSourceVersion() const
+FreeSurferAsciiMeshIOFactory::GetITKSourceVersion() const
 {
   return ITK_SOURCE_VERSION;
 }
 
 const char *
-FreeSurferAsciiMeshIOFactory ::GetDescription() const
+FreeSurferAsciiMeshIOFactory::GetDescription() const
 {
   return "FreeSurfer ASCII Mesh IO Factory, allows the loading of FreeSurfer Ascii mesh into insight";
 }

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIOFactory.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIOFactory.cxx
@@ -24,10 +24,10 @@
 namespace itk
 {
 void
-FreeSurferBinaryMeshIOFactory ::PrintSelf(std::ostream &, Indent) const
+FreeSurferBinaryMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
-FreeSurferBinaryMeshIOFactory ::FreeSurferBinaryMeshIOFactory()
+FreeSurferBinaryMeshIOFactory::FreeSurferBinaryMeshIOFactory()
 {
   this->RegisterOverride("itkMeshIOBase",
                          "itkFreeSurferBinaryMeshIO",
@@ -39,13 +39,13 @@ FreeSurferBinaryMeshIOFactory ::FreeSurferBinaryMeshIOFactory()
 FreeSurferBinaryMeshIOFactory ::~FreeSurferBinaryMeshIOFactory() = default;
 
 const char *
-FreeSurferBinaryMeshIOFactory ::GetITKSourceVersion() const
+FreeSurferBinaryMeshIOFactory::GetITKSourceVersion() const
 {
   return ITK_SOURCE_VERSION;
 }
 
 const char *
-FreeSurferBinaryMeshIOFactory ::GetDescription() const
+FreeSurferBinaryMeshIOFactory::GetDescription() const
 {
   return "FreeSurfer BINARY Mesh IO Factory, allows the loading of FreeSurfer Binary mesh into insight";
 }

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIOFactory.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIOFactory.cxx
@@ -24,10 +24,10 @@
 namespace itk
 {
 void
-GiftiMeshIOFactory ::PrintSelf(std::ostream &, Indent) const
+GiftiMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
-GiftiMeshIOFactory ::GiftiMeshIOFactory()
+GiftiMeshIOFactory::GiftiMeshIOFactory()
 {
   this->RegisterOverride(
     "itkMeshIOBase", "itkGiftiMeshIO", "Gifti Mesh IO", true, CreateObjectFunction<GiftiMeshIO>::New());
@@ -36,13 +36,13 @@ GiftiMeshIOFactory ::GiftiMeshIOFactory()
 GiftiMeshIOFactory ::~GiftiMeshIOFactory() = default;
 
 const char *
-GiftiMeshIOFactory ::GetITKSourceVersion() const
+GiftiMeshIOFactory::GetITKSourceVersion() const
 {
   return ITK_SOURCE_VERSION;
 }
 
 const char *
-GiftiMeshIOFactory ::GetDescription() const
+GiftiMeshIOFactory::GetDescription() const
 {
   return "Gifti MeshIO Factory, allows the loading of Gifti meshs into insight";
 }

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIOFactory.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIOFactory.cxx
@@ -24,7 +24,7 @@
 namespace itk
 {
 void
-OBJMeshIOFactory ::PrintSelf(std::ostream &, Indent) const
+OBJMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
 OBJMeshIOFactory ::OBJMeshIOFactory()
@@ -35,13 +35,13 @@ OBJMeshIOFactory ::OBJMeshIOFactory()
 OBJMeshIOFactory ::~OBJMeshIOFactory() = default;
 
 const char *
-OBJMeshIOFactory ::GetITKSourceVersion() const
+OBJMeshIOFactory::GetITKSourceVersion() const
 {
   return ITK_SOURCE_VERSION;
 }
 
 const char *
-OBJMeshIOFactory ::GetDescription() const
+OBJMeshIOFactory::GetDescription() const
 {
   return "OBJ Mesh IO Factory, allows the loading of OBJ mesh into insight";
 }

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIOFactory.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIOFactory.cxx
@@ -24,7 +24,7 @@
 namespace itk
 {
 void
-OFFMeshIOFactory ::PrintSelf(std::ostream &, Indent) const
+OFFMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
 OFFMeshIOFactory ::OFFMeshIOFactory()
@@ -35,13 +35,13 @@ OFFMeshIOFactory ::OFFMeshIOFactory()
 OFFMeshIOFactory ::~OFFMeshIOFactory() = default;
 
 const char *
-OFFMeshIOFactory ::GetITKSourceVersion() const
+OFFMeshIOFactory::GetITKSourceVersion() const
 {
   return ITK_SOURCE_VERSION;
 }
 
 const char *
-OFFMeshIOFactory ::GetDescription() const
+OFFMeshIOFactory::GetDescription() const
 {
   return "OFF Mesh IO Factory, allows the loading of OFF mesh into insight";
 }

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
@@ -25,7 +25,7 @@ namespace itk
 {
 
 void
-VTKPolyDataMeshIOFactory ::PrintSelf(std::ostream &, Indent) const
+VTKPolyDataMeshIOFactory::PrintSelf(std::ostream &, Indent) const
 {}
 
 
@@ -39,14 +39,14 @@ VTKPolyDataMeshIOFactory ::~VTKPolyDataMeshIOFactory() = default;
 
 
 const char *
-VTKPolyDataMeshIOFactory ::GetITKSourceVersion() const
+VTKPolyDataMeshIOFactory::GetITKSourceVersion() const
 {
   return ITK_SOURCE_VERSION;
 }
 
 
 const char *
-VTKPolyDataMeshIOFactory ::GetDescription() const
+VTKPolyDataMeshIOFactory::GetDescription() const
 {
   return "VTK MeshIO Factory, allows the loading of VTK polydata into insight";
 }

--- a/Modules/IO/Meta/src/itkMetaArrayReader.cxx
+++ b/Modules/IO/Meta/src/itkMetaArrayReader.cxx
@@ -20,7 +20,7 @@
 namespace itk
 {
 
-MetaArrayReader ::MetaArrayReader()
+MetaArrayReader::MetaArrayReader()
   : m_FileName("")
 
 {}
@@ -28,19 +28,19 @@ MetaArrayReader ::MetaArrayReader()
 MetaArrayReader ::~MetaArrayReader() = default;
 
 void
-MetaArrayReader ::SetBuffer(void * _buffer)
+MetaArrayReader::SetBuffer(void * _buffer)
 {
   m_Buffer = _buffer;
 }
 
 MetaArray *
-MetaArrayReader ::GetMetaArrayPointer()
+MetaArrayReader::GetMetaArrayPointer()
 {
   return &m_MetaArray;
 }
 
 void
-MetaArrayReader ::Update()
+MetaArrayReader::Update()
 {
   m_MetaArray.Read(m_FileName.c_str(), true, m_Buffer);
 }

--- a/Modules/IO/Meta/src/itkMetaArrayWriter.cxx
+++ b/Modules/IO/Meta/src/itkMetaArrayWriter.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-MetaArrayWriter ::MetaArrayWriter()
+MetaArrayWriter::MetaArrayWriter()
   : m_FileName("")
   , m_DataFileName("")
 
@@ -28,7 +28,7 @@ MetaArrayWriter ::MetaArrayWriter()
 MetaArrayWriter ::~MetaArrayWriter() = default;
 
 void
-MetaArrayWriter ::ConvertTo(MET_ValueEnumType _metaElementType)
+MetaArrayWriter::ConvertTo(MET_ValueEnumType _metaElementType)
 {
   if (m_Buffer != nullptr)
   {
@@ -38,7 +38,7 @@ MetaArrayWriter ::ConvertTo(MET_ValueEnumType _metaElementType)
 }
 
 void
-MetaArrayWriter ::Update()
+MetaArrayWriter::Update()
 {
   m_MetaArray.SetDoublePrecision(m_Precision);
 

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
@@ -123,7 +123,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   std::cout << "PAR_MaxNumberOfCardiacPhases = " << tempInt << std::endl;
 
   PhilipsRECImageIOType::TriggerTimesContainerType::Pointer ptrToTimePoints = nullptr;
-  if (!itk::ExposeMetaData<PhilipsRECImageIOType::TriggerTimesContainerType ::Pointer>(
+  if (!itk::ExposeMetaData<PhilipsRECImageIOType::TriggerTimesContainerType::Pointer>(
         imageIO->GetMetaDataDictionary(), "PAR_TriggerTimes", ptrToTimePoints))
   {
     std::cerr << "Cannot read PAR_TriggerTimes" << std::endl;
@@ -150,7 +150,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   std::cout << "PAR_MaxNumberOfEchoes = " << tempInt << std::endl;
 
   PhilipsRECImageIOType::EchoTimesContainerType::Pointer ptrToEchoes = nullptr;
-  if (!itk::ExposeMetaData<PhilipsRECImageIOType::EchoTimesContainerType ::Pointer>(
+  if (!itk::ExposeMetaData<PhilipsRECImageIOType::EchoTimesContainerType::Pointer>(
         imageIO->GetMetaDataDictionary(), "PAR_EchoTimes", ptrToEchoes))
   {
     std::cerr << "Cannot read PAR_EchoTimes" << std::endl;
@@ -227,7 +227,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   std::cout << "PAR_ScanResolution = " << scanRes << std::endl;
 
   PhilipsRECImageIOType::RepetitionTimesContainerType::Pointer ptrToTR = nullptr;
-  if (!itk::ExposeMetaData<PhilipsRECImageIOType::RepetitionTimesContainerType ::Pointer>(
+  if (!itk::ExposeMetaData<PhilipsRECImageIOType::RepetitionTimesContainerType::Pointer>(
         imageIO->GetMetaDataDictionary(), "PAR_RepetitionTimes", ptrToTR))
   {
     std::cerr << "Cannot read PAR_RepetitionTimes" << std::endl;
@@ -386,7 +386,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   std::cout << "PAR_MaxNumberOfDiffusionValues = " << tempInt << std::endl;
 
   PhilipsRECImageIOType::GradientBvalueContainerType::Pointer ptrToBValues = nullptr;
-  if (!itk::ExposeMetaData<PhilipsRECImageIOType::GradientBvalueContainerType ::Pointer>(
+  if (!itk::ExposeMetaData<PhilipsRECImageIOType::GradientBvalueContainerType::Pointer>(
         imageIO->GetMetaDataDictionary(), "PAR_GradientBValues", ptrToBValues))
   {
     std::cerr << "Cannot read PAR_GradientBValues" << std::endl;
@@ -413,7 +413,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   std::cout << "PAR_MaxNumberOfGradientOrients = " << tempInt << std::endl;
 
   PhilipsRECImageIOType::GradientDirectionContainerType::Pointer ptrToGradValues = nullptr;
-  if (!itk::ExposeMetaData<PhilipsRECImageIOType::GradientDirectionContainerType ::Pointer>(
+  if (!itk::ExposeMetaData<PhilipsRECImageIOType::GradientDirectionContainerType::Pointer>(
         imageIO->GetMetaDataDictionary(), "PAR_GradientDirectionValues", ptrToGradValues))
   {
     std::cerr << "Cannot read PAR_GradientDirectionValues" << std::endl;
@@ -514,7 +514,7 @@ itkPhilipsRECImageIOPrintTest(int argc, char * argv[])
   std::cout << "PAR_NumberOfASLLabelTypes = " << tempInt << std::endl;
 
   PhilipsRECImageIOType::LabelTypesASLContainerType::Pointer ptrToASLLabelTypes = nullptr;
-  if (!itk::ExposeMetaData<PhilipsRECImageIOType::LabelTypesASLContainerType ::Pointer>(
+  if (!itk::ExposeMetaData<PhilipsRECImageIOType::LabelTypesASLContainerType::Pointer>(
         imageIO->GetMetaDataDictionary(), "PAR_ASLLabelTypes", ptrToASLLabelTypes))
   {
     std::cerr << "Cannot read PAR_ASLLabelTypes" << std::endl;

--- a/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
@@ -71,7 +71,7 @@ StochasticFractalDimensionImageFilter<TInputImage, TMaskImage, TOutputImage>::Ge
 
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 100);
 
-  using FaceCalculatorType = typename NeighborhoodAlgorithm ::ImageBoundaryFacesCalculator<InputImageType>;
+  using FaceCalculatorType = typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>;
   FaceCalculatorType faceCalculator;
 
   typename FaceCalculatorType::FaceListType faceList = faceCalculator(inputImage, region, this->m_NeighborhoodRadius);

--- a/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
@@ -57,7 +57,7 @@ itkGridForwardWarpImageFilterTest(int argc, char * argv[])
   using RegionType = itk::ImageRegion<ImageDimension>;
 
   // Create an input image
-  DisplacementFieldType ::Pointer inputDisplacementField = DisplacementFieldType ::New();
+  DisplacementFieldType::Pointer inputDisplacementField = DisplacementFieldType::New();
 
   // Define its size, and start index
   SizeType size;

--- a/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
@@ -52,7 +52,7 @@ itkWarpHarmonicEnergyCalculatorTest(int argc, char * argv[])
   using RegionType = itk::ImageRegion<ImageDimension>;
 
   // Create the input image
-  DisplacementFieldType ::Pointer inputDisplacementField = DisplacementFieldType ::New();
+  DisplacementFieldType::Pointer inputDisplacementField = DisplacementFieldType::New();
 
   // Define its size, and start index
   SizeType size;

--- a/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
@@ -48,7 +48,7 @@ itkWarpJacobianDeterminantFilterTest(int, char *[])
   using RegionType = itk::ImageRegion<ImageDimension>;
 
   // Create two images
-  DisplacementFieldType ::Pointer inputDisplacementField = DisplacementFieldType ::New();
+  DisplacementFieldType::Pointer inputDisplacementField = DisplacementFieldType::New();
 
   // Define their size, and start index
   SizeType size;

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLine.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLine.cxx
@@ -23,10 +23,10 @@ namespace itk
 namespace fem
 {
 void
-Element2DC0LinearLine ::GetIntegrationPointAndWeight(unsigned int i,
-                                                     VectorType & pt,
-                                                     Float &      w,
-                                                     unsigned int order) const
+Element2DC0LinearLine::GetIntegrationPointAndWeight(unsigned int i,
+                                                    VectorType & pt,
+                                                    Float &      w,
+                                                    unsigned int order) const
 {
 
   // default integration order
@@ -42,7 +42,7 @@ Element2DC0LinearLine ::GetIntegrationPointAndWeight(unsigned int i,
 }
 
 unsigned int
-Element2DC0LinearLine ::GetNumberOfIntegrationPoints(unsigned int order) const
+Element2DC0LinearLine::GetNumberOfIntegrationPoints(unsigned int order) const
 {
   // default integration order
   if ((order == 0) || (order >= Element::gaussMaxOrder))
@@ -54,7 +54,7 @@ Element2DC0LinearLine ::GetNumberOfIntegrationPoints(unsigned int order) const
 }
 
 Element2DC0LinearLine::VectorType
-Element2DC0LinearLine ::ShapeFunctions(const VectorType & pt) const
+Element2DC0LinearLine::ShapeFunctions(const VectorType & pt) const
 {
   /* Linear Line element has two shape functions  */
   VectorType shapeF(2);
@@ -66,7 +66,7 @@ Element2DC0LinearLine ::ShapeFunctions(const VectorType & pt) const
 }
 
 void
-Element2DC0LinearLine ::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
+Element2DC0LinearLine::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
 {
   shapeD.set_size(1, 2);
 
@@ -75,7 +75,7 @@ Element2DC0LinearLine ::ShapeFunctionDerivatives(const VectorType &, MatrixType 
 }
 
 void
-Element2DC0LinearLine ::Jacobian(const VectorType &, MatrixType & J, const MatrixType *) const
+Element2DC0LinearLine::Jacobian(const VectorType &, MatrixType & J, const MatrixType *) const
 {
   // Since the line element defines only one global coordinate
   // and lives in 2D space, we need to provide a custom Jacobian.
@@ -90,7 +90,7 @@ Element2DC0LinearLine ::Jacobian(const VectorType &, MatrixType & J, const Matri
 }
 
 bool
-Element2DC0LinearLine ::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & pcoords) const
+Element2DC0LinearLine::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & pcoords) const
 {
   VectorType closestPoint(3);
 

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLineStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLineStress.cxx
@@ -39,11 +39,11 @@ Element2DC0LinearLineStress::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0LinearLineStress ::Element2DC0LinearLineStress()
+Element2DC0LinearLineStress::Element2DC0LinearLineStress()
   : Superclass()
 {}
 
-Element2DC0LinearLineStress ::Element2DC0LinearLineStress(NodeIDType n1_, NodeIDType n2_, Material::ConstPointer m_)
+Element2DC0LinearLineStress::Element2DC0LinearLineStress(NodeIDType n1_, NodeIDType n2_, Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points
@@ -64,7 +64,7 @@ Element2DC0LinearLineStress ::Element2DC0LinearLineStress(NodeIDType n1_, NodeID
 }
 
 void
-Element2DC0LinearLineStress ::GetMassMatrix(MatrixType & Me) const
+Element2DC0LinearLineStress::GetMassMatrix(MatrixType & Me) const
 {
   Me.set_size(4, 4);
   Me.fill(0.0);

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateral.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateral.cxx
@@ -23,10 +23,10 @@ namespace itk
 namespace fem
 {
 void
-Element2DC0LinearQuadrilateral ::GetIntegrationPointAndWeight(unsigned int i,
-                                                              VectorType & pt,
-                                                              Float &      w,
-                                                              unsigned int order) const
+Element2DC0LinearQuadrilateral::GetIntegrationPointAndWeight(unsigned int i,
+                                                             VectorType & pt,
+                                                             Float &      w,
+                                                             unsigned int order) const
 {
   // default integration order
   if ((order == 0) || (order >= Element::gaussMaxOrder))
@@ -43,7 +43,7 @@ Element2DC0LinearQuadrilateral ::GetIntegrationPointAndWeight(unsigned int i,
 }
 
 unsigned int
-Element2DC0LinearQuadrilateral ::GetNumberOfIntegrationPoints(unsigned int order) const
+Element2DC0LinearQuadrilateral::GetNumberOfIntegrationPoints(unsigned int order) const
 {
   // default integration order
   if ((order == 0) || (order >= Element::gaussMaxOrder))
@@ -55,7 +55,7 @@ Element2DC0LinearQuadrilateral ::GetNumberOfIntegrationPoints(unsigned int order
 }
 
 Element2DC0LinearQuadrilateral::VectorType
-Element2DC0LinearQuadrilateral ::ShapeFunctions(const VectorType & pt) const
+Element2DC0LinearQuadrilateral::ShapeFunctions(const VectorType & pt) const
 {
   /* Linear quadrilateral element has four shape functions  */
   VectorType shapeF(4);
@@ -83,7 +83,7 @@ Element2DC0LinearQuadrilateral ::ShapeFunctions(const VectorType & pt) const
 }
 
 void
-Element2DC0LinearQuadrilateral ::ShapeFunctionDerivatives(const VectorType & pt, MatrixType & shapeD) const
+Element2DC0LinearQuadrilateral::ShapeFunctionDerivatives(const VectorType & pt, MatrixType & shapeD) const
 {
   /** functions at directions r and s.  */
   shapeD.set_size(2, 4);
@@ -114,7 +114,7 @@ Element2DC0LinearQuadrilateral ::ShapeFunctionDerivatives(const VectorType & pt,
 }
 
 bool
-Element2DC0LinearQuadrilateral ::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
+Element2DC0LinearQuadrilateral::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
 {
   Float x1, x2, x3, x4, y1, y2, y3, y4, xce, yce, xb, yb, xcn, ycn, A, J1, J2, x0, y0, dx, dy, be, bn, ce, cn;
 

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralMembrane.cxx
@@ -41,15 +41,15 @@ Element2DC0LinearQuadrilateralMembrane::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0LinearQuadrilateralMembrane ::Element2DC0LinearQuadrilateralMembrane()
+Element2DC0LinearQuadrilateralMembrane::Element2DC0LinearQuadrilateralMembrane()
   : Superclass()
 {}
 
-Element2DC0LinearQuadrilateralMembrane ::Element2DC0LinearQuadrilateralMembrane(NodeIDType             n1_,
-                                                                                NodeIDType             n2_,
-                                                                                NodeIDType             n3_,
-                                                                                NodeIDType             n4_,
-                                                                                Material::ConstPointer m_)
+Element2DC0LinearQuadrilateralMembrane::Element2DC0LinearQuadrilateralMembrane(NodeIDType             n1_,
+                                                                               NodeIDType             n2_,
+                                                                               NodeIDType             n3_,
+                                                                               NodeIDType             n4_,
+                                                                               Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStrain.cxx
@@ -41,17 +41,17 @@ Element2DC0LinearQuadrilateralStrain::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0LinearQuadrilateralStrain ::Element2DC0LinearQuadrilateralStrain()
+Element2DC0LinearQuadrilateralStrain::Element2DC0LinearQuadrilateralStrain()
   : Superclass()
 {
   this->PopulateEdgeIds();
 }
 
-Element2DC0LinearQuadrilateralStrain ::Element2DC0LinearQuadrilateralStrain(NodeIDType             n1_,
-                                                                            NodeIDType             n2_,
-                                                                            NodeIDType             n3_,
-                                                                            NodeIDType             n4_,
-                                                                            Material::ConstPointer m_)
+Element2DC0LinearQuadrilateralStrain::Element2DC0LinearQuadrilateralStrain(NodeIDType             n1_,
+                                                                           NodeIDType             n2_,
+                                                                           NodeIDType             n3_,
+                                                                           NodeIDType             n4_,
+                                                                           Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStress.cxx
@@ -41,17 +41,17 @@ Element2DC0LinearQuadrilateralStress::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0LinearQuadrilateralStress ::Element2DC0LinearQuadrilateralStress()
+Element2DC0LinearQuadrilateralStress::Element2DC0LinearQuadrilateralStress()
   : Superclass()
 {
   this->PopulateEdgeIds();
 }
 
-Element2DC0LinearQuadrilateralStress ::Element2DC0LinearQuadrilateralStress(NodeIDType             n1_,
-                                                                            NodeIDType             n2_,
-                                                                            NodeIDType             n3_,
-                                                                            NodeIDType             n4_,
-                                                                            Material::ConstPointer m_)
+Element2DC0LinearQuadrilateralStress::Element2DC0LinearQuadrilateralStress(NodeIDType             n1_,
+                                                                           NodeIDType             n2_,
+                                                                           NodeIDType             n3_,
+                                                                           NodeIDType             n4_,
+                                                                           Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangular.cxx
@@ -58,13 +58,13 @@ const double Element2DC0LinearTriangular ::trigGaussRuleInfo[6][7][4] = {
     { 0.47014206410511509, 0.47014206410511509, 0.05971587178976982, 0.13239415278850618 } }
 };
 
-const unsigned int Element2DC0LinearTriangular ::Nip[6] = { 0, 1, 3, 3, 6, 7 };
+const unsigned int Element2DC0LinearTriangular::Nip[6] = { 0, 1, 3, 3, 6, 7 };
 
 void
-Element2DC0LinearTriangular ::GetIntegrationPointAndWeight(unsigned int i,
-                                                           VectorType & pt,
-                                                           Float &      w,
-                                                           unsigned int order) const
+Element2DC0LinearTriangular::GetIntegrationPointAndWeight(unsigned int i,
+                                                          VectorType & pt,
+                                                          Float &      w,
+                                                          unsigned int order) const
 {
   // default integration order
   if (order == 0 || order > 5)
@@ -95,7 +95,7 @@ Element2DC0LinearTriangular ::GetIntegrationPointAndWeight(unsigned int i,
 }
 
 unsigned int
-Element2DC0LinearTriangular ::GetNumberOfIntegrationPoints(unsigned int order) const
+Element2DC0LinearTriangular::GetNumberOfIntegrationPoints(unsigned int order) const
 {
   // default integration order
   if (order == 0 || order > 5)
@@ -107,7 +107,7 @@ Element2DC0LinearTriangular ::GetNumberOfIntegrationPoints(unsigned int order) c
 }
 
 Element2DC0LinearTriangular::VectorType
-Element2DC0LinearTriangular ::ShapeFunctions(const VectorType & pt) const
+Element2DC0LinearTriangular::ShapeFunctions(const VectorType & pt) const
 {
   // Linear triangular element has 3 shape functions
   VectorType shapeF(3);
@@ -119,7 +119,7 @@ Element2DC0LinearTriangular ::ShapeFunctions(const VectorType & pt) const
 }
 
 void
-Element2DC0LinearTriangular ::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
+Element2DC0LinearTriangular::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
 {
   // Matrix of shape functions derivatives is an
   // identity matrix for linear triangular element.
@@ -131,7 +131,7 @@ Element2DC0LinearTriangular ::ShapeFunctionDerivatives(const VectorType &, Matri
 }
 
 bool
-Element2DC0LinearTriangular ::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
+Element2DC0LinearTriangular::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
 {
   Float x, x1, x2, x3, y, y1, y2, y3, A;
 
@@ -163,7 +163,7 @@ Element2DC0LinearTriangular ::GetLocalFromGlobalCoordinates(const VectorType & g
 }
 
 Element2DC0LinearTriangular::Float
-Element2DC0LinearTriangular ::JacobianDeterminant(const VectorType & pt, const MatrixType * pJ) const
+Element2DC0LinearTriangular::JacobianDeterminant(const VectorType & pt, const MatrixType * pJ) const
 {
 
   MatrixType * pJlocal = nullptr;
@@ -186,7 +186,7 @@ Element2DC0LinearTriangular ::JacobianDeterminant(const VectorType & pt, const M
 }
 
 void
-Element2DC0LinearTriangular ::JacobianInverse(const VectorType & pt, MatrixType & invJ, const MatrixType * pJ) const
+Element2DC0LinearTriangular::JacobianInverse(const VectorType & pt, MatrixType & invJ, const MatrixType * pJ) const
 {
   MatrixType * pJlocal = nullptr;
 

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularMembrane.cxx
@@ -40,14 +40,14 @@ Element2DC0LinearTriangularMembrane::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0LinearTriangularMembrane ::Element2DC0LinearTriangularMembrane()
+Element2DC0LinearTriangularMembrane::Element2DC0LinearTriangularMembrane()
   : Superclass()
 {}
 
-Element2DC0LinearTriangularMembrane ::Element2DC0LinearTriangularMembrane(NodeIDType             n1_,
-                                                                          NodeIDType             n2_,
-                                                                          NodeIDType             n3_,
-                                                                          Material::ConstPointer m_)
+Element2DC0LinearTriangularMembrane::Element2DC0LinearTriangularMembrane(NodeIDType             n1_,
+                                                                         NodeIDType             n2_,
+                                                                         NodeIDType             n3_,
+                                                                         Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStrain.cxx
@@ -40,14 +40,14 @@ Element2DC0LinearTriangularStrain::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0LinearTriangularStrain ::Element2DC0LinearTriangularStrain()
+Element2DC0LinearTriangularStrain::Element2DC0LinearTriangularStrain()
   : Superclass()
 {}
 
-Element2DC0LinearTriangularStrain ::Element2DC0LinearTriangularStrain(NodeIDType             n1_,
-                                                                      NodeIDType             n2_,
-                                                                      NodeIDType             n3_,
-                                                                      Material::ConstPointer m_)
+Element2DC0LinearTriangularStrain::Element2DC0LinearTriangularStrain(NodeIDType             n1_,
+                                                                     NodeIDType             n2_,
+                                                                     NodeIDType             n3_,
+                                                                     Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStress.cxx
@@ -40,14 +40,14 @@ Element2DC0LinearTriangularStress::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0LinearTriangularStress ::Element2DC0LinearTriangularStress()
+Element2DC0LinearTriangularStress::Element2DC0LinearTriangularStress()
   : Superclass()
 {}
 
-Element2DC0LinearTriangularStress ::Element2DC0LinearTriangularStress(NodeIDType             n1_,
-                                                                      NodeIDType             n2_,
-                                                                      NodeIDType             n3_,
-                                                                      Material::ConstPointer m_)
+Element2DC0LinearTriangularStress::Element2DC0LinearTriangularStress(NodeIDType             n1_,
+                                                                     NodeIDType             n2_,
+                                                                     NodeIDType             n3_,
+                                                                     Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
@@ -25,10 +25,10 @@ namespace itk
 namespace fem
 {
 void
-Element2DC0QuadraticTriangular ::GetIntegrationPointAndWeight(unsigned int i,
-                                                              VectorType & pt,
-                                                              Float &      w,
-                                                              unsigned int order) const
+Element2DC0QuadraticTriangular::GetIntegrationPointAndWeight(unsigned int i,
+                                                             VectorType & pt,
+                                                             Float &      w,
+                                                             unsigned int order) const
 {
   // default integration order
   if (order == 0 || order > 5)
@@ -59,7 +59,7 @@ Element2DC0QuadraticTriangular ::GetIntegrationPointAndWeight(unsigned int i,
 }
 
 unsigned int
-Element2DC0QuadraticTriangular ::GetNumberOfIntegrationPoints(unsigned int order) const
+Element2DC0QuadraticTriangular::GetNumberOfIntegrationPoints(unsigned int order) const
 {
   // default integration order
   if (order == 0 || order > 5)
@@ -71,7 +71,7 @@ Element2DC0QuadraticTriangular ::GetNumberOfIntegrationPoints(unsigned int order
 }
 
 Element2DC0QuadraticTriangular::VectorType
-Element2DC0QuadraticTriangular ::ShapeFunctions(const VectorType & pt) const
+Element2DC0QuadraticTriangular::ShapeFunctions(const VectorType & pt) const
 {
   // Quadratic triangular element has 6 shape functions
   VectorType shapeF(6);
@@ -90,7 +90,7 @@ Element2DC0QuadraticTriangular ::ShapeFunctions(const VectorType & pt) const
 }
 
 void
-Element2DC0QuadraticTriangular ::ShapeFunctionDerivatives(const VectorType & pt, MatrixType & shapeD) const
+Element2DC0QuadraticTriangular::ShapeFunctionDerivatives(const VectorType & pt, MatrixType & shapeD) const
 {
   VectorType::element_type p2 = 1.0 - pt[0] - pt[1];
 
@@ -111,7 +111,7 @@ Element2DC0QuadraticTriangular ::ShapeFunctionDerivatives(const VectorType & pt,
 }
 
 Element2DC0QuadraticTriangular::Float
-Element2DC0QuadraticTriangular ::JacobianDeterminant(const VectorType & pt, const MatrixType * pJ) const
+Element2DC0QuadraticTriangular::JacobianDeterminant(const VectorType & pt, const MatrixType * pJ) const
 {
   //  return Superclass::JacobianDeterminant( pt, pJ );
 
@@ -135,7 +135,7 @@ Element2DC0QuadraticTriangular ::JacobianDeterminant(const VectorType & pt, cons
 }
 
 void
-Element2DC0QuadraticTriangular ::JacobianInverse(const VectorType & pt, MatrixType & invJ, const MatrixType * pJ) const
+Element2DC0QuadraticTriangular::JacobianInverse(const VectorType & pt, MatrixType & invJ, const MatrixType * pJ) const
 {
   MatrixType * pJlocal = nullptr;
 

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStrain.cxx
@@ -43,17 +43,17 @@ Element2DC0QuadraticTriangularStrain::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0QuadraticTriangularStrain ::Element2DC0QuadraticTriangularStrain()
+Element2DC0QuadraticTriangularStrain::Element2DC0QuadraticTriangularStrain()
   : Superclass()
 {}
 
-Element2DC0QuadraticTriangularStrain ::Element2DC0QuadraticTriangularStrain(NodeIDType             n1_,
-                                                                            NodeIDType             n2_,
-                                                                            NodeIDType             n3_,
-                                                                            NodeIDType             n4_,
-                                                                            NodeIDType             n5_,
-                                                                            NodeIDType             n6_,
-                                                                            Material::ConstPointer m_)
+Element2DC0QuadraticTriangularStrain::Element2DC0QuadraticTriangularStrain(NodeIDType             n1_,
+                                                                           NodeIDType             n2_,
+                                                                           NodeIDType             n3_,
+                                                                           NodeIDType             n4_,
+                                                                           NodeIDType             n5_,
+                                                                           NodeIDType             n6_,
+                                                                           Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStress.cxx
@@ -43,17 +43,17 @@ Element2DC0QuadraticTriangularStress::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC0QuadraticTriangularStress ::Element2DC0QuadraticTriangularStress()
+Element2DC0QuadraticTriangularStress::Element2DC0QuadraticTriangularStress()
   : Superclass()
 {}
 
-Element2DC0QuadraticTriangularStress ::Element2DC0QuadraticTriangularStress(NodeIDType             n1_,
-                                                                            NodeIDType             n2_,
-                                                                            NodeIDType             n3_,
-                                                                            NodeIDType             n4_,
-                                                                            NodeIDType             n5_,
-                                                                            NodeIDType             n6_,
-                                                                            Material::ConstPointer m_)
+Element2DC0QuadraticTriangularStress::Element2DC0QuadraticTriangularStress(NodeIDType             n1_,
+                                                                           NodeIDType             n2_,
+                                                                           NodeIDType             n3_,
+                                                                           NodeIDType             n4_,
+                                                                           NodeIDType             n5_,
+                                                                           NodeIDType             n6_,
+                                                                           Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC1Beam.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC1Beam.cxx
@@ -39,11 +39,11 @@ Element2DC1Beam::CreateAnother() const
   return smartPtr;
 }
 
-Element2DC1Beam ::Element2DC1Beam()
+Element2DC1Beam::Element2DC1Beam()
   : Superclass()
 {}
 
-Element2DC1Beam ::Element2DC1Beam(NodeIDType n1_, NodeIDType n2_, Material::ConstPointer m_)
+Element2DC1Beam::Element2DC1Beam(NodeIDType n1_, NodeIDType n2_, Material::ConstPointer m_)
 {
   // Set the geometrical points
   this->SetNode(0, n1_);
@@ -62,7 +62,7 @@ Element2DC1Beam ::Element2DC1Beam(NodeIDType n1_, NodeIDType n2_, Material::Cons
 }
 
 void
-Element2DC1Beam ::GetIntegrationPointAndWeight(unsigned int i, VectorType & pt, Float & w, unsigned int order) const
+Element2DC1Beam::GetIntegrationPointAndWeight(unsigned int i, VectorType & pt, Float & w, unsigned int order) const
 {
   // default integration order
   if ((order == 0) || (order >= 9))
@@ -77,7 +77,7 @@ Element2DC1Beam ::GetIntegrationPointAndWeight(unsigned int i, VectorType & pt, 
 }
 
 unsigned int
-Element2DC1Beam ::GetNumberOfIntegrationPoints(unsigned int order) const
+Element2DC1Beam::GetNumberOfIntegrationPoints(unsigned int order) const
 {
   // default integration order
   if ((order == 0) || (order >= 9))
@@ -89,7 +89,7 @@ Element2DC1Beam ::GetNumberOfIntegrationPoints(unsigned int order) const
 }
 
 Element2DC1Beam::VectorType
-Element2DC1Beam ::ShapeFunctions(const VectorType & pt) const
+Element2DC1Beam::ShapeFunctions(const VectorType & pt) const
 {
   // 2D Beam element has four shape functions, but we only
   // define two of them, since we're only interested in
@@ -103,7 +103,7 @@ Element2DC1Beam ::ShapeFunctions(const VectorType & pt) const
 }
 
 void
-Element2DC1Beam ::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
+Element2DC1Beam::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
 {
   // FIXME: write proper implementation, since we need the 2nd
   //        order derivatives
@@ -112,7 +112,7 @@ Element2DC1Beam ::ShapeFunctionDerivatives(const VectorType &, MatrixType & shap
 }
 
 Element2DC1Beam::Float
-Element2DC1Beam ::JacobianDeterminant(const VectorType &, const MatrixType *) const
+Element2DC1Beam::JacobianDeterminant(const VectorType &, const MatrixType *) const
 {
   // FIXME: this is only temporary implementation, so that GenericBodyLoads
   //        implementation works. Write the proper geometric definition
@@ -128,7 +128,7 @@ Element2DC1Beam ::JacobianDeterminant(const VectorType &, const MatrixType *) co
 }
 
 void
-Element2DC1Beam ::GetStiffnessMatrix(MatrixType & Ke) const
+Element2DC1Beam::GetStiffnessMatrix(MatrixType & Ke) const
 {
   const unsigned int NDOF = this->GetNumberOfDegreesOfFreedom();
 
@@ -261,7 +261,7 @@ Element2DC1Beam ::GetStiffnessMatrix(MatrixType & Ke) const
 }
 
 void
-Element2DC1Beam ::GetMassMatrix(MatrixType & Me) const
+Element2DC1Beam::GetMassMatrix(MatrixType & Me) const
 {
   const unsigned int NDOF = this->GetNumberOfDegreesOfFreedom();
   MatrixType         m(NDOF, NDOF, 0.0);

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedron.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedron.cxx
@@ -23,10 +23,10 @@ namespace itk
 namespace fem
 {
 void
-Element3DC0LinearHexahedron ::GetIntegrationPointAndWeight(unsigned int i,
-                                                           VectorType & pt,
-                                                           Float &      w,
-                                                           unsigned int order) const
+Element3DC0LinearHexahedron::GetIntegrationPointAndWeight(unsigned int i,
+                                                          VectorType & pt,
+                                                          Float &      w,
+                                                          unsigned int order) const
 {
   if (order == 0 || order > 9)
   {
@@ -43,7 +43,7 @@ Element3DC0LinearHexahedron ::GetIntegrationPointAndWeight(unsigned int i,
 }
 
 unsigned int
-Element3DC0LinearHexahedron ::GetNumberOfIntegrationPoints(unsigned int order) const
+Element3DC0LinearHexahedron::GetNumberOfIntegrationPoints(unsigned int order) const
 {
   // default integration order=2
   if (order == 0 || order > 9)
@@ -55,7 +55,7 @@ Element3DC0LinearHexahedron ::GetNumberOfIntegrationPoints(unsigned int order) c
 }
 
 Element3DC0LinearHexahedron::VectorType
-Element3DC0LinearHexahedron ::ShapeFunctions(const VectorType & pt) const
+Element3DC0LinearHexahedron::ShapeFunctions(const VectorType & pt) const
 {
   /* Linear hexahedral element has eight shape functions  */
   VectorType shapeF(8);
@@ -95,7 +95,7 @@ Element3DC0LinearHexahedron ::ShapeFunctions(const VectorType & pt) const
 }
 
 void
-Element3DC0LinearHexahedron ::ShapeFunctionDerivatives(const VectorType & pt, MatrixType & shapeD) const
+Element3DC0LinearHexahedron::ShapeFunctionDerivatives(const VectorType & pt, MatrixType & shapeD) const
 {
   /** functions at directions r and s.  */
   shapeD.set_size(3, 8);
@@ -174,7 +174,7 @@ Element3DC0LinearHexahedron ::ShapeFunctionDerivatives(const VectorType & pt, Ma
 }
 
 bool
-Element3DC0LinearHexahedron ::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
+Element3DC0LinearHexahedron::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
 {
   int   MAX_ITERATIONS = 10;
   Float CONVERGED = 1.0e-03;

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronMembrane.cxx
@@ -45,11 +45,11 @@ Element3DC0LinearHexahedronMembrane::CreateAnother() const
   return smartPtr;
 }
 
-Element3DC0LinearHexahedronMembrane ::Element3DC0LinearHexahedronMembrane()
+Element3DC0LinearHexahedronMembrane::Element3DC0LinearHexahedronMembrane()
   : Superclass()
 {}
 
-Element3DC0LinearHexahedronMembrane ::Element3DC0LinearHexahedronMembrane(NodeIDType ns_[], Material::ConstPointer m_)
+Element3DC0LinearHexahedronMembrane::Element3DC0LinearHexahedronMembrane(NodeIDType ns_[], Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronStrain.cxx
@@ -45,11 +45,11 @@ Element3DC0LinearHexahedronStrain::CreateAnother() const
   return smartPtr;
 }
 
-Element3DC0LinearHexahedronStrain ::Element3DC0LinearHexahedronStrain()
+Element3DC0LinearHexahedronStrain::Element3DC0LinearHexahedronStrain()
   : Superclass()
 {}
 
-Element3DC0LinearHexahedronStrain ::Element3DC0LinearHexahedronStrain(NodeIDType ns_[], Material::ConstPointer m_)
+Element3DC0LinearHexahedronStrain::Element3DC0LinearHexahedronStrain(NodeIDType ns_[], Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedron.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedron.cxx
@@ -24,10 +24,7 @@ namespace fem
 {
 
 void
-Element3DC0LinearTetrahedron ::GetIntegrationPointAndWeight(unsigned int,
-                                                            VectorType & pt,
-                                                            Float &      w,
-                                                            unsigned int) const
+Element3DC0LinearTetrahedron::GetIntegrationPointAndWeight(unsigned int, VectorType & pt, Float & w, unsigned int) const
 {
   // FIXME: Write rules for other integration orders
   // for tetrahedral elements a single point should suffice
@@ -44,13 +41,13 @@ Element3DC0LinearTetrahedron ::GetIntegrationPointAndWeight(unsigned int,
 }
 
 unsigned int
-Element3DC0LinearTetrahedron ::GetNumberOfIntegrationPoints(unsigned int) const
+Element3DC0LinearTetrahedron::GetNumberOfIntegrationPoints(unsigned int) const
 {
   return 1;
 }
 
 Element3DC0LinearTetrahedron::VectorType
-Element3DC0LinearTetrahedron ::ShapeFunctions(const VectorType & pt) const
+Element3DC0LinearTetrahedron::ShapeFunctions(const VectorType & pt) const
 {
   /* Linear tetrahedral element has four shape functions  */
   VectorType shapeF(4);
@@ -78,7 +75,7 @@ Element3DC0LinearTetrahedron ::ShapeFunctions(const VectorType & pt) const
 }
 
 void
-Element3DC0LinearTetrahedron ::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
+Element3DC0LinearTetrahedron::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
 {
   /** functions at directions r and s.  */
   shapeD.set_size(3, 4);
@@ -96,7 +93,7 @@ Element3DC0LinearTetrahedron ::ShapeFunctionDerivatives(const VectorType &, Matr
 }
 
 bool
-Element3DC0LinearTetrahedron ::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
+Element3DC0LinearTetrahedron::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
 {
   Float x = globalPt[0];
   Float y = globalPt[1];

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronMembrane.cxx
@@ -41,11 +41,11 @@ Element3DC0LinearTetrahedronMembrane::CreateAnother() const
   return smartPtr;
 }
 
-Element3DC0LinearTetrahedronMembrane ::Element3DC0LinearTetrahedronMembrane()
+Element3DC0LinearTetrahedronMembrane::Element3DC0LinearTetrahedronMembrane()
   : Superclass()
 {}
 
-Element3DC0LinearTetrahedronMembrane ::Element3DC0LinearTetrahedronMembrane(NodeIDType ns_[], Material::ConstPointer m_)
+Element3DC0LinearTetrahedronMembrane::Element3DC0LinearTetrahedronMembrane(NodeIDType ns_[], Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronStrain.cxx
@@ -41,11 +41,11 @@ Element3DC0LinearTetrahedronStrain::CreateAnother() const
   return smartPtr;
 }
 
-Element3DC0LinearTetrahedronStrain ::Element3DC0LinearTetrahedronStrain()
+Element3DC0LinearTetrahedronStrain::Element3DC0LinearTetrahedronStrain()
   : Superclass()
 {}
 
-Element3DC0LinearTetrahedronStrain ::Element3DC0LinearTetrahedronStrain(NodeIDType ns_[], Material::ConstPointer m_)
+Element3DC0LinearTetrahedronStrain::Element3DC0LinearTetrahedronStrain(NodeIDType ns_[], Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
@@ -62,13 +62,13 @@ const Element3DC0LinearTriangular::Float Element3DC0LinearTriangular ::trigGauss
     { 0.47014206410511509, 0.47014206410511509, 0.05971587178976982, 0.13239415278850618 } }
 };
 
-const unsigned int Element3DC0LinearTriangular ::Nip[6] = { 0, 1, 3, 3, 6, 7 };
+const unsigned int Element3DC0LinearTriangular::Nip[6] = { 0, 1, 3, 3, 6, 7 };
 
 void
-Element3DC0LinearTriangular ::GetIntegrationPointAndWeight(unsigned int i,
-                                                           VectorType & pt,
-                                                           Float &      w,
-                                                           unsigned int order) const
+Element3DC0LinearTriangular::GetIntegrationPointAndWeight(unsigned int i,
+                                                          VectorType & pt,
+                                                          Float &      w,
+                                                          unsigned int order) const
 {
   // default integration order
   if (order == 0 || order > 5)
@@ -101,7 +101,7 @@ Element3DC0LinearTriangular ::GetIntegrationPointAndWeight(unsigned int i,
 }
 
 unsigned int
-Element3DC0LinearTriangular ::GetNumberOfIntegrationPoints(unsigned int order) const
+Element3DC0LinearTriangular::GetNumberOfIntegrationPoints(unsigned int order) const
 {
   // default integration order
   if (order == 0 || order > 5)
@@ -113,7 +113,7 @@ Element3DC0LinearTriangular ::GetNumberOfIntegrationPoints(unsigned int order) c
 }
 
 Element3DC0LinearTriangular::VectorType
-Element3DC0LinearTriangular ::ShapeFunctions(const VectorType & pt) const
+Element3DC0LinearTriangular::ShapeFunctions(const VectorType & pt) const
 {
   // Linear triangular element has 3 shape functions
   VectorType shapeF(3);
@@ -125,7 +125,7 @@ Element3DC0LinearTriangular ::ShapeFunctions(const VectorType & pt) const
 }
 
 void
-Element3DC0LinearTriangular ::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
+Element3DC0LinearTriangular::ShapeFunctionDerivatives(const VectorType &, MatrixType & shapeD) const
 {
   // Matrix of shape functions derivatives is an
   // identity matrix for linear triangular element.
@@ -137,7 +137,7 @@ Element3DC0LinearTriangular ::ShapeFunctionDerivatives(const VectorType &, Matri
 }
 
 bool
-Element3DC0LinearTriangular ::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
+Element3DC0LinearTriangular::GetLocalFromGlobalCoordinates(const VectorType & globalPt, VectorType & localPt) const
 {
   int        i, j;
   VectorType pt1, pt2, pt3, n(3);
@@ -217,7 +217,7 @@ Element3DC0LinearTriangular ::GetLocalFromGlobalCoordinates(const VectorType & g
 }
 
 Element3DC0LinearTriangular::Float
-Element3DC0LinearTriangular ::JacobianDeterminant(const VectorType & /*HACK pt*/, const MatrixType * /*HACK pJ*/) const
+Element3DC0LinearTriangular::JacobianDeterminant(const VectorType & /*HACK pt*/, const MatrixType * /*HACK pJ*/) const
 {
   // use heron's formula
   constexpr int na = 0;
@@ -256,7 +256,7 @@ Element3DC0LinearTriangular ::JacobianDeterminant(const VectorType & /*HACK pt*/
 }
 
 void
-Element3DC0LinearTriangular ::JacobianInverse(const VectorType & pt, MatrixType & invJ, const MatrixType * pJ) const
+Element3DC0LinearTriangular::JacobianInverse(const VectorType & pt, MatrixType & invJ, const MatrixType * pJ) const
 {
   MatrixType * pJlocal = nullptr;
 

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.cxx
@@ -41,14 +41,14 @@ Element3DC0LinearTriangularLaplaceBeltrami::CreateAnother() const
   return smartPtr;
 }
 
-Element3DC0LinearTriangularLaplaceBeltrami ::Element3DC0LinearTriangularLaplaceBeltrami()
+Element3DC0LinearTriangularLaplaceBeltrami::Element3DC0LinearTriangularLaplaceBeltrami()
   : Superclass()
 {}
 
-Element3DC0LinearTriangularLaplaceBeltrami ::Element3DC0LinearTriangularLaplaceBeltrami(NodeIDType             n1_,
-                                                                                        NodeIDType             n2_,
-                                                                                        NodeIDType             n3_,
-                                                                                        Material::ConstPointer m_)
+Element3DC0LinearTriangularLaplaceBeltrami::Element3DC0LinearTriangularLaplaceBeltrami(NodeIDType             n1_,
+                                                                                       NodeIDType             n2_,
+                                                                                       NodeIDType             n3_,
+                                                                                       Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularMembrane.cxx
@@ -42,14 +42,14 @@ Element3DC0LinearTriangularMembrane::CreateAnother() const
   return smartPtr;
 }
 
-Element3DC0LinearTriangularMembrane ::Element3DC0LinearTriangularMembrane()
+Element3DC0LinearTriangularMembrane::Element3DC0LinearTriangularMembrane()
   : Superclass()
 {}
 
-Element3DC0LinearTriangularMembrane ::Element3DC0LinearTriangularMembrane(NodeIDType             n1_,
-                                                                          NodeIDType             n2_,
-                                                                          NodeIDType             n3_,
-                                                                          Material::ConstPointer m_)
+Element3DC0LinearTriangularMembrane::Element3DC0LinearTriangularMembrane(NodeIDType             n1_,
+                                                                         NodeIDType             n2_,
+                                                                         NodeIDType             n3_,
+                                                                         Material::ConstPointer m_)
   : Superclass()
 {
   // Set the geometrical points

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
@@ -198,7 +198,7 @@ LinearSystemWrapper::OptimizeMatrixStorage(unsigned int matrixIndex, unsigned in
 }
 
 void
-LinearSystemWrapper ::CopyMatrix(unsigned int matrixIndex1, unsigned int matrixIndex2)
+LinearSystemWrapper::CopyMatrix(unsigned int matrixIndex1, unsigned int matrixIndex2)
 {
   ColumnArray  cols;
   unsigned int r;
@@ -215,7 +215,7 @@ LinearSystemWrapper ::CopyMatrix(unsigned int matrixIndex1, unsigned int matrixI
 }
 
 void
-LinearSystemWrapper ::AddMatrixMatrix(unsigned int matrixIndex1, unsigned int matrixIndex2)
+LinearSystemWrapper::AddMatrixMatrix(unsigned int matrixIndex1, unsigned int matrixIndex2)
 {
   ColumnArray  cols;
   unsigned int r;
@@ -230,7 +230,7 @@ LinearSystemWrapper ::AddMatrixMatrix(unsigned int matrixIndex1, unsigned int ma
 }
 
 void
-LinearSystemWrapper ::CopyVector(unsigned int vectorSource, unsigned int vectorDestination)
+LinearSystemWrapper::CopyVector(unsigned int vectorSource, unsigned int vectorDestination)
 {
   unsigned int r;
   for (r = 0; r < this->m_Order; r++)
@@ -240,7 +240,7 @@ LinearSystemWrapper ::CopyVector(unsigned int vectorSource, unsigned int vectorD
 }
 
 void
-LinearSystemWrapper ::AddVectorVector(unsigned int vectorIndex1, unsigned int vectorIndex2)
+LinearSystemWrapper::AddVectorVector(unsigned int vectorIndex1, unsigned int vectorIndex2)
 {
   unsigned int r;
   for (r = 0; r < this->m_Order; r++)

--- a/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
@@ -22,7 +22,7 @@ namespace itk
 {
 
 
-AmoebaOptimizer ::AmoebaOptimizer()
+AmoebaOptimizer::AmoebaOptimizer()
   : m_InitialSimplexDelta(1)
 {
   this->m_MaximumNumberOfIterations = 500;
@@ -42,14 +42,14 @@ AmoebaOptimizer ::~AmoebaOptimizer()
 
 
 const std::string
-AmoebaOptimizer ::GetStopConditionDescription() const
+AmoebaOptimizer::GetStopConditionDescription() const
 {
   return this->m_StopConditionDescription.str();
 }
 
 
 void
-AmoebaOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+AmoebaOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "MaximumNumberOfIterations: " << this->m_MaximumNumberOfIterations << std::endl;
@@ -61,7 +61,7 @@ AmoebaOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
 
 
 AmoebaOptimizer::MeasureType
-AmoebaOptimizer ::GetValue() const
+AmoebaOptimizer::GetValue() const
 {
   ParametersType                                               parameters = this->GetCurrentPosition();
   const unsigned int                                           numberOfParameters = parameters.Size();
@@ -92,7 +92,7 @@ AmoebaOptimizer ::GetValue() const
 
 /** Get the Optimizer */
 vnl_amoeba *
-AmoebaOptimizer ::GetOptimizer() const
+AmoebaOptimizer::GetOptimizer() const
 {
   return this->m_VnlOptimizer;
 }
@@ -107,7 +107,7 @@ AmoebaOptimizer::SetInitialSimplexDelta(ParametersType initialSimplexDelta, bool
 
 
 void
-AmoebaOptimizer ::SetCostFunction(SingleValuedCostFunction * costFunction)
+AmoebaOptimizer::SetCostFunction(SingleValuedCostFunction * costFunction)
 {
   // call our ancestors SetCostFunction, we are overriding it - this would
   // be the correct thing to do so that the GetCostFunction() would work
@@ -130,7 +130,7 @@ AmoebaOptimizer ::SetCostFunction(SingleValuedCostFunction * costFunction)
 
 
 void
-AmoebaOptimizer ::StartOptimization()
+AmoebaOptimizer::StartOptimization()
 {
   const ScalesType &                                           scales = GetScales();
   const ParametersType &                                       initialPosition = GetInitialPosition();
@@ -277,7 +277,7 @@ AmoebaOptimizer ::StartOptimization()
 
 
 void
-AmoebaOptimizer ::ValidateSettings()
+AmoebaOptimizer::ValidateSettings()
 {
   // we have to have a cost function
   if (GetCostFunctionAdaptor() == nullptr)

--- a/Modules/Numerics/Optimizers/src/itkConjugateGradientOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkConjugateGradientOptimizer.cxx
@@ -25,7 +25,7 @@ namespace itk
 /**
  * Constructor
  */
-ConjugateGradientOptimizer ::ConjugateGradientOptimizer()
+ConjugateGradientOptimizer::ConjugateGradientOptimizer()
 {
   m_OptimizerInitialized = false;
   m_VnlOptimizer = nullptr;
@@ -43,7 +43,7 @@ ConjugateGradientOptimizer ::~ConjugateGradientOptimizer()
  * Get the Optimizer
  */
 vnl_conjugate_gradient *
-ConjugateGradientOptimizer ::GetOptimizer()
+ConjugateGradientOptimizer::GetOptimizer()
 {
   return m_VnlOptimizer;
 }
@@ -52,7 +52,7 @@ ConjugateGradientOptimizer ::GetOptimizer()
  * Connect a Cost Function
  */
 void
-ConjugateGradientOptimizer ::SetCostFunction(SingleValuedCostFunction * costFunction)
+ConjugateGradientOptimizer::SetCostFunction(SingleValuedCostFunction * costFunction)
 {
   const unsigned int numberOfParameters = costFunction->GetNumberOfParameters();
 
@@ -73,7 +73,7 @@ ConjugateGradientOptimizer ::SetCostFunction(SingleValuedCostFunction * costFunc
 
 /** Return Current Value */
 ConjugateGradientOptimizer::MeasureType
-ConjugateGradientOptimizer ::GetValue() const
+ConjugateGradientOptimizer::GetValue() const
 {
   ParametersType parameters = this->GetCurrentPosition();
 
@@ -92,7 +92,7 @@ ConjugateGradientOptimizer ::GetValue() const
  * Start the optimization
  */
 void
-ConjugateGradientOptimizer ::StartOptimization()
+ConjugateGradientOptimizer::StartOptimization()
 {
   this->InvokeEvent(StartEvent());
 
@@ -145,7 +145,7 @@ ConjugateGradientOptimizer ::StartOptimization()
  * given that an iteration could imply several evaluations.
  */
 SizeValueType
-ConjugateGradientOptimizer ::GetNumberOfIterations() const
+ConjugateGradientOptimizer::GetNumberOfIterations() const
 {
   return m_VnlOptimizer->get_max_function_evals();
 }
@@ -154,7 +154,7 @@ ConjugateGradientOptimizer ::GetNumberOfIterations() const
  * Get the number of iterations in the last optimization.
  */
 SizeValueType
-ConjugateGradientOptimizer ::GetCurrentIteration() const
+ConjugateGradientOptimizer::GetCurrentIteration() const
 {
   return m_VnlOptimizer->get_num_iterations();
 }

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -23,7 +23,7 @@
 
 namespace itk
 {
-CumulativeGaussianCostFunction ::CumulativeGaussianCostFunction()
+CumulativeGaussianCostFunction::CumulativeGaussianCostFunction()
 {
   // Initial values for fit error and range dimension.
   m_RangeDimension = 0;
@@ -38,7 +38,7 @@ CumulativeGaussianCostFunction ::~CumulativeGaussianCostFunction()
 }
 
 void
-CumulativeGaussianCostFunction ::SetOriginalDataArray(MeasureType * setOriginalDataArray)
+CumulativeGaussianCostFunction::SetOriginalDataArray(MeasureType * setOriginalDataArray)
 {
   // Set the original data array.
   m_OriginalDataArray->SetSize(m_RangeDimension);
@@ -50,7 +50,7 @@ CumulativeGaussianCostFunction ::SetOriginalDataArray(MeasureType * setOriginalD
 }
 
 double
-CumulativeGaussianCostFunction ::CalculateFitError(MeasureType * setTestArray)
+CumulativeGaussianCostFunction::CalculateFitError(MeasureType * setTestArray)
 {
   // Use root mean square error as a measure of fit quality.
   unsigned int numberOfElements = m_OriginalDataArray->GetNumberOfElements();
@@ -68,7 +68,7 @@ CumulativeGaussianCostFunction ::CalculateFitError(MeasureType * setTestArray)
 }
 
 double
-CumulativeGaussianCostFunction ::EvaluateCumulativeGaussian(double argument) const
+CumulativeGaussianCostFunction::EvaluateCumulativeGaussian(double argument) const
 {
   // Evaluate the Cumulative Gaussian for a given argument.
   double erfValue;
@@ -151,7 +151,7 @@ CumulativeGaussianCostFunction ::EvaluateCumulativeGaussian(double argument) con
 }
 
 CumulativeGaussianCostFunction::MeasureType
-CumulativeGaussianCostFunction ::GetValue(const ParametersType & parameters) const
+CumulativeGaussianCostFunction::GetValue(const ParametersType & parameters) const
 {
   for (unsigned int i = 0; i < m_RangeDimension; i++)
   {
@@ -165,7 +165,7 @@ CumulativeGaussianCostFunction ::GetValue(const ParametersType & parameters) con
 }
 
 CumulativeGaussianCostFunction::MeasureType *
-CumulativeGaussianCostFunction ::GetValuePointer(ParametersType & parameters)
+CumulativeGaussianCostFunction::GetValuePointer(ParametersType & parameters)
 {
   m_MeasurePointer->SetSize(m_RangeDimension);
 
@@ -182,21 +182,21 @@ CumulativeGaussianCostFunction ::GetValuePointer(ParametersType & parameters)
 }
 
 unsigned int
-CumulativeGaussianCostFunction ::GetNumberOfParameters() const
+CumulativeGaussianCostFunction::GetNumberOfParameters() const
 {
   // Return the number of parameters.
   return SpaceDimension;
 }
 
 unsigned int
-CumulativeGaussianCostFunction ::GetNumberOfValues() const
+CumulativeGaussianCostFunction::GetNumberOfValues() const
 {
   // Return the number of data samples.
   return m_RangeDimension;
 }
 
 void
-CumulativeGaussianCostFunction ::Initialize(unsigned int rangeDimension)
+CumulativeGaussianCostFunction::Initialize(unsigned int rangeDimension)
 {
   // Initialize the arrays.
   m_RangeDimension = rangeDimension;
@@ -204,7 +204,7 @@ CumulativeGaussianCostFunction ::Initialize(unsigned int rangeDimension)
 }
 
 void
-CumulativeGaussianCostFunction ::PrintSelf(std::ostream & os, Indent indent) const
+CumulativeGaussianCostFunction::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Range Dimension = " << m_RangeDimension << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -47,9 +47,9 @@ CumulativeGaussianOptimizer::~CumulativeGaussianOptimizer()
 }
 
 CumulativeGaussianOptimizer::MeasureType *
-CumulativeGaussianOptimizer ::ExtendGaussian(MeasureType * originalArray,
-                                             MeasureType * extendedArray,
-                                             int           startingPointForInsertion)
+CumulativeGaussianOptimizer::ExtendGaussian(MeasureType * originalArray,
+                                            MeasureType * extendedArray,
+                                            int           startingPointForInsertion)
 {
   // Use the parameters from originalArray to construct a Gaussian in
   // extendedArray
@@ -73,7 +73,7 @@ CumulativeGaussianOptimizer ::ExtendGaussian(MeasureType * originalArray,
 }
 
 double
-CumulativeGaussianOptimizer ::FindAverageSumOfSquaredDifferences(MeasureType * array1, MeasureType * array2)
+CumulativeGaussianOptimizer::FindAverageSumOfSquaredDifferences(MeasureType * array1, MeasureType * array2)
 {
   // Given two arrays array1 and array2 of equal length, calculate the average
   // sum of squared
@@ -89,7 +89,7 @@ CumulativeGaussianOptimizer ::FindAverageSumOfSquaredDifferences(MeasureType * a
 }
 
 void
-CumulativeGaussianOptimizer ::FindParametersOfGaussian(MeasureType * sampledGaussianArray)
+CumulativeGaussianOptimizer::FindParametersOfGaussian(MeasureType * sampledGaussianArray)
 {
   // Measure the parameters of the sampled Gaussian curve and use these
   // parameters to
@@ -164,7 +164,7 @@ CumulativeGaussianOptimizer ::FindParametersOfGaussian(MeasureType * sampledGaus
 }
 
 void
-CumulativeGaussianOptimizer ::MeasureGaussianParameters(MeasureType * array)
+CumulativeGaussianOptimizer::MeasureGaussianParameters(MeasureType * array)
 {
   // Assuming the input array is Gaussian, compute the mean, SD, amplitude, and
   // change in intensity.
@@ -201,7 +201,7 @@ CumulativeGaussianOptimizer ::MeasureGaussianParameters(MeasureType * array)
 }
 
 void
-CumulativeGaussianOptimizer ::PrintComputedParameterHeader()
+CumulativeGaussianOptimizer::PrintComputedParameterHeader()
 {
   std::cerr << "Mean\t"
             << "SD\t"
@@ -210,7 +210,7 @@ CumulativeGaussianOptimizer ::PrintComputedParameterHeader()
 }
 
 void
-CumulativeGaussianOptimizer ::PrintComputedParameters() const
+CumulativeGaussianOptimizer::PrintComputedParameters() const
 {
   std::cerr << m_ComputedMean - m_OffsetForMean << "\t" // Printed mean is
                                                         // shifted.
@@ -219,9 +219,9 @@ CumulativeGaussianOptimizer ::PrintComputedParameters() const
 }
 
 CumulativeGaussianOptimizer::MeasureType *
-CumulativeGaussianOptimizer ::RecalculateExtendedArrayFromGaussianParameters(MeasureType * originalArray,
-                                                                             MeasureType * extendedArray,
-                                                                             int startingPointForInsertion) const
+CumulativeGaussianOptimizer::RecalculateExtendedArrayFromGaussianParameters(MeasureType * originalArray,
+                                                                            MeasureType * extendedArray,
+                                                                            int startingPointForInsertion) const
 {
   // From the Gaussian parameters stored with the extendedArray,
   // recalculate the extended portion of the extendedArray,
@@ -242,13 +242,13 @@ CumulativeGaussianOptimizer ::RecalculateExtendedArrayFromGaussianParameters(Mea
 }
 
 void
-CumulativeGaussianOptimizer ::SetDataArray(MeasureType * cumGaussianArray)
+CumulativeGaussianOptimizer::SetDataArray(MeasureType * cumGaussianArray)
 {
   m_CumulativeGaussianArray = cumGaussianArray;
 }
 
 void
-CumulativeGaussianOptimizer ::StartOptimization()
+CumulativeGaussianOptimizer::StartOptimization()
 {
   this->InvokeEvent(StartEvent());
   m_StopConditionDescription.str("");
@@ -341,7 +341,7 @@ CumulativeGaussianOptimizer::PrintArray(MeasureType * array)
 }
 
 double
-CumulativeGaussianOptimizer ::VerticalBestShift(MeasureType * originalArray, MeasureType * newArray)
+CumulativeGaussianOptimizer::VerticalBestShift(MeasureType * originalArray, MeasureType * newArray)
 {
   // Find the constant to minimize the sum of squares of the difference between
   // original Array and newArray+c
@@ -375,13 +375,13 @@ CumulativeGaussianOptimizer ::VerticalBestShift(MeasureType * originalArray, Mea
 }
 
 const std::string
-CumulativeGaussianOptimizer ::GetStopConditionDescription() const
+CumulativeGaussianOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();
 }
 
 void
-CumulativeGaussianOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+CumulativeGaussianOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -22,7 +22,7 @@ namespace itk
 /**
  * Constructor
  */
-ExhaustiveOptimizer ::ExhaustiveOptimizer()
+ExhaustiveOptimizer::ExhaustiveOptimizer()
 {
   itkDebugMacro("Constructor");
 
@@ -48,7 +48,7 @@ ExhaustiveOptimizer::StartOptimization()
 }
 
 void
-ExhaustiveOptimizer ::StartWalking()
+ExhaustiveOptimizer::StartWalking()
 {
   itkDebugMacro("StartWalking");
   this->InvokeEvent(StartEvent());
@@ -101,7 +101,7 @@ ExhaustiveOptimizer ::StartWalking()
  * Resume the optimization
  */
 void
-ExhaustiveOptimizer ::ResumeWalking()
+ExhaustiveOptimizer::ResumeWalking()
 {
   itkDebugMacro("ResumeWalk");
   m_Stop = false;
@@ -146,7 +146,7 @@ ExhaustiveOptimizer ::ResumeWalking()
 }
 
 void
-ExhaustiveOptimizer ::StopWalking()
+ExhaustiveOptimizer::StopWalking()
 {
   itkDebugMacro("StopWalking");
 
@@ -155,7 +155,7 @@ ExhaustiveOptimizer ::StopWalking()
 }
 
 void
-ExhaustiveOptimizer ::AdvanceOneStep()
+ExhaustiveOptimizer::AdvanceOneStep()
 {
   itkDebugMacro("AdvanceOneStep");
 
@@ -170,7 +170,7 @@ ExhaustiveOptimizer ::AdvanceOneStep()
 }
 
 void
-ExhaustiveOptimizer ::IncrementIndex(ParametersType & newPosition)
+ExhaustiveOptimizer::IncrementIndex(ParametersType & newPosition)
 {
   unsigned int       idx = 0;
   const unsigned int spaceDimension = m_CostFunction->GetNumberOfParameters();
@@ -207,13 +207,13 @@ ExhaustiveOptimizer ::IncrementIndex(ParametersType & newPosition)
 }
 
 const std::string
-ExhaustiveOptimizer ::GetStopConditionDescription() const
+ExhaustiveOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();
 }
 
 void
-ExhaustiveOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+ExhaustiveOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -33,7 +33,7 @@ FRPROptimizer ::FRPROptimizer()
 FRPROptimizer ::~FRPROptimizer() = default;
 
 void
-FRPROptimizer ::GetValueAndDerivative(ParametersType & p, double * val, ParametersType * xi)
+FRPROptimizer::GetValueAndDerivative(ParametersType & p, double * val, ParametersType * xi)
 {
   this->m_CostFunction->GetValueAndDerivative(p, *val, *xi);
   if (this->GetMaximize())
@@ -60,7 +60,7 @@ FRPROptimizer ::GetValueAndDerivative(ParametersType & p, double * val, Paramete
 }
 
 void
-FRPROptimizer ::LineOptimize(ParametersType * p, ParametersType & xi, double * val)
+FRPROptimizer::LineOptimize(ParametersType * p, ParametersType & xi, double * val)
 {
   ParametersType tempCoord(this->GetSpaceDimension());
 
@@ -68,7 +68,7 @@ FRPROptimizer ::LineOptimize(ParametersType * p, ParametersType & xi, double * v
 }
 
 void
-FRPROptimizer ::LineOptimize(ParametersType * p, ParametersType & xi, double * val, ParametersType & tempCoord)
+FRPROptimizer::LineOptimize(ParametersType * p, ParametersType & xi, double * val, ParametersType & tempCoord)
 {
   this->SetLine(*p, xi);
 
@@ -93,7 +93,7 @@ FRPROptimizer ::LineOptimize(ParametersType * p, ParametersType & xi, double * v
 }
 
 void
-FRPROptimizer ::StartOptimization()
+FRPROptimizer::StartOptimization()
 {
   unsigned int i;
 
@@ -205,7 +205,7 @@ FRPROptimizer ::StartOptimization()
  *
  */
 void
-FRPROptimizer ::SetToPolakRibiere()
+FRPROptimizer::SetToPolakRibiere()
 {
   m_OptimizationType = OptimizationEnum::PolakRibiere;
 }
@@ -214,7 +214,7 @@ FRPROptimizer ::SetToPolakRibiere()
  *
  */
 void
-FRPROptimizer ::SetToFletchReeves()
+FRPROptimizer::SetToFletchReeves()
 {
   m_OptimizationType = OptimizationEnum::FletchReeves;
 }
@@ -223,7 +223,7 @@ FRPROptimizer ::SetToFletchReeves()
  *
  */
 void
-FRPROptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+FRPROptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Optimization Type = " << m_OptimizationType << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -25,7 +25,7 @@ namespace itk
 /**
  * Constructor
  */
-GradientDescentOptimizer ::GradientDescentOptimizer()
+GradientDescentOptimizer::GradientDescentOptimizer()
 
 {
   itkDebugMacro("Constructor");
@@ -34,13 +34,13 @@ GradientDescentOptimizer ::GradientDescentOptimizer()
 }
 
 const std::string
-GradientDescentOptimizer ::GetStopConditionDescription() const
+GradientDescentOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();
 }
 
 void
-GradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+GradientDescentOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -63,7 +63,7 @@ GradientDescentOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
  * Start the optimization
  */
 void
-GradientDescentOptimizer ::StartOptimization()
+GradientDescentOptimizer::StartOptimization()
 {
   itkDebugMacro("StartOptimization");
 
@@ -77,7 +77,7 @@ GradientDescentOptimizer ::StartOptimization()
  * Resume the optimization
  */
 void
-GradientDescentOptimizer ::ResumeOptimization()
+GradientDescentOptimizer::ResumeOptimization()
 {
   itkDebugMacro("ResumeOptimization");
 
@@ -128,7 +128,7 @@ GradientDescentOptimizer ::ResumeOptimization()
  * Stop optimization
  */
 void
-GradientDescentOptimizer ::StopOptimization()
+GradientDescentOptimizer::StopOptimization()
 {
   itkDebugMacro("StopOptimization");
 
@@ -140,7 +140,7 @@ GradientDescentOptimizer ::StopOptimization()
  * Advance one Step following the gradient direction
  */
 void
-GradientDescentOptimizer ::AdvanceOneStep()
+GradientDescentOptimizer::AdvanceOneStep()
 {
   itkDebugMacro("AdvanceOneStep");
 

--- a/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
@@ -20,7 +20,7 @@
 namespace itk
 {
 
-InitializationBiasedParticleSwarmOptimizer ::InitializationBiasedParticleSwarmOptimizer()
+InitializationBiasedParticleSwarmOptimizer::InitializationBiasedParticleSwarmOptimizer()
 {
   // magic numbers from Wachowiak et al. "An approach to multimodal biomedical
   // image registration utilizing particle swarm optimization"
@@ -32,7 +32,7 @@ InitializationBiasedParticleSwarmOptimizer ::InitializationBiasedParticleSwarmOp
 
 
 void
-InitializationBiasedParticleSwarmOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+InitializationBiasedParticleSwarmOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << "Acceleration coefficients [inertia, personal, global, initialization]: ";
@@ -42,7 +42,7 @@ InitializationBiasedParticleSwarmOptimizer ::PrintSelf(std::ostream & os, Indent
 
 
 void
-InitializationBiasedParticleSwarmOptimizer ::UpdateSwarm()
+InitializationBiasedParticleSwarmOptimizer::UpdateSwarm()
 {
   unsigned int                                                    j, k, n;
   itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -72,7 +72,7 @@ LBFGSBOptimizer ::~LBFGSBOptimizer()
  * PrintSelf
  */
 void
-LBFGSBOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+LBFGSBOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Trace: ";
@@ -116,7 +116,7 @@ LBFGSBOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
  * Set the optimizer trace flag
  */
 void
-LBFGSBOptimizer ::SetTrace(bool flag)
+LBFGSBOptimizer::SetTrace(bool flag)
 {
   if (flag == m_Trace)
   {
@@ -136,7 +136,7 @@ LBFGSBOptimizer ::SetTrace(bool flag)
  * Set lower bound
  */
 void
-LBFGSBOptimizer ::SetLowerBound(const BoundValueType & value)
+LBFGSBOptimizer::SetLowerBound(const BoundValueType & value)
 {
   this->m_LowerBound = value;
   if (m_OptimizerInitialized)
@@ -150,7 +150,7 @@ LBFGSBOptimizer ::SetLowerBound(const BoundValueType & value)
  * Set upper bound
  */
 void
-LBFGSBOptimizer ::SetUpperBound(const BoundValueType & value)
+LBFGSBOptimizer::SetUpperBound(const BoundValueType & value)
 {
   this->m_UpperBound = value;
   if (m_OptimizerInitialized)
@@ -164,7 +164,7 @@ LBFGSBOptimizer ::SetUpperBound(const BoundValueType & value)
  * Return Current Value
  */
 LBFGSBOptimizer::MeasureType
-LBFGSBOptimizer ::GetValue() const
+LBFGSBOptimizer::GetValue() const
 {
   return this->GetCachedValue();
 }
@@ -173,7 +173,7 @@ LBFGSBOptimizer ::GetValue() const
  * Set bound selection array
  */
 void
-LBFGSBOptimizer ::SetBoundSelection(const BoundSelectionType & value)
+LBFGSBOptimizer::SetBoundSelection(const BoundSelectionType & value)
 {
   m_BoundSelection = value;
   if (m_OptimizerInitialized)
@@ -190,7 +190,7 @@ LBFGSBOptimizer ::SetBoundSelection(const BoundSelectionType & value)
  * 1e+7 for moderate accuracy and 1e+1 for extremely high accuracy.
  */
 void
-LBFGSBOptimizer ::SetCostFunctionConvergenceFactor(double value)
+LBFGSBOptimizer::SetCostFunctionConvergenceFactor(double value)
 {
   if (value < 0.0)
   {
@@ -210,7 +210,7 @@ LBFGSBOptimizer ::SetCostFunctionConvergenceFactor(double value)
  * is 1e-5.
  */
 void
-LBFGSBOptimizer ::SetProjectedGradientTolerance(double value)
+LBFGSBOptimizer::SetProjectedGradientTolerance(double value)
 {
   m_ProjectedGradientTolerance = value;
   if (m_OptimizerInitialized)
@@ -222,7 +222,7 @@ LBFGSBOptimizer ::SetProjectedGradientTolerance(double value)
 
 /** Set/Get the MaximumNumberOfIterations. Default is 500 */
 void
-LBFGSBOptimizer ::SetMaximumNumberOfIterations(unsigned int value)
+LBFGSBOptimizer::SetMaximumNumberOfIterations(unsigned int value)
 {
   m_MaximumNumberOfIterations = value;
   this->Modified();
@@ -230,7 +230,7 @@ LBFGSBOptimizer ::SetMaximumNumberOfIterations(unsigned int value)
 
 /** Set/Get the MaximumNumberOfEvaluations. Default is 500 */
 void
-LBFGSBOptimizer ::SetMaximumNumberOfEvaluations(unsigned int value)
+LBFGSBOptimizer::SetMaximumNumberOfEvaluations(unsigned int value)
 {
   m_MaximumNumberOfEvaluations = value;
   if (m_OptimizerInitialized)
@@ -242,7 +242,7 @@ LBFGSBOptimizer ::SetMaximumNumberOfEvaluations(unsigned int value)
 
 /** Set/Get the MaximumNumberOfCorrections. Default is 5 */
 void
-LBFGSBOptimizer ::SetMaximumNumberOfCorrections(unsigned int value)
+LBFGSBOptimizer::SetMaximumNumberOfCorrections(unsigned int value)
 {
   m_MaximumNumberOfCorrections = value;
   if (m_OptimizerInitialized)
@@ -293,7 +293,7 @@ LBFGSBOptimizer::SetCostFunction(SingleValuedCostFunction * costFunction)
  * Start the optimization
  */
 void
-LBFGSBOptimizer ::StartOptimization()
+LBFGSBOptimizer::StartOptimization()
 {
   // Check if all the bounds parameters are the same size as the initial
   // parameters.

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -49,7 +49,7 @@ LBFGSOptimizer ::~LBFGSOptimizer()
  * PrintSelf
  */
 void
-LBFGSOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+LBFGSOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Trace: ";
@@ -72,7 +72,7 @@ LBFGSOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
  * Set the optimizer trace flag
  */
 void
-LBFGSOptimizer ::SetTrace(bool flag)
+LBFGSOptimizer::SetTrace(bool flag)
 {
   if (flag == m_Trace)
   {
@@ -92,7 +92,7 @@ LBFGSOptimizer ::SetTrace(bool flag)
  * Set the maximum number of function evaluations
  */
 void
-LBFGSOptimizer ::SetMaximumNumberOfFunctionEvaluations(unsigned int n)
+LBFGSOptimizer::SetMaximumNumberOfFunctionEvaluations(unsigned int n)
 {
   if (n == m_MaximumNumberOfFunctionEvaluations)
   {
@@ -112,7 +112,7 @@ LBFGSOptimizer ::SetMaximumNumberOfFunctionEvaluations(unsigned int n)
  * Set the gradient convergence tolerance
  */
 void
-LBFGSOptimizer ::SetGradientConvergenceTolerance(double f)
+LBFGSOptimizer::SetGradientConvergenceTolerance(double f)
 {
   if (Math::ExactlyEquals(f, m_GradientConvergenceTolerance))
   {
@@ -132,7 +132,7 @@ LBFGSOptimizer ::SetGradientConvergenceTolerance(double f)
  * Set the line search accuracy
  */
 void
-LBFGSOptimizer ::SetLineSearchAccuracy(double f)
+LBFGSOptimizer::SetLineSearchAccuracy(double f)
 {
   if (Math::ExactlyEquals(f, m_LineSearchAccuracy))
   {
@@ -152,7 +152,7 @@ LBFGSOptimizer ::SetLineSearchAccuracy(double f)
  * Set the default step length
  */
 void
-LBFGSOptimizer ::SetDefaultStepLength(double f)
+LBFGSOptimizer::SetDefaultStepLength(double f)
 {
   if (Math::ExactlyEquals(f, m_DefaultStepLength))
   {
@@ -170,7 +170,7 @@ LBFGSOptimizer ::SetDefaultStepLength(double f)
 
 /** Return Current Value */
 LBFGSOptimizer::MeasureType
-LBFGSOptimizer ::GetValue() const
+LBFGSOptimizer::GetValue() const
 {
   return this->GetCachedValue();
 }
@@ -179,7 +179,7 @@ LBFGSOptimizer ::GetValue() const
  * Connect a Cost Function
  */
 void
-LBFGSOptimizer ::SetCostFunction(SingleValuedCostFunction * costFunction)
+LBFGSOptimizer::SetCostFunction(SingleValuedCostFunction * costFunction)
 {
   const unsigned int numberOfParameters = costFunction->GetNumberOfParameters();
 
@@ -212,7 +212,7 @@ LBFGSOptimizer ::SetCostFunction(SingleValuedCostFunction * costFunction)
  * Start the optimization
  */
 void
-LBFGSOptimizer ::StartOptimization()
+LBFGSOptimizer::StartOptimization()
 {
   this->InvokeEvent(StartEvent());
 
@@ -265,7 +265,7 @@ LBFGSOptimizer ::StartOptimization()
  * Get the Optimizer
  */
 vnl_lbfgs *
-LBFGSOptimizer ::GetOptimizer()
+LBFGSOptimizer::GetOptimizer()
 {
   return m_VnlOptimizer;
 }

--- a/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
@@ -25,7 +25,7 @@ namespace itk
 /**
  * Constructor
  */
-LevenbergMarquardtOptimizer ::LevenbergMarquardtOptimizer()
+LevenbergMarquardtOptimizer::LevenbergMarquardtOptimizer()
 {
   m_OptimizerInitialized = false;
   m_VnlOptimizer = nullptr;
@@ -47,7 +47,7 @@ LevenbergMarquardtOptimizer ::~LevenbergMarquardtOptimizer()
  * Connect a Cost Function
  */
 void
-LevenbergMarquardtOptimizer ::SetCostFunction(MultipleValuedCostFunction * costFunction)
+LevenbergMarquardtOptimizer::SetCostFunction(MultipleValuedCostFunction * costFunction)
 {
   const unsigned int numberOfParameters = costFunction->GetNumberOfParameters();
   const unsigned int numberOfValues = costFunction->GetNumberOfValues();
@@ -75,7 +75,7 @@ LevenbergMarquardtOptimizer ::SetCostFunction(MultipleValuedCostFunction * costF
 
 /** Return Current Value */
 LevenbergMarquardtOptimizer::MeasureType
-LevenbergMarquardtOptimizer ::GetValue() const
+LevenbergMarquardtOptimizer::GetValue() const
 {
   MeasureType measures;
 
@@ -107,7 +107,7 @@ LevenbergMarquardtOptimizer ::GetValue() const
  * Start the optimization
  */
 void
-LevenbergMarquardtOptimizer ::StartOptimization()
+LevenbergMarquardtOptimizer::StartOptimization()
 {
   this->InvokeEvent(StartEvent());
 
@@ -155,7 +155,7 @@ LevenbergMarquardtOptimizer ::StartOptimization()
 
 /** Set the maximum number of iterations */
 void
-LevenbergMarquardtOptimizer ::SetNumberOfIterations(unsigned int iterations)
+LevenbergMarquardtOptimizer::SetNumberOfIterations(unsigned int iterations)
 {
   if (m_VnlOptimizer)
   {
@@ -167,7 +167,7 @@ LevenbergMarquardtOptimizer ::SetNumberOfIterations(unsigned int iterations)
 
 /** Set the maximum number of iterations */
 void
-LevenbergMarquardtOptimizer ::SetValueTolerance(double tol)
+LevenbergMarquardtOptimizer::SetValueTolerance(double tol)
 {
   if (m_VnlOptimizer)
   {
@@ -179,7 +179,7 @@ LevenbergMarquardtOptimizer ::SetValueTolerance(double tol)
 
 /** Set Gradient Tolerance */
 void
-LevenbergMarquardtOptimizer ::SetGradientTolerance(double tol)
+LevenbergMarquardtOptimizer::SetGradientTolerance(double tol)
 {
   if (m_VnlOptimizer)
   {
@@ -191,7 +191,7 @@ LevenbergMarquardtOptimizer ::SetGradientTolerance(double tol)
 
 /** Set Epsilon function */
 void
-LevenbergMarquardtOptimizer ::SetEpsilonFunction(double epsilon)
+LevenbergMarquardtOptimizer::SetEpsilonFunction(double epsilon)
 {
   if (m_VnlOptimizer)
   {
@@ -203,13 +203,13 @@ LevenbergMarquardtOptimizer ::SetEpsilonFunction(double epsilon)
 
 /** Get the Optimizer */
 vnl_levenberg_marquardt *
-LevenbergMarquardtOptimizer ::GetOptimizer() const
+LevenbergMarquardtOptimizer::GetOptimizer() const
 {
   return m_VnlOptimizer;
 }
 
 const std::string
-LevenbergMarquardtOptimizer ::GetStopConditionDescription() const
+LevenbergMarquardtOptimizer::GetStopConditionDescription() const
 {
   std::ostringstream reason, outcome;
 

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearOptimizer.cxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-MultipleValuedNonLinearOptimizer ::MultipleValuedNonLinearOptimizer()
+MultipleValuedNonLinearOptimizer::MultipleValuedNonLinearOptimizer()
 {
   m_CostFunction = nullptr;
 }
@@ -31,7 +31,7 @@ MultipleValuedNonLinearOptimizer ::MultipleValuedNonLinearOptimizer()
  * Connect a Cost Function
  */
 void
-MultipleValuedNonLinearOptimizer ::SetCostFunction(CostFunctionType * costFunction)
+MultipleValuedNonLinearOptimizer::SetCostFunction(CostFunctionType * costFunction)
 {
   if (m_CostFunction == costFunction)
   {
@@ -56,7 +56,7 @@ MultipleValuedNonLinearOptimizer ::SetCostFunction(CostFunctionType * costFuncti
 }
 
 void
-MultipleValuedNonLinearOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+MultipleValuedNonLinearOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   if (m_CostFunction)

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
@@ -25,7 +25,7 @@ namespace itk
 /**
  * Constructor
  */
-MultipleValuedNonLinearVnlOptimizer ::MultipleValuedNonLinearVnlOptimizer()
+MultipleValuedNonLinearVnlOptimizer::MultipleValuedNonLinearVnlOptimizer()
 {
   m_CostFunctionAdaptor = nullptr;
   m_UseGradient = true;
@@ -46,7 +46,7 @@ MultipleValuedNonLinearVnlOptimizer ::~MultipleValuedNonLinearVnlOptimizer()
 }
 
 void
-MultipleValuedNonLinearVnlOptimizer ::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
+MultipleValuedNonLinearVnlOptimizer::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
 {
   if (m_CostFunctionAdaptor == adaptor)
   {
@@ -63,13 +63,13 @@ MultipleValuedNonLinearVnlOptimizer ::SetCostFunctionAdaptor(CostFunctionAdaptor
 }
 
 const MultipleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
-MultipleValuedNonLinearVnlOptimizer ::GetCostFunctionAdaptor() const
+MultipleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor() const
 {
   return m_CostFunctionAdaptor;
 }
 
 MultipleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
-MultipleValuedNonLinearVnlOptimizer ::GetCostFunctionAdaptor()
+MultipleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor()
 {
   return m_CostFunctionAdaptor;
 }
@@ -77,13 +77,13 @@ MultipleValuedNonLinearVnlOptimizer ::GetCostFunctionAdaptor()
 /** The purpose of this method is to get around the lack of const
  * correctness in vnl cost_functions and optimizers */
 MultipleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
-MultipleValuedNonLinearVnlOptimizer ::GetNonConstCostFunctionAdaptor() const
+MultipleValuedNonLinearVnlOptimizer::GetNonConstCostFunctionAdaptor() const
 {
   return m_CostFunctionAdaptor;
 }
 
 void
-MultipleValuedNonLinearVnlOptimizer ::SetUseCostFunctionGradient(bool useGradient)
+MultipleValuedNonLinearVnlOptimizer::SetUseCostFunctionGradient(bool useGradient)
 {
   if (m_CostFunctionAdaptor)
   {
@@ -96,7 +96,7 @@ MultipleValuedNonLinearVnlOptimizer ::SetUseCostFunctionGradient(bool useGradien
 }
 
 bool
-MultipleValuedNonLinearVnlOptimizer ::GetUseCostFunctionGradient() const
+MultipleValuedNonLinearVnlOptimizer::GetUseCostFunctionGradient() const
 {
   if (m_CostFunctionAdaptor)
   {
@@ -115,7 +115,7 @@ MultipleValuedNonLinearVnlOptimizer ::GetUseCostFunctionGradient() const
  * vnl optimizer. Optimizers that evaluate the metric multiple times at each
  * iteration will generate a lot more of Iteration events here. */
 void
-MultipleValuedNonLinearVnlOptimizer ::IterationReport(const EventObject & event)
+MultipleValuedNonLinearVnlOptimizer::IterationReport(const EventObject & event)
 {
   const CostFunctionAdaptorType * adaptor = this->GetCostFunctionAdaptor();
 
@@ -129,7 +129,7 @@ MultipleValuedNonLinearVnlOptimizer ::IterationReport(const EventObject & event)
  * PrintSelf
  */
 void
-MultipleValuedNonLinearVnlOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+MultipleValuedNonLinearVnlOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Cached Value: " << m_CachedValue << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
@@ -20,8 +20,8 @@
 namespace itk
 {
 /**  Constructor.  */
-MultipleValuedVnlCostFunctionAdaptor ::MultipleValuedVnlCostFunctionAdaptor(unsigned int spaceDimension,
-                                                                            unsigned int numberOfValues)
+MultipleValuedVnlCostFunctionAdaptor::MultipleValuedVnlCostFunctionAdaptor(unsigned int spaceDimension,
+                                                                           unsigned int numberOfValues)
   : vnl_least_squares_function(spaceDimension, numberOfValues)
 {
   this->m_ScalesInitialized = false;
@@ -30,7 +30,7 @@ MultipleValuedVnlCostFunctionAdaptor ::MultipleValuedVnlCostFunctionAdaptor(unsi
 
 /** Set current parameters scaling. */
 void
-MultipleValuedVnlCostFunctionAdaptor ::SetScales(const ScalesType & scales)
+MultipleValuedVnlCostFunctionAdaptor::SetScales(const ScalesType & scales)
 {
   // Only the inverse is used computes the inverse at each iteration.
   // provides 1 commone place where the inverse can be computes
@@ -156,8 +156,8 @@ MultipleValuedVnlCostFunctionAdaptor ::compute(const InternalParametersType & x,
 
 /**  Convert external derivative measures into internal type  */
 void
-MultipleValuedVnlCostFunctionAdaptor ::ConvertExternalToInternalGradient(const DerivativeType &   input,
-                                                                         InternalDerivativeType & output)
+MultipleValuedVnlCostFunctionAdaptor::ConvertExternalToInternalGradient(const DerivativeType &   input,
+                                                                        InternalDerivativeType & output)
 {
   const unsigned int rows = input.rows();
   const unsigned int cols = input.cols();
@@ -179,8 +179,8 @@ MultipleValuedVnlCostFunctionAdaptor ::ConvertExternalToInternalGradient(const D
 
 /**  Convert external Measures into internal type  */
 void
-MultipleValuedVnlCostFunctionAdaptor ::ConvertExternalToInternalMeasures(const MeasureType &   input,
-                                                                         InternalMeasureType & output)
+MultipleValuedVnlCostFunctionAdaptor::ConvertExternalToInternalMeasures(const MeasureType &   input,
+                                                                        InternalMeasureType & output)
 {
   const unsigned int size = input.size();
 
@@ -192,7 +192,7 @@ MultipleValuedVnlCostFunctionAdaptor ::ConvertExternalToInternalMeasures(const M
 
 /**  Define if the cost function will provide a Gradient computation */
 void
-MultipleValuedVnlCostFunctionAdaptor ::SetUseGradient(bool useGradient)
+MultipleValuedVnlCostFunctionAdaptor::SetUseGradient(bool useGradient)
 {
   // delegate the task to the base class
   this->vnl_least_squares_function::use_gradient_ = useGradient;
@@ -200,7 +200,7 @@ MultipleValuedVnlCostFunctionAdaptor ::SetUseGradient(bool useGradient)
 
 /**  Return true if the cost function will provide a Gradient computation */
 bool
-MultipleValuedVnlCostFunctionAdaptor ::GetUseGradient() const
+MultipleValuedVnlCostFunctionAdaptor::GetUseGradient() const
 {
   // delegate the task to the base class
   return this->vnl_least_squares_function::has_gradient();
@@ -209,7 +209,7 @@ MultipleValuedVnlCostFunctionAdaptor ::GetUseGradient() const
 /**  This method reports iterations events. It is intended to
  *   help monitoring the progress of the optimization process. */
 void
-MultipleValuedVnlCostFunctionAdaptor ::ReportIteration(const EventObject & event) const
+MultipleValuedVnlCostFunctionAdaptor::ReportIteration(const EventObject & event) const
 {
   this->m_Reporter->InvokeEvent(event);
 }
@@ -217,21 +217,21 @@ MultipleValuedVnlCostFunctionAdaptor ::ReportIteration(const EventObject & event
 /**  Connects a Command/Observer to the internal reporter class.
  *   This is useful for reporting iteration event to potential observers. */
 unsigned long
-MultipleValuedVnlCostFunctionAdaptor ::AddObserver(const EventObject & event, Command * command) const
+MultipleValuedVnlCostFunctionAdaptor::AddObserver(const EventObject & event, Command * command) const
 {
   return this->m_Reporter->AddObserver(event, command);
 }
 
 /**  Return the cached value of the cost function */
 const MultipleValuedVnlCostFunctionAdaptor::MeasureType &
-MultipleValuedVnlCostFunctionAdaptor ::GetCachedValue() const
+MultipleValuedVnlCostFunctionAdaptor::GetCachedValue() const
 {
   return m_CachedValue;
 }
 
 /**  Return the cached value of the cost function derivative */
 const MultipleValuedVnlCostFunctionAdaptor::DerivativeType &
-MultipleValuedVnlCostFunctionAdaptor ::GetCachedDerivative() const
+MultipleValuedVnlCostFunctionAdaptor::GetCachedDerivative() const
 {
   return m_CachedDerivative;
 }
@@ -239,7 +239,7 @@ MultipleValuedVnlCostFunctionAdaptor ::GetCachedDerivative() const
 /**  Return the cached value of the parameters used for computing the function
  */
 const MultipleValuedVnlCostFunctionAdaptor::ParametersType &
-MultipleValuedVnlCostFunctionAdaptor ::GetCachedCurrentParameters() const
+MultipleValuedVnlCostFunctionAdaptor::GetCachedCurrentParameters() const
 {
   return m_CachedCurrentParameters;
 }

--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -23,7 +23,7 @@
 #include "itkMath.h"
 namespace itk
 {
-OnePlusOneEvolutionaryOptimizer ::OnePlusOneEvolutionaryOptimizer()
+OnePlusOneEvolutionaryOptimizer::OnePlusOneEvolutionaryOptimizer()
 {
   m_CatchGetValueException = false;
   m_MetricWorstPossibleValue = 0;
@@ -45,7 +45,7 @@ OnePlusOneEvolutionaryOptimizer ::OnePlusOneEvolutionaryOptimizer()
 }
 
 void
-OnePlusOneEvolutionaryOptimizer ::SetNormalVariateGenerator(NormalVariateGeneratorType * generator)
+OnePlusOneEvolutionaryOptimizer::SetNormalVariateGenerator(NormalVariateGeneratorType * generator)
 {
   if (m_RandomGenerator != generator)
   {
@@ -55,7 +55,7 @@ OnePlusOneEvolutionaryOptimizer ::SetNormalVariateGenerator(NormalVariateGenerat
 }
 
 void
-OnePlusOneEvolutionaryOptimizer ::Initialize(double initialRadius, double grow, double shrink)
+OnePlusOneEvolutionaryOptimizer::Initialize(double initialRadius, double grow, double shrink)
 {
   m_InitialRadius = initialRadius;
 
@@ -78,7 +78,7 @@ OnePlusOneEvolutionaryOptimizer ::Initialize(double initialRadius, double grow, 
 }
 
 void
-OnePlusOneEvolutionaryOptimizer ::StartOptimization()
+OnePlusOneEvolutionaryOptimizer::StartOptimization()
 {
   if (m_CostFunction.IsNull())
   {
@@ -287,7 +287,7 @@ OnePlusOneEvolutionaryOptimizer ::StartOptimization()
  */
 
 const std::string
-OnePlusOneEvolutionaryOptimizer ::GetStopConditionDescription() const
+OnePlusOneEvolutionaryOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();
 }
@@ -296,7 +296,7 @@ OnePlusOneEvolutionaryOptimizer ::GetStopConditionDescription() const
  *
  */
 void
-OnePlusOneEvolutionaryOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+OnePlusOneEvolutionaryOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
@@ -26,13 +26,13 @@ namespace itk
  * Constructor
  */
 
-Optimizer ::Optimizer() = default;
+Optimizer::Optimizer() = default;
 
 /**
  * Set scaling as an array of factors
  */
 void
-Optimizer ::SetScales(const ScalesType & scales)
+Optimizer::SetScales(const ScalesType & scales)
 {
   itkDebugMacro("setting scales to " << scales);
   m_Scales = scales;
@@ -57,7 +57,7 @@ Optimizer ::SetScales(const ScalesType & scales)
  * Set the initial position
  */
 void
-Optimizer ::SetInitialPosition(const ParametersType & param)
+Optimizer::SetInitialPosition(const ParametersType & param)
 {
   m_InitialPosition = param;
   this->Modified();
@@ -67,14 +67,14 @@ Optimizer ::SetInitialPosition(const ParametersType & param)
  * Set the current position
  */
 void
-Optimizer ::SetCurrentPosition(const ParametersType & param)
+Optimizer::SetCurrentPosition(const ParametersType & param)
 {
   m_CurrentPosition = param;
   this->Modified();
 }
 
 const std::string
-Optimizer ::GetStopConditionDescription() const
+Optimizer::GetStopConditionDescription() const
 {
   std::ostringstream description;
 
@@ -87,7 +87,7 @@ Optimizer ::GetStopConditionDescription() const
  * Print Self method
  */
 void
-Optimizer ::PrintSelf(std::ostream & os, Indent indent) const
+Optimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
@@ -21,7 +21,7 @@ namespace itk
 {
 
 
-ParticleSwarmOptimizer ::ParticleSwarmOptimizer()
+ParticleSwarmOptimizer::ParticleSwarmOptimizer()
 {
   // magic numbers based on the analysis described in M. Clerc, J. Kennedy,
   //"The particle swarm - explosion, stability, and convergence in a
@@ -35,7 +35,7 @@ ParticleSwarmOptimizer ::ParticleSwarmOptimizer()
 ParticleSwarmOptimizer ::~ParticleSwarmOptimizer() = default;
 
 void
-ParticleSwarmOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+ParticleSwarmOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << "Acceleration coefficients [inertia, personal, global]: ";
@@ -44,7 +44,7 @@ ParticleSwarmOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 void
-ParticleSwarmOptimizer ::UpdateSwarm()
+ParticleSwarmOptimizer::UpdateSwarm()
 {
   unsigned int                                                    j, k, n;
   itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -22,7 +22,7 @@ namespace itk
 {
 
 
-ParticleSwarmOptimizerBase ::ParticleSwarmOptimizerBase()
+ParticleSwarmOptimizerBase::ParticleSwarmOptimizerBase()
 
 {
   this->m_PrintSwarm = false;
@@ -41,7 +41,7 @@ ParticleSwarmOptimizerBase ::~ParticleSwarmOptimizerBase() = default;
 
 
 void
-ParticleSwarmOptimizerBase ::SetNumberOfParticles(unsigned int n)
+ParticleSwarmOptimizerBase::SetNumberOfParticles(unsigned int n)
 {
   if (!this->m_Particles.empty() && n != this->m_Particles.size())
   {
@@ -56,7 +56,7 @@ ParticleSwarmOptimizerBase ::SetNumberOfParticles(unsigned int n)
 
 
 void
-ParticleSwarmOptimizerBase ::SetInitialSwarm(const SwarmType & initialSwarm)
+ParticleSwarmOptimizerBase::SetInitialSwarm(const SwarmType & initialSwarm)
 {
   // Always clear the m_Particles.
   this->m_Particles.clear();
@@ -81,7 +81,7 @@ ParticleSwarmOptimizerBase ::SetInitialSwarm(const SwarmType & initialSwarm)
 
 
 void
-ParticleSwarmOptimizerBase ::ClearSwarm()
+ParticleSwarmOptimizerBase::ClearSwarm()
 {
   if (!this->m_Particles.empty())
   {
@@ -92,7 +92,7 @@ ParticleSwarmOptimizerBase ::ClearSwarm()
 
 
 void
-ParticleSwarmOptimizerBase ::SetParameterBounds(ParameterBoundsType & bounds)
+ParticleSwarmOptimizerBase::SetParameterBounds(ParameterBoundsType & bounds)
 {
   this->m_ParameterBounds.clear();
   this->m_ParameterBounds.insert(m_ParameterBounds.begin(), bounds.begin(), bounds.end());
@@ -101,9 +101,8 @@ ParticleSwarmOptimizerBase ::SetParameterBounds(ParameterBoundsType & bounds)
 
 
 void
-ParticleSwarmOptimizerBase ::SetParameterBounds(
-  std::pair<ParametersType::ValueType, ParametersType::ValueType> & bounds,
-  unsigned int                                                      n)
+ParticleSwarmOptimizerBase::SetParameterBounds(std::pair<ParametersType::ValueType, ParametersType::ValueType> & bounds,
+                                               unsigned int                                                      n)
 {
   this->m_ParameterBounds.clear();
   this->m_ParameterBounds.insert(m_ParameterBounds.begin(), n, bounds);
@@ -112,15 +111,15 @@ ParticleSwarmOptimizerBase ::SetParameterBounds(
 
 
 ParticleSwarmOptimizerBase::ParameterBoundsType
-ParticleSwarmOptimizerBase ::GetParameterBounds() const
+ParticleSwarmOptimizerBase::GetParameterBounds() const
 {
   return this->m_ParameterBounds;
 }
 
 
 void
-ParticleSwarmOptimizerBase ::SetParametersConvergenceTolerance(ParametersType::ValueType convergenceTolerance,
-                                                               unsigned int              sz)
+ParticleSwarmOptimizerBase::SetParametersConvergenceTolerance(ParametersType::ValueType convergenceTolerance,
+                                                              unsigned int              sz)
 {
   this->m_ParametersConvergenceTolerance.SetSize(sz);
   this->m_ParametersConvergenceTolerance.Fill(convergenceTolerance);
@@ -128,21 +127,21 @@ ParticleSwarmOptimizerBase ::SetParametersConvergenceTolerance(ParametersType::V
 
 
 ParticleSwarmOptimizerBase::CostFunctionType::MeasureType
-ParticleSwarmOptimizerBase ::GetValue() const
+ParticleSwarmOptimizerBase::GetValue() const
 {
   return this->m_FunctionBestValue;
 }
 
 
 const std::string
-ParticleSwarmOptimizerBase ::GetStopConditionDescription() const
+ParticleSwarmOptimizerBase::GetStopConditionDescription() const
 {
   return this->m_StopConditionDescription.str();
 }
 
 
 void
-ParticleSwarmOptimizerBase ::PrintSelf(std::ostream & os, Indent indent) const
+ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
 {
 
   Superclass::PrintSelf(os, indent);
@@ -177,7 +176,7 @@ ParticleSwarmOptimizerBase ::PrintSelf(std::ostream & os, Indent indent) const
 
 
 void
-ParticleSwarmOptimizerBase ::PrintSwarm(std::ostream & os, Indent indent) const
+ParticleSwarmOptimizerBase::PrintSwarm(std::ostream & os, Indent indent) const
 {
   std::vector<ParticleData>::const_iterator it, end;
   end = this->m_Particles.end();
@@ -198,7 +197,7 @@ ParticleSwarmOptimizerBase ::PrintSwarm(std::ostream & os, Indent indent) const
 
 
 void
-ParticleSwarmOptimizerBase ::PrintParamtersType(const ParametersType & x, std::ostream & os) const
+ParticleSwarmOptimizerBase::PrintParamtersType(const ParametersType & x, std::ostream & os) const
 {
   unsigned int sz = x.size();
   for (unsigned int i = 0; i < sz; i++)
@@ -209,7 +208,7 @@ ParticleSwarmOptimizerBase ::PrintParamtersType(const ParametersType & x, std::o
 
 
 void
-ParticleSwarmOptimizerBase ::StartOptimization()
+ParticleSwarmOptimizerBase::StartOptimization()
 {
   unsigned int j, k, n, index, prevIndex;
   bool         converged = false;
@@ -289,7 +288,7 @@ ParticleSwarmOptimizerBase ::StartOptimization()
 
 
 void
-ParticleSwarmOptimizerBase ::ValidateSettings()
+ParticleSwarmOptimizerBase::ValidateSettings()
 {
   unsigned int i, n;
 
@@ -375,7 +374,7 @@ ParticleSwarmOptimizerBase ::ValidateSettings()
 }
 
 void
-ParticleSwarmOptimizerBase ::Initialize()
+ParticleSwarmOptimizerBase::Initialize()
 {
   itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =
     Statistics::MersenneTwisterRandomVariateGenerator::GetInstance();
@@ -415,7 +414,7 @@ ParticleSwarmOptimizerBase ::Initialize()
 
 
 void
-ParticleSwarmOptimizerBase ::RandomInitialization()
+ParticleSwarmOptimizerBase::RandomInitialization()
 {
   unsigned int i, j, n;
   n = GetInitialPosition().Size();

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -24,7 +24,7 @@
 
 namespace itk
 {
-PowellOptimizer ::PowellOptimizer()
+PowellOptimizer::PowellOptimizer()
 {
   m_CatchGetValueException = false;
   m_MetricWorstPossibleValue = 0;
@@ -52,7 +52,7 @@ PowellOptimizer ::PowellOptimizer()
 PowellOptimizer ::~PowellOptimizer() = default;
 
 void
-PowellOptimizer ::SetLine(const PowellOptimizer::ParametersType & origin, const vnl_vector<double> & direction)
+PowellOptimizer::SetLine(const PowellOptimizer::ParametersType & origin, const vnl_vector<double> & direction)
 {
   const Optimizer::ScalesType & inv_scales = this->GetInverseScales();
   for (unsigned int i = 0; i < m_SpaceDimension; ++i)
@@ -63,7 +63,7 @@ PowellOptimizer ::SetLine(const PowellOptimizer::ParametersType & origin, const 
 }
 
 double
-PowellOptimizer ::GetLineValue(double x) const
+PowellOptimizer::GetLineValue(double x) const
 {
   PowellOptimizer::ParametersType tempCoord(m_SpaceDimension);
 
@@ -71,7 +71,7 @@ PowellOptimizer ::GetLineValue(double x) const
 }
 
 double
-PowellOptimizer ::GetLineValue(double x, ParametersType & tempCoord) const
+PowellOptimizer::GetLineValue(double x, ParametersType & tempCoord) const
 {
   for (unsigned int i = 0; i < m_SpaceDimension; i++)
   {
@@ -103,7 +103,7 @@ PowellOptimizer ::GetLineValue(double x, ParametersType & tempCoord) const
 }
 
 void
-PowellOptimizer ::SetCurrentLinePoint(double x, double fx)
+PowellOptimizer::SetCurrentLinePoint(double x, double fx)
 {
   for (unsigned int i = 0; i < m_SpaceDimension; i++)
   {
@@ -121,7 +121,7 @@ PowellOptimizer ::SetCurrentLinePoint(double x, double fx)
 }
 
 void
-PowellOptimizer ::Swap(double * a, double * b) const
+PowellOptimizer::Swap(double * a, double * b) const
 {
   double tf;
 
@@ -131,7 +131,7 @@ PowellOptimizer ::Swap(double * a, double * b) const
 }
 
 void
-PowellOptimizer ::Shift(double * a, double * b, double * c, double d) const
+PowellOptimizer::Shift(double * a, double * b, double * c, double d) const
 {
   *a = *b;
   *b = *c;
@@ -157,7 +157,7 @@ PowellOptimizer ::Shift(double * a, double * b, double * c, double d) const
 // the end of the iterations.
 //
 void
-PowellOptimizer ::LineBracket(double * x1, double * x2, double * x3, double * f1, double * f2, double * f3)
+PowellOptimizer::LineBracket(double * x1, double * x2, double * x3, double * f1, double * f2, double * f3)
 {
   PowellOptimizer::ParametersType tempCoord(m_SpaceDimension);
 
@@ -165,13 +165,13 @@ PowellOptimizer ::LineBracket(double * x1, double * x2, double * x3, double * f1
 }
 
 void
-PowellOptimizer ::LineBracket(double *         x1,
-                              double *         x2,
-                              double *         x3,
-                              double *         f1,
-                              double *         f2,
-                              double *         f3,
-                              ParametersType & tempCoord)
+PowellOptimizer::LineBracket(double *         x1,
+                             double *         x2,
+                             double *         x3,
+                             double *         f1,
+                             double *         f2,
+                             double *         f3,
+                             ParametersType & tempCoord)
 {
   //
   // Compute the golden ratio as a constant to be
@@ -218,14 +218,14 @@ PowellOptimizer ::LineBracket(double *         x1,
 }
 
 void
-PowellOptimizer ::BracketedLineOptimize(double   ax,
-                                        double   bx,
-                                        double   cx,
-                                        double   fa,
-                                        double   functionValueOfb,
-                                        double   fc,
-                                        double * extX,
-                                        double * extVal)
+PowellOptimizer::BracketedLineOptimize(double   ax,
+                                       double   bx,
+                                       double   cx,
+                                       double   fa,
+                                       double   functionValueOfb,
+                                       double   fc,
+                                       double * extX,
+                                       double * extVal)
 {
   PowellOptimizer::ParametersType tempCoord(m_SpaceDimension);
 
@@ -233,15 +233,15 @@ PowellOptimizer ::BracketedLineOptimize(double   ax,
 }
 
 void
-PowellOptimizer ::BracketedLineOptimize(double           ax,
-                                        double           bx,
-                                        double           cx,
-                                        double           itkNotUsed(fa),
-                                        double           functionValueOfb,
-                                        double           itkNotUsed(fc),
-                                        double *         extX,
-                                        double *         extVal,
-                                        ParametersType & tempCoord)
+PowellOptimizer::BracketedLineOptimize(double           ax,
+                                       double           bx,
+                                       double           cx,
+                                       double           itkNotUsed(fa),
+                                       double           functionValueOfb,
+                                       double           itkNotUsed(fc),
+                                       double *         extX,
+                                       double *         extVal,
+                                       ParametersType & tempCoord)
 {
   double x;
   double v = 0.0;
@@ -406,7 +406,7 @@ PowellOptimizer ::BracketedLineOptimize(double           ax,
 }
 
 void
-PowellOptimizer ::StartOptimization()
+PowellOptimizer::StartOptimization()
 {
   if (m_CostFunction.IsNull())
   {
@@ -531,7 +531,7 @@ PowellOptimizer ::StartOptimization()
  *
  */
 const std::string
-PowellOptimizer ::GetStopConditionDescription() const
+PowellOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();
 }
@@ -540,7 +540,7 @@ PowellOptimizer ::GetStopConditionDescription() const
  *
  */
 void
-PowellOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+PowellOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
@@ -27,7 +27,7 @@ namespace itk
  * Advance one Step following the gradient direction
  */
 void
-QuaternionRigidTransformGradientDescentOptimizer ::AdvanceOneStep()
+QuaternionRigidTransformGradientDescentOptimizer::AdvanceOneStep()
 {
   const double       direction = (m_Maximize) ? 1.0 : -1.0;
   const ScalesType & scales = this->GetScales();

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -25,7 +25,7 @@ namespace itk
 /**
  * Constructor
  */
-RegularStepGradientDescentBaseOptimizer ::RegularStepGradientDescentBaseOptimizer()
+RegularStepGradientDescentBaseOptimizer::RegularStepGradientDescentBaseOptimizer()
 
 {
   itkDebugMacro("Constructor");
@@ -50,7 +50,7 @@ RegularStepGradientDescentBaseOptimizer ::RegularStepGradientDescentBaseOptimize
  * Start the optimization
  */
 void
-RegularStepGradientDescentBaseOptimizer ::StartOptimization()
+RegularStepGradientDescentBaseOptimizer::StartOptimization()
 {
   itkDebugMacro("StartOptimization");
 
@@ -84,7 +84,7 @@ RegularStepGradientDescentBaseOptimizer ::StartOptimization()
  * Resume the optimization
  */
 void
-RegularStepGradientDescentBaseOptimizer ::ResumeOptimization()
+RegularStepGradientDescentBaseOptimizer::ResumeOptimization()
 {
   itkDebugMacro("ResumeOptimization");
 
@@ -132,7 +132,7 @@ RegularStepGradientDescentBaseOptimizer ::ResumeOptimization()
  * Stop optimization
  */
 void
-RegularStepGradientDescentBaseOptimizer ::StopOptimization()
+RegularStepGradientDescentBaseOptimizer::StopOptimization()
 {
   itkDebugMacro("StopOptimization");
 
@@ -144,7 +144,7 @@ RegularStepGradientDescentBaseOptimizer ::StopOptimization()
  * Advance one Step following the gradient direction
  */
 void
-RegularStepGradientDescentBaseOptimizer ::AdvanceOneStep()
+RegularStepGradientDescentBaseOptimizer::AdvanceOneStep()
 {
   itkDebugMacro("AdvanceOneStep");
 
@@ -241,13 +241,13 @@ RegularStepGradientDescentBaseOptimizer ::AdvanceOneStep()
 }
 
 const std::string
-RegularStepGradientDescentBaseOptimizer ::GetStopConditionDescription() const
+RegularStepGradientDescentBaseOptimizer::GetStopConditionDescription() const
 {
   return m_StopConditionDescription.str();
 }
 
 void
-RegularStepGradientDescentBaseOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+RegularStepGradientDescentBaseOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "MaximumStepLength: " << m_MaximumStepLength << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
@@ -27,7 +27,7 @@ namespace itk
  * This method will be overridden in non-vector spaces
  */
 void
-RegularStepGradientDescentOptimizer ::StepAlongGradient(double factor, const DerivativeType & transformedGradient)
+RegularStepGradientDescentOptimizer::StepAlongGradient(double factor, const DerivativeType & transformedGradient)
 {
   itkDebugMacro(<< "factor = " << factor << "  transformedGradient= " << transformedGradient);
 

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -52,7 +52,7 @@ SPSAOptimizer ::SPSAOptimizer()
  * ************************* PrintSelf **************************
  */
 void
-SPSAOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+SPSAOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -90,7 +90,7 @@ SPSAOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
  * Get the cost function value at a position.
  */
 SPSAOptimizer::MeasureType
-SPSAOptimizer ::GetValue(const ParametersType & parameters) const
+SPSAOptimizer::GetValue(const ParametersType & parameters) const
 {
   /**
    * This method just calls the Superclass' implementation,
@@ -105,7 +105,7 @@ SPSAOptimizer ::GetValue(const ParametersType & parameters) const
  * Get the cost function value at the current position.
  */
 SPSAOptimizer::MeasureType
-SPSAOptimizer ::GetValue() const
+SPSAOptimizer::GetValue() const
 {
   /**
    * The SPSA does not compute the cost function value at
@@ -119,7 +119,7 @@ SPSAOptimizer ::GetValue() const
  * *********************** StartOptimization ********************
  */
 void
-SPSAOptimizer ::StartOptimization()
+SPSAOptimizer::StartOptimization()
 {
   itkDebugMacro("StartOptimization");
 
@@ -148,7 +148,7 @@ SPSAOptimizer ::StartOptimization()
  */
 
 void
-SPSAOptimizer ::ResumeOptimization()
+SPSAOptimizer::ResumeOptimization()
 {
   itkDebugMacro("ResumeOptimization");
 
@@ -189,7 +189,7 @@ SPSAOptimizer ::ResumeOptimization()
  * ********************** StopOptimization **********************
  */
 void
-SPSAOptimizer ::StopOptimization()
+SPSAOptimizer::StopOptimization()
 {
   itkDebugMacro("StopOptimization");
   m_Stop = true;
@@ -200,7 +200,7 @@ SPSAOptimizer ::StopOptimization()
  * ********************** AdvanceOneStep ************************
  */
 void
-SPSAOptimizer ::AdvanceOneStep()
+SPSAOptimizer::AdvanceOneStep()
 {
   itkDebugMacro("AdvanceOneStep");
 
@@ -266,7 +266,7 @@ SPSAOptimizer ::AdvanceOneStep()
  */
 
 double
-SPSAOptimizer ::Compute_a(SizeValueType k) const
+SPSAOptimizer::Compute_a(SizeValueType k) const
 {
   return static_cast<double>(m_Sa / std::pow(m_A + k + 1, m_Alpha));
 } // end Compute_a
@@ -279,7 +279,7 @@ SPSAOptimizer ::Compute_a(SizeValueType k) const
  */
 
 double
-SPSAOptimizer ::Compute_c(SizeValueType k) const
+SPSAOptimizer::Compute_c(SizeValueType k) const
 {
   return static_cast<double>(m_Sc / std::pow(k + 1, m_Gamma));
 } // end Compute_c
@@ -293,7 +293,7 @@ SPSAOptimizer ::Compute_c(SizeValueType k) const
  */
 
 void
-SPSAOptimizer ::GenerateDelta(const unsigned int spaceDimension)
+SPSAOptimizer::GenerateDelta(const unsigned int spaceDimension)
 {
   m_Delta = DerivativeType(spaceDimension);
 

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearOptimizer.cxx
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-SingleValuedNonLinearOptimizer ::SingleValuedNonLinearOptimizer()
+SingleValuedNonLinearOptimizer::SingleValuedNonLinearOptimizer()
 {
   m_CostFunction = nullptr;
 }
@@ -31,7 +31,7 @@ SingleValuedNonLinearOptimizer ::SingleValuedNonLinearOptimizer()
  * Connect a Cost Function
  */
 void
-SingleValuedNonLinearOptimizer ::SetCostFunction(CostFunctionType * costFunction)
+SingleValuedNonLinearOptimizer::SetCostFunction(CostFunctionType * costFunction)
 {
   if (m_CostFunction == costFunction)
   {
@@ -59,7 +59,7 @@ SingleValuedNonLinearOptimizer ::SetCostFunction(CostFunctionType * costFunction
  * Get the cost function value at the given parameters
  */
 SingleValuedNonLinearOptimizer::MeasureType
-SingleValuedNonLinearOptimizer ::GetValue(const ParametersType & parameters) const
+SingleValuedNonLinearOptimizer::GetValue(const ParametersType & parameters) const
 {
   itkDebugMacro("Computing CostFunction value at " << parameters);
 
@@ -75,7 +75,7 @@ SingleValuedNonLinearOptimizer ::GetValue(const ParametersType & parameters) con
 }
 
 void
-SingleValuedNonLinearOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+SingleValuedNonLinearOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   if (m_CostFunction)

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
@@ -23,7 +23,7 @@
 namespace itk
 {
 /** Constructor */
-SingleValuedNonLinearVnlOptimizer ::SingleValuedNonLinearVnlOptimizer()
+SingleValuedNonLinearVnlOptimizer::SingleValuedNonLinearVnlOptimizer()
 {
   m_CostFunctionAdaptor = nullptr;
   m_Maximize = false;
@@ -42,7 +42,7 @@ SingleValuedNonLinearVnlOptimizer ::~SingleValuedNonLinearVnlOptimizer()
 }
 
 void
-SingleValuedNonLinearVnlOptimizer ::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
+SingleValuedNonLinearVnlOptimizer::SetCostFunctionAdaptor(CostFunctionAdaptorType * adaptor)
 {
   if (m_CostFunctionAdaptor == adaptor)
   {
@@ -57,13 +57,13 @@ SingleValuedNonLinearVnlOptimizer ::SetCostFunctionAdaptor(CostFunctionAdaptorTy
 }
 
 const SingleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
-SingleValuedNonLinearVnlOptimizer ::GetCostFunctionAdaptor() const
+SingleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor() const
 {
   return m_CostFunctionAdaptor;
 }
 
 SingleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
-SingleValuedNonLinearVnlOptimizer ::GetCostFunctionAdaptor()
+SingleValuedNonLinearVnlOptimizer::GetCostFunctionAdaptor()
 {
   return m_CostFunctionAdaptor;
 }
@@ -71,7 +71,7 @@ SingleValuedNonLinearVnlOptimizer ::GetCostFunctionAdaptor()
 /** The purpose of this method is to get around the lack of
  *  const-correctness in VNL cost-functions and optimizers */
 SingleValuedNonLinearVnlOptimizer::CostFunctionAdaptorType *
-SingleValuedNonLinearVnlOptimizer ::GetNonConstCostFunctionAdaptor() const
+SingleValuedNonLinearVnlOptimizer::GetNonConstCostFunctionAdaptor() const
 {
   return m_CostFunctionAdaptor;
 }
@@ -83,7 +83,7 @@ SingleValuedNonLinearVnlOptimizer ::GetNonConstCostFunctionAdaptor() const
  * vnl optimizer. Optimizers that evaluate the metric multiple times at each
  * iteration will generate a lot more of Iteration events here. */
 void
-SingleValuedNonLinearVnlOptimizer ::IterationReport(const EventObject & event)
+SingleValuedNonLinearVnlOptimizer::IterationReport(const EventObject & event)
 {
   const CostFunctionAdaptorType * adaptor = this->GetCostFunctionAdaptor();
 
@@ -97,7 +97,7 @@ SingleValuedNonLinearVnlOptimizer ::IterationReport(const EventObject & event)
  * PrintSelf
  */
 void
-SingleValuedNonLinearVnlOptimizer ::PrintSelf(std::ostream & os, Indent indent) const
+SingleValuedNonLinearVnlOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Maximize flag: " << (m_Maximize ? "On" : "Off") << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
@@ -20,7 +20,7 @@
 namespace itk
 {
 /**  Constructor.  */
-SingleValuedVnlCostFunctionAdaptor ::SingleValuedVnlCostFunctionAdaptor(unsigned int spaceDimension)
+SingleValuedVnlCostFunctionAdaptor::SingleValuedVnlCostFunctionAdaptor(unsigned int spaceDimension)
   : vnl_cost_function(spaceDimension)
 {
   m_ScalesInitialized = false;
@@ -32,7 +32,7 @@ SingleValuedVnlCostFunctionAdaptor ::SingleValuedVnlCostFunctionAdaptor(unsigned
 
 /** Set current parameters scaling. */
 void
-SingleValuedVnlCostFunctionAdaptor ::SetScales(const ScalesType & scales)
+SingleValuedVnlCostFunctionAdaptor::SetScales(const ScalesType & scales)
 {
   // Only the inverse is used computes the inverse at each iteration.
   // provides 1 commone place where the inverse can be computes
@@ -178,8 +178,8 @@ SingleValuedVnlCostFunctionAdaptor ::compute(const InternalParametersType & x,
 
 /**  Convert external derivative measures into internal type  */
 void
-SingleValuedVnlCostFunctionAdaptor ::ConvertExternalToInternalGradient(const DerivativeType &   input,
-                                                                       InternalDerivativeType & output) const
+SingleValuedVnlCostFunctionAdaptor::ConvertExternalToInternalGradient(const DerivativeType &   input,
+                                                                      InternalDerivativeType & output) const
 {
   const unsigned int size = input.size();
 
@@ -206,7 +206,7 @@ SingleValuedVnlCostFunctionAdaptor ::ConvertExternalToInternalGradient(const Der
 /**  Set whether the cost function should be negated or not. This is useful for
  * adapting optimizers that are only minimizers. */
 void
-SingleValuedVnlCostFunctionAdaptor ::SetNegateCostFunction(bool flag)
+SingleValuedVnlCostFunctionAdaptor::SetNegateCostFunction(bool flag)
 {
   m_NegateCostFunction = flag;
 }
@@ -214,7 +214,7 @@ SingleValuedVnlCostFunctionAdaptor ::SetNegateCostFunction(bool flag)
 /**  Returns whether the cost function is going to be negated or not.
  *   This is useful for adapting optimizers that are only minimizers. */
 bool
-SingleValuedVnlCostFunctionAdaptor ::GetNegateCostFunction() const
+SingleValuedVnlCostFunctionAdaptor::GetNegateCostFunction() const
 {
   return m_NegateCostFunction;
 }
@@ -222,7 +222,7 @@ SingleValuedVnlCostFunctionAdaptor ::GetNegateCostFunction() const
 /**  This method reports iterations events. It is intended to
  *   help monitoring the progress of the optimization process. */
 void
-SingleValuedVnlCostFunctionAdaptor ::ReportIteration(const EventObject & event) const
+SingleValuedVnlCostFunctionAdaptor::ReportIteration(const EventObject & event) const
 {
   this->m_Reporter->InvokeEvent(event);
 }
@@ -230,21 +230,21 @@ SingleValuedVnlCostFunctionAdaptor ::ReportIteration(const EventObject & event) 
 /**  Connects a Command/Observer to the internal reporter class.
  *   This is useful for reporting iteration event to potential observers. */
 unsigned long
-SingleValuedVnlCostFunctionAdaptor ::AddObserver(const EventObject & event, Command * command) const
+SingleValuedVnlCostFunctionAdaptor::AddObserver(const EventObject & event, Command * command) const
 {
   return m_Reporter->AddObserver(event, command);
 }
 
 /**  Return the cached value of the cost function */
 const SingleValuedVnlCostFunctionAdaptor::MeasureType &
-SingleValuedVnlCostFunctionAdaptor ::GetCachedValue() const
+SingleValuedVnlCostFunctionAdaptor::GetCachedValue() const
 {
   return m_CachedValue;
 }
 
 /**  Return the cached value of the cost function derivative */
 const SingleValuedVnlCostFunctionAdaptor::DerivativeType &
-SingleValuedVnlCostFunctionAdaptor ::GetCachedDerivative() const
+SingleValuedVnlCostFunctionAdaptor::GetCachedDerivative() const
 {
   return m_CachedDerivative;
 }
@@ -252,7 +252,7 @@ SingleValuedVnlCostFunctionAdaptor ::GetCachedDerivative() const
 /**  Return the cached value of the parameters used for computing the function
  */
 const SingleValuedVnlCostFunctionAdaptor::ParametersType &
-SingleValuedVnlCostFunctionAdaptor ::GetCachedCurrentParameters() const
+SingleValuedVnlCostFunctionAdaptor::GetCachedCurrentParameters() const
 {
   return m_CachedCurrentParameters;
 }

--- a/Modules/Numerics/Optimizers/src/itkVersorRigid3DTransformOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkVersorRigid3DTransformOptimizer.cxx
@@ -27,7 +27,7 @@ namespace itk
  * This method will be overridden in non-vector spaces
  */
 void
-VersorRigid3DTransformOptimizer ::StepAlongGradient(double factor, const DerivativeType & transformedGradient)
+VersorRigid3DTransformOptimizer::StepAlongGradient(double factor, const DerivativeType & transformedGradient)
 {
   const ParametersType & currentPosition = this->GetCurrentPosition();
 

--- a/Modules/Numerics/Optimizers/src/itkVersorTransformOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkVersorTransformOptimizer.cxx
@@ -27,7 +27,7 @@ namespace itk
  * This method will be overridden in non-vector spaces
  */
 void
-VersorTransformOptimizer ::StepAlongGradient(double factor, const DerivativeType & transformedGradient)
+VersorTransformOptimizer::StepAlongGradient(double factor, const DerivativeType & transformedGradient)
 {
   const ParametersType & currentPosition = this->GetCurrentPosition();
   unsigned int           NumberOfParameters = m_CostFunction->GetNumberOfParameters();

--- a/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
+++ b/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
@@ -20,9 +20,9 @@
 
 namespace itk
 {
-MultivariateLegendrePolynomial ::MultivariateLegendrePolynomial(unsigned int           dimension,
-                                                                unsigned int           degree,
-                                                                const DomainSizeType & domainSize)
+MultivariateLegendrePolynomial::MultivariateLegendrePolynomial(unsigned int           dimension,
+                                                               unsigned int           degree,
+                                                               const DomainSizeType & domainSize)
 {
   if (dimension > 3 || dimension < 2)
   {
@@ -59,7 +59,7 @@ MultivariateLegendrePolynomial ::MultivariateLegendrePolynomial(unsigned int    
 MultivariateLegendrePolynomial ::~MultivariateLegendrePolynomial() = default;
 
 void
-MultivariateLegendrePolynomial ::Print(std::ostream & os) const
+MultivariateLegendrePolynomial::Print(std::ostream & os) const
 {
   itk::Indent indent(4);
 
@@ -67,7 +67,7 @@ MultivariateLegendrePolynomial ::Print(std::ostream & os) const
 }
 
 void
-MultivariateLegendrePolynomial ::PrintSelf(std::ostream & os, Indent indent) const
+MultivariateLegendrePolynomial::PrintSelf(std::ostream & os, Indent indent) const
 {
   os << indent << "Dimension: " << m_Dimension << std::endl;
   os << indent << "Degree: " << m_Degree << std::endl;
@@ -118,7 +118,7 @@ MultivariateLegendrePolynomial ::PrintSelf(std::ostream & os, Indent indent) con
 }
 
 void
-MultivariateLegendrePolynomial ::SetCoefficients(const CoefficientArrayType & coefficients)
+MultivariateLegendrePolynomial::SetCoefficients(const CoefficientArrayType & coefficients)
 {
   if (coefficients.size() != m_NumberOfCoefficients)
   {
@@ -139,7 +139,7 @@ MultivariateLegendrePolynomial ::SetCoefficients(const CoefficientArrayType & co
 }
 
 void
-MultivariateLegendrePolynomial ::SetCoefficients(const ParametersType & coefficients)
+MultivariateLegendrePolynomial::SetCoefficients(const ParametersType & coefficients)
 {
   if (coefficients.size() != m_NumberOfCoefficients)
   {
@@ -160,13 +160,13 @@ MultivariateLegendrePolynomial ::SetCoefficients(const ParametersType & coeffici
 }
 
 const MultivariateLegendrePolynomial::CoefficientArrayType &
-MultivariateLegendrePolynomial ::GetCoefficients() const
+MultivariateLegendrePolynomial::GetCoefficients() const
 {
   return m_CoefficientArray;
 }
 
 void
-MultivariateLegendrePolynomial ::CalculateXCoef(double norm_y, const CoefficientArrayType & coef)
+MultivariateLegendrePolynomial::CalculateXCoef(double norm_y, const CoefficientArrayType & coef)
 {
   // compute x_coef[i] = sum (0 <= j <= m-i) pij * P(y)]
   int offset = 0;
@@ -180,7 +180,7 @@ MultivariateLegendrePolynomial ::CalculateXCoef(double norm_y, const Coefficient
 }
 
 void
-MultivariateLegendrePolynomial ::CalculateYCoef(double norm_z, const CoefficientArrayType & coef)
+MultivariateLegendrePolynomial::CalculateYCoef(double norm_z, const CoefficientArrayType & coef)
 {
   // compute y_coef[i,j] = sum (0 <= k <= m-i-j) pijk * P(z)
   unsigned int       y_index = 0;
@@ -206,7 +206,7 @@ MultivariateLegendrePolynomial ::CalculateYCoef(double norm_z, const Coefficient
 }
 
 double
-MultivariateLegendrePolynomial ::LegendreSum(const double x, int n, const CoefficientArrayType & coef, int offset)
+MultivariateLegendrePolynomial::LegendreSum(const double x, int n, const CoefficientArrayType & coef, int offset)
 // n+1 elements !
 {
   if (n == 0)
@@ -226,7 +226,7 @@ MultivariateLegendrePolynomial ::LegendreSum(const double x, int n, const Coeffi
 }
 
 unsigned int
-MultivariateLegendrePolynomial ::GetNumberOfCoefficients(unsigned int dimension, unsigned int degree)
+MultivariateLegendrePolynomial::GetNumberOfCoefficients(unsigned int dimension, unsigned int degree)
 {
   // calculate the number of parameters
   unsigned int numerator = 1;

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -29,14 +29,14 @@ namespace itk
 {
 namespace Statistics
 {
-ChiSquareDistribution ::ChiSquareDistribution()
+ChiSquareDistribution::ChiSquareDistribution()
 {
   m_Parameters = ParametersType(1);
   m_Parameters[0] = 1.0;
 }
 
 void
-ChiSquareDistribution ::SetDegreesOfFreedom(SizeValueType dof)
+ChiSquareDistribution::SetDegreesOfFreedom(SizeValueType dof)
 {
   bool modified = false;
 
@@ -62,7 +62,7 @@ ChiSquareDistribution ::SetDegreesOfFreedom(SizeValueType dof)
 }
 
 SizeValueType
-ChiSquareDistribution ::GetDegreesOfFreedom() const
+ChiSquareDistribution::GetDegreesOfFreedom() const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -127,7 +127,7 @@ ChiSquareDistribution ::CDF(double x, const ParametersType & p)
 }
 
 double
-ChiSquareDistribution ::InverseCDF(double p, SizeValueType degreesOfFreedom)
+ChiSquareDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
 {
   if (p <= 0.0)
   {
@@ -189,7 +189,7 @@ ChiSquareDistribution ::InverseCDF(double p, SizeValueType degreesOfFreedom)
 }
 
 double
-ChiSquareDistribution ::InverseCDF(double p, const ParametersType & params)
+ChiSquareDistribution::InverseCDF(double p, const ParametersType & params)
 {
   if (params.GetSize() != 1)
   {
@@ -200,7 +200,7 @@ ChiSquareDistribution ::InverseCDF(double p, const ParametersType & params)
 }
 
 double
-ChiSquareDistribution ::EvaluatePDF(double x) const
+ChiSquareDistribution::EvaluatePDF(double x) const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -211,7 +211,7 @@ ChiSquareDistribution ::EvaluatePDF(double x) const
 }
 
 double
-ChiSquareDistribution ::EvaluatePDF(double x, const ParametersType & p) const
+ChiSquareDistribution::EvaluatePDF(double x, const ParametersType & p) const
 {
   if (p.GetSize() != 1)
   {
@@ -222,13 +222,13 @@ ChiSquareDistribution ::EvaluatePDF(double x, const ParametersType & p) const
 }
 
 double
-ChiSquareDistribution ::EvaluatePDF(double x, SizeValueType degreesOfFreedom) const
+ChiSquareDistribution::EvaluatePDF(double x, SizeValueType degreesOfFreedom) const
 {
   return ChiSquareDistribution::PDF(x, degreesOfFreedom);
 }
 
 double
-ChiSquareDistribution ::EvaluateCDF(double x) const
+ChiSquareDistribution::EvaluateCDF(double x) const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -239,7 +239,7 @@ ChiSquareDistribution ::EvaluateCDF(double x) const
 }
 
 double
-ChiSquareDistribution ::EvaluateCDF(double x, const ParametersType & p) const
+ChiSquareDistribution::EvaluateCDF(double x, const ParametersType & p) const
 {
   if (p.GetSize() != 1)
   {
@@ -250,13 +250,13 @@ ChiSquareDistribution ::EvaluateCDF(double x, const ParametersType & p) const
 }
 
 double
-ChiSquareDistribution ::EvaluateCDF(double x, SizeValueType degreesOfFreedom) const
+ChiSquareDistribution::EvaluateCDF(double x, SizeValueType degreesOfFreedom) const
 {
   return ChiSquareDistribution::CDF(x, degreesOfFreedom);
 }
 
 double
-ChiSquareDistribution ::EvaluateInverseCDF(double p) const
+ChiSquareDistribution::EvaluateInverseCDF(double p) const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -267,7 +267,7 @@ ChiSquareDistribution ::EvaluateInverseCDF(double p) const
 }
 
 double
-ChiSquareDistribution ::EvaluateInverseCDF(double p, const ParametersType & params) const
+ChiSquareDistribution::EvaluateInverseCDF(double p, const ParametersType & params) const
 {
   if (params.GetSize() != 1)
   {
@@ -278,13 +278,13 @@ ChiSquareDistribution ::EvaluateInverseCDF(double p, const ParametersType & para
 }
 
 double
-ChiSquareDistribution ::EvaluateInverseCDF(double p, SizeValueType degreesOfFreedom) const
+ChiSquareDistribution::EvaluateInverseCDF(double p, SizeValueType degreesOfFreedom) const
 {
   return ChiSquareDistribution::InverseCDF(p, degreesOfFreedom);
 }
 
 double
-ChiSquareDistribution ::GetMean() const
+ChiSquareDistribution::GetMean() const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -295,7 +295,7 @@ ChiSquareDistribution ::GetMean() const
 }
 
 double
-ChiSquareDistribution ::GetVariance() const
+ChiSquareDistribution::GetVariance() const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -306,7 +306,7 @@ ChiSquareDistribution ::GetVariance() const
 }
 
 void
-ChiSquareDistribution ::PrintSelf(std::ostream & os, Indent indent) const
+ChiSquareDistribution::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Numerics/Statistics/src/itkDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkDecisionRule.cxx
@@ -21,7 +21,7 @@ namespace itk
 {
 namespace Statistics
 {
-DecisionRule ::DecisionRule() = default;
+DecisionRule::DecisionRule() = default;
 
 DecisionRule ::~DecisionRule() = default;
 

--- a/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
@@ -23,7 +23,7 @@ namespace itk
 {
 namespace Statistics
 {
-GaussianDistribution ::GaussianDistribution()
+GaussianDistribution::GaussianDistribution()
 {
   m_Parameters = ParametersType(2);
   m_Parameters[0] = 0.0;
@@ -31,7 +31,7 @@ GaussianDistribution ::GaussianDistribution()
 }
 
 double
-GaussianDistribution ::GetMean() const
+GaussianDistribution::GetMean() const
 {
   if (m_Parameters.GetSize() != 2)
   {
@@ -42,7 +42,7 @@ GaussianDistribution ::GetMean() const
 }
 
 void
-GaussianDistribution ::SetMean(double mean)
+GaussianDistribution::SetMean(double mean)
 {
   bool modified = false;
 
@@ -91,7 +91,7 @@ GaussianDistribution ::SetMean(double mean)
 }
 
 double
-GaussianDistribution ::GetVariance() const
+GaussianDistribution::GetVariance() const
 {
   if (m_Parameters.GetSize() != 2)
   {
@@ -102,7 +102,7 @@ GaussianDistribution ::GetVariance() const
 }
 
 void
-GaussianDistribution ::SetVariance(double variance)
+GaussianDistribution::SetVariance(double variance)
 {
   bool modified = false;
 
@@ -206,7 +206,7 @@ GaussianDistribution ::CDF(double x, const ParametersType & p)
 }
 
 double
-GaussianDistribution ::InverseCDF(double p)
+GaussianDistribution::InverseCDF(double p)
 {
   double dp, dx, dt, ddq, dq;
   int    newt;
@@ -257,7 +257,7 @@ GaussianDistribution ::InverseCDF(double p)
 }
 
 double
-GaussianDistribution ::InverseCDF(double p, double mean, double variance)
+GaussianDistribution::InverseCDF(double p, double mean, double variance)
 {
   double x = GaussianDistribution::InverseCDF(p);
 
@@ -279,7 +279,7 @@ GaussianDistribution ::InverseCDF(double p, double mean, double variance)
 }
 
 double
-GaussianDistribution ::InverseCDF(double p, const ParametersType & params)
+GaussianDistribution::InverseCDF(double p, const ParametersType & params)
 {
   if (params.GetSize() != 2)
   {
@@ -290,7 +290,7 @@ GaussianDistribution ::InverseCDF(double p, const ParametersType & params)
 }
 
 double
-GaussianDistribution ::EvaluatePDF(double x) const
+GaussianDistribution::EvaluatePDF(double x) const
 {
   if (m_Parameters.GetSize() == 2)
   {
@@ -309,7 +309,7 @@ GaussianDistribution ::EvaluatePDF(double x) const
 }
 
 double
-GaussianDistribution ::EvaluatePDF(double x, const ParametersType & p) const
+GaussianDistribution::EvaluatePDF(double x, const ParametersType & p) const
 {
   if (p.GetSize() == 2)
   {
@@ -328,7 +328,7 @@ GaussianDistribution ::EvaluatePDF(double x, const ParametersType & p) const
 }
 
 double
-GaussianDistribution ::EvaluatePDF(double x, double mean, double variance) const
+GaussianDistribution::EvaluatePDF(double x, double mean, double variance) const
 {
   if (mean == 0.0 && variance == 1.0)
   {
@@ -339,7 +339,7 @@ GaussianDistribution ::EvaluatePDF(double x, double mean, double variance) const
 }
 
 double
-GaussianDistribution ::EvaluateCDF(double x) const
+GaussianDistribution::EvaluateCDF(double x) const
 {
   if (m_Parameters.GetSize() == 2)
   {
@@ -358,7 +358,7 @@ GaussianDistribution ::EvaluateCDF(double x) const
 }
 
 double
-GaussianDistribution ::EvaluateCDF(double x, const ParametersType & p) const
+GaussianDistribution::EvaluateCDF(double x, const ParametersType & p) const
 {
   if (p.GetSize() == 2)
   {
@@ -377,7 +377,7 @@ GaussianDistribution ::EvaluateCDF(double x, const ParametersType & p) const
 }
 
 double
-GaussianDistribution ::EvaluateCDF(double x, double mean, double variance) const
+GaussianDistribution::EvaluateCDF(double x, double mean, double variance) const
 {
   if (mean == 0.0 && variance == 1.0)
   {
@@ -388,7 +388,7 @@ GaussianDistribution ::EvaluateCDF(double x, double mean, double variance) const
 }
 
 double
-GaussianDistribution ::EvaluateInverseCDF(double p) const
+GaussianDistribution::EvaluateInverseCDF(double p) const
 {
   if (m_Parameters.GetSize() == 2)
   {
@@ -407,7 +407,7 @@ GaussianDistribution ::EvaluateInverseCDF(double p) const
 }
 
 double
-GaussianDistribution ::EvaluateInverseCDF(double p, const ParametersType & params) const
+GaussianDistribution::EvaluateInverseCDF(double p, const ParametersType & params) const
 {
   if (params.GetSize() == 2)
   {
@@ -426,7 +426,7 @@ GaussianDistribution ::EvaluateInverseCDF(double p, const ParametersType & param
 }
 
 double
-GaussianDistribution ::EvaluateInverseCDF(double p, double mean, double variance) const
+GaussianDistribution::EvaluateInverseCDF(double p, double mean, double variance) const
 {
   if (mean == 0.0 && variance == 1.0)
   {
@@ -437,7 +437,7 @@ GaussianDistribution ::EvaluateInverseCDF(double p, double mean, double variance
 }
 
 void
-GaussianDistribution ::PrintSelf(std::ostream & os, Indent indent) const
+GaussianDistribution::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
@@ -22,7 +22,7 @@ namespace itk
 namespace Statistics
 {
 MaximumDecisionRule::ClassIdentifierType
-MaximumDecisionRule ::Evaluate(const MembershipVectorType & discriminantScores) const
+MaximumDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) const
 {
   ClassIdentifierType maxIndex = 0;
 

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -22,10 +22,10 @@ namespace itk
 {
 namespace Statistics
 {
-MaximumRatioDecisionRule ::MaximumRatioDecisionRule() = default;
+MaximumRatioDecisionRule::MaximumRatioDecisionRule() = default;
 
 void
-MaximumRatioDecisionRule ::PrintSelf(std::ostream & os, Indent indent) const
+MaximumRatioDecisionRule::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -52,7 +52,7 @@ MaximumRatioDecisionRule ::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 void
-MaximumRatioDecisionRule ::SetPriorProbabilities(const PriorProbabilityVectorType & p)
+MaximumRatioDecisionRule::SetPriorProbabilities(const PriorProbabilityVectorType & p)
 {
   if (p.size() != m_PriorProbabilities.size())
   {
@@ -79,7 +79,7 @@ MaximumRatioDecisionRule ::SetPriorProbabilities(const PriorProbabilityVectorTyp
 }
 
 MaximumRatioDecisionRule::ClassIdentifierType
-MaximumRatioDecisionRule ::Evaluate(const MembershipVectorType & discriminantScores) const
+MaximumRatioDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) const
 {
   bool uniformPrior = false;
   if (discriminantScores.size() != m_PriorProbabilities.size())

--- a/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
@@ -22,7 +22,7 @@ namespace itk
 namespace Statistics
 {
 MinimumDecisionRule::ClassIdentifierType
-MinimumDecisionRule ::Evaluate(const MembershipVectorType & discriminantScores) const
+MinimumDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) const
 {
   ClassIdentifierType minIndex = 0;
 

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -37,7 +37,7 @@ TDistribution ::TDistribution()
 }
 
 void
-TDistribution ::SetDegreesOfFreedom(SizeValueType dof)
+TDistribution::SetDegreesOfFreedom(SizeValueType dof)
 {
   bool modified = false;
 
@@ -63,7 +63,7 @@ TDistribution ::SetDegreesOfFreedom(SizeValueType dof)
 }
 
 SizeValueType
-TDistribution ::GetDegreesOfFreedom() const
+TDistribution::GetDegreesOfFreedom() const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -156,7 +156,7 @@ TDistribution ::CDF(double x, const ParametersType & p)
 }
 
 double
-TDistribution ::InverseCDF(double p, SizeValueType degreesOfFreedom)
+TDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
 {
   if (p <= 0.0)
   {
@@ -222,7 +222,7 @@ TDistribution ::InverseCDF(double p, SizeValueType degreesOfFreedom)
 }
 
 double
-TDistribution ::InverseCDF(double p, const ParametersType & params)
+TDistribution::InverseCDF(double p, const ParametersType & params)
 {
   if (params.GetSize() != 1)
   {
@@ -233,7 +233,7 @@ TDistribution ::InverseCDF(double p, const ParametersType & params)
 }
 
 double
-TDistribution ::EvaluatePDF(double x) const
+TDistribution::EvaluatePDF(double x) const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -244,7 +244,7 @@ TDistribution ::EvaluatePDF(double x) const
 }
 
 double
-TDistribution ::EvaluatePDF(double x, const ParametersType & p) const
+TDistribution::EvaluatePDF(double x, const ParametersType & p) const
 {
   if (p.GetSize() != 1)
   {
@@ -255,13 +255,13 @@ TDistribution ::EvaluatePDF(double x, const ParametersType & p) const
 }
 
 double
-TDistribution ::EvaluatePDF(double x, SizeValueType degreesOfFreedom) const
+TDistribution::EvaluatePDF(double x, SizeValueType degreesOfFreedom) const
 {
   return TDistribution::PDF(x, degreesOfFreedom);
 }
 
 double
-TDistribution ::EvaluateCDF(double x) const
+TDistribution::EvaluateCDF(double x) const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -272,7 +272,7 @@ TDistribution ::EvaluateCDF(double x) const
 }
 
 double
-TDistribution ::EvaluateCDF(double x, const ParametersType & p) const
+TDistribution::EvaluateCDF(double x, const ParametersType & p) const
 {
   if (p.GetSize() != 1)
   {
@@ -283,13 +283,13 @@ TDistribution ::EvaluateCDF(double x, const ParametersType & p) const
 }
 
 double
-TDistribution ::EvaluateCDF(double x, SizeValueType degreesOfFreedom) const
+TDistribution::EvaluateCDF(double x, SizeValueType degreesOfFreedom) const
 {
   return TDistribution::CDF(x, degreesOfFreedom);
 }
 
 double
-TDistribution ::EvaluateInverseCDF(double p) const
+TDistribution::EvaluateInverseCDF(double p) const
 {
   if (m_Parameters.GetSize() != 1)
   {
@@ -300,7 +300,7 @@ TDistribution ::EvaluateInverseCDF(double p) const
 }
 
 double
-TDistribution ::EvaluateInverseCDF(double p, const ParametersType & params) const
+TDistribution::EvaluateInverseCDF(double p, const ParametersType & params) const
 {
   if (params.GetSize() != 1)
   {
@@ -311,13 +311,13 @@ TDistribution ::EvaluateInverseCDF(double p, const ParametersType & params) cons
 }
 
 double
-TDistribution ::EvaluateInverseCDF(double p, SizeValueType degreesOfFreedom) const
+TDistribution::EvaluateInverseCDF(double p, SizeValueType degreesOfFreedom) const
 {
   return TDistribution::InverseCDF(p, degreesOfFreedom);
 }
 
 bool
-TDistribution ::HasVariance() const
+TDistribution::HasVariance() const
 {
   if (m_Parameters.GetSize() == 1)
   {
@@ -336,13 +336,13 @@ TDistribution ::HasVariance() const
 }
 
 double
-TDistribution ::GetMean() const
+TDistribution::GetMean() const
 {
   return 0.0;
 }
 
 double
-TDistribution ::GetVariance() const
+TDistribution::GetVariance() const
 {
   if (m_Parameters.GetSize() == 1)
   {
@@ -365,7 +365,7 @@ TDistribution ::GetVariance() const
 }
 
 void
-TDistribution ::PrintSelf(std::ostream & os, Indent indent) const
+TDistribution::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -433,7 +433,7 @@ protected:
   static constexpr unsigned int DeformationSplineOrder = 3;
 
   using BSplineTransformType =
-    BSplineBaseTransform<CoordinateRepresentationType, FixedImageType ::ImageDimension, Self::DeformationSplineOrder>;
+    BSplineBaseTransform<CoordinateRepresentationType, FixedImageType::ImageDimension, Self::DeformationSplineOrder>;
 
   using BSplineTransformWeightsType = typename BSplineTransformType::WeightsType;
   using WeightsValueType = typename BSplineTransformWeightsType::ValueType;
@@ -445,7 +445,7 @@ protected:
 
   using MovingImagePointArrayType = std::vector<MovingImagePointType>;
   using BooleanArrayType = std::vector<bool>;
-  using BSplineParametersOffsetType = FixedArray<SizeValueType, FixedImageType ::ImageDimension>;
+  using BSplineParametersOffsetType = FixedArray<SizeValueType, FixedImageType::ImageDimension>;
   /**
    * If a BSplineInterpolationFunction is used, this class obtain
    * image derivatives from the BSpline interpolator. Otherwise,

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -591,7 +591,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
                                             TMovingImage,
                                             TVirtualImage,
                                             TInternalComputationValueType,
-                                            TMetricTraits>::DerivativeBufferManager ::DoubleBufferSize()
+                                            TMetricTraits>::DerivativeBufferManager::DoubleBufferSize()
 {
   m_MaxBufferSize = m_MaxBufferSize * 2;
   m_MemoryBlockSize = m_MemoryBlockSize * 2;
@@ -614,7 +614,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
                                             TMovingImage,
                                             TVirtualImage,
                                             TInternalComputationValueType,
-                                            TMetricTraits>::DerivativeBufferManager ::CheckAndReduceIfNecessary()
+                                            TMetricTraits>::DerivativeBufferManager::CheckAndReduceIfNecessary()
 {
   if (m_CurrentFillSize == m_MaxBufferSize)
   {
@@ -653,7 +653,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
                                             TMovingImage,
                                             TVirtualImage,
                                             TInternalComputationValueType,
-                                            TMetricTraits>::DerivativeBufferManager ::BlockAndReduce()
+                                            TMetricTraits>::DerivativeBufferManager::BlockAndReduce()
 {
   if (m_CurrentFillSize > 0)
   {
@@ -672,7 +672,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
                                             TMovingImage,
                                             TVirtualImage,
                                             TInternalComputationValueType,
-                                            TMetricTraits>::DerivativeBufferManager ::ReduceBuffer()
+                                            TMetricTraits>::DerivativeBufferManager::ReduceBuffer()
 {
   auto BufferOffsetContainerIter(this->m_BufferOffsetContainer.begin());
   auto BufferPDFValuesContainerIter(this->m_BufferPDFValuesContainer.begin());

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.h
@@ -82,7 +82,7 @@ template <typename TInputVectorImage,
           typename TPosteriorsPrecisionType = double,
           typename TPriorsPrecisionType = double>
 class ITK_TEMPLATE_EXPORT BayesianClassifierImageFilter
-  : public ImageToImageFilter<TInputVectorImage, Image<TLabelsType, TInputVectorImage ::ImageDimension>>
+  : public ImageToImageFilter<TInputVectorImage, Image<TLabelsType, TInputVectorImage::ImageDimension>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BayesianClassifierImageFilter);
@@ -104,7 +104,7 @@ public:
   using InputImageType = typename Superclass::InputImageType;
 
   /** Dimension of the input image. */
-  static constexpr unsigned int Dimension = InputImageType ::ImageDimension;
+  static constexpr unsigned int Dimension = InputImageType::ImageDimension;
 
   using OutputImageType = Image<TLabelsType, Self::Dimension>;
   using InputImagePointer = typename InputImageType::ConstPointer;

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.h
@@ -86,7 +86,7 @@ public:
   using ProbabilityPrecisionType = TProbabilityPrecisionType;
 
   /** Dimension of the input image */
-  static constexpr unsigned int Dimension = InputImageType ::ImageDimension;
+  static constexpr unsigned int Dimension = InputImageType::ImageDimension;
 
   using OutputImageType = VectorImage<ProbabilityPrecisionType, Self::Dimension>;
   using Superclass = ImageToImageFilter<InputImageType, OutputImageType>;

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
@@ -32,7 +32,7 @@ KLMSegmentationBorder ::~KLMSegmentationBorder() = default;
  * PrintSelf
  */
 void
-KLMSegmentationBorder ::PrintSelf(std::ostream & os, Indent indent) const
+KLMSegmentationBorder::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Lambda  = " << m_Lambda << std::endl;
@@ -41,37 +41,37 @@ KLMSegmentationBorder ::PrintSelf(std::ostream & os, Indent indent) const
 } // end PrintSelf
 
 void
-KLMSegmentationBorder ::SetRegion1(KLMSegmentationRegion * Region1)
+KLMSegmentationBorder::SetRegion1(KLMSegmentationRegion * Region1)
 {
   m_Region1 = Region1;
 } // end SetRegion1
 
 KLMSegmentationRegion *
-KLMSegmentationBorder ::GetRegion1()
+KLMSegmentationBorder::GetRegion1()
 {
   return m_Region1;
 } // end GetRegion2
 
 void
-KLMSegmentationBorder ::SetRegion2(KLMSegmentationRegion * Region2)
+KLMSegmentationBorder::SetRegion2(KLMSegmentationRegion * Region2)
 {
   m_Region2 = Region2;
 } // end SetRegion2
 
 KLMSegmentationRegion *
-KLMSegmentationBorder ::GetRegion2()
+KLMSegmentationBorder::GetRegion2()
 {
   return m_Region2;
 } // end GetRegion2
 
 void
-KLMSegmentationBorder ::EvaluateLambda()
+KLMSegmentationBorder::EvaluateLambda()
 {
   m_Lambda = m_Region1->EnergyFunctional(m_Region2) / this->GetBorderLength();
 } // end EvaluateLambda()
 
 void
-KLMSegmentationBorder ::PrintBorderInfo()
+KLMSegmentationBorder::PrintBorderInfo()
 {
   itkDebugMacro(<< "------------------------------");
   itkDebugMacro(<< "Location      : " << this);

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
@@ -27,7 +27,7 @@ KLMSegmentationRegion ::KLMSegmentationRegion()
 KLMSegmentationRegion ::~KLMSegmentationRegion() = default;
 
 void
-KLMSegmentationRegion ::PrintSelf(std::ostream & os, Indent indent) const
+KLMSegmentationRegion::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Mean region intensity   : " << m_MeanRegionIntensity << std::endl;
@@ -35,9 +35,9 @@ KLMSegmentationRegion ::PrintSelf(std::ostream & os, Indent indent) const
 } // end PrintSelf
 
 void
-KLMSegmentationRegion ::SetRegionParameters(MeanRegionIntensityType meanRegionIntensity,
-                                            double                  regionArea,
-                                            RegionLabelType         label)
+KLMSegmentationRegion::SetRegionParameters(MeanRegionIntensityType meanRegionIntensity,
+                                           double                  regionArea,
+                                           RegionLabelType         label)
 {
   // Set the area, mean, and label associated with the region
   this->SetRegionArea(regionArea);
@@ -46,7 +46,7 @@ KLMSegmentationRegion ::SetRegionParameters(MeanRegionIntensityType meanRegionIn
 } // end SetRegionParameters
 
 void
-KLMSegmentationRegion ::CombineRegionParameters(const Self * region)
+KLMSegmentationRegion::CombineRegionParameters(const Self * region)
 {
   // Reset the area and mean associated with the merged region
 
@@ -69,7 +69,7 @@ KLMSegmentationRegion ::CombineRegionParameters(const Self * region)
 } // end CombineRegionParameters
 
 double
-KLMSegmentationRegion ::EnergyFunctional(const Self * region)
+KLMSegmentationRegion::EnergyFunctional(const Self * region)
 {
   MeanRegionIntensityType region1_2MeanDiff = this->m_MeanRegionIntensity - region->m_MeanRegionIntensity;
 
@@ -86,7 +86,7 @@ KLMSegmentationRegion ::EnergyFunctional(const Self * region)
 }
 
 void
-KLMSegmentationRegion ::DeleteRegionBorder(KLMSegmentationBorder * pBorderCandidate)
+KLMSegmentationRegion::DeleteRegionBorder(KLMSegmentationBorder * pBorderCandidate)
 {
   if (pBorderCandidate == nullptr)
   {
@@ -116,7 +116,7 @@ KLMSegmentationRegion ::DeleteRegionBorder(KLMSegmentationBorder * pBorderCandid
 } // end DeleteRegionBorder()
 
 void
-KLMSegmentationRegion ::PushBackRegionBorder(KLMSegmentationBorder * pBorderCandidate)
+KLMSegmentationRegion::PushBackRegionBorder(KLMSegmentationBorder * pBorderCandidate)
 {
   if (pBorderCandidate == nullptr)
   {
@@ -126,7 +126,7 @@ KLMSegmentationRegion ::PushBackRegionBorder(KLMSegmentationBorder * pBorderCand
 }
 
 void
-KLMSegmentationRegion ::PushFrontRegionBorder(KLMSegmentationBorder * pBorderCandidate)
+KLMSegmentationRegion::PushFrontRegionBorder(KLMSegmentationBorder * pBorderCandidate)
 {
   if (pBorderCandidate == nullptr)
   {
@@ -136,7 +136,7 @@ KLMSegmentationRegion ::PushFrontRegionBorder(KLMSegmentationBorder * pBorderCan
 }
 
 void
-KLMSegmentationRegion ::InsertRegionBorder(KLMSegmentationBorder * pBorderCandidate)
+KLMSegmentationRegion::InsertRegionBorder(KLMSegmentationBorder * pBorderCandidate)
 {
   // Ensure that the border candidate is not a null pointer
   if (pBorderCandidate == nullptr)
@@ -187,8 +187,8 @@ KLMSegmentationRegion ::InsertRegionBorder(KLMSegmentationBorder * pBorderCandid
 } // end InsertRegionBorder
 
 void
-KLMSegmentationRegion ::InsertRegionBorder(RegionBorderVectorIterator RegionBorderVectorIt,
-                                           KLMSegmentationBorder *    pBorderCandidate)
+KLMSegmentationRegion::InsertRegionBorder(RegionBorderVectorIterator RegionBorderVectorIt,
+                                          KLMSegmentationBorder *    pBorderCandidate)
 {
   // Ensure that the border candidate is not a null pointer
   if (pBorderCandidate == nullptr)
@@ -204,7 +204,7 @@ KLMSegmentationRegion ::InsertRegionBorder(RegionBorderVectorIterator RegionBord
 } // end InsertRegionBorder
 
 void
-KLMSegmentationRegion ::ResetRegionLabelAndUpdateBorders(Self * region)
+KLMSegmentationRegion::ResetRegionLabelAndUpdateBorders(Self * region)
 {
   // Assign new equivalence label to the old region
   this->SetRegionLabel(region->GetRegionLabel());
@@ -277,7 +277,7 @@ KLMSegmentationRegion ::ResetRegionLabelAndUpdateBorders(Self * region)
 } // end ResetRegionLabelAndUpdateBorders
 
 void
-KLMSegmentationRegion ::SpliceRegionBorders(Self * region)
+KLMSegmentationRegion::SpliceRegionBorders(Self * region)
 {
   // Do the actual union of the borders
 
@@ -396,7 +396,7 @@ KLMSegmentationRegion ::SpliceRegionBorders(Self * region)
 } // end SpliceRegionBorders
 
 void
-KLMSegmentationRegion ::UpdateRegionBorderLambda()
+KLMSegmentationRegion::UpdateRegionBorderLambda()
 {
   // Check if the number of borders for this region is nullptr
   if (m_RegionBorderVector.empty())
@@ -417,43 +417,43 @@ KLMSegmentationRegion ::UpdateRegionBorderLambda()
 } // end UpdateRegionBorderLambda
 
 void
-KLMSegmentationRegion ::DeleteAllRegionBorders()
+KLMSegmentationRegion::DeleteAllRegionBorders()
 {
   m_RegionBorderVector.resize(0);
 } // end DeleteAllRegionBorders
 
 KLMSegmentationRegion::RegionBorderVectorIterator
-KLMSegmentationRegion ::GetRegionBorderItBegin()
+KLMSegmentationRegion::GetRegionBorderItBegin()
 {
   return m_RegionBorderVector.begin();
 } // end GetRegionBorderItBegin
 
 KLMSegmentationRegion::RegionBorderVectorConstIterator
-KLMSegmentationRegion ::GetRegionBorderConstItBegin()
+KLMSegmentationRegion::GetRegionBorderConstItBegin()
 {
   return m_RegionBorderVector.begin();
 } // end GetRegionBorderConstItBegin
 
 KLMSegmentationRegion::RegionBorderVectorIterator
-KLMSegmentationRegion ::GetRegionBorderItEnd()
+KLMSegmentationRegion::GetRegionBorderItEnd()
 {
   return m_RegionBorderVector.end();
 } // end GetRegionBorderItEnd
 
 KLMSegmentationRegion::RegionBorderVectorConstIterator
-KLMSegmentationRegion ::GetRegionBorderConstItEnd()
+KLMSegmentationRegion::GetRegionBorderConstItEnd()
 {
   return m_RegionBorderVector.end();
 } // end GetRegionBorderConstItEnd
 
 KLMSegmentationRegion::RegionBorderVectorSizeType
-KLMSegmentationRegion ::GetRegionBorderSize() const
+KLMSegmentationRegion::GetRegionBorderSize() const
 {
   return m_RegionBorderVector.size();
 } // end GetRegionBorderSize
 
 void
-KLMSegmentationRegion ::PrintRegionInfo()
+KLMSegmentationRegion::PrintRegionInfo()
 {
   int region1label;
   int region2label;

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationBorder.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-SegmentationBorder ::SegmentationBorder() = default;
+SegmentationBorder::SegmentationBorder() = default;
 
 SegmentationBorder ::~SegmentationBorder() = default;
 
@@ -27,7 +27,7 @@ SegmentationBorder ::~SegmentationBorder() = default;
  * PrintSelf
  */
 void
-SegmentationBorder ::PrintSelf(std::ostream & os, Indent indent) const
+SegmentationBorder::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Segmentation border object" << std::endl;

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationRegion.cxx
@@ -19,7 +19,7 @@
 
 namespace itk
 {
-SegmentationRegion ::SegmentationRegion() = default;
+SegmentationRegion::SegmentationRegion() = default;
 
 SegmentationRegion ::~SegmentationRegion() = default;
 
@@ -27,7 +27,7 @@ SegmentationRegion ::~SegmentationRegion() = default;
  * PrintSelf
  */
 void
-SegmentationRegion ::PrintSelf(std::ostream & os, Indent indent) const
+SegmentationRegion::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.h
@@ -85,7 +85,7 @@ class ITK_TEMPLATE_EXPORT NarrowBandThresholdSegmentationLevelSetImageFilter
   : public NarrowBandLevelSetImageFilter<TInputImage,
                                          TFeatureImage,
                                          TOutputPixelType,
-                                         Image<TOutputPixelType, TInputImage ::ImageDimension>>
+                                         Image<TOutputPixelType, TInputImage::ImageDimension>>
 {
 public:
   /** Standard class type aliases */

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
@@ -48,7 +48,7 @@ public:
   using IndexType = typename LevelSetImageType::IndexType;
 
   /** The definition for the normal vector type of the scalar image. */
-  using NodeDataType = Vector<NodeValueType, TImageType ::ImageDimension>;
+  using NodeDataType = Vector<NodeValueType, TImageType::ImageDimension>;
 
   /** Container for output data (normal vectors). */
   NodeDataType m_Data;

--- a/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
+++ b/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
@@ -80,7 +80,7 @@ OneWayEquivalencyTable::RecursiveLookup(const unsigned long a) const
 }
 
 void
-OneWayEquivalencyTable ::PrintSelf(std::ostream & os, Indent indent) const
+OneWayEquivalencyTable::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }

--- a/Modules/Segmentation/Watersheds/src/itkWatershedMiniPipelineProgressCommand.cxx
+++ b/Modules/Segmentation/Watersheds/src/itkWatershedMiniPipelineProgressCommand.cxx
@@ -20,7 +20,7 @@
 namespace itk
 {
 void
-WatershedMiniPipelineProgressCommand ::Execute(Object * caller, const EventObject & event)
+WatershedMiniPipelineProgressCommand::Execute(Object * caller, const EventObject & event)
 {
   auto * po = dynamic_cast<ProcessObject *>(caller);
 
@@ -40,7 +40,7 @@ WatershedMiniPipelineProgressCommand ::Execute(Object * caller, const EventObjec
 }
 
 void
-WatershedMiniPipelineProgressCommand ::Execute(const Object * caller, const EventObject & event)
+WatershedMiniPipelineProgressCommand::Execute(const Object * caller, const EventObject & event)
 {
   auto * po = dynamic_cast<ProcessObject *>(const_cast<Object *>(caller));
 
@@ -60,7 +60,7 @@ WatershedMiniPipelineProgressCommand ::Execute(const Object * caller, const Even
 }
 
 void
-WatershedMiniPipelineProgressCommand ::PrintSelf(std::ostream & os, Indent indent) const
+WatershedMiniPipelineProgressCommand::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "NumberOfFilters: " << m_NumberOfFilters << std::endl;

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -46,42 +46,42 @@ TemporalDataObject ::~TemporalDataObject() = default;
 
 //----------------------------------------------------------------------------
 TemporalDataObject::TemporalUnitType
-TemporalDataObject ::GetTemporalUnit() const
+TemporalDataObject::GetTemporalUnit() const
 {
   return m_TemporalUnit;
 }
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::SetTemporalUnitToFrame()
+TemporalDataObject::SetTemporalUnitToFrame()
 {
   m_TemporalUnit = TemporalUnitEnum::Frame;
 }
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::SetTemporalUnitToRealTime()
+TemporalDataObject::SetTemporalUnitToRealTime()
 {
   m_TemporalUnit = TemporalUnitEnum::RealTime;
 }
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::SetTemporalUnitToFrameAndRealTime()
+TemporalDataObject::SetTemporalUnitToFrameAndRealTime()
 {
   m_TemporalUnit = TemporalUnitEnum::FrameAndRealTime;
 }
 
 //----------------------------------------------------------------------------
 SizeValueType
-TemporalDataObject ::GetNumberOfBuffers()
+TemporalDataObject::GetNumberOfBuffers()
 {
   return m_DataObjectBuffer->GetNumberOfBuffers();
 }
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::SetNumberOfBuffers(SizeValueType num)
+TemporalDataObject::SetNumberOfBuffers(SizeValueType num)
 {
   m_DataObjectBuffer->SetNumberOfBuffers(num);
 }
@@ -96,14 +96,14 @@ TemporalDataObject::SetLargestPossibleTemporalRegion(const TemporalRegionType & 
 
 //----------------------------------------------------------------------------
 const TemporalDataObject::TemporalRegionType &
-TemporalDataObject ::GetLargestPossibleTemporalRegion() const
+TemporalDataObject::GetLargestPossibleTemporalRegion() const
 {
   return m_LargestPossibleTemporalRegion;
 }
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::SetBufferedTemporalRegion(const TemporalRegionType & region)
+TemporalDataObject::SetBufferedTemporalRegion(const TemporalRegionType & region)
 {
   m_BufferedTemporalRegion = region;
   this->Modified();
@@ -111,14 +111,14 @@ TemporalDataObject ::SetBufferedTemporalRegion(const TemporalRegionType & region
 
 //----------------------------------------------------------------------------
 const TemporalDataObject::TemporalRegionType &
-TemporalDataObject ::GetBufferedTemporalRegion() const
+TemporalDataObject::GetBufferedTemporalRegion() const
 {
   return m_BufferedTemporalRegion;
 }
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::SetRequestedTemporalRegion(const TemporalRegionType & region)
+TemporalDataObject::SetRequestedTemporalRegion(const TemporalRegionType & region)
 {
   m_RequestedTemporalRegion = region;
   this->Modified();
@@ -126,14 +126,14 @@ TemporalDataObject ::SetRequestedTemporalRegion(const TemporalRegionType & regio
 
 //----------------------------------------------------------------------------
 const TemporalDataObject::TemporalRegionType &
-TemporalDataObject ::GetRequestedTemporalRegion() const
+TemporalDataObject::GetRequestedTemporalRegion() const
 {
   return m_RequestedTemporalRegion;
 }
 
 //----------------------------------------------------------------------------
 const TemporalDataObject::TemporalRegionType
-TemporalDataObject ::GetUnbufferedRequestedTemporalRegion()
+TemporalDataObject::GetUnbufferedRequestedTemporalRegion()
 {
   // If nothing is buffered or nothing is requested, just return the entire request
   if (m_BufferedTemporalRegion.GetFrameDuration() == 0 || m_RequestedTemporalRegion.GetFrameDuration() == 0)
@@ -192,14 +192,14 @@ TemporalDataObject ::GetUnbufferedRequestedTemporalRegion()
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::SetRequestedRegionToLargestPossibleRegion()
+TemporalDataObject::SetRequestedRegionToLargestPossibleRegion()
 {
   this->SetRequestedTemporalRegion(this->GetLargestPossibleTemporalRegion());
 }
 
 //----------------------------------------------------------------------------
 bool
-TemporalDataObject ::RequestedRegionIsOutsideOfTheBufferedRegion()
+TemporalDataObject::RequestedRegionIsOutsideOfTheBufferedRegion()
 {
   bool frameFlag = m_RequestedTemporalRegion.GetFrameStart() < m_BufferedTemporalRegion.GetFrameStart();
   frameFlag |= m_RequestedTemporalRegion.GetFrameDuration() + m_RequestedTemporalRegion.GetFrameStart() >
@@ -231,7 +231,7 @@ TemporalDataObject ::RequestedRegionIsOutsideOfTheBufferedRegion()
 
 //----------------------------------------------------------------------------
 bool
-TemporalDataObject ::VerifyRequestedRegion()
+TemporalDataObject::VerifyRequestedRegion()
 {
   bool frameFlag = m_RequestedTemporalRegion.GetFrameStart() >= m_LargestPossibleTemporalRegion.GetFrameStart();
   frameFlag &= m_RequestedTemporalRegion.GetFrameDuration() <= m_LargestPossibleTemporalRegion.GetFrameDuration();
@@ -259,7 +259,7 @@ TemporalDataObject ::VerifyRequestedRegion()
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::CopyInformation(const DataObject * data)
+TemporalDataObject::CopyInformation(const DataObject * data)
 {
   // Standard call to the superclass' method
   Superclass::CopyInformation(data);
@@ -290,7 +290,7 @@ TemporalDataObject ::CopyInformation(const DataObject * data)
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::Graft(const DataObject * data)
+TemporalDataObject::Graft(const DataObject * data)
 {
   const TemporalDataObject * temporalData;
 
@@ -322,7 +322,7 @@ TemporalDataObject ::Graft(const DataObject * data)
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::SetRequestedRegion(const DataObject * data)
+TemporalDataObject::SetRequestedRegion(const DataObject * data)
 {
   const TemporalDataObject * temporalData;
 
@@ -352,7 +352,7 @@ TemporalDataObject ::SetRequestedRegion(const DataObject * data)
 
 //----------------------------------------------------------------------------
 void
-TemporalDataObject ::PrintSelf(std::ostream & os, Indent indent) const
+TemporalDataObject::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Data Object Buffer: " << m_DataObjectBuffer.GetPointer() << std::endl;

--- a/Modules/Video/Core/src/itkTemporalRegion.cxx
+++ b/Modules/Video/Core/src/itkTemporalRegion.cxx
@@ -23,7 +23,7 @@ namespace itk
 //
 // Constructor
 //
-TemporalRegion ::TemporalRegion()
+TemporalRegion::TemporalRegion()
   : m_RealStart()
   , m_RealDuration(0, 0)
 
@@ -36,76 +36,76 @@ TemporalRegion ::~TemporalRegion() = default;
 
 // ---------------------------------------------------------------------------
 void
-TemporalRegion ::SetRealStart(const RealTimeStamp s)
+TemporalRegion::SetRealStart(const RealTimeStamp s)
 {
   this->m_RealStart = s;
 }
 
 // ---------------------------------------------------------------------------
 RealTimeStamp
-TemporalRegion ::GetRealStart() const
+TemporalRegion::GetRealStart() const
 {
   return this->m_RealStart;
 }
 
 // ---------------------------------------------------------------------------
 void
-TemporalRegion ::SetRealDuration(const RealTimeInterval d)
+TemporalRegion::SetRealDuration(const RealTimeInterval d)
 {
   this->m_RealDuration = d;
 }
 
 RealTimeInterval
-TemporalRegion ::GetRealDuration() const
+TemporalRegion::GetRealDuration() const
 {
   return this->m_RealDuration;
 }
 
 // ---------------------------------------------------------------------------
 void
-TemporalRegion ::SetFrameStart(const FrameOffsetType s)
+TemporalRegion::SetFrameStart(const FrameOffsetType s)
 {
   this->m_FrameStart = s;
 }
 
 // ---------------------------------------------------------------------------
 TemporalRegion::FrameOffsetType
-TemporalRegion ::GetFrameStart() const
+TemporalRegion::GetFrameStart() const
 {
   return this->m_FrameStart;
 }
 
 // ---------------------------------------------------------------------------
 void
-TemporalRegion ::SetFrameDuration(const FrameOffsetType d)
+TemporalRegion::SetFrameDuration(const FrameOffsetType d)
 {
   this->m_FrameDuration = d;
 }
 
 // ---------------------------------------------------------------------------
 TemporalRegion::FrameOffsetType
-TemporalRegion ::GetFrameDuration() const
+TemporalRegion::GetFrameDuration() const
 {
   return this->m_FrameDuration;
 }
 
 // ---------------------------------------------------------------------------
 TemporalRegion::RegionEnum
-TemporalRegion ::GetRegionType() const
+TemporalRegion::GetRegionType() const
 {
   return RegionEnum::ITK_STRUCTURED_REGION;
 }
 
 // ---------------------------------------------------------------------------
 bool
-TemporalRegion ::IsEqualInFrames(const Self & region) const
+TemporalRegion::IsEqualInFrames(const Self & region) const
 {
   return m_FrameStart == region.m_FrameStart && m_FrameDuration == region.m_FrameDuration;
 }
 
 // ---------------------------------------------------------------------------
 bool
-TemporalRegion ::IsEqualInRealTime(const Self & region) const
+TemporalRegion::IsEqualInRealTime(const Self & region) const
 {
   return m_RealStart == region.m_RealStart && m_RealDuration == region.m_RealDuration;
 }
@@ -126,7 +126,7 @@ TemporalRegion ::operator!=(const Self & region) const
 
 // ---------------------------------------------------------------------------
 void
-TemporalRegion ::PrintSelf(std::ostream & os, Indent indent) const
+TemporalRegion::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "RealTime Start: " << m_RealStart << std::endl;

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -192,7 +192,7 @@ VideoFileReader<TOutputVideoStream>::InitializeVideoIO()
   }
 
   // See if a buffer conversion is needed
-  IOComponentEnum ioType = ImageIOBase ::MapPixelType<typename ConvertPixelTraits::ComponentType>::CType;
+  IOComponentEnum ioType = ImageIOBase::MapPixelType<typename ConvertPixelTraits::ComponentType>::CType;
   if (m_VideoIO->GetComponentType() != ioType ||
       m_VideoIO->GetNumberOfComponents() != ConvertPixelTraits::GetNumberOfComponents())
   {


### PR DESCRIPTION
It appears that clang-format has in some cases introduced a space
character between `ClassName` and `::MemberName`. This typically seems
to have happened when there originally was a line break between the
class name and the member name.

This commit fixes the formatting by removing those spaces, as follows:

    find . \( -iname *.cxx -and ! -path *ThirdParty* \) -exec perl -pi -w -e 's/([A-Z][a-z]+) \:\:([A-Z][a-z])/$1::$2/g;' {} \;
    find . \( -iname *.hxx -and ! -path *ThirdParty* \) -exec perl -pi -w -e 's/([A-Z][a-z]+) \:\:([A-Z][a-z])/$1::$2/g;' {} \;
    find . \( -iname *.h -and ! -path *ThirdParty* \) -exec perl -pi -w -e 's/([A-Z][a-z]+) \:\:([A-Z][a-z])/$1::$2/g;' {} \;