### PR TITLE
COMP: remove CastImageFilter "template already defined" warnings

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -47,6 +47,14 @@ VTKImageImport<TOutputImage>::VTKImageImport()
   {
     m_ScalarTypeName = "float";
   }
+  else if (typeid(ScalarType) == typeid(long long))
+  {
+    m_ScalarTypeName = "long long";
+  }
+  else if (typeid(ScalarType) == typeid(unsigned long long))
+  {
+    m_ScalarTypeName = "unsigned long long";
+  }
   else if (typeid(ScalarType) == typeid(long))
   {
     m_ScalarTypeName = "long";

--- a/Modules/Filtering/ImageFilterBase/wrapping/itkCastImageFilter.wrap
+++ b/Modules/Filtering/ImageFilterBase/wrapping/itkCastImageFilter.wrap
@@ -72,8 +72,8 @@ itk_wrap_class("itk::CastImageFilter" POINTER_WITH_SUPERCLASS)
   # itk_wrap_image_filter_combinations("${WRAP_ITK_VECTOR}" "${WRAP_ITK_RGB}")
   # itk_wrap_image_filter_combinations("${WRAP_ITK_RGB}" "${WRAP_ITK_VECTOR}")
 
-  # Enable casting 64 bit unsigned int to smaller integer types
-  if(ITK_WRAP_unsigned_long OR NOT ${ITKM_IT} STREQUAL "ULL")
+  # Enable casting 64 bit unsigned int to smaller integer types if we haven't done so already
+  if(NOT ITK_WRAP_unsigned_long_long AND NOT ${ITKM_IT} STREQUAL "ULL")
     itk_wrap_image_filter_combinations("ULL" "${WRAP_ITK_INT}")
   endif()
 itk_end_wrap_class()


### PR DESCRIPTION
COMP: remove CastImageFilter "template already defined" warnings

Addresses CastImageFilter "template already defined" warnings described in Issue #2083.

- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)
