### PR TITLE
STYLE: Use default member initialization

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
@@ -131,9 +131,9 @@ public:
   }
 
 private:
-  RealType m_Alpha;
-  RealType m_Beta;
-  RealType m_KernelSize;
+  RealType m_Alpha{};
+  RealType m_Beta{};
+  RealType m_KernelSize{};
 
   TInputPixel m_Minimum;
   TInputPixel m_Maximum;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
@@ -153,7 +153,7 @@ private:
   typename AnchorFilterType::Pointer m_AnchorFilter;
 
   // and the name of the filter
-  AlgorithmEnum m_Algorithm;
+  AlgorithmEnum m_Algorithm{ AlgorithmEnum::HISTO };
 
   bool m_SafeBorder{ true };
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.hxx
@@ -36,8 +36,6 @@ GrayscaleMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Gr
   , m_VanHerkGilWermanDilateFilter(VanHerkGilWermanDilateFilterType::New())
   , m_VanHerkGilWermanErodeFilter(VanHerkGilWermanErodeFilterType::New())
   , m_AnchorFilter(AnchorFilterType::New())
-  , m_Algorithm(AlgorithmEnum::HISTO)
-
 {}
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
@@ -169,7 +169,7 @@ public:
   EraseFirstColumnHeader();
 
 protected:
-  CSVArray2DDataObject();
+  CSVArray2DDataObject() = default;
   ~CSVArray2DDataObject() override = default;
   /** Print method */
   void
@@ -177,10 +177,10 @@ protected:
 
 private:
   MatrixType       m_Matrix;
-  StringVectorType m_ColumnHeaders;
-  StringVectorType m_RowHeaders;
-  bool             m_HasRowHeaders;
-  bool             m_HasColumnHeaders;
+  StringVectorType m_ColumnHeaders{};
+  StringVectorType m_RowHeaders{};
+  bool             m_HasRowHeaders{ false };
+  bool             m_HasColumnHeaders{ false };
 };
 
 } // end namespace itk

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
@@ -25,12 +25,6 @@
 
 namespace itk
 {
-template <typename TData>
-CSVArray2DDataObject<TData>::CSVArray2DDataObject()
-{
-  this->m_HasRowHeaders = false;
-  this->m_HasColumnHeaders = false;
-}
 
 template <typename TData>
 typename CSVArray2DDataObject<TData>::StringVectorType


### PR DESCRIPTION
Converts a default constructor’s member initializers into the new
default member initializers in C++11. Other member initializers that match the
default member initializer are removed. This can reduce repeated code or allow
use of ‘= default’.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
