### PR TITLE
ENH: Update to newer third-party update script from CMake

### DIFF
--- a/Utilities/Maintenance/update-third-party.bash
+++ b/Utilities/Maintenance/update-third-party.bash
@@ -71,8 +71,6 @@ warn () {
 
 readonly regex_date='20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
 readonly basehash_regex="$name $regex_date ([0-9a-f]*)"
-readonly basehash="$( git rev-list --author="$ownership" --grep="$basehash_regex" -n 1 HEAD )"
-readonly upstream_old_short="$( git cat-file commit "$basehash" | sed -n '/'"$basehash_regex"'/ {s/.*(//;s/)//;p}' | egrep '^[0-9a-f]+$' )"
 
 ########################################################################
 # Sanity checking
@@ -87,6 +85,18 @@ readonly upstream_old_short="$( git cat-file commit "$basehash" | sed -n '/'"$ba
     die "'repo' is empty"
 [ -n "$tag" ] || \
     die "'tag' is empty"
+
+# Check for an empty destination directory on disk.  By checking on disk and
+# not in the repo it allows a library to be freshly re-inialized in a single
+# commit rather than first deleting the old copy in one commit and adding the
+# new copy in a seperate commit.
+if [ ! -d "$(git rev-parse --show-toplevel)/$subtree" ]; then
+    readonly basehash=""
+else
+    readonly basehash="$( git rev-list --author="$ownership" --grep="$basehash_regex" -n 1 HEAD )"
+fi
+readonly upstream_old_short="$( git cat-file commit "$basehash" | sed -n '/'"$basehash_regex"'/ {s/.*(//;s/)//;p}' | egrep '^[0-9a-f]+$' )"
+
 [ -n "$basehash" ] || \
     warn "'basehash' is empty; performing initial import"
 readonly do_shortlog="${shortlog-false}"
@@ -104,6 +114,8 @@ trap "rm -rf '$workdir'" EXIT
 git clone "$repo" "$upstreamdir"
 
 if [ -n "$basehash" ]; then
+    # Remove old worktrees
+    git worktree prune
     # Use the existing package's history
     git worktree add "$extractdir" "$basehash"
     # Clear out the working tree
@@ -142,8 +154,6 @@ popd
     die "expected directory to extract does not exist"
 readonly commit_summary="$name $upstream_date ($upstream_hash_short)"
 
-readonly change_id=$(git commit-tree $(git write-tree) </dev/null)
-
 # Commit the subset
 pushd "$extractdir"
 mv -v "$name-reduced/"* .
@@ -157,8 +167,6 @@ Code extracted from:
     $repo
 
 at commit $upstream_hash ($tag).$commit_shortlog
-
-Change-Id: I$change_id
 EOF
 git branch -f "upstream-$name"
 popd
@@ -167,13 +175,17 @@ popd
 if [ -n "$basehash" ]; then
     git merge --log -s recursive "-Xsubtree=$subtree/" --no-commit "upstream-$name"
 else
+    # Note: on Windows 'git merge --help' will open a browser, and the check
+    # will fail, so use the flag by default.
     unrelated_histories_flag=""
-    if git merge --help | grep -q -e allow-unrelated-histories; then
+    if git --version | grep -q windows; then
+        unrelated_histories_flag="--allow-unrelated-histories "
+    elif git merge --help | grep -q -e allow-unrelated-histories; then
         unrelated_histories_flag="--allow-unrelated-histories "
     fi
     readonly unrelated_histories_flag
 
-    git fetch "$extractdir" "upstream-$name:upstream-$name"
+    git fetch "$extractdir" "+upstream-$name:upstream-$name"
     git merge --log -s ours --no-commit $unrelated_histories_flag "upstream-$name"
     git read-tree -u --prefix="$subtree/" "upstream-$name"
 fi


### PR DESCRIPTION
Use the CMake `Utilities/Scripts/update-third-party.bash` as of commit
`693f4c70ff`.  Manually preserve ITK's change from commit 5dccc2207e
(BUG: Do not gpg sign third party updates, 2018-11-19, `v5.0b02~82^2~1`).
