### PR TITLE
ENH: Improve coverage for `itk::RayCastInterpolateImageFunction` class

### DIFF
--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -87,8 +87,11 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
 
   /* Create and initialize the interpolator */
   RayCastInterpolatorType::Pointer interp = RayCastInterpolatorType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(interp, RayCastInterpolateImageFunction, InterpolateImageFunction);
+
+
   interp->SetInputImage(image);
-  interp->Print(std::cout);
 
   PointType focus;
   focus[0] = 15.0;
@@ -96,13 +99,16 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
   focus[2] = 100.0;
 
   interp->SetFocalPoint(focus);
+  ITK_TEST_SET_GET_VALUE(focus, interp->GetFocalPoint());
 
 
   /* Create the transform */
   using TransformType = itk::TranslationTransform<double, ImageDimension>;
 
   TransformType::Pointer transform = TransformType::New();
+
   interp->SetTransform(transform);
+  ITK_TEST_SET_GET_VALUE(transform, interp->GetTransform());
 
   /* Create the auxiliary interpolator */
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, double>;
@@ -110,9 +116,12 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
   InterpolatorType::Pointer auxInterpolator = InterpolatorType::New();
 
   interp->SetInterpolator(auxInterpolator);
+  ITK_TEST_SET_GET_VALUE(auxInterpolator, interp->GetInterpolator());
 
   /* Exercise the SetThreshold() method */
-  interp->SetThreshold(1.0);
+  double threshold = 1.0;
+  interp->SetThreshold(threshold);
+  ITK_TEST_SET_GET_VALUE(threshold, interp->GetThreshold());
 
   /* Evaluate the function */
   double    integral;
@@ -132,5 +141,7 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
 
   ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(integral, 1276.));
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve coverage `itk::RayCastInterpolateImageFunction` class:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Make the calls to the Get methods be quantitative where they were just
  being called without being compared to the expected value.
- Remove explicit calls to the `Print` method and rely on the basic
  method exercising macro call.
- Improve slightly the test style to make them more consistent (e.g.
  test finishing message).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)