### PR TITLE
COMP: Force runtime output with Visual Studio and Python wrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,8 +297,8 @@ if(ITK_WRAPPING)
     # When wrapping, the multi-config generators can only be used in degraded state
     # of allowing only a single element int the CMAKE_CONFIGURATION_TYPES and enforcing
     # that CMAKE_BUILD_TYPE match that type (see Wrapping/CMakeLists.txt enforcement)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$<1:${ITK_PYTHON_PACKAGE_DIR}>" CACHE PATH "Shared library directory with generator override")
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "$<1:${ITK_PYTHON_PACKAGE_DIR}>" CACHE PATH "Shared library directory with generator override")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$<1:${ITK_PYTHON_PACKAGE_DIR}>" CACHE PATH "Shared library directory with generator override" FORCE)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "$<1:${ITK_PYTHON_PACKAGE_DIR}>" CACHE PATH "Shared library directory with generator override" FORCE)
   endif()
 else()
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${NO_WRAP_CMAKE_LIBRARY_OUTPUT_DIRECTORY}   CACHE PATH "Shared library directory")


### PR DESCRIPTION
To use WrapITK.pth with a build tree, the .pyd files must be deposited
with the rest of the Python runtime tree. Force the runtime output
directory location. If initial configuration with the CMake GUI does not
have ITK_WRAP_PYTHON enabled, the correct value is not set.

Closes #2252

