### PR TITLE
BUG: DICOMParser should use `&&` instead of comma in for-loop condition

### DIFF
--- a/Modules/ThirdParty/DICOMParser/src/DICOMParser/DICOMParser.cxx
+++ b/Modules/ThirdParty/DICOMParser/src/DICOMParser/DICOMParser.cxx
@@ -827,7 +827,7 @@ void DICOMParser::GetGroupsElementsDatatypes(dicom_stl::vector<doublebyte>& grou
   dicom_stl::vector<DICOMParser::VRTypes>::iterator diter; // = this->Datatypes.begin();
   
   for (giter = this->Implementation->Groups.begin(), eiter = this->Implementation->Elements.begin(), diter = this->Implementation->Datatypes.begin();
-       giter != this->Implementation->Groups.end(), eiter != this->Implementation->Elements.end(), diter != this->Implementation->Datatypes.end();
+       giter != this->Implementation->Groups.end() && eiter != this->Implementation->Elements.end() && diter != this->Implementation->Datatypes.end();
        giter++, eiter++, diter++)
     {
     groups.push_back(*giter);


### PR DESCRIPTION
Fixed the following warning from Visual C++ 2019:

> DICOMParser.cxx(830,14): warning C4834: discarding return value of
> function with 'nodiscard' attribute

Potentially a serious bug.