### PR TITLE
BUG: Fix crash of PythonExtrasTest when extra types are wrapped

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -390,7 +390,7 @@ for t in [
     [np.float64, np.float64, "VIF2VID2"],
 ]:
     if hasattr(itk.CastImageFilter, t[2]):
-        cast = vectorimage.astype(t[0])
+        cast = image.astype(t[0])
         (cast_image_template, (cast_pixel_type, cast_image_dimension)) = itk.template(
             cast
         )


### PR DESCRIPTION
Resolves Issue #2293.  Uses `image` Python variable in lieu of no-longer-defined `vectorimage` variable.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)
