### PR TITLE
BUG: Fix Euler3DTransform::SetFixedParameters crash when too few params

### DIFF
--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -135,6 +135,12 @@ template <typename TParametersValueType>
 void
 Euler3DTransform<TParametersValueType>::SetFixedParameters(const FixedParametersType & parameters)
 {
+  if (parameters.size() < InputSpaceDimension)
+  {
+    itkExceptionMacro(<< "Error setting fixed parameters: parameters array size (" << parameters.size()
+                      << ") is less than expected  (InputSpaceDimension = " << InputSpaceDimension << ")");
+  }
+
   InputPointType c;
   for (unsigned int i = 0; i < InputSpaceDimension; i++)
   {

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -181,6 +181,7 @@ set_tests_properties( itkTestTransformGetInverse PROPERTIES COST 50 )
 
 set(ITKTransformGTests
   itkBSplineTransformGTest.cxx
+  itkEuler3DTransformGTest.cxx
   itkMatrixOffsetTransformBaseGTest.cxx
 )
 CreateGoogleTestDriver(ITKTransform "${ITKTransform-Test_LIBRARIES}" "${ITKTransformGTests}")

--- a/Modules/Core/Transform/test/itkEuler3DTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler3DTransformGTest.cxx
@@ -1,0 +1,35 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkEuler3DTransform.h"
+
+#include <gtest/gtest.h>
+
+
+TEST(Euler3DTransform, SetFixedParametersThrowsWhenSizeIsLessThanInputSpaceDimension)
+{
+  using TransformType = itk::Euler3DTransform<>;
+
+  for (unsigned int size{}; size < TransformType::InputSpaceDimension; ++size)
+  {
+    const auto                               transform = TransformType::New();
+    const TransformType::FixedParametersType fixedParameters(size);
+    ASSERT_THROW(transform->SetFixedParameters(fixedParameters), itk::ExceptionObject);
+  }
+}


### PR DESCRIPTION
When the argument passed to `Euler3DTransform` member function
`SetFixedParameters` would contain less than `InputSpaceDimension`
values, the member function would have undefined behavior, which would
typically just cause a crash.

A crash could occur when reading a transform from a transform file, when
this file has an insufficient number of fixed parameters. It was
encountered when loading a transform within 3DSlicer (Preview Release
version 4.13.0-2020-12-15).

The fix consists of throwing an exception when the number of fixed
parameters is too small. A GoogleTest unit test is included.

Follow-up to:
"BUG: Fix MatrixOffsetTransformBase SetFixedParameters if too few params"
Pull request: https://github.com/InsightSoftwareConsortium/ITK/pull/2118
Commit: fcb85b3a1e4f78d3c9c3742f213e7acefb87314f