### PR TITLE
WIP: STYLE: Prefer c++11 'using' to 'typedef'

### DIFF
--- a/Modules/Core/Common/include/itkSpatialOrientation.h
+++ b/Modules/Core/Common/include/itkSpatialOrientation.h
@@ -41,8 +41,7 @@ namespace SpatialOrientation
 //  Right to Left varies fastest, then Inferior to Superior, and Posterior
 //  to
 //  Anterior varies the slowest.
-typedef enum
-{
+using CoordinateTerms = enum {
   ITK_COORDINATE_UNKNOWN = 0,
   ITK_COORDINATE_Right = 2,
   ITK_COORDINATE_Left = 3,
@@ -52,10 +51,9 @@ typedef enum
   ITK_COORDINATE_Superior = 9   // above
                                 // ITK_COORDINATE_Historical=16,
                                 // ITK_COORDINATE_Future=17
-} CoordinateTerms;
+};
 
-typedef enum
-{
+using CoordinateMajornessTerms = enum {
   // These code place values have to be far enough apart to
   // separate the CoordinateTerms above.
   // However, if we added History/Future direction in time,
@@ -69,7 +67,7 @@ typedef enum
   // major than the
   // PrimaryMajor==TertiaryMinor.
   // ITK_COORDINATE_QuaternaryMinor=24
-} CoordinateMajornessTerms;
+};
 // Adding time IN GENERAL would make these 8 x 6 = 48 triples into 16
 // x 24 = 384 4-tuples.
 // A general fourth dimension would need a unique pair of letters to
@@ -81,8 +79,7 @@ typedef enum
 // co-registered and pieced together.... PD-T2 interleaving of
 // slices is handled with choosing
 // which spectrum to load via the prototypical file name.
-typedef enum
-{
+using ValidCoordinateOrientationFlags = enum {
   ITK_COORDINATE_ORIENTATION_INVALID = ITK_COORDINATE_UNKNOWN,
   ITK_COORDINATE_ORIENTATION_RIP = (ITK_COORDINATE_Right << ITK_COORDINATE_PrimaryMinor) +
                                    (ITK_COORDINATE_Inferior << ITK_COORDINATE_SecondaryMinor) +
@@ -233,7 +230,7 @@ typedef enum
   ITK_COORDINATE_ORIENTATION_ASL = (ITK_COORDINATE_Anterior << ITK_COORDINATE_PrimaryMinor) +
                                    (ITK_COORDINATE_Superior << ITK_COORDINATE_SecondaryMinor) +
                                    (ITK_COORDINATE_Left << ITK_COORDINATE_TertiaryMinor)
-} ValidCoordinateOrientationFlags;
+};
 // ^^^
 // |||
 // ||\Sequential indexes are separated by (planes=rows*columns) memory
@@ -243,8 +240,7 @@ typedef enum
 // \Sequential indexes are adjacent memory locations (sweep out a row)
 
 #ifndef __TEMPORARILY_INCLUDED_IN_COMPILATIONS__
-typedef enum
-{
+using ValidOriginFlags = enum {
   ITK_ORIGIN_IRP = 0, /**< Denotes a zeroCorner (image origin) */
   /* is Inferior Right Posterior */
   ITK_ORIGIN_IRA = 1, /**< Denotes a zeroCorner (image origin) */
@@ -261,7 +257,7 @@ typedef enum
   /* is Superior Left Posterior */
   ITK_ORIGIN_SLA = 7 /**< Denotes a zeroCorner (image origin) */
                      /* is Superior Left Anterior */
-} ValidOriginFlags;
+};
 #endif
 } // end of namespace SpatialOrientation
 } // end namespace itk

--- a/Modules/Core/Common/include/itkThreadLogger.h
+++ b/Modules/Core/Common/include/itkThreadLogger.h
@@ -58,14 +58,7 @@ public:
   using DelayType = unsigned int;
 
   /** Definition of types of operations for ThreadLogger. */
-  typedef enum
-  {
-    SET_PRIORITY_LEVEL,
-    SET_LEVEL_FOR_FLUSHING,
-    ADD_LOG_OUTPUT,
-    WRITE,
-    FLUSH
-  } OperationType;
+  using OperationType = enum { SET_PRIORITY_LEVEL, SET_LEVEL_FOR_FLUSHING, ADD_LOG_OUTPUT, WRITE, FLUSH };
 
   /** Set the priority level for the current logger. Only messages that have
    * priorities equal or greater than the one set here will be posted to the

--- a/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.h
@@ -77,8 +77,8 @@ public:
   std::list<typename OutputSpatialObjectT::Pointer> *
   GetOutput() const
   {
-    typedef OutputSpatialObjectT                       OutObjectType;
-    typedef std::list<typename OutObjectType::Pointer> OutListType;
+    using OutObjectType = OutputSpatialObjectT;
+    using OutListType = std::list<typename OutObjectType::Pointer>;
 
     auto * outputList = new OutListType;
 

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -68,15 +68,13 @@ struct bioradheader
   unsigned char reserved[6];   // 70  6    NOT USED (old ver.=real lens mag.)
 };
 
-typedef enum
-{
+using biorad_notestatus = enum {
   NOTE_STATUS_ALL = 0x0100,
   NOTE_STATUS_DISPLAY = 0x0200,
   NOTE_STATUS_POSITION = 0x0400
-} biorad_notestatus;
+};
 
-typedef enum
-{
+using biorad_notetype = enum {
   NOTE_TYPE_LIVE = 1,       // info about live collection
   NOTE_TYPE_FILE1 = 2,      // note from image #1
   NOTE_TYPE_NUMBER = 3,     // number in multiple image file
@@ -92,7 +90,7 @@ typedef enum
   NOTE_TYPE_STRUCTURE = 21, // again internal variable, as a
                             // structure.
   NOTE_TYPE_4D_SERIES = 22  // 4D acquisition information
-} biorad_notetype;
+};
 
 struct bioradnote
 {

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1782,7 +1782,7 @@ IsAffine(const mat44 & nifti_mat)
 void
 NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short int dims)
 {
-  typedef SpatialOrientationAdapter OrientAdapterType;
+  using OrientAdapterType = SpatialOrientationAdapter;
   // in the case of an Analyze75 file, use old analyze orient method.
   // but this could be a nifti file without qform and sform
   if (this->m_NiftiImage->qform_code == NIFTI_XFORM_UNKNOWN && this->m_NiftiImage->sform_code == NIFTI_XFORM_UNKNOWN)


### PR DESCRIPTION
The check converts the usage of typedef with using keyword.

cd ${BLDDIR}
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-using  -header-filter=.* -fix
# https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-using.html

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
