### PR TITLE
ENH: support multiple labels in ContourExtractor2DImageFilter

### DIFF
--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -46,17 +46,18 @@ namespace itk
  * Proceedings) 21(4) July 1987, p. 163-170). A simple explanation is available
  * here: http://users.polytech.unice.fr/~lingrand/MarchingCubes/algo.html
  *
- * There is a single ambiguous case in the marching squares algorithm: if a
- * given 2x2-pixel square has two high-valued and two low-valued pixels, each
- * pair diagonally adjacent. (Where high- and low-valued is with respect to the
- * contour value sought.) In this case, either the high-valued pixels can be
- * connected into the same "object" (where groups of pixels encircled by a given
- * contour are considered an object), or the low-valued pixels can be connected.
- * This is the "face connected" versus "face + vertex connected" (or 4- versus
- * 4-connected) distinction: high-valued pixels most be treated as one, and
- * low-valued as the other. By default, high-valued pixels are treated as
- * "face-connected" and low-valued pixels are treated as "face + vertex"
- * connected. To reverse this, call VertexConnectHighPixelsOn();
+ * There is an ambiguous case in the marching squares algorithm: if a given
+ * 2x2-pixel square has two high-valued and two low-valued pixels, each pair
+ * diagonally adjacent. (Note that high-valued and low-valued are with respect
+ * to the contour value sought when LabelContours is false. When
+ * LabelContours is true, high-valued means the label being traced and
+ * low-valued means any other label.) In this case, the default behavior is that
+ * the low-valued pixels are connected into the same contour via an isthmus that
+ * separates the high-valued pixels into separate contours. To reverse this,
+ * call VertexConnectHighPixelsOn(). Note that when LabelContours is true, the
+ * default behavior will leave all four pixels in separate contours. In this
+ * case, VertexConnectHighPixels equal to true can instead create contours that
+ * are crossing barbells.
  *
  * Outputs are not guaranteed to be closed paths: contours which intersect the
  * image edge will be left open. All other paths will be closed. (The
@@ -74,6 +75,12 @@ namespace itk
  * below-contour-value intensity. This convention can be reversed by calling
  * ReverseContourOrientationOn().
  *
+ * By default values are interpreted as intensities relative to a contour value.
+ * First calling LabelContoursOn() changes this behavior to instead interpret each
+ * value as a label.  Boundaries are computed for each label separately and all are
+ * returned.  The value of LabelContours affects the interpretation of
+ * VertexConnectHighPixels; see above.
+
  * By default the input image's largest possible region will be processed; call
  * SetRequestedRegion() to process a different region, or ClearRequestedRegion()
  * to revert to the default value. Note that the requested regions are usually
@@ -148,6 +155,11 @@ public:
   itkGetConstReferenceMacro(VertexConnectHighPixels, bool);
   itkBooleanMacro(VertexConnectHighPixels);
 
+  /** Return contours for all distinct labels */
+  itkSetMacro(LabelContours, bool);
+  itkGetConstReferenceMacro(LabelContours, bool);
+  itkBooleanMacro(LabelContours);
+
   /** Control whether the largest possible input region is used, or if a
    * custom requested region is to be used. */
   void
@@ -180,6 +192,16 @@ protected:
   void
   GenerateData() override;
 
+  /** Subroutine to handle the case that the supplied values are
+   * intensities to be compared to a contour value. */
+  void
+  GenerateDataForIntensities();
+
+  /** Subroutine to handle the case that the supplied values are
+   * labels, which are *not* compared to a contour value. */
+  void
+  GenerateDataForLabels();
+
   /** ContourExtractor2DImageFilter manually controls the input requested
    * region via SetRequestedRegion and ClearRequestedRegion, so it must
    * override the superclass method. */
@@ -202,6 +224,7 @@ private:
   InputRealType   m_ContourValue;
   bool            m_ReverseContourOrientation;
   bool            m_VertexConnectHighPixels;
+  bool            m_LabelContours;
   bool            m_UseCustomRegion;
   InputRegionType m_RequestedRegion;
   unsigned int    m_NumberOfContoursCreated;
@@ -290,6 +313,15 @@ private:
   // And indexed by their beginning and ending points here
   VertexToContourMap m_ContourStarts;
   VertexToContourMap m_ContourEnds;
+
+  // The number of outputs we have allocated capacity for
+  unsigned int m_NumberOutputsAllocated;
+
+  // The number of outputs we have written out so far
+  unsigned int m_NumberOutputsWritten;
+
+  // The number of labels we have yet to write outputs for
+  unsigned int m_NumberLabelsRemaining;
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterTest.cxx
@@ -15,6 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+#include <iomanip>
 #include "itkImageFileReader.h"
 #include "itkContourExtractor2DImageFilter.h"
 #include "itkTestingMacros.h"
@@ -391,7 +392,103 @@ itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_disconn
                                                                                                                 _edcro +
                                                                                                                   11);
 
+itkContourExtractor2DImageFilterTestNamespace::MyVertexType _labels0[] = {
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 7.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 7.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 7.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(-0.5, 7),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(-0.5, 6),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(-0.5, 5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(-0.5, 4),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0, 3.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 3.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 3.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2.5, 4),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 4.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 4.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 6),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 6.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1.5, 6),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 5.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2.5, 6),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2.5, 7),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 7.5),
+};
+itkContourExtractor2DImageFilterTestNamespace::MyVertexListType labels0(_labels0, _labels0 + 21);
+
+itkContourExtractor2DImageFilterTestNamespace::MyVertexType _labels1[] = {
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 6.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 6),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(0.5, 5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 4.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 4.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2.5, 5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(2, 5.5),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1.5, 6),
+  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(1, 6.5),
+};
+itkContourExtractor2DImageFilterTestNamespace::MyVertexListType labels1(_labels1, _labels1 + 9);
+
+itkContourExtractor2DImageFilterTestNamespace::MyVertexListType labels[]{
+  labels0,
+  labels1,
+};
+itkContourExtractor2DImageFilterTestNamespace::MyVertexListList expected_values_as_labels_outputs(labels, labels + 2);
 /*--------------------------------------------------------------------------*/
+
+void
+ShowExtractorAsVariables(itkContourExtractor2DImageFilterTestNamespace::ExtractorType::Pointer extractor,
+                         std::string                                                           name)
+{
+  for (unsigned long i = 0; i < extractor->GetNumberOfIndexedOutputs(); ++i)
+  {
+    itkContourExtractor2DImageFilterTestNamespace::ExtractorType::VertexListConstPointer vertices =
+      extractor->GetOutput(i)->GetVertexList();
+    std::cout << "itkContourExtractor2DImageFilterTestNamespace::MyVertexType _" << name << i << "[] = {" << std::endl;
+    for (unsigned j = 0; j < vertices->Size(); ++j)
+    {
+      std::cout << "  itkContourExtractor2DImageFilterTestNamespace::MyVertexType(" << vertices->ElementAt(j)[0] << ", "
+                << vertices->ElementAt(j)[1] << ")," << std::endl;
+    }
+    std::cout << "};" << std::endl;
+    std::cout << "itkContourExtractor2DImageFilterTestNamespace::MyVertexListType " << name << i << "(_" << name << i
+              << ", _" << name << i << " + " << vertices->Size() << ");" << std::endl
+              << std::endl;
+  }
+  std::cout << "itkContourExtractor2DImageFilterTestNamespace::MyVertexListType " << name << "[] {" << std::endl;
+  for (unsigned long i = 0; i < extractor->GetNumberOfIndexedOutputs(); ++i)
+  {
+    std::cout << name << i << ", ";
+  }
+  std::cout << std::endl << "};" << std::endl;
+  std::cout << "itkContourExtractor2DImageFilterTestNamespace::MyVertexListList "
+               "expected_values_as_"
+            << name << "_outputs(" << name << ", " << name << " + " << extractor->GetNumberOfIndexedOutputs() << ");"
+            << std::endl;
+}
+
+void
+showImage(const itkContourExtractor2DImageFilterTestNamespace::ImageType::ConstPointer toshowImage)
+{
+  using RegionType = itkContourExtractor2DImageFilterTestNamespace::ImageType::RegionType;
+  using SizeType = itkContourExtractor2DImageFilterTestNamespace::ImageType::RegionType::SizeType;
+  using SizeValueType = itkContourExtractor2DImageFilterTestNamespace::ImageType::RegionType::SizeType::SizeValueType;
+  using RegionConstIterator = itk::ImageRegionConstIterator<itkContourExtractor2DImageFilterTestNamespace::ImageType>;
+
+  const RegionType    toshowRegion{ toshowImage->GetRequestedRegion() };
+  const SizeType      toshowSize{ toshowRegion.GetSize() };
+  RegionConstIterator it{ toshowImage, toshowRegion };
+  for (SizeValueType row = 0; row < toshowSize[1]; ++row)
+  {
+    for (SizeValueType col = 0; col < toshowSize[0]; ++col)
+    {
+      std::cout << std::setw(4) << static_cast<int>(it.Get());
+      ++it;
+    }
+    std::cout << std::endl;
+  }
+}
 
 bool
 HasCorrectOutput(itkContourExtractor2DImageFilterTestNamespace::ExtractorType::Pointer extractor,
@@ -460,28 +557,35 @@ itkContourExtractor2DImageFilterTest(int argc, char * argv[])
 
   extractor->SetContourValue(127.5);
 
+  // verify that the default VertexConnectHighPixels is false
+  ITK_TEST_EXPECT_TRUE(!extractor->GetVertexConnectHighPixels());
+
   // exercise Set/Get methods of VertexConnectHighPixels
   extractor->VertexConnectHighPixelsOn();
-  if (extractor->GetVertexConnectHighPixels() != true)
-  {
-    std::cerr << "VertexConnectHighPixels Set/Get Problem" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_TRUE(extractor->GetVertexConnectHighPixels());
+
+  // verify that the default ReverseContourOrientation is false
+  ITK_TEST_EXPECT_TRUE(!extractor->GetReverseContourOrientation());
 
   // exercise Set/Get methods of ReverseContourOrientation
   extractor->ReverseContourOrientationOn();
-  if (extractor->GetReverseContourOrientation() != true)
-  {
-    std::cerr << "ReverseContourOrientation Set/Get Problem" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_TRUE(extractor->GetReverseContourOrientation());
+
+  // verify that the default LabelContours is false
+  ITK_TEST_EXPECT_TRUE(!extractor->GetLabelContours());
+
+  // exercise Set/Get methods of LabelContours
+  extractor->LabelContoursOn();
+  ITK_TEST_EXPECT_TRUE(extractor->GetLabelContours());
 
   bool testsPassed = true;
   try
   {
     extractor->VertexConnectHighPixelsOff();
     extractor->ReverseContourOrientationOff();
+    extractor->LabelContoursOff();
     extractor->Update();
+
     std::cout << "Test 1... ";
     if (!HasCorrectOutput(extractor, expected_disconnected_clockwise_outputs))
     {
@@ -489,10 +593,13 @@ itkContourExtractor2DImageFilterTest(int argc, char * argv[])
       std::cout << "failed." << std::endl;
     }
     else
+    {
       std::cout << "passed." << std::endl;
+    }
 
     extractor->VertexConnectHighPixelsOff();
     extractor->ReverseContourOrientationOn();
+    extractor->LabelContoursOff();
     extractor->Update();
     std::cout << "Test 2... ";
     if (!HasCorrectOutput(extractor, expected_disconnected_counterclockwise_outputs))
@@ -507,6 +614,7 @@ itkContourExtractor2DImageFilterTest(int argc, char * argv[])
 
     extractor->VertexConnectHighPixelsOn();
     extractor->ReverseContourOrientationOff();
+    extractor->LabelContoursOff();
     extractor->Update();
     std::cout << "Test 3... ";
     if (!HasCorrectOutput(extractor, expected_connected_clockwise_outputs))
@@ -521,6 +629,7 @@ itkContourExtractor2DImageFilterTest(int argc, char * argv[])
 
     extractor->VertexConnectHighPixelsOff();
     extractor->ReverseContourOrientationOff();
+    extractor->LabelContoursOff();
     // Move the region to evaluate in by one on the top and bottom
     itkContourExtractor2DImageFilterTestNamespace::ImageType::RegionType region =
       reader->GetOutput()->GetLargestPossibleRegion();
@@ -548,6 +657,30 @@ itkContourExtractor2DImageFilterTest(int argc, char * argv[])
     {
       testsPassed = false;
       std::cerr << "failed." << std::endl;
+    }
+    else
+    {
+      std::cout << "passed." << std::endl;
+    }
+
+    extractor->SetRequestedRegion({ { 0, 4 }, { 3, 4 } });
+    extractor->VertexConnectHighPixelsOff();
+    extractor->ReverseContourOrientationOff();
+    extractor->LabelContoursOn();
+    extractor->Update();
+
+    // showImage(extractor->GetInput()); // Produces:
+    //   0   0   0
+    //   0 255 255
+    //   0 255   0
+    //   0   0   0
+
+    // ShowExtractorAsVariables(extractor, "labels"); // Produces _label0 through expected_values_as_labels_outputs
+    std::cout << "Test 5... ";
+    if (!HasCorrectOutput(extractor, expected_values_as_labels_outputs))
+    {
+      testsPassed = false;
+      std::cout << "failed." << std::endl;
     }
     else
     {


### PR DESCRIPTION
The previously existing function of ContourExtractor2DImageFilter is to trace the contour between regions of a 2-dimensional image defined by values that are higher and lower, respectively, than a specified contour value.  To that we add a `LabelContoursOn()` option; when set then every distinct value in the 2-dimensional image defines its own region, and boundaries for all such regions are generated.

At present this is WIP.  Please review for the API changes.  The implementation works, but is not performant; it needs additional work.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)
