### PR TITLE
ENH: Improve coverage for `MathematicalMorphology` module classes.

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedClosingImageFilterTest.cxx
@@ -52,26 +52,24 @@ itkGrayscaleConnectedClosingImageFilterTest(int argc, char * argv[])
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
   using WriteImageType = itk::Image<WritePixelType, Dimension>;
 
-
-  // readers/writers
-  using ReaderType = itk::ImageFileReader<InputImageType>;
-  using WriterType = itk::ImageFileWriter<WriteImageType>;
-
-  // define the connected closing filter
+  // Define the connected closing filter
   using ConnectedClosingFilterType = itk::GrayscaleConnectedClosingImageFilter<InputImageType, OutputImageType>;
-
-
-  // Creation of Reader and Writer filters
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
 
   // Create the filter
   ConnectedClosingFilterType::Pointer connectedClosing = ConnectedClosingFilterType::New();
-  itk::SimpleFilterWatcher            watcher(connectedClosing, "connectedClosing");
 
-  // Setup the input and output files
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(connectedClosing, GrayscaleConnectedClosingImageFilter, ImageToImageFilter);
+
+
+  itk::SimpleFilterWatcher watcher(connectedClosing, "connectedClosing");
+
+  using ReaderType = itk::ImageFileReader<InputImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+
   reader->SetFileName(argv[1]);
-  writer->SetFileName(argv[2]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   // Setup the connectedopening method
   connectedClosing->SetInput(reader->GetOutput());
@@ -80,10 +78,20 @@ itkGrayscaleConnectedClosingImageFilterTest(int argc, char * argv[])
   seed[0] = std::stoi(argv[3]);
   seed[1] = std::stoi(argv[4]);
   connectedClosing->SetSeed(seed);
+  ITK_TEST_SET_GET_VALUE(seed, connectedClosing->GetSeed());
 
-  // Run the filter
+  ITK_TRY_EXPECT_NO_EXCEPTION(connectedClosing->Update());
+
+
+  using WriterType = itk::ImageFileWriter<WriteImageType>;
+  WriterType::Pointer writer = WriterType::New();
+
+  writer->SetFileName(argv[2]);
   writer->SetInput(connectedClosing->GetOutput());
-  writer->Update();
 
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedOpeningImageFilterTest.cxx
@@ -31,9 +31,9 @@ itkGrayscaleConnectedOpeningImageFilterTest(int argc, char * argv[])
 {
   if (argc < 5)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << itkNameOfTestExecutableMacro(argv) << "  inputImageFile  ";
-    std::cerr << " outputImageFile seedX seedY " << std::endl;
+    std::cerr << "Missing Parameters " << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputImageFile"
+              << " outputImageFile seedX seedY " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -52,27 +52,25 @@ itkGrayscaleConnectedOpeningImageFilterTest(int argc, char * argv[])
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
   using WriteImageType = itk::Image<WritePixelType, Dimension>;
 
-
-  // readers/writers
-  using ReaderType = itk::ImageFileReader<InputImageType>;
-  using WriterType = itk::ImageFileWriter<WriteImageType>;
-
-  // define the fillhole filter
+  // Define the fillhole filter
   using ConnectedOpeningFilterType = itk::GrayscaleConnectedOpeningImageFilter<InputImageType, OutputImageType>;
-
-
-  // Creation of Reader and Writer filters
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
 
   // Create the filter
   ConnectedOpeningFilterType::Pointer connectedOpening = ConnectedOpeningFilterType::New();
-  itk::SimpleFilterWatcher            watcher(connectedOpening, "Opening");
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(connectedOpening, GrayscaleConnectedOpeningImageFilter, ImageToImageFilter);
+
+
+  itk::SimpleFilterWatcher watcher(connectedOpening, "Opening");
   watcher.QuietOn();
 
-  // Setup the input and output files
+  using ReaderType = itk::ImageFileReader<InputImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+
   reader->SetFileName(argv[1]);
-  writer->SetFileName(argv[2]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   // Setup the connected opening method
   connectedOpening->SetInput(reader->GetOutput());
@@ -81,10 +79,20 @@ itkGrayscaleConnectedOpeningImageFilterTest(int argc, char * argv[])
   seed[0] = std::stoi(argv[3]);
   seed[1] = std::stoi(argv[4]);
   connectedOpening->SetSeed(seed);
+  ITK_TEST_SET_GET_VALUE(seed, connectedOpening->GetSeed());
 
-  // Run the filter
+  ITK_TRY_EXPECT_NO_EXCEPTION(connectedOpening->Update());
+
+
+  using WriterType = itk::ImageFileWriter<WriteImageType>;
+  WriterType::Pointer writer = WriterType::New();
+
+  writer->SetFileName(argv[2]);
   writer->SetInput(connectedOpening->GetOutput());
-  writer->Update();
 
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve coverage for `MathematicalMorphology` module classes:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Make the calls to the Get methods be quantitative where they were just
  being called without being compared to the expected value.
- Use the `ITK_TRY_EXPECT_NO_EXCEPTION` macro to avoid boilerplate code.
- Remove explicit calls to the `Print` method and rely on the basic
  method exercising macro call.
- Improve slightly the test style to make them more consistent (e.g.
  input argument checking, test finishing message, make the types and
  variables dwell closer to the place where they are instantiated, etc.)

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)