### PR TITLE
COMP: Support calls to ComputeTangentAndNormals() and ComputeTangentsAndNormals()

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -86,7 +86,7 @@ public:
   bool
   ComputeTangentAndNormals()
   {
-    return this->ComputeTangetsAndNormals();
+    return this->ComputeTangentsAndNormals();
   };
 
   /** Remove duplicate points */

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -83,6 +83,12 @@ public:
   bool
   ComputeTangentsAndNormals();
 
+  bool
+  ComputeTangentAndNormals()
+  {
+    return this->ComputeTangetsAndNormals();
+  };
+
   /** Remove duplicate points */
   unsigned int
   RemoveDuplicatePointsInObjectSpace(double minSpacingInObjectSpace = 0);


### PR DESCRIPTION
The name of a function was changed to fix grammar (Tangents vs Tangent), but it broke backwards compatibility.   Here support is added for the original function name to restore backward compatibility.