### PR TITLE
ENH: Update SpatialObject and SpatialObjectPoint Sphinx

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
@@ -34,6 +34,9 @@ namespace itk
  * \sa LineSpatialObjectPoint
  * \ingroup ITKSpatialObjects
  *
+ * \sphinx
+ * \sphinxexample{Core/SpatialObjects/LineSpatialObject,Line Spatial Object}
+ * \endsphinx
  */
 
 template <unsigned int TDimension = 3>

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup ITKSpatialObjects
  *
  * \sphinx
- * \sphinxexample{Core/SpatialObjects/LineSpacialObject,Line Spatial Object}
+ * \sphinxexample{Core/SpatialObjects/LineSpatialObject,Line Spatial Object}
  * \endsphinx
  */
 


### PR DESCRIPTION
This will accomplish the following:

- Reference the correct path to the `LineSpatialObject` example in the ITKExamples repository
- Include the `LineSpatialObject` example in the `itkLineSpatialObject` Doxygen in source ITK, as the example heavily uses the class and references it in its documentation

**NOTE:** The path to the `LineSpatialObject` example in ITKExamples is being updated in this PR as well: 
https://github.com/InsightSoftwareConsortium/ITKExamples/pull/185

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)


