### PR TITLE
BUG: Missing end-of line macro changes for DCMTK module

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -264,7 +264,7 @@ DCMTKImageIO ::OpenDicomImage()
   }
   if (this->m_DImage == nullptr)
   {
-    itkExceptionMacro(<< "Can't create DicomImage for " << this->m_FileName)
+    itkExceptionMacro(<< "Can't create DicomImage for " << this->m_FileName);
   }
 }
 
@@ -276,7 +276,7 @@ DCMTKImageIO ::Read(void * buffer)
   this->OpenDicomImage();
   if (m_DImage->getStatus() != EIS_Normal)
   {
-    itkExceptionMacro(<< "Error: cannot load DICOM image (" << DicomImage::getString(m_DImage->getStatus()) << ")")
+    itkExceptionMacro(<< "Error: cannot load DICOM image (" << DicomImage::getString(m_DImage->getStatus()) << ")");
   }
 
   m_Dimensions[0] = (unsigned int)(m_DImage->getWidth());


### PR DESCRIPTION
The macros now require a `;` at the end of their respective line. A PR was pushed updating the definitions to fit this requirement. However, the `DCMTK` module was not corrected. This verifies the `;` is placed accordingly.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
