### PR TITLE
COMP: Do not enable whole program optimization with MSVC

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -477,7 +477,7 @@ ${DO_NOT_WAIT_FOR_THREADS_DECLS}
         set_target_properties(${lib} PROPERTIES COMPILE_FLAGS "/wd4244")
       endif()
     endif()
-    if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL 3.13.0)
+    if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL 3.13.0 AND NOT MSVC)
       include(CheckIPOSupported)
       check_ipo_supported()
       set_property(TARGET ${lib} PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)


### PR DESCRIPTION
With MSVC 2019, even using the 64-bit host toolchain tools as suggested:

  https://docs.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?view=msvc-160

The Python package build fails after enabling 4D image support with:

  LINK: command "C:\PROGRA~2\MICROS~1\2019\COMMUN~1\VC\Tools\MSVC\1425~1.286\bin\Hostx86\x64\link.exe /nologo @CMakeFiles\ITKImageIntensityPython.rsp /out:Wrapping\Generators\Python\itk\_ITKImageIntensityPython.pyd /implib:lib\ITKImageIntensityPython.lib /pdb:Wrapping\Generators\Python\itk\_ITKImageIntensityPython.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO /INCREMENTAL:NO /LTCG /MANIFEST /MANIFESTFILE:Wrapping\Generators\Python\itk\_ITKImageIntensityPython.pyd.manifest" failed (exit code 1257) with the following output:
   Creating library lib\ITKImageIntensityPython.lib and object lib\ITKImageIntensityPython.exp
Generating code
C:\P\IPP\ITK-source\ITK\Modules\Filtering\ImageFilterBase\include\itkBinaryGeneratorImageFilter.h(68) : fatal error C1083: Cannot open compiler intermediate file: 'Wrapping\Modules\ITKImageIntensity\CMakeFiles\ITKImageIntensityPython.dir\itkAddImageFilterPython.cpp.obj': Not enough space
LINK : fatal error LNK1257: code generation failed

