### PR TITLE
ENH: Provide better failure diagnostics

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -98,7 +98,7 @@ Updated style
 Important changes in style have also been integrated in ITK to match
 C++11 best practices. This includes replacing `typedef` calls with
 the keyword `using`, the usage of the keyword `auto` when appropriate,
-and moving the macro `ITK_DISALLOW_COPY_AND_ASSIGN` from the private
+and moving the macros `ITK_DISALLOW_COPY_AND_ASSIGN` or `ITK_DISALLOW_COPY_AND_MOVE` from the private
 class section to the public class section. The ITK Software Guide has
 been updated to match these changes.
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -389,6 +389,9 @@ namespace itk
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
 #  define ITK_DISALLOW_COPY_AND_ASSIGN(TypeName) ITK_DISALLOW_COPY_AND_MOVE(TypeName)
+#else
+#  define ITK_DISALLOW_COPY_AND_ASSIGN(TypeName)                                                                       \
+    static_assert(false, "Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE")
 #endif
 
 /** Macro used to add standard methods to all classes, mainly type


### PR DESCRIPTION
The error messages when ITK_FUTURE_LEGACY_REMOVE is used
can provide better diagnostic message to describe
how to fix the use of deprecated code.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
