### PR TITLE
COMP: Remove -fopenmp in castxml invocation

### DIFF
--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -205,6 +205,8 @@ macro(itk_end_wrap_submodule_castxml module)
     set(_ccache_cmd ${CCACHE_EXECUTABLE})
   endif()
   set(_castxml_cc_flags ${CMAKE_CXX_FLAGS})
+  # Avoid missing omp.h include
+  string(REPLACE "-fopenmp" "" _castxml_cc_flags "${_castxml_cc_flags}")
   if(CMAKE_CXX_EXTENSIONS)
     set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX11_EXTENSION_COMPILE_OPTION}")
   else()


### PR DESCRIPTION
To address:

  FAILED:
  /home/matt/bin/ITK-Wrap-Release/Wrapping/elxParameterObject.xml cd /home/matt/bin/ITKElastix-Wrap-Release/Wrapping/Modules/Elastix && /home/matt/bin/ITKElastix-Wrap-Release/Wrapping/Generators/CastXML/castxml/bin/castxml -o /home/matt/bin/ITK-Wrap-Release/Wrapping/elxParameterObject.xml --castxml-gccxml --castxml-start _wrapping_ --castxml-cc-gnu "(" /usr/bin/c++ -Wno-aggressive-loop-optimizations -fopenmp -std=c++11 ")" -w -c @/home/matt/bin/ITK-Wrap-Release/Wrapping/Elastix.castxml.inc /home/matt/bin/ITK-Wrap-Release/Wrapping/elxParameterObject.cxx
  In file included from /home/matt/bin/ITK-Wrap-Release/Wrapping/elxParameterObject.cxx:11:
  In file included from /home/matt/src/ITK/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h:29:
  In file included from /home/matt/src/ITK/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h:23:
  In file included from /home/matt/src/ITK/Modules/ThirdParty/Eigen3/src/itkeigen/../itkeigen/Eigen/Eigenvalues:11:
  /home/matt/src/ITK/Modules/ThirdParty/Eigen3/src/itkeigen/../itkeigen/Eigen/Core:266:10: fatal error: 'omp.h' file not found
  #include <omp.h>

When building ITKElastix with Linux / GCC 9.3 on Ubuntu 20.04.