### PR TITLE
ENH: Add static ImageFileWriter<>::WriteImage(image, fileName) member function

### DIFF
--- a/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
@@ -37,8 +37,6 @@ itkImageDuplicatorTest2(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
   using DuplicatorType = itk::ImageDuplicator<ImageType>;
   DuplicatorType::Pointer dup = DuplicatorType::New();
   using AbsType = itk::AbsImageFilter<ImageType, ImageType>;
@@ -69,9 +67,7 @@ itkImageDuplicatorTest2(int argc, char * argv[])
     dup->Update();
     ImageType::ConstPointer dupImage = dup->GetOutput();
 
-    writer->SetInput(dupImage);
-    writer->SetFileName(argv[2]);
-    writer->Update();
+    itk::ImageFileWriter<>::WriteImage(*dupImage, argv[2]);
     std::cout << "Test SUCCESS" << std::endl;
   }
   catch (const itk::ExceptionObject & e)

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -41,11 +41,8 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
   using PixelType = unsigned long;
 
   using ImageType = itk::Image<PixelType, ImageDimension>;
-  using WriterType = itk::ImageFileWriter<ImageType>;
 
   ImageType::Pointer image = ImageType::New();
-
-  WriterType::Pointer writer = WriterType::New();
 
   ImageType::SizeType size;
 
@@ -84,9 +81,8 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
     ++counter;
   }
 
-  writer->SetInput(image);
-  writer->SetFileName(argv[1]);
-  writer->Update();
+
+  itk::ImageFileWriter<>::WriteImage(*image, argv[1]);
 
   if (argc > 4)
   {

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest3.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest3.cxx
@@ -64,13 +64,7 @@ itkStreamingImageFilterTest3(int argc, char * argv[])
   streamer->SetNumberOfStreamDivisions(numberOfStreamDivisions);
   streamer->SetRegionSplitter(splitter);
 
-
-  using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(outputFilename);
-  writer->SetInput(streamer->GetOutput());
-  writer->Update();
-
+  itk::ImageFileWriter<>::WriteImage(*(streamer->GetOutput()), outputFilename);
 
   unsigned int expectedNumberOfStreams =
     splitter->GetNumberOfSplits(streamer->GetOutput()->GetLargestPossibleRegion(), numberOfStreamDivisions);

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -82,16 +82,9 @@ itkSymmetricSecondRankTensorImageReadTest(int ac, char * av[])
     ++itr;
   }
 
-  using MatrixWriterType = itk::ImageFileWriter<MatrixImageType>;
-
-  MatrixWriterType::Pointer matrixWriter = MatrixWriterType::New();
-
-  matrixWriter->SetInput(matrixImage);
-  matrixWriter->SetFileName(av[1]);
-
   try
   {
-    matrixWriter->Update();
+    itk::ImageFileWriter<>::WriteImage(*matrixImage, av[1]);
   }
   catch (const itk::ExceptionObject & excp)
   {

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -67,16 +67,9 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int ac, char * av[])
     ++itr;
   }
 
-  using TensorWriterType = itk::ImageFileWriter<TensorImageType>;
-
-  TensorWriterType::Pointer tensorWriter = TensorWriterType::New();
-
-  tensorWriter->SetInput(tensorImageInput);
-  tensorWriter->SetFileName(av[1]);
-
   try
   {
-    tensorWriter->Update();
+    itk::ImageFileWriter<>::WriteImage(*tensorImageInput, av[1]);
   }
   catch (const itk::ExceptionObject & excp)
   {

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -82,7 +82,7 @@ public:
  * \sphinxexample{IO/ImageBase/WriteAnImage,Write An image}
  * \endsphinx
  */
-template <typename TInputImage>
+template <typename TInputImage = void>
 class ITK_TEMPLATE_EXPORT ImageFileWriter : public ProcessObject
 {
 public:
@@ -235,6 +235,32 @@ private:
   int  m_CompressionLevel{ -1 };
   bool m_UseInputMetaDataDictionary{ true };
 };
+
+template <>
+class ImageFileWriter<void>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(ImageFileWriter);
+
+  ImageFileWriter() = delete;
+  ~ImageFileWriter() = delete;
+
+  /** Writes an image to the specified file. Example:
+    \code
+    itk::ImageFileWriter<>::WriteImage(*imagePointer, outputFileName);
+    \endcode
+   */
+  template <typename TInputImage>
+  static void
+  WriteImage(const TInputImage & image, const std::string & fileName)
+  {
+    const auto writer = itk::ImageFileWriter<TInputImage>::New();
+    writer->SetFileName(fileName);
+    writer->SetInput(&image);
+    writer->Update();
+  }
+};
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION


### PR DESCRIPTION
Added `ImageFileWriter<>` specialization that has a static `WriteImage(image, fileName)` member function. Introduced in various tests in "Modules/Core/Common/test"