### PR TITLE
STYLE: Replace `vnl_vector[vnl_vector.size() - 1]` by vnl_vector.back(). Also add vnl_vector::front()

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -464,7 +464,7 @@ CLANG_SUPPRESS_Wfloat_equal
         }
         else
         {
-          correctedPixel = E[E.size() - 1];
+          correctedPixel = E.back();
         }
         sharpenedImageBufferRange[indexValue] = correctedPixel;
       }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -104,7 +104,7 @@ public:
     svd.zero_out_relative(m_SVDRelativeThreshold);
     CoordType oError = inner_product(iP.GetVnlVector(), svd.recompose() * iP.GetVnlVector());
 
-    return this->m_Coefficients[this->m_Coefficients.size() - 1] - oError;
+    return this->m_Coefficients.back() - oError;
     /*
     CoordType oError( 0. );
 

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
@@ -248,7 +248,7 @@ print_vector(std::ofstream & s, vnl_vector<TParametersValueType> const & v)
   }
   if (!v.empty())
   {
-    s << convert(v[v.size() - 1]);
+    s << convert(v.back());
   }
 }
 } // namespace itk_impl_details


### PR DESCRIPTION
Follow-up to pull request #2099 (STYLE: Replace `container[container.size() - 1]` by `container.back()`), commit 5eb4697 (6 November 2020)

Discussed with Hans @hjmjohnson at https://github.com/InsightSoftwareConsortium/ITK/pull/2099#pullrequestreview-525170416 