### PR TITLE
COMP: Fix itkGPUKernelClassMacro(kernel) backward compatibility

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1214,7 +1214,14 @@ compilers.
  * Construct a non-templatized helper class that
  * provides the GPU kernel source code as a const char*
  */
-#define itkGPUKernelClassMacro(kernel)                                                                                 \
+#define itkGPUKernelClassMacro(kernel) class itkGPUKernelMacro(kernel)
+
+/**\def itkGPUKernelMacro
+ * Equivalent to the original `itkGPUKernelClassMacro(kernel)` macro, but
+ * then without adding the `class` keyword. Useful when an export specifier
+ * needs to be added between the `class` keyword and the class name.
+ */
+#define itkGPUKernelMacro(kernel)                                                                                      \
   kernel                                                                                                               \
   {                                                                                                                    \
   public:                                                                                                              \

--- a/Modules/Core/GPUCommon/include/itkGPUImageOps.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageOps.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 /** Create a helper GPU Kernel class for GPUImageOps */
-class itkGPUKernelClassMacro(GPUImageOpsKernel);
+itkGPUKernelClassMacro(GPUImageOpsKernel);
 
 /** \class GPUImageOps
  *

--- a/Modules/Core/GPUCommon/include/itkGPUReduction.h
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.h
@@ -26,7 +26,7 @@
 namespace itk
 {
 /** Create a helper GPU Kernel class for GPUReduction */
-class itkGPUKernelClassMacro(GPUReductionKernel);
+itkGPUKernelClassMacro(GPUReductionKernel);
 
 /**
  * \class GPUReduction

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.h
@@ -24,7 +24,7 @@
 namespace itk
 {
 /** Create a helper GPU Kernel class for GPUDenseFiniteDifferenceImageFilter */
-class ITKGPUFiniteDifference_EXPORT itkGPUKernelClassMacro(GPUDenseFiniteDifferenceImageFilterKernel);
+class ITKGPUFiniteDifference_EXPORT itkGPUKernelMacro(GPUDenseFiniteDifferenceImageFilterKernel);
 
 /**
  * \class GPUDenseFiniteDifferenceImageFilter

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.h
@@ -54,7 +54,7 @@ namespace itk
  */
 
 /** Create a helper GPU Kernel class for GPUGradientNDAnisotropicDiffusionFunction */
-class itkGPUKernelClassMacro(GPUGradientNDAnisotropicDiffusionFunctionKernel);
+itkGPUKernelClassMacro(GPUGradientNDAnisotropicDiffusionFunctionKernel);
 
 template <typename TImage>
 class ITK_TEMPLATE_EXPORT GPUGradientNDAnisotropicDiffusionFunction

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.h
@@ -32,7 +32,7 @@ namespace itk
  * */
 
 /** Create a helper GPU Kernel class for GPUScalarAnisotropicDiffusionFunction */
-class itkGPUKernelClassMacro(GPUScalarAnisotropicDiffusionFunctionKernel);
+itkGPUKernelClassMacro(GPUScalarAnisotropicDiffusionFunctionKernel);
 
 template <typename TImage>
 class ITK_TEMPLATE_EXPORT GPUScalarAnisotropicDiffusionFunction : public GPUAnisotropicDiffusionFunction<TImage>

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.h
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.h
@@ -29,7 +29,7 @@ namespace itk
 {
 
 /** Create a helper GPU Kernel class for GPUCastImageFilter */
-class itkGPUKernelClassMacro(GPUCastImageFilterKernel);
+itkGPUKernelClassMacro(GPUCastImageFilterKernel);
 
 /** \class GPUCastImageFilter
  * \brief GPU version of CastImageFilter.

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.h
@@ -41,7 +41,7 @@ namespace itk
  */
 
 /** Create a helper GPU Kernel class for GPUNeighborhoodOperatorImageFilter */
-class itkGPUKernelClassMacro(GPUNeighborhoodOperatorImageFilterKernel);
+itkGPUKernelClassMacro(GPUNeighborhoodOperatorImageFilterKernel);
 
 template <typename TInputImage,
           typename TOutputImage,

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUMeanImageFilter.h
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUMeanImageFilter.h
@@ -37,7 +37,7 @@ namespace itk
  */
 
 /** Create a helper GPU Kernel class for GPUMeanImageFilter */
-class itkGPUKernelClassMacro(GPUMeanImageFilterKernel);
+itkGPUKernelClassMacro(GPUMeanImageFilterKernel);
 
 template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT GPUMeanImageFilter

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
@@ -85,7 +85,7 @@ private:
 } // end of namespace Functor
 
 /** Create a helper GPU Kernel class for GPUBinaryThresholdImageFilter */
-class itkGPUKernelClassMacro(GPUBinaryThresholdImageFilterKernel);
+itkGPUKernelClassMacro(GPUBinaryThresholdImageFilterKernel);
 
 /**
  * \class GPUBinaryThresholdImageFilter

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -51,7 +51,7 @@ namespace itk
  * \ingroup ITKGPUPDEDeformableRegistration
  */
 /** Create a helper GPU Kernel class for GPUDemonsRegistrationFunction */
-class itkGPUKernelClassMacro(GPUDemonsRegistrationFunctionKernel);
+itkGPUKernelClassMacro(GPUDemonsRegistrationFunctionKernel);
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 class ITK_TEMPLATE_EXPORT GPUDemonsRegistrationFunction

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.h
@@ -73,7 +73,7 @@ namespace itk
  */
 
 /** Create a helper GPU Kernel class for GPUPDEDeformableRegistrationFilter */
-class itkGPUKernelClassMacro(GPUPDEDeformableRegistrationFilterKernel);
+itkGPUKernelClassMacro(GPUPDEDeformableRegistrationFilterKernel);
 
 template <typename TFixedImage,
           typename TMovingImage,


### PR DESCRIPTION
Backward compatibility with ITK 5.0 and ITK 5.1 client code (including
SuperElastix/elastix) appears broken by the removal of the C++ `class`
keyword from the definition of `itkGPUKernelClassMacro(kernel)`, with
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/1814
commit 518349019984699b8d35a953bf4fc8a4324897fa

This commit restores the backward compatibility, and adds an extra
macro, `itkGPUKernelMacro(kernel)`, which defines the kernel without
`class` keyword.