### PR TITLE
20201119 vxl update

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_vector.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_vector.cxx
@@ -18,6 +18,14 @@ test_common_interface()
 
   const typename TContainer::element_type l_values[4] = { 0, 1, 2, 3 };
   TContainer l(4, 4, l_values);
+  TEST("l.front()", l.front() , 0);
+  TEST("l.back()", l.back() , 3);
+
+  const TContainer l_const(4, 4, l_values);
+
+  TEST("l_const.front()", l_const.front() , 0);
+  TEST("l_const.back()", l_const.back() , 3);
+
   TContainer l_swap(l);
   TContainer l_std_swap(l);
 
@@ -33,6 +41,7 @@ test_common_interface()
   std::swap(l_std_swap, r_std_swap);
   TEST("std::swap left-right", l.is_equal(r_std_swap, 10e-6), true);
   TEST("std::swap right-left", r.is_equal(l_std_swap, 10e-6), true);
+
 }
 
 

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_vector_fixed_ref.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/tests/test_vector_fixed_ref.cxx
@@ -44,10 +44,20 @@ test_vector_fixed_ref()
     //      << static_cast<void *>(rval_initialized_independant_matrix.data_block()) << "\n";
   }
 
-  enum
+  constexpr size_t size = 4;
+
   {
-    size = 4
-  };
+    vnl_vector_fixed<unsigned int, size> test_front_back{11, 22, 33, 44};
+    TEST("test_front_back.front()", test_front_back.front() , 11);
+    TEST("test_front_back.back()", test_front_back.back() , 44);
+  }
+
+  {
+    const vnl_vector_fixed<unsigned int, size> test_front_back_const{11, 22, 33, 44};
+    TEST("test_front_back_const.front()", test_front_back_const.front() , 11);
+    TEST("test_front_back_const.back()", test_front_back_const.back() , 44);
+  }
+
   typedef vnl_vector_fixed<double, size> vf;
   typedef vnl_vector_fixed_ref<double, size> vfr;
   typedef vnl_vector_fixed_ref_const<double, size> vfrc;

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
@@ -293,6 +293,16 @@ class VNL_EXPORT vnl_vector
   //: Iterator pointing to element beyond end of data
   const_iterator end() const { return data+num_elmts; }
 
+  //: Analogous to std::vector::front().
+  T& front() { return *data; }
+  //: Analogous to std::vector::back().
+  T& back() { return data[num_elmts - 1]; }
+
+  //: Analogous to std::vector::front() (const overload).
+  const T& front() const { return *data; }
+  //: Analogous to std::vector::back() (const overload).
+  const T& back() const { return data[num_elmts - 1]; }
+
   //: Return a reference to this.
   // Useful in code which would prefer not to know if its argument
   // is a vector, vector_ref or a vector_fixed.  Note that it doesn't

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector_fixed.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector_fixed.h
@@ -301,6 +301,15 @@ class VNL_EXPORT vnl_vector_fixed
   //: Iterator pointing to element beyond end of data
   const_iterator end() const { return data_+n; }
 
+  //: Analogous to std::array::front().
+  T& front() { return *data_; }
+  //: Analogous to std::array::back().
+  T& back() { return data_[n - 1]; }
+
+  //: Analogous to std::array::front() (const overload).
+  const T& front() const { return *data_; }
+  //: Analogous to std::array::back() (const overload).
+  const T& back() const { return data_[n - 1]; }
 
   //: Apply f to each element.
   // Returns a new vector with the result.


### PR DESCRIPTION
Expand the vnl_vector and vnl_vector_fixed to include stl compatible "front" and "back" methods.

