### PR TITLE
COMP: Work around GCC-4.8 error converting to OptimizerParametersHelper

### DIFF
--- a/Modules/Core/Common/include/itkOptimizerParameters.h
+++ b/Modules/Core/Common/include/itkOptimizerParameters.h
@@ -168,7 +168,8 @@ public:
   ~OptimizerParameters() override = default;
 
 private:
-  std::unique_ptr<OptimizerParametersHelperType> m_Helper{ new OptimizerParametersHelperType };
+  std::unique_ptr<OptimizerParametersHelperType> m_Helper =
+    std::unique_ptr<OptimizerParametersHelperType>{ new OptimizerParametersHelperType };
 };
 
 } // namespace itk


### PR DESCRIPTION
Worked around an apparent compiler bug in GCC 4.8 (which seems to be
fixed with GCC 4.9.2), causing a compile error from GCC 4.8.4 at
https://open.cdash.org/viewBuildError.php?buildid=6897873 saying:

> Core/Common/include/itkOptimizerParameters.h:53:3:
> error: converting to 'std::unique_ptr< itk::OptimizerParametersHelper>'
> from initializer list would use explicit constructor...

Reported by Bradley Lowekamp (@blowekamp) at
https://github.com/InsightSoftwareConsortium/ITK/pull/2114#issuecomment-733741732