### PR TITLE
STYLE: Use the static `FixedArray::Filled` to initialize array ivars

### DIFF
--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -486,13 +486,13 @@ protected:
   }
 
   /** The weights used to scale derivatives during processing */
-  DerivativeWeightsType m_DerivativeWeights;
+  DerivativeWeightsType m_DerivativeWeights = DerivativeWeightsType::Filled(1);
 
   /** These weights are used to scale
       vector component values when they are combined to produce  a scalar.  The
       square root */
-  ComponentWeightsType m_ComponentWeights;
-  ComponentWeightsType m_SqrtComponentWeights;
+  ComponentWeightsType m_ComponentWeights = ComponentWeightsType::Filled(1);
+  ComponentWeightsType m_SqrtComponentWeights = ComponentWeightsType::Filled(1);
 
 private:
   bool m_UseImageSpacing;

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -33,20 +33,9 @@ namespace itk
 template <typename TInputImage, typename TRealType, typename TOutputImage>
 VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::VectorGradientMagnitudeImageFilter()
 {
-  unsigned int i;
-
   m_UseImageSpacing = true;
   m_UsePrincipleComponents = true;
   m_RequestedNumberOfThreads = this->GetNumberOfWorkUnits();
-  for (i = 0; i < ImageDimension; i++)
-  {
-    m_DerivativeWeights[i] = static_cast<TRealType>(1.0);
-  }
-  for (i = 0; i < VectorDimension; i++)
-  {
-    m_ComponentWeights[i] = static_cast<TRealType>(1.0);
-    m_SqrtComponentWeights[i] = static_cast<TRealType>(1.0);
-  }
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();
 }


### PR DESCRIPTION
Improve array ivar initialization in
`itk::VectorGradientMagnitudeImageFilter` constructor using the static
`Fixed::Fill(const ValueType &)` method.

Avoids static casts and unnecessary boilerplate code.

Also, take advantage of the commit to perform such initialization in the
header file.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)