### PR TITLE
ENH: Array, OptimizerParameters constructors with size and initial value

### DIFF
--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -65,8 +65,13 @@ public:
   /** Construct from a VnlVectorType */
   explicit Array(const VnlVectorType &);
 
-  /** Constructor with size. Size can only be changed by assignment */
+  /** Constructor with size. Size can only be changed by assignment.
+   * \note This constructor may not initialize its elements.
+   */
   explicit Array(SizeValueType dimension);
+
+  /** Constructor with size and initial value for each element. */
+  explicit Array(SizeValueType dimension, const ValueType & value);
 
   /** Constructor that initializes array with contents from a user supplied
    * buffer. The pointer to the buffer and the length is specified. By default,

--- a/Modules/Core/Common/include/itkArray.hxx
+++ b/Modules/Core/Common/include/itkArray.hxx
@@ -60,6 +60,13 @@ Array<TValue>::Array(SizeValueType dimension)
   m_LetArrayManageMemory(true)
 {}
 
+/** Constructor with size and initial value for each element. */
+template <typename TValue>
+Array<TValue>::Array(const SizeValueType dimension, const TValue & value)
+  : vnl_vector<TValue>(dimension, value)
+  , m_LetArrayManageMemory{ true }
+{}
+
 /** Constructor with user specified data */
 template <typename TValue>
 Array<TValue>::Array(ValueType * datain, SizeValueType sz, bool LetArrayManageMemory)

--- a/Modules/Core/Common/include/itkOptimizerParameters.h
+++ b/Modules/Core/Common/include/itkOptimizerParameters.h
@@ -67,7 +67,9 @@ public:
     // something different.
   }
 
-  /** Constructor with size. Size can only be changed by assignment */
+  /** Constructor with size. Size can only be changed by assignment.
+   * \note This constructor may not initialize its elements.
+   */
   explicit OptimizerParameters(SizeValueType dimension)
     : Array<TParametersValueType>(dimension)
   {}
@@ -75,6 +77,11 @@ public:
   /** Constructor with Array assignment */
   OptimizerParameters(const ArrayType & array)
     : Array<TParametersValueType>(array)
+  {}
+
+  /** Constructor with size and initial value for each element. */
+  explicit OptimizerParameters(const SizeValueType dimension, const ValueType & value)
+    : Array<TParametersValueType>(dimension, value)
   {}
 
   /** Initialize. Initialization called by constructors. */

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -617,6 +617,7 @@ set(ITKCommonGTests
       itkIndexRangeGTest.cxx
       itkMersenneTwisterRandomVariateGeneratorGTest.cxx
       itkNeighborhoodAllocatorGTest.cxx
+      itkOptimizerParametersGTest.cxx
       itkPointGTest.cxx
       itkShapedImageNeighborhoodRangeGTest.cxx
       itkSizeGTest.cxx

--- a/Modules/Core/Common/test/itkOptimizerParametersGTest.cxx
+++ b/Modules/Core/Common/test/itkOptimizerParametersGTest.cxx
@@ -1,0 +1,42 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkOptimizerParameters.h"
+#include <gtest/gtest.h>
+#include <algorithm> // For std::count.
+
+
+// Tests constructing OptimizerParameters of the specified size and initial value.
+TEST(OptimizerParameters, ConstructWithSpecifiedSizeAndInitialValue)
+{
+  using OptimizerParametersType = itk::OptimizerParameters<double>;
+
+  for (double initialValue{ -1.0 }; initialValue <= 1.0; ++initialValue)
+  {
+    EXPECT_EQ(OptimizerParametersType(0, initialValue).size(), 0);
+
+    for (std::size_t size{ 1 }; size <= 4; ++size)
+    {
+      const OptimizerParametersType optimizerParameters(size, initialValue);
+
+      EXPECT_EQ(optimizerParameters.size(), size);
+      EXPECT_EQ(std::count(optimizerParameters.begin(), optimizerParameters.end(), initialValue), size);
+    }
+  }
+}


### PR DESCRIPTION
Added explicit constructors to `Array` and `OptimizerParameters`, allowing to specify the size (dimension) and the initial value of each element.

Both `std::vector` and `vnl_vector` have a similar constructor.

Included a GoogleTest unit test for `OptimizerParameters`.