### PR TITLE
ENH: Ignore huge file warning for HDF5 paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -56,3 +56,9 @@ Modules/ThirdParty/GDCM/src/gdcm/Source/DataDictionary/gdcmPrivateDefaultDicts.c
 Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/src/lib/openjp2/j2k.c hook-max-size=654063
 Modules/ThirdParty/GDCM/src/gdcm/Source/InformationObjectDefinition/Part3.xml hook-max-size=4336000
 Source/InformationObjectDefinition/Part3.xml hook-max-size=4336000
+
+# Avoid ghostflow-check-master failures
+Modules/ThirdParty/HDF5/src/itkhdf5/src/H5C.c      hook-max-size=400000
+Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Dchunk.c hook-max-size=400000
+Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Shyper.c hook-max-size=500000
+Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Tconv.c  hook-max-size=500000


### PR DESCRIPTION
The ghostflow-check-master check failure needs to be
ignored for ThirdParty HDF5 large files.
