### PR TITLE
BUG: Fix `itkMultiphaseSparseFiniteDifferenceImageFilterTest`

### DIFF
--- a/Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterTest.cxx
@@ -105,8 +105,12 @@ itkMultiphaseSparseFiniteDifferenceImageFilterTest(int, char *[])
 
   FilterType::Pointer filter = FilterType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(
-    filter, MultiphaseSparseFiniteDifferenceImageFilterTestHelper, MultiphaseFiniteDifferenceImageFilter);
+  // Instantiate the filter of interest to exercise its basic object methods
+  typename FilterType::Superclass::Pointer multiphaseSparseFiniteDiffFilter = FilterType::Superclass::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(multiphaseSparseFiniteDiffFilter,
+                                    MultiphaseSparseFiniteDifferenceImageFilter,
+                                    MultiphaseFiniteDifferenceImageFilter);
 
 
   // Exercise the class Set/Get methods to increase coverage
@@ -122,13 +126,6 @@ itkMultiphaseSparseFiniteDifferenceImageFilterTest(int, char *[])
 
   bool interpolateSurfaceLocation = true;
   ITK_TEST_SET_GET_BOOLEAN(filter, InterpolateSurfaceLocation, interpolateSurfaceLocation);
-
-  ValueType valueZero = itk::NumericTraits<ValueType>::ZeroValue();
-  ITK_TEST_SET_GET_VALUE(valueZero, filter->GetValueZero());
-
-  ValueType valueOne = itk::NumericTraits<ValueType>::OneValue();
-
-  ITK_TEST_SET_GET_VALUE(valueOne, filter->GetValueOne());
 
 
   std::cout << "Test finished." << std::endl;


### PR DESCRIPTION
Fix `itkMultiphaseSparseFiniteDifferenceImageFilterTest`:
- Use the appropriate class instance to exercise basic object methods.
- Remove calls to protected methods.

Fixes:
```
Modules/Core/TestKernel/include/itkTestingMacros.h:69:63: error:
'itk::MultiphaseSparseFiniteDifferenceImageFilterTestHelper<itk::Image<double,
3>, itk::Image<float, 3>, itk::Image<unsigned char, 3>,
itk::ScalarChanAndVeseLevelSetFunction<itk::Image<double, 3>,
itk::Image<float, 3>,
itk::ConstrainedRegionBasedLevelSetFunctionSharedData<itk::Image<double,
3>, itk::Image<float, 3>,
itk::ScalarChanAndVeseLevelSetFunctionData<itk::Image<double, 3>,
itk::Image<float, 3> > > >, long unsigned int>::Superclass {aka
itk::MultiphaseSparseFiniteDifferenceImageFilter<itk::Image<double,
3>, itk::Image<float, 3>, itk::Image<unsigned char, 3>,
itk::ScalarChanAndVeseLevelSetFunction<itk::Image<double, 3>,
itk::Image<float, 3>,
itk::ConstrainedRegionBasedLevelSetFunctionSharedData<itk::Image<double,
3>, itk::Image<float, 3>,
itk::ScalarChanAndVeseLevelSetFunctionData<itk::Image<double, 3>,
itk::Image<float, 3> > > >, unsigned int>}' is not a base of
'itk::SmartPointer<itk::MultiphaseSparseFiniteDifferenceImageFilterTestHelper<itk::Image<double,
3>, itk::Image<float, 3>, itk::Image<unsigned char, 3>,
itk::ScalarChanAndVeseLevelSetFunction<itk::Image<double, 3>,
itk::Image<float, 3>,
itk::ConstrainedRegionBasedLevelSetFunctionSharedData<itk::Image<double,
3>, itk::Image<float, 3>,
itk::ScalarChanAndVeseLevelSetFunctionData<itk::Image<double, 3>,
itk::Image<float, 3> > > >, long unsigned int> >::ObjectType {aka
itk::MultiphaseSparseFiniteDifferenceImageFilterTestHelper<itk::Image<double,
3>, itk::Image<float, 3>, itk::Image<unsigned char, 3>,
itk::ScalarChanAndVeseLevelSetFunction<itk::Image<double, 3>,
itk::Image<float, 3>,
itk::ConstrainedRegionBasedLevelSetFunctionSharedData<itk::Image<double,
3>, itk::Image<float, 3>,
itk::ScalarChanAndVeseLevelSetFunctionData<itk::Image<double, 3>,
itk::Image<float, 3> > > >, long unsigned int>}'
```

and
```
Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterTest.cxx:127:58:
error: 'itk::MultiphaseSparseFiniteDifferenceImageFilter<TInputImage,
TFeatureImage, TOutputImage, TFunction, TIdCell>::ValueType
itk::MultiphaseSparseFiniteDifferenceImageFilter<TInputImage,
TFeatureImage, TOutputImage, TFunction, TIdCell>::GetValueZero() const
[with TInputImage = itk::Image<double, 3>; TFeatureImage =
itk::Image<float, 3>; TOutputImage = itk::Image<unsigned char, 3>;
TFunction = itk::ScalarChanAndVeseLevelSetFunction<itk::Image<double, 3>,
itk::Image<float, 3>,
itk::ConstrainedRegionBasedLevelSetFunctionSharedData<itk::Image<double,
3>, itk::Image<float, 3>,
itk::ScalarChanAndVeseLevelSetFunctionData<itk::Image<double, 3>,
itk::Image<float, 3> > > >; TIdCell = long unsigned int;
itk::MultiphaseSparseFiniteDifferenceImageFilter<TInputImage,
TFeatureImage, TOutputImage, TFunction, TIdCell>::ValueType = double]' is
protected within this context
```

and
```
Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterTest.cxx:131:56:
error: 'itk::MultiphaseSparseFiniteDifferenceImageFilter<TInputImage,
TFeatureImage, TOutputImage, TFunction, TIdCell>::ValueType
itk::MultiphaseSparseFiniteDifferenceImageFilter<TInputImage,
TFeatureImage, TOutputImage, TFunction, TIdCell>::GetValueOne() const
[with TInputImage = itk::Image<double, 3>; TFeatureImage =
itk::Image<float, 3>; TOutputImage = itk::Image<unsigned char, 3>;
TFunction = itk::ScalarChanAndVeseLevelSetFunction<itk::Image<double, 3>,
itk::Image<float, 3>,
itk::ConstrainedRegionBasedLevelSetFunctionSharedData<itk::Image<double,
3>, itk::Image<float, 3>,
itk::ScalarChanAndVeseLevelSetFunctionData<itk::Image<double, 3>,
itk::Image<float, 3> > > >; TIdCell = long unsigned int;
itk::MultiphaseSparseFiniteDifferenceImageFilter<TInputImage,
TFeatureImage, TOutputImage, TFunction, TIdCell>::ValueType = double]' is
protected within this context
```

signaled at:
https://open.cdash.org/viewBuildError.php?buildid=7065228

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)