### PR TITLE
BUG: Incorrect syntax for doxygen code block

### DIFF
--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -76,20 +76,16 @@ namespace itk
    \code
    using ImageType = Image<float, 3>;
    ShapedNeighborhoodIterator<ImageType> it(radius, image, region);
-   .
-   .
-   .
+   ...
    it.ActivateOffset(offset1);
    it.ActivateOffset(offset2);
    it.ActivateOffset(offset3);
-   etc..
-   .
-   .
-   .
+   // etc..
+   ...
    ShapedNeighborhoodIterator<ImageType>::Iterator i;
    for (i = it.Begin(); ! i.IsAtEnd(); i++)
    { i.Set(i.Get() + 1.0); }
-   \\ you may also use i != i.End(), but IsAtEnd() may be slightly faster.
+   // you may also use i != i.End(), but IsAtEnd() may be slightly faster.
    \endcode
  *
  * You can also iterate backward through the neighborhood active list.


### PR DESCRIPTION
## Description
This hopefully should be the final change in ITK's Doxygen to get a clean Documentation build for the ITKExamples repository. Essentially, the code block cannot be properly highlighted as `c++` code, because `etc..` is not a valid `c++` command. This comments it out to allow proper highlighting and remove the warnings below.
```
ITKExamples-documentation-build/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Documentation.rst: WARNING: Could not lex literal_block as "c++". Highlighting skipped.
ITKExamples-documentation-build/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Documentation.rst: WARNING: Could not lex literal_block as "c++". Highlighting skipped.
```
---------------------------
One can inspect the unhighlighted code at either of these examples (under classes demonstrated): 

- https://itk.org/ITKExamples/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Documentation.html
- https://itk.org/ITKExamples/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Documentation.html


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

