### PR TITLE
STYLE: Fix clang-format styling require macro ';' end

### DIFF
--- a/Modules/Core/Common/include/itkEventObject.h
+++ b/Modules/Core/Common/include/itkEventObject.h
@@ -138,7 +138,8 @@ operator<<(std::ostream & os, const EventObject & e)
   private:                                                                                                             \
     void                                                                                                               \
     operator=(const Self &);                                                                                           \
-  };
+  };                                                                                                                   \
+  static_assert(true, "Compile time eliminated. Used to require a semi-colon at end of macro.")
 
 #define itkEventMacroDefinition(classname, super)                                                                      \
   classname::classname(const classname & s)                                                                            \
@@ -149,9 +150,12 @@ operator<<(std::ostream & os, const EventObject & e)
   {                                                                                                                    \
     return (dynamic_cast<const classname *>(e) != nullptr);                                                            \
   }                                                                                                                    \
-  ::itk::EventObject * classname::MakeObject() const { return new classname; }
+  ::itk::EventObject * classname::MakeObject() const { return new classname; }                                         \
+  static_assert(true, "Compile time eliminated. Used to require a semi-colon at end of macro.")
 
-//
+#if !defined(ITK_LEGACY_REMOVE)
+// Suppport Pre 2015 code bases
+
 // This macro duplicates some of the declaration and definition
 // macro code. The purpose is to provide a backward compatibility API
 // for ITK applications.
@@ -160,54 +164,61 @@ operator<<(std::ostream & os, const EventObject & e)
 // file). This new approach guarantees that only one copy of the
 // implementation will be present.
 //
-#define itkEventMacro(classname, super)                                                                                \
-  /** \class classname */                                                                                              \
-  class ITKEvent_EXPORT classname : public super                                                                       \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using Self = classname;                                                                                            \
-    using Superclass = super;                                                                                          \
-    classname() {}                                                                                                     \
-    virtual ~classname() {}                                                                                            \
-    virtual const char *                                                                                               \
-    GetEventName() const                                                                                               \
+#  define itkEventMacro(classname, super)                                                                              \
+    /** \class classname */                                                                                            \
+    class ITKEvent_EXPORT classname : public super                                                                     \
     {                                                                                                                  \
-      return #classname;                                                                                               \
-    }                                                                                                                  \
-    virtual bool                                                                                                       \
-    CheckEvent(const ::itk::EventObject * e) const                                                                     \
-    {                                                                                                                  \
-      return (dynamic_cast<const Self *>(e) != nullptr);                                                               \
-    }                                                                                                                  \
-    virtual ::itk::EventObject *                                                                                       \
-    MakeObject() const                                                                                                 \
-    {                                                                                                                  \
-      return new Self;                                                                                                 \
-    }                                                                                                                  \
-    classname(const Self & s)                                                                                          \
-      : super(s){};                                                                                                    \
+    public:                                                                                                            \
+      using Self = classname;                                                                                          \
+      using Superclass = super;                                                                                        \
+      classname() {}                                                                                                   \
+      virtual ~classname() {}                                                                                          \
+      virtual const char *                                                                                             \
+      GetEventName() const                                                                                             \
+      {                                                                                                                \
+        return #classname;                                                                                             \
+      }                                                                                                                \
+      virtual bool                                                                                                     \
+      CheckEvent(const ::itk::EventObject * e) const                                                                   \
+      {                                                                                                                \
+        return (dynamic_cast<const Self *>(e) != nullptr);                                                             \
+      }                                                                                                                \
+      virtual ::itk::EventObject *                                                                                     \
+      MakeObject() const                                                                                               \
+      {                                                                                                                \
+        return new Self;                                                                                               \
+      }                                                                                                                \
+      classname(const Self & s)                                                                                        \
+        : super(s){};                                                                                                  \
                                                                                                                        \
-  private:                                                                                                             \
-    void                                                                                                               \
-    operator=(const Self &);                                                                                           \
-  };
-
+    private:                                                                                                           \
+      void                                                                                                             \
+      operator=(const Self &);                                                                                         \
+    };
+#endif
 /**
  *      Delclare some common ITK events
  */
-itkEventMacroDeclaration(NoEvent, EventObject) itkEventMacroDeclaration(AnyEvent, EventObject)
-  itkEventMacroDeclaration(DeleteEvent, AnyEvent) itkEventMacroDeclaration(StartEvent, AnyEvent)
-    itkEventMacroDeclaration(EndEvent, AnyEvent) itkEventMacroDeclaration(ProgressEvent, AnyEvent)
-      itkEventMacroDeclaration(ExitEvent, AnyEvent) itkEventMacroDeclaration(AbortEvent, AnyEvent)
-        itkEventMacroDeclaration(ModifiedEvent, AnyEvent) itkEventMacroDeclaration(InitializeEvent, AnyEvent)
-          itkEventMacroDeclaration(IterationEvent, AnyEvent)
-            itkEventMacroDeclaration(MultiResolutionIterationEvent, IterationEvent)
-              itkEventMacroDeclaration(PickEvent, AnyEvent) itkEventMacroDeclaration(StartPickEvent, PickEvent)
-                itkEventMacroDeclaration(EndPickEvent, PickEvent) itkEventMacroDeclaration(AbortCheckEvent, PickEvent)
-                  itkEventMacroDeclaration(FunctionEvaluationIterationEvent, IterationEvent)
-                    itkEventMacroDeclaration(GradientEvaluationIterationEvent, IterationEvent)
-                      itkEventMacroDeclaration(FunctionAndGradientEvaluationIterationEvent, IterationEvent)
-                        itkEventMacroDeclaration(UserEvent, AnyEvent)
+itkEventMacroDeclaration(NoEvent, EventObject);
+itkEventMacroDeclaration(AnyEvent, EventObject);
+itkEventMacroDeclaration(DeleteEvent, AnyEvent);
+itkEventMacroDeclaration(StartEvent, AnyEvent);
+itkEventMacroDeclaration(EndEvent, AnyEvent);
+itkEventMacroDeclaration(ProgressEvent, AnyEvent);
+itkEventMacroDeclaration(ExitEvent, AnyEvent);
+itkEventMacroDeclaration(AbortEvent, AnyEvent);
+itkEventMacroDeclaration(ModifiedEvent, AnyEvent);
+itkEventMacroDeclaration(InitializeEvent, AnyEvent);
+itkEventMacroDeclaration(IterationEvent, AnyEvent);
+itkEventMacroDeclaration(MultiResolutionIterationEvent, IterationEvent);
+itkEventMacroDeclaration(PickEvent, AnyEvent);
+itkEventMacroDeclaration(StartPickEvent, PickEvent);
+itkEventMacroDeclaration(EndPickEvent, PickEvent);
+itkEventMacroDeclaration(AbortCheckEvent, PickEvent);
+itkEventMacroDeclaration(FunctionEvaluationIterationEvent, IterationEvent);
+itkEventMacroDeclaration(GradientEvaluationIterationEvent, IterationEvent);
+itkEventMacroDeclaration(FunctionAndGradientEvaluationIterationEvent, IterationEvent);
+itkEventMacroDeclaration(UserEvent, AnyEvent);
 
 #undef ITKEvent_EXPORT
 #define ITKEvent_EXPORT ITK_ABI_EXPORT

--- a/Modules/Core/Common/src/itkEventObject.cxx
+++ b/Modules/Core/Common/src/itkEventObject.cxx
@@ -55,18 +55,25 @@ EventObject::PrintSelf(std::ostream &, Indent) const
 /**
  * Define some common ITK events
  */
-itkEventMacroDefinition(NoEvent, EventObject) itkEventMacroDefinition(AnyEvent, EventObject)
-  itkEventMacroDefinition(DeleteEvent, AnyEvent) itkEventMacroDefinition(StartEvent, AnyEvent)
-    itkEventMacroDefinition(EndEvent, AnyEvent) itkEventMacroDefinition(ProgressEvent, AnyEvent)
-      itkEventMacroDefinition(ExitEvent, AnyEvent) itkEventMacroDefinition(AbortEvent, AnyEvent)
-        itkEventMacroDefinition(ModifiedEvent, AnyEvent) itkEventMacroDefinition(InitializeEvent, AnyEvent)
-          itkEventMacroDefinition(IterationEvent, AnyEvent)
-            itkEventMacroDefinition(MultiResolutionIterationEvent, IterationEvent)
-              itkEventMacroDefinition(PickEvent, AnyEvent) itkEventMacroDefinition(StartPickEvent, PickEvent)
-                itkEventMacroDefinition(EndPickEvent, PickEvent) itkEventMacroDefinition(AbortCheckEvent, PickEvent)
-                  itkEventMacroDefinition(FunctionEvaluationIterationEvent, IterationEvent)
-                    itkEventMacroDefinition(GradientEvaluationIterationEvent, IterationEvent)
-                      itkEventMacroDefinition(FunctionAndGradientEvaluationIterationEvent, IterationEvent)
-                        itkEventMacroDefinition(UserEvent, AnyEvent)
+itkEventMacroDefinition(NoEvent, EventObject);
+itkEventMacroDefinition(AnyEvent, EventObject);
+itkEventMacroDefinition(DeleteEvent, AnyEvent);
+itkEventMacroDefinition(StartEvent, AnyEvent);
+itkEventMacroDefinition(EndEvent, AnyEvent);
+itkEventMacroDefinition(ProgressEvent, AnyEvent);
+itkEventMacroDefinition(ExitEvent, AnyEvent);
+itkEventMacroDefinition(AbortEvent, AnyEvent);
+itkEventMacroDefinition(ModifiedEvent, AnyEvent);
+itkEventMacroDefinition(InitializeEvent, AnyEvent);
+itkEventMacroDefinition(IterationEvent, AnyEvent);
+itkEventMacroDefinition(MultiResolutionIterationEvent, IterationEvent);
+itkEventMacroDefinition(PickEvent, AnyEvent);
+itkEventMacroDefinition(StartPickEvent, PickEvent);
+itkEventMacroDefinition(EndPickEvent, PickEvent);
+itkEventMacroDefinition(AbortCheckEvent, PickEvent);
+itkEventMacroDefinition(FunctionEvaluationIterationEvent, IterationEvent);
+itkEventMacroDefinition(GradientEvaluationIterationEvent, IterationEvent);
+itkEventMacroDefinition(FunctionAndGradientEvaluationIterationEvent, IterationEvent);
+itkEventMacroDefinition(UserEvent, AnyEvent);
 
 } // end namespace itk


### PR DESCRIPTION
Require that macros end with a semi-colon so that
the macros look function-like to the clang-format
configurations.

Requiring a semi-colon makes the code easier to
parse, format, and read.

Use ITK_LEGACY_REMOVE to disable old, slightly
incorrect code that is recommended not to be used.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
