### PR TITLE
STYLE: Use `itkBooleanMacro` to avoid boilerplate code

### DIFF
--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -192,10 +192,22 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
+  /** Set/Get whether or not the filter will use the spacing of the input
+      image (1/spacing) in the calculation of the derivative weights. Use On
+      if you want to calculate the gradient in the space in which the data was
+      acquired; use Off to ignore image spacing and to calculate the gradient
+      in the image space. Default is On. */
+  void
+  SetUseImageSpacing(bool);
+  itkGetConstMacro(UseImageSpacing, bool);
+  itkBooleanMacro(UseImageSpacing);
+
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
   /** Set the derivative weights according to the spacing of the input image
       (1/spacing). Use this option if you want to calculate the gradient in the
       space in which the data was acquired. Default is
-      ImageSpacingOn. */
+      ImageSpacingOn.
+      \deprecated Use VectorGradientMagnitudeImageFilter::UseImageSpacingOn instead. */
   void
   SetUseImageSpacingOn()
   {
@@ -204,19 +216,14 @@ public:
 
   /** Reset the derivative weights to ignore image spacing.  Use this option if
       you want to calculate the gradient in the image space.  Default is
-      ImageSpacingOn. */
+      ImageSpacingOn.
+     \deprecated Use VectorGradientMagnitudeImageFilter::UseImageSpacingOff instead. */
   void
   SetUseImageSpacingOff()
   {
     this->SetUseImageSpacing(false);
   }
-
-  /** Set/Get whether or not the filter will use the spacing of the input
-      image in its calculations */
-  void
-  SetUseImageSpacing(bool);
-
-  itkGetConstMacro(UseImageSpacing, bool);
+#endif
 
   using WeightsType = FixedArray<TRealType, VectorDimension>;
 
@@ -237,17 +244,23 @@ public:
       derivatives squared.  Default is UsePrincipleComponents = true. */
   itkSetMacro(UsePrincipleComponents, bool);
   itkGetConstMacro(UsePrincipleComponents, bool);
+  itkBooleanMacro(UsePrincipleComponents);
+
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
+  /** \deprecated Use VectorGradientMagnitudeImageFilter::UsePrincipleComponentsOn instead. */
   void
   SetUsePrincipleComponentsOn()
   {
     this->SetUsePrincipleComponents(true);
   }
 
+  /** \deprecated Use VectorGradientMagnitudeImageFilter::UsePrincipleComponentsOff instead. */
   void
   SetUsePrincipleComponentsOff()
   {
     this->SetUsePrincipleComponents(false);
   }
+#endif
 
   /** A specialized solver for finding the roots of a cubic polynomial.
    *  Necessary to multi-thread the 3D case */

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
@@ -53,11 +53,17 @@ itkVectorGradientMagnitudeImageFilterTest1(int ac, char * av[])
   int mode = ::std::stoi(av[3]);
   if (mode == 1)
   {
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOn();
+#endif
+    filter->UsePrincipleComponentsOn();
   }
   else
   {
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOff();
+#endif
+    filter->UsePrincipleComponentsOff();
   }
 
   RescaleFilterType::Pointer rescale = RescaleFilterType::New();

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
@@ -56,11 +56,17 @@ itkVectorGradientMagnitudeImageFilterTest2(int ac, char * av[])
 
   if (mode == 1)
   {
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOn();
+#endif
+    filter->UsePrincipleComponentsOn();
   }
   else
   {
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOff();
+#endif
+    filter->UsePrincipleComponentsOff();
   }
 
   RescaleFilterType::Pointer rescale = RescaleFilterType::New();

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
@@ -58,11 +58,17 @@ itkVectorGradientMagnitudeImageFilterTest3(int ac, char * av[])
 
   if (mode == 1)
   {
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOn();
+#endif
+    filter->UsePrincipleComponentsOn();
   }
   else
   {
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOff();
+#endif
+    filter->UsePrincipleComponentsOff();
   }
 
   Monitor2Filter::Pointer monitor2 = Monitor2Filter::New();


### PR DESCRIPTION
Use the `itkBooleanMacro` macro for the boolean ivars in
`itk::VectorGradientMagnitudeImageFilter` to avoid boilerplate code.

Mark the corresponding previous methods as deprecated.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)