### PR TITLE
DOC: Update macOS Python package Release build instructions

### DIFF
--- a/Documentation/Maintenance/Release.md
+++ b/Documentation/Maintenance/Release.md
@@ -480,8 +480,8 @@ cd ..
 Build the wheels for macOS:
 
 ```sh
-ssh misty
-cd ~/Dashboards/ITK/ITKPythonPackage
+ssh computron
+cd ~/D/P/ITKPythonPackage
 git reset --hard HEAD
 git checkout release
 git pull


### PR DESCRIPTION
Now on Kitware's computron system, in a different path.