### PR TITLE
ENH: add additional assertions for `ttype` parameter

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -344,6 +344,8 @@ assert m_itk(0, 0) == 1
 numpyImage = np.random.randint(0, 256, (8, 12, 5)).astype(np.uint8)
 image = itk.image_from_array(numpyImage, is_vector=False)
 assert type(image) == type(itk.image_from_array(numpyImage, ttype=(type(image),)))
+assert type(image) == type(itk.image_from_array(numpyImage, ttype=[type(image)]))
+assert type(image) == type(itk.image_from_array(numpyImage, ttype=type(image)))
 cast = image.astype(np.uint8)
 assert cast == image
 (input_image_template, (input_pixel_type, input_image_dimension)) = itk.template(image)
@@ -369,6 +371,8 @@ for t in [
 numpyImage = np.random.randint(0, 256, (8, 5, 3)).astype(np.float32)
 image = itk.image_from_array(numpyImage, is_vector=True)
 assert type(image) == type(itk.image_from_array(numpyImage, ttype=(type(image),)))
+assert type(image) == type(itk.image_from_array(numpyImage, ttype=[type(image)]))
+assert type(image) == type(itk.image_from_array(numpyImage, ttype=type(image)))
 vectorimage = itk.cast_image_filter(
     Input=image, ttype=(type(image), itk.VectorImage[itk.F, 2])
 )


### PR DESCRIPTION
ENH: test for ttype=`ImageType` instead of `(ImageType,)`

Adding testing for new functionality added with Pull Request #2141 (Commit 5741f877be0116190000fbe47f2679039c2eddbb).

- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)
