### PR TITLE
COMP: Remove InvalidImageMomentsError from itkImageMomentsCalculator.hxx

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -25,29 +25,6 @@
 
 namespace itk
 {
-class InvalidImageMomentsError : public ExceptionObject
-{
-public:
-  /**
-   * Constructor. Needed to ensure the exception object can be copied.
-   */
-  InvalidImageMomentsError(const char * file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {
-    this->SetDescription("No valid image moments are available.");
-  }
-
-  /**
-   * Constructor. Needed to ensure the exception object can be copied.
-   */
-  InvalidImageMomentsError(const std::string & file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {
-    this->SetDescription("No valid image moments are available.");
-  }
-
-  itkTypeMacro(InvalidImageMomentsError, ExceptionObject);
-};
 
 //----------------------------------------------------------------------
 // Construct without computing moments


### PR DESCRIPTION
The class `InvalidImageMomentsError` appears unused, untested, and
undocumented. It is not defined in a .h file, so it is not a part of
the public API of ITK.

The class was introduced by Jim Miller, September 13, 2001,
"ENH: Modifications to pipeline to throw an exception...",
commit 78e889ed46d36131f5de552d76bd5326121222ae

Its uses were removed by Luis Ibanez, 26 April 2004,
"ENH: Explicit exception throws replaces with itkExceptionMacro...",
commit 96d0ce4317e1047de9b9ef2aa153a1ea98d24138

This commit removes the class to avoid conflicts between ITK and elastix,
which happened to have a copy of the very same class definition:
https://github.com/SuperElastix/elastix/blob/5.0.1/Common/Transforms/itkAdvancedImageMomentsCalculator.hxx#L29