### PR TITLE
STYLE: Remove virtual from itkGPUKernelClassMacro, use C++11 `= delete`

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1218,14 +1218,11 @@ compilers.
   kernel                                                                                                               \
   {                                                                                                                    \
   public:                                                                                                              \
+    ITK_DISALLOW_COPY_AND_MOVE(kernel);                                                                                \
+    kernel() = delete;                                                                                                 \
+    ~kernel() = delete;                                                                                                \
     static const char * GetOpenCLSource();                                                                             \
-                                                                                                                       \
-  private:                                                                                                             \
-    kernel();                                                                                                          \
-    virtual ~kernel();                                                                                                 \
-    kernel(const kernel &);                                                                                            \
-    void operator=(const kernel &);                                                                                    \
-  };
+  }
 
 #define itkGetOpenCLSourceFromKernelMacro(kernel)                                                                      \
   static const char * GetOpenCLSource() { return kernel::GetOpenCLSource(); }


### PR DESCRIPTION
Deleted all special member functions of GPU kernel helper classes
defined by `itkGPUKernelClassMacro(kernel)`, by C++11 `= delete`.

Note that construction, destruction, copy, and move were previously
already disabled by declaring their special member functions `private`.
So this adjustment is just a style modernization, not an API change.

Made the destructor non-virtual, to avoid the definition of a virtual
table for these classes.