### PR TITLE
BUG: Fix MatrixOffsetTransformBase SetFixedParameters if too few params

### DIFF
--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -484,6 +484,11 @@ void
 MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::SetFixedParameters(
   const FixedParametersType & fp)
 {
+  if (fp.size() < NInputDimensions)
+  {
+    itkExceptionMacro(<< "Error setting fixed parameters: parameters array size (" << fp.size()
+                      << ") is less than expected  (NInputDimensions = " << NInputDimensions << ")");
+  }
   this->m_FixedParameters = fp;
   InputPointType c;
   for (unsigned int i = 0; i < NInputDimensions; i++)

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -181,5 +181,6 @@ set_tests_properties( itkTestTransformGetInverse PROPERTIES COST 50 )
 
 set(ITKTransformGTests
   itkBSplineTransformGTest.cxx
+  itkMatrixOffsetTransformBaseGTest.cxx
 )
 CreateGoogleTestDriver(ITKTransform "${ITKTransform-Test_LIBRARIES}" "${ITKTransformGTests}")

--- a/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
+++ b/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
@@ -1,0 +1,50 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkMatrixOffsetTransformBase.h"
+
+#include <gtest/gtest.h>
+
+
+namespace
+{
+template <unsigned int NDimensions>
+void
+Assert_SetFixedParameters_throws_when_size_is_less_than_NDimensions()
+{
+  for (unsigned int size{}; size < NDimensions; ++size)
+  {
+    using TransformBaseType = itk::MatrixOffsetTransformBase<double, NDimensions, NDimensions>;
+    using FixedParametersType = typename TransformBaseType::FixedParametersType;
+
+    const auto                transformBase = TransformBaseType::New();
+    const FixedParametersType fixedParameters(size);
+    ASSERT_THROW(transformBase->SetFixedParameters(fixedParameters), itk::ExceptionObject);
+  }
+}
+
+} // namespace
+
+
+TEST(MatrixOffsetTransformBase, SetFixedParametersThrowsWhenSizeIsLessThanNDimensions)
+{
+  Assert_SetFixedParameters_throws_when_size_is_less_than_NDimensions<2>();
+  Assert_SetFixedParameters_throws_when_size_is_less_than_NDimensions<3>();
+  Assert_SetFixedParameters_throws_when_size_is_less_than_NDimensions<4>();
+}


### PR DESCRIPTION
When a user provided too few parameters as argument to
`MatrixOffsetTransformBase::SetFixedParameters`, the member function
would have undefined behavior, which would typically just cause a crash.

This issue affects transforms derived from `MatrixOffsetTransformBase`, including:

    AffineTransform
    AzimuthElevationToCartesianTransform
    CenteredAffineTransform
    Euler2DTransform
    FixedCenterOfRotationAffineTransform
    QuaternionRigidTransform
    Rigid2DTransform
    Rigid3DTransform
    ScalableAffineTransform
    ScaleLogarithmicTransform
    ScaleSkewVersor3DTransform
    ScaleTransform
    ScaleVersor3DTransform
    Similarity2DTransform
    Similarity3DTransform
    VersorRigid3DTransform
    VersorTransform

A crash could occur when reading a transform from a transform file, when
this file has an insufficient number of fixed parameters. It was
encountered when loading a transform within 3DSlicer (version
4.11.20200930).

The fix consists of throwing an exception when the number of fixed
parameters is too small.