### PR TITLE
ENH: Allow running various tests without arguments

### DIFF
--- a/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
@@ -44,14 +44,8 @@ CheckEqual(const itk::Point<double, 2> & p1, const itk::Point<double, 2> & p2)
 } // namespace
 
 int
-itkCenteredRigid2DTransformTest(int argc, char * argv[])
+itkCenteredRigid2DTransformTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   std::cout << "==================================" << std::endl;
   std::cout << "Testing CenteredRigid 2D Transform" << std::endl << std::endl;
 

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -45,14 +45,8 @@ CheckEqual(itk::Point<double, 2> p1, itk::Point<double, 2> p2)
 } // namespace
 
 int
-itkEuler2DTransformTest(int argc, char * argv[])
+itkEuler2DTransformTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   std::cout << "==================================" << std::endl;
   std::cout << "Testing Euler Angles 2D Transform" << std::endl << std::endl;
 

--- a/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest.cxx
@@ -23,14 +23,8 @@
  * derived using the Cox-DeBoor recursion algorithm
  */
 int
-itkCoxDeBoorBSplineKernelFunctionTest(int argc, char * argv[])
+itkCoxDeBoorBSplineKernelFunctionTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   using KernelType = itk::CoxDeBoorBSplineKernelFunction<3>;
   KernelType::Pointer    kernel = KernelType::New();
   KernelType::MatrixType coefficients;

--- a/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest2.cxx
@@ -22,14 +22,8 @@
  * correctly for spline orders 2 through 10
  */
 int
-itkCoxDeBoorBSplineKernelFunctionTest2(int argc, char * argv[])
+itkCoxDeBoorBSplineKernelFunctionTest2(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cerr << "Usage: " << argv[0] << std::endl;
-    return EXIT_FAILURE;
-  }
-
   using KernelType = itk::CoxDeBoorBSplineKernelFunction<3>;
   KernelType::Pointer kernel = KernelType::New();
 

--- a/Modules/IO/TransformBase/test/itkTransformFileReaderTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileReaderTest.cxx
@@ -21,15 +21,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkTransformFileReaderTest(int argc, char * argv[])
+itkTransformFileReaderTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
-    std::cerr << std::endl;
-    return EXIT_FAILURE;
-  }
-
   using TransformReaderType = itk::TransformFileReader;
 
   TransformReaderType::Pointer transformReader = TransformReaderType::New();

--- a/Modules/IO/TransformBase/test/itkTransformFileWriterTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileWriterTest.cxx
@@ -21,15 +21,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkTransformFileWriterTest(int argc, char * argv[])
+itkTransformFileWriterTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
-    std::cerr << std::endl;
-    return EXIT_FAILURE;
-  }
-
   using TransformWriterType = itk::TransformFileWriter;
 
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -21,16 +21,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkLevelSetDomainPartitionImageTest(int argc, char * argv[])
+itkLevelSetDomainPartitionImageTest(int, char *[])
 {
-
-  if (argc < 1)
-  {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned short;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -21,16 +21,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkLevelSetDomainPartitionImageWithKdTreeTest(int argc, char * argv[])
+itkLevelSetDomainPartitionImageWithKdTreeTest(int, char *[])
 {
-
-  if (argc < 1)
-  {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned short;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -25,16 +25,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkLevelSetEquationBinaryMaskTermTest(int argc, char * argv[])
+itkLevelSetEquationBinaryMaskTermTest(int, char *[])
 {
-
-  if (argc < 1)
-  {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned short;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -25,16 +25,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkLevelSetEquationOverlapPenaltyTermTest(int argc, char * argv[])
+itkLevelSetEquationOverlapPenaltyTermTest(int, char *[])
 {
-
-  if (argc < 1)
-  {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned short;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -30,14 +30,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkMultiLevelSetDenseImageSubset2DTest(int argc, char * argv[])
+itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cerr << "Missing Arguments: " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned short;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -31,14 +31,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkMultiLevelSetMalcolmImageSubset2DTest(int argc, char * argv[])
+itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cerr << "Missing Arguments: " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned short;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -31,14 +31,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkMultiLevelSetShiImageSubset2DTest(int argc, char * argv[])
+itkMultiLevelSetShiImageSubset2DTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cerr << "Missing Arguments: " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned short;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -31,14 +31,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkMultiLevelSetWhitakerImageSubset2DTest(int argc, char * argv[])
+itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
 {
-  if (argc < 1)
-  {
-    std::cerr << "Missing Arguments: " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned short;


### PR DESCRIPTION
Various tests did fail directly on the condition `if (argc < 1)`, even
if they would not actually use any command-line argument.

This commit removed these checks from those tests, in order to allow
running such a test directly from the command-line by starting its
TestDriver executable and then entering its test number.