### PR TITLE
BUG: Wrap `itk::Analyze75Flavor` enum before `itk::NiftiImageIO`

### DIFF
--- a/Modules/IO/NIFTI/wrapping/itkNiftiImageIO.wrap
+++ b/Modules/IO/NIFTI/wrapping/itkNiftiImageIO.wrap
@@ -2,6 +2,6 @@ set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkNiftiImageIO.h")
 itk_wrap_include("itkNiftiImageIOFactory.h")
 
+itk_wrap_simple_class("itk::Analyze75Flavor")
 itk_wrap_simple_class("itk::NiftiImageIO" POINTER)
 itk_wrap_simple_class("itk::NiftiImageIOFactory" POINTER)
-itk_wrap_simple_class("itk::Analyze75Flavor" ENUM)


### PR DESCRIPTION
Wrap `itk::Analyze75Flavor` enum before `itk::NiftiImageIO`: since
itk::NiftiImageIO uses `itk::Analyze75Flavor`, we want its wrapping to be
declared before `itk::NiftiImageIO`'s.

Take advantage of the commit to remove the `ENUM` specifier, which is no
longer required following the use of strongly typed enums.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)