### PR TITLE
STYLE: Rename `ITK_EXERCISE_BASIC_OBJECT_METHODS` class names arguments

### DIFF
--- a/Modules/Core/TestKernel/include/itkTestingMacros.h
+++ b/Modules/Core/TestKernel/include/itkTestingMacros.h
@@ -63,11 +63,11 @@ namespace itk
 #endif
 
 // object's Class must be specified to build on sun studio
-#define ITK_EXERCISE_BASIC_OBJECT_METHODS(object, Class, SuperClass)                                                   \
+#define ITK_EXERCISE_BASIC_OBJECT_METHODS(object, ClassName, SuperclassName)                                           \
   object->Print(std::cout);                                                                                            \
   std::cout << "Name of Class = " << object->GetNameOfClass() << std::endl;                                            \
   std::cout << "Name of Superclass = " << object->Superclass::GetNameOfClass() << std::endl;                           \
-  if (!std::strcmp(object->GetNameOfClass(), #Class))                                                                  \
+  if (!std::strcmp(object->GetNameOfClass(), #ClassName))                                                              \
   {                                                                                                                    \
     std::cout << "Class name is correct" << std::endl;                                                                 \
   }                                                                                                                    \
@@ -76,7 +76,7 @@ namespace itk
     std::cerr << "Class name provided does not match object's NameOfClass" << std::endl;                               \
     return EXIT_FAILURE;                                                                                               \
   }                                                                                                                    \
-  if (!std::strcmp(object->Superclass::GetNameOfClass(), #SuperClass))                                                 \
+  if (!std::strcmp(object->Superclass::GetNameOfClass(), #SuperclassName))                                             \
   {                                                                                                                    \
     std::cout << "Superclass name is correct" << std::endl;                                                            \
   }                                                                                                                    \


### PR DESCRIPTION
Rename `ITK_EXERCISE_BASIC_OBJECT_METHODS` class names arguments in order
to make explicit their use within the macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)