### PR TITLE
STYLE: Remove dynamic_cast and GetPointer() from LightObject::Clone()

### DIFF
--- a/Modules/Core/Common/include/itkLightObject.h
+++ b/Modules/Core/Common/include/itkLightObject.h
@@ -78,7 +78,12 @@ public:
   virtual Pointer
   CreateAnother() const;
 
-  itkCloneMacro(Self);
+  /** Creates and returns a clone of this object. */
+  Pointer
+  Clone() const
+  {
+    return this->InternalClone();
+  }
 
   /** Delete an itk object.  This method should always be used to delete an
    * object when the new operator was used to create it. Using the C


### PR DESCRIPTION
Simplified the `LightObject::Clone()` implementation. The original
version did return `dynamic_cast<x*>(this->InternalClone().GetPointer())`,
as implemented by `itkCloneMacro(x)`. Obviously when `x` = `LightObject`,
the `dynamic_cast` and the `GetPointer()` call are unnecessary.