### PR TITLE
BUG: Prevent HDF5 from overwritting ITK library names

### DIFF
--- a/Modules/ThirdParty/HDF5/src/itkhdf5/config/cmake_ext_mod/HDFMacros.cmake
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/config/cmake_ext_mod/HDFMacros.cmake
@@ -110,6 +110,8 @@ endmacro ()
 
 #-------------------------------------------------------------------------------
 macro (HDF_SET_LIB_OPTIONS libtarget libname libtype)
+  # ITK: use ITK library naming
+  if(FALSE)
   if (${libtype} MATCHES "SHARED")
     set (LIB_RELEASE_NAME "${libname}")
     set (LIB_DEBUG_NAME "${libname}${CMAKE_DEBUG_POSTFIX}")
@@ -163,6 +165,8 @@ macro (HDF_SET_LIB_OPTIONS libtarget libname libtype)
         PREFIX ""
     )
   endif ()
+  # ITK: use ITK library naming
+  endif()
 endmacro ()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The OUTPUT_NAME variants, e.g. OUTPUT_NAME_RELEASE, interfere with the
OUTPUT_NAME set by the itk_module_target_name macro.

 libitkhdf5.so ->  libitkhdf5-shared-5.2.so

 Closes #1971


