### PR TITLE
BUG: Missing output dependency shared/H5init.c

### DIFF
--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/CMakeLists.txt
@@ -1024,7 +1024,8 @@ else ()
   )
   if (BUILD_SHARED_LIBS)
     add_custom_command (
-        OUTPUT     ${HDF5_GENERATED_SOURCE_DIR}/shared/shared_gen_SRCS.stamp1
+        OUTPUT     ${HDF5_GENERATED_SOURCE_DIR}/shared/H5Tinit.c
+                   ${HDF5_GENERATED_SOURCE_DIR}/shared/shared_gen_SRCS.stamp1
         COMMAND    ${CMAKE_COMMAND}
         ARGS       -E copy_if_different "${HDF5_GENERATED_SOURCE_DIR}/H5Tinit.c" "${HDF5_GENERATED_SOURCE_DIR}/shared/H5Tinit.c"
         COMMAND    ${CMAKE_COMMAND}


### PR DESCRIPTION
All outputs dependencies need to be listed for
the custom command.

ninja: error: 'cmake_object_order_depends_target_hdf5-shared_DEBUG',
  needed by 'Modules/ThirdParty/HDF5/src/itkhdf5/shared/H5Tinit.c',
  missing and no known rule to make it

Upstream HDF5 patch also submitted.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Issue present in "Ninja Multi-Config" builds with shared libraries turned on.