### PR TITLE
BUG: Invalid URLs and Sphinx Example Paths in Doxygen

### DIFF
--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -81,7 +81,7 @@ extern ITKCommon_EXPORT std::ostream &
  * Primal Sketch. Dissertation. Royal Institute of Technology, Stockholm,
  * Sweden. May 1991.).
  *
- * \author Ivan Macia, VICOMTech, Spain, http://www.vicomtech.es
+ * \author Ivan Macia, Vicomtech, Spain, https://www.vicomtech.org/en
  *
  * This implementation is derived from the Insight Journal paper:
  * https://www.insight-journal.org/browse/publication/179

--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -62,7 +62,7 @@ class ITK_TEMPLATE_EXPORT ImageBase;
  * \sphinxexample{Core/Common/CreateAnImageRegion,An object which holds the index (start) and size of a region of an
  * image} \sphinxexample{Core/Common/ImageRegionIntersection,Determine image region intersection}
  * \sphinxexample{Core/Common/IsPixelInsideRegion,Determine if a pixel is inside of a region}
- * \sphinxexample{Core/Common/RegionOverlap,Determine the overlap of two regions}
+ * \sphinxexample{Core/Common/ImageRegionOverlap,Determine the overlap of two regions}
  * \endsphinx
  */
 template <unsigned int VImageDimension>

--- a/Modules/Core/Common/include/itkImageToImageFilter.h
+++ b/Modules/Core/Common/include/itkImageToImageFilter.h
@@ -99,7 +99,7 @@ namespace itk
  * \sphinxexample{Core/Common/MultipleInputsOfSameType,Multiple Inputs Of Same Type}
  * \sphinxexample{Core/Common/MultipleInputsOfDifferentType,Multiple Inputs Of Different Type}
  * \sphinxexample{Core/Common/MultipleOutputsOfSameType,Multiple Outputs Of Same Type}
- * \sphinxexample{Core/Common/MultThreadOilPainting,Mult-thread Oil Painting}
+ * \sphinxexample{Core/Common/MultiThreadOilPainting,Multi-thread Oil Painting}
  * \sphinxexample{Core/Common/MultipleOutputsOfDifferentType,Multiple Outputs Of Different Type}
  * \sphinxexample{Core/Common/FilterImageUsingMultipleThreads,Filter Image Using Multiple Threads}
  * \endsphinx

--- a/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.h
+++ b/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.h
@@ -37,7 +37,7 @@ namespace itk
  *
  * \sphinx
  * \sphinxexample{Core/Common/FindMaxAndMinInImage,Find Max And Min In Image}
- * \sphinxexample{Developer/OilPaintingImageFilter,Multi-threaded oil painting image filter}
+ * \sphinxexample{Core/Common/MultiThreadOilPainting,Multi-thread Oil Painting}
  * \endsphinx
  */
 template <typename TInputImage>

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -205,7 +205,7 @@ std::cout << *iterator[c]              << std::endl;
  *
  * \sphinx
  * \sphinxexample{Core/Common/IterateRegionWithNeighborhood,Iterate Region In Image With Neighborhood}
- * \sphinxexample{VectorImages/NeighborhoodIterator,Neighborhood Iterator On Vector Image}
+ * \sphinxexample{Core/Common/NeighborhoodIteratorOnVectorImage,Neighborhood Iterator On Vector Image}
  * \endsphinx
  */
 template <typename TImage, typename TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TImage>>

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -51,7 +51,7 @@ namespace itk
  * \ingroup ITKCommon
  *
  * \sphinx
- * \sphinxexample{Core/CommonTransparency,Make Part Of An Image Transparent}
+ * \sphinxexample{Core/Common/Transparency,Make Part Of An Image Transparent}
  * \endsphinx
  */
 

--- a/Modules/Core/Common/include/itkUnaryFunctorImageFilter.h
+++ b/Modules/Core/Common/include/itkUnaryFunctorImageFilter.h
@@ -43,7 +43,7 @@ namespace itk
  * \ingroup ITKCommon
  *
  * \sphinx
- * \sphinxexample{ImageProcessing/UnaryFunctorImageFilter,Apply Custom Operation To Each Pixel In Image}
+ * \sphinxexample{Core/Common/CustomOperationToEachPixelInImage,Apply Custom Operation To Each Pixel In Image}
  * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage, typename TFunction>

--- a/Modules/Core/Common/include/itkVectorImage.h
+++ b/Modules/Core/Common/include/itkVectorImage.h
@@ -74,7 +74,7 @@ namespace itk
  * \sphinx
  * \sphinxexample{Core/Common/CastVectorImageToAnotherType,Cast Vector Image To Another Type}
  * \sphinxexample{Core/Common/CreateVectorImage,Create Vector Image}
- * \sphinxexample{VectorImages/NeighborhoodIterator,Neighborhood Iterator On Vector Image}
+ * \sphinxexample{Core/Common/NeighborhoodIteratorOnVectorImage,Neighborhood Iterator On Vector Image}
  * \endsphinx
  */
 template <typename TPixel, unsigned int VImageDimension = 3>

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup ITKSpatialObjects
  *
  * \sphinx
- * \sphinxexample{Core/SpatialObjects/ConvertSpacialObjectToImage,Convert Spacial Object To Image}
+ * \sphinxexample{Core/SpatialObjects/ConvertSpatialObjectToImage,Convert Spatial Object To Image}
  * \endsphinx
  */
 template <typename TInputSpatialObject, typename TOutputImage>

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -106,7 +106,7 @@ outputPoint = transform->TransformPoint( inputPoint );
  * \sa BSplineTransform
  *
  * \sphinx
- * \sphinxexample{Registration/ImageRegistrationMethodBSpline,Global Registration Of Two Images (BSpline)}
+ * \sphinxexample{Core/Transform/GlobalRegistrationTwoImagesBSpline,Global Registration Of Two Images (BSpline)}
  * \endsphinx
  */
 template <typename TParametersValueType = double, unsigned int NDimensions = 3, unsigned int VSplineOrder = 3>

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
@@ -43,7 +43,7 @@ namespace itk
  *
  * \sphinx
  * \sphinxexample{Filtering/ImageFeature/DerivativeImage,Apply A Filter Only To A Specified Region Of An Image}
- * \sphinxexample{Filtering/ImageFeature/RequesterRegion, Apply A Filter Only To A Specified Region Of An Image}
+ * \sphinxexample{Filtering/ImageFeature/RequestedRegion,Apply A Filter Only To A Specified Region Of An Image}
  * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.h
@@ -41,7 +41,7 @@ namespace itk
  * When the Gaussian kernel is small, this filter tends to run faster than
  * itk::RecursiveGaussianImageFilter.
  *
- * \author Ivan Macia, VICOMTech, Spain, http://www.vicomtech.es
+ * \author Ivan Macia, Vicomtech, Spain, https://www.vicomtech.org/en
  *
  * This implementation was taken from the Insight Journal paper:
  * https://www.insight-journal.org/browse/publication/179

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.h
@@ -61,7 +61,7 @@ namespace itk
  * Yoshinobu Sato, Shin Nakajima, Hideki Atsumi, Thomas Koller,
  * Guido Gerig, Shigeyuki Yoshida, Ron Kikinis.
  *
- * http://www.spl.harvard.edu/archive/spl-pre2007/pages/papers/yoshi/
+ * http://www.image.med.osaka-u.ac.jp/member/yoshi/paper/linefilter.pdf
  *
  *
  * \sa HessianRecursiveGaussianImageFilter
@@ -108,12 +108,12 @@ public:
   itkNewMacro(Self);
 
   /** Set/Get macros for alpha_1. Please refer to
-   * http://www.spl.harvard.edu/archive/spl-pre2007/pages/papers/yoshi/ */
+   * http://www.image.med.osaka-u.ac.jp/member/yoshi/paper/linefilter.pdf */
   itkSetMacro(Alpha1, double);
   itkGetConstMacro(Alpha1, double);
 
   /** Set/Get macros for alpha_2. Please refer to
-   * http://www.spl.harvard.edu/archive/spl-pre2007/pages/papers/yoshi/ */
+   * http://www.image.med.osaka-u.ac.jp/member/yoshi/paper/linefilter.pdf */
   itkSetMacro(Alpha2, double);
   itkGetConstMacro(Alpha2, double);
 

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  * \ingroup ITKImageFilterBase
  *
  * \sphinx
- * \sphinxexample{Filtering/ImageFilterBase/ComputerLocalNoise,Compute Local Noise In Image}
+ * \sphinxexample{Filtering/ImageFilterBase/ComputeLocalNoise,Compute Local Noise In Image}
  * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
  *
  * \ingroup ITKImageIntensity
  * \sphinx
- * \sphinxexample{,}
+ * \sphinxexample{Filtering/ImageIntensity/ComputeEdgePotential,Compute Edge Potential}
  * \endsphinx
  */
 namespace Functor

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.h
@@ -63,7 +63,7 @@ namespace itk
  * \ingroup ITKLabelMap
  *
  * \sphinx
- * \sphinxexample{Filtering/LabelMap/RemoveLabelsFromLabelMa,Remove Labels From Label Map}
+ * \sphinxexample{Filtering/LabelMap/RemoveLabelsFromLabelMap,Remove Labels From Label Map}
  * \endsphinx
  */
 template <typename TLabelObject>

--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -101,7 +101,7 @@ extern ITKIOGDCM_EXPORT std::ostream &
  * \ingroup ITKIOGDCM
  *
  * \sphinx
- * \sphinxexample{IO/GDCM/ResamleDICOMSeries,Resample DICOM Series}
+ * \sphinxexample{IO/GDCM/ResampleDICOMSeries,Resample DICOM Series}
  * \sphinxexample{IO/GDCM/ReadDICOMSeriesAndWrite3DImage,Read DICOM Series and Write 3D Image}
  * \endsphinx
  */

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.h
@@ -70,7 +70,6 @@ namespace itk
  * \author Wanlin Zhu. Uviversity of New South Wales, Australia.
  *
  * \sphinx
- * \sphinxexample{IO/Mesh/WriteMesh,Write Mesh}
  * \sphinxexample{IO/Mesh/ReadMesh,Read Mesh}
  * \endsphinx
  */

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.h
@@ -34,7 +34,7 @@ namespace itk
  * The Initialize() method must be called after setting the parameters and before
  * evaluating the function.
  *
- * \author Ivan Macia, VICOMTech, Spain, http://www.vicomtech.es
+ * \author Ivan Macia, Vicomtech, Spain, https://www.vicomtech.org/en
  *
  * This implementation was taken from the Insight Journal paper:
  * https://hdl.handle.net/1926/1290

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.h
@@ -34,7 +34,7 @@ namespace itk
  * The Initialize() method must be called after setting the parameters and before
  * evaluating the function.
  *
- * \author Ivan Macia, VICOMTech, Spain, http://www.vicomtech.es
+ * \author Ivan Macia, Vicomtech, Spain, https://www.vicomtech.org/en
  *
  * This implementation was taken from the Insight Journal paper:
  * https://hdl.handle.net/1926/1290

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.h
@@ -33,7 +33,7 @@ namespace itk
  * The Initialize() method must be called after setting the parameters and before
  * evaluating the function.
  *
- * \author Ivan Macia, VICOMTech, Spain, http://www.vicomtech.es
+ * \author Ivan Macia, Vicomtech, Spain, https://www.vicomtech.org/en
  *
  * This implementation was taken from the Insight Journal paper:
  * https://hdl.handle.net/1926/1290

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -65,7 +65,6 @@ namespace itk
  *  "A Label Geometry Image Filter for Multiple Object Measurement"
  *  by Padfield D., Miller J
  *  http://www.insight-journal.org/browse/publication/301
- *  https://hdl.handle.net/1926/1493
  *
  * \ingroup ITKReview
  *


### PR DESCRIPTION
First. several of the paths relating to the Sphinx Examples were incorrect. Many of these either contained spelling errors or the path had been changed.

Second, a few urls referenced in the Doxygen were unable to be found when the Sphinx Examples repository is built with Documentation `ON`. This required:
 - Changing http://www.vicomtech.es to https://www.vicomtech.org/en
 - Changing http://www.spl.harvard.edu/archive/spl-pre2007/pages/papers/yoshi/ to http://www.image.med.osaka-u.ac.jp/member/yoshi/paper/linefilter.pdf
 - Removing https://hdl.handle.net/1926/1493
For https://hdl.handle.net/1926/1493, the web page does not exist when I checked my web browser.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)