### PR TITLE
STYLE: Macros should respect an end-of line ;

### DIFF
--- a/Modules/Core/Common/include/itkConceptChecking.h
+++ b/Modules/Core/Common/include/itkConceptChecking.h
@@ -60,12 +60,14 @@
     template <void (Constraints::*)()>                                                                                 \
     struct Enforcer                                                                                                    \
     {};                                                                                                                \
-    using EnforcerInstantiation = Enforcer<&Constraints::constraints>;
+    using EnforcerInstantiation = Enforcer<&Constraints::constraints>;                                                 \
+    ITK_MACROEND_NOOP_STATEMENT
 #  define itkConceptMacro(name, concept)                                                                               \
     enum                                                                                                               \
     {                                                                                                                  \
       name = sizeof concept                                                                                            \
-    }
+    };                                                                                                                 \
+    ITK_MACROEND_NOOP_STATEMENT
 
 #elif defined(ITK_CONCEPT_IMPLEMENTATION_VTABLE)
 

--- a/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
@@ -163,7 +163,7 @@ public:
           }
           offsetValue = -1;
         }
-      };
+      }
     }
   }
 

--- a/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.hxx
+++ b/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.hxx
@@ -72,7 +72,7 @@ ImageVectorOptimizerParametersHelper<TValue, NVectorDimension, VImageDimension>:
     {
       itkGenericExceptionMacro("ImageVectorOptimizerParametersHelper::SetParametersObject: object is "
                                "not of proper image type. Expected VectorImage, received "
-                               << object->GetNameOfClass())
+                               << object->GetNameOfClass());
     }
     m_ParameterImage = image;
     // The PixelContainer for Image<Vector> points to type Vector, so we have

--- a/Modules/Core/Common/include/itkSingletonMacro.h
+++ b/Modules/Core/Common/include/itkSingletonMacro.h
@@ -29,9 +29,10 @@
   {                                                                                                                    \
     static auto * staticGlobals = Get##VarName##Pointer();                                                             \
     (void)staticGlobals;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
-#define itkGetGlobalDeclarationMacro(Type, VarName) static Type * Get##VarName##Pointer();
+#define itkGetGlobalDeclarationMacro(Type, VarName) static Type * Get##VarName##Pointer()
 
 #define itkGetGlobalSimpleMacro(Class, Type, Name) itkGetGlobalInitializeMacro(Class, Type, Name, Class, (void)0)
 
@@ -59,6 +60,7 @@
       }                                                                                                                \
     }                                                                                                                  \
     return m_##VarName;                                                                                                \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #endif

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix_signalhandler.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix_signalhandler.cxx
@@ -72,13 +72,13 @@ typedef union
 #if DEFINED_INTEL
 
 // x87 fpu
-#  define getx87cr(x) asm("fnstcw %0" : "=m"(x));
-#  define setx87cr(x) asm("fldcw %0" : "=m"(x));
-#  define getx87sr(x) asm("fnstsw %0" : "=m"(x));
+#  define getx87cr(x) asm("fnstcw %0" : "=m"(x))
+#  define setx87cr(x) asm("fldcw %0" : "=m"(x))
+#  define getx87sr(x) asm("fnstsw %0" : "=m"(x))
 
 // SIMD, gcc with Intel Core 2 Duo uses SSE2(4)
-#  define getmxcsr(x) asm("stmxcsr %0" : "=m"(x));
-#  define setmxcsr(x) asm("ldmxcsr %0" : "=m"(x));
+#  define getmxcsr(x) asm("stmxcsr %0" : "=m"(x))
+#  define setmxcsr(x) asm("ldmxcsr %0" : "=m"(x))
 
 #endif // DEFINED_INTEL
 

--- a/Modules/Core/Common/src/itkRealTimeInterval.cxx
+++ b/Modules/Core/Common/src/itkRealTimeInterval.cxx
@@ -31,7 +31,8 @@
   {                                                                                                                    \
     seconds += 1;                                                                                                      \
     micro_seconds = 1000000L + micro_seconds;                                                                          \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk
 {

--- a/Modules/Core/Common/src/itkRealTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkRealTimeStamp.cxx
@@ -28,7 +28,8 @@
   {                                                                                                                    \
     seconds += 1;                                                                                                      \
     micro_seconds -= 1000000L;                                                                                         \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define CARRY_UNITS_OVER_SIGNED(seconds, micro_seconds)                                                                \
   if (micro_seconds > 1000000L)                                                                                        \
@@ -40,7 +41,8 @@
   {                                                                                                                    \
     seconds -= 1;                                                                                                      \
     micro_seconds += 1000000L;                                                                                         \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 // This macro ensures that the sign of the seconds is the same as the sign of
 // the microseconds. In other words, both of them are measured toward the same
@@ -55,7 +57,8 @@
   {                                                                                                                    \
     seconds += 1;                                                                                                      \
     micro_seconds = 1000000L + micro_seconds;                                                                          \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk
 {

--- a/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
@@ -80,7 +80,8 @@ itkBSplineKernelFunctionTest(int, char *[])
         return EXIT_FAILURE;                                                                                           \
       }                                                                                                                \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   TEST_BSPLINE_KERNEL(0);
   TEST_BSPLINE_KERNEL(1);

--- a/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
+++ b/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
@@ -355,7 +355,7 @@ itkDataObjectAndProcessObjectTest(int, char *[])
   process->SetNumberOfRequiredInputs(1);
   process->AddOptionalInputName("OptImage", 1);
   ITK_TEST_EXPECT_EQUAL(1, process->GetRequiredInputNames().size());
-  ITK_TEST_EXPECT_EQUAL(2, process->GetInputNames().size())
+  ITK_TEST_EXPECT_EQUAL(2, process->GetInputNames().size());
   ITK_TEST_EXPECT_TRUE(!process->IsRequiredInputName("OptImage"));
   process->SetInput("OptImage", input0);
   ITK_TEST_EXPECT_EQUAL(input0, process->GetInput("OptImage"));

--- a/Modules/Core/Common/test/itkFixedArrayTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest.cxx
@@ -145,7 +145,9 @@ itkFixedArrayTest(int, char *[])
       std::cerr << "index failed" << std::endl;                                                                        \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
+
   TRY_INDEX_CONST(short);
   TRY_INDEX_CONST(unsigned short);
   TRY_INDEX_CONST(int);
@@ -158,7 +160,9 @@ itkFixedArrayTest(int, char *[])
   {                                                                                                                    \
     T in = 10;                                                                                                         \
     array20[in] = 10;                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
+
   TRY_INDEX(short);
   TRY_INDEX(unsigned short);
   TRY_INDEX(int);

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -142,7 +142,9 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
       repeat = 1;                                                                                                      \
     ComputeFastIndex<ImageType>(myImage, totalSize, repeat);                                                           \
     collector.Stop("ComputeIndexFast " #dim "D");                                                                      \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
+
 #define TRY_INDEX(dim)                                                                                                 \
   {                                                                                                                    \
     using PixelType = char;                                                                                            \
@@ -172,7 +174,8 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
       repeat = 1;                                                                                                      \
     ComputeIndex<ImageType>(myImage, totalSize, repeat);                                                               \
     collector.Stop("ComputeIndex " #dim "D");                                                                          \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define TRY_FAST_OFFSET(dim)                                                                                           \
   {                                                                                                                    \
@@ -199,7 +202,8 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
       totalSize *= size[i];                                                                                            \
     ComputeFastOffset<ImageType>(myImage, size[0], totalSize * repeat);                                                \
     collector.Stop("ComputeOffsetFast " #dim "D");                                                                     \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 #define TRY_OFFSET(dim)                                                                                                \
   {                                                                                                                    \
     using PixelType = char;                                                                                            \
@@ -225,7 +229,8 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
       totalSize *= size[i];                                                                                            \
     ComputeOffset<ImageType>(myImage, size[0], totalSize * repeat);                                                    \
     collector.Stop("ComputeOffset " #dim "D");                                                                         \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   TRY_INDEX(1);
   TRY_INDEX(2);

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -206,7 +206,7 @@ Expect_ImageRegionRange_iterates_backward_over_same_pixels_as_ImageRegionIterato
     --imageRegionIterator;
     --rangeIterator;
     EXPECT_EQ(*rangeIterator, imageRegionIterator.Get());
-  };
+  }
 
   EXPECT_EQ(rangeIterator, range.begin());
 }

--- a/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
@@ -39,8 +39,8 @@ itkMathRoundTestHelperFunction(double x)
       y = static_cast<int>(x + 0.5);                                                                                   \
     }                                                                                                                  \
     else { y = static_cast<int>(x - 0.5); }                                                                            \
-  }
-
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 int
 itkMathRoundProfileTest1(int, char *[])

--- a/Modules/Core/Common/test/itkMathRoundTest2.cxx
+++ b/Modules/Core/Common/test/itkMathRoundTest2.cxx
@@ -25,7 +25,8 @@
     std::cout << "Failure! " << #rndname << "(" << (int)(input) << ") expected " << (int)(output) << " but got "       \
               << (int)rndname((input)) << std::endl;                                                                   \
     ok = false;                                                                                                        \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 namespace
 {

--- a/Modules/Core/Common/test/itkMultiThreaderBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderBaseTest.cxx
@@ -97,7 +97,8 @@ SetAndVerify(int number)
     }                                                                                                                  \
                                                                                                                        \
     ITK_EXERCISE_BASIC_OBJECT_METHODS(threader, ClassName, MultiThreaderBase);                                         \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 int
 itkMultiThreaderBaseTest(int argc, char * argv[])

--- a/Modules/Core/Common/test/itkObjectFactoryTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest.cxx
@@ -27,7 +27,8 @@
       std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 template <typename TPixel, unsigned int VImageDimension = 2>
 class TestImage : public itk::Image<TPixel, VImageDimension>

--- a/Modules/Core/Common/test/itkRealTimeIntervalTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeIntervalTest.cxx
@@ -32,7 +32,8 @@
       std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define CHECK_FOR_BOOLEAN(x, expected)                                                                                 \
   {                                                                                                                    \
@@ -41,7 +42,8 @@
       std::cerr << "Error in " #x << std::endl;                                                                        \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 
 int

--- a/Modules/Core/Common/test/itkRealTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeStampTest.cxx
@@ -31,7 +31,8 @@
       std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define CHECK_FOR_BOOLEAN(x, expected)                                                                                 \
   {                                                                                                                    \
@@ -40,8 +41,8 @@
       std::cerr << "Error in " #x << std::endl;                                                                        \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
-
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 int
 itkRealTimeStampTest(int, char *[])

--- a/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
@@ -38,7 +38,8 @@ itkVNLRoundTestHelperFunction(double x)
   else                                                                                                                 \
   {                                                                                                                    \
     y = static_cast<int>(x - 0.5f);                                                                                    \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 
 int

--- a/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
@@ -27,7 +27,8 @@
     std::cerr << __FILE__ << ":" << __LINE__ << ":"                                                                    \
               << "Assertion failed: " << #cond << ": " << text << std::endl;                                           \
     result = EXIT_FAILURE;                                                                                             \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 int
 itkVariableLengthVectorTest(int, char *[])
@@ -101,18 +102,18 @@ itkVariableLengthVectorTest(int, char *[])
     // Tests for SetSize(size, allocation policy, values keeping policy)
     {
       DoubleVariableLengthVectorType ref(d, 3, false);
-      ASSERT(ref.IsAProxy(), "Unexpected Reference VLV value")
-      ASSERT((ref[0] == 0.1) && (d[0] == 0.1), "Unexpected Reference VLV value")
+      ASSERT(ref.IsAProxy(), "Unexpected Reference VLV value");
+      ASSERT((ref[0] == 0.1) && (d[0] == 0.1), "Unexpected Reference VLV value");
 
       DoubleVariableLengthVectorType x(d, 3, false);
-      ASSERT(x.IsAProxy(), "Unexpected VLV value")
-      ASSERT((x[0] == 0.1) && (x[0] == 0.1), "Unexpected VLV value")
+      ASSERT(x.IsAProxy(), "Unexpected VLV value");
+      ASSERT((x[0] == 0.1) && (x[0] == 0.1), "Unexpected VLV value");
 
       // ===[ Keep old values
       // ---[ Shrink To Fit
       x.SetSize(5, DoubleVariableLengthVectorType::ShrinkToFit(), DoubleVariableLengthVectorType::KeepOldValues());
-      ASSERT(!x.IsAProxy(), "After resizing a proxy, it shall not be a proxy anymore")
-      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept")
+      ASSERT(!x.IsAProxy(), "After resizing a proxy, it shall not be a proxy anymore");
+      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept");
       x[3] = 3.0;
       x[4] = 4.0;
       double * start = &x[0];
@@ -128,7 +129,7 @@ itkVariableLengthVectorTest(int, char *[])
       // ---[ Don't Shrink To Fit
       x.SetSize(5, DoubleVariableLengthVectorType::DontShrinkToFit(), DoubleVariableLengthVectorType::KeepOldValues());
       ASSERT(!x.IsAProxy(), "After resizing, it shall never be a proxy");
-      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept")
+      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept");
       ASSERT(&x[0] != start, "DontShrinkToFit shall induce a resizing when the size grows");
       x[3] = 3.0;
       x[4] = 4.0;
@@ -136,31 +137,31 @@ itkVariableLengthVectorTest(int, char *[])
 
       x.SetSize(3, DoubleVariableLengthVectorType::DontShrinkToFit(), DoubleVariableLengthVectorType::KeepOldValues());
       ASSERT(!x.IsAProxy(), "After resizing, it shall never be a proxy");
-      ASSERT(ref == x, "Old Values shall have been kept")
+      ASSERT(ref == x, "Old Values shall have been kept");
       ASSERT(&x[0] == start, "DontShrinkToFit shall not induce a resizing when the size diminishes");
       start = &x[0];
 
       x.SetSize(3, DoubleVariableLengthVectorType::DontShrinkToFit(), DoubleVariableLengthVectorType::KeepOldValues());
       ASSERT(!x.IsAProxy(), "After resizing, it shall never be a proxy");
-      ASSERT(ref == x, "Old Values shall have been kept")
+      ASSERT(ref == x, "Old Values shall have been kept");
       ASSERT(&x[0] == start, "DontShrinkToFit shall not induce a resizing when the size stays the same");
 
       // ---[ Always Reallocate
       x.SetSize(5, DoubleVariableLengthVectorType::AlwaysReallocate(), DoubleVariableLengthVectorType::KeepOldValues());
       ASSERT(!x.IsAProxy(), "After resizing, it shall never be a proxy");
-      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept")
+      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept");
       ASSERT(&x[0] != start, "AlwaysReallocate shall induce a reallocation when resizing");
       start = &x[0];
 
       x.SetSize(3, DoubleVariableLengthVectorType::AlwaysReallocate(), DoubleVariableLengthVectorType::KeepOldValues());
       ASSERT(!x.IsAProxy(), "After resizing, it shall never be a proxy");
-      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept")
+      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept");
       ASSERT(&x[0] != start, "AlwaysReallocate shall induce a reallocation when resizing");
       start = &x[0];
 
       x.SetSize(3, DoubleVariableLengthVectorType::AlwaysReallocate(), DoubleVariableLengthVectorType::KeepOldValues());
       ASSERT(!x.IsAProxy(), "After resizing, it shall never be a proxy");
-      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept")
+      ASSERT(ref[0] == x[0] && ref[1] == x[1] && ref[2] == x[2], "Old Values shall have been kept");
       ASSERT(&x[0] != start, "AlwaysReallocate shall induce a reallocation when resizing, even with the same size");
       start = &x[0];
 

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -61,7 +61,7 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::SetInputIma
           itkExceptionMacro("The OutputType is not the right size (" << nComponents << ") for the given pixel size ("
                                                                      << inputData->GetNumberOfComponentsPerPixel()
                                                                      << ") and image dimension ("
-                                                                     << TInputImage::ImageDimension << ").")
+                                                                     << TInputImage::ImageDimension << ").");
         }
       }
     }

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -651,7 +651,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcRayIntercepts()
 
   if (nSidesCrossed >= 5)
   {
-    itkDebugStatement(std::cerr << "WARNING: No. of sides crossed equals: " << nSidesCrossed << std::endl;);
+    itkDebugStatement(std::cerr << "WARNING: No. of sides crossed equals: " << nSidesCrossed << std::endl);
   }
 
   // If 'nSidesCrossed' is larger than 2, this means that the ray goes through

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
@@ -33,14 +33,16 @@
     itkmsg << "Debug: In " __FILE__ ", line " << __LINE__ << "\n"                                                      \
            << " (" << this << "): " x << "\n\n";                                                                       \
     OutputWindowDisplayDebugText(itkmsg.str().c_str());                                                                \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 #define itkQEWarningMacro(x)                                                                                           \
   {                                                                                                                    \
     std::ostringstream itkmsg;                                                                                         \
     itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n"                                                    \
            << " (" << this << "): " x << "\n\n";                                                                       \
     OutputWindowDisplayWarningText(itkmsg.str().c_str());                                                              \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 // -------------------------------------------------------------------------
 /**

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -28,7 +28,8 @@
                                                                                                                        \
   virtual Iterator End##Op() { return Iterator(this, Self::Iterator::Operator##Op, false); }                           \
                                                                                                                        \
-  virtual ConstIterator End##Op() const { return ConstIterator(this, Self::ConstIterator::Operator##Op, false); }
+  virtual ConstIterator End##Op() const { return ConstIterator(this, Self::ConstIterator::Operator##Op, false); }      \
+  ITK_MACROEND_NOOP_STATEMENT
 
 // -------------------------------------------------------------------------
 #define itkQEDefineIteratorGeomMethodsMacro(Op)                                                                        \
@@ -44,7 +45,8 @@
   virtual ConstIteratorGeom EndGeom##Op() const                                                                        \
   {                                                                                                                    \
     return ConstIteratorGeom(this, Self::ConstIteratorGeom::Operator##Op, false);                                      \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk
 {

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -231,7 +231,7 @@ ContourSpatialObject<TDimension>::Update()
         this->m_Points.push_back(newSOPoint);
       }
       break;
-  };
+  }
 
   // Call this last to compute MyBoundingBoxInWorldSpace
   Superclass::Update();

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -124,7 +124,7 @@ ComparisonImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(const Out
 
   if (validImage->GetBufferedRegion() != testImage->GetBufferedRegion())
   {
-    itkExceptionMacro(<< "Input images have different Buffered Regions.")
+    itkExceptionMacro(<< "Input images have different Buffered Regions.");
   }
 
   // Create a radius of pixels.

--- a/Modules/Core/TestKernel/include/itkTestingMacros.h
+++ b/Modules/Core/TestKernel/include/itkTestingMacros.h
@@ -84,7 +84,8 @@ namespace itk
   {                                                                                                                    \
     std::cerr << "Superclass name provided does not match object's Superclass::NameOfClass" << std::endl;              \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define ITK_TRY_EXPECT_EXCEPTION(command)                                                                              \
   try                                                                                                                  \
@@ -99,7 +100,8 @@ namespace itk
   {                                                                                                                    \
     std::cout << "Caught expected exception" << std::endl;                                                             \
     std::cout << excp << std::endl;                                                                                    \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 
 #define ITK_TRY_EXPECT_NO_EXCEPTION(command)                                                                           \
@@ -113,7 +115,8 @@ namespace itk
     std::cerr << excp << std::endl;                                                                                    \
     std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;                                                  \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define ITK_TEST_EXPECT_TRUE_STATUS_VALUE(command, statusVal)                                                          \
   {                                                                                                                    \
@@ -128,7 +131,8 @@ namespace itk
       std::cerr << "  but got  " << _ITK_TEST_EXPECT_TRUE_command << std::endl;                                        \
       statusVal = EXIT_FAILURE;                                                                                        \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define ITK_TEST_EXPECT_TRUE(command)                                                                                  \
   {                                                                                                                    \
@@ -143,7 +147,8 @@ namespace itk
       std::cerr << "  but got  " << _ITK_TEST_EXPECT_TRUE_command << std::endl;                                        \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 
 #define ITK_TEST_EXPECT_EQUAL_STATUS_VALUE(lh, rh, statusVal)                                                          \
@@ -160,7 +165,8 @@ namespace itk
       std::cerr << "Expression is not equal" << std::endl;                                                             \
       statusVal = EXIT_FAILURE;                                                                                        \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define ITK_TEST_EXPECT_EQUAL(lh, rh)                                                                                  \
   {                                                                                                                    \
@@ -176,7 +182,8 @@ namespace itk
       std::cerr << "Expression is not equal" << std::endl;                                                             \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 
 #define ITK_TEST_SET_GET(variable, command)                                                                            \
@@ -187,7 +194,8 @@ namespace itk
     std::cerr << "Expected " << variable.GetPointer() << std::endl;                                                    \
     std::cerr << "but got  " << command << std::endl;                                                                  \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 
 #define ITK_TEST_SET_GET_VALUE(variable, command)                                                                      \
@@ -199,7 +207,8 @@ namespace itk
     std::cerr << "Expected " << variable << std::endl;                                                                 \
     std::cerr << "but got  " << command << std::endl;                                                                  \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define ITK_TEST_SET_GET_NULL_VALUE(command)                                                                           \
   if (nullptr != command)                                                                                              \
@@ -210,7 +219,8 @@ namespace itk
               << "nullptr" << std::endl;                                                                               \
     std::cerr << "but got  " << command << std::endl;                                                                  \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define ITK_TEST_SET_GET_BOOLEAN(object, variable, value)                                                              \
   object->Set##variable(false);                                                                                        \
@@ -242,7 +252,7 @@ namespace itk
               << " instead of 0" << std::endl;                                                                         \
     return EXIT_FAILURE;                                                                                               \
   }                                                                                                                    \
-  object->Set##variable(value);
+  object->Set##variable(value)
 
 /** The name of the executable, argv[0], is not always available as argv[0] may be null.
  * In that case, use the name of the test function.

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -255,7 +255,8 @@ itkBSplineDeformableTransformTest1()
 
 #define PRINT_VALUE(R, C)                                                                                              \
   std::cout << "Jacobian[" #R "," #C "] = ";                                                                           \
-  std::cout << jacobian[R][C] << std::endl;
+  std::cout << jacobian[R][C] << std::endl;                                                                            \
+  ITK_MACROEND_NOOP_STATEMENT
 
   {
     // point inside the grid support region

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -291,7 +291,8 @@ itkBSplineTransformTest1()
 
 #define PRINT_VALUE(R, C)                                                                                              \
   std::cout << "Jacobian[" #R "," #C "] = ";                                                                           \
-  std::cout << jacobian[R][C] << std::endl;
+  std::cout << jacobian[R][C] << std::endl;                                                                            \
+  ITK_MACROEND_NOOP_STATEMENT
 
   {
     // point inside the grid support region

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -231,7 +231,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Initialize()
     // throw an exception when this isn't the case
     itkExceptionMacro(<< "Patch is larger than the entire image (in at least one dimension)."
                       << "\nImage region: " << largestRegion << "\nPatch length (2*radius + 1): "
-                      << this->GetPatchDiameterInVoxels() << "\nUse a smaller patch for this image.\n";)
+                      << this->GetPatchDiameterInVoxels() << "\nUse a smaller patch for this image.\n";);
   }
 
   // Get the number of pixels in the input image.

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
@@ -197,7 +197,8 @@ public:
 
   /* Use input field to define the B-spline doain. */
   itkSetMacro(UseInputFieldToDefineTheBSplineDomain, bool);
-  itkGetConstMacro(UseInputFieldToDefineTheBSplineDomain, bool) itkBooleanMacro(UseInputFieldToDefineTheBSplineDomain);
+  itkGetConstMacro(UseInputFieldToDefineTheBSplineDomain, bool);
+  itkBooleanMacro(UseInputFieldToDefineTheBSplineDomain);
 
   /**
    * Set the spline order defining the bias field estimate.  Default = 3.

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -133,7 +133,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
 
   if (this->m_BSplineDomainIsDefined == false)
   {
-    itkExceptionMacro("Output (B-spline) domain is undefined.")
+    itkExceptionMacro("Output (B-spline) domain is undefined.");
   }
 
   using ContinuousIndexType = ContinuousIndex<typename InputFieldPointType::CoordRepType, ImageDimension>;

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
@@ -183,7 +183,7 @@ RecursiveSeparableImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequested
     // verify sane parameter
     if (this->m_Direction >= outputRegion.GetImageDimension())
     {
-      itkExceptionMacro("Direction selected for filtering is greater than ImageDimension")
+      itkExceptionMacro("Direction selected for filtering is greater than ImageDimension");
     }
 
     // expand output region to match largest in the "Direction" dimension

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.h
@@ -100,7 +100,8 @@ public:
   itkGetConstMacro(Distance, double);
 
   /** Get/Set the interpolator function */
-  itkSetObjectMacro(Interpolator, InterpolatorType) itkGetModifiableObjectMacro(Interpolator, InterpolatorType);
+  itkSetObjectMacro(Interpolator, InterpolatorType);
+  itkGetModifiableObjectMacro(Interpolator, InterpolatorType);
 
   /** This method is used to set the state of the filter before
    * multi-threading. */

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
@@ -89,7 +89,7 @@ PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::VerifyPreconditions()
 
   if (sourceInput == nullptr && constantInput == nullptr)
   {
-    itkExceptionMacro("The Source or the Constant input are required.")
+    itkExceptionMacro("The Source or the Constant input are required.");
   }
 
 
@@ -283,7 +283,7 @@ PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::GetPresumedDestinatio
 
   if (numberSkippedAxis != (InputImageDimension - SourceImageDimension))
   {
-    itkExceptionMacro("Number of skipped axis " << m_DestinationSkipAxes)
+    itkExceptionMacro("Number of skipped axis " << m_DestinationSkipAxes);
   }
 
   InputImageSizeType ret;

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -128,7 +128,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::BeforeThreadedGe
 
   if (numberOfComponents != this->GetInput()->GetNumberOfComponentsPerPixel())
   {
-    PixelComponentType zeroComponent = NumericTraits<PixelComponentType>::ZeroValue(zeroComponent);
+    PixelComponentType zeroComponent = NumericTraits<PixelComponentType>::ZeroValue(PixelComponentType{});
     numberOfComponents = this->GetInput()->GetNumberOfComponentsPerPixel();
     NumericTraits<PixelType>::SetLength(m_EdgePaddingValue, numberOfComponents);
 

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -33,7 +33,8 @@ using MonitorFilter = itk::PipelineMonitorImageFilter<ImageType>;
     rval->SetSpacing(spacing);                                                                                         \
     rval->SetRegions(region);                                                                                          \
     rval->Allocate();                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 namespace
 {

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -119,14 +119,14 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
   {
     if (this->GetReferenceImage() == nullptr)
     {
-      itkExceptionMacro(<< "ReferenceImage required when GenerateReferenceHistogramFromImage is true.")
+      itkExceptionMacro(<< "ReferenceImage required when GenerateReferenceHistogramFromImage is true.");
     }
   }
   else
   {
     if (this->GetReferenceHistogram() == nullptr)
     {
-      itkExceptionMacro(<< "ReferenceHistogram required when GenerateReferenceHistogramFromImage is false.")
+      itkExceptionMacro(<< "ReferenceHistogram required when GenerateReferenceHistogramFromImage is false.");
     }
   }
 }
@@ -147,7 +147,7 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
     InputImageConstPointer reference = this->GetReferenceImage();
     if (reference.IsNull())
     {
-      itkExceptionMacro(<< "ERROR: ReferenceImage required when GenerateReferenceHistogramFromImage is true.\n")
+      itkExceptionMacro(<< "ERROR: ReferenceImage required when GenerateReferenceHistogramFromImage is true.\n");
     }
     this->ComputeMinMaxMean(reference, m_ReferenceMinValue, m_ReferenceMaxValue, referenceMeanValue);
     if (m_ThresholdAtMeanIntensity)
@@ -174,7 +174,7 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
     const HistogramType * const referenceHistogram = this->GetReferenceHistogram();
     if (referenceHistogram == nullptr)
     {
-      itkExceptionMacro(<< "ERROR: ReferenceHistogram required when GenerateReferenceHistogramFromImage is false.\n")
+      itkExceptionMacro(<< "ERROR: ReferenceHistogram required when GenerateReferenceHistogramFromImage is false.\n");
     }
 
     // If the reference histogram is provided, then extract summary statistics

--- a/Modules/Filtering/ImageIntensity/test/itkModulusImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkModulusImageFilterTest.cxx
@@ -59,7 +59,7 @@ itkModulusImageFilterTest(int argc, char * argv[])
 
   FilterType::InputPixelType dividend = 8;
   filter->SetDividend(dividend);
-  ITK_TEST_SET_GET_VALUE(dividend, filter->GetDividend())
+  ITK_TEST_SET_GET_VALUE(dividend, filter->GetDividend());
 
   filter->InPlaceOn();
 

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -81,9 +81,9 @@ itkLabelImageToLabelMapFilterTest(int argc, char * argv[])
   conversion->SetBackgroundValue(255);
   conversion->Update();
 
-  itkAssertOrThrowMacro((conversion->GetBackgroundValue() == 255), "Error conversion background value.")
+  itkAssertOrThrowMacro((conversion->GetBackgroundValue() == 255), "Error conversion background value.");
 
-    LabelMapType::Pointer map;
+  LabelMapType::Pointer map;
   map = conversion->GetOutput();
 
   itkAssertOrThrowMacro((map->GetBackgroundValue() == 255), "Error in Label Image (background).");

--- a/Modules/Filtering/LabelMap/test/itkLabelMapToBinaryImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapToBinaryImageFilterTest.cxx
@@ -78,7 +78,7 @@ itkLabelMapToBinaryImageFilterTest(int argc, char * argv[])
   l2i->SetInput(i2l->GetOutput());
   writer->SetInput(l2i->GetOutput());
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update())
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   i2l->GetOutput()->PrintLabelObjects();
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.h
@@ -118,9 +118,10 @@ public:
   using RadiusType = typename KernelType::SizeType;
 
   itkSetClampMacro(Rank, float, 0.0, 1.0);
-  itkGetConstMacro(Rank, float)
+  itkGetConstMacro(Rank, float);
 
-    bool GetUseVectorBasedAlgorithm() const
+  bool
+  GetUseVectorBasedAlgorithm() const
   {
     return HistogramType::UseVectorBasedAlgorithm();
   }

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.h
@@ -118,9 +118,10 @@ public:
   using RadiusType = typename KernelType::SizeType;
 
   itkSetClampMacro(Rank, float, 0.0, 1.0);
-  itkGetConstMacro(Rank, float)
+  itkGetConstMacro(Rank, float);
 
-    bool GetUseVectorBasedAlgorithm() const
+  bool
+  GetUseVectorBasedAlgorithm() const
   {
     return HistogramType::UseVectorBasedAlgorithm();
   }

--- a/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.h
+++ b/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.h
@@ -76,9 +76,10 @@ public:
    * harmonics (due to the Nyquist criterion), then as many harmonics as are
    * possible (input->NumberOfSteps()/2) will be calculated, but at least 2
    * harmonics will always be calculated.*/
-  itkSetMacro(NumberOfHarmonics, unsigned int)
+  itkSetMacro(NumberOfHarmonics, unsigned int);
 
-    protected : ChainCodeToFourierSeriesPathFilter();
+protected:
+  ChainCodeToFourierSeriesPathFilter();
   ~ChainCodeToFourierSeriesPathFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
@@ -109,17 +109,18 @@ public:
 
   /** Set the size of the swath image.
    * The number of rows (size[1]) MUST be odd */
-  itkSetMacro(Size, SizeType)
+  itkSetMacro(Size, SizeType);
 
-    /** Set the default pixel value of the swath image, to be used if the swath
-     * extends past the edge of the input image data. */
-    itkSetMacro(DefaultPixelValue, ImagePixelType)
+  /** Set the default pixel value of the swath image, to be used if the swath
+   * extends past the edge of the input image data. */
+  itkSetMacro(DefaultPixelValue, ImagePixelType);
 
-    //--------------------------------------------------------------------------
-    //
+  //--------------------------------------------------------------------------
+  //
 
-    /** Request the largest possible region on all outputs. */
-    void EnlargeOutputRequestedRegion(DataObject * output) override
+  /** Request the largest possible region on all outputs. */
+  void
+  EnlargeOutputRequestedRegion(DataObject * output) override
   {
     output->SetRequestedRegionToLargestPossibleRegion();
   }

--- a/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.hxx
@@ -59,7 +59,7 @@ ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetNonConstIma
   auto * temp_return = dynamic_cast<TInputImage *>(this->ProcessObject::GetInput(0));
   if (temp_return == nullptr)
   {
-    itkExceptionMacro("Invalid type conversion in GetNonConstImageInput()")
+    itkExceptionMacro("Invalid type conversion in GetNonConstImageInput()");
   }
   return temp_return;
 }
@@ -88,7 +88,7 @@ ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetNonConstPat
   auto * temp_return = dynamic_cast<TInputPath *>(this->ProcessObject::GetInput(1));
   if (temp_return == nullptr)
   {
-    itkExceptionMacro("Invalid type conversion in GetNonConstPathInput()")
+    itkExceptionMacro("Invalid type conversion in GetNonConstPathInput()");
   }
   return temp_return;
 }

--- a/Modules/Filtering/Path/include/itkOrthogonallyCorrected2DParametricPath.h
+++ b/Modules/Filtering/Path/include/itkOrthogonallyCorrected2DParametricPath.h
@@ -88,10 +88,10 @@ public:
   SetOriginalPath(const OriginalPathType * originalPath);
 
   /** Set table of evenly-spaced orthogonal offsets for the original path. */
-  itkSetObjectMacro(OrthogonalCorrectionTable, OrthogonalCorrectionTableType)
+  itkSetObjectMacro(OrthogonalCorrectionTable, OrthogonalCorrectionTableType);
 
-    /** New() method for dynamic construction */
-    itkNewMacro(Self);
+  /** New() method for dynamic construction */
+  itkNewMacro(Self);
 
   /** Needed for Pipelining */
   void

--- a/Modules/Filtering/Path/include/itkParametricPath.h
+++ b/Modules/Filtering/Path/include/itkParametricPath.h
@@ -119,9 +119,11 @@ public:
   virtual VectorType
   EvaluateDerivative(const InputType & input) const;
 
-  itkSetMacro(DefaultInputStepSize, InputType) itkGetConstReferenceMacro(DefaultInputStepSize, InputType)
+  itkSetMacro(DefaultInputStepSize, InputType);
+  itkGetConstReferenceMacro(DefaultInputStepSize, InputType);
 
-    protected : ParametricPath();
+protected:
+  ParametricPath();
   ~ParametricPath() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
@@ -64,9 +64,12 @@ public:
   using OffsetType = typename InputPathType::OffsetType;
 
   /** Set/Get the direction in which to reflect the data. Default is "Off". */
-  itkSetMacro(MaximallyConnected, bool) itkGetConstMacro(MaximallyConnected, bool) itkBooleanMacro(MaximallyConnected)
+  itkSetMacro(MaximallyConnected, bool);
+  itkGetConstMacro(MaximallyConnected, bool);
+  itkBooleanMacro(MaximallyConnected);
 
-    protected : PathToChainCodePathFilter();
+protected:
+  PathToChainCodePathFilter();
   ~PathToChainCodePathFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -236,7 +236,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   }
   else
   {
-    itkExceptionMacro(<< "Currently, the user MUST specify an image size")
+    itkExceptionMacro(<< "Currently, the user MUST specify an image size");
     // region.SetSize( size );
   }
   region.SetIndex(index);
@@ -266,7 +266,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   }
   else
   {
-    itkExceptionMacro(<< "Currently, the user MUST specify an image spacing")
+    itkExceptionMacro(<< "Currently, the user MUST specify an image spacing");
     // OutputImage->SetSpacing(InputObject->GetIndexToObjectTransform()->GetScaleComponent());
     //   // set spacing
   }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
@@ -124,10 +124,10 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
-  itkTypeMacro(LaplacianDeformationQuadEdgeMeshFilter, QuadEdgeMeshToQuadEdgeMeshFilter)
+  itkTypeMacro(LaplacianDeformationQuadEdgeMeshFilter, QuadEdgeMeshToQuadEdgeMeshFilter);
 
-    /** Input types. */
-    using InputMeshType = TInputMesh;
+  /** Input types. */
+  using InputMeshType = TInputMesh;
   using InputPointType = typename Superclass::InputPointType;
 
   static constexpr unsigned int InputPointDimension = InputMeshType::PointDimension;

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersTest.cxx
@@ -431,7 +431,7 @@ itkRecursiveGaussianImageFiltersTest(int, char *[])
     }
 
     filter->SetSigma(0.0);
-    ITK_TRY_EXPECT_EXCEPTION(filter->Update())
+    ITK_TRY_EXPECT_EXCEPTION(filter->Update());
   }
 
   {
@@ -508,7 +508,7 @@ itkRecursiveGaussianImageFiltersTest(int, char *[])
     }
 
     filter->SetSigma(0.0);
-    ITK_TRY_EXPECT_EXCEPTION(filter->Update())
+    ITK_TRY_EXPECT_EXCEPTION(filter->Update());
   }
 
   // Test streaming enumeration for RecursiveGaussianImageFilterEnums::GaussianOrder elements

--- a/Modules/IO/IPL/include/itkIPLCommonImageIO.h
+++ b/Modules/IO/IPL/include/itkIPLCommonImageIO.h
@@ -202,7 +202,8 @@ protected:
     ExceptionObject exception(__FILE__, __LINE__);                                                                     \
     exception.SetDescription("File cannot be read");                                                                   \
     throw exception;                                                                                                   \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define IOCHECK()                                                                                                      \
   if (f.fail())                                                                                                        \
@@ -212,6 +213,7 @@ protected:
       f.close();                                                                                                       \
     }                                                                                                                  \
     RAISE_EXCEPTION();                                                                                                 \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #endif // itkIPLCommonImageIO_h

--- a/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
@@ -42,7 +42,7 @@ StreamingImageIOBase::StreamReadBufferAsBinary(std::istream & file, void * _buff
   std::streampos dataPos = this->GetDataPosition();
 
   itkDebugStatement(const std::streamsize sizeOfRegion =
-                      static_cast<std::streamsize>(m_IORegion.GetNumberOfPixels()) * this->GetPixelSize(););
+                      static_cast<std::streamsize>(m_IORegion.GetNumberOfPixels()) * this->GetPixelSize());
 
   // compute the number of continuous bytes to be read
   std::streamsize sizeOfChunk = 1;

--- a/Modules/IO/ImageBase/test/itkConvertBufferTest.cxx
+++ b/Modules/IO/ImageBase/test/itkConvertBufferTest.cxx
@@ -108,7 +108,7 @@ itkConvertBufferTest(int, char *[])
   for (int i = 0; i < arraySize; ++i)
   {
     std::cerr << farray[i] << " ";
-    ITK_TEST_EXPECT_EQUAL(darray[i], static_cast<double>(farray[i]))
+    ITK_TEST_EXPECT_EQUAL(darray[i], static_cast<double>(farray[i]));
   }
   // convert a float array to an int array
   itk::ConvertPixelBuffer<float, int, itk::DefaultConvertPixelTraits<int>>::Convert(farray, 1, iarray, arraySize);

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1969,7 +1969,7 @@ NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short int dims)
       return this->m_NiftiImage->qto_xyz;
     }
 
-    itkGenericExceptionMacro("ITK only supports orthonormal direction cosines.  No orthonormal definition found!")
+    itkGenericExceptionMacro("ITK only supports orthonormal direction cosines.  No orthonormal definition found!");
   }();
 
   //

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -25,7 +25,8 @@
     ExceptionObject exception(__FILE__, __LINE__);                                                                     \
     exception.SetDescription(s);                                                                                       \
     throw exception;                                                                                                   \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk
 {

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1204,7 +1204,8 @@ TIFFImageIO::ReadTIFFTags()
   else                                                                                                                 \
   {                                                                                                                    \
     EncapsulateMetaData<T1>(dict, field_name, (static_cast<const T2 *>(raw_data))[0]);                                 \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
     try
     {
@@ -1295,7 +1296,7 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
     }
     else
     {
-      itkExceptionMacro("Logic Error: Unexpected buffer type!")
+      itkExceptionMacro("Logic Error: Unexpected buffer type!");
     }
 
     if (!TIFFReadRGBAImageOriented(m_InternalImage->m_Image, width, height, tempImage, ORIENTATION_TOPLEFT, 1))

--- a/Modules/Numerics/Optimizers/include/itkInitializationBiasedParticleSwarmOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkInitializationBiasedParticleSwarmOptimizer.h
@@ -83,34 +83,38 @@ public:
   using CoefficientType = double;
 
   /** Method for creation through the object factory. */
-  itkNewMacro(Self)
+  itkNewMacro(Self);
 
-    /** Run-time type information (and related methods). */
-    itkTypeMacro(InitializationBiasedParticleSwarmOptimizer, ParticleSwarmOptimizerBase)
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(InitializationBiasedParticleSwarmOptimizer, ParticleSwarmOptimizerBase);
 
-    /** The Particle swarm optimizer uses the following update formula:
-     * \f[c_3 =  c_{3initial}(1.0 - IterationIndex/MaximalNumberOfIterations)\f]
-     * \f[v_i(t+1) = w*v_i(t) +
-     *            c_1*uniform(0,1)*(p_i-x_i(t)) +
-     *            c_2*uniform(0,1)*(p_g-x_i(t)) +
-     *            c_3*uniform(0,1)*(x_{init}-x_i(t))\f]
-     * \f[x_i(t+1) = clampToBounds(x_i(t) + v_i(t+1))\f]
-     * where
-     * \f$w\f$ - inertia constant
-     * \f$c_1\f$ - personal coefficient
-     * \f$c_2\f$ - global coefficient
-     * \f$c_3\f$ - initial location coefficient
-     * \f$p_i\f$ - parameters yielding the best function value obtained by this particle
-     * \f$p_g\f$ - parameters yielding the best function value obtained by all particles
-     * \f$x_{init}\f$ - initial parameter values provided by user
-     */
-    itkSetMacro(InertiaCoefficient, CoefficientType) itkGetMacro(InertiaCoefficient, CoefficientType)
-      itkSetMacro(PersonalCoefficient, CoefficientType) itkGetMacro(PersonalCoefficient, CoefficientType)
-        itkSetMacro(GlobalCoefficient, CoefficientType) itkGetMacro(GlobalCoefficient, CoefficientType)
-          itkSetMacro(InitializationCoefficient, CoefficientType)
-            itkGetMacro(InitializationCoefficient, CoefficientType)
+  /** The Particle swarm optimizer uses the following update formula:
+   * \f[c_3 =  c_{3initial}(1.0 - IterationIndex/MaximalNumberOfIterations)\f]
+   * \f[v_i(t+1) = w*v_i(t) +
+   *            c_1*uniform(0,1)*(p_i-x_i(t)) +
+   *            c_2*uniform(0,1)*(p_g-x_i(t)) +
+   *            c_3*uniform(0,1)*(x_{init}-x_i(t))\f]
+   * \f[x_i(t+1) = clampToBounds(x_i(t) + v_i(t+1))\f]
+   * where
+   * \f$w\f$ - inertia constant
+   * \f$c_1\f$ - personal coefficient
+   * \f$c_2\f$ - global coefficient
+   * \f$c_3\f$ - initial location coefficient
+   * \f$p_i\f$ - parameters yielding the best function value obtained by this particle
+   * \f$p_g\f$ - parameters yielding the best function value obtained by all particles
+   * \f$x_{init}\f$ - initial parameter values provided by user
+   */
+  itkSetMacro(InertiaCoefficient, CoefficientType);
+  itkGetMacro(InertiaCoefficient, CoefficientType);
+  itkSetMacro(PersonalCoefficient, CoefficientType);
+  itkGetMacro(PersonalCoefficient, CoefficientType);
+  itkSetMacro(GlobalCoefficient, CoefficientType);
+  itkGetMacro(GlobalCoefficient, CoefficientType);
+  itkSetMacro(InitializationCoefficient, CoefficientType);
+  itkGetMacro(InitializationCoefficient, CoefficientType);
 
-              protected : InitializationBiasedParticleSwarmOptimizer();
+protected:
+  InitializationBiasedParticleSwarmOptimizer();
   ~InitializationBiasedParticleSwarmOptimizer() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizer.h
@@ -69,28 +69,32 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
-  itkNewMacro(Self)
+  itkNewMacro(Self);
 
-    /** Run-time type information (and related methods). */
-    itkTypeMacro(ParticleSwarmOptimizer, ParticleSwarmOptimizerBase)
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ParticleSwarmOptimizer, ParticleSwarmOptimizerBase);
 
-    /** The Particle swarm optimizer uses the following update formula:
-     * v_i(t+1) = w*v_i(t) +
-     *            c_1*uniform(0,1)*(p_i-x_i(t)) +
-     *            c_2*uniform(0,1)*(p_g-x_i(t))
-     * x_i(t+1) = clampToBounds(x_i(t) + v_i(t+1))
-     * where
-     * w - inertia constant
-     * c_1 - personal coefficient
-     * c_2 - global coefficient
-     * p_i - parameters yielding the best function value obtained by this particle
-     * p_g - parameters yielding the best function value obtained by all particles
-     */
-    itkSetMacro(InertiaCoefficient, double) itkGetMacro(InertiaCoefficient, double)
-      itkSetMacro(PersonalCoefficient, double) itkGetMacro(PersonalCoefficient, double)
-        itkSetMacro(GlobalCoefficient, double) itkGetMacro(GlobalCoefficient, double)
+  /** The Particle swarm optimizer uses the following update formula:
+   * v_i(t+1) = w*v_i(t) +
+   *            c_1*uniform(0,1)*(p_i-x_i(t)) +
+   *            c_2*uniform(0,1)*(p_g-x_i(t))
+   * x_i(t+1) = clampToBounds(x_i(t) + v_i(t+1))
+   * where
+   * w - inertia constant
+   * c_1 - personal coefficient
+   * c_2 - global coefficient
+   * p_i - parameters yielding the best function value obtained by this particle
+   * p_g - parameters yielding the best function value obtained by all particles
+   */
+  itkSetMacro(InertiaCoefficient, double);
+  itkGetMacro(InertiaCoefficient, double);
+  itkSetMacro(PersonalCoefficient, double);
+  itkGetMacro(PersonalCoefficient, double);
+  itkSetMacro(GlobalCoefficient, double);
+  itkGetMacro(GlobalCoefficient, double);
 
-          protected : ParticleSwarmOptimizer();
+protected:
+  ParticleSwarmOptimizer();
   ~ParticleSwarmOptimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
@@ -65,9 +65,9 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ParticleSwarmOptimizerBase, SingleValuedNonLinearOptimizer)
+  itkTypeMacro(ParticleSwarmOptimizerBase, SingleValuedNonLinearOptimizer);
 
-    using ParameterBoundsType = std::vector<std::pair<ParametersType::ValueType, ParametersType::ValueType>>;
+  using ParameterBoundsType = std::vector<std::pair<ParametersType::ValueType, ParametersType::ValueType>>;
 
   struct ParticleData
   {
@@ -91,15 +91,17 @@ public:
    * If the optimum is expected to be near the initial value it is likely
    * that initializing with a normal distribution will result in faster
    * convergence.*/
-  itkSetMacro(InitializeNormalDistribution, bool) itkGetMacro(InitializeNormalDistribution, bool)
-    itkBooleanMacro(InitializeNormalDistribution)
+  itkSetMacro(InitializeNormalDistribution, bool);
+  itkGetMacro(InitializeNormalDistribution, bool);
+  itkBooleanMacro(InitializeNormalDistribution);
 
-    /**
-     * Specify the initial swarm. Useful for evaluating PSO variants. If the
-     * initial swarm is set it will be used. To revert to random initialization
-     * (uniform or normal particle distributions) set using an empty swarm.
-     */
-    void SetInitialSwarm(const SwarmType & initialSwarm);
+  /**
+   * Specify the initial swarm. Useful for evaluating PSO variants. If the
+   * initial swarm is set it will be used. To revert to random initialization
+   * (uniform or normal particle distributions) set using an empty swarm.
+   */
+  void
+  SetInitialSwarm(const SwarmType & initialSwarm);
   void
   ClearSwarm();
 
@@ -108,34 +110,38 @@ public:
    * object. By default this option is turned off as it generates too much
    * information.
    */
-  itkSetMacro(PrintSwarm, bool) itkGetMacro(PrintSwarm, bool) itkBooleanMacro(PrintSwarm)
+  itkSetMacro(PrintSwarm, bool);
+  itkGetMacro(PrintSwarm, bool);
+  itkBooleanMacro(PrintSwarm);
 
-    /** Start optimization. */
-    void StartOptimization() override;
+  /** Start optimization. */
+  void
+  StartOptimization() override;
 
 
   /** Set/Get number of particles in the swarm - the maximal number of function
       evaluations is m_MaximalNumberOfIterations*m_NumberOfParticles */
   void
   SetNumberOfParticles(NumberOfParticlesType n);
-  itkGetMacro(NumberOfParticles, NumberOfParticlesType)
+  itkGetMacro(NumberOfParticles, NumberOfParticlesType);
 
-    /** Set/Get maximal number of iterations - the maximal number of function
-        evaluations is m_MaximalNumberOfIterations*m_NumberOfParticles */
-    itkSetMacro(MaximalNumberOfIterations, NumberOfIterationsType)
-      itkGetMacro(MaximalNumberOfIterations, NumberOfIterationsType)
+  /** Set/Get maximal number of iterations - the maximal number of function
+      evaluations is m_MaximalNumberOfIterations*m_NumberOfParticles */
+  itkSetMacro(MaximalNumberOfIterations, NumberOfIterationsType);
+  itkGetMacro(MaximalNumberOfIterations, NumberOfIterationsType);
 
-    /** Set/Get the number of generations to continue with minimal improvement in
-     *  the function value, |f_best(g_i) - f_best(g_k)|<threshold where
-     *  k <= i+NumberOfGenerationsWithMinimalImprovement
-     *  Minimal value is one.*/
-    itkSetMacro(NumberOfGenerationsWithMinimalImprovement, NumberOfGenerationsType)
-      itkGetMacro(NumberOfGenerationsWithMinimalImprovement, NumberOfGenerationsType)
+  /** Set/Get the number of generations to continue with minimal improvement in
+   *  the function value, |f_best(g_i) - f_best(g_k)|<threshold where
+   *  k <= i+NumberOfGenerationsWithMinimalImprovement
+   *  Minimal value is one.*/
+  itkSetMacro(NumberOfGenerationsWithMinimalImprovement, NumberOfGenerationsType);
+  itkGetMacro(NumberOfGenerationsWithMinimalImprovement, NumberOfGenerationsType);
 
-    /**Set/Get the parameter bounds. Search for optimal value is inside these
-       bounds. NOTE: It is assumed that the first entry is the minimal value,
-       second is the maximal value. */
-    virtual void SetParameterBounds(ParameterBoundsType & bounds);
+  /**Set/Get the parameter bounds. Search for optimal value is inside these
+     bounds. NOTE: It is assumed that the first entry is the minimal value,
+     second is the maximal value. */
+  virtual void
+  SetParameterBounds(ParameterBoundsType & bounds);
   void
   SetParameterBounds(std::pair<ParametersType::ValueType, ParametersType::ValueType> & bounds, unsigned int n);
 
@@ -156,29 +162,35 @@ public:
    *         translation). Alternatively, we could use ITK's parameter scaling
    *         approach. The current approach seems more intuitive.
    */
-  itkSetMacro(FunctionConvergenceTolerance, MeasureType) itkGetMacro(FunctionConvergenceTolerance, MeasureType)
-    /**Set parameters convergence tolerance using the same value for all, sz,
-       parameters*/
-    void SetParametersConvergenceTolerance(ValueType convergenceTolerance, unsigned int sz);
-  itkSetMacro(ParametersConvergenceTolerance, ParametersType)
-    itkGetMacro(ParametersConvergenceTolerance, ParametersType) itkGetMacro(PercentageParticlesConverged, double)
-      itkSetMacro(PercentageParticlesConverged, double)
+  itkSetMacro(FunctionConvergenceTolerance, MeasureType);
+  itkGetMacro(FunctionConvergenceTolerance, MeasureType);
+  /**Set parameters convergence tolerance using the same value for all, sz,
+     parameters*/
+  void
+  SetParametersConvergenceTolerance(ValueType convergenceTolerance, unsigned int sz);
+  itkSetMacro(ParametersConvergenceTolerance, ParametersType);
+  itkGetMacro(ParametersConvergenceTolerance, ParametersType);
+  itkGetMacro(PercentageParticlesConverged, double);
+  itkSetMacro(PercentageParticlesConverged, double);
 
-    /**Set the random number seed for the swarm. Use this method to
-     * produce reaptible results, typically, for testing.
-     */
-    itkSetMacro(Seed, RandomVariateGeneratorType::IntegerType)
-      itkGetMacro(Seed, RandomVariateGeneratorType::IntegerType)
+  /**Set the random number seed for the swarm. Use this method to
+   * produce reaptible results, typically, for testing.
+   */
+  itkSetMacro(Seed, RandomVariateGeneratorType::IntegerType);
+  itkGetMacro(Seed, RandomVariateGeneratorType::IntegerType);
 
-    /** Use a specific seed to initialize the random number
-     * generator. If On, use m_Seed to seed the random number
-     * generator. Default is Off. */
-    itkSetMacro(UseSeed, bool) itkGetMacro(UseSeed, bool) itkBooleanMacro(UseSeed)
+  /** Use a specific seed to initialize the random number
+   * generator. If On, use m_Seed to seed the random number
+   * generator. Default is Off. */
+  itkSetMacro(UseSeed, bool);
+  itkGetMacro(UseSeed, bool);
+  itkBooleanMacro(UseSeed);
 
-    /** Get the function value for the current position.
-     *  NOTE: This value is only valid during and after the execution of the
-     *        StartOptimization() method.*/
-    MeasureType GetValue() const;
+  /** Get the function value for the current position.
+   *  NOTE: This value is only valid during and after the execution of the
+   *        StartOptimization() method.*/
+  MeasureType
+  GetValue() const;
 
   /** Get the reason for termination */
   const std::string

--- a/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
@@ -282,7 +282,7 @@ AmoebaOptimizer::ValidateSettings()
   // we have to have a cost function
   if (GetCostFunctionAdaptor() == nullptr)
   {
-    itkExceptionMacro(<< "nullptr cost function")
+    itkExceptionMacro(<< "nullptr cost function");
   }
   // if we got here it is safe to get the number of parameters the cost
   // function expects
@@ -291,7 +291,7 @@ AmoebaOptimizer::ValidateSettings()
   // check that the number of parameters match
   if (GetInitialPosition().Size() != n)
   {
-    itkExceptionMacro(<< "cost function and initial position dimensions mismatch")
+    itkExceptionMacro(<< "cost function and initial position dimensions mismatch");
   }
 
   // the user gave us data to use for the initial simplex, check that it
@@ -302,7 +302,7 @@ AmoebaOptimizer::ValidateSettings()
   {
     if (m_InitialSimplexDelta.size() != n)
     {
-      itkExceptionMacro(<< "cost function and simplex delta dimensions mismatch")
+      itkExceptionMacro(<< "cost function and simplex delta dimensions mismatch");
     }
   }
   // check that the number of scale factors matches
@@ -310,18 +310,18 @@ AmoebaOptimizer::ValidateSettings()
   {
     if (this->GetScales().Size() != n)
     {
-      itkExceptionMacro(<< "cost function and scaling information dimensions mismatch")
+      itkExceptionMacro(<< "cost function and scaling information dimensions mismatch");
     }
   }
   // parameters' convergence tolerance has to be positive
   if (this->m_ParametersConvergenceTolerance < 0)
   {
-    itkExceptionMacro(<< "negative parameters convergence tolerance")
+    itkExceptionMacro(<< "negative parameters convergence tolerance");
   }
   // function convergence tolerance has to be positive
   if (this->m_FunctionConvergenceTolerance < 0)
   {
-    itkExceptionMacro(<< "negative function convergence tolerance")
+    itkExceptionMacro(<< "negative function convergence tolerance");
   }
 }
 

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -45,7 +45,7 @@ ParticleSwarmOptimizerBase::SetNumberOfParticles(unsigned int n)
 {
   if (!this->m_Particles.empty() && n != this->m_Particles.size())
   {
-    itkExceptionMacro(<< "swarm already set with different size, clear swarm and then set")
+    itkExceptionMacro(<< "swarm already set with different size, clear swarm and then set");
   }
   if (this->m_NumberOfParticles != n)
   {
@@ -70,7 +70,7 @@ ParticleSwarmOptimizerBase::SetInitialSwarm(const SwarmType & initialSwarm)
       if ((*it).m_CurrentParameters.GetSize() != n || (*it).m_CurrentVelocity.GetSize() != n ||
           (*it).m_BestParameters.GetSize() != n)
       {
-        itkExceptionMacro(<< "inconsistent dimensions in swarm data")
+        itkExceptionMacro(<< "inconsistent dimensions in swarm data");
       }
     }
     this->m_Particles.insert(m_Particles.begin(), initialSwarm.begin(), initialSwarm_END);
@@ -295,7 +295,7 @@ ParticleSwarmOptimizerBase::ValidateSettings()
   // we have to have a cost function
   if (GetCostFunction() == nullptr)
   {
-    itkExceptionMacro(<< "nullptr cost function")
+    itkExceptionMacro(<< "nullptr cost function");
   }
   // if we got here it is safe to get the number of parameters the cost
   // function expects
@@ -305,34 +305,34 @@ ParticleSwarmOptimizerBase::ValidateSettings()
   ParametersType initialPosition = GetInitialPosition();
   if (initialPosition.Size() != n)
   {
-    itkExceptionMacro(<< "cost function and initial position dimensions mismatch")
+    itkExceptionMacro(<< "cost function and initial position dimensions mismatch");
   }
   // at least one particle
   if (this->m_NumberOfParticles == 0)
   {
-    itkExceptionMacro(<< "number of particles is zero")
+    itkExceptionMacro(<< "number of particles is zero");
   }
   // at least one iteration (the initialization phase)
   if (this->m_MaximalNumberOfIterations == 0)
   {
-    itkExceptionMacro(<< "number of iterations is zero")
+    itkExceptionMacro(<< "number of iterations is zero");
   }
   // we need at least one generation difference to
   // compare to the previous one
   if (this->m_NumberOfGenerationsWithMinimalImprovement == 0)
   {
-    itkExceptionMacro(<< "number of generations with minimal improvement is zero")
+    itkExceptionMacro(<< "number of generations with minimal improvement is zero");
   }
 
   if (this->m_ParameterBounds.size() != n)
   {
-    itkExceptionMacro(<< "cost function and parameter bounds dimensions mismatch")
+    itkExceptionMacro(<< "cost function and parameter bounds dimensions mismatch");
   }
   for (i = 0; i < n; i++)
   {
     if (initialPosition[i] < this->m_ParameterBounds[i].first || initialPosition[i] > this->m_ParameterBounds[i].second)
     {
-      itkExceptionMacro(<< "initial position is outside specified parameter bounds")
+      itkExceptionMacro(<< "initial position is outside specified parameter bounds");
     }
   }
   // if the user set an initial swarm, check that the number of parameters
@@ -341,7 +341,7 @@ ParticleSwarmOptimizerBase::ValidateSettings()
   {
     if (this->m_Particles[0].m_CurrentParameters.GetSize() != n)
     {
-      itkExceptionMacro(<< "cost function and particle data dimensions mismatch")
+      itkExceptionMacro(<< "cost function and particle data dimensions mismatch");
     }
     std::vector<ParticleData>::iterator it, end = this->m_Particles.end();
     for (it = this->m_Particles.begin(); it != end; ++it)
@@ -353,7 +353,7 @@ ParticleSwarmOptimizerBase::ValidateSettings()
             p.m_CurrentParameters[i] > m_ParameterBounds[i].second ||
             p.m_BestParameters[i] < m_ParameterBounds[i].first || p.m_BestParameters[i] > m_ParameterBounds[i].second)
         {
-          itkExceptionMacro(<< "initial position is outside specified parameter bounds")
+          itkExceptionMacro(<< "initial position is outside specified parameter bounds");
         }
       }
     }
@@ -363,13 +363,13 @@ ParticleSwarmOptimizerBase::ValidateSettings()
   {
     if (this->m_ParametersConvergenceTolerance[i] < 0)
     {
-      itkExceptionMacro(<< "negative parameters convergence tolerance")
+      itkExceptionMacro(<< "negative parameters convergence tolerance");
     }
   }
   // function convergence tolerance has to be positive
   if (this->m_FunctionConvergenceTolerance < 0)
   {
-    itkExceptionMacro(<< "negative function convergence tolerance")
+    itkExceptionMacro(<< "negative function convergence tolerance");
   }
 }
 

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
@@ -213,28 +213,29 @@ public:
 
   /** Get the number of valid points after a call to evaluate the
    * metric. */
-  itkGetConstMacro(NumberOfValidPoints, SizeValueType)
+  itkGetConstMacro(NumberOfValidPoints, SizeValueType);
 
-    /** Define the virtual reference space. This space defines the resolution
-     * at which the registration is performed as well as the physical coordinate
-     * system.  Useful for unbiased registration.
-     * This method will allocate \c m_VirtualImage with the passed
-     * information, with the pixel buffer left unallocated.
-     * Metric evaluation will be performed within the constraints of the virtual
-     * domain depending on implementation in derived classes.
-     * A default domain is created during initialization in derived
-     * classes according to their need.
-     * \param spacing   spacing
-     * \param origin    origin
-     * \param direction direction
-     * \param region    region is used to set all image regions.
-     *
-     * \sa SetVirtualDomainFromImage
-     */
-    void SetVirtualDomain(const VirtualSpacingType &   spacing,
-                          const VirtualOriginType &    origin,
-                          const VirtualDirectionType & direction,
-                          const VirtualRegionType &    region);
+  /** Define the virtual reference space. This space defines the resolution
+   * at which the registration is performed as well as the physical coordinate
+   * system.  Useful for unbiased registration.
+   * This method will allocate \c m_VirtualImage with the passed
+   * information, with the pixel buffer left unallocated.
+   * Metric evaluation will be performed within the constraints of the virtual
+   * domain depending on implementation in derived classes.
+   * A default domain is created during initialization in derived
+   * classes according to their need.
+   * \param spacing   spacing
+   * \param origin    origin
+   * \param direction direction
+   * \param region    region is used to set all image regions.
+   *
+   * \sa SetVirtualDomainFromImage
+   */
+  void
+  SetVirtualDomain(const VirtualSpacingType &   spacing,
+                   const VirtualOriginType &    origin,
+                   const VirtualDirectionType & direction,
+                   const VirtualRegionType &    region);
 
   /** Use a virtual domain image to define the virtual reference space.
    * \sa SetVirtualDomain */

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
@@ -304,10 +304,10 @@ protected:
 
   /** Get the current sampling strategy. Note that this is changed
    * internally as the class is used for scale or step estimation. */
-  itkGetMacro(SamplingStrategy, SamplingStrategyType)
+  itkGetMacro(SamplingStrategy, SamplingStrategyType);
 
-    /** the metric object */
-    MetricPointer m_Metric;
+  /** the metric object */
+  MetricPointer m_Metric;
 
   /** the samples in the virtual domain */
   SamplePointContainerType m_SamplePoints;

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
@@ -47,13 +47,13 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SingleValuedNonLinearVnlOptimizerv4, ObjectToObjectOptimizerBase)
+  itkTypeMacro(SingleValuedNonLinearVnlOptimizerv4, ObjectToObjectOptimizerBase);
 
-    /** Command observer that will interact with the ITKVNL cost-function
-     * adaptor in order to generate iteration events. This will allow to overcome
-     * the limitation of VNL optimizers not offering callbacks for every
-     * iteration */
-    using CommandType = ReceptorMemberCommand<Self>;
+  /** Command observer that will interact with the ITKVNL cost-function
+   * adaptor in order to generate iteration events. This will allow to overcome
+   * the limitation of VNL optimizers not offering callbacks for every
+   * iteration */
+  using CommandType = ReceptorMemberCommand<Self>;
 
   using MetricType = Superclass::MetricType;
   using DerivativeType = Superclass::DerivativeType;

--- a/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
@@ -265,7 +265,7 @@ AmoebaOptimizerv4 ::ValidateSettings()
   {
     if (m_InitialSimplexDelta.size() != n)
     {
-      itkExceptionMacro(<< "cost function and simplex delta dimensions mismatch")
+      itkExceptionMacro(<< "cost function and simplex delta dimensions mismatch");
     }
   }
 
@@ -274,19 +274,19 @@ AmoebaOptimizerv4 ::ValidateSettings()
   {
     if (this->GetScales().Size() != n)
     {
-      itkExceptionMacro(<< "cost function and scaling information dimensions mismatch")
+      itkExceptionMacro(<< "cost function and scaling information dimensions mismatch");
     }
   }
 
   // parameters' convergence tolerance has to be positive
   if (this->m_ParametersConvergenceTolerance < 0)
   {
-    itkExceptionMacro(<< "negative parameters convergence tolerance")
+    itkExceptionMacro(<< "negative parameters convergence tolerance");
   }
   // function convergence tolerance has to be positive
   if (this->m_FunctionConvergenceTolerance < 0)
   {
-    itkExceptionMacro(<< "negative function convergence tolerance")
+    itkExceptionMacro(<< "negative function convergence tolerance");
   }
 }
 

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
@@ -144,7 +144,7 @@ ImageToHistogramFilter<TImage>::InitializeOutputHistogram()
   {
     if (this->GetInput()->GetBufferedRegion() != this->GetInput()->GetLargestPossibleRegion())
     {
-      itkExceptionMacro(<< "AutoMinimumMaximumInput is not supported with streaming.")
+      itkExceptionMacro(<< "AutoMinimumMaximumInput is not supported with streaming.");
     }
 
     // we have to compute the minimum and maximum values

--- a/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
@@ -23,7 +23,8 @@
   if (itk::NumericTraits<type>::GetLength((measure)) != len2)                                                          \
   {                                                                                                                    \
     std::cerr << "Set/GetLength() failed in measure " << std::endl;                                                    \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define itkSetLengthExceptionMacro(measure, type, len)                                                                 \
   try                                                                                                                  \
@@ -34,7 +35,8 @@
     return EXIT_FAILURE;                                                                                               \
   }                                                                                                                    \
   catch (itk::ExceptionObject &)                                                                                       \
-  {}
+  {}                                                                                                                   \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define itkAssertLengthExceptionMacro(m1, m2)                                                                          \
   try                                                                                                                  \
@@ -45,7 +47,8 @@
     return EXIT_FAILURE;                                                                                               \
   }                                                                                                                    \
   catch (itk::ExceptionObject &)                                                                                       \
-  {}
+  {}                                                                                                                   \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define itkAssertLengthSameValueReturn(m1, type1, m2)                                                                  \
   if (itk::Statistics::MeasurementVectorTraits::Assert((m1), (m2)) != itk::NumericTraits<type1>::GetLength((m1)))      \
@@ -53,7 +56,8 @@
     std::cerr << "Failed to get expected VLenght for Assert() ";                                                       \
     std::cerr << std::endl;                                                                                            \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define itkAssertSameLengthTest(m1, m2)                                                                                \
   if (itk::Statistics::MeasurementVectorTraits::Assert((m1), (m2)) != 0)                                               \
@@ -61,7 +65,8 @@
     std::cerr << "Failed to recognize same length in Assert() ";                                                       \
     std::cerr << std::endl;                                                                                            \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 
 int

--- a/Modules/Numerics/Statistics/test/itkStatisticsTypesTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsTypesTest.cxx
@@ -28,8 +28,8 @@
   else                                                                                                                 \
   {                                                                                                                    \
     std::cout << " Real type " << std::endl;                                                                           \
-  }
-
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 int
 itkStatisticsTypesTest(int, char *[])

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
@@ -148,7 +148,7 @@ CenteredTransformInitializer<TTransform, TFixedImage, TMovingImage>::PrintSelf(s
 
   os << indent << "UseMoments  = " << m_UseMoments << std::endl;
   itkPrintSelfObjectMacro(MovingCalculator);
-  itkPrintSelfObjectMacro(FixedCalculator)
+  itkPrintSelfObjectMacro(FixedCalculator);
 }
 } // namespace itk
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
@@ -133,7 +133,8 @@ itkImageRegistrationMethodTest(int, char *[])
   {                                                                                                                    \
     std::cout << "Test failed." << std::endl;                                                                          \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(InitialTransformParameters, badParameters, initialParameters);
   TEST_INITIALIZATION_ERROR(Metric, nullptr, metric);

--- a/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
@@ -360,7 +360,8 @@ itkMeanSquaresImageMetricTest(int, char *[])
   {                                                                                                                    \
     std::cout << "Test failed." << std::endl;                                                                          \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(Transform, nullptr, transform);
   TEST_INITIALIZATION_ERROR(FixedImage, nullptr, fixedImage);

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
@@ -155,7 +155,8 @@ itkMultiResolutionImageRegistrationMethodTest(int, char *[])
   {                                                                                                                    \
     std::cout << "Test failed." << std::endl;                                                                          \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(Metric, nullptr, metric);
   TEST_INITIALIZATION_ERROR(Optimizer, nullptr, optimizer);

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -369,7 +369,7 @@ public:
     }
     else
     {
-      itkExceptionMacro("Incorrect object type.  Should be an image.")
+      itkExceptionMacro("Incorrect object type.  Should be an image.");
     }
   }
 
@@ -384,7 +384,7 @@ public:
     }
     else
     {
-      itkExceptionMacro("Incorrect object type.  Should be an image.")
+      itkExceptionMacro("Incorrect object type.  Should be an image.");
     }
   }
 

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -190,7 +190,7 @@ public:
     }
     else
     {
-      itkExceptionMacro("Incorrect object type.  Should be a point set.")
+      itkExceptionMacro("Incorrect object type.  Should be a point set.");
     }
   }
 
@@ -205,7 +205,7 @@ public:
     }
     else
     {
-      itkExceptionMacro("Incorrect object type.  Should be a point set.")
+      itkExceptionMacro("Incorrect object type.  Should be a point set.");
     }
   }
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -461,7 +461,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
         }
         else
         {
-          itkExceptionMacro("Invalid metric type.")
+          itkExceptionMacro("Invalid metric type.");
         }
       }
     }
@@ -692,7 +692,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
       }
       else
       {
-        itkExceptionMacro("Invalid metric type.")
+        itkExceptionMacro("Invalid metric type.");
       }
     }
     else if (this->m_Metric->GetMetricCategory() ==
@@ -720,12 +720,12 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
       }
       else
       {
-        itkExceptionMacro("Invalid metric type.")
+        itkExceptionMacro("Invalid metric type.");
       }
     }
     else
     {
-      itkExceptionMacro("Invalid metric type.")
+      itkExceptionMacro("Invalid metric type.");
     }
   }
 

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationRegion.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationRegion.h
@@ -147,8 +147,8 @@ public:
   GetRegionBorderSize() const;
 
   /** Set/Get the mean pixel intensity in the region. */
-  itkSetMacro(MeanRegionIntensity, MeanRegionIntensityType)
-    itkGetConstReferenceMacro(MeanRegionIntensity, MeanRegionIntensityType);
+  itkSetMacro(MeanRegionIntensity, MeanRegionIntensityType);
+  itkGetConstReferenceMacro(MeanRegionIntensity, MeanRegionIntensityType);
 
   /** Set the region with parameter values
    * defining the region. */

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -172,7 +172,8 @@ test_RegionGrowKLMExceptionHandling()
   {                                                                                                                    \
     std::cout << "Test FAILED" << std::endl;                                                                           \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   // maximum number of regions must be greater than 1
 

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
@@ -409,7 +409,8 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest(int, char *[])
   {                                                                                                                    \
     std::cout << "Test failed." << std::endl;                                                                          \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(ShapeFunction, nullptr, shape);
   TEST_INITIALIZATION_ERROR(CostFunction, nullptr, costFunction);

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
@@ -244,7 +244,8 @@ itkShapePriorMAPCostFunctionTest(int, char *[])
   {                                                                                                                    \
     std::cout << "Test failed." << std::endl;                                                                          \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(ShapeFunction, nullptr, shape);
   TEST_INITIALIZATION_ERROR(ActiveRegion, nullptr, activeRegion);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
@@ -46,7 +46,7 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::SetTimeStep(const LevelSet
   }
   else
   {
-    itkGenericExceptionMacro(<< "iDt should be > epsilon")
+    itkGenericExceptionMacro(<< "iDt should be > epsilon");
   }
 }
 

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
@@ -228,7 +228,8 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   {                                                                                                                    \
     std::cout << "Test failed." << std::endl;                                                                          \
     return EXIT_FAILURE;                                                                                               \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   // nullptr MeanImage
   TEST_INITIALIZATION_ERROR(MeanImage, nullptr, meanImage);

--- a/Modules/Video/Core/test/itkTemporalDataObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalDataObjectTest.cxx
@@ -32,7 +32,8 @@ itkTemporalDataObjectTest(int, char *[])
       std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
 #define ITK_CHECK_FOR_VALUE(a, b)                                                                                      \
   {                                                                                                                    \
@@ -44,7 +45,8 @@ itkTemporalDataObjectTest(int, char *[])
       b.Print(std::cerr);                                                                                              \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   // TODO HACK FIXME
   // This should be also verify that the temporal region functions handle

--- a/Modules/Video/Core/test/itkTemporalRegionTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalRegionTest.cxx
@@ -31,7 +31,8 @@ itkTemporalRegionTest(int, char *[])
       std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
       return EXIT_FAILURE;                                                                                             \
     }                                                                                                                  \
-  }
+  }                                                                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
 
   // Test arrays for frame durations
   itk::SizeValueType testFrameStart = 0;


### PR DESCRIPTION
To get nice formatting, and to avoid agressive compiler warnings,
instrument macros such that they require an end of line ; after the
macro consistently.

An example warning:
warning: empty expression statement has no effect;
         remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
itkGenericExceptionMacro(<< "Singular matrix. Determinant is 0.");

This change also improves readability of the code by adding uniformity
to the formatting (especially with clang-format automation).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
