### PR TITLE
BUG: Update itkEventObjectTest to use new event macros

### DIFF
--- a/Modules/Core/Common/test/itkEventObjectTest.cxx
+++ b/Modules/Core/Common/test/itkEventObjectTest.cxx
@@ -21,9 +21,12 @@
 
 namespace itk
 {
-itkEventMacro(TestEvent, UserEvent);
-itkEventMacro(TestDerivedEvent, TestEvent);
-itkEventMacro(TestOtherEvent, AnyEvent);
+itkEventMacroDeclaration(TestEvent, UserEvent);
+itkEventMacroDefinition(TestEvent, UserEvent);
+itkEventMacroDeclaration(TestDerivedEvent, TestEvent);
+itkEventMacroDefinition(TestDerivedEvent, TestEvent);
+itkEventMacroDeclaration(TestOtherEvent, AnyEvent);
+itkEventMacroDefinition(TestOtherEvent, AnyEvent);
 } // namespace itk
 
 


### PR DESCRIPTION
VS2017 produces errors when compiling line 24 of itkEventObjectTest:

>> ITK\Modules\Core\Common\test\itkEventObjectTest.cxx(24): error C2065: 'TestEvent': undeclared identifier
>> ITK\Modules\Core\Common\test\itkEventObjectTest.cxx(24): error C2275: 'itk::UserEvent': illegal use of this type as an expression

Updating that test to use the preferred itkEventDefinitionMacro() and itkEventDeclarationMacro() fixes this issue.