### PR TITLE
COMP: Fix `itk::DCMTKSeriesFileNames` compilation issues

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -194,9 +194,21 @@ DCMTKSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
 
   os << indent << "InputDirectory: " << m_InputDirectory << std::endl;
   os << indent << "OutputDirectory: " << m_OutputDirectory << std::endl;
-  os << indent << "InputFileNames: " << m_InputFileNames << std::endl;
-  os << indent << "OutputFileNames: " << m_OutputFileNames << std::endl;
-  os << indent << "SeriesUIDs: " << m_SeriesUIDs << std::endl;
+
+  for (unsigned int i = 0; i < m_InputFileNames.size(); i++)
+  {
+    os << indent << "InputFileNames[" << i << "]: " << m_InputFileNames[i] << std::endl;
+  }
+
+  for (unsigned int i = 0; i < m_OutputFileNames.size(); i++)
+  {
+    os << indent << "OutputFileNames[" << i << "]: " << m_OutputFileNames[i] << std::endl;
+  }
+
+  for (unsigned int i = 0; i < m_SeriesUIDs.size(); i++)
+  {
+    os << indent << "SeriesUIDs[" << i << "]: " << m_SeriesUIDs[i] << std::endl;
+  }
 
   if (m_UseSeriesDetails)
   {

--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
@@ -86,8 +86,6 @@ itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
   }
 
   reader->SetFileNames(fileNames);
-  ITK_TEST_SET_GET_VALUE(fileNames, reader->GetFileNames());
-
   reader->SetImageIO(dcmtkIO);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx
@@ -22,6 +22,7 @@
 #include "itkDCMTKSeriesFileNames.h"
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkStreamingImageFilter.h"
+#include "itkTestingMacros.h"
 
 /// \brief is comparison with a percentage tolerance
 ///


### PR DESCRIPTION
Fix `itk::DCMTKSeriesFileNames` compilation issues:
- The filename and series UID container types seem not be overloaded for
  printing.
- There was a call that was not checking the intended left-hand and
  right-hand arguments in the `itkDCMTKSeriesReadImageWrite.cxx` test
- The `itkTestingMacros.h` had not beein include in
  `itkDCMTKSeriesStreamReadImageWrite.cxx`.

Fixes:
```
/tmp/bld/ITK/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx: In member
function 'virtual void itk::DCMTKSeriesFileNames::PrintSelf(std::ostream&,
itk::Indent) const':
bld/ITK/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx:197:16: error:
cannot bind 'std::basic_ostream<char>' lvalue to
'std::basic_ostream<char>&&'
   os << indent << "InputFileNames: " << m_InputFileNames << std::endl;
                   ^

bld/ITK/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx:198:16: error:
cannot bind 'std::basic_ostream<char>' lvalue to
'std::basic_ostream<char>&&'
   os << indent << "OutputFileNames: " << m_OutputFileNames << std::endl;
                   ^

bld/ITK/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx:199:16: error:
cannot bind 'std::basic_ostream<char>' lvalue to
'std::basic_ostream<char>&&'
   os << indent << "SeriesUIDs: " << m_SeriesUIDs << std::endl;
                   ^
```

and

```
In file included from
bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx:31:0:
/tmp/bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx: In
function 'int itkDCMTKSeriesReadImageWrite(int, char**)':
bld/ITK/Modules/Core/TestKernel/include/itkTestingMacros.h:199:15: error:
cannot bind 'std::basic_ostream<char>' lvalue to 'std::basic_ostream<char>&&'
     std::cerr << "Expected " << variable << std::endl; \
               ^
bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx:89:3:
note: in expansion of macro 'ITK_TEST_SET_GET_VALUE'
     ITK_TEST_SET_GET_VALUE(fileNames, reader->GetFileNames());
     ^
```

and
```
/tmp/bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx:
In function 'int itkDCMTKSeriesStreamReadImageWrite(int, char**)':
bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx:52:64:
error: 'itkNameOfTestExecutableMacro' was not declared in this scope
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
                                                                ^
bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx:183:47: error:
'ITK_TRY_EXPECT_NO_EXCEPTION' was not declared in this scope
     ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
                                                 ^
```

Reported at:
https://open.cdash.org/viewBuildError.php?buildid=6945069

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)