### PR TITLE
STYLE: Remove unintended extra space from destructors and operators

### DIFF
--- a/Modules/Core/Common/src/itkFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkFileOutputWindow.cxx
@@ -30,7 +30,7 @@ FileOutputWindow::FileOutputWindow()
   m_FileName = "";
 }
 
-FileOutputWindow ::~FileOutputWindow()
+FileOutputWindow::~FileOutputWindow()
 {
   delete m_Stream;
   m_Stream = nullptr;

--- a/Modules/Core/Common/src/itkHexahedronCellTopology.cxx
+++ b/Modules/Core/Common/src/itkHexahedronCellTopology.cxx
@@ -33,5 +33,5 @@ const int HexahedronCellTopology ::m_Faces[6][4] = { { 0, 4, 7, 3 }, { 1, 2, 6, 
 
 HexahedronCellTopology::HexahedronCellTopology() = default;
 
-HexahedronCellTopology ::~HexahedronCellTopology() = default;
+HexahedronCellTopology::~HexahedronCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkImageIORegion.cxx
+++ b/Modules/Core/Common/src/itkImageIORegion.cxx
@@ -22,7 +22,7 @@
 namespace itk
 {
 
-ImageIORegion ::~ImageIORegion() = default;
+ImageIORegion::~ImageIORegion() = default;
 
 ImageIORegion::ImageIORegion(unsigned int dimension)
   : m_ImageDimension{ dimension }
@@ -32,7 +32,7 @@ ImageIORegion::ImageIORegion(unsigned int dimension)
 
 
 ImageIORegion &
-ImageIORegion ::operator=(const Self & region)
+ImageIORegion::operator=(const Self & region)
 {
   if ((region.m_Index.size() == m_Index.size()) && (region.m_Size.size() == m_Size.size()))
   {
@@ -229,14 +229,14 @@ ImageIORegion::GetNumberOfPixels() const
 }
 
 bool
-ImageIORegion ::operator==(const Self & region) const
+ImageIORegion::operator==(const Self & region) const
 {
   return (m_Index == region.m_Index) && (m_Size == region.m_Size) && (m_ImageDimension == region.m_ImageDimension);
 }
 
 /** Compare two regions. */
 bool
-ImageIORegion ::operator!=(const Self & region) const
+ImageIORegion::operator!=(const Self & region) const
 {
   return !(*this == region);
 }

--- a/Modules/Core/Common/src/itkLightObject.cxx
+++ b/Modules/Core/Common/src/itkLightObject.cxx
@@ -88,25 +88,25 @@ LightObject::Delete()
  */
 #ifdef _WIN32
 void *
-LightObject ::operator new(size_t n)
+LightObject::operator new(size_t n)
 {
   return new char[n];
 }
 
 void *
-LightObject ::operator new[](size_t n)
+LightObject::operator new[](size_t n)
 {
   return new char[n];
 }
 
 void
-LightObject ::operator delete(void * m)
+LightObject::operator delete(void * m)
 {
   delete[](char *) m;
 }
 
 void
-LightObject ::operator delete[](void * m, size_t)
+LightObject::operator delete[](void * m, size_t)
 {
   delete[](char *) m;
 }
@@ -172,7 +172,7 @@ LightObject::SetReferenceCount(int ref)
   }
 }
 
-LightObject ::~LightObject()
+LightObject::~LightObject()
 {
   /**
    * warn user if reference counting is on and the object is being referenced

--- a/Modules/Core/Common/src/itkLightProcessObject.cxx
+++ b/Modules/Core/Common/src/itkLightProcessObject.cxx
@@ -32,7 +32,7 @@ LightProcessObject::LightProcessObject()
  * Destructor for the LightProcessObject class. We've got to
  * UnRegister() the use of any input classes.
  */
-LightProcessObject ::~LightProcessObject() = default;
+LightProcessObject::~LightProcessObject() = default;
 
 /**
  * Update the progress of the process object. If a ProgressMethod exists,

--- a/Modules/Core/Common/src/itkMemoryProbe.cxx
+++ b/Modules/Core/Common/src/itkMemoryProbe.cxx
@@ -23,7 +23,7 @@ MemoryProbe::MemoryProbe()
   : ResourceProbe<MemoryProbe::MemoryLoadType, double>("Memory", "kB")
 {}
 
-MemoryProbe ::~MemoryProbe() = default;
+MemoryProbe::~MemoryProbe() = default;
 
 MemoryProbe::MemoryLoadType
 MemoryProbe::GetInstantValue() const

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -86,7 +86,7 @@ MersenneTwisterRandomVariateGenerator::MersenneTwisterRandomVariateGenerator()
   SetSeed(121212);
 }
 
-MersenneTwisterRandomVariateGenerator ::~MersenneTwisterRandomVariateGenerator() = default;
+MersenneTwisterRandomVariateGenerator::~MersenneTwisterRandomVariateGenerator() = default;
 
 MersenneTwisterRandomVariateGenerator::IntegerType
 MersenneTwisterRandomVariateGenerator ::hash(time_t t, clock_t c)

--- a/Modules/Core/Common/src/itkMetaDataDictionary.cxx
+++ b/Modules/Core/Common/src/itkMetaDataDictionary.cxx
@@ -23,14 +23,14 @@ MetaDataDictionary::MetaDataDictionary()
   : m_Dictionary(std::make_shared<MetaDataDictionaryMapType>())
 {}
 
-MetaDataDictionary ::~MetaDataDictionary() = default;
+MetaDataDictionary::~MetaDataDictionary() = default;
 
 // NOTE: Desired behavior is to perform shallow copy, so m_Dictionary is shared
 //       as is thee default behavior for copy constructors.
 MetaDataDictionary::MetaDataDictionary(const MetaDataDictionary &) = default;
 
 MetaDataDictionary &
-MetaDataDictionary ::operator=(const MetaDataDictionary & old)
+MetaDataDictionary::operator=(const MetaDataDictionary & old)
 {
   if (this != &old)
   {
@@ -51,13 +51,13 @@ MetaDataDictionary::Print(std::ostream & os) const
   }
 }
 
-MetaDataObjectBase::Pointer & MetaDataDictionary ::operator[](const std::string & key)
+MetaDataObjectBase::Pointer & MetaDataDictionary::operator[](const std::string & key)
 {
   MakeUnique();
   return (*m_Dictionary)[key];
 }
 
-const MetaDataObjectBase * MetaDataDictionary ::operator[](const std::string & key) const
+const MetaDataObjectBase * MetaDataDictionary::operator[](const std::string & key) const
 {
   auto iter = m_Dictionary->find(key);
   if (iter == m_Dictionary->end())

--- a/Modules/Core/Common/src/itkMetaDataObjectBase.cxx
+++ b/Modules/Core/Common/src/itkMetaDataObjectBase.cxx
@@ -23,7 +23,7 @@ namespace itk
 MetaDataObjectBase::MetaDataObjectBase() = default;
 
 
-MetaDataObjectBase ::~MetaDataObjectBase() = default;
+MetaDataObjectBase::~MetaDataObjectBase() = default;
 
 
 const char *

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -589,7 +589,7 @@ Object::Object()
   this->Modified();
 }
 
-Object ::~Object()
+Object::~Object()
 {
   itkDebugMacro(<< "Destructing!");
   delete m_SubjectImplementation;

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -519,7 +519,7 @@ ObjectFactoryBase::ObjectFactoryBase()
 /**
  * Unload the library and free the path string
  */
-ObjectFactoryBase ::~ObjectFactoryBase()
+ObjectFactoryBase::~ObjectFactoryBase()
 {
   m_OverrideMap->erase(m_OverrideMap->begin(), m_OverrideMap->end());
   delete m_OverrideMap;

--- a/Modules/Core/Common/src/itkOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkOutputWindow.cxx
@@ -45,7 +45,7 @@ OutputWindow::OutputWindow()
   m_PromptUser = false;
 }
 
-OutputWindow ::~OutputWindow() = default;
+OutputWindow::~OutputWindow() = default;
 
 void
 OutputWindowDisplayText(const char * message)

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -101,7 +101,7 @@ DataObject::Pointer ProcessObject::MakeOutput(DataObjectPointerArraySizeType)
 }
 
 
-ProcessObject ::~ProcessObject()
+ProcessObject::~ProcessObject()
 {
   /*
    * Destructor for the ProcessObject class. We've got to

--- a/Modules/Core/Common/src/itkProgressAccumulator.cxx
+++ b/Modules/Core/Common/src/itkProgressAccumulator.cxx
@@ -32,7 +32,7 @@ ProgressAccumulator::ProgressAccumulator()
   m_CallbackCommand->SetCallbackFunction(this, &Self::ReportProgress);
 }
 
-ProgressAccumulator ::~ProgressAccumulator()
+ProgressAccumulator::~ProgressAccumulator()
 {
   UnregisterAllFilters();
 }

--- a/Modules/Core/Common/src/itkQuadraticTriangleCellTopology.cxx
+++ b/Modules/Core/Common/src/itkQuadraticTriangleCellTopology.cxx
@@ -26,5 +26,5 @@ const int QuadraticTriangleCellTopology ::m_Edges[3][3] = { { 0, 4, 1 }, { 1, 5,
 
 QuadraticTriangleCellTopology::QuadraticTriangleCellTopology() = default;
 
-QuadraticTriangleCellTopology ::~QuadraticTriangleCellTopology() = default;
+QuadraticTriangleCellTopology::~QuadraticTriangleCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkQuadrilateralCellTopology.cxx
+++ b/Modules/Core/Common/src/itkQuadrilateralCellTopology.cxx
@@ -26,5 +26,5 @@ const int QuadrilateralCellTopology ::m_Edges[4][2] = { { 0, 1 }, { 1, 2 }, { 2,
 
 QuadrilateralCellTopology::QuadrilateralCellTopology() = default;
 
-QuadrilateralCellTopology ::~QuadrilateralCellTopology() = default;
+QuadrilateralCellTopology::~QuadrilateralCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkSimpleFilterWatcher.cxx
+++ b/Modules/Core/Common/src/itkSimpleFilterWatcher.cxx
@@ -58,7 +58,7 @@ SimpleFilterWatcher::SimpleFilterWatcher(const SimpleFilterWatcher & watch)
 }
 
 SimpleFilterWatcher &
-SimpleFilterWatcher ::operator=(const SimpleFilterWatcher & watch)
+SimpleFilterWatcher::operator=(const SimpleFilterWatcher & watch)
 {
   this->DeepCopy(watch);
   return *this;
@@ -147,7 +147,7 @@ SimpleFilterWatcher::RemoveObservers()
   }
 }
 
-SimpleFilterWatcher ::~SimpleFilterWatcher()
+SimpleFilterWatcher::~SimpleFilterWatcher()
 {
   if (m_Process)
   {

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -440,7 +440,7 @@ SmapsData_2_6::GetStackUsage()
 
 VMMapData_10_2 ::VMMapData_10_2() = default;
 
-VMMapData_10_2 ::~VMMapData_10_2() = default;
+VMMapData_10_2::~VMMapData_10_2() = default;
 
 std::istream &
 operator>>(std::istream & stream, VMMapData_10_2 & data)

--- a/Modules/Core/Common/src/itkTetrahedronCellTopology.cxx
+++ b/Modules/Core/Common/src/itkTetrahedronCellTopology.cxx
@@ -31,5 +31,5 @@ const int TetrahedronCellTopology ::m_Edges[6][2] = { { 0, 1 }, { 1, 2 }, { 2, 0
 
 TetrahedronCellTopology::TetrahedronCellTopology() = default;
 
-TetrahedronCellTopology ::~TetrahedronCellTopology() = default;
+TetrahedronCellTopology::~TetrahedronCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkThreadLogger.cxx
+++ b/Modules/Core/Common/src/itkThreadLogger.cxx
@@ -29,7 +29,7 @@ ThreadLogger::ThreadLogger()
   m_Thread = std::thread(&ThreadLogger::ThreadFunction, this);
 }
 
-ThreadLogger ::~ThreadLogger()
+ThreadLogger::~ThreadLogger()
 {
   if (m_Thread.joinable())
   {

--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -132,7 +132,7 @@ ThreadPool::GetNumberOfCurrentlyIdleThreads() const
   return int(m_Threads.size()) - int(m_WorkQueue.size()); // lousy approximation
 }
 
-ThreadPool ::~ThreadPool()
+ThreadPool::~ThreadPool()
 {
   {
     std::unique_lock<std::mutex> mutexHolder(m_PimplGlobals->m_Mutex);

--- a/Modules/Core/Common/src/itkThreadedIndexedContainerPartitioner.cxx
+++ b/Modules/Core/Common/src/itkThreadedIndexedContainerPartitioner.cxx
@@ -23,7 +23,7 @@ namespace itk
 
 ThreadedIndexedContainerPartitioner::ThreadedIndexedContainerPartitioner() = default;
 
-ThreadedIndexedContainerPartitioner ::~ThreadedIndexedContainerPartitioner() = default;
+ThreadedIndexedContainerPartitioner::~ThreadedIndexedContainerPartitioner() = default;
 
 ThreadIdType
 ThreadedIndexedContainerPartitioner::PartitionDomain(const ThreadIdType threadId,

--- a/Modules/Core/Common/src/itkTimeProbe.cxx
+++ b/Modules/Core/Common/src/itkTimeProbe.cxx
@@ -25,7 +25,7 @@ TimeProbe::TimeProbe()
   m_RealTimeClock = RealTimeClock::New();
 }
 
-TimeProbe ::~TimeProbe() = default;
+TimeProbe::~TimeProbe() = default;
 
 TimeProbe::TimeStampType
 TimeProbe::GetInstantValue() const

--- a/Modules/Core/Common/src/itkTimeProbesCollectorBase.cxx
+++ b/Modules/Core/Common/src/itkTimeProbesCollectorBase.cxx
@@ -22,5 +22,5 @@ namespace itk
 {
 TimeProbesCollectorBase::TimeProbesCollectorBase() = default;
 
-TimeProbesCollectorBase ::~TimeProbesCollectorBase() = default;
+TimeProbesCollectorBase::~TimeProbesCollectorBase() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkTriangleCellTopology.cxx
+++ b/Modules/Core/Common/src/itkTriangleCellTopology.cxx
@@ -26,5 +26,5 @@ const int TriangleCellTopology ::m_Edges[3][2] = { { 0, 1 }, { 1, 2 }, { 2, 0 } 
 
 TriangleCellTopology::TriangleCellTopology() = default;
 
-TriangleCellTopology ::~TriangleCellTopology() = default;
+TriangleCellTopology::~TriangleCellTopology() = default;
 } // end namespace itk

--- a/Modules/Core/Common/src/itkWin32OutputWindow.cxx
+++ b/Modules/Core/Common/src/itkWin32OutputWindow.cxx
@@ -32,7 +32,7 @@ namespace itk
 /** */
 HWND Win32OutputWindow::m_OutputWindow = nullptr;
 
-Win32OutputWindow ::~Win32OutputWindow()
+Win32OutputWindow::~Win32OutputWindow()
 {
   if (Win32OutputWindow::m_OutputWindow)
   {

--- a/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
@@ -27,7 +27,7 @@ namespace itk
  */
 XMLFileOutputWindow ::XMLFileOutputWindow() = default;
 
-XMLFileOutputWindow ::~XMLFileOutputWindow() = default;
+XMLFileOutputWindow::~XMLFileOutputWindow() = default;
 
 void
 XMLFileOutputWindow::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Core/Mesh/src/itkMeshRegion.cxx
+++ b/Modules/Core/Mesh/src/itkMeshRegion.cxx
@@ -31,5 +31,5 @@ MeshRegion::MeshRegion()
 /**
  * Destructor for the MeshRegion class.
  */
-MeshRegion ::~MeshRegion() = default;
+MeshRegion::~MeshRegion() = default;
 } // end namespace itk

--- a/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
+++ b/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
@@ -54,7 +54,7 @@ SimplexMeshGeometry::SimplexMeshGeometry()
   closestAttractorIndex = 0;
 }
 
-SimplexMeshGeometry ::~SimplexMeshGeometry()
+SimplexMeshGeometry::~SimplexMeshGeometry()
 {
   delete this->neighborSet;
   this->neighborSet = nullptr;

--- a/Modules/Core/QuadEdgeMesh/src/itkQuadEdge.cxx
+++ b/Modules/Core/QuadEdgeMesh/src/itkQuadEdge.cxx
@@ -27,7 +27,7 @@ QuadEdge::QuadEdge()
 }
 
 // ---------------------------------------------------------------------
-QuadEdge ::~QuadEdge()
+QuadEdge::~QuadEdge()
 {
   this->m_Onext = nullptr;
   this->m_Rot = nullptr;

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -174,7 +174,7 @@ SpatialObjectProperty::SetTagStringDictionary(const std::map<std::string, std::s
 }
 
 SpatialObjectProperty::Self &
-SpatialObjectProperty ::operator=(const SpatialObjectProperty & rhs)
+SpatialObjectProperty::operator=(const SpatialObjectProperty & rhs)
 {
   if (this != &rhs)
   {

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -53,7 +53,7 @@ struct FFTWGlobalConfigurationGlobals
 
 WisdomFilenameGeneratorBase::WisdomFilenameGeneratorBase() = default;
 
-WisdomFilenameGeneratorBase ::~WisdomFilenameGeneratorBase() = default;
+WisdomFilenameGeneratorBase::~WisdomFilenameGeneratorBase() = default;
 
 ManualWisdomFilenameGenerator::ManualWisdomFilenameGenerator(std::string wfn)
   : m_WisdomFilename(std::move(wfn))
@@ -489,7 +489,7 @@ FFTWGlobalConfiguration ::FFTWGlobalConfiguration()
   }
 }
 
-FFTWGlobalConfiguration ::~FFTWGlobalConfiguration()
+FFTWGlobalConfiguration::~FFTWGlobalConfiguration()
 {
   if (this->m_WriteWisdomCache && this->m_NewWisdomAvailable)
   {

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -316,7 +316,7 @@ DCMTKSequence::GetElementTM(const unsigned short group,
   return EXIT_SUCCESS;
 }
 
-DCMTKFileReader ::~DCMTKFileReader()
+DCMTKFileReader::~DCMTKFileReader()
 {
   delete m_DFile;
 }

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -36,7 +36,7 @@ DCMTKSeriesFileNames ::DCMTKSeriesFileNames()
   m_LoadPrivateTags = false;
 }
 
-DCMTKSeriesFileNames ::~DCMTKSeriesFileNames() = default;
+DCMTKSeriesFileNames::~DCMTKSeriesFileNames() = default;
 
 void
 DCMTKSeriesFileNames::SetInputDirectory(const char * name)

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIO.cxx
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIO.cxx
@@ -27,7 +27,7 @@ namespace itk
 
 FileFreeImageIO ::FileFreeImageIO() {}
 
-FileFreeImageIO ::~FileFreeImageIO() {}
+FileFreeImageIO::~FileFreeImageIO() {}
 
 bool
 FileFreeImageIO ::CanReadFile(const char * filename)

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -30,7 +30,7 @@ BYUMeshIO ::BYUMeshIO()
   this->AddSupportedWriteExtension(".byu");
 }
 
-BYUMeshIO ::~BYUMeshIO() = default;
+BYUMeshIO::~BYUMeshIO() = default;
 
 bool
 BYUMeshIO ::CanReadFile(const char * fileName)

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
@@ -34,7 +34,7 @@ BYUMeshIOFactory ::BYUMeshIOFactory()
 }
 
 
-BYUMeshIOFactory ::~BYUMeshIOFactory() = default;
+BYUMeshIOFactory::~BYUMeshIOFactory() = default;
 
 
 const char *

--- a/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
@@ -23,7 +23,7 @@ namespace itk
 
 MeshIOFactory::MeshIOFactory() = default;
 
-MeshIOFactory ::~MeshIOFactory() = default;
+MeshIOFactory::~MeshIOFactory() = default;
 
 
 MeshIOBase::Pointer

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -27,7 +27,7 @@ FreeSurferAsciiMeshIO ::FreeSurferAsciiMeshIO()
   this->AddSupportedWriteExtension(".fsa");
 }
 
-FreeSurferAsciiMeshIO ::~FreeSurferAsciiMeshIO() = default;
+FreeSurferAsciiMeshIO::~FreeSurferAsciiMeshIO() = default;
 
 bool
 FreeSurferAsciiMeshIO ::CanReadFile(const char * fileName)

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIOFactory.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIOFactory.cxx
@@ -36,7 +36,7 @@ FreeSurferAsciiMeshIOFactory::FreeSurferAsciiMeshIOFactory()
                          CreateObjectFunction<FreeSurferAsciiMeshIO>::New());
 }
 
-FreeSurferAsciiMeshIOFactory ::~FreeSurferAsciiMeshIOFactory() = default;
+FreeSurferAsciiMeshIOFactory::~FreeSurferAsciiMeshIOFactory() = default;
 
 const char *
 FreeSurferAsciiMeshIOFactory::GetITKSourceVersion() const

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -29,7 +29,7 @@ FreeSurferBinaryMeshIO ::FreeSurferBinaryMeshIO()
   this->AddSupportedWriteExtension(".fcv");
 }
 
-FreeSurferBinaryMeshIO ::~FreeSurferBinaryMeshIO() = default;
+FreeSurferBinaryMeshIO::~FreeSurferBinaryMeshIO() = default;
 
 bool
 FreeSurferBinaryMeshIO ::CanReadFile(const char * fileName)

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIOFactory.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIOFactory.cxx
@@ -36,7 +36,7 @@ FreeSurferBinaryMeshIOFactory::FreeSurferBinaryMeshIOFactory()
                          CreateObjectFunction<FreeSurferBinaryMeshIO>::New());
 }
 
-FreeSurferBinaryMeshIOFactory ::~FreeSurferBinaryMeshIOFactory() = default;
+FreeSurferBinaryMeshIOFactory::~FreeSurferBinaryMeshIOFactory() = default;
 
 const char *
 FreeSurferBinaryMeshIOFactory::GetITKSourceVersion() const

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIOFactory.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIOFactory.cxx
@@ -33,7 +33,7 @@ GiftiMeshIOFactory::GiftiMeshIOFactory()
     "itkMeshIOBase", "itkGiftiMeshIO", "Gifti Mesh IO", true, CreateObjectFunction<GiftiMeshIO>::New());
 }
 
-GiftiMeshIOFactory ::~GiftiMeshIOFactory() = default;
+GiftiMeshIOFactory::~GiftiMeshIOFactory() = default;
 
 const char *
 GiftiMeshIOFactory::GetITKSourceVersion() const

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -30,7 +30,7 @@ OBJMeshIO ::OBJMeshIO()
   this->AddSupportedWriteExtension(".obj");
 }
 
-OBJMeshIO ::~OBJMeshIO() = default;
+OBJMeshIO::~OBJMeshIO() = default;
 
 bool
 OBJMeshIO ::CanReadFile(const char * fileName)

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIOFactory.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIOFactory.cxx
@@ -32,7 +32,7 @@ OBJMeshIOFactory ::OBJMeshIOFactory()
   this->RegisterOverride("itkMeshIOBase", "itkOBJMeshIO", "OBJ Mesh IO", true, CreateObjectFunction<OBJMeshIO>::New());
 }
 
-OBJMeshIOFactory ::~OBJMeshIOFactory() = default;
+OBJMeshIOFactory::~OBJMeshIOFactory() = default;
 
 const char *
 OBJMeshIOFactory::GetITKSourceVersion() const

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -30,7 +30,7 @@ OFFMeshIO ::OFFMeshIO()
   m_TriangleCellType = true;
 }
 
-OFFMeshIO ::~OFFMeshIO() = default;
+OFFMeshIO::~OFFMeshIO() = default;
 
 bool
 OFFMeshIO ::CanReadFile(const char * fileName)

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIOFactory.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIOFactory.cxx
@@ -32,7 +32,7 @@ OFFMeshIOFactory ::OFFMeshIOFactory()
   this->RegisterOverride("itkMeshIOBase", "itkOFFMeshIO", "OFF Mesh IO", true, CreateObjectFunction<OFFMeshIO>::New());
 }
 
-OFFMeshIOFactory ::~OFFMeshIOFactory() = default;
+OFFMeshIOFactory::~OFFMeshIOFactory() = default;
 
 const char *
 OFFMeshIOFactory::GetITKSourceVersion() const

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -40,7 +40,7 @@ VTKPolyDataMeshIO ::VTKPolyDataMeshIO()
   EncapsulateMetaData<StringType>(metaDic, "cellTensorDataName", "CellTensorData");
 }
 
-VTKPolyDataMeshIO ::~VTKPolyDataMeshIO() = default;
+VTKPolyDataMeshIO::~VTKPolyDataMeshIO() = default;
 
 
 int

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
@@ -35,7 +35,7 @@ VTKPolyDataMeshIOFactory ::VTKPolyDataMeshIOFactory()
     "itkMeshIOBase", "itkVTKPolyDataMeshIO", "VTK Polydata IO", true, CreateObjectFunction<VTKPolyDataMeshIO>::New());
 }
 
-VTKPolyDataMeshIOFactory ::~VTKPolyDataMeshIOFactory() = default;
+VTKPolyDataMeshIOFactory::~VTKPolyDataMeshIOFactory() = default;
 
 
 const char *

--- a/Modules/IO/Meta/src/itkMetaArrayReader.cxx
+++ b/Modules/IO/Meta/src/itkMetaArrayReader.cxx
@@ -25,7 +25,7 @@ MetaArrayReader::MetaArrayReader()
 
 {}
 
-MetaArrayReader ::~MetaArrayReader() = default;
+MetaArrayReader::~MetaArrayReader() = default;
 
 void
 MetaArrayReader::SetBuffer(void * _buffer)

--- a/Modules/IO/Meta/src/itkMetaArrayWriter.cxx
+++ b/Modules/IO/Meta/src/itkMetaArrayWriter.cxx
@@ -25,7 +25,7 @@ MetaArrayWriter::MetaArrayWriter()
 
 {}
 
-MetaArrayWriter ::~MetaArrayWriter() = default;
+MetaArrayWriter::~MetaArrayWriter() = default;
 
 void
 MetaArrayWriter::ConvertTo(MET_ValueEnumType _metaElementType)

--- a/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
@@ -35,7 +35,7 @@ AmoebaOptimizer::AmoebaOptimizer()
 }
 
 
-AmoebaOptimizer ::~AmoebaOptimizer()
+AmoebaOptimizer::~AmoebaOptimizer()
 {
   delete m_VnlOptimizer;
 }

--- a/Modules/Numerics/Optimizers/src/itkConjugateGradientOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkConjugateGradientOptimizer.cxx
@@ -32,7 +32,7 @@ ConjugateGradientOptimizer::ConjugateGradientOptimizer()
 /**
  * Destructor
  */
-ConjugateGradientOptimizer ::~ConjugateGradientOptimizer()
+ConjugateGradientOptimizer::~ConjugateGradientOptimizer()
 {
   delete m_VnlOptimizer;
 }

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -29,7 +29,7 @@ CumulativeGaussianCostFunction::CumulativeGaussianCostFunction()
   m_MeasurePointer = new MeasureType();
 }
 
-CumulativeGaussianCostFunction ::~CumulativeGaussianCostFunction()
+CumulativeGaussianCostFunction::~CumulativeGaussianCostFunction()
 {
   delete m_OriginalDataArray;
   delete m_MeasurePointer;

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -28,7 +28,7 @@ FRPROptimizer ::FRPROptimizer()
   m_OptimizationType = OptimizationEnum::PolakRibiere;
 }
 
-FRPROptimizer ::~FRPROptimizer() = default;
+FRPROptimizer::~FRPROptimizer() = default;
 
 void
 FRPROptimizer::GetValueAndDerivative(ParametersType & p, double * val, ParametersType * xi)

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -63,7 +63,7 @@ LBFGSBOptimizer ::LBFGSBOptimizer()
 /**
  * Destructor
  */
-LBFGSBOptimizer ::~LBFGSBOptimizer()
+LBFGSBOptimizer::~LBFGSBOptimizer()
 {
   delete m_VnlOptimizer;
 }

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -38,7 +38,7 @@ LBFGSOptimizer ::LBFGSOptimizer()
 /**
  * Destructor
  */
-LBFGSOptimizer ::~LBFGSOptimizer()
+LBFGSOptimizer::~LBFGSOptimizer()
 {
   delete m_VnlOptimizer;
 }

--- a/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
@@ -36,7 +36,7 @@ LevenbergMarquardtOptimizer::LevenbergMarquardtOptimizer()
 /**
  * Destructor
  */
-LevenbergMarquardtOptimizer ::~LevenbergMarquardtOptimizer()
+LevenbergMarquardtOptimizer::~LevenbergMarquardtOptimizer()
 {
   delete m_VnlOptimizer;
 }

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
@@ -37,7 +37,7 @@ MultipleValuedNonLinearVnlOptimizer::MultipleValuedNonLinearVnlOptimizer()
 /**
  * Destructor
  */
-MultipleValuedNonLinearVnlOptimizer ::~MultipleValuedNonLinearVnlOptimizer()
+MultipleValuedNonLinearVnlOptimizer::~MultipleValuedNonLinearVnlOptimizer()
 {
   delete m_CostFunctionAdaptor;
   m_CostFunctionAdaptor = nullptr;

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
@@ -32,7 +32,7 @@ ParticleSwarmOptimizer::ParticleSwarmOptimizer()
 }
 
 
-ParticleSwarmOptimizer ::~ParticleSwarmOptimizer() = default;
+ParticleSwarmOptimizer::~ParticleSwarmOptimizer() = default;
 
 void
 ParticleSwarmOptimizer::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -37,7 +37,7 @@ ParticleSwarmOptimizerBase::ParticleSwarmOptimizerBase()
   this->m_UseSeed = false;
 }
 
-ParticleSwarmOptimizerBase ::~ParticleSwarmOptimizerBase() = default;
+ParticleSwarmOptimizerBase::~ParticleSwarmOptimizerBase() = default;
 
 
 void

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -47,7 +47,7 @@ PowellOptimizer::PowellOptimizer()
   m_StopConditionDescription << this->GetNameOfClass() << ": ";
 }
 
-PowellOptimizer ::~PowellOptimizer() = default;
+PowellOptimizer::~PowellOptimizer() = default;
 
 void
 PowellOptimizer::SetLine(const PowellOptimizer::ParametersType & origin, const vnl_vector<double> & direction)

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
@@ -33,7 +33,7 @@ SingleValuedNonLinearVnlOptimizer::SingleValuedNonLinearVnlOptimizer()
 }
 
 /** Destructor */
-SingleValuedNonLinearVnlOptimizer ::~SingleValuedNonLinearVnlOptimizer()
+SingleValuedNonLinearVnlOptimizer::~SingleValuedNonLinearVnlOptimizer()
 {
   delete m_CostFunctionAdaptor;
   m_CostFunctionAdaptor = nullptr;

--- a/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
@@ -35,7 +35,7 @@ AmoebaOptimizerv4 ::AmoebaOptimizerv4()
 }
 
 
-AmoebaOptimizerv4 ::~AmoebaOptimizerv4()
+AmoebaOptimizerv4::~AmoebaOptimizerv4()
 {
   delete m_VnlOptimizer;
 }

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
@@ -39,7 +39,7 @@ LBFGS2Optimizerv4 ::LBFGS2Optimizerv4()
 }
 
 
-LBFGS2Optimizerv4 ::~LBFGS2Optimizerv4() = default;
+LBFGS2Optimizerv4::~LBFGS2Optimizerv4() = default;
 
 void
 LBFGS2Optimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -63,7 +63,7 @@ LBFGSBOptimizerv4 ::LBFGSBOptimizerv4()
   , m_BoundSelection(0)
 {}
 
-LBFGSBOptimizerv4 ::~LBFGSBOptimizerv4() = default;
+LBFGSBOptimizerv4::~LBFGSBOptimizerv4() = default;
 
 void
 LBFGSBOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
@@ -23,7 +23,7 @@ namespace itk
 {
 LBFGSOptimizerv4 ::LBFGSOptimizerv4() = default;
 
-LBFGSOptimizerv4 ::~LBFGSOptimizerv4() = default;
+LBFGSOptimizerv4::~LBFGSOptimizerv4() = default;
 
 void
 LBFGSOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
@@ -29,7 +29,7 @@ SingleValuedNonLinearVnlOptimizerv4 ::SingleValuedNonLinearVnlOptimizerv4()
   this->m_CachedDerivative.Fill(NumericTraits<DerivativeType::ValueType>::ZeroValue());
 }
 
-SingleValuedNonLinearVnlOptimizerv4 ::~SingleValuedNonLinearVnlOptimizerv4()
+SingleValuedNonLinearVnlOptimizerv4::~SingleValuedNonLinearVnlOptimizerv4()
 {
   if (this->m_CostFunctionAdaptor)
   {

--- a/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
+++ b/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
@@ -56,7 +56,7 @@ MultivariateLegendrePolynomial::MultivariateLegendrePolynomial(unsigned int     
   }
 }
 
-MultivariateLegendrePolynomial ::~MultivariateLegendrePolynomial() = default;
+MultivariateLegendrePolynomial::~MultivariateLegendrePolynomial() = default;
 
 void
 MultivariateLegendrePolynomial::Print(std::ostream & os) const

--- a/Modules/Numerics/Statistics/src/itkDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkDecisionRule.cxx
@@ -23,7 +23,7 @@ namespace Statistics
 {
 DecisionRule::DecisionRule() = default;
 
-DecisionRule ::~DecisionRule() = default;
+DecisionRule::~DecisionRule() = default;
 
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
@@ -26,7 +26,7 @@ KLMSegmentationBorder ::KLMSegmentationBorder()
   m_Region2 = nullptr;
 }
 
-KLMSegmentationBorder ::~KLMSegmentationBorder() = default;
+KLMSegmentationBorder::~KLMSegmentationBorder() = default;
 
 /**
  * PrintSelf

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
@@ -24,7 +24,7 @@ KLMSegmentationRegion ::KLMSegmentationRegion()
   m_MeanRegionIntensity = 0;
 }
 
-KLMSegmentationRegion ::~KLMSegmentationRegion() = default;
+KLMSegmentationRegion::~KLMSegmentationRegion() = default;
 
 void
 KLMSegmentationRegion::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationBorder.cxx
@@ -21,7 +21,7 @@ namespace itk
 {
 SegmentationBorder::SegmentationBorder() = default;
 
-SegmentationBorder ::~SegmentationBorder() = default;
+SegmentationBorder::~SegmentationBorder() = default;
 
 /**
  * PrintSelf

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationRegion.cxx
@@ -21,7 +21,7 @@ namespace itk
 {
 SegmentationRegion::SegmentationRegion() = default;
 
-SegmentationRegion ::~SegmentationRegion() = default;
+SegmentationRegion::~SegmentationRegion() = default;
 
 /**
  * PrintSelf

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -42,7 +42,7 @@ TemporalDataObject::TemporalDataObject()
 }
 
 //----------------------------------------------------------------------------
-TemporalDataObject ::~TemporalDataObject() = default;
+TemporalDataObject::~TemporalDataObject() = default;
 
 //----------------------------------------------------------------------------
 TemporalDataObject::TemporalUnitType

--- a/Modules/Video/Core/src/itkTemporalRegion.cxx
+++ b/Modules/Video/Core/src/itkTemporalRegion.cxx
@@ -32,7 +32,7 @@ TemporalRegion::TemporalRegion()
 //
 // Destructor
 //
-TemporalRegion ::~TemporalRegion() = default;
+TemporalRegion::~TemporalRegion() = default;
 
 // ---------------------------------------------------------------------------
 void
@@ -112,14 +112,14 @@ TemporalRegion::IsEqualInRealTime(const Self & region) const
 
 // ---------------------------------------------------------------------------
 bool
-TemporalRegion ::operator==(const Self & region) const
+TemporalRegion::operator==(const Self & region) const
 {
   return IsEqualInFrames(region) && IsEqualInRealTime(region);
 }
 
 // ---------------------------------------------------------------------------
 bool
-TemporalRegion ::operator!=(const Self & region) const
+TemporalRegion::operator!=(const Self & region) const
 {
   return !(operator==(region));
 }


### PR DESCRIPTION
It appears that clang-format has in some cases introduced an unintended
space character between the class name and the `::~`, in the definition
of a destructor. This typically seems to have happened when there
originally was a line break between the class name and the colon
characters.

Follow-up to:
"STYLE: Remove space between class and member names in C++ source files"
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2096
commit 734d6f84d728b343baae5ef66643a5568a5a30c7