### PR TITLE
BUG: Fix multiprocessing imread LazyLoading failures

### DIFF
--- a/Wrapping/Generators/Python/Tests/CMakeLists.txt
+++ b/Wrapping/Generators/Python/Tests/CMakeLists.txt
@@ -35,7 +35,7 @@ if(ITK_WRAP_unsigned_char AND WRAP_2)
     itk_python_add_test(NAME PythonTemplatedPipelineTest
       TEST_DRIVER_ARGS
         --compare ${ITK_TEST_OUTPUT_DIR}/templated_pipeline.png DATA{${WrapITK_SOURCE_DIR}/images/templated_pipeline.png}
-      COMMAND templated_pipeline.py
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/templated_pipeline.py
         DATA{${WrapITK_SOURCE_DIR}/images/2th_cthead1.png}
         ${ITK_TEST_OUTPUT_DIR}/templated_pipeline.png
         10
@@ -64,7 +64,7 @@ foreach(d ${ITK_WRAP_IMAGE_DIMS})
     itk_python_add_test(NAME PythonSimplePipeline${t}${d}
       TEST_DRIVER_ARGS
         --compare ${ITK_TEST_OUTPUT_DIR}/simple_pipeline${t}${d}.nrrd DATA{${WrapITK_SOURCE_DIR}/images/cthead1.png}
-      COMMAND simple_pipeline.py
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/simple_pipeline.py
         ${t}
         ${d}
         DATA{${WrapITK_SOURCE_DIR}/images/cthead1.png}
@@ -72,3 +72,10 @@ foreach(d ${ITK_WRAP_IMAGE_DIMS})
     )
   endforeach()
 endforeach()
+
+
+# Test the lazyloading in a multiprocessing environment
+itk_python_add_test(NAME PythonMultiprocessLazyLoad
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/multiprocess_lazy_loading.py
+        DATA{${WrapITK_SOURCE_DIR}/images/cthead1.png} DATA{${WrapITK_SOURCE_DIR}/images/templated_pipeline.png} DATA{${WrapITK_SOURCE_DIR}/images/2th_cthead1.png}
+    )

--- a/Wrapping/Generators/Python/Tests/PythonTypeTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTypeTest.py
@@ -37,7 +37,7 @@ exclude = [
     "templated_class",
     "auto_pipeline",
     "pipeline",
-    "cvar"
+    "cvar",
 ]
 
 

--- a/Wrapping/Generators/Python/Tests/findEmptyClasses.py
+++ b/Wrapping/Generators/Python/Tests/findEmptyClasses.py
@@ -64,7 +64,7 @@ exclude = [
     "HammingWindowFunction",
     "LanczosWindowFunction",
     "WelchWindowFunction",
-    "Tile", # include from itkTileMontage remote module but only templated over dimension.
+    "Tile",  # include from itkTileMontage remote module but only templated over dimension.
     "cvar",
 ]
 

--- a/Wrapping/Generators/Python/Tests/multiprocess_lazy_loading.py
+++ b/Wrapping/Generators/Python/Tests/multiprocess_lazy_loading.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# LazyLoading must be threadsafe
+#
+# The loading of modules in python *must* occur as a
+# single atomic transaction in multiprocessing environments (i.e.
+# the module should only be loaded by one thread).
+#
+# The LazyLoading of ITK did not treat the loading of
+# modules as an atomic transaction, and multiple threads
+# would attempt to load the cascading dependancies out of
+# order.
+#
+# The `getattr` override that allows LazyLoading to work
+# in the case where the module is *not* loaded now blocks
+# while the first thread completes the delayed module loading.
+# After the first thread completes module load as an atomic
+# transaction, the other threads fall through (skip loading)
+# and return the value requested.
+#
+# Need to use a recursive lock for thread ownership so that the
+# first thread can can acquire a RLock as often as needed while
+# recursively processing dependant modules lazy loads.  Other threads need
+# to wait until this first thread releases the RLock.
+
+
+# NOTE: This test requires itkConfig.LazyLoading=True
+#       Explicitly set to override potential environmental
+#       variable settings.
+import itkConfig
+
+itkConfig.LazyLoading = True
+
+from multiprocessing.pool import ThreadPool
+from multiprocessing import cpu_count
+
+from typing import List
+
+import sys
+
+
+test_image_fn: List[str] = sys.argv[1:]
+# print(f"Reading: {test_image_fn}")
+
+
+def test_itk_multi_load(num_workers: int):
+    num_images_to_be_read: int = max(100, 4 * num_workers)
+    all_filenames = [test_image_fn] * num_images_to_be_read
+
+    def local_image_load(idx: int):
+        # Purposely import inside of thread pool call
+        # to ensure that all the lazy loading of modules
+        # can be configured consistently when all threads
+        # attempt ot load itk at the same time
+        import itk
+
+        return itk.imread(all_filenames[idx])
+
+    with ThreadPool(num_workers) as p:
+        return list(p.map(local_image_load, range(len(all_filenames))))
+
+
+simultaneous_loads: int = max(cpu_count(), 4)  # use at least 4 threads for testing
+test_itk_multi_load(simultaneous_loads)
+
+import sys
+
+sys.exit(0)

--- a/Wrapping/Generators/Python/itk/__init__.py
+++ b/Wrapping/Generators/Python/itk/__init__.py
@@ -36,6 +36,11 @@ def _initialize_module():
     """
     from .support.itkBase import ITKModuleInfo, ITKTemplateFeatures
 
+    # Needed to avoid problem with aliasing of itk.set (itkTemplate)
+    # inside the itk namespace.  We need to explictly specify the
+    # use of the builtin set
+    from builtins import set as _builtin_set
+
     def _get_lazy_attributes(local_lazy_attributes, l_module, l_data: ITKModuleInfo):
         """
         Set up lazy attribute relationships
@@ -57,7 +62,7 @@ def _initialize_module():
             local_lazy_attributes.setdefault(function, []).append(l_module)
         # Remove duplicates in attributes, preserving only the first
         def _dedup(seq):
-            seen = set()
+            seen = _builtin_set()
             seen_add = seen.add
             return [x for x in seq if not (x in seen or seen_add(x))]
 

--- a/Wrapping/Generators/Python/itk/__init__.py
+++ b/Wrapping/Generators/Python/itk/__init__.py
@@ -37,6 +37,9 @@ def _initialize_module():
     from .support.itkBase import ITKModuleInfo, ITKTemplateFeatures
 
     def _get_lazy_attributes(local_lazy_attributes, l_module, l_data: ITKModuleInfo):
+        """
+        Set up lazy attribute relationships
+        """
         for template_feature in l_data._template_feature_tuples:
             if template_feature._class_in_module:
                 # insert in front front if in library
@@ -52,6 +55,14 @@ def _initialize_module():
         for function in l_data._snake_case_functions:
             # snake case always appended to end
             local_lazy_attributes.setdefault(function, []).append(l_module)
+        # Remove duplicates in attributes, preserving only the first
+        def _dedup(seq):
+            seen = set()
+            seen_add = seen.add
+            return [x for x in seq if not (x in seen or seen_add(x))]
+
+        for k, v in local_lazy_attributes.items():
+            local_lazy_attributes[k] = _dedup(v)
 
     from .support import itkBase as _itkBase
     from .support import itkLazy as _itkLazy

--- a/Wrapping/Generators/Python/itk/support/itkBuildOptions.py
+++ b/Wrapping/Generators/Python/itk/support/itkBuildOptions.py
@@ -23,27 +23,37 @@ REALS: List[itkTypes.itkCType] = [
 ]
 
 VECTOR_REALS: List[itkTemplate] = [
-    itkTemplateBase.__template_instantiations_name_to_object__[itkTemplate.normalizeName(s)]
+    itkTemplateBase.__template_instantiations_name_to_object__[
+        itkTemplate.normalizeName(s)
+    ]
     for s in _itkwrapbo["ITK_WRAP_PYTHON_VECTOR_REAL"]
     if s
 ]
 COV_VECTOR_REALS: List[itkTemplate] = [
-    itkTemplateBase.__template_instantiations_name_to_object__[itkTemplate.normalizeName(s)]
+    itkTemplateBase.__template_instantiations_name_to_object__[
+        itkTemplate.normalizeName(s)
+    ]
     for s in _itkwrapbo["ITK_WRAP_PYTHON_COV_VECTOR_REAL"]
     if s
 ]
 RGBS: List[itkTemplate] = [
-    itkTemplateBase.__template_instantiations_name_to_object__[itkTemplate.normalizeName(s)]
+    itkTemplateBase.__template_instantiations_name_to_object__[
+        itkTemplate.normalizeName(s)
+    ]
     for s in _itkwrapbo["ITK_WRAP_PYTHON_RGB"]
     if s
 ]
 RGBAS: List[itkTemplate] = [
-    itkTemplateBase.__template_instantiations_name_to_object__[itkTemplate.normalizeName(s)]
+    itkTemplateBase.__template_instantiations_name_to_object__[
+        itkTemplate.normalizeName(s)
+    ]
     for s in _itkwrapbo["ITK_WRAP_PYTHON_RGBA"]
     if s
 ]
 COMPLEX_REALS: List[itkTemplate] = [
-    itkTemplateBase.__template_instantiations_name_to_object__[itkTemplate.normalizeName(s)]
+    itkTemplateBase.__template_instantiations_name_to_object__[
+        itkTemplate.normalizeName(s)
+    ]
     for s in _itkwrapbo["ITK_WRAP_PYTHON_COMPLEX_REAL"]
     if s
 ]

--- a/Wrapping/Generators/Python/itk/support/itkExtras.py
+++ b/Wrapping/Generators/Python/itk/support/itkExtras.py
@@ -192,7 +192,9 @@ def _get_itk_pixelid(numpy_array_type):
             raise e
 
 
-def _GetArrayFromImage(image_or_filter, function_name: str, keep_axes: bool, update: bool, ttype):
+def _GetArrayFromImage(
+    image_or_filter, function_name: str, keep_axes: bool, update: bool, ttype
+):
     """Get an Array with the content of the image buffer"""
     # Finds the image type
     import itk
@@ -215,16 +217,20 @@ def _GetArrayFromImage(image_or_filter, function_name: str, keep_axes: bool, upd
     return templatedFunction(img, keep_axes, update)
 
 
-def GetArrayFromImage(image_or_filter, keep_axes: bool = False, update: bool = True, ttype = None):
+def GetArrayFromImage(
+    image_or_filter, keep_axes: bool = False, update: bool = True, ttype=None
+):
     """Get an array with the content of the image buffer"""
-    return _GetArrayFromImage(image_or_filter, "GetArrayFromImage", keep_axes, update, ttype)
+    return _GetArrayFromImage(
+        image_or_filter, "GetArrayFromImage", keep_axes, update, ttype
+    )
 
 
 array_from_image = GetArrayFromImage
 
 
 def GetArrayViewFromImage(
-    image_or_filter, keep_axes: bool = False, update: bool = True, ttype = None
+    image_or_filter, keep_axes: bool = False, update: bool = True, ttype=None
 ):
     """Get an array view with the content of the image buffer"""
     return _GetArrayFromImage(
@@ -250,7 +256,7 @@ def _GetImageFromArray(arr, function_name: str, is_vector: bool, ttype):
             ImageType = ttype
         if type(itk.template(ImageType)) != tuple or len(itk.template(ImageType)) < 2:
             raise RuntimeError("Cannot determine pixel type from supplied ttype.")
-        is_vector = (type(itk.template(ImageType)[1][0]) != itk.support.itkTypes.itkCType)
+        is_vector = type(itk.template(ImageType)[1][0]) != itk.support.itkTypes.itkCType
     else:
         PixelType = _get_itk_pixelid(arr)
         Dimension = arr.ndim
@@ -270,14 +276,16 @@ def _GetImageFromArray(arr, function_name: str, is_vector: bool, ttype):
                 ImageType = itk.Image[itk.Vector[PixelType, VectorDimension], Dimension]
     keys = [k for k in itk.PyBuffer.keys() if k[0] == ImageType]
     if len(keys) == 0:
-        raise RuntimeError("""No suitable template parameter can be found.
+        raise RuntimeError(
+            """No suitable template parameter can be found.
 
-Please specify an output type via the 'ttype' keyword parameter.""")
+Please specify an output type via the 'ttype' keyword parameter."""
+        )
     templatedFunction = getattr(itk.PyBuffer[keys[0]], function_name)
     return templatedFunction(arr, is_vector)
 
 
-def GetImageFromArray(arr, is_vector: bool = False, ttype = None):
+def GetImageFromArray(arr, is_vector: bool = False, ttype=None):
     """Get an ITK image from a Python array."""
     return _GetImageFromArray(arr, "GetImageFromArray", is_vector, ttype)
 
@@ -285,7 +293,7 @@ def GetImageFromArray(arr, is_vector: bool = False, ttype = None):
 image_from_array = GetImageFromArray
 
 
-def GetImageViewFromArray(arr, is_vector: bool = False, ttype = None):
+def GetImageViewFromArray(arr, is_vector: bool = False, ttype=None):
     """Get an ITK image view from a Python array."""
     return _GetImageFromArray(arr, "GetImageViewFromArray", is_vector, ttype)
 
@@ -315,7 +323,7 @@ def _GetArrayFromVnlObject(vnl_object, function_name: str, ttype):
     return templatedFunction(vnl_object)
 
 
-def GetArrayFromVnlVector(vnl_vector, ttype = None):
+def GetArrayFromVnlVector(vnl_vector, ttype=None):
     """Get an array with the content of vnl_vector"""
     return _GetArrayFromVnlObject(vnl_vector, "GetArrayFromVnlVector", ttype)
 
@@ -323,7 +331,7 @@ def GetArrayFromVnlVector(vnl_vector, ttype = None):
 array_from_vnl_vector = GetArrayFromVnlVector
 
 
-def GetArrayViewFromVnlVector(vnl_vector, ttype = None):
+def GetArrayViewFromVnlVector(vnl_vector, ttype=None):
     """Get an array view of vnl_vector"""
     return _GetArrayFromVnlObject(vnl_vector, "GetArrayViewFromVnlVector", ttype)
 
@@ -331,12 +339,12 @@ def GetArrayViewFromVnlVector(vnl_vector, ttype = None):
 array_view_from_vnl_vector = GetArrayFromVnlVector
 
 
-def GetArrayFromVnlMatrix(vnl_matrix, ttype = None):
+def GetArrayFromVnlMatrix(vnl_matrix, ttype=None):
     """Get an array with the content of vnl_matrix"""
     return _GetArrayFromVnlObject(vnl_matrix, "GetArrayFromVnlMatrix", ttype)
 
 
-def GetArrayViewFromVnlMatrix(vnl_matrix, ttype = None):
+def GetArrayViewFromVnlMatrix(vnl_matrix, ttype=None):
     """Get an array view of vnl_matrix"""
     return _GetArrayFromVnlObject(vnl_matrix, "GetArrayViewFromVnlMatrix", ttype)
 
@@ -364,7 +372,7 @@ def _GetVnlObjectFromArray(arr, function_name: str, ttype):
     return templatedFunction(arr)
 
 
-def GetVnlVectorFromArray(arr, ttype = None):
+def GetVnlVectorFromArray(arr, ttype=None):
     """Get a vnl vector from a Python array."""
     return _GetVnlObjectFromArray(arr, "GetVnlVectorFromArray", ttype)
 
@@ -372,7 +380,7 @@ def GetVnlVectorFromArray(arr, ttype = None):
 vnl_vector_from_array = GetVnlVectorFromArray
 
 
-def GetVnlMatrixFromArray(arr, ttype = None):
+def GetVnlMatrixFromArray(arr, ttype=None):
     """Get a vnl matrix from a Python array."""
     return _GetVnlObjectFromArray(arr, "GetVnlMatrixFromArray", ttype)
 

--- a/Wrapping/Generators/Python/itk/support/itkLazy.py
+++ b/Wrapping/Generators/Python/itk/support/itkLazy.py
@@ -18,6 +18,12 @@
 import types
 from itk.support import itkBase
 
+# Needed to avoid problem with aliasing of itk.set (itkTemplate)
+# inside the itk namespace.  We need to explictly specify the
+# use of the builtin set
+from builtins import set as _builtin_set
+
+
 not_loaded: str = "not loaded"
 
 
@@ -37,7 +43,9 @@ class LazyITKModule(types.ModuleType):
     def __init__(self, name, lazy_attributes):
         types.ModuleType.__init__(self, name)
         for k, v in lazy_attributes.items():
-            itkBase.itk_base_global_lazy_attributes.setdefault(k, set()).update(v)
+            itkBase.itk_base_global_lazy_attributes.setdefault(
+                k, _builtin_set()
+            ).update(v)
         self.__belong_lazy_attributes = dict(
             (k, v[0]) for k, v in lazy_attributes.items() if len(v) > 0
         )
@@ -46,7 +54,7 @@ class LazyITKModule(types.ModuleType):
         # For PEP 366
         setattr(self, "__package__", "itk")
         setattr(self, "itk_base_global_lazy_attributes", lazy_attributes)
-        setattr(self, "loaded_lazy_modules", set())
+        setattr(self, "loaded_lazy_modules", _builtin_set())
 
     def __getattribute__(self, attr):
         value = types.ModuleType.__getattribute__(self, attr)

--- a/Wrapping/Generators/Python/itk/support/itkLazy.py
+++ b/Wrapping/Generators/Python/itk/support/itkLazy.py
@@ -23,6 +23,17 @@ from itk.support import itkBase
 # use of the builtin set
 from builtins import set as _builtin_set
 
+# Need to use a recursive lock for thread ownership
+# within the given thread you can acquire a RLock as often as you like.
+# Other threads need to wait until this thread releases the resource again.
+from multiprocessing import RLock as _mp_RLock
+
+# A single lock is needed for all lazy loading.  This lock blocks
+# across all threads until this thread has completed all its imports
+# and dependancies.  The complex inter-relationship, and the recursive
+# nature of imports, makes a more fine-grained locking very difficult
+# to implement robustly.
+_gbl_lazy_load_lock: _mp_RLock = _mp_RLock()
 
 not_loaded: str = "not loaded"
 
@@ -59,13 +70,22 @@ class LazyITKModule(types.ModuleType):
     def __getattribute__(self, attr):
         value = types.ModuleType.__getattribute__(self, attr)
         if value is not_loaded:
-            module = self.__belong_lazy_attributes[attr]
-            namespace = {}
-            itkBase.itk_load_swig_module(module, namespace)
-            self.loaded_lazy_modules.add(module)
-            for k, v in namespace.items():
-                setattr(self, k, v)
-            value = namespace[attr]
+            with _gbl_lazy_load_lock:  # All but one thread will block here.
+                if value is not_loaded:
+                    # Only the first thread needs to run this code, all other blocked threads skip
+                    module = self.__belong_lazy_attributes[attr]
+                    namespace = {}
+                    itkBase.itk_load_swig_module(module, namespace)
+                    self.loaded_lazy_modules.add(module)
+                    for k, v in namespace.items():
+                        setattr(self, k, v)
+                    value = namespace[attr]
+                else:  # one of the other threads that had been blocking
+                    # waiting for first thread to complete. Now the
+                    # attribute is REQUIRED to be available
+                    # can just fall through now.
+                    value = types.ModuleType.__getattribute__(self, attr)
+                    assert value is not not_loaded
         return value
 
     # For pickle support

--- a/Wrapping/Generators/Python/itk/support/itkTemplate.py
+++ b/Wrapping/Generators/Python/itk/support/itkTemplate.py
@@ -45,14 +45,18 @@ class itkTemplateBase:
     #
     # 'itk::FixedArray<unsignedint,2>' = {type} <class 'itk.itkFixedArrayPython.itkFixedArrayUI2'>
     #          thisown = {property} <property object at 0x7ff800995710>
-    __template_instantiations_name_to_object__: Dict[str, _SWIG_CALLABLE_TYPE] = collections.OrderedDict()
+    __template_instantiations_name_to_object__: Dict[
+        str, _SWIG_CALLABLE_TYPE
+    ] = collections.OrderedDict()
 
     #
     # __template_instantiations_name_to_object__ = {dict}
     #          <class 'itk.itkFixedArrayPython.itkFixedArrayF2'> = {tuple}
     #               0 = {itkTemplate} <itkTemplate itk::FixedArray>
     #               1 = {tuple} (<itkCType float>, 2)
-    __template_instantiations_object_to_name__: Dict[_SWIG_CALLABLE_TYPE, "itkTemplate"] = {}
+    __template_instantiations_object_to_name__: Dict[
+        _SWIG_CALLABLE_TYPE, "itkTemplate"
+    ] = {}
 
     # __named_template_registry__ = {dict}
     #    'std::list' = {itkTemplate}
@@ -110,7 +114,9 @@ class itkTemplate(Mapping):
         useful until the SmartPointer template was generated), but those classes
         can be used as template argument of classes with template.
         """
-        itkTemplateBase.__template_instantiations_name_to_object__[itkTemplate.normalizeName(name)] = cl
+        itkTemplateBase.__template_instantiations_name_to_object__[
+            itkTemplate.normalizeName(name)
+        ] = cl
 
     @staticmethod
     def _NewImageReader(
@@ -287,7 +293,9 @@ class itkTemplate(Mapping):
         so that the singleton takes preference.
         Use this to define the class member elements
         """
-        self.__template__: Dict[str, Union[str, Callable[..., Any]]] = collections.OrderedDict()
+        self.__template__: Dict[
+            str, Union[str, Callable[..., Any]]
+        ] = collections.OrderedDict()
         self.__name__: str = new_object_name
 
     def __new__(cls, new_object_name: str) -> "itkTemplate":
@@ -297,9 +305,13 @@ class itkTemplate(Mapping):
         if new_object_name not in itkTemplateBase.__named_template_registry__:
             # Create an raw itkTemplate object without calling the __init__
             # New object of type itkTemplate
-            itkTemplateBase.__named_template_registry__[new_object_name] = object.__new__(cls)
+            itkTemplateBase.__named_template_registry__[
+                new_object_name
+            ] = object.__new__(cls)
             # Must explicitly initialize the raw object.
-            itkTemplateBase.__named_template_registry__[new_object_name].__local__init__(new_object_name)
+            itkTemplateBase.__named_template_registry__[
+                new_object_name
+            ].__local__init__(new_object_name)
         return itkTemplateBase.__named_template_registry__[new_object_name]
 
     def __getnewargs_ex__(self):
@@ -432,7 +444,9 @@ class itkTemplate(Mapping):
             if paramNorm in itkTemplateBase.__template_instantiations_name_to_object__:
                 # the parameter is registered.
                 # just get the real class form the dictionary
-                param = itkTemplateBase.__template_instantiations_name_to_object__[paramNorm]
+                param = itkTemplateBase.__template_instantiations_name_to_object__[
+                    paramNorm
+                ]
 
             elif itkCType.GetCType(param_stripped):
                 # the parameter is a c type

--- a/Wrapping/Generators/Python/itk/support/itkTemplate.py
+++ b/Wrapping/Generators/Python/itk/support/itkTemplate.py
@@ -33,6 +33,11 @@ from ..support.itkTypes import itkCType
 import math
 from collections.abc import Mapping
 
+# Needed to avoid problem with aliasing of itk.set (itkTemplate)
+# inside the itk namespace.  We need to explictly specify the
+# use of the builtin set
+from builtins import set as _builtin_set
+
 # A valid type for holding swig classes and functions
 _SWIG_CALLABLE_TYPE = Callable[..., Any]
 
@@ -560,7 +565,7 @@ class itkTemplate(Mapping):
             return obj.__dict__.keys()
 
         def dir2(obj):
-            attrs = set()
+            attrs = _builtin_set()
             if not hasattr(obj, "__bases__"):
                 # obj is an instance
                 if not hasattr(obj, "__class__"):


### PR DESCRIPTION
The loading of modules in python *must* occur as a
single atomic transaction in multiprocessing environments (i.e.
the module should only be loaded by one thread).
    
The LazyLoading of ITK did not treat the loading of
modules as an atomic transaction, and multiple threads
would attempt to load the cascading dependencies out of
order.
    
The `getattr` override that allows LazyLoading to work
in the case where the module is *not* loaded now blocks
while the first thread completes the delayed module loading.
After the first thread completes module load as an atomic
transaction, the other threads fall through (skip loading)
and return the value requested.
    
Need to use a recursive lock for thread ownership so that the
first thread can acquire a RLock as often as needed while
recursively processing dependant modules lazy loads.  Other threads need
to wait until this first thread releases the RLock.


## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
