### PR TITLE
COMP: Migrate ITKVtkGlue library configuration to itk-module-init.cmake

### DIFF
--- a/Modules/Bridge/VtkGlue/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/CMakeLists.txt
@@ -3,23 +3,6 @@ if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
   set(ITKVtkGlue_LIBRARIES ITKVtkGlue)
 endif()
 
-if(NOT COMMAND vtk_module_config)
-  macro(vtk_module_config ns)
-     foreach(arg ${ARGN})
-      if(${arg} MATCHES "^[Vv][Tt][Kk]")
-        string(REGEX REPLACE "^[Vv][Tt][Kk]" "" _arg ${arg})
-      else()
-        set(_arg ${arg})
-      endif()
-      set(${ns}_LIBRARIES ${${ns}_LIBRARIES} VTK::${_arg})
-     endforeach()
-  endmacro()
-
-  if(NOT VTK_RENDERING_BACKEND)
-    set(VTK_RENDERING_BACKEND OpenGL2)
-  endif()
-endif()
-
 #
 # Add the third party includes and libraries
 #
@@ -30,55 +13,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VTK_REQUIRED_CXX_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${VTK_REQUIRED_EXE_LINKER_FLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${VTK_REQUIRED_SHARED_LINKER_FLAGS}")
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${VTK_REQUIRED_MODULE_LINKER_FLAGS}")
-
-# Older versions of VTK (VTK 5.5 for example) do not have VTK_VERSION, in this
-# case it needs to be defined manually
-if(NOT VTK_VERSION)
-  set(VTK_VERSION "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}.${VTK_BUILD_VERSION}")
-endif()
-if(NOT VTK_RENDERING_BACKEND)
-  if(NOT COMMAND vtk_module_config)
-    set(VTK_RENDERING_BACKEND OpenGL2)
-  else()
-    set(VTK_RENDERING_BACKEND OpenGL)
-  endif()
-endif()
-set(_target_prefix "vtk")
-if(VTK_VERSION VERSION_GREATER_EQUAL 8.90.0)
-  set(_target_prefix "VTK::")
-endif()
-set(_target_freetypeopengl)
-if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
-  set(_target_freetypeopengl ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
-endif()
-
-set(_required_vtk_libraries
-  ${_target_prefix}IOImage
-  ${_target_prefix}ImagingSources
-  )
-if(ITK_WRAP_PYTHON)
-  list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore)
-endif()
-if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
-  list(APPEND _required_vtk_libraries
-    ${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
-    ${_target_prefix}RenderingFreeType
-    ${_target_freetypeopengl}
-    ${_target_prefix}InteractionStyle
-    ${_target_prefix}InteractionWidgets
-  )
-endif()
-if (${VTK_VERSION} VERSION_LESS ${VERSION_MIN})
-  message(ERROR " VtkGlue requires VTK version ${VERSION_MIN} or newer but the current version is ${VTK_VERSION}")
-elseif( ${VTK_VERSION} VERSION_LESS 6.0.0 )
-  set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
-  set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
-else()
-  vtk_module_config(ITKVtkGlue_VTK
-    ${_required_vtk_libraries}
-    )
-  set(ITKVtkGlue_VTK_LIBRARIES ${_required_vtk_libraries})
-endif()
 
 # The VTK DICOMParser and vtkmetaio includes conflict with the ITK
 # versions. Here we remove them from the include directories.

--- a/Modules/Bridge/VtkGlue/itk-module-init.cmake
+++ b/Modules/Bridge/VtkGlue/itk-module-init.cmake
@@ -7,3 +7,69 @@ set(VERSION_MIN "5.10.0")
 
 # Look for VTK
 find_package(VTK NO_MODULE REQUIRED)
+
+if(NOT COMMAND vtk_module_config)
+  macro(vtk_module_config ns)
+     foreach(arg ${ARGN})
+      if(${arg} MATCHES "^[Vv][Tt][Kk]")
+        string(REGEX REPLACE "^[Vv][Tt][Kk]" "" _arg ${arg})
+      else()
+        set(_arg ${arg})
+      endif()
+      set(${ns}_LIBRARIES ${${ns}_LIBRARIES} VTK::${_arg})
+     endforeach()
+  endmacro()
+
+  if(NOT VTK_RENDERING_BACKEND)
+    set(VTK_RENDERING_BACKEND OpenGL2)
+  endif()
+endif()
+
+# Older versions of VTK (VTK 5.5 for example) do not have VTK_VERSION, in this
+# case it needs to be defined manually
+if(NOT VTK_VERSION)
+  set(VTK_VERSION "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}.${VTK_BUILD_VERSION}")
+endif()
+if(NOT VTK_RENDERING_BACKEND)
+  if(NOT COMMAND vtk_module_config)
+    set(VTK_RENDERING_BACKEND OpenGL2)
+  else()
+    set(VTK_RENDERING_BACKEND OpenGL)
+  endif()
+endif()
+set(_target_prefix "vtk")
+if(VTK_VERSION VERSION_GREATER_EQUAL 8.90.0)
+  set(_target_prefix "VTK::")
+endif()
+set(_target_freetypeopengl)
+if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+  set(_target_freetypeopengl ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+endif()
+
+set(_required_vtk_libraries
+  ${_target_prefix}IOImage
+  ${_target_prefix}ImagingSources
+  )
+if(ITK_WRAP_PYTHON)
+  list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore)
+endif()
+if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
+  list(APPEND _required_vtk_libraries
+    ${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
+    ${_target_prefix}RenderingFreeType
+    ${_target_freetypeopengl}
+    ${_target_prefix}InteractionStyle
+    ${_target_prefix}InteractionWidgets
+  )
+endif()
+if (${VTK_VERSION} VERSION_LESS ${VERSION_MIN})
+  message(ERROR " VtkGlue requires VTK version ${VERSION_MIN} or newer but the current version is ${VTK_VERSION}")
+elseif( ${VTK_VERSION} VERSION_LESS 6.0.0 )
+  set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
+  set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
+else()
+  vtk_module_config(ITKVtkGlue_VTK
+    ${_required_vtk_libraries}
+    )
+  set(ITKVtkGlue_VTK_LIBRARIES ${_required_vtk_libraries})
+endif()

--- a/Modules/Bridge/VtkGlue/itk-module-init.cmake
+++ b/Modules/Bridge/VtkGlue/itk-module-init.cmake
@@ -51,7 +51,8 @@ set(_required_vtk_libraries
   ${_target_prefix}ImagingSources
   )
 if(ITK_WRAP_PYTHON)
-  list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore)
+  list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore
+    ${_target_prefix}CommonCore ${_target_prefix}CommonDataModel ${_target_prefix}kwiml ${_target_prefix}CommonExecutionModel)
 endif()
 if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
   list(APPEND _required_vtk_libraries

--- a/Modules/Bridge/VtkGlue/test/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/test/CMakeLists.txt
@@ -22,7 +22,7 @@ CreateTestDriver(ITKVtkGlue "${ITKVtkGlue-Test_LIBRARIES}" "${ITKVtkGlueTests}")
 if(VTK_VERSION VERSION_GREATER_EQUAL "8.90.0")
   vtk_module_autoinit(
     TARGETS ITKVtkGlueTestDriver
-  MODULES ${VTK_LIBRARIES})
+  MODULES ${_required_vtk_libraries})
 endif()
 
 itk_add_test(

--- a/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Forward include directories to CastXML
+if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
+  foreach(_vtk_lib IN LISTS ITKVtkGlue_VTK_LIBRARIES)
+    get_target_property(_vtk_lib_include_dirs ${_vtk_lib} INTERFACE_INCLUDE_DIRECTORIES)
+    include_directories(${_vtk_lib_include_dirs})
+  endforeach()
+endif()
+
 itk_wrap_module(ITKVtkGlue)
   if("${VTK_VERSION}" VERSION_LESS 7.0.0)
     message(WARNING


### PR DESCRIPTION
This enables specifying only the required modules in
test/CMakeLists.txt.

To address #2333
