### PR TITLE
ENH: Support `ttype` parameter for numpy<->ITK conversions

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -343,6 +343,7 @@ assert m_itk(0, 0) == 1
 # test .astype for itk.Image
 numpyImage = np.random.randint(0, 256, (8, 12, 5)).astype(np.uint8)
 image = itk.image_from_array(numpyImage, is_vector=False)
+assert type(image) == type(itk.image_from_array(numpyImage, ttype=(type(image),)))
 cast = image.astype(np.uint8)
 assert cast == image
 (input_image_template, (input_pixel_type, input_image_dimension)) = itk.template(image)
@@ -367,6 +368,7 @@ for t in [
 # test .astype for itk.VectorImage
 numpyImage = np.random.randint(0, 256, (8, 5, 3)).astype(np.float32)
 image = itk.image_from_array(numpyImage, is_vector=True)
+assert type(image) == type(itk.image_from_array(numpyImage, ttype=(type(image),)))
 vectorimage = itk.cast_image_filter(
     Input=image, ttype=(type(image), itk.VectorImage[itk.F, 2])
 )


### PR DESCRIPTION
Resolves #1348 by adding `ttype` keyword parameter to the functions `_GetArrayFromImage`, `GetArrayFromImage`, `array_from_image`, `GetArrayViewFromImage`, `array_view_from_image`, `_GetImageFromArray`, `GetImageFromArray`, `image_from_array`, `GetImageViewFromArray`, `image_view_from_array`, `_GetArrayFromVnlObject`, `GetArrayFromVnlVector`, `array_from_vnl_vector`, `GetArrayViewFromVnlVector`, `GetArrayFromVnlMatrix`, `GetArrayViewFromVnlMatrix`, `array_from_vnl_matrix`, `_GetVnlObjectFromArray`, `GetVnlVectorFromArray`, `vnl_vector_from_array`, `GetVnlMatrixFromArray`, and `vnl_matrix_from_array`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)