### PR TITLE
WIP: ENH: Use extern template and explicit instantiation to speed up tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,7 +620,14 @@ if(BUILD_TESTING)
   add_subdirectory(Utilities/InstallTest)
 endif()
 
-
+# Enable extern template and explicit instantiation for classes used in tests
+# The extra header and source file needed for this feature are named with the suffix ExternTemplate.h|cxx
+# and placed in a subfolder named ExternTemplate inside the test folder of their module.
+# For example:
+#  itkImageExternTemplate.h and itkImageExternTemplate.cxx
+#  are placed in in Modules/Core/Common/test/ExternTemplate/
+option(ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION "Enable extern template and explicit instantiation for classes used in tests to speed up compilation." ON) # TODO turn it OFF by default, ON for CIpurposes.
+mark_as_advanced(ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION_FOR_TEST)
 
 #-----------------------------------------------------------------------------
 # The subdirectories added below this line should use only the public

--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -391,4 +391,8 @@ private:
 #  include "itkImage.hxx"
 #endif
 
+#ifdef ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION
+#  include "itkImageExternTemplate.h"
+#endif
+
 #endif

--- a/Modules/Core/Common/include/itkImageSource.h
+++ b/Modules/Core/Common/include/itkImageSource.h
@@ -407,4 +407,8 @@ protected:
 #  include "itkImageSource.hxx"
 #endif
 
+#ifdef ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION
+#  include "itkImageSourceExternTemplate.h"
+#endif
+
 #endif

--- a/Modules/Core/Common/include/itkImageToImageFilter.h
+++ b/Modules/Core/Common/include/itkImageToImageFilter.h
@@ -387,4 +387,8 @@ private:
 #  include "itkImageToImageFilter.hxx"
 #endif
 
+#ifdef ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION
+#  include "itkImageToImageFilterExternTemplate.h"
+#endif
+
 #endif

--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -182,9 +182,26 @@ elseif( MSVC )
   set_source_files_properties( itkCompensatedSummation.cxx PROPERTIES COMPILE_FLAGS -fp:precise )
 endif()
 
+if(BUILD_TESTING AND ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION)
+  set(ExternTemplate_SRCS
+    itkImageExternTemplate.cxx
+    itkImageSourceExternTemplate.cxx
+    itkImageToImageFilterExternTemplate.cxx
+    )
+  list(TRANSFORM ExternTemplate_SRCS PREPEND "../test/ExternTemplate/")
+  list(APPEND ITKCommon_SRCS ${ExternTemplate_SRCS})
+endif()
 
 ### generating libraries
 itk_module_add_library( ITKCommon ${ITKCommon_SRCS})
+
+if(BUILD_TESTING AND ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION)
+  # Do not use these files in the install tree
+  target_include_directories(ITKCommon PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../test/ExternTemplate>)
+  target_compile_definitions(ITKCommon PUBLIC
+    $<BUILD_INTERFACE:ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION>)
+endif()
 
 target_link_libraries(ITKCommon LINK_PUBLIC itksys ITKVNLInstantiation)
 

--- a/Modules/Core/Common/test/ExternTemplate/itkImageExternTemplate.cxx
+++ b/Modules/Core/Common/test/ExternTemplate/itkImageExternTemplate.cxx
@@ -1,0 +1,46 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImage.h"
+
+namespace itk
+{
+// 2D
+template class Image<signed short, 2>;
+template class Image<unsigned short, 2>;
+template class Image<char, 2>;
+template class Image<unsigned char, 2>;
+template class Image<int, 2>;
+template class Image<unsigned int, 2>;
+template class Image<long, 2>;
+template class Image<unsigned long, 2>;
+template class Image<float, 2>;
+template class Image<double, 2>;
+
+// 3D
+template class Image<signed short, 3>;
+template class Image<unsigned short, 3>;
+template class Image<char, 3>;
+template class Image<unsigned char, 3>;
+template class Image<int, 3>;
+template class Image<unsigned int, 3>;
+template class Image<long, 3>;
+template class Image<unsigned long, 3>;
+template class Image<float, 3>;
+template class Image<double, 3>;
+} // end namespace itk

--- a/Modules/Core/Common/test/ExternTemplate/itkImageExternTemplate.h
+++ b/Modules/Core/Common/test/ExternTemplate/itkImageExternTemplate.h
@@ -1,0 +1,48 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkImageExternTemplate_h
+#define itkImageExternTemplate_h
+
+namespace itk
+{
+// 2D
+extern template class Image<signed short, 2>;
+extern template class Image<unsigned short, 2>;
+extern template class Image<char, 2>;
+extern template class Image<unsigned char, 2>;
+extern template class Image<int, 2>;
+extern template class Image<unsigned int, 2>;
+extern template class Image<long, 2>;
+extern template class Image<unsigned long, 2>;
+extern template class Image<float, 2>;
+extern template class Image<double, 2>;
+
+// 3D
+extern template class Image<signed short, 3>;
+extern template class Image<unsigned short, 3>;
+extern template class Image<char, 3>;
+extern template class Image<unsigned char, 3>;
+extern template class Image<int, 3>;
+extern template class Image<unsigned int, 3>;
+extern template class Image<long, 3>;
+extern template class Image<unsigned long, 3>;
+extern template class Image<float, 3>;
+extern template class Image<double, 3>;
+} // end namespace itk
+#endif

--- a/Modules/Core/Common/test/ExternTemplate/itkImageSourceExternTemplate.cxx
+++ b/Modules/Core/Common/test/ExternTemplate/itkImageSourceExternTemplate.cxx
@@ -1,0 +1,47 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImage.h"
+#include "itkImageSource.h"
+
+namespace itk
+{
+// 2D
+template class ImageSource<Image<signed short, 2>>;
+template class ImageSource<Image<unsigned short, 2>>;
+template class ImageSource<Image<char, 2>>;
+template class ImageSource<Image<unsigned char, 2>>;
+template class ImageSource<Image<int, 2>>;
+template class ImageSource<Image<unsigned int, 2>>;
+template class ImageSource<Image<long, 2>>;
+template class ImageSource<Image<unsigned long, 2>>;
+template class ImageSource<Image<float, 2>>;
+template class ImageSource<Image<double, 2>>;
+
+// 3D
+template class ImageSource<Image<signed short, 3>>;
+template class ImageSource<Image<unsigned short, 3>>;
+template class ImageSource<Image<char, 3>>;
+template class ImageSource<Image<unsigned char, 3>>;
+template class ImageSource<Image<int, 3>>;
+template class ImageSource<Image<unsigned int, 3>>;
+template class ImageSource<Image<long, 3>>;
+template class ImageSource<Image<unsigned long, 3>>;
+template class ImageSource<Image<float, 3>>;
+template class ImageSource<Image<double, 3>>;
+} // end namespace itk

--- a/Modules/Core/Common/test/ExternTemplate/itkImageSourceExternTemplate.h
+++ b/Modules/Core/Common/test/ExternTemplate/itkImageSourceExternTemplate.h
@@ -1,0 +1,51 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkImageSourceExternTemplate_h
+#define itkImageSourceExternTemplate_h
+
+#include "itkImage.h"
+
+namespace itk
+{
+// 2D
+extern template class ImageSource<Image<signed short, 2>>;
+extern template class ImageSource<Image<unsigned short, 2>>;
+extern template class ImageSource<Image<char, 2>>;
+extern template class ImageSource<Image<unsigned char, 2>>;
+extern template class ImageSource<Image<int, 2>>;
+extern template class ImageSource<Image<unsigned int, 2>>;
+extern template class ImageSource<Image<long, 2>>;
+extern template class ImageSource<Image<unsigned long, 2>>;
+extern template class ImageSource<Image<float, 2>>;
+extern template class ImageSource<Image<double, 2>>;
+
+// 3D
+extern template class ImageSource<Image<signed short, 3>>;
+extern template class ImageSource<Image<unsigned short, 3>>;
+extern template class ImageSource<Image<char, 3>>;
+extern template class ImageSource<Image<unsigned char, 3>>;
+extern template class ImageSource<Image<int, 3>>;
+extern template class ImageSource<Image<unsigned int, 3>>;
+extern template class ImageSource<Image<long, 3>>;
+extern template class ImageSource<Image<unsigned long, 3>>;
+extern template class ImageSource<Image<float, 3>>;
+extern template class ImageSource<Image<double, 3>>;
+} // end namespace itk
+
+#endif

--- a/Modules/Core/Common/test/ExternTemplate/itkImageToImageFilterExternTemplate.cxx
+++ b/Modules/Core/Common/test/ExternTemplate/itkImageToImageFilterExternTemplate.cxx
@@ -1,0 +1,48 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImageToImageFilter.h"
+
+namespace itk
+{
+// 2D
+// InputImageType equals OutputImageType
+template class ImageToImageFilter<Image<signed short, 2>, Image<signed short, 2>>;
+template class ImageToImageFilter<Image<unsigned short, 2>, Image<unsigned short, 2>>;
+template class ImageToImageFilter<Image<char, 2>, Image<char, 2>>;
+template class ImageToImageFilter<Image<unsigned char, 2>, Image<unsigned char, 2>>;
+template class ImageToImageFilter<Image<int, 2>, Image<int, 2>>;
+template class ImageToImageFilter<Image<unsigned int, 2>, Image<unsigned int, 2>>;
+template class ImageToImageFilter<Image<long, 2>, Image<long, 2>>;
+template class ImageToImageFilter<Image<unsigned long, 2>, Image<unsigned long, 2>>;
+template class ImageToImageFilter<Image<float, 2>, Image<float, 2>>;
+template class ImageToImageFilter<Image<double, 2>, Image<double, 2>>;
+
+// 3D
+// InputImageType equals OutputImageType
+template class ImageToImageFilter<Image<signed short, 3>, Image<signed short, 3>>;
+template class ImageToImageFilter<Image<unsigned short, 3>, Image<unsigned short, 3>>;
+template class ImageToImageFilter<Image<char, 3>, Image<char, 3>>;
+template class ImageToImageFilter<Image<unsigned char, 3>, Image<unsigned char, 3>>;
+template class ImageToImageFilter<Image<int, 3>, Image<int, 3>>;
+template class ImageToImageFilter<Image<unsigned int, 3>, Image<unsigned int, 3>>;
+template class ImageToImageFilter<Image<long, 3>, Image<long, 3>>;
+template class ImageToImageFilter<Image<unsigned long, 3>, Image<unsigned long, 3>>;
+template class ImageToImageFilter<Image<float, 3>, Image<float, 3>>;
+template class ImageToImageFilter<Image<double, 3>, Image<double, 3>>;
+} // end namespace itk

--- a/Modules/Core/Common/test/ExternTemplate/itkImageToImageFilterExternTemplate.h
+++ b/Modules/Core/Common/test/ExternTemplate/itkImageToImageFilterExternTemplate.h
@@ -1,0 +1,53 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkImageToImageFilterExternTemplate_h
+#define itkImageToImageFilterExternTemplate_h
+
+#include "itkImage.h"
+
+namespace itk
+{
+// 2D
+// InputImageType equals OutputImageType
+extern template class ImageToImageFilter<Image<signed short, 2>, Image<signed short, 2>>;
+extern template class ImageToImageFilter<Image<unsigned short, 2>, Image<unsigned short, 2>>;
+extern template class ImageToImageFilter<Image<char, 2>, Image<char, 2>>;
+extern template class ImageToImageFilter<Image<unsigned char, 2>, Image<unsigned char, 2>>;
+extern template class ImageToImageFilter<Image<int, 2>, Image<int, 2>>;
+extern template class ImageToImageFilter<Image<unsigned int, 2>, Image<unsigned int, 2>>;
+extern template class ImageToImageFilter<Image<long, 2>, Image<long, 2>>;
+extern template class ImageToImageFilter<Image<unsigned long, 2>, Image<unsigned long, 2>>;
+extern template class ImageToImageFilter<Image<float, 2>, Image<float, 2>>;
+extern template class ImageToImageFilter<Image<double, 2>, Image<double, 2>>;
+
+// 3D
+// InputImageType equals OutputImageType
+extern template class ImageToImageFilter<Image<signed short, 3>, Image<signed short, 3>>;
+extern template class ImageToImageFilter<Image<unsigned short, 3>, Image<unsigned short, 3>>;
+extern template class ImageToImageFilter<Image<char, 3>, Image<char, 3>>;
+extern template class ImageToImageFilter<Image<unsigned char, 3>, Image<unsigned char, 3>>;
+extern template class ImageToImageFilter<Image<int, 3>, Image<int, 3>>;
+extern template class ImageToImageFilter<Image<unsigned int, 3>, Image<unsigned int, 3>>;
+extern template class ImageToImageFilter<Image<long, 3>, Image<long, 3>>;
+extern template class ImageToImageFilter<Image<unsigned long, 3>, Image<unsigned long, 3>>;
+extern template class ImageToImageFilter<Image<float, 3>, Image<float, 3>>;
+extern template class ImageToImageFilter<Image<double, 3>, Image<double, 3>>;
+} // end namespace itk
+
+#endif

--- a/Modules/IO/ImageBase/src/CMakeLists.txt
+++ b/Modules/IO/ImageBase/src/CMakeLists.txt
@@ -13,4 +13,20 @@ set(ITKIOImageBase_SRCS
   itkRawImageIOUtilities.cxx
   )
 
+if(BUILD_TESTING AND ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION)
+  set(ExternTemplate_SRCS
+    itkImageFileReaderExternTemplate.cxx
+    )
+  list(TRANSFORM ExternTemplate_SRCS PREPEND "../test/ExternTemplate/")
+  list(APPEND ITKIOImageBase_SRCS ${ExternTemplate_SRCS})
+endif()
+
 itk_module_add_library(ITKIOImageBase ${ITKIOImageBase_SRCS})
+
+if(BUILD_TESTING AND ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION)
+  # Do not use these files in the install tree
+  target_include_directories(ITKCommon PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../test/ExternTemplate>)
+  target_compile_definitions(ITKCommon PUBLIC
+    $<BUILD_INTERFACE:ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION>)
+endif()

--- a/Modules/IO/ImageBase/test/ExternTemplate/itkImageFileReaderExternTemplate.cxx
+++ b/Modules/IO/ImageBase/test/ExternTemplate/itkImageFileReaderExternTemplate.cxx
@@ -1,0 +1,47 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+
+namespace itk
+{
+// 2D
+template class ImageFileReader<Image<signed short, 2>>;
+template class ImageFileReader<Image<unsigned short, 2>>;
+template class ImageFileReader<Image<char, 2>>;
+template class ImageFileReader<Image<unsigned char, 2>>;
+template class ImageFileReader<Image<int, 2>>;
+template class ImageFileReader<Image<unsigned int, 2>>;
+template class ImageFileReader<Image<long, 2>>;
+template class ImageFileReader<Image<unsigned long, 2>>;
+template class ImageFileReader<Image<float, 2>>;
+template class ImageFileReader<Image<double, 2>>;
+
+// 3D
+template class ImageFileReader<Image<signed short, 3>>;
+template class ImageFileReader<Image<unsigned short, 3>>;
+template class ImageFileReader<Image<char, 3>>;
+template class ImageFileReader<Image<unsigned char, 3>>;
+template class ImageFileReader<Image<int, 3>>;
+template class ImageFileReader<Image<unsigned int, 3>>;
+template class ImageFileReader<Image<long, 3>>;
+template class ImageFileReader<Image<unsigned long, 3>>;
+template class ImageFileReader<Image<float, 3>>;
+template class ImageFileReader<Image<double, 3>>;
+} // end namespace itk

--- a/Modules/IO/ImageBase/test/ExternTemplate/itkImageFileReaderExternTemplate.h
+++ b/Modules/IO/ImageBase/test/ExternTemplate/itkImageFileReaderExternTemplate.h
@@ -1,0 +1,48 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkImageFileReaderExternTemplate_h
+#define itkImageFileReaderExternTemplate_h
+
+namespace itk
+{
+// 2D
+extern template class ImageFileReader<Image<signed short, 2>>;
+extern template class ImageFileReader<Image<unsigned short, 2>>;
+extern template class ImageFileReader<Image<char, 2>>;
+extern template class ImageFileReader<Image<unsigned char, 2>>;
+extern template class ImageFileReader<Image<int, 2>>;
+extern template class ImageFileReader<Image<unsigned int, 2>>;
+extern template class ImageFileReader<Image<long, 2>>;
+extern template class ImageFileReader<Image<unsigned long, 2>>;
+extern template class ImageFileReader<Image<float, 2>>;
+extern template class ImageFileReader<Image<double, 2>>;
+
+// 3D
+extern template class ImageFileReader<Image<signed short, 3>>;
+extern template class ImageFileReader<Image<unsigned short, 3>>;
+extern template class ImageFileReader<Image<char, 3>>;
+extern template class ImageFileReader<Image<unsigned char, 3>>;
+extern template class ImageFileReader<Image<int, 3>>;
+extern template class ImageFileReader<Image<unsigned int, 3>>;
+extern template class ImageFileReader<Image<long, 3>>;
+extern template class ImageFileReader<Image<unsigned long, 3>>;
+extern template class ImageFileReader<Image<float, 3>>;
+extern template class ImageFileReader<Image<double, 3>>;
+} // end namespace itk
+#endif


### PR DESCRIPTION
Add CMake option `ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION`
to enable this option.
This is only useful if BUILD_TESTING is ON, and it is ignored in the
install tree.

The idea is to speed up compilation instantiating only once the
templates with the set of types used.

Similar instantiation of selected types are used for python wrappings.
The CMake machinery to generate bindings should be re-used here, but
I have done it manually for the selected classes as a proof-of-work.

Opening this PR to compare test times in CI. Setting the option to ON by
default for this purpose.

This option also enable third-parties using ITK to compile their targets
with: `target_compile_definition(target PUBLIC ITK_EXTERN_TEMPLATE_AND_EXPLICIT_INSTANTIATION)`
And provide their own set of files `itkImageSourceExternTemplate.h`
and the associated `itkImageSourceExternTemplate.cxx` to instantiate the types they use.

CI preliminary results:

```
        Description        |    Windows    |     Linux     |     MacOs     |
============================================================================
Without                    |   1h.59m      |   1h.21m      |    2h.7m      |
----------------------------------------------------------------------------
Image,ISource, ItoIFilter  |   1h.25m      |   1h.15m      |    2h.3m      |
----------------------------------------------------------------------------
+ IFileReader              |   xh.xxm      |   xh.xxm      |    xh.xm      |
----------------------------------------------------------------------------
```

Reading [this SO question](https://stackoverflow.com/questions/61477486/using-extern-template-with-third-party-header-only-library), we might need to wait for C++20 modules.

> Unfortunately, there’s no way to avoid these [class] instantiations. An
> explicit instantiation declaration of a class template doesn’t prevent
> (implicit) instantiation of that template; it merely prevents
> instantiating its non-inline, non-template member functions (which is
> often none of them!) because some other translation unit will supply the
> actual function symbols and object code.


## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
