### PR TITLE
STYLE: Remove empty ResourceProbe legacy function GetSystemInformation()

### DIFF
--- a/Modules/Core/Common/include/itkResourceProbe.h
+++ b/Modules/Core/Common/include/itkResourceProbe.h
@@ -177,9 +177,6 @@ protected:
   void
   PrintJSONvar(std::ostream & os, const char * varName, T varValue, unsigned int indent = 4, bool comma = true);
 
-  /** Obsolete member function from ITK 4.8 - 4.13. Does not do anything anymore. */
-  itkLegacyMacro(virtual void GetSystemInformation());
-
   /** Cause the object to print itself out. */
   virtual void
   Print(std::ostream & os, Indent indent) const;

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -593,16 +593,6 @@ ResourceProbe<ValueType, MeanType>::PrintJSONSystemInformation(std::ostream & os
   os << "  }";
 }
 
-
-// This protected member function that was introduced with ITK 4.8 has been deprecated
-// as of ITK 5.0. Please do not call or override this member function.
-#if !defined(ITK_LEGACY_REMOVE)
-template <typename ValueType, typename MeanType>
-void
-ResourceProbe<ValueType, MeanType>::GetSystemInformation()
-{}
-#endif
-
 } // end namespace itk
 
 #endif


### PR DESCRIPTION
Follow-up to:
"PERF: Remove SystemInformation data from ResourceProbe, fix issue #350"
Pull request https://github.com/InsightSoftwareConsortium/ITK/pull/351
Commit 747f3d143359cf15c3c4ed9e266125f96d198f8d, 2018-12-24