### PR TITLE
BUG: Fix `itkDCMTKSeriesREadImageWrite.cxx` test failures

### DIFF
--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
@@ -55,12 +55,17 @@ itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(it, DCMTKSeriesFileNames, ProcessObject);
 
+
   // Test exceptions
-  std::string inputDirectory = "";
+  const char * pInputDirectory = nullptr;
   ITK_TRY_EXPECT_EXCEPTION(it->SetInputDirectory(inputDirectory));
 
+  // Exercise warnings
+  std::string inputDirectory = "";
+  it->SetInputDirectory(inputDirectory);
+
   inputDirectory = "NotADirectory";
-  ITK_TRY_EXPECT_EXCEPTION(it->SetInputDirectory(inputDirectory));
+  it->SetInputDirectory(inputDirectory);
 
   inputDirectory = argv[1];
   it->SetInputDirectory(inputDirectory);


### PR DESCRIPTION
Fix `itkDCMTKSeriesREadImageWrite.cxx` test failures: the tested
conditions throw warnings and not exceptions. Do not expect an exception
and simply call the statement to exercise the warning condition.

Fixes:
```
Trying it->SetInputDirectory(inputDirectory)
WARNING: In /tmp/bld/ITK/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx,
line 58
DCMTKSeriesFileNames (0x55d8574bf600): You need to specify a directory
where the DICOM files are located

Failed to catch expected exception
  In /tmp/bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx,
  line 60
```

Raised at:
https://open.cdash.org/viewTest.php?onlyfailed&buildid=6958922

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)