### PR TITLE
STYLE: Use single forward slashes in `CMakeLists.txt` data paths

### DIFF
--- a/Modules/Filtering/BiasCorrection/test/CMakeLists.txt
+++ b/Modules/Filtering/BiasCorrection/test/CMakeLists.txt
@@ -17,7 +17,7 @@ itk_add_test(NAME itkN4BiasFieldCorrectionImageFilterTest1
               ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_2D.nii.gz
     itkN4BiasFieldCorrectionImageFilterTest 2
     ${ITK_EXAMPLE_DATA_ROOT}/BrainT1SliceBorder20.png           # input
-    ${ITK_TEST_OUTPUT_DIR}//N4ControlPoints_2D.nii.gz           # control point lattice
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_2D.nii.gz            # control point lattice
     4                                                           # shrink factor
     20x20                                                       # number of iterations
     none                                                        # mask
@@ -30,7 +30,7 @@ itk_add_test(NAME itkN4BiasFieldCorrectionImageFilterTest2
     itkN4BiasFieldCorrectionImageFilterTest
     3
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeCompressed.mha}            # input
-    ${ITK_TEST_OUTPUT_DIR}//N4ControlPoints_3D_Test2.nii.gz                  # control point lattice
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_3D_Test2.nii.gz             # control point lattice
     3                                                                  # shrink factor
     10x10x10                                                           # number of iterations
     none                                                               # mask
@@ -44,7 +44,7 @@ itk_add_test(NAME itkN4BiasFieldCorrectionImageFilterTest3
     itkN4BiasFieldCorrectionImageFilterTest
     3
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeCompressed.mha}            # input
-    ${ITK_TEST_OUTPUT_DIR}//N4ControlPoints_3D_Test3.nii.gz                  # control point lattice
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_3D_Test3.nii.gz             # control point lattice
     3                                                                  # shrink factor
     10x10x10                                                           # number of iterations
     none                                                               # mask

--- a/Modules/Filtering/ImageCompare/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompare/test/CMakeLists.txt
@@ -34,6 +34,6 @@ itk_add_test(NAME itkSTAPLEImageFilterTest
     itkSTAPLEImageFilterTest 2 ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha 255 0.5 DATA{${ITK_DATA_ROOT}/Input/STAPLE1.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE2.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE3.png} DATA{${ITK_DATA_ROOT}/Input/STAPLE4.png})
 itk_add_test(NAME itkTestingComparisonImageFilterTest
       COMMAND ITKImageCompareTestDriver
-      --compare DATA{Input//itkTestingComparisonImageFilterTest.png}
+      --compare DATA{Input/itkTestingComparisonImageFilterTest.png}
               ${ITK_TEST_OUTPUT_DIR}/itkTestingComparisonImageFilterTest.png
     itkTestingComparisonImageFilterTest DATA{${ITK_DATA_ROOT}/Input/cake_easy.png} DATA{${ITK_DATA_ROOT}/Input/cake_hard.png} ${ITK_TEST_OUTPUT_DIR}/itkTestingComparisonImageFilterTest.png 10 1 1647)


### PR DESCRIPTION
Use single forward slashes as data path separators in `CMakeLists.txt`
files.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)