### PR TITLE
COMP: Use CMake 3.18.4 in macOS CI builds

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -60,6 +60,10 @@ jobs:
     - bash: |
         set -x
 
+        curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/de946dd0c0a91ecf6c78c843a4580bd7116c6bf0/Formula/cmake.rb
+        brew unlink cmake
+        brew install ./cmake.rb
+
         c++ --version
         cmake --version
 

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -67,6 +67,10 @@ jobs:
     - bash: |
         set -x
 
+        curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/de946dd0c0a91ecf6c78c843a4580bd7116c6bf0/Formula/cmake.rb
+        brew unlink cmake
+        brew install ./cmake.rb
+
         c++ --version
         cmake --version
 


### PR DESCRIPTION
To work around:

  > CMake Error: install(EXPORT "ITKTargets" ...) includes target "gdcmjpeg8" more than once in the export set.

Likely related to:

  https://gitlab.kitware.com/cmake/cmake/-/issues/21529

Downgrade CMake from 3.19.1 to 3.18.4 until 3.19.2 is released.
