### PR TITLE
ENH: xarray_from_image .attr, image_from_xarray MetaDataDictionary support

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -435,6 +435,7 @@ try:
     sine = np.sin(theta)
     rotation = np.array(((cosine, -sine), (sine, cosine)))
     image.SetDirection(rotation)
+    image["MyMeta"] = 4.0
 
     data_array = itk.xarray_from_image(image)
     assert data_array.dims[0] == "y"
@@ -454,6 +455,7 @@ try:
     assert data_array.attrs["direction"][0, 1] == sine
     assert data_array.attrs["direction"][1, 0] == -sine
     assert data_array.attrs["direction"][1, 1] == cosine
+    assert data_array.attrs["MyMeta"] == 4.0
 
     round_trip = itk.image_from_xarray(data_array)
     assert np.array_equal(itk.array_from_image(round_trip), itk.array_from_image(image))
@@ -468,6 +470,7 @@ try:
     assert np.isclose(direction(0, 1), -sine)
     assert np.isclose(direction(1, 0), sine)
     assert np.isclose(direction(1, 1), cosine)
+    assert round_trip["MyMeta"] == 4.0
 
     wrong_order = data_array.swap_dims({"y": "z"})
     try:

--- a/Wrapping/Generators/Python/itk/support/itkExtras.py
+++ b/Wrapping/Generators/Python/itk/support/itkExtras.py
@@ -448,8 +448,15 @@ def xarray_from_image(l_image):
         dims.append("c")
         coords["c"] = np.arange(components, dtype=np.uint32)
 
+    direction = np.flip(itk.array_from_matrix(l_image.GetDirection()))
+    attrs = {"direction": direction}
+    metadata = dict(l_image)
+    ignore_keys = set(['direction', 'origin', 'spacing'])
+    for key in metadata:
+        if not key in ignore_keys:
+            attrs[key] = metadata[key]
     data_array = xr.DataArray(
-        array_view, dims=dims, coords=coords, attrs={"direction": direction}
+        array_view, dims=dims, coords=coords, attrs=attrs
     )
     return data_array
 
@@ -498,6 +505,10 @@ def image_from_xarray(data_array):
     if "direction" in data_array.attrs:
         direction = data_array.attrs["direction"]
         itk_image.SetDirection(np.flip(direction))
+    ignore_keys = set(['direction', 'origin', 'spacing'])
+    for key in data_array.attrs:
+        if not key in ignore_keys:
+            itk_image[key] = data_array.attrs[key]
 
     return itk_image
 


### PR DESCRIPTION
Metadata is mapped to / from the itk.Image MetaDataDictionary and the
xarray.DataArray attrs. Exclude origin, spacing, direction as
appropriate because they are handled specially in itk and xarray.
