### PR TITLE
ENH: Declare FixedArray::size() constexpr

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -426,8 +426,11 @@ public:
   SizeType
   Size() const;
 
-  SizeType
-  size() const;
+  constexpr SizeType
+  size() const
+  {
+    return VLength;
+  }
 
   /** Set all the elements of the container to the input value. */
   void

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -162,13 +162,6 @@ FixedArray<TValue, VLength>::Size() const
   return VLength;
 }
 
-template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::SizeType
-FixedArray<TValue, VLength>::size() const
-{
-  return VLength;
-}
-
 /**
  * Fill all elements of the array with the given value.
  */

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -279,6 +279,10 @@ TEST(FixedArray, IteratorIncrementReturnValue)
 TEST(FixedArray, StdMemberFunctionsWork)
 {
   using FixedArrayType = itk::FixedArray<double, 3>;
+
+  // FixedArray::size() may be evaluated at compile-time, just like std::array::size().
+  static_assert(FixedArrayType{}.size() == FixedArrayType::Dimension, "FixedArray::size() should equal its dimension");
+
   auto d3arr = FixedArrayType(3);
   d3arr[0] = 1;
   d3arr[1] = 2;


### PR DESCRIPTION
Eases writing generic code that supports both `std::array` and `FixedArray`.

Follow-up to "ENH: Add data() and size() member functions to FixedArray"
pull request #1800 commit 38939ff86d97777e8d507963c13a2221e86b601e
by Pablo Hernandez-Cerdan (@phcerdan), May 10, 2020