### PR TITLE
COMP: Adds ComputeTangentAndNormals() function

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -83,12 +83,10 @@ public:
   bool
   ComputeTangentsAndNormals();
 
+#if !defined(ITK_LEGACY_REMOVE)
   /** Calculate the normalized tangent - Old spelling of function name */
-  bool
-  ComputeTangentAndNormals()
-  {
-    return ComputeTangentsAndNormals();
-  }
+  itkLegacyMacro(bool ComputeTangentAndNormals()) { return ComputeTangentsAndNormals(); }
+#endif
 
   /** Remove duplicate points */
   unsigned int

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -83,6 +83,13 @@ public:
   bool
   ComputeTangentsAndNormals();
 
+  /** Calculate the normalized tangent - Old spelling of function name */
+  bool
+  ComputeTangentAndNormals()
+  {
+    return ComputeTangentsAndNormals();
+  }
+
   /** Remove duplicate points */
   unsigned int
   RemoveDuplicatePointsInObjectSpace(double minSpacingInObjectSpace = 0);


### PR DESCRIPTION
A function name was changed to correct grammar and improve clarity, but
it broke backwards compatibility.   This request adds a function
with the old name to restore backward compatibility.