### PR TITLE
ENH: Read DICOM directory with Python imread

### DIFF
--- a/Wrapping/Generators/Python/Tests/CMakeLists.txt
+++ b/Wrapping/Generators/Python/Tests/CMakeLists.txt
@@ -19,6 +19,10 @@ itk_python_add_test(NAME PythonComplex COMMAND complex.py)
 itk_python_add_test(NAME PythonHelperFunctions COMMAND helpers.py)
 itk_python_add_test(NAME PythonLazyModule COMMAND lazy.py)
 itk_python_add_test(NAME PythonNoLazyModule COMMAND nolazy.py)
+itk_python_add_test(NAME PythonDICOMSeries COMMAND dicomSeries.py
+              DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0075.dcm}
+              DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0076.dcm}
+              DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0077.dcm})
 
 # some tests will fail if dim=2 and unsigned short are not wrapped
 INTERSECTION(WRAP_2 2 "${ITK_WRAP_IMAGE_DIMS}")

--- a/Wrapping/Generators/Python/Tests/dicomSeries.py
+++ b/Wrapping/Generators/Python/Tests/dicomSeries.py
@@ -1,0 +1,27 @@
+#==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+import itk
+import os
+import argparse
+
+parser = argparse.ArgumentParser(description='dicomSeries.py dicom_volume_series_files')
+parser.add_argument('files', metavar='file', type=str, nargs='+', help='a file in a DICOM volume series')
+args = parser.parse_args()
+dicom_dir = os.path.dirname(args.files[0])
+image = itk.imread(dicom_dir)


### PR DESCRIPTION
Adding feature to Python `imread` function.  If the filename provided is a directory then the directory is assumed to be for a DICOM image and the filename is replaced with list of DICOM filenames within that directory.

- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

