### PR TITLE
ENH: Test that MetaIO supports a string value of up to 32767 chars

### DIFF
--- a/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
@@ -142,7 +142,6 @@ TestMatch(itk::MetaDataDictionary & dict, const char * const key, TValue expecte
     std::cerr << "Key " << key << " found with unexpected value " << nativeValue << std::endl;
     return false;
   }
-  std::cout << "Key " << key << " found with expected value " << nativeValue << std::endl;
   return true;
 }
 
@@ -178,6 +177,17 @@ itkMetaImageIOMetaDataTest(int argc, char * argv[])
     // Add string key
     std::string key("hello");
     std::string value("world");
+    itk::EncapsulateMetaData<std::string>(dict, key, value);
+  }
+
+  const auto maxSupportedStringSize = (MET_MAX_NUMBER_OF_FIELD_VALUES * sizeof(double)) - 1;
+  static_assert(maxSupportedStringSize == std::numeric_limits<std::int16_t>::max(),
+                "Assert that this max value is 32767");
+
+  {
+    // Add string of the maximum supported size.
+    const std::string key("max_string");
+    const std::string value(maxSupportedStringSize, 'x');
     itk::EncapsulateMetaData<std::string>(dict, key, value);
   }
   {
@@ -263,6 +273,10 @@ itkMetaImageIOMetaDataTest(int argc, char * argv[])
 
   std::string value("world");
   if (!TestMatch<std::string>(dict, "hello", value))
+  {
+    return 1; // error
+  }
+  if (!TestMatch<std::string>(dict, "max_string", std::string(maxSupportedStringSize, 'x')))
   {
     return 1; // error
   }


### PR DESCRIPTION
Added a field whose value is a string of 32767 characters to the test,
to ensure that the following MetaIO improvement is included:

  "ENH: MetaIO support reading strings of >= 500 chars (up to 32767 chars)"
  Pull request https://github.com/Kitware/MetaIO/pull/93
  Commit https://github.com/Kitware/MetaIO/commit/c9db10ecf0ee2193cfc57f8b01674ca0ef305316

No longer printed the content of a field in case of a correct test
result, as it would produce too much noise with such a large string.