### PR TITLE
ENH: Increase `itk::ImageDuplicator` class coverage

### DIFF
--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -22,6 +22,7 @@
 #include "itkRGBPixel.h"
 #include "itkVectorImage.h"
 #include "itkShiftScaleImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageDuplicatorTest(int, char *[])
@@ -68,6 +69,9 @@ itkImageDuplicatorTest(int, char *[])
     std::cout << "Testing duplicator with float images: ";
     using DuplicatorType = itk::ImageDuplicator<ImageType>;
     DuplicatorType::Pointer duplicator = DuplicatorType::New();
+
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(duplicator, ImageDuplicator, Object);
+
 
     duplicator->SetInputImage(shift->GetOutput());
     duplicator->Update();
@@ -284,5 +288,8 @@ itkImageDuplicatorTest(int, char *[])
 
     std::cout << "[DONE]" << std::endl;
   }
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Increase `itk::ImageDuplicator` class coverage:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Improve slightly the test style to make them more consistent (e.g.
  input argument checking or test finishing message).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)