### PR TITLE
BUG: SetPixelTypeInfo for VARIABLELENGTHVECTOR, ARRAY, VARIABLESIZEMATRIX

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -205,19 +205,12 @@ ImageFileWriter<TInputImage>::Write()
     m_ImageIO->SetMetaDataDictionary(input->GetMetaDataDictionary());
   }
 
-  // Make sure that the image is the right type
-  // confiugure pixel type
+  // Set the pixel and component type; the number of components.
+  m_ImageIO->SetPixelTypeInfo(static_cast<const InputImagePixelType *>(nullptr));
   if (strcmp(input->GetNameOfClass(), "VectorImage") == 0)
   {
-    using VectorImageScalarType = typename InputImageType::InternalPixelType;
-    m_ImageIO->SetPixelTypeInfo(static_cast<const VectorImageScalarType *>(nullptr));
     using AccessorFunctorType = typename InputImageType::AccessorFunctorType;
     m_ImageIO->SetNumberOfComponents(AccessorFunctorType::GetVectorLength(input));
-  }
-  else
-  {
-    // Set the pixel and component type; the number of components.
-    m_ImageIO->SetPixelTypeInfo(static_cast<const InputImagePixelType *>(nullptr));
   }
 
   // Setup the image IO for writing.

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -29,6 +29,8 @@
 #include "itkCovariantVector.h"
 #include "itkSymmetricSecondRankTensor.h"
 #include "itkDiffusionTensor3D.h"
+#include "itkArray.h"
+#include "itkVariableSizeMatrix.h"
 #include "itkImageRegionSplitterBase.h"
 #include "itkCommonEnums.h"
 
@@ -577,6 +579,14 @@ public:
     this->SetPixelType(IOPixelEnum::RGBA);
     this->SetComponentType(MapPixelType<TPixel>::CType);
   }
+  template <unsigned VLength>
+  void
+  SetPixelTypeInfo(const Offset<VLength> *)
+  {
+    this->SetNumberOfComponents(VLength);
+    this->SetPixelType(IOPixelEnum::OFFSET);
+    this->SetComponentType(IOComponentEnum::LONG);
+  }
   template <typename TPixel, unsigned VLength>
   void
   SetPixelTypeInfo(const Vector<TPixel, VLength> *)
@@ -585,13 +595,13 @@ public:
     this->SetPixelType(IOPixelEnum::VECTOR);
     this->SetComponentType(MapPixelType<TPixel>::CType);
   }
-  template <typename TPixel>
+  template <typename TCoordRep, unsigned NPointDimension>
   void
-  SetPixelTypeInfo(const VariableLengthVector<TPixel> *)
+  SetPixelTypeInfo(const Point<TCoordRep, NPointDimension> *)
   {
-    this->SetNumberOfComponents(1);
-    this->SetPixelType(IOPixelEnum::VECTOR);
-    this->SetComponentType(MapPixelType<TPixel>::CType);
+    this->SetNumberOfComponents(NPointDimension);
+    this->SetPixelType(IOPixelEnum::POINT);
+    this->SetComponentType(MapPixelType<TCoordRep>::CType);
   }
   template <typename TPixel, unsigned VLength>
   void
@@ -603,40 +613,20 @@ public:
   }
   template <typename TPixel, unsigned VLength>
   void
-  SetPixelTypeInfo(const FixedArray<TPixel, VLength> *)
-  {
-    this->SetNumberOfComponents(VLength);
-    this->SetPixelType(IOPixelEnum::COVARIANTVECTOR);
-    this->SetComponentType(MapPixelType<TPixel>::CType);
-  }
-
-  template <typename TPixel, unsigned VLength>
-  void
   SetPixelTypeInfo(const SymmetricSecondRankTensor<TPixel, VLength> *)
   {
     this->SetNumberOfComponents(VLength * (VLength + 1) / 2);
     this->SetPixelType(IOPixelEnum::SYMMETRICSECONDRANKTENSOR);
     this->SetComponentType(MapPixelType<TPixel>::CType);
   }
-
   template <typename TPixel>
-  inline void
+  void
   SetPixelTypeInfo(const DiffusionTensor3D<TPixel> *)
   {
     this->SetNumberOfComponents(6);
     this->SetPixelType(IOPixelEnum::DIFFUSIONTENSOR3D);
     this->SetComponentType(MapPixelType<TPixel>::CType);
   }
-
-  template <typename TPixel, unsigned VLength>
-  void
-  SetPixelTypeInfo(const Matrix<TPixel, VLength, VLength> *)
-  {
-    this->SetNumberOfComponents(VLength * VLength);
-    this->SetPixelType(IOPixelEnum::MATRIX);
-    this->SetComponentType(MapPixelType<TPixel>::CType);
-  }
-
   template <typename TPixel>
   void
   SetPixelTypeInfo(const std::complex<TPixel> *)
@@ -645,15 +635,47 @@ public:
     this->SetPixelType(IOPixelEnum::COMPLEX);
     this->SetComponentType(MapPixelType<TPixel>::CType);
   }
-
-  template <unsigned VLength>
+  template <typename TPixel, unsigned VLength>
   void
-  SetPixelTypeInfo(const Offset<VLength> *)
+  SetPixelTypeInfo(const FixedArray<TPixel, VLength> *)
   {
     this->SetNumberOfComponents(VLength);
-    this->SetPixelType(IOPixelEnum::OFFSET);
-    this->SetComponentType(IOComponentEnum::LONG);
+    this->SetPixelType(IOPixelEnum::FIXEDARRAY);
+    this->SetComponentType(MapPixelType<TPixel>::CType);
   }
+  template <typename TPixel>
+  void
+  SetPixelTypeInfo(const VariableLengthVector<TPixel> *)
+  {
+    this->SetNumberOfComponents(1);
+    this->SetPixelType(IOPixelEnum::VARIABLELENGTHVECTOR);
+    this->SetComponentType(MapPixelType<TPixel>::CType);
+  }
+  template <typename TValue>
+  void
+  SetPixelTypeInfo(const Array<TValue> *)
+  {
+    this->SetNumberOfComponents(1);
+    this->SetPixelType(IOPixelEnum::ARRAY);
+    this->SetComponentType(MapPixelType<TValue>::CType);
+  }
+  template <typename TPixel, unsigned VLength>
+  void
+  SetPixelTypeInfo(const Matrix<TPixel, VLength, VLength> *)
+  {
+    this->SetNumberOfComponents(VLength * VLength);
+    this->SetPixelType(IOPixelEnum::MATRIX);
+    this->SetComponentType(MapPixelType<TPixel>::CType);
+  }
+  template <typename TValue>
+  void
+  SetPixelTypeInfo(const VariableSizeMatrix<TValue> *)
+  {
+    this->SetNumberOfComponents(1);
+    this->SetPixelType(IOPixelEnum::VARIABLESIZEMATRIX);
+    this->SetComponentType(MapPixelType<TValue>::CType);
+  }
+
 
 protected:
   ImageIOBase();

--- a/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
@@ -17,6 +17,9 @@
  *=========================================================================*/
 
 #include "itkMetaImageIO.h"
+#include "itkTestingMacros.h"
+#include "itkImage.h"
+#include "itkVectorImage.h"
 
 #include "itkImageIOFactory.h" // required to instantiate an instance of ImageIOBase
 
@@ -259,6 +262,83 @@ itkImageIOBaseTest(int, char *[])
         }
       }
     } // end Test the non-static version of the string <-> type conversions
+  }
+
+  { // Test SetPixelTypeInfo
+    using IOPixelEnum = itk::CommonEnums::IOPixel;
+    using IOComponentEnum = itk::CommonEnums::IOComponent;
+
+    itk::MetaImageIO::Pointer imageIO = itk::MetaImageIO::New();
+
+    imageIO->SetPixelTypeInfo(static_cast<const unsigned char *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 1);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::SCALAR);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::UCHAR);
+
+    imageIO->SetPixelTypeInfo(static_cast<const float *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 1);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::SCALAR);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::FLOAT);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::RGBPixel<unsigned char> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 3);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::RGB);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::UCHAR);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::RGBAPixel<unsigned char> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 4);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::RGBA);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::UCHAR);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::Vector<float, 3> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 3);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::VECTOR);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::FLOAT);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::VariableLengthVector<unsigned char> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 1);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::VARIABLELENGTHVECTOR);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::UCHAR);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::CovariantVector<float, 2> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 2);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::COVARIANTVECTOR);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::FLOAT);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::SymmetricSecondRankTensor<float, 2> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 3);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::SYMMETRICSECONDRANKTENSOR);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::FLOAT);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::DiffusionTensor3D<double> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 6);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::DIFFUSIONTENSOR3D);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::DOUBLE);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::Matrix<float, 2, 2> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 4);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::MATRIX);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::FLOAT);
+
+    imageIO->SetPixelTypeInfo(static_cast<const std::complex<double> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 2);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::COMPLEX);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::DOUBLE);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::Offset<3> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 3);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::OFFSET);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::LONG);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::Array<float> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 1);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::ARRAY);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::FLOAT);
+
+    imageIO->SetPixelTypeInfo(static_cast<const itk::VariableSizeMatrix<double> *>(nullptr));
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetNumberOfComponents(), 1);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetPixelType(), IOPixelEnum::VARIABLESIZEMATRIX);
+    ITK_TEST_EXPECT_EQUAL(imageIO->GetComponentType(), IOComponentEnum::DOUBLE);
   }
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1643,6 +1643,7 @@ NiftiImageIO ::WriteImageInformation()
   {
     case IOPixelEnum::VECTOR: // NOTE: VECTOR is un-rolled by nifti to look like a
                               // multi-dimensional scalar image
+    case IOPixelEnum::VARIABLELENGTHVECTOR:
     case IOPixelEnum::SCALAR:
       break;
     case IOPixelEnum::RGB:


### PR DESCRIPTION
This addresses:

- SetPixelTypeInfo for VariableLengthVector was set to VECTOR instead of VARIABLELENGTHVECTOR
- ImageFileWriter was identifying VariableLengthVector as SCALAR
- ARRAY, VARIABLESIZEMATRIX was missing from SetPixelTypeInfo
