### PR TITLE
STYLE: Remove 9 no-op dynamic_casts (casting T* to T*)

### DIFF
--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
@@ -54,7 +54,7 @@ UnaryGeneratorImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation(
   // this filter allows the input the output to be of different dimensions
 
   // get pointers to the input and output
-  auto *                 outputPtr = dynamic_cast<OutputImageType *>(this->GetOutput());
+  OutputImageType *      outputPtr = this->GetOutput();
   const InputImageType * inputPtr = this->GetInput();
 
   if (!outputPtr || !inputPtr)

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -200,8 +200,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>                        bC;
   RadiusType                                                                                      r1;
   r1.Fill(1);
-  faceList =
-    bC(dynamic_cast<const RealVectorImageType *>(m_RealValuedInputImage.GetPointer()), outputRegionForThread, r1);
+  faceList = bC(m_RealValuedInputImage.GetPointer(), outputRegionForThread, r1);
 
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>::FaceListType::iterator fit;
   fit = faceList.begin();
@@ -213,8 +212,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
   // conditions.
   for (fit = faceList.begin(); fit != faceList.end(); ++fit)
   {
-    bit = ConstNeighborhoodIteratorType(
-      r1, dynamic_cast<const RealVectorImageType *>(m_RealValuedInputImage.GetPointer()), *fit);
+    bit = ConstNeighborhoodIteratorType(r1, m_RealValuedInputImage.GetPointer(), *fit);
     it = ImageRegionIterator<TOutputImage>(this->GetOutput(), *fit);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();

--- a/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
@@ -70,7 +70,7 @@ InPlaceLabelMapFilter<TInputImage>::AllocateOutputs()
     // Graft this first input to the output.  Later, we'll need to
     // remove the input's hold on the bulk data.
     //
-    OutputImagePointer inputAsOutput = dynamic_cast<TOutputImage *>(const_cast<TInputImage *>(this->GetInput()));
+    OutputImagePointer inputAsOutput = const_cast<TInputImage *>(this->GetInput());
 
     if (inputAsOutput)
     {

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -310,7 +310,7 @@ AddToTransformList(typename TInputTransformType::ConstPointer &             tran
     for (; it != inputTransformList.end(); ++it)
     {
       // get the input sub transform
-      const auto * inSub = dynamic_cast<const InputTransformType *>((*it).GetPointer());
+      const InputTransformType * const inSub = it->GetPointer();
       // convert each sub transform and push them to the output transform list
       std::string            inSubName = inSub->GetTransformTypeAsString();
       OutputTransformPointer convertedSub = IOhelper::CreateNewTypeTransform(inSubName);

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -271,8 +271,7 @@ itkMetricImageGradientTestRunTest(unsigned int                 imageSize,
   //  typename TTransform::InverseTransformBasePointer
   //      movingTransform = transform->GetInverseTransform();
 
-  typename TTransform::Pointer movingTransform =
-    dynamic_cast<TTransform *>(transform->GetInverseTransform().GetPointer());
+  typename TTransform::Pointer movingTransform = transform->GetInverseTransform().GetPointer();
 
   // Write out the images if requested, for debugging only
   if (false)

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -262,7 +262,7 @@ public:
     for (SizeValueType i = 0; i < x; ++i)
     {
       // Create a new DataObject
-      DataObject::Pointer obj = dynamic_cast<DataObject *>(DataObject::New().GetPointer());
+      DataObject::Pointer obj = DataObject::New().GetPointer();
 
       // Append to the end of the buffer
       m_DataObjectBuffer->MoveHeadForward();
@@ -362,7 +362,7 @@ public:
     // Just pass frames from the input through to the output and add debug info
     for (SizeValueType i = outputStart; i < outputStart + numFramesOut; ++i)
     {
-      DataObject::Pointer newObj = dynamic_cast<DataObject *>(DataObject::New().GetPointer());
+      DataObject::Pointer newObj = DataObject::New().GetPointer();
 
       // Set the output
       this->GetOutput()->SetObjectAtFrame(i, newObj);

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -217,8 +217,8 @@ void
 VideoFileWriter<TInputVideoStream>::TemporalStreamingGenerateData()
 {
   // Get a non-const pointer to the input and output
-  const auto * input = dynamic_cast<const VideoStreamType *>(this->GetInput());
-  auto *       output = dynamic_cast<TemporalDataObject *>(this->GetOutput(0));
+  const VideoStreamType * const input = this->GetInput();
+  auto *                        output = dynamic_cast<TemporalDataObject *>(this->GetOutput(0));
   if (!output)
   {
     itkExceptionMacro("Could not cast output to TemporalDataObject");


### PR DESCRIPTION
Removed nine "no-op" dynamic_casts that just cast pointers to their own
compile-time type.

Note: in those cases where `auto` was used to declare a variable
initialized by such a no-op `dynamic_cast`, this commit replaced
`auto` by the explicitly specified declaration type.