### PR TITLE
ENH: ttype can be `ImageType` whenever `(ImageType,)` is accepted

### DIFF
--- a/Wrapping/Generators/Python/itk/support/itkTemplate.py
+++ b/Wrapping/Generators/Python/itk/support/itkTemplate.py
@@ -661,9 +661,14 @@ class itkTemplate(Mapping):
             # Note that the function `itk.template()` which returns the template
             # arguments of an object returns tuples and its returned value
             # should be usable in this context.
-            # However, it is easy for a user to pass a list (e.g. [ImageType, ImageType]) and
-            # this needs to work too.
-            ttype = tuple(kwargs.pop("ttype"))
+            # However, it is easy for a user to pass a list (e.g. [ImageType, ImageType]) or
+            # a type (e.g., ImageType), and these need to work too.
+            ttype = kwargs.pop("ttype")
+            if not isinstance(ttype, tuple):
+                if isinstance(ttype, list):
+                    ttype = tuple(ttype)
+                else:
+                    ttype = (ttype,)
             # If there is not the correct number of template parameters, throw an error.
             if len(ttype) != len(list(keys)[0]):
                 raise RuntimeError(


### PR DESCRIPTION
When exactly one type must be supplied via `ttype`, the following three are now equivalent
```python
ttype=ImageType
ttype=(ImageType,)
ttype=[ImageType]
```
so long as `ImageType` is itself a type, not a tuple or list.  When other than exactly one type needs to be supplied, it continues to be the case that only the tuple and list forms work.

- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)
