### PR TITLE
ENH: Increase `ITKImageGradient` module classes coverage

### DIFF
--- a/Modules/Filtering/ImageGradient/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGradient/test/CMakeLists.txt
@@ -18,7 +18,7 @@ itkGradientRecursiveGaussianFilterSpeedTest.cxx
 CreateTestDriver(ITKImageGradient  "${ITKImageGradient-Test_LIBRARIES}" "${ITKImageGradientTests}")
 
 itk_add_test(NAME itkGradientImageFilterTest
-      COMMAND ITKImageGradientTestDriver itkGradientImageFilterTest)
+      COMMAND ITKImageGradientTestDriver itkGradientImageFilterTest 1 1)
 itk_add_test(NAME itkGradientImageFilterTest2
       COMMAND ITKImageGradientTestDriver
    --compare DATA{${ITK_DATA_ROOT}/Baseline/Filtering/GradientMagnitudeImageFilterTest2.mha}
@@ -30,12 +30,12 @@ itk_add_test(NAME itkVectorGradientMagnitudeImageFilterTest1a
       COMMAND ITKImageGradientTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/VectorGradientMagnitudeImageFilterTest1a.png}
               ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest1a.png
-    itkVectorGradientMagnitudeImageFilterTest1 DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png} ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest1a.png 0)
+    itkVectorGradientMagnitudeImageFilterTest1 DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png} ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest1a.png 1 1.0 1.0 0)
 itk_add_test(NAME itkVectorGradientMagnitudeImageFilterTest1b
       COMMAND ITKImageGradientTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/VectorGradientMagnitudeImageFilterTest1b.png}
               ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest1b.png
-    itkVectorGradientMagnitudeImageFilterTest1 DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png} ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest1b.png 1)
+    itkVectorGradientMagnitudeImageFilterTest1 DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png} ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest1b.png 1 1.0 1.0 1)
 itk_add_test(NAME itkVectorGradientMagnitudeImageFilterTest2
       COMMAND ITKImageGradientTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/VectorGradientMagnitudeImageFilterTest2.png}

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
@@ -32,66 +32,74 @@ operator<<(std::ostream & o, const itk::CovariantVector<float, 3> & v)
 }
 
 int
-itkGradientImageFilterTest(int, char *[])
+itkGradientImageFilterTest(int argc, char * argv[])
 {
-  try
+  if (argc != 3)
   {
-    using ImageType = itk::Image<unsigned short, 2>;
-    using FilterType = itk::GradientImageFilter<ImageType, float, float>;
-    using OutputImageType = FilterType::OutputImageType;
-
-
-    // Set up filter
-    FilterType::Pointer filter = FilterType::New();
-
-    ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, GradientImageFilter, ImageToImageFilter);
-
-    // Run test
-    itk::Size<2> sz;
-    sz[0] = 100;
-    sz[1] = 100;
-    itk::NullImageToImageFilterDriver<ImageType, OutputImageType> test1;
-    test1.SetImageSize(sz);
-    test1.SetFilter(filter);
-    test1.Execute();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    (&err)->Print(std::cerr);
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " useImageSpacing useImageDirection" << std::endl;
     return EXIT_FAILURE;
   }
+
+  using InputImageType1 = itk::Image<unsigned short, 2>;
+  using FilterType1 = itk::GradientImageFilter<InputImageType1, float, float>;
+  using OutputImageType1 = FilterType1::OutputImageType;
+
+
+  // Set up filter
+  FilterType1::Pointer filter1 = FilterType1::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter1, GradientImageFilter, ImageToImageFilter);
+
+
+  auto useImageSpacing = static_cast<bool>(std::stoi(argv[1]));
+  ITK_TEST_SET_GET_BOOLEAN(filter1, UseImageSpacing, useImageSpacing);
+
+  auto useImageDirection = static_cast<bool>(std::stoi(argv[2]));
+  ITK_TEST_SET_GET_BOOLEAN(filter1, UseImageDirection, useImageDirection);
+
+  // Run test
+  itk::Size<2> sz1;
+  sz1[0] = 100;
+  sz1[1] = 100;
+  itk::NullImageToImageFilterDriver<InputImageType1, OutputImageType1> test1;
+  test1.SetImageSize(sz1);
+  test1.SetFilter(filter1);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(test1.Execute());
+
 
   // Verify that we can run with VectorImages
-  try
-  {
-    using InputImageType = itk::Image<float, 3>;
-    using OutputImageType = itk::VectorImage<float, 3>;
+  using InputImageType2 = itk::Image<float, 3>;
+  using OutputImageType2 = itk::VectorImage<float, 3>;
 
-    using FilterType = itk::GradientImageFilter<InputImageType, float, float, OutputImageType>;
+  using FilterType2 = itk::GradientImageFilter<InputImageType2, float, float, OutputImageType2>;
 
-    FilterType::Pointer filter = FilterType::New();
+  FilterType2::Pointer filter2 = FilterType2::New();
 
-    using PeriodicBoundaryType = itk::PeriodicBoundaryCondition<InputImageType>;
-    // Test the OverrideBoundaryCondition setting;
-    filter->OverrideBoundaryCondition(new PeriodicBoundaryType);
+  using PeriodicBoundaryType = itk::PeriodicBoundaryCondition<InputImageType2>;
+  // Test the OverrideBoundaryCondition setting;
+  filter2->OverrideBoundaryCondition(new PeriodicBoundaryType);
 
-    ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, GradientImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter2, GradientImageFilter, ImageToImageFilter);
 
-    // Run test
-    itk::Size<3> sz;
-    sz[0] = 25;
-    sz[1] = 25;
-    sz[2] = 25;
-    itk::NullImageToImageFilterDriver<InputImageType, OutputImageType> test1;
-    test1.SetImageSize(sz);
-    test1.SetFilter(filter);
-    test1.Execute();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    (&err)->Print(std::cerr);
-    return EXIT_FAILURE;
-  }
 
+  ITK_TEST_SET_GET_BOOLEAN(filter2, UseImageSpacing, useImageSpacing);
+
+  ITK_TEST_SET_GET_BOOLEAN(filter2, UseImageDirection, useImageDirection);
+
+  // Run test
+  itk::Size<3> sz2;
+  sz2[0] = 25;
+  sz2[1] = 25;
+  sz2[2] = 25;
+  itk::NullImageToImageFilterDriver<InputImageType2, OutputImageType2> test2;
+  test2.SetImageSize(sz2);
+  test2.SetFilter(filter2);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(test2.Execute());
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
@@ -22,10 +22,23 @@
 #include "itkImageFileWriter.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkRGBToVectorImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int
-itkVectorGradientMagnitudeImageFilterTest1(int ac, char * av[])
+itkVectorGradientMagnitudeImageFilterTest1(int argc, char * argv[])
 {
+  if (argc != 7)
+  {
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputImage"
+              << " outputImage"
+              << " useImageSpacing"
+              << " derivativeWeightsValue"
+              << " componentsWeightsValue"
+              << " mode" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   using RGBPixelType = itk::RGBPixel<unsigned short>;
   using CharImageType = itk::Image<unsigned char, 2>;
   using RGBImageType = itk::Image<RGBPixelType, 2>;
@@ -35,36 +48,45 @@ itkVectorGradientMagnitudeImageFilterTest1(int ac, char * av[])
   using RescaleFilterType = itk::RescaleIntensityImageFilter<FilterType::OutputImageType, CharImageType>;
   using WriterType = itk::ImageFileWriter<CharImageType>;
 
-  if (ac < 4)
-  {
-    std::cerr << "Usage: " << av[0] << " InputImage OutputImage Mode\n";
-    return EXIT_FAILURE;
-  }
-
   // Create a reader and filter
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
   AdaptorType::Pointer adaptor = AdaptorType::New();
   adaptor->SetImage(reader->GetOutput());
   FilterType::Pointer filter = FilterType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, VectorGradientMagnitudeImageFilter, ImageToImageFilter);
+
+
   filter->SetInput(adaptor);
 
-  int mode = ::std::stoi(av[3]);
-  if (mode == 1)
-  {
+  auto useImageSpacing = static_cast<bool>(std::stoi(argv[3]));
+  ITK_TEST_SET_GET_BOOLEAN(filter, UseImageSpacing, useImageSpacing);
+
+  auto                    derivativeWeightsValue = static_cast<FilterType::WeightsType::ValueType>(std::stod(argv[4]));
+  FilterType::WeightsType derivativeWeights;
+  derivativeWeights.Fill(derivativeWeightsValue);
+  filter->SetDerivativeWeights(derivativeWeights);
+  ITK_TEST_SET_GET_VALUE(derivativeWeights, filter->GetDerivativeWeights());
+
+  auto                    componentWeightsValue = static_cast<FilterType::WeightsType::ValueType>(std::stod(argv[5]));
+  FilterType::WeightsType componentWeights;
+  componentWeights.Fill(componentWeightsValue);
+  filter->SetComponentWeights(componentWeights);
+  ITK_TEST_SET_GET_VALUE(componentWeights, filter->GetComponentWeights());
+
+  auto mode = static_cast<bool>(std::stoi(argv[6]));
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
+  if (mode)
+  {
     filter->SetUsePrincipleComponentsOn();
-#endif
-    filter->UsePrincipleComponentsOn();
   }
   else
   {
-#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOff();
-#endif
-    filter->UsePrincipleComponentsOff();
   }
+#endif
+  ITK_TEST_SET_GET_BOOLEAN(filter, UsePrincipleComponents, mode);
 
   RescaleFilterType::Pointer rescale = RescaleFilterType::New();
   rescale->SetOutputMinimum(0);
@@ -73,32 +95,16 @@ itkVectorGradientMagnitudeImageFilterTest1(int ac, char * av[])
 
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(rescale->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return EXIT_FAILURE;
-  }
-  catch (...)
-  {
-    std::cerr << "Some other exception occurred" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Exercise the Print method
-  std::cout << "-- Test of the Print method --------------" << std::endl;
-  filter->Print(std::cout);
-  std::cout << "-- End of Print method test --------------" << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "The gradient image range was (low, high) = (" << rescale->GetInputMinimum() << ", "
             << rescale->GetInputMaximum() << ")" << std::endl;
   std::cout << "Output was scaled, shifted = " << rescale->GetScale() << ", " << rescale->GetShift() << std::endl;
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkRGBToVectorImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -52,22 +53,18 @@ itkVectorGradientMagnitudeImageFilterTest2(int ac, char * av[])
   FilterType::Pointer filter = FilterType::New();
   filter->SetInput(adaptor);
 
-  const int mode = ::std::stoi(av[3]);
-
-  if (mode == 1)
-  {
+  auto mode = static_cast<bool>(std::stoi(av[3]));
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
+  if (mode)
+  {
     filter->SetUsePrincipleComponentsOn();
-#endif
-    filter->UsePrincipleComponentsOn();
   }
   else
   {
-#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOff();
-#endif
-    filter->UsePrincipleComponentsOff();
   }
+#endif
+  ITK_TEST_SET_GET_BOOLEAN(filter, UsePrincipleComponents, mode);
 
   RescaleFilterType::Pointer rescale = RescaleFilterType::New();
   rescale->SetOutputMinimum(0);

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
@@ -21,6 +21,7 @@
 #include "itkImageFileWriter.h"
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkRGBToVectorImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int
 itkVectorGradientMagnitudeImageFilterTest3(int ac, char * av[])
@@ -54,22 +55,18 @@ itkVectorGradientMagnitudeImageFilterTest3(int ac, char * av[])
   FilterType::Pointer filter = FilterType::New();
   filter->SetInput(adaptor);
 
-  const int mode = ::std::stoi(av[3]);
-
-  if (mode == 1)
-  {
+  auto mode = static_cast<bool>(std::stoi(av[3]));
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
+  if (mode)
+  {
     filter->SetUsePrincipleComponentsOn();
-#endif
-    filter->UsePrincipleComponentsOn();
   }
   else
   {
-#if !defined(ITK_FUTURE_LEGACY_REMOVE)
     filter->SetUsePrincipleComponentsOff();
-#endif
-    filter->UsePrincipleComponentsOff();
   }
+#endif
+  ITK_TEST_SET_GET_BOOLEAN(filter, UsePrincipleComponents, mode);
 
   Monitor2Filter::Pointer monitor2 = Monitor2Filter::New();
   monitor2->SetInput(filter->GetOutput());


### PR DESCRIPTION
Increase `ITKImageGradient` module classes coverage:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Test the boolean ivars using the `ITK_TEST_SET_GET_BOOLEAN` macro.
- Add the corresponding test arguments to the appropriate
  `CMakeLists.txt` test driver command.
- Remove the global `try/catch` block and use the
  `ITK_TRY_EXPECT_NO_EXCEPTION` macro around the statement that is liable
  to throw and exception to avoid boilerplate code and to improve
  readability.
- Remove explicit calls to the `Print` method and rely on the basic method
  exercising macro call.
- Improve slightly the test style to make them more consistent (e.g.
  input argument checking or test finishing message).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)