### PR TITLE
ENH: xarray_from_image "c" coords uint32 type

### DIFF
--- a/Wrapping/Generators/Python/itk/support/itkExtras.py
+++ b/Wrapping/Generators/Python/itk/support/itkExtras.py
@@ -446,7 +446,7 @@ def xarray_from_image(l_image):
     components = l_image.GetNumberOfComponentsPerPixel()
     if components > 1:
         dims.append("c")
-        coords["c"] = np.arange(components, dtype=np.uint64)
+        coords["c"] = np.arange(components, dtype=np.uint32)
 
     data_array = xr.DataArray(
         array_view, dims=dims, coords=coords, attrs={"direction": direction}


### PR DESCRIPTION
uint64 is unnecessary and in a JavaScript environment is not currently
supported on the Safari browser.
