### PR TITLE
ENH: Improve coverage for `itk::DCMTKSeriesFileNames` class

### DIFF
--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
@@ -55,8 +55,15 @@ itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(it, DCMTKSeriesFileNames, ProcessObject);
 
+  // Test exceptions
+  std::string inputDirectory = "";
+  ITK_TRY_EXPECT_EXCEPTION(it->SetInputDirectory());
 
-  it->SetInputDirectory(argv[1]);
+  inputDirectory = "NotADirectory";
+  ITK_TRY_EXPECT_EXCEPTION(it->SetInputDirectory());
+
+  inputDirectory = argv[1];
+  it->SetInputDirectory(inputDirectory);
 
   auto recursive = static_cast<bool>(std::stoi(argv[3]));
   ITK_TEST_SET_GET_BOOLEAN(it, Recursive, recursive);
@@ -79,6 +86,8 @@ itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
   }
 
   reader->SetFileNames(fileNames);
+  ITK_TEST_SET_GET_VALUE(fileNames, reader->GetFileNames());
+
   reader->SetImageIO(dcmtkIO);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx
@@ -48,9 +48,12 @@ itkDCMTKSeriesStreamReadImageWrite(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cerr << "Usage: " << argv[0];
-    std::cerr << " DicomDirectory  outputFile ";
-    std::cerr << " spacingX spacingY spacingZ [ force-no-streaming 1|0]" << std::endl;
+    std::cerr << "Missing Parameters " << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " DicomDirectory"
+              << " outputFile"
+              << " spacingX spacingY spacingZ"
+              << " [ force-no-streaming 1|0]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -177,16 +180,9 @@ itkDCMTKSeriesStreamReadImageWrite(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown while writing the image" << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve coverage for `itk::DCMTKSeriesFileNames` class:
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Use the `ITK_TRY_EXPECT_NO_EXCEPTION` macro to avoid boilerplate code.
- Test the exceptions.
- Improve slightly the test style to make them more consistent (e.g.
  input argument checking or test finishing message).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)