### PR TITLE
BUG: Fix uninitialized variable use in `ANTS` neighborhood correlation metric

### DIFF
--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -483,8 +483,14 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
     scanMem.sFixedFixed = sFixedFixed;
     scanMem.sMovingMoving = sMovingMoving;
 
-    scanMem.fixedImageGradient = fixedImageGradient;
-    scanMem.movingImageGradient = movingImageGradient;
+    if (this->m_ANTSAssociate->GetComputeDerivative() && this->m_ANTSAssociate->GetGradientSourceIncludesFixed())
+    {
+      scanMem.fixedImageGradient = fixedImageGradient;
+    }
+    if (this->m_ANTSAssociate->GetComputeDerivative() && this->m_ANTSAssociate->GetGradientSourceIncludesMoving())
+    {
+      scanMem.movingImageGradient = movingImageGradient;
+    }
 
     scanMem.mappedFixedPoint = mappedFixedPoint;
     scanMem.mappedMovingPoint = mappedMovingPoint;


### PR DESCRIPTION
Fix uninitialized variable use in `ANTS` neighborhood correlation metric:
ensure that `fixedImageGradient` and `movingImageGradient` have valid
values before assigning them to the `scanMem` struct that scans over
images.

Fixes:
```
Run-Time Check Failure #3 - The variable 'fixedImageGradient' is being
used without being initialized.
```

The bug was affecting a number of tests in the
`ITKRegistrationMethodsv4Test` module.

Signaled at
https://open.cdash.org/viewTest.php?onlyfailed&buildid=7067466
and
https://open.cdash.org/viewTest.php?onlyfailed&buildid=7069241

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)