### PR TITLE
STYLE: Avoid "no-op" dynamic_cast from inside LightObject::New()

### DIFF
--- a/Modules/Core/Common/src/itkLightObject.cxx
+++ b/Modules/Core/Common/src/itkLightObject.cxx
@@ -16,7 +16,7 @@
  *
  *=========================================================================*/
 #include "itkLightObject.h"
-#include "itkObjectFactory.h"
+#include "itkObjectFactoryBase.h"
 #include <mutex>
 
 // Better name demanging for gcc
@@ -47,7 +47,7 @@ LightObject::Pointer
 LightObject::New()
 {
   Pointer       smartPtr;
-  LightObject * rawPtr = ::itk::ObjectFactory<LightObject>::Create();
+  LightObject * rawPtr = ObjectFactoryBase::CreateInstance(typeid(LightObject).name());
 
   if (rawPtr == nullptr)
   {


### PR DESCRIPTION
`LightObject::New()` did call `ObjectFactory<LightObject>::Create()`,
which would do a `dynamic_cast` from `LightObject*` to `LightObject*`
on the result of `ObjectFactoryBase::CreateInstance`.

With this commit, such a "no-op" cast is avoided, by calling
`ObjectFactoryBase::CreateInstance` directly.