### PR TITLE
BUG: CASTXML fails with aggressive optimizer flags

### DIFF
--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -206,12 +206,18 @@ macro(itk_end_wrap_submodule_castxml module)
   endif()
   set(_castxml_cc_flags ${CMAKE_CXX_FLAGS})
   # Avoid missing omp.h include
-  string(REPLACE "-fopenmp" "" _castxml_cc_flags "${_castxml_cc_flags}")
   if(CMAKE_CXX_EXTENSIONS)
     set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX11_EXTENSION_COMPILE_OPTION}")
   else()
     set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX11_STANDARD_COMPILE_OPTION}")
   endif()
+
+  # Agressive optimization flags cause cast_xml to give invalid error conditions
+  set(INVALID_OPTIMIZATION_FLAGS "-fopenmp;-march=[a-zA-Z0-9\-]*;-mtune=[a-zA-Z0-9\-]*;-mfma")
+  foreach( rmmatch ${INVALID_OPTIMIZATION_FLAGS})
+    string(REGEX REPLACE ${rmmatch} "" _castxml_cc_flags "${_castxml_cc_flags}")
+  endforeach()
+
   separate_arguments(_castxml_cc_flags)
   if(MSVC)
     set(_castxml_cc --castxml-cc-msvc ( "${CMAKE_CXX_COMPILER}" ${_castxml_cc_flags} ) -fexceptions)


### PR DESCRIPTION
Incompatibilties with advanced compiler optimization
flags are not properly managed with CASTXML.

export FAILING_FLAG="-mfma"

ITK-bld/Wrapping/Modules/ITKCommon && \\
    ITK-bld/Wrapping/Generators/CastXML/castxml/bin/castxml \\
    -o ITK-bld/Wrapping/itkPointSetToImageFilter.xml --castxml-gccxml \\
    --castxml-start _wrapping_ \\
    --castxml-cc-gnu "(" /usr/bin/c++ ${FAILING_FLAG} ")" \\
    -w \\
    -c @ITK-bld/Wrapping/ITKCommon.castxml.inc ITK-bld/Wrapping/itkPointSetToImageFilter.cxx

In file included from ITK/Modules/ThirdParty/Eigen3/src/itkeigen/../itkeigen/Eigen/Core:391:
ITK/Modules/ThirdParty/Eigen3/src/itkeigen/../itkeigen/Eigen/src/Core/arch/AVX/PacketMath.h:169:54: error: invalid output size for constraint '+x'
  __asm__("vfmadd231ps %[a], %[b], %[c]" : [c] "+x" (res) : [a] "x" (a), [b] "x" (b));
                                                     ^
ITK/Modules/ThirdParty/Eigen3/src/itkeigen/../itkeigen/Eigen/src/Core/arch/AVX/PacketMath.h:179:54: error: invalid output size for constraint '+x'
  __asm__("vfmadd231pd %[a], %[b], %[c]" : [c] "+x" (res) : [a] "x" (a), [b] "x" (b));
2 errors generated.

Expand the removal of "-fopenmp" to also include the identified
compiler optimization flags.


## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
