### PR TITLE
ENH: Add convenience function ReadImage

### DIFF
--- a/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
@@ -35,19 +35,14 @@ itkImageDuplicatorTest2(int argc, char * argv[])
   constexpr unsigned int Dimension = 3;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
   using DuplicatorType = itk::ImageDuplicator<ImageType>;
   DuplicatorType::Pointer dup = DuplicatorType::New();
   using AbsType = itk::AbsImageFilter<ImageType, ImageType>;
   AbsType::Pointer absF = AbsType::New();
 
-  reader->SetFileName(argv[1]);
-
   try
   {
-    reader->Update();
-    ImageType::Pointer inImage = reader->GetOutput();
+    const auto inImage = itk::ReadImage<ImageType>(argv[1]);
 
     ImageType::RegionType lpr = inImage->GetLargestPossibleRegion();
     ImageType::RegionType region = lpr;

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -86,13 +86,6 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
 
   if (argc > 4)
   {
-
-    using ReaderType = itk::ImageFileReader<ImageType>;
-
-    ReaderType::Pointer reader = ReaderType::New();
-
-    reader->SetFileName(argv[2]);
-
     using DifferencePixelType = signed long;
     using DifferenceImageType = itk::Image<DifferencePixelType, ImageDimension>;
 
@@ -101,7 +94,7 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
     DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
 
     difference->SetValidInput(image);
-    difference->SetTestInput(reader->GetOutput());
+    difference->SetTestInput(itk::ReadImage<ImageType>(argv[2]));
     difference->SetToleranceRadius(0);
     difference->SetDifferenceThreshold(0);
 

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -85,64 +85,46 @@ itkSymmetricSecondRankTensorImageReadTest(int ac, char * av[])
   try
   {
     itk::WriteImage(matrixImage, av[1]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+    const TensorImageType::ConstPointer tensorImage = itk::ReadImage<TensorImageType>(av[1]);
 
+    // Compare the read values to the original values
+    const float tolerance = 1e-5;
 
-  using TensorReaderType = itk::ImageFileReader<TensorImageType>;
+    itk::ImageRegionConstIterator<TensorImageType> tItr(tensorImage, region);
+    itk::ImageRegionConstIterator<MatrixImageType> mItr(matrixImage, region);
 
-  TensorReaderType::Pointer tensorReader = TensorReaderType::New();
+    tItr.GoToBegin();
+    mItr.GoToBegin();
 
-  tensorReader->SetFileName(av[1]);
-
-  try
-  {
-    tensorReader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  TensorImageType::ConstPointer tensorImage = tensorReader->GetOutput();
-
-  // Compare the read values to the original values
-  const float tolerance = 1e-5;
-
-  itk::ImageRegionConstIterator<TensorImageType> tItr(tensorImage, region);
-  itk::ImageRegionConstIterator<MatrixImageType> mItr(matrixImage, region);
-
-  tItr.GoToBegin();
-  mItr.GoToBegin();
-
-  while (!mItr.IsAtEnd())
-  {
-    matrixPixel = mItr.Get();
-    const TensorPixelType tensorPixel = tItr.Get();
-
-    for (unsigned int i = 0; i < 3; i++)
+    while (!mItr.IsAtEnd())
     {
-      for (unsigned int j = 0; j < 3; j++)
+      matrixPixel = mItr.Get();
+      const TensorPixelType tensorPixel = tItr.Get();
+
+      for (unsigned int i = 0; i < 3; i++)
       {
-        if (std::abs(matrixPixel[i][j] - tensorPixel(i, j)) > tolerance)
+        for (unsigned int j = 0; j < 3; j++)
         {
-          std::cerr << "Tensor read does not match expected values " << std::endl;
-          std::cerr << "Index " << tItr.GetIndex() << std::endl;
-          std::cerr << "Tensor value " << std::endl << tensorPixel << std::endl;
-          std::cerr << "Matrix value " << std::endl << matrixPixel << std::endl;
-          return EXIT_FAILURE;
+          if (std::abs(matrixPixel[i][j] - tensorPixel(i, j)) > tolerance)
+          {
+            std::cerr << "Tensor read does not match expected values " << std::endl;
+            std::cerr << "Index " << tItr.GetIndex() << std::endl;
+            std::cerr << "Tensor value " << std::endl << tensorPixel << std::endl;
+            std::cerr << "Matrix value " << std::endl << matrixPixel << std::endl;
+            return EXIT_FAILURE;
+          }
         }
       }
+      ++mItr;
+      ++tItr;
     }
-    ++mItr;
-    ++tItr;
+
+
+    return EXIT_SUCCESS;
   }
-
-
-  return EXIT_SUCCESS;
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
 }

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -70,59 +70,41 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int ac, char * av[])
   try
   {
     itk::WriteImage(tensorImageInput, av[1]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+    const TensorImageType::ConstPointer tensorImageOutput = itk::ReadImage<TensorImageType>(av[1]);
 
-  using TensorReaderType = itk::ImageFileReader<TensorImageType>;
+    // Compare the read values to the original values
+    const float tolerance = 1e-5;
 
-  TensorReaderType::Pointer tensorReader = TensorReaderType::New();
+    itk::ImageRegionConstIterator<TensorImageType> inIt(tensorImageInput, region);
+    itk::ImageRegionConstIterator<TensorImageType> outIt(tensorImageOutput, region);
 
-  tensorReader->SetFileName(av[1]);
+    inIt.GoToBegin();
+    outIt.GoToBegin();
 
-  try
-  {
-    tensorReader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  TensorImageType::ConstPointer tensorImageOutput = tensorReader->GetOutput();
-
-  // Compare the read values to the original values
-  const float tolerance = 1e-5;
-
-  itk::ImageRegionConstIterator<TensorImageType> inIt(tensorImageInput, region);
-  itk::ImageRegionConstIterator<TensorImageType> outIt(tensorImageOutput, region);
-
-  inIt.GoToBegin();
-  outIt.GoToBegin();
-
-  while (!outIt.IsAtEnd())
-  {
-    tensorPixelInput = inIt.Get();
-    const TensorPixelType tensorPixelOutput = outIt.Get();
-
-    for (unsigned int i = 0; i < 3; i++)
+    while (!outIt.IsAtEnd())
     {
-      if (std::abs(tensorPixelInput[i] - tensorPixelOutput[i]) > tolerance)
-      {
-        std::cerr << "Tensor read does not match expected values " << std::endl;
-        std::cerr << "Index " << inIt.GetIndex() << std::endl;
-        std::cerr << "Tensor input value " << std::endl << tensorPixelInput << std::endl;
-        std::cerr << "Tensor output value " << std::endl << tensorPixelOutput << std::endl;
-        return EXIT_FAILURE;
-      }
-    }
-    ++inIt;
-    ++outIt;
-  }
+      tensorPixelInput = inIt.Get();
+      const TensorPixelType tensorPixelOutput = outIt.Get();
 
-  return EXIT_SUCCESS;
+      for (unsigned int i = 0; i < 3; i++)
+      {
+        if (std::abs(tensorPixelInput[i] - tensorPixelOutput[i]) > tolerance)
+        {
+          std::cerr << "Tensor read does not match expected values " << std::endl;
+          std::cerr << "Index " << inIt.GetIndex() << std::endl;
+          std::cerr << "Tensor input value " << std::endl << tensorPixelInput << std::endl;
+          std::cerr << "Tensor output value " << std::endl << tensorPixelOutput << std::endl;
+          return EXIT_FAILURE;
+        }
+      }
+      ++inIt;
+      ++outIt;
+    }
+    return EXIT_SUCCESS;
+  }
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
 }

--- a/Modules/IO/ImageBase/include/itkImageFileReader.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.h
@@ -45,7 +45,7 @@ namespace itk
  * filter. If data stored in the file is stored in a different format
  * then specified by TOutputImage, than this filter converts data
  * between the file type and the external expected type.  The
- * ConvertTraits template argument is used to do the conversion.
+ * `ConvertPixelTraits` template parameter is used to do the conversion.
  *
  * A Pluggable factory pattern is used this allows different kinds of readers
  * to be registered (even at run time) without having to modify the
@@ -167,6 +167,29 @@ private:
   // produce the requested region.
   ImageIORegion m_ActualIORegion;
 };
+
+
+/** Convenience function for reading an image.
+ *
+ * `TOutputImage` is the expected output image type, and the optional
+ * `ConvertPixelTraits` template parameter is used to do the conversion,
+ * as specified by ImageFileReader.
+ *
+ * The function reads the image from the specified file, and returns the
+ * image that it has read.
+ * */
+template <typename TOutputImage,
+          typename ConvertPixelTraits = DefaultConvertPixelTraits<typename TOutputImage::IOPixelType>>
+typename TOutputImage::Pointer
+ReadImage(const std::string & filename)
+{
+  const auto reader = ImageFileReader<TOutputImage, ConvertPixelTraits>::New();
+  reader->SetFileName(filename);
+  reader->Update();
+  return reader->GetOutput();
+}
+
+
 } // namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION


### PR DESCRIPTION
Added `itk::ReadImage<TOutputImage>(const std::string & filename)`, to
allows simplifying the C++ code for reading an image.

Suggested by Dženan Zukić (@dzenanz) at
https://github.com/InsightSoftwareConsortium/ITK/pull/2102#issuecomment-723232937

Follow-up to:
"ENH: add a convenience function WriteImage"
Pull request: #2160
Commit: 60b0984d4196841844424e33963e161f3f0c709d

Replaced manual creation of `ImageFileReader` objects in Common tests by
calls to the new `itk::ReadImage` function. Also removed related
redundant try-catch blocks from SymmetricSecondRankTensorImage tests.