### PR TITLE
ENH: Increase `itk::ObjectByObjectLabelMapFilter` class coverage

### DIFF
--- a/Modules/Filtering/LabelMap/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/test/CMakeLists.txt
@@ -484,12 +484,12 @@ itk_add_test(NAME itkObjectByObjectLabelMapFilterTest0
       COMMAND ITKLabelMapTestDriver
     --compare DATA{Baseline/itkObjectByObjectLabelMapFilterTest0.png}
               ${ITK_TEST_OUTPUT_DIR}/itkObjectByObjectLabelMapFilterTest0.png
-    itkObjectByObjectLabelMapFilterTest DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png} ${ITK_TEST_OUTPUT_DIR}/itkObjectByObjectLabelMapFilterTest0.png 0)
+    itkObjectByObjectLabelMapFilterTest DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png} ${ITK_TEST_OUTPUT_DIR}/itkObjectByObjectLabelMapFilterTest0.png 0 0 1)
 itk_add_test(NAME itkObjectByObjectLabelMapFilterTest1
       COMMAND ITKLabelMapTestDriver
     --compare DATA{Baseline/itkObjectByObjectLabelMapFilterTest1.png}
               ${ITK_TEST_OUTPUT_DIR}/itkObjectByObjectLabelMapFilterTest1.png
-    itkObjectByObjectLabelMapFilterTest DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png} ${ITK_TEST_OUTPUT_DIR}/itkObjectByObjectLabelMapFilterTest1.png 1)
+    itkObjectByObjectLabelMapFilterTest DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png} ${ITK_TEST_OUTPUT_DIR}/itkObjectByObjectLabelMapFilterTest1.png 1 0 1)
 itk_add_test(NAME itkPadLabelMapFilterTest1
       COMMAND ITKLabelMapTestDriver
     --compare DATA{Baseline/cthead1-label-pad.mha}


### PR DESCRIPTION
Increase `itk::ObjectByObjectLabelMapFilter` class coverage:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Add the corresponding test arguments to the appropriate
  `CMakeLists.txt`test driver command.
- Use the `ITK_TRY_EXPECT_NO_EXCEPTION` macro to avoid boilerplate code.
- Improve slightly the test style to make them more consistent (e.g.
  input argument checking or test finishing message).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)