### PR TITLE
COMP: Fix undeclared identifier

### DIFF
--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
@@ -58,7 +58,7 @@ itkDCMTKSeriesReadImageWrite(int argc, char * argv[])
 
   // Test exceptions
   const char * pInputDirectory = nullptr;
-  ITK_TRY_EXPECT_EXCEPTION(it->SetInputDirectory(inputDirectory));
+  ITK_TRY_EXPECT_EXCEPTION(it->SetInputDirectory(pInputDirectory));
 
   // Exercise warnings
   std::string inputDirectory = "";


### PR DESCRIPTION
Fix undeclared identifier error.

Fixes:
```
In file included from
bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx:31:0:
/tmp/bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx: In function 'int itkDCMTKSeriesReadImageWrite(int, char**)':
bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx:61:50: error: 'inputDirectory' was not declared in this scope
   ITK_TRY_EXPECT_EXCEPTION(it->SetInputDirectory(inputDirectory));
                                                  ^

bld/ITK/Modules/Core/TestKernel/include/itkTestingMacros.h:94:5: note: in definition of macro 'ITK_TRY_EXPECT_EXCEPTION'
      command;
			               		                                                                        \
      ^
bld/ITK/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx:60:16: warning: unused variable 'pInputDirectory' [-Wunused-variable]
  const char * pInputDirectory = nullptr;
               ^
```

Raised at:
https://open.cdash.org/viewBuildError.php?buildid=6961464

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)