### PR TITLE
COMP: externally built remote module libs went in /lib or C:/lib

### DIFF
--- a/CMake/ITKModuleExternal.cmake
+++ b/CMake/ITKModuleExternal.cmake
@@ -39,7 +39,10 @@ endif()
 # Setup build locations for shared libraries ----START
 #     ITK/CMakeLists.txt -- use ITK_BINARY_DIR as root
 #     ITK/CMake/ITKModuleExternal.cmake -- use ITK_DIR as root
-#
+if(NOT ITK_BINARY_DIR)
+  set(ITK_BINARY_DIR ${ITK_DIR})
+endif()
+
 # The default path when not wrapping.  Restore standard build location
 # if python wrapping is turned on, and then turned off.
 if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)


### PR DESCRIPTION
Example failure:
```text
dzenan@corista:~/ITKSplitComponents-deb$ make
[  3%] Built target ITKData
[  5%] Linking CXX executable ../Wrapping/bin/ITKSplitComponentsTestDriver
[  8%] Built target ITKSplitComponentsTestDriver
[ 10%] Linking CXX executable Wrapping/bin/SplitComponentsHeaderTest1
[ 13%] Built target SplitComponentsHeaderTest1
[ 13%] Built target SplitComponents-all
[ 27%] Built target ClangFormat
[ 41%] Built target KWStyle
[ 55%] Built target PCRE
[ 68%] Built target swig
[ 82%] Built target castxml
[ 84%] Built target SplitComponentsCastXML
[ 87%] Built target SplitComponentsSwig
Scanning dependencies of target SplitComponentsPython
[ 89%] Building CXX object Wrapping/Modules/SplitComponents/CMakeFiles/SplitComponentsPython.dir/itkSplitComponentsImageFilterPython.cpp.o
[ 91%] Linking CXX shared module /lib/_SplitComponentsPython.so
/usr/bin/ld: cannot open output file /lib/_SplitComponentsPython.so: Permission denied
collect2: error: ld returned 1 exit status
Wrapping/Modules/SplitComponents/CMakeFiles/SplitComponentsPython.dir/build.make:355: recipe for target '/lib/_SplitComponentsPython.so' failed
make[2]: *** [/lib/_SplitComponentsPython.so] Error 1
CMakeFiles/Makefile2:1407: recipe for target 'Wrapping/Modules/SplitComponents/CMakeFiles/SplitComponentsPython.dir/all' failed
make[1]: *** [Wrapping/Modules/SplitComponents/CMakeFiles/SplitComponentsPython.dir/all] Error 2
Makefile:159: recipe for target 'all' failed
make: *** [all] Error 2
dzenan@corista:~/ITKSplitComponents-deb$
```
`CMAKE_LIBRARY_OUTPUT_DIRECTORY` and `NO_WRAP_CMAKE_LIBRARY_OUTPUT_DIRECTORY` need to be removed from CMake cache of the remote module before reconfiguring for this patch to have effect.