### PR TITLE
BUG: New test for 3D support

### DIFF
--- a/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
+++ b/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
@@ -58,8 +58,7 @@ class EigenAnalysis2DImageFilterTester
 
     // Define their size, and start index
     mySizeType size;
-    size[0] = 2;
-    size[1] = 2;
+    size.Fill(2);
 
     myIndexType start;
     start.Fill(0);


### PR DESCRIPTION
A newly added test that exercises 3D
support did not initialize the size
of the image in the 3rd dimension.

Changed 2D hard coded size to fill
in the size in all dimensions.

- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
