### PR TITLE
emscripten upstream

### DIFF
--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -136,7 +136,7 @@ void
 FloatingPointExceptions::Enable()
 {
   itkInitGlobalsMacro(PimplGlobals);
-#if defined(ITK_HAS_FPE_CAPABILITY) && !defined(__EMSCRIPTEN__)
+#if defined(ITK_HAS_FPE_CAPABILITY)
   itk_feenableexcept(FE_DIVBYZERO);
   itk_feenableexcept(FE_INVALID);
 #  if defined(ITK_FPE_USE_SIGNAL_HANDLER)
@@ -158,7 +158,7 @@ void
 FloatingPointExceptions::Disable()
 {
   itkInitGlobalsMacro(PimplGlobals);
-#if defined(ITK_HAS_FPE_CAPABILITY) && !defined(__EMSCRIPTEN__)
+#if defined(ITK_HAS_FPE_CAPABILITY)
   itk_fedisableexcept(FE_DIVBYZERO);
   itk_fedisableexcept(FE_INVALID);
   FloatingPointExceptions::m_PimplGlobals->m_Enabled = false;

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/CMakeLists.txt
@@ -992,7 +992,7 @@ if (NOT EXISTS "${HDF5_GENERATED_SOURCE_DIR}/H5Tinit.c")
         OUTPUT ${HDF5_GENERATED_SOURCE_DIR}/H5Tinit.c
                ${HDF5_GENERATED_SOURCE_DIR}/gen_SRCS.stamp1
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:H5detect>
-        ARGS ${HDF5_GENERATED_SOURCE_DIR}/H5Tinit.c
+        ARGS > ${HDF5_GENERATED_SOURCE_DIR}/H5Tinit.c
         COMMAND    ${CMAKE_COMMAND}
         ARGS       -E touch ${HDF5_GENERATED_SOURCE_DIR}/gen_SRCS.stamp1
         DEPENDS H5detect
@@ -1048,7 +1048,7 @@ add_custom_command (
     OUTPUT ${HDF5_BINARY_DIR}/H5lib_settings.c
            ${HDF5_BINARY_DIR}/gen_SRCS.stamp2
     COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:H5make_libsettings>
-    ARGS ${HDF5_BINARY_DIR}/H5lib_settings.c
+    ARGS > ${HDF5_BINARY_DIR}/H5lib_settings.c
     COMMAND    ${CMAKE_COMMAND}
     ARGS       -E touch ${HDF5_GENERATED_SOURCE_DIR}/gen_SRCS.stamp2
     DEPENDS H5make_libsettings

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/CMakeLists.txt
@@ -952,7 +952,6 @@ if (NOT EXISTS "${HDF5_GENERATED_SOURCE_DIR}/H5Tinit.c")
   TARGET_C_PROPERTIES (H5detect STATIC)
   target_link_libraries (H5detect
       PRIVATE "$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_LIBRARIES}>" $<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:MinGW>>:ws2_32.lib>
-      PRIVATE $<$<PLATFORM_ID:Emscripten>:"-O0">
   )
 
   if (HDF5_BATCH_H5DETECT)
@@ -1043,7 +1042,6 @@ target_compile_definitions(H5make_libsettings PUBLIC ${HDF_EXTRA_C_FLAGS} ${HDF_
 TARGET_C_PROPERTIES (H5make_libsettings STATIC)
 target_link_libraries (H5make_libsettings
     PRIVATE "$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_LIBRARIES}>" $<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:MinGW>>:ws2_32.lib>
-    PRIVATE $<$<PLATFORM_ID:Emscripten>:"-O0">
 )
 
 add_custom_command (

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Fsuper.c
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Fsuper.c
@@ -54,6 +54,7 @@
 /********************/
 static herr_t H5F__super_ext_create(H5F_t *f, H5O_loc_t *ext_ptr);
 static herr_t H5F__update_super_ext_driver_msg(H5F_t *f);
+static herr_t H5O__fsinfo_set_version(H5F_t *f, H5O_fsinfo_t *fsinfo);
 
 
 /*********************/

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Odeprec.c
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Odeprec.c
@@ -32,6 +32,7 @@
 /* Headers */
 /***********/
 #include "H5private.h"      /* Generic Functions    */
+#include "H5CXprivate.h"    /* API Contexts         */
 #include "H5Eprivate.h"     /* Error handling       */
 #include "H5Opkg.h"         /* Object headers       */
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Oint.c
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Oint.c
@@ -31,6 +31,7 @@
 /* Headers */
 /***********/
 #include "H5private.h"          /* Generic Functions                        */
+#include "H5CXprivate.h"        /* API Contexts                             */
 #include "H5Eprivate.h"         /* Error handling                           */
 #include "H5Fprivate.h"         /* File access                              */
 #include "H5FLprivate.h"        /* Free lists                               */

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Rint.c
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/src/H5Rint.c
@@ -23,6 +23,7 @@
 /***********/
 #include "H5private.h"          /* Generic Functions                        */
 #include "H5ACprivate.h"        /* Metadata cache                           */
+#include "H5CXprivate.h"        /* API Contexts                             */
 #include "H5Dprivate.h"         /* Datasets                                 */
 #include "H5Eprivate.h"         /* Error handling                           */
 #include "H5Gprivate.h"         /* Groups                                   */

--- a/Modules/ThirdParty/MINC/src/libminc/libcommon/restructure.c
+++ b/Modules/ThirdParty/MINC/src/libminc/libcommon/restructure.c
@@ -5,6 +5,9 @@
  ************************************************************************/
 #include <stdlib.h>
 #include <memory.h>
+#ifdef _DEBUG
+#include <stdio.h>
+#endif
 
 #include "restructure.h"
 
@@ -180,7 +183,7 @@ void restructure_array(size_t ndims,    /* Dimension count */
          **/
 
         offset_next = index_to_offset(ndims, lengths, index);
-#ifdef DEBUG
+#ifdef _DEBUG
         if (offset_next >= total) {
           printf("Fatal - offset %ld out of bounds!\n", offset_next);
           printf("lengths %lld,%lld,%lld\n",

--- a/Modules/ThirdParty/MINC/src/libminc/libsrc2/hyper.c
+++ b/Modules/ThirdParty/MINC/src/libminc/libsrc2/hyper.c
@@ -12,6 +12,9 @@
 #include <math.h>
 #include <stdlib.h>
 #include <limits.h>
+#ifdef _DEBUG
+#include <stdio.h>
+#endif
 
 #include "minc2.h"
 #include "minc2_private.h"

--- a/Modules/ThirdParty/MINC/src/libminc/volume_io/Volumes/input_mgh.c
+++ b/Modules/ThirdParty/MINC/src/libminc/volume_io/Volumes/input_mgh.c
@@ -16,6 +16,9 @@
 #endif
 #include "znzlib.h"
 #include "errno.h"
+#ifdef DEBUG
+#include <stdio.h>
+#endif
 
 #define NUM_BYTE_VALUES      (UCHAR_MAX + 1)
 

--- a/Modules/ThirdParty/MINC/src/libminc/volume_io/Volumes/input_nifti.c
+++ b/Modules/ThirdParty/MINC/src/libminc/volume_io/Volumes/input_nifti.c
@@ -10,6 +10,9 @@
 
 #include "nifti1.h"
 #include "nifti1_io.h"
+#ifdef DEBUG
+#include <stdio.h>
+#endif
 
 #define NUM_BYTE_VALUES (UCHAR_MAX + 1)
 


### PR DESCRIPTION
- COMP: Remove invalid Emscripten HDF5 link flags
- COMP: Declare H5O__fsinfo_set_version
- COMP: Provide H5CX_set_apl declaration in H5Odeprec.c
- COMP: Provide H5CX_get_ohdr_flags declaration in H5Oint.c
- COMP: Declare H5CX_set_libver_bounds in H5Rint.c
- COMP: Add output redirection for H5Tinit.c, H5lib_settings.c generation
- BUG: Disable Emscripten exception for floating point exceptions
- COMP: Include stdio.h for printf
