### PR TITLE
COMP: Use of uninitialzed variable warning

### DIFF
--- a/Modules/Core/Common/include/itkConceptChecking.h
+++ b/Modules/Core/Common/include/itkConceptChecking.h
@@ -706,8 +706,7 @@ struct HasNumericTraits
       Detail::UniqueType<typename NumericTraits<T>::RealType>();
       Detail::UniqueType<typename NumericTraits<T>::ScalarRealType>();
       Detail::UniqueType<typename NumericTraits<T>::FloatType>();
-      T    a;
-      bool b;
+      T a{ 0 };
 
       // Test these methods that take an instance of T to
       // allow for types with variable length.
@@ -715,10 +714,10 @@ struct HasNumericTraits
       a = NumericTraits<T>::ZeroValue(a);
       a = NumericTraits<T>::OneValue(a);
 
-      b = NumericTraits<T>::IsPositive(a);
-      b = NumericTraits<T>::IsNonpositive(a);
-      b = NumericTraits<T>::IsNegative(a);
-      b = NumericTraits<T>::IsNonnegative(a);
+      bool b = NumericTraits<T>::IsPositive(a);
+      b &= NumericTraits<T>::IsNonpositive(a);
+      b &= NumericTraits<T>::IsNegative(a);
+      b &= NumericTraits<T>::IsNonnegative(a);
       Detail::IgnoreUnusedVariable(a);
       Detail::IgnoreUnusedVariable(b);
     }

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
@@ -26,7 +26,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 ConstantBoundaryCondition<TInputImage, TOutputImage>::ConstantBoundaryCondition()
 {
-  OutputPixelType p;
+  OutputPixelType p{};
   m_Constant = NumericTraits<OutputPixelType>::ZeroValue(p);
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -175,7 +175,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
 
   if (nComponents == 0)
   {
-    PixelComponentType zeroComponent = NumericTraits<PixelComponentType>::ZeroValue(zeroComponent);
+    PixelComponentType tempZeroComponents{ 0 };
+    PixelComponentType zeroComponent = NumericTraits<PixelComponentType>::ZeroValue(tempZeroComponents);
     nComponents = this->GetInput()->GetNumberOfComponentsPerPixel();
     NumericTraits<PixelType>::SetLength(m_DefaultPixelValue, nComponents);
     for (unsigned int n = 0; n < nComponents; n++)


### PR DESCRIPTION
warning: variable 'a' is uninitialized when passed as a const reference argument here [-Wuninitialized-const-reference]

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes]