### PR TITLE
STYLE: Replace `container[container.size() - 1]` by `container.back()`

### DIFF
--- a/Modules/Core/Common/include/itkPolygonCell.hxx
+++ b/Modules/Core/Common/include/itkPolygonCell.hxx
@@ -317,7 +317,7 @@ PolygonCell<TCellInterface>::PointIdsEnd()
 {
   if (!m_PointIds.empty())
   {
-    return &m_PointIds[m_PointIds.size() - 1] + 1;
+    return &m_PointIds.back() + 1;
   }
   else
   {
@@ -336,7 +336,7 @@ PolygonCell<TCellInterface>::PointIdsEnd() const
 {
   if (!m_PointIds.empty())
   {
-    return &m_PointIds[m_PointIds.size() - 1] + 1;
+    return &m_PointIds.back() + 1;
   }
   else
   {

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -371,7 +371,7 @@ CreateFullPath(const char * path, const char * file)
    * make sure the end of path is a separator
    */
   ret = path;
-  if (!ret.empty() && ret[ret.size() - 1] != sep)
+  if (!ret.empty() && ret.back() != sep)
   {
     ret += sep;
   }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
@@ -223,7 +223,7 @@ public:
     }
     else
     {
-      return &m_PointIds[m_PointIds.size() - 1] + 1;
+      return &m_PointIds.back() + 1;
     }
   }
 
@@ -252,7 +252,7 @@ public:
     }
     else
     {
-      return &m_PointIds[m_PointIds.size() - 1] + 1;
+      return &m_PointIds.back() + 1;
     }
   }
 

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
@@ -89,7 +89,7 @@ IntermodesThresholdCalculator<THistogram, TOutput>::GenerateData()
       next = smoothedHist[i + 1];
       smoothedHist[i] = (previous + current + next) / 3.;
     }
-    smoothedHist[smoothedHist.size() - 1] = (current + next) / 3.;
+    smoothedHist.back() = (current + next) / 3.;
     ++smIter;
 
     if (smIter > m_MaximumSmoothingIterations)

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -203,7 +203,7 @@ GDCMSeriesFileNames::GetOutputFileNames()
   }
 
   itksys::SystemTools::ConvertToUnixSlashes(m_OutputDirectory);
-  if (m_OutputDirectory[m_OutputDirectory.size() - 1] != '/')
+  if (m_OutputDirectory.back() != '/')
   {
     m_OutputDirectory += '/';
   }

--- a/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
@@ -97,7 +97,7 @@ MRCImageIOTester<TImageType>::Write(const std::string & filePrefix, std::string 
 
 #if defined(WIN32) // windows
     // if it ends in \\ just append the name
-    if (outputPath[outputPath.size() - 1] == '\\')
+    if (outputPath.back() == '\\')
     {
       m_OutputFileName << outputPath << m_NameWithIndex.str();
     }
@@ -109,7 +109,7 @@ MRCImageIOTester<TImageType>::Write(const std::string & filePrefix, std::string 
 #else /// POSIX UNIX
 
     // if it ends in / just append the name
-    if (outputPath[outputPath.size() - 1] == '/')
+    if (outputPath.back() == '/')
     {
       m_OutputFileName << outputPath << m_NameWithIndex.str();
     }
@@ -164,7 +164,7 @@ MRCImageIOTester<TImageType>::Read(const std::string & filePrefix, std::string &
 
 #if defined(WIN32) // windows
     // if it ends in \\ just append the name
-    if (outputPath[outputPath.size() - 1] == '\\')
+    if (outputPath.back() == '\\')
     {
       m_OutputFileName << outputPath << m_NameWithIndex.str();
     }
@@ -176,7 +176,7 @@ MRCImageIOTester<TImageType>::Read(const std::string & filePrefix, std::string &
 #else /// POSIX UNIX
 
     // if it ends in / just append the name
-    if (outputPath[outputPath.size() - 1] == '/')
+    if (outputPath.back() == '/')
     {
       m_OutputFileName << outputPath << m_NameWithIndex.str();
     }

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -236,8 +236,8 @@ MINCTransformIOTemplate<TParametersValueType>::WriteOneTransform(const int      
       Transform_elem(lin, 3, 3) = 1.0;
 
       xfm.emplace_back();
-      memset(&xfm[xfm.size() - 1], 0, sizeof(VIO_General_transform));
-      create_linear_transform(&xfm[xfm.size() - 1], &lin);
+      memset(&xfm.back(), 0, sizeof(VIO_General_transform));
+      create_linear_transform(&xfm.back(), &lin);
     }
     else if (transformType.find("DisplacementFieldTransform_") != std::string::npos &&
              transformType.find("_3_3") != std::string::npos && curTransform->GetFixedParameters().Size() == 18)
@@ -272,10 +272,10 @@ MINCTransformIOTemplate<TParametersValueType>::WriteOneTransform(const int      
       writer->Update();
 
       xfm.emplace_back();
-      create_grid_transform_no_copy(&xfm[xfm.size() - 1], nullptr, nullptr); // relying on volume_io using the same name
+      create_grid_transform_no_copy(&xfm.back(), nullptr, nullptr); // relying on volume_io using the same name
       if (_inverse_grid)
       {
-        xfm[xfm.size() - 1].inverse_flag = TRUE;
+        xfm.back().inverse_flag = TRUE;
       }
     }
     else
@@ -324,7 +324,7 @@ MINCTransformIOTemplate<TParametersValueType>::Write()
     this->WriteOneTransform(count, (*it).GetPointer(), xfm, xfm_file_base.c_str(), serial);
   }
 
-  VIO_General_transform transform = xfm[xfm.size() - 1];
+  VIO_General_transform transform = xfm.back();
 
   for (int i = xfm.size() - 2; i >= 0; --i)
   {

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
@@ -46,7 +46,7 @@ public:
 
 #if defined(WIN32) // windows
     // if it ends in \\ just append the name
-    if (outputPath[outputPath.size() - 1] == '\\')
+    if (outputPath.back() == '\\')
     {
       m_OutputFileName << outputPath << m_NameWithIndex.str();
     }
@@ -57,7 +57,7 @@ public:
 
 #else /// POSIX UNIX
     // if it ends in / just append the name
-    if (outputPath[outputPath.size() - 1] == '/')
+    if (outputPath.back() == '/')
     {
       m_OutputFileName << outputPath << m_NameWithIndex.str();
     }

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -503,7 +503,7 @@ VoxBoCUBImageIO::ReadImageInformation()
 
     const std::string::size_type keysize = key.size();
 
-    if ((keysize > 0) && (key[key.size() - 1] == ':'))
+    if ((keysize > 0) && (key.back() == ':'))
     {
       // Strip the colon off the key
       key = key.substr(0, key.size() - 1);

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -678,7 +678,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
   os << indent << "Bin Maxima: ";
   for (unsigned int i = 0; i < m_Max.size(); i++)
   {
-    os << m_Max[i][m_Max[i].size() - 1] << "  ";
+    os << m_Max[i].back() << "  ";
   }
   os << std::endl;
   os << indent << "ClipBinsAtEnds: " << itk::NumericTraits<bool>::PrintType(this->GetClipBinsAtEnds()) << std::endl;

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -550,7 +550,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::InitializeKLM()
                    (m_BordersDynamicPointer.end()),
                    std::greater<KLMDynamicBorderArray<BorderType>>());
 
-  m_BorderCandidate = &(m_BordersDynamicPointer[m_BordersDynamicPointer.size() - 1]);
+  m_BorderCandidate = &(m_BordersDynamicPointer.back());
   m_InternalLambda = m_BorderCandidate->m_Pointer->GetLambda();
 
   if (m_InternalLambda < 0.0)
@@ -681,7 +681,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::MergeRegions()
 
   // Assign new BorderCandidate (it is always the last element).
   // Set Pointer to BorderCandidate to the last element
-  m_BorderCandidate = &(m_BordersDynamicPointer[m_BordersDynamicPointer.size() - 1]);
+  m_BorderCandidate = &(m_BordersDynamicPointer.back());
   m_InternalLambda = m_BorderCandidate->m_Pointer->GetLambda();
 
   // Remove any duplicate borders found during SpliceRegionBorders:
@@ -696,7 +696,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::MergeRegions()
       itkExceptionMacro(<< "KLM algorithm error");
     }
 
-    m_BorderCandidate = &(m_BordersDynamicPointer[m_BordersDynamicPointer.size() - 1]);
+    m_BorderCandidate = &(m_BordersDynamicPointer.back());
     m_InternalLambda = m_BorderCandidate->m_Pointer->GetLambda();
   }
 } // end MergeRegions


### PR DESCRIPTION
Improved code readability and simplicity by using the member function `back()`.

With help from Perl scripts like:

     find . \( -iname *.cxx -and ! -path *ThirdParty* \) -exec perl -pi -w -e 's/\[.+\.size\(\) - 1\]/.back()/g;' {} \;

Note: such adjustments could not be applied to itkTxtTransformIO.cxx,
itkQuadEdgeMeshDecimationQuadricElementHelper.h, and
itkN4BiasFieldCorrectionImageFilter.hxx, because they use `vnl_vector`,
which currently does not (yet) have a `back()` member function!