### PR TITLE
ENH: update MetaIO to 8053356e from 2020-12-02

### DIFF
--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaTube.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaTube.cxx
@@ -329,24 +329,23 @@ PrintInfo() const
 }
 
 void MetaTube::
-CopyInfo(const MetaObject * _object)
+CopyInfo(const MetaTube * _object)
 {
   Clear();
 
   MetaObject::CopyInfo(_object);
 
-  const MetaTube * tubeObject = static_cast<const MetaTube*>(_object);
-  PointListType::const_iterator it = tubeObject->GetPoints().begin();
-  while(it != tubeObject->GetPoints().end())
+  PointListType::const_iterator it = _object->GetPoints().begin();
+  while(it != _object->GetPoints().end())
     {
     TubePnt * pnt = new TubePnt( *it );
     m_PointList.push_back(pnt);
     ++it;
     }
 
-  m_ParentPoint = tubeObject->ParentPoint();
-  m_Artery = tubeObject->Artery();
-  m_Root = tubeObject->Root();
+  m_ParentPoint = _object->ParentPoint();
+  m_Artery = _object->Artery();
+  m_Root = _object->Root();
 }
 
 /** Clear Tube information */

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaTube.h
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaTube.h
@@ -117,9 +117,9 @@ class METAIO_EXPORT MetaTube : public MetaObject
 
     void PrintInfo(void) const override;
 
-    void CopyInfo(const MetaObject * _object) override;
+    void CopyInfo(const MetaTube * _object);
 
-    void Clear(void) override;
+    void Clear(void);
 
     MET_ValueEnumType ElementType(void) const;
     void              ElementType(MET_ValueEnumType _elementType);

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaUtils.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaUtils.cxx
@@ -1227,7 +1227,7 @@ bool MET_Read(std::istream &fp,
         MET_FieldRecordType * mF = new MET_FieldRecordType;
         MET_InitReadField(mF, s, MET_STRING, false);
         MET_ASCII_CHAR_TYPE * str = (MET_ASCII_CHAR_TYPE *)(mF->value);
-        fp.getline( str, 500 );
+        fp.getline( str, sizeof(mF->value) );
         MET_StringStripEnd(str);
         mF->length = static_cast<int>( strlen( str ) );
         newFields->push_back(mF);


### PR DESCRIPTION
Update script failed, so I copied the directories. I got the commit message from the script.

```text
Dženan Zukić (2):
      eb179906 COMP: remove pre-VS2015 backwards compatibility definition of snprintf
      8053356e STYLE: trim trailing spaces

Niels Dekker (1):
      c9db10ec ENH: MetaIO support reading strings of >= 500 chars (up to 32767 chars) (#93)

Sean McBride (1):
      e0cab79d Applied a bunch of clang-tidy suggestions

Stephen R. Aylward (2):
      f473b7b8 ENH: Parse() should handle char *argv[] as const (#91)
      34db3e80 Tube point fields (#92)
```