### PR TITLE
COMP: Update legacy boolean ivar set method call to current API

### DIFF
--- a/Examples/IO/VisibleHumanPasteWrite.cxx
+++ b/Examples/IO/VisibleHumanPasteWrite.cxx
@@ -69,7 +69,7 @@ main(int argc, char * argv[])
     GradientMagnitudeImageFilter::New();
   grad->SetInput(reader->GetOutput());
 
-  grad->SetUseImageSpacingOn();
+  grad->UseImageSpacingOn();
 
   using GradientMagnitudeOutputImageType =
     GradientMagnitudeImageFilter::OutputImageType;


### PR DESCRIPTION
Update legacy boolean ivar set method call to current API: the
`itk::VectorGradientMagnitudeImageFilter::m_UseImageSpacing` ivar got the
boolean macro methods in commit c6610df51b741eac1dab172f58852ad79ffdf5a2,
and the former methods were marked as legacy code.

Fixes:
```
/Users/builder/externalExamples/IO/VisibleHumanPasteWrite.cxx:72:9:
error: no member named 'SetUseImageSpacingOn' in
'itk::VectorGradientMagnitudeImageFilter<itk::Image<itk::RGBPixel<unsigned char>, 2>, float, itk::Image<float, 2> >'
  grad->SetUseImageSpacingOn();
  ~~~~  ^
1 error generated.
```

Raised for example at:
https://open.cdash.org/viewBuildError.php?buildid=6964751

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)