### PR TITLE
ENH: Use strongly typed enums for `itk::NiftiImageIO` readable formats

### DIFF
--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -28,28 +28,58 @@
 namespace itk
 {
 
-
-/** \class Analyze75Flavor
+/**\class NiftiImageIOEnums
+ * \brief
  * \ingroup ITKIONIFTI
- * Enum used to define way to treat legacy Analyze75 files
  */
-enum class Analyze75Flavor : uint8_t
+class NiftiImageIOEnums
 {
-  /** Behavior introduced in ITK4.0 by NIFTI reader interpreting Analyze files */
-  AnalyzeITK4 = 4,
-  /** Will ignore orientation code and negative pixel dimensions */
-  AnalyzeFSL = 3,
-  /** Will ignore orientation code and respect negative pixel dimensions */
-  AnalyzeSPM = 2,
-  /** Same as AnalyzeITK4 but will show warning about deprecated file format (Default)*/
-  AnalyzeITK4Warning = 1,
-  /** Reject Analyze files as potentially wrong  */
-  AnalyzeReject = 0
+public:
+  /** \class Analyze75Flavor
+   * \ingroup ITKIONIFTI
+   * Enum used to define the way to treat legacy Analyze75 files.
+   */
+  enum class Analyze75Flavor : uint8_t
+  {
+    /** Behavior introduced in ITK4.0 by NIFTI reader interpreting Analyze files */
+    AnalyzeITK4 = 4,
+    /** Will ignore orientation code and negative pixel dimensions */
+    AnalyzeFSL = 3,
+    /** Will ignore orientation code and respect negative pixel dimensions */
+    AnalyzeSPM = 2,
+    /** Same as AnalyzeITK4 but will show warning about deprecated file format (Default)*/
+    AnalyzeITK4Warning = 1,
+    /** Reject Analyze files as potentially wrong  */
+    AnalyzeReject = 0
+  };
+
+  /** \class NiftiFileEnum
+   * \ingroup ITKIONIFTI
+   * Enum used to define the possible file formats readable by this ImageIO implementation.
+   */
+  enum class NiftiFileEnum : int8_t
+  {
+    /** 2-file Nifti (consisting of .hdr and .img file). */
+    TwoFileNifti = 2,
+    /** 1-file Nifti (consisting of .nii file). */
+    OneFileNifti = 1,
+    /** Legacy Analyze 7.5 format (consisting of .hdr and .img file). */
+    Analyze75 = 0,
+    /** Some other file format, or file system error. */
+    OtherOrError = -1,
+  };
 };
+
+/** Backwards compatibility for enum values */
+#if !defined(ITK_LEGACY_REMOVE)
+using Analyze75Flavor = NiftiImageIOEnums::Analyze75Flavor;
+#endif
 
 /** Define how to print enumerations */
 extern ITKIONIFTI_EXPORT std::ostream &
-                         operator<<(std::ostream & out, const Analyze75Flavor value);
+                         operator<<(std::ostream & out, const NiftiImageIOEnums::Analyze75Flavor value);
+extern ITKIONIFTI_EXPORT std::ostream &
+                         operator<<(std::ostream & out, const NiftiImageIOEnums::NiftiFileEnum value);
 
 /**
  *\class NiftiImageIO
@@ -82,20 +112,16 @@ public:
 
   //-------- This part of the interfaces deals with reading data. -----
 
-  /** Possible file formats readable by this ImageIO implementation.
-   * Used by DetermineFileType(). */
-  enum FileType
-  {
-    /** 2-file Nifti (consisting of .hdr and .img file). */
-    TwoFileNifti = 2,
-    /** 1-file Nifti (consisting of .nii file). */
-    OneFileNifti = 1,
-    /** Legacy Analyze 7.5 format (consisting of .hdr and .img file). */
-    Analyze75 = 0,
-    /** Some other file format, or file system error. */
-    OtherOrError = -1,
-  };
-
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Backwards compatibility for enum values */
+  using FileType = NiftiImageIOEnums::NiftiFileEnum;
+  // We need to expose the enum values at the class level
+  // for backwards compatibility
+  static constexpr FileType TwoFileNifti = NiftiImageIOEnums::NiftiFileEnum::TwoFileNifti;
+  static constexpr FileType OneFileNifti = NiftiImageIOEnums::NiftiFileEnum::OneFileNifti;
+  static constexpr FileType Analyze75 = NiftiImageIOEnums::NiftiFileEnum::Analyze75;
+  static constexpr FileType OtherOrError = NiftiImageIOEnums::NiftiFileEnum::OtherOrError;
+#endif
 
   /** Reads the file to determine if it can be read with this ImageIO implementation,
    * and to determine what kind of file it is (Analyze vs NIfTI). Note that the value
@@ -103,7 +129,7 @@ public:
    * \param FileNameToRead The name of the file to test for reading.
    * \return Returns one of the IOFileEnum enumerations.
    */
-  FileType
+  NiftiImageIOEnums::NiftiFileEnum
   DetermineFileType(const char * FileNameToRead);
 
   /** Reads the file to determine if it can be read with this ImageIO implementation.
@@ -159,8 +185,8 @@ public:
    * the nifti library maintainers.  This format does not properly respect the file orientation fields.
    * By default this is set by configuration option ITK_NIFTI_IO_ANALYZE_FLAVOR
    */
-  itkSetMacro(LegacyAnalyze75Mode, Analyze75Flavor);
-  itkGetConstMacro(LegacyAnalyze75Mode, Analyze75Flavor);
+  itkSetMacro(LegacyAnalyze75Mode, NiftiImageIOEnums::Analyze75Flavor);
+  itkGetConstMacro(LegacyAnalyze75Mode, NiftiImageIOEnums::Analyze75Flavor);
 
 protected:
   NiftiImageIO();
@@ -214,7 +240,7 @@ private:
 
   IOComponentEnum m_OnDiskComponentType{ IOComponentEnum::UNKNOWNCOMPONENTTYPE };
 
-  Analyze75Flavor m_LegacyAnalyze75Mode;
+  NiftiImageIOEnums::Analyze75Flavor m_LegacyAnalyze75Mode;
 };
 
 

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -787,7 +787,7 @@ NiftiImageIO::Read(void * buffer)
   }
 }
 
-NiftiImageIO::FileType
+NiftiImageIOEnums::NiftiFileEnum
 NiftiImageIO::DetermineFileType(const char * FileNameToRead)
 {
   // is_nifti_file returns
@@ -797,7 +797,7 @@ NiftiImageIO::DetermineFileType(const char * FileNameToRead)
   //      == -1 for an error,
   const int imageFTYPE = is_nifti_file(FileNameToRead);
 
-  return static_cast<NiftiImageIO::FileType>(imageFTYPE);
+  return static_cast<NiftiImageIOEnums::NiftiFileEnum>(imageFTYPE);
 }
 
 // This method will only test if the header looks like an
@@ -816,7 +816,7 @@ NiftiImageIO ::CanReadFile(const char * FileNameToRead)
   {
     return true;
   }
-  else if (imageFTYPE == 0 && (this->GetLegacyAnalyze75Mode() != Analyze75Flavor::AnalyzeReject))
+  else if (imageFTYPE == 0 && (this->GetLegacyAnalyze75Mode() != NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject))
   {
     return true;
   }
@@ -997,7 +997,7 @@ NiftiImageIO ::ReadImageInformation()
   const int image_FTYPE = is_nifti_file(this->GetFileName());
   if (image_FTYPE == 0)
   {
-    if (this->GetLegacyAnalyze75Mode() == Analyze75Flavor::AnalyzeReject)
+    if (this->GetLegacyAnalyze75Mode() == NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject)
     {
       itkExceptionMacro(<< this->GetFileName()
                         << " is Analyze file and reader is instructed to reject it, specify preferred Analyze flavor "
@@ -1005,7 +1005,7 @@ NiftiImageIO ::ReadImageInformation()
     }
     else
     {
-      if (this->GetLegacyAnalyze75Mode() == Analyze75Flavor::AnalyzeITK4Warning)
+      if (this->GetLegacyAnalyze75Mode() == NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4Warning)
         itkWarningMacro(<< this->GetFileName() << " is Analyze file and it's deprecated ");
       // to disable this message, specify preferred Analyze flavor using SetLegacyAnalyze75Mode
     }
@@ -1283,8 +1283,8 @@ NiftiImageIO ::ReadImageInformation()
       break;
   }
   // see http://www.grahamwideman.com/gw/brain/analyze/formatdoc.htm
-  bool ignore_negative_pixdim =
-    this->m_NiftiImage->nifti_type == 0 && this->GetLegacyAnalyze75Mode() == Analyze75Flavor::AnalyzeFSL;
+  bool ignore_negative_pixdim = this->m_NiftiImage->nifti_type == 0 &&
+                                this->GetLegacyAnalyze75Mode() == NiftiImageIOEnums::Analyze75Flavor::AnalyzeFSL;
 
   const int dims = this->GetNumberOfDimensions();
   switch (dims)
@@ -1797,8 +1797,9 @@ NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short int dims)
       m_Origin[2] = 0.0;
     }
 
-    if (this->m_NiftiImage->nifti_type == 0 && this->GetLegacyAnalyze75Mode() != Analyze75Flavor::AnalyzeITK4 &&
-        this->GetLegacyAnalyze75Mode() != Analyze75Flavor::AnalyzeITK4Warning)
+    if (this->m_NiftiImage->nifti_type == 0 &&
+        this->GetLegacyAnalyze75Mode() != NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4 &&
+        this->GetLegacyAnalyze75Mode() != NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4Warning)
     { // only do this for Analyze file format
       SpatialOrientationAdapter::OrientationType orient;
       switch (this->m_NiftiImage->analyze75_orient)
@@ -2267,25 +2268,44 @@ NiftiImageIO ::Write(const void * buffer)
   }
 }
 
-/** Define how to print enumerations */
 std::ostream &
-operator<<(std::ostream & out, const Analyze75Flavor value)
+operator<<(std::ostream & out, const NiftiImageIOEnums::Analyze75Flavor value)
 {
   return out << [value] {
     switch (value)
     {
-      case Analyze75Flavor::AnalyzeReject:
-        return "Analyze75Flavor::AnalyzeReject";
-      case Analyze75Flavor::AnalyzeITK4:
-        return "Analyze75Flavor::AnalyzeITK4";
-      case Analyze75Flavor::AnalyzeITK4Warning:
-        return "Analyze75Flavor::AnalyzeITK4Warning";
-      case Analyze75Flavor::AnalyzeSPM:
-        return "Analyze75Flavor::AnalyzeSPM";
-      case Analyze75Flavor::AnalyzeFSL:
-        return "Analyze75Flavor::AnalyzeFSL";
+      case NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject:
+        return "itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject";
+      case NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4:
+        return "itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4";
+      case NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4Warning:
+        return "itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4Warning";
+      case NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM:
+        return "itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM";
+      case NiftiImageIOEnums::Analyze75Flavor::AnalyzeFSL:
+        return "itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeFSL";
       default:
-        return "INVALID VALUE FOR Analyze75Flavor";
+        return "INVALID VALUE FOR itk::NiftiImageIOEnums::Analyze75Flavor";
+    }
+  }();
+}
+
+std::ostream &
+operator<<(std::ostream & out, const NiftiImageIOEnums::NiftiFileEnum value)
+{
+  return out << [value] {
+    switch (value)
+    {
+      case NiftiImageIOEnums::NiftiFileEnum::TwoFileNifti:
+        return "itk::NiftiImageIOEnums::TwoFileNifti";
+      case NiftiImageIOEnums::NiftiFileEnum::OneFileNifti:
+        return "itk::NiftiImageIOEnums::NiftiFileEnum::OneFileNifti";
+      case NiftiImageIOEnums::NiftiFileEnum::Analyze75:
+        return "itk::NiftiImageIOEnums::NiftiFileEnum::Analyze75";
+      case NiftiImageIOEnums::NiftiFileEnum::OtherOrError:
+        return "itk::NiftiImageIOEnums::NiftiFileEnum::OtherOrError";
+      default:
+        return "INVALID VALUE FOR itk::NiftiImageIOEnums::NiftiFileEnum";
     }
   }();
 }

--- a/Modules/IO/NIFTI/src/itkNiftiImageIOConfigurePrivate.h.in
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIOConfigurePrivate.h.in
@@ -22,6 +22,6 @@
 // IO/NIFTI module and should not be installed.
 
 // Analyze default flavour
-#define ITK_NIFTI_IO_ANALYZE_FLAVOR_DEFAULT Analyze75Flavor::Analyze@ITK_NIFTI_IO_ANALYZE_FLAVOR@
+#define ITK_NIFTI_IO_ANALYZE_FLAVOR_DEFAULT NiftiImageIOEnums::Analyze75Flavor::Analyze@ITK_NIFTI_IO_ANALYZE_FLAVOR@
 
 #endif //itkNiftiImageIOConfigurePrivate_h

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
@@ -128,7 +128,7 @@ itkNiftiImageIOTest(int ac, char * av[])
     ImageType::Pointer         input;
     itk::NiftiImageIO::Pointer imageIO = itk::NiftiImageIO::New();
     // enable old behavior of NIFTI reader
-    imageIO->SetLegacyAnalyze75Mode(itk::Analyze75Flavor::AnalyzeITK4);
+    imageIO->SetLegacyAnalyze75Mode(itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4);
     for (int imagenameindex = 1; imagenameindex < ac; imagenameindex++)
     {
       try
@@ -230,5 +230,8 @@ itkNiftiImageIOTest(int ac, char * av[])
     }
     // This was made a protected function.  MyFactoryTest->PrintSelf(std::cout,0);
   }
+
+  TestEnumStreaming();
+
   return rval;
 }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -572,5 +572,6 @@ int
 TestNiftiByteSwap(const std::string & prefix);
 void
 RemoveNiftiByteSwapTestFiles(const std::string & prefix);
-
+void
+TestEnumStreaming();
 #endif

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <set>
 #include "itkNiftiImageIOTest.h"
 
 // The WriteNiftiTestFiles function writes binary data to disk to ensure that both big and little endian files are
@@ -123,4 +124,33 @@ RemoveNiftiByteSwapTestFiles(const std::string & prefix)
   itk::IOTestHelper::Remove((prefix + "NiftiLittleEndian.img").c_str());
   itk::IOTestHelper::Remove((prefix + "NiftiBigEndian.hdr").c_str());
   itk::IOTestHelper::Remove((prefix + "NiftiBigEndian.img").c_str());
+}
+
+void
+TestEnumStreaming()
+{
+  // Test streaming enumeration for Analyze75Flavor elements
+  const std::set<itk::NiftiImageIOEnums::Analyze75Flavor> allAnalyze75Flavor{
+    itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject,
+    itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4,
+    itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4Warning,
+    itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM,
+    itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeFSL
+  };
+  for (const auto & ee : allAnalyze75Flavor)
+  {
+    std::cout << "STREAMED ENUM VALUE itk::NiftiImageIOEnums::Analyze75Flavor: " << ee << std::endl;
+  }
+
+  // Test streaming enumeration for NiftiFileEnum elements
+  const std::set<itk::NiftiImageIOEnums::NiftiFileEnum> allNiftiFileEnum{
+    itk::NiftiImageIOEnums::NiftiFileEnum::TwoFileNifti,
+    itk::NiftiImageIOEnums::NiftiFileEnum::OneFileNifti,
+    itk::NiftiImageIOEnums::NiftiFileEnum::Analyze75,
+    itk::NiftiImageIOEnums::NiftiFileEnum::OtherOrError
+  };
+  for (const auto & ee : allNiftiFileEnum)
+  {
+    std::cout << "STREAMED ENUM VALUE itk::NiftiImageIOEnums::NiftiFileEnum: " << ee << std::endl;
+  }
 }

--- a/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
@@ -194,7 +194,8 @@ WriteFile(const std::string & name, const unsigned char * buf, size_t buflen)
  */
 template <typename TImage>
 typename TImage::Pointer
-ReadImage(const std::string & fileName, itk::Analyze75Flavor analyze_mode = itk::Analyze75Flavor::AnalyzeSPM)
+ReadImage(const std::string &                     fileName,
+          itk::NiftiImageIOEnums::Analyze75Flavor analyze_mode = itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM)
 {
   using ReaderType = itk::ImageFileReader<TImage>;
 
@@ -231,7 +232,7 @@ int
 itkNiftiAnalyzeContentsAndCoordinatesTest(char *                                                   av[],
                                           unsigned char                                            hist_orient_code,
                                           itk::SpatialOrientation::ValidCoordinateOrientationFlags expected_code,
-                                          itk::Analyze75Flavor                                     analyze_mode,
+                                          itk::NiftiImageIOEnums::Analyze75Flavor                  analyze_mode,
                                           bool                                                     flip_x = false)
 {
   std::string hdrName(av[1]);
@@ -275,7 +276,7 @@ itkNiftiAnalyzeContentsAndCoordinatesTest(char *                                
   }
   catch (...)
   {
-    if (analyze_mode == itk::Analyze75Flavor::AnalyzeReject)
+    if (analyze_mode == itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject)
       std::cerr << "Failure is expected" << std::endl << std::endl;
     return EXIT_FAILURE;
   }
@@ -337,69 +338,96 @@ itkNiftiReadAnalyzeTest(int ac, char * av[])
   // https://web.archive.org/web/20121116093304/http://wideman-one.com/gw/brain/analyze/formatdoc.htm Analyze code 5
   // should have been PSR but it was revised in NIFTI somehow to PIL
 
-  return itkNiftiAnalyzeContentsAndCoordinatesTest(
-           av, 0, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI, itk::Analyze75Flavor::AnalyzeReject) !=
+  return itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                   0,
+                                                   itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI,
+                                                   itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject) !=
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 0, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI, itk::Analyze75Flavor::AnalyzeSPM) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       0,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 1, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP, itk::Analyze75Flavor::AnalyzeSPM) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       1,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 2, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIR, itk::Analyze75Flavor::AnalyzeSPM) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       2,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIR,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 3, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI, itk::Analyze75Flavor::AnalyzeSPM) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       3,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 4, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSP, itk::Analyze75Flavor::AnalyzeSPM) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       4,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSP,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 5, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIL, itk::Analyze75Flavor::AnalyzeSPM) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       5,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIL,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
              // ITK4 default behaviour: reader should ignore orientation code and always produce RAI ,
              // there should be a warning on console
              itkNiftiAnalyzeContentsAndCoordinatesTest(av,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
-                                                       itk::Analyze75Flavor::AnalyzeITK4Warning) == EXIT_FAILURE ||
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4Warning) ==
+               EXIT_FAILURE ||
              // ITK4 reader should ignore orientation code and always produce RAI
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 0, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI, itk::Analyze75Flavor::AnalyzeITK4) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       0,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 1, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI, itk::Analyze75Flavor::AnalyzeITK4) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       1,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 2, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI, itk::Analyze75Flavor::AnalyzeITK4) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       2,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 3, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI, itk::Analyze75Flavor::AnalyzeITK4) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       3,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 5, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI, itk::Analyze75Flavor::AnalyzeITK4) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       5,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(
-               av, 5, itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI, itk::Analyze75Flavor::AnalyzeITK4) ==
+             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+                                                       5,
+                                                       itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
              // flip X  axis , SPM reader should respect this
              itkNiftiAnalyzeContentsAndCoordinatesTest(av,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LPI,
-                                                       itk::Analyze75Flavor::AnalyzeSPM,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM,
                                                        true) == EXIT_FAILURE ||
              // flip X  axis , ITK4 reader should respect this
              itkNiftiAnalyzeContentsAndCoordinatesTest(av,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LAI,
-                                                       itk::Analyze75Flavor::AnalyzeITK4,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4,
                                                        true) == EXIT_FAILURE ||
              // flip X  axis , FSL reader should ignore this
              itkNiftiAnalyzeContentsAndCoordinatesTest(av,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI,
-                                                       itk::Analyze75Flavor::AnalyzeFSL,
+                                                       itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeFSL,
                                                        true) == EXIT_FAILURE
 
            ? EXIT_FAILURE

--- a/Modules/IO/NIFTI/wrapping/itkNiftiImageIO.wrap
+++ b/Modules/IO/NIFTI/wrapping/itkNiftiImageIO.wrap
@@ -2,6 +2,6 @@ set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkNiftiImageIO.h")
 itk_wrap_include("itkNiftiImageIOFactory.h")
 
+itk_wrap_simple_class("itk::NiftiImageIOEnums")
 itk_wrap_simple_class("itk::NiftiImageIO" POINTER)
 itk_wrap_simple_class("itk::NiftiImageIOFactory" POINTER)
-itk_wrap_simple_class("itk::Analyze75Flavor" ENUM)


### PR DESCRIPTION
Use strongly typed enums to define the file formats readable by the
`itk::NiftiImageIO` class,

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5