### PR TITLE
STYLE: Remove local possibleTransformIO from TransformIOFactoryTemplate

### DIFF
--- a/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
@@ -31,29 +31,16 @@ template <typename TParametersValueType>
 typename TransformIOBaseTemplate<TParametersValueType>::Pointer
 TransformIOFactoryTemplate<TParametersValueType>::CreateTransformIO(const char * path, IOFileModeEnum mode)
 {
-  typename std::list<typename TransformIOBaseTemplate<TParametersValueType>::Pointer> possibleTransformIO;
-  for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkTransformIOBaseTemplate"))
+  for (const auto & allobject : ObjectFactoryBase::CreateAllInstance("itkTransformIOBaseTemplate"))
   {
-    auto * io = dynamic_cast<TransformIOBaseTemplate<TParametersValueType> *>(allobject.GetPointer());
-    if (io)
+    auto * const io = dynamic_cast<TransformIOBaseTemplate<TParametersValueType> *>(allobject.GetPointer());
+
+    if (io != nullptr)
     {
-      possibleTransformIO.push_back(io);
-    }
-  }
-  for (auto k = possibleTransformIO.begin(); k != possibleTransformIO.end(); ++k)
-  {
-    if (mode == IOFileModeEnum::ReadMode)
-    {
-      if ((*k)->CanReadFile(path))
+      if (((mode == IOFileModeEnum::ReadMode) && (io->CanReadFile(path))) ||
+          ((mode == IOFileModeEnum::WriteMode) && (io->CanWriteFile(path))))
       {
-        return *k;
-      }
-    }
-    else if (mode == IOFileModeEnum::WriteMode)
-    {
-      if ((*k)->CanWriteFile(path))
-      {
-        return *k;
+        return io;
       }
     }
   }


### PR DESCRIPTION
Removed the local `possibleTransformIO` variable from the member
function `TransformIOFactoryTemplate::CreateTransformIO`, as it appears
unnecessary to put all IO objects into that list, before finding the one
that can process the specified file path.

Reduced amount of duplicate code for read and write, and improved
const-correctness.