### PR TITLE
COMP: Set runtime output directory for Windows Python tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,11 @@ if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 else()
   set(NO_WRAP_CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} CACHE PATH "Shared library directory")
 endif()
+if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+  set(NO_WRAP_CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ITK_BINARY_DIR}/bin CACHE PATH "Shared library directory")
+else()
+  set(NO_WRAP_CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} CACHE PATH "Shared library directory")
+endif()
 
 if(ITK_WRAPPING)
   # WRAPPER_LIBRARY_OUTPUT_DIR. Directory in which generated cxx, xml, and idx files will be placed.
@@ -293,9 +298,11 @@ if(ITK_WRAPPING)
     # of allowing only a single element int the CMAKE_CONFIGURATION_TYPES and enforcing
     # that CMAKE_BUILD_TYPE match that type (see Wrapping/CMakeLists.txt enforcement)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$<1:${ITK_PYTHON_PACKAGE_DIR}>" CACHE PATH "Shared library directory with generator override")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "$<1:${ITK_PYTHON_PACKAGE_DIR}>" CACHE PATH "Shared library directory with generator override")
   endif()
 else()
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${NO_WRAP_CMAKE_LIBRARY_OUTPUT_DIRECTORY}   CACHE PATH "Shared library directory")
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${NO_WRAP_CMAKE_RUNTIME_OUTPUT_DIRECTORY}   CACHE PATH "Runtime library directory")
 endif()
 # Setup build locations for shared libraries ----STOP
 
@@ -312,9 +319,6 @@ if(CMAKE_CONFIGURATION_TYPES AND ITK_WRAPPING)
   )
 endif()
 
-if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ITK_BINARY_DIR}/bin)
-endif()
 if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${ITK_BINARY_DIR}/lib)
 endif()


### PR DESCRIPTION
Place the ITK library .dll's next to the CPython extension modules so
they can be loaded on Python import. To address the shared library
Windows Python CI test failures:

181: Loading ITKPyBase... done
181: Loading ITKCommon... Traceback (most recent call last):
181:   File "D:/a/1/s/Modules/Core/SpatialObjects/wrapping/test/SpatialObjectTest.py", line 24, in <module>
181:     SOType = itk.SpatialObject[dim]
181:   File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\itkLazy.py", line 78, in __getattribute__
181:     itkBase.itk_load_swig_module(module, namespace)
181:   File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\itkBase.py", line 102, in itk_load_swig_module
181:     itk_load_swig_module(dep, namespace)
181:   File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\itkBase.py", line 110, in itk_load_swig_module
181:     l_module = loader.load(swig_module_name)
181:   File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\itkBase.py", line 262, in load
181:     l_spec.loader.exec_module(l_module)  # pytype: disable=attribute-error
181:   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
181:   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
181:   File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\..\ITKCommonPython.py", line 13, in <module>
181:     from . import _ITKCommonPython
181: ImportError: DLL load failed: The specified module could not be found.
181: itkTestDriver: Process exited with return value: 1
55/55 Test #181: PythonSpatialObjectTest .............................***Failed    0.55 sec
Loading ITKPyBase... done
Loading ITKCommon... Traceback (most recent call last):
  File "D:/a/1/s/Modules/Core/SpatialObjects/wrapping/test/SpatialObjectTest.py", line 24, in <module>
    SOType = itk.SpatialObject[dim]
  File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\itkLazy.py", line 78, in __getattribute__
    itkBase.itk_load_swig_module(module, namespace)
  File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\itkBase.py", line 102, in itk_load_swig_module
    itk_load_swig_module(dep, namespace)
  File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\itkBase.py", line 110, in itk_load_swig_module
    l_module = loader.load(swig_module_name)
  File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\itkBase.py", line 262, in load
    l_spec.loader.exec_module(l_module)  # pytype: disable=attribute-error
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "D:\a\1\s-build\Wrapping\Generators\Python\itk\support\..\ITKCommonPython.py", line 13, in <module>

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
