### PR TITLE
ENH: Increase `ITKImageFeature` module classes coverage

### DIFF
--- a/Modules/Filtering/ImageFeature/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFeature/test/CMakeLists.txt
@@ -32,7 +32,7 @@ CreateTestDriver(ITKImageFeature  "${ITKImageFeature-Test_LIBRARIES}" "${ITKImag
 set(TEMP ${ITK_TEST_OUTPUT_DIR})
 
 itk_add_test(NAME itkZeroCrossingBasedEdgeDetectionImageFilterTest
-      COMMAND ITKImageFeatureTestDriver itkZeroCrossingBasedEdgeDetectionImageFilterTest)
+      COMMAND ITKImageFeatureTestDriver itkZeroCrossingBasedEdgeDetectionImageFilterTest 1.0 0.01)
 itk_add_test(NAME itkLaplacianImageFilterTest
       COMMAND ITKImageFeatureTestDriver itkLaplacianImageFilterTest)
 itk_add_test(NAME itkSobelEdgeDetectionImageFilterTest

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
@@ -20,35 +20,77 @@
 #include "itkZeroCrossingBasedEdgeDetectionImageFilter.h"
 #include "itkNullImageToImageFilterDriver.hxx"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
-itkZeroCrossingBasedEdgeDetectionImageFilterTest(int, char *[])
+itkZeroCrossingBasedEdgeDetectionImageFilterTest(int argc, char * argv[])
 {
-  try
+  if (argc < 3)
   {
-    using ImageType = itk::Image<float, 2>;
-
-    // Set up filter
-    itk::ZeroCrossingBasedEdgeDetectionImageFilter<ImageType, ImageType>::Pointer filter =
-      itk::ZeroCrossingBasedEdgeDetectionImageFilter<ImageType, ImageType>::New();
-
-    itk::SimpleFilterWatcher watcher(filter);
-    filter->SetVariance(1.0f);
-    filter->SetMaximumError(.01f);
-
-    // Run Test
-    itk::Size<2> sz;
-    sz[0] = 100;
-    sz[1] = 100;
-    itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
-    test1.SetImageSize(sz);
-    test1.SetFilter(filter);
-    test1.Execute();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    (&err)->Print(std::cerr);
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " varianceValue maximumErrorValue" << std::endl;
     return EXIT_FAILURE;
   }
+
+  using ImageType = itk::Image<float, 2>;
+
+  // Set up filter
+  using FilterType = itk::ZeroCrossingBasedEdgeDetectionImageFilter<ImageType, ImageType>;
+
+  FilterType::Pointer filter = FilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, ZeroCrossingBasedEdgeDetectionImageFilter, ImageToImageFilter);
+
+
+  itk::SimpleFilterWatcher watcher(filter);
+
+  float varianceValue = std::stod(argv[1]);
+  filter->SetVariance(varianceValue);
+  for (auto i : filter->GetVariance())
+  {
+    if (i != varianceValue)
+    {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in itk::ZeroCrossingBasedEdgeDetectionImageFilter::GetVariance" << std::endl;
+      std::cerr << "Expected: " << varianceValue << ", but got: " << i << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  FilterType::ArrayType variance;
+  variance.Fill(varianceValue);
+  filter->SetVariance(variance);
+  ITK_TEST_SET_GET_VALUE(variance, filter->GetVariance());
+
+  float maximumErrorValue = std::stod(argv[2]);
+  filter->SetMaximumError(maximumErrorValue);
+  for (auto i : filter->GetMaximumError())
+  {
+    if (i != maximumErrorValue)
+    {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error in itk::ZeroCrossingBasedEdgeDetectionImageFilter::GetMaximumError" << std::endl;
+      std::cerr << "Expected: " << maximumErrorValue << ", but got: " << i << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  FilterType::ArrayType maximumError;
+  maximumError.Fill(maximumErrorValue);
+  filter->SetMaximumError(maximumError);
+  ITK_TEST_SET_GET_VALUE(maximumError, filter->GetMaximumError());
+
+  // Run Test
+  itk::Size<2> sz;
+  sz[0] = 100;
+  sz[1] = 100;
+  itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
+  test1.SetImageSize(sz);
+  test1.SetFilter(filter);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(test1.Execute());
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include <iostream>
 #include "itkZeroCrossingImageFilter.h"
 #include "itkNullImageToImageFilterDriver.hxx"
+#include "itkTestingMacros.h"
 
 inline std::ostream &
 operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
@@ -30,29 +31,28 @@ operator<<(std::ostream & o, const itk::Vector<float, 3> & v)
 int
 itkZeroCrossingImageFilterTest(int, char *[])
 {
-  try
-  {
-    using ImageType = itk::Image<float, 2>;
+  using ImageType = itk::Image<float, 2>;
 
-    // Set up filter
-    itk::ZeroCrossingImageFilter<ImageType, ImageType>::Pointer filter =
-      itk::ZeroCrossingImageFilter<ImageType, ImageType>::New();
+  // Set up filter
+  itk::ZeroCrossingImageFilter<ImageType, ImageType>::Pointer filter =
+    itk::ZeroCrossingImageFilter<ImageType, ImageType>::New();
 
-    std::cout << "filter: " << filter;
-    // Run Test
-    itk::Size<2> sz;
-    sz[0] = 100;
-    sz[1] = 100;
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, ZeroCrossingImageFilter, ImageToImageFilter);
 
-    itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
-    test1.SetImageSize(sz);
-    test1.SetFilter(filter);
-    test1.Execute();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    (&err)->Print(std::cerr);
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "filter: " << filter;
+  // Run Test
+  itk::Size<2> sz;
+  sz[0] = 100;
+  sz[1] = 100;
+
+  itk::NullImageToImageFilterDriver<ImageType, ImageType> test1;
+  test1.SetImageSize(sz);
+  test1.SetFilter(filter);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(test1.Execute());
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Increase `ITKImageFeature` module classes coverage:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Add the corresponding test arguments to the appropriate`CMakeLists.txt`
  test driver command.
- Remove the global `try/catch` block and use the
  `ITK_TRY_EXPECT_NO_EXCEPTION` macro around the statement that is
  liable to throw and exception to avoid boilerplate code and to improve
  readability.
- Improve slightly the test style to make them more consistent (e.g.
  input argument checking or test finishing message).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)