### PR TITLE
STYLE: Remove 6 no-op dynamic_casts (casting T* to T*) from Modules/Core

### DIFF
--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -91,7 +91,7 @@ ProcessObject::MakeOutput(const DataObjectIdentifierType & name)
     return this->MakeOutput(this->MakeIndexFromOutputName(name));
   }
 
-  return itkDynamicCastInDebugMode<DataObject *>(DataObject::New().GetPointer());
+  return DataObject::New().GetPointer();
 }
 
 

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -41,7 +41,7 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CopyInputToOutput()
   // Check if we are doing in-place filtering
   if (this->GetInPlace() && this->CanRunInPlace())
   {
-    typename TInputImage::Pointer tempPtr = dynamic_cast<TInputImage *>(output.GetPointer());
+    typename TInputImage::Pointer tempPtr = output.GetPointer();
     if (tempPtr && tempPtr->GetPixelContainer() == input->GetPixelContainer())
     {
       // the input and output container are the same - no need to copy

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -1128,7 +1128,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::FindEdge(const PointIdentifier & pid0
     {
       if (it.Value()->GetDestination() == pid1)
       {
-        return (dynamic_cast<QEPrimal *>(it.Value()));
+        return it.Value();
       }
       ++it;
     }

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -421,7 +421,7 @@ CompositeTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse
   inverse->ClearTransformQueue();
   for (it = this->m_TransformQueue.begin(); it != this->m_TransformQueue.end(); ++it)
   {
-    TransformTypePointer inverseTransform = dynamic_cast<TransformType *>(((*it)->GetInverseTransform()).GetPointer());
+    TransformTypePointer inverseTransform = ((*it)->GetInverseTransform()).GetPointer();
     if (!inverseTransform)
     {
       inverse->ClearTransformQueue();

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -333,7 +333,7 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetInverse(Se
   inverse->ClearTransformQueue();
   for (it = this->m_TransformQueue.begin(); it != this->m_TransformQueue.end(); ++it)
   {
-    TransformTypePointer inverseTransform = dynamic_cast<TransformType *>(((*it)->GetInverseTransform()).GetPointer());
+    TransformTypePointer inverseTransform = ((*it)->GetInverseTransform()).GetPointer();
     if (!inverseTransform)
     {
       inverse->ClearTransformQueue();

--- a/Modules/Core/Transform/test/itkTransformCloneTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformCloneTest.cxx
@@ -100,8 +100,7 @@ itkTransformCloneTest(int, char *[])
   compositeXfrm->AddTransform(clonePtr);
   compositeXfrm->SetOnlyMostRecentTransformToOptimizeOn();
 
-  CompositeTransformType::Pointer cloneCompositeXfrm =
-    dynamic_cast<CompositeTransformType *>(compositeXfrm->Clone().GetPointer());
+  CompositeTransformType::Pointer cloneCompositeXfrm = compositeXfrm->Clone().GetPointer();
 
   if ((compositeXfrm->GetNumberOfTransforms() != cloneCompositeXfrm->GetNumberOfTransforms()))
   {


### PR DESCRIPTION
Removed six "no-op" dynamic_casts that just cast pointers to their own compile-time type from Modules/Core.