### PR TITLE
BUG: Remove unnecessary IO member filter name of class print calls

### DIFF
--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
@@ -339,10 +339,8 @@ ObjectByObjectLabelMapFilter<TInputImage,
   os << indent << "KeepLabels: " << m_KeepLabels << std::endl;
   os << indent << "InternalForegroundValue: "
      << static_cast<typename NumericTraits<InternalOutputPixelType>::PrintType>(m_InternalForegroundValue) << std::endl;
-  os << indent << "InputFilter: " << this->m_InputFilter->GetNameOfClass() << " " << this->m_InputFilter.GetPointer()
-     << std::endl;
-  os << indent << "OutputFilter: " << this->m_OutputFilter->GetNameOfClass() << " " << this->m_OutputFilter.GetPointer()
-     << std::endl;
+  os << indent << "InputFilter: " << m_InputFilter << std::endl;
+  os << indent << "OutputFilter: " << m_OutputFilter << std::endl;
   os << indent << "Label: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Label)
      << std::endl;
 }


### PR DESCRIPTION
Remove unnecessary IO member filter name of class print calls in
`PrintSelf` method.

The related `itkObjectByObjectLabelMapFilterTest.cxx` test was segfaulting
when the `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro was calling the
`PrintSelf` member. The segfaults were caused by the `m_InputFilter` and
`m_OutputFilter` members being initialized to the null pointer, and hence
calling the `GetNameOfClass()` method using a null pointer.

Fixes the segfault errors raised at:
https://open.cdash.org/viewTest.php?onlyfailed&buildid=6959862
https://open.cdash.org/viewTest.php?onlyfailed&buildid=6960004
https://open.cdash.org/viewTest.php?onlyfailed&buildid=6959902

Take advantage of the commit to remove the `GetPointer` call: the `<<`
operator is overloaded to print all relevant smart pointer data (including
if class name).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)