### PR TITLE
STYLE: Use the WriteImage convenience function anywhere in Modules/Core

### DIFF
--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -667,11 +667,7 @@ itkVectorImageTest(int, char * argv[])
 
 
     // Now write this out this VectorImage and read it again
-    using WriterType = itk::ImageFileWriter<VectorImageType>;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput(vectorImage);
-    writer->SetFileName(argv[1]);
-    writer->Update();
+    itk::WriteImage(vectorImage, argv[1]);
   }
 
 

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest.cxx
@@ -101,12 +101,7 @@ itkTriangleMeshToBinaryImageFilterTest(int argc, char * argv[])
 
   if (argc > 1)
   {
-    using WriterType = itk::ImageFileWriter<ImageType>;
-
-    WriterType::Pointer ImageWriter = WriterType::New();
-    ImageWriter->SetInput(imageFilter->GetOutput());
-    ImageWriter->SetFileName(argv[1]);
-    ImageWriter->Update();
+    itk::WriteImage(imageFilter->GetOutput(), argv[1]);
   }
 
   std::cout << "Test [DONE]" << std::endl;

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest1.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest1.cxx
@@ -76,11 +76,7 @@ itkTriangleMeshToBinaryImageFilterTest1(int argc, char * argv[])
 
   if (argc > 1)
   {
-    using WriterType = itk::ImageFileWriter<ImageType>;
-    WriterType::Pointer ImageWriter = WriterType::New();
-    ImageWriter->SetInput(imageFilter->GetOutput());
-    ImageWriter->SetFileName(argv[1]);
-    ITK_TRY_EXPECT_NO_EXCEPTION(ImageWriter->Update());
+    ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(imageFilter->GetOutput(), argv[1]));
   }
 
   std::cout << "TEST PASSED" << std::endl;

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest2.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest2.cxx
@@ -105,12 +105,7 @@ itkTriangleMeshToBinaryImageFilterTest2(int argc, char * argv[])
 
   if (argc > 1)
   {
-    using WriterType = itk::ImageFileWriter<ImageType>;
-
-    WriterType::Pointer ImageWriter = WriterType::New();
-    ImageWriter->SetInput(imageFilter->GetOutput());
-    ImageWriter->SetFileName(argv[1]);
-    ImageWriter->Update();
+    itk::WriteImage(imageFilter->GetOutput(), argv[1]);
   }
 
   std::cout << "[TEST DONE]" << std::endl;

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest3.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest3.cxx
@@ -161,13 +161,7 @@ itkTriangleMeshToBinaryImageFilterTest3(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  using WriterType = itk::ImageFileWriter<ImageType>;
-
-  WriterType::Pointer imageWriter = WriterType::New();
-  imageWriter->SetInput(imageFilter->GetOutput());
-  imageWriter->SetFileName(argv[2]);
-  imageWriter->UseCompressionOn();
-  imageWriter->Update();
+  itk::WriteImage(imageFilter->GetOutput(), argv[2], true);
 
   std::cout << "[TEST DONE]" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
@@ -264,12 +264,7 @@ itkTriangleMeshToBinaryImageFilterTest4(int argc, char * argv[])
   // Exercising Printself//
   imageFilter->Print(std::cout);
 
-  using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer imageWriter = WriterType::New();
-  imageWriter->SetInput(imageFilter->GetOutput());
-  imageWriter->SetFileName(argv[2]);
-  imageWriter->UseCompressionOn();
-  imageWriter->Update();
+  itk::WriteImage(imageFilter->GetOutput(), argv[2], true);
 
   std::cout << "[TEST DONE]" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
@@ -37,7 +37,6 @@ itkBoxSpatialObjectTest(int argc, char * argv[])
   using SceneType = itk::GroupSpatialObject<Dimension>;
   using BoxType = itk::BoxSpatialObject<Dimension>;
   using OutputImageType = itk::Image<unsigned char, Dimension>;
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
   using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<SceneType, OutputImageType>;
 
   SceneType::Pointer scene = SceneType::New();
@@ -155,13 +154,7 @@ itkBoxSpatialObjectTest(int argc, char * argv[])
   imageFilter->SetOutsideValue(0);
   imageFilter->Update();
 
-  const char *        outputFilename = argv[1];
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(outputFilename);
-  writer->SetInput(imageFilter->GetOutput());
-
-  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
-
+  ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(imageFilter->GetOutput(), argv[1]));
 
   std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -900,7 +900,6 @@ HashTestImage(const char * testImageFilename, const std::vector<std::string> & b
   using ReaderType = itk::ImageFileReader<ImageType>;
   using RescaleType = itk::Testing::StretchIntensityImageFilter<SliceImageType, OutputType>;
   using ExtractType = itk::Testing::ExtractSliceImageFilter<ImageType, SliceImageType>;
-  using WriterType = itk::ImageFileWriter<OutputType>;
 
   // setup reader
   ReaderType::Pointer reader = ReaderType::New();
@@ -937,19 +936,13 @@ HashTestImage(const char * testImageFilename, const std::vector<std::string> & b
   rescale->SetOutputMaximum(itk::NumericTraits<unsigned char>::max());
   rescale->SetInput(extract->GetOutput());
 
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetInput(rescale->GetOutput());
-
-
   std::ostringstream testName;
   testName << testImageFilename << ".test.png";
-
-  writer->SetFileName(testName.str().c_str());
 
   try
   {
     rescale->UpdateLargestPossibleRegion();
-    writer->Update();
+    itk::WriteImage(rescale->GetOutput(), testName.str());
   }
   catch (const std::exception & e)
   {

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest2.cxx
@@ -75,9 +75,6 @@ public:
     using FixedReaderType = itk::ImageFileReader<FixedImageType>;
     using MovingReaderType = itk::ImageFileReader<MovingImageType>;
 
-    using MovingWriterType = itk::ImageFileWriter<MovingImageType>;
-
-
     typename FixedReaderType::Pointer fixedReader = FixedReaderType::New();
     fixedReader->SetFileName(argv[2]);
 
@@ -94,11 +91,8 @@ public:
 
 
     typename MovingReaderType::Pointer movingReader = MovingReaderType::New();
-    typename MovingWriterType::Pointer movingWriter = MovingWriterType::New();
 
     movingReader->SetFileName(argv[3]);
-    movingWriter->SetFileName(argv[4]);
-
 
     typename FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
@@ -129,9 +123,6 @@ public:
 
 
     resampler->SetInput(movingReader->GetOutput());
-
-    movingWriter->SetInput(resampler->GetOutput());
-
 
     const unsigned int SpaceDimension = ImageDimension;
     using CoordinateRepType = double;
@@ -207,7 +198,7 @@ public:
 
     try
     {
-      movingWriter->Update();
+      itk::WriteImage(resampler->GetOutput(), argv[4]);
     }
     catch (const itk::ExceptionObject & excp)
     {
@@ -248,18 +239,11 @@ public:
       ++fi;
     }
 
-
-    using FieldWriterType = itk::ImageFileWriter<DeformationFieldType>;
-    typename FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
-
-    fieldWriter->SetInput(field);
-
     if (argc >= 6)
     {
-      fieldWriter->SetFileName(argv[5]);
       try
       {
-        fieldWriter->Update();
+        itk::WriteImage(field, argv[5]);
       }
       catch (const itk::ExceptionObject & excp)
       {

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest3.cxx
@@ -76,9 +76,6 @@ public:
     using FixedReaderType = itk::ImageFileReader<FixedImageType>;
     using MovingReaderType = itk::ImageFileReader<MovingImageType>;
 
-    using MovingWriterType = itk::ImageFileWriter<MovingImageType>;
-
-
     typename FixedReaderType::Pointer fixedReader = FixedReaderType::New();
     fixedReader->SetFileName(argv[2]);
 
@@ -95,11 +92,8 @@ public:
 
 
     typename MovingReaderType::Pointer movingReader = MovingReaderType::New();
-    typename MovingWriterType::Pointer movingWriter = MovingWriterType::New();
 
     movingReader->SetFileName(argv[3]);
-    movingWriter->SetFileName(argv[4]);
-
 
     typename FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
@@ -130,9 +124,6 @@ public:
 
 
     resampler->SetInput(movingReader->GetOutput());
-
-    movingWriter->SetInput(resampler->GetOutput());
-
 
     const unsigned int SpaceDimension = ImageDimension;
     using CoordinateRepType = double;
@@ -221,7 +212,7 @@ public:
 
     try
     {
-      movingWriter->Update();
+      itk::WriteImage(resampler->GetOutput(), argv[4]);
     }
     catch (const itk::ExceptionObject & excp)
     {
@@ -262,18 +253,11 @@ public:
       ++fi;
     }
 
-
-    using FieldWriterType = itk::ImageFileWriter<DeformationFieldType>;
-    typename FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
-
-    fieldWriter->SetInput(field);
-
     if (argc >= 6)
     {
-      fieldWriter->SetFileName(argv[5]);
       try
       {
-        fieldWriter->Update();
+        itk::WriteImage(field, argv[5]);
       }
       catch (const itk::ExceptionObject & excp)
       {

--- a/Modules/Core/Transform/test/itkBSplineTransformInitializerTest1.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformInitializerTest1.cxx
@@ -52,8 +52,6 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
   using FixedReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingReaderType = itk::ImageFileReader<MovingImageType>;
 
-  using MovingWriterType = itk::ImageFileWriter<MovingImageType>;
-
   FixedReaderType::Pointer fixedReader = FixedReaderType::New();
   fixedReader->SetFileName(argv[2]);
 
@@ -69,10 +67,8 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
   }
 
   MovingReaderType::Pointer movingReader = MovingReaderType::New();
-  MovingWriterType::Pointer movingWriter = MovingWriterType::New();
 
   movingReader->SetFileName(argv[3]);
-  movingWriter->SetFileName(argv[4]);
 
   FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
@@ -100,8 +96,6 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
   resampler->SetOutputStartIndex(fixedRegion.GetIndex());
 
   resampler->SetInput(movingReader->GetOutput());
-
-  movingWriter->SetInput(resampler->GetOutput());
 
   const unsigned int     SpaceDimension = ImageDimension;
   constexpr unsigned int SplineOrder = 3;
@@ -154,7 +148,7 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
 
   try
   {
-    movingWriter->Update();
+    itk::WriteImage(resampler->GetOutput(), argv[4]);
   }
   catch (const itk::ExceptionObject & excp)
   {
@@ -196,17 +190,11 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
     ++fi;
   }
 
-  using FieldWriterType = itk::ImageFileWriter<DeformationFieldType>;
-  FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
-
-  fieldWriter->SetInput(field);
-
   if (argc >= 6)
   {
-    fieldWriter->SetFileName(argv[5]);
     try
     {
-      fieldWriter->Update();
+      itk::WriteImage(field, argv[5]);
     }
     catch (const itk::ExceptionObject & excp)
     {

--- a/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
@@ -75,9 +75,6 @@ public:
     using FixedReaderType = itk::ImageFileReader<FixedImageType>;
     using MovingReaderType = itk::ImageFileReader<MovingImageType>;
 
-    using MovingWriterType = itk::ImageFileWriter<MovingImageType>;
-
-
     typename FixedReaderType::Pointer fixedReader = FixedReaderType::New();
     fixedReader->SetFileName(argv[2]);
 
@@ -94,11 +91,8 @@ public:
 
 
     typename MovingReaderType::Pointer movingReader = MovingReaderType::New();
-    typename MovingWriterType::Pointer movingWriter = MovingWriterType::New();
 
     movingReader->SetFileName(argv[3]);
-    movingWriter->SetFileName(argv[4]);
-
 
     typename FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
@@ -129,9 +123,6 @@ public:
 
 
     resampler->SetInput(movingReader->GetOutput());
-
-    movingWriter->SetInput(resampler->GetOutput());
-
 
     const unsigned int SpaceDimension = ImageDimension;
     using CoordinateRepType = double;
@@ -183,7 +174,7 @@ public:
 
     try
     {
-      movingWriter->Update();
+      itk::WriteImage(resampler->GetOutput(), argv[4]);
     }
     catch (const itk::ExceptionObject & excp)
     {
@@ -224,18 +215,11 @@ public:
       ++fi;
     }
 
-
-    using FieldWriterType = itk::ImageFileWriter<DeformationFieldType>;
-    typename FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
-
-    fieldWriter->SetInput(field);
-
     if (argc >= 6)
     {
-      fieldWriter->SetFileName(argv[5]);
       try
       {
-        fieldWriter->Update();
+        itk::WriteImage(field, argv[5]);
       }
       catch (const itk::ExceptionObject & excp)
       {

--- a/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
@@ -75,9 +75,6 @@ public:
     using FixedReaderType = itk::ImageFileReader<FixedImageType>;
     using MovingReaderType = itk::ImageFileReader<MovingImageType>;
 
-    using MovingWriterType = itk::ImageFileWriter<MovingImageType>;
-
-
     typename FixedReaderType::Pointer fixedReader = FixedReaderType::New();
     fixedReader->SetFileName(argv[2]);
 
@@ -94,11 +91,8 @@ public:
 
 
     typename MovingReaderType::Pointer movingReader = MovingReaderType::New();
-    typename MovingWriterType::Pointer movingWriter = MovingWriterType::New();
 
     movingReader->SetFileName(argv[3]);
-    movingWriter->SetFileName(argv[4]);
-
 
     typename FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
@@ -129,9 +123,6 @@ public:
 
 
     resampler->SetInput(movingReader->GetOutput());
-
-    movingWriter->SetInput(resampler->GetOutput());
-
 
     const unsigned int SpaceDimension = ImageDimension;
     using CoordinateRepType = double;
@@ -208,7 +199,7 @@ public:
 
     try
     {
-      movingWriter->Update();
+      itk::WriteImage(resampler->GetOutput(), argv[4]);
     }
     catch (const itk::ExceptionObject & excp)
     {
@@ -249,18 +240,11 @@ public:
       ++fi;
     }
 
-
-    using FieldWriterType = itk::ImageFileWriter<DeformationFieldType>;
-    typename FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
-
-    fieldWriter->SetInput(field);
-
     if (argc >= 6)
     {
-      fieldWriter->SetFileName(argv[5]);
       try
       {
-        fieldWriter->Update();
+        itk::WriteImage(field, argv[5]);
       }
       catch (const itk::ExceptionObject & excp)
       {


### PR DESCRIPTION
Replaced explicit creation of `itk::ImageFileWriter` objects by calling
the new `itk::WriteImage` convenience function. Aims to reduces the
amount of boilerplate code.