### PR TITLE
BUG: Initialize member variables

### DIFF
--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -30,7 +30,6 @@ namespace itk
 {
 template <typename TInputImage1, typename TInputImage2>
 DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::DirectedHausdorffDistanceImageFilter()
-  : m_MaxDistance(1)
 {
   // this filter requires two input images
   this->SetNumberOfRequiredInputs(2);

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -202,7 +202,7 @@ private:
 
   VectorOfDoubleType m_EigenVectorNormalizedEnergy;
 
-  ImageSizeType m_InputImageSize;
+  ImageSizeType m_InputImageSize{ {} };
 
   unsigned int m_NumberOfPixels{ 0 };
 

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
@@ -541,8 +541,8 @@ protected:
 private:
   unsigned int m_CurrentFunctionIndex;
 
-  double       m_RMSSum;
-  unsigned int m_RMSCounter;
+  double       m_RMSSum{ 0. };
+  unsigned int m_RMSCounter{ 0 };
 
   /** This flag is true when methods need to check boundary conditions and
       false when methods do not need to check for boundary conditions. */


### PR DESCRIPTION
Initialize member variables.

Fixes:
```
UMC ==4407== Conditional jump or move depends on uninitialised value(s)
==4407==    at 0xC3A9316:
double_conversion::DoubleToStringConverter::ToShortestIeeeNumber(double,
double_conversion::StringBuilder*,
double_conversion::DoubleToStringConverter::DtoaMode) const
(double-to-string.cc:172)
==4407==    by 0x6835CE6:
double_conversion::DoubleToStringConverter::ToShortest(double,
double_conversion::StringBuilder*) const (double-to-string.h:166)
==4407==    by 0x68354F6: (anonymous
namespace)::ConvertToShortest(double_conversion::DoubleToStringConverter
const&, double, double_conversion::StringBuilder&)
(itkNumberToString.cxx:31)
==4407==    by 0x68355F8: std::string (anonymous
namespace)::FloatingPointNumberToString(double) (itkNumberToString.cxx:55)
==4407==    by 0x683555B: itk::NumberToString::operator()(double) const
(itkNumberToString.cxx:71)
==4407==    by 0x6834EC5: std::ostream& itk::operator<< (std::ostream&,
itk::Array const&) (itkArrayOutputSpecialization.cxx:37)
==4407==    by 0x250C46: itk::DirectedHausdorffDistanceImageFilter,
itk::Image >::PrintSelf(std::ostream&, itk::Indent) const
(itkDirectedHausdorffDistanceImageFilter.hxx:222)
==4407==    by 0x67FBB8D: itk::LightObject::Print(std::ostream&,
itk::Indent) const (itkLightObject.cxx:125)
==4407==    by 0x24E25F: itkDirectedHausdorffDistanceImageFilterTest(int,
char**) (itkDirectedHausdorffDistanceImageFilterTest.cxx:60)
==4407==    by 0x1D634B: main (ITKDistanceMapTestDriver.cxx:217)
```

and
```
UMC ==5645== Conditional jump or move depends on uninitialised value(s)
==5645==    at 0x927FDB0: std::ostreambuf_iterator > std::num_put >
>::_M_insert_int(std::ostreambuf_iterator >, std::ios_base&, char,
>unsigned long) const (in /usr/lib64/libstdc++.so.6.0.19)
==5645==    by 0x928004C: std::num_put >
>::do_put(std::ostreambuf_iterator >, std::ios_base&, char, unsigned long)
>const (in /usr/lib64/libstdc++.so.6.0.19)
==5645==    by 0x928C2ED: std::ostream& std::ostream::_M_insert(unsigned
long) (in /usr/lib64/libstdc++.so.6.0.19)
==5645==    by 0x24F2B6: std::ostream& itk::operator<< <2u>(std::ostream&,
itk::Size<2u> const&) (itkSize.h:412)
==5645==    by 0x2C6068: itk::ImagePCAShapeModelEstimator, itk::Image
>::PrintSelf(std::ostream&, itk::Indent) const
>(itkImagePCAShapeModelEstimator.hxx:52)
==5645==    by 0x6DBFB8D: itk::LightObject::Print(std::ostream&,
itk::Indent) const (itkLightObject.cxx:125)
==5645==    by 0x2C2F09: itkImagePCAShapeModelEstimatorTest(int, char**)
(itkImagePCAShapeModelEstimatorTest.cxx:141)
==5645==    by 0x20DA6B: main (ITKImageStatisticsTestDriver.cxx:272)
```

and
```
UMC ==6426== Conditional jump or move depends on uninitialised value(s)
==6426==    at 0x10E3942C: __printf_fp_l (in /usr/lib64/libc-2.17.so)
==6426==    by 0x10E38526: vfprintf (in /usr/lib64/libc-2.17.so)
==6426==    by 0x10E63178: vsnprintf (in /usr/lib64/libc-2.17.so)
==6426==    by 0x1095263C: ??? (in /usr/lib64/libstdc++.so.6.0.19)
==6426==    by 0x10958CA3: std::ostreambuf_iterator > std::num_put >
>::_M_insert_float(std::ostreambuf_iterator >, std::ios_base&, char, char,
>double) const (in /usr/lib64/libstdc++.so.6.0.19)
==6426==    by 0x10958F8F: std::num_put >
>::do_put(std::ostreambuf_iterator >, std::ios_base&, char, double) const
>(in /usr/lib64/libstdc++.so.6.0.19)
==6426==    by 0x10964B94: std::ostream& std::ostream::_M_insert(double)
(in /usr/lib64/libstdc++.so.6.0.19)
==6426==    by 0x738573: itk::MultiphaseSparseFiniteDifferenceImageFilter,
itk::Image, itk::Image, itk::ScalarChanAndVeseLevelSetFunction,
itk::Image, itk::ConstrainedRegionBasedLevelSetFunctionSharedData,
itk::Image, itk::ScalarChanAndVeseLevelSetFunctionData, itk::Image > > >,
unsigned int>::PrintSelf(std::ostream&, itk::Indent) const
(itkMultiphaseSparseFiniteDifferenceImageFilter.hxx:1421)
==6426==    by 0xE497B8D: itk::LightObject::Print(std::ostream&,
itk::Indent) const (itkLightObject.cxx:125)
==6426==    by 0x736F6D:
itkScalarChanAndVeseSparseLevelSetImageFilterTest1(int, char**)
(itkScalarChanAndVeseSparseLevelSetImageFilterTest1.cxx:54)
==6426==    by 0x331ADE: main (ITKReviewTestDriver.cxx:327)

UMC ==6426== Conditional jump or move depends on uninitialised value(s)
==6426==    at 0x10957DB0: std::ostreambuf_iterator > std::num_put >
>::_M_insert_int(std::ostreambuf_iterator >, std::ios_base&, char,
>unsigned long) const (in /usr/lib64/libstdc++.so.6.0.19)
==6426==    by 0x1095804C: std::num_put >
>::do_put(std::ostreambuf_iterator >, std::ios_base&, char, unsigned long)
>const (in /usr/lib64/libstdc++.so.6.0.19)
==6426==    by 0x109642ED: std::ostream& std::ostream::_M_insert(unsigned
long) (in /usr/lib64/libstdc++.so.6.0.19)
==6426==    by 0x7385BB: itk::MultiphaseSparseFiniteDifferenceImageFilter,
itk::Image, itk::Image, itk::ScalarChanAndVeseLevelSetFunction,
itk::Image, itk::ConstrainedRegionBasedLevelSetFunctionSharedData,
itk::Image, itk::ScalarChanAndVeseLevelSetFunctionData, itk::Image > > >,
unsigned int>::PrintSelf(std::ostream&, itk::Indent) const
(itkMultiphaseSparseFiniteDifferenceImageFilter.hxx:1422)
==6426==    by 0xE497B8D: itk::LightObject::Print(std::ostream&,
itk::Indent) const (itkLightObject.cxx:125)
==6426==    by 0x736F6D:
itkScalarChanAndVeseSparseLevelSetImageFilterTest1(int, char**)
(itkScalarChanAndVeseSparseLevelSetImageFilterTest1.cxx:54)
==6426==    by 0x331ADE: main (ITKReviewTestDriver.cxx:327
```
signaled at:
https://open.cdash.org/viewDynamicAnalysis.php?buildid=7070588

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)