### PR TITLE
Modernize the implementation of ExceptionObject

### DIFF
--- a/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
+++ b/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
@@ -19,6 +19,7 @@
 #define itkMetaProgrammingLibrary_h
 
 #include "itkMacro.h"
+#include "itkSmartPointer.h"
 
 namespace itk
 {

--- a/Modules/Core/Common/include/itkResourceProbe.h
+++ b/Modules/Core/Common/include/itkResourceProbe.h
@@ -21,6 +21,7 @@
 #include "itkMacro.h"
 #include "itkIntTypes.h"
 
+#include <iostream> // For cout.
 #include <string>
 #include <vector>
 

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -47,7 +47,6 @@ protected:
     m_What = m_File;
     m_What += loc.str();
     m_What += m_Description;
-    m_WhatPointer = m_What.c_str();
   }
 
 private:
@@ -61,7 +60,6 @@ private:
   const std::string  m_File;
   const unsigned int m_Line;
   std::string        m_What;
-  const char *       m_WhatPointer;
 };
 
 /** \class ExceptionObject::ReferenceCountedExceptionData
@@ -262,21 +260,18 @@ ExceptionObject::SetDescription(const char * s)
 const char *
 ExceptionObject::GetLocation() const
 {
-  // Note: std::string::c_str() might throw an exception.
   return m_ExceptionData.IsNull() ? "" : this->GetExceptionData()->m_Location.c_str();
 }
 
 const char *
 ExceptionObject::GetDescription() const
 {
-  // Note: std::string::c_str() might throw an exception.
   return m_ExceptionData.IsNull() ? "" : this->GetExceptionData()->m_Description.c_str();
 }
 
 const char *
 ExceptionObject::GetFile() const
 {
-  // Note: std::string::c_str() might throw an exception.
   return m_ExceptionData.IsNull() ? "" : this->GetExceptionData()->m_File.c_str();
 }
 
@@ -291,9 +286,7 @@ ExceptionObject::what() const noexcept
 {
   const ExceptionData * const thisData = this->GetExceptionData();
 
-  // Note: m_What.c_str() wouldn't be safe, because c_str() might throw an
-  // exception.
-  return thisData ? thisData->m_WhatPointer : "ExceptionObject";
+  return thisData ? thisData->m_What.c_str() : "ExceptionObject";
 }
 
 void

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -15,10 +15,11 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+
+#include "itkIndent.h"
+#include "itkMacro.h"
+
 #include <utility>
-
-#include "itkLightObject.h"
-
 
 namespace itk
 {
@@ -28,12 +29,11 @@ namespace itk
  * Contains the location and description of the error, as well as
  * the text that should be returned by itk::ExceptionObject::what().
  */
-class ExceptionObject::ExceptionData : public ReferenceCounterInterface
+class ExceptionObject::ExceptionData
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ExceptionData);
 
-protected:
   // Constructor. Might throw an exception.
   ExceptionData(std::string file, unsigned int line, std::string description, std::string location)
     : m_Location(std::move(location))
@@ -62,141 +62,26 @@ private:
   std::string        m_What;
 };
 
-/** \class ExceptionObject::ReferenceCountedExceptionData
- * \brief Reference counted exception data, used to implement itk::ExceptionObject.
- *
- * Its first base class, ExceptionObject::ExceptionData, holds its data, while its second
- * base class, itk::LightObject, takes care of the reference counting.
- *
- * \note ExceptionData is constructed before LightObject, thereby it is ensured that
- * an exception within the constructor of ExceptionData won't trigger the destruction
- * of LightObject.
- */
-class ExceptionObject::ReferenceCountedExceptionData
-  : public ExceptionData
-  , public LightObject
-{
-public:
-  ITK_DISALLOW_COPY_AND_MOVE(ReferenceCountedExceptionData);
-
-  using Self = ReferenceCountedExceptionData;
-  using ConstPointer = SmartPointer<const Self>;
-  static ConstPointer
-  ConstNew(const std::string & file, unsigned int line, const std::string & description, const std::string & location)
-  {
-    ConstPointer       smartPtr;
-    const Self * const rawPtr = new Self(file, line, description, location);
-
-    smartPtr = rawPtr;
-    rawPtr->LightObject::UnRegister();
-    return smartPtr;
-  }
-
-  /** Increase the reference count (mark as used by another object).
-   * Delegates the counting to its LightObject superclass  */
-  void
-  Register() const override
-  {
-    this->LightObject::Register();
-  }
-
-  /** Decrease the reference count (release by another object).
-   * Delegates the counting to its LightObject superclass  */
-  void
-  UnRegister() const noexcept override
-  {
-    this->LightObject::UnRegister();
-  }
-
-private:
-  // Constructor. Might throw an exception.
-  ReferenceCountedExceptionData(const std::string & file,
-                                unsigned int        line,
-                                const std::string & description,
-                                const std::string & location)
-    : ExceptionData(file, line, description, location)
-    , LightObject()
-  {}
-
-  // Destructor. Only invoked via LightObject::UnRegister(), when its reference
-  // count drops to zero.
-  ~ReferenceCountedExceptionData() override = default;
-};
-
-ExceptionObject::ExceptionObject() noexcept
-{
-  // The default construction never throws an exception.
-}
 
 ExceptionObject::ExceptionObject(const char * file, unsigned int lineNumber, const char * desc, const char * loc)
-  : m_ExceptionData(ReferenceCountedExceptionData::ConstNew(file == nullptr ? "" : file,
-                                                            lineNumber,
-                                                            desc == nullptr ? "" : desc,
-                                                            loc == nullptr ? "" : loc))
+  : m_ExceptionData(std::make_shared<const ExceptionData>(file == nullptr ? "" : file,
+                                                          lineNumber,
+                                                          desc == nullptr ? "" : desc,
+                                                          loc == nullptr ? "" : loc))
 {}
 
 ExceptionObject::ExceptionObject(std::string file, unsigned int lineNumber, std::string desc, std::string loc)
-  : m_ExceptionData(
-      ReferenceCountedExceptionData::ConstNew(std::move(file), lineNumber, std::move(desc), std::move(loc)))
+  : m_ExceptionData(std::make_shared<const ExceptionData>(std::move(file), lineNumber, std::move(desc), std::move(loc)))
 {}
 
-ExceptionObject::ExceptionObject(const ExceptionObject & orig) noexcept
-  : Superclass(orig)
-  , m_ExceptionData(orig.m_ExceptionData)
-{
-  // This copy construction never throws, because it just copies the smart
-  // pointer.
-}
-
-ExceptionObject::~ExceptionObject() noexcept
-{
-  // During destruction, the reference count of the
-  // ReferenceCountedExceptionData will be decreased
-  // automatically, by the destructor of the smart pointer.
-}
-
-const ExceptionObject::ExceptionData *
-ExceptionObject::GetExceptionData() const
-{
-  // Note: dynamic_cast does a runtime check if the m_ExceptionData pointer is
-  // indeed
-  // pointing to an ExceptionData object. In this case, a static_cast could have
-  // been
-  // used instead, which only does compile time checking. But we expect the
-  // runtime overhead of this particular dynamic_cast to be insignificant.
-  const auto * thisData = dynamic_cast<const ExceptionData *>(this->m_ExceptionData.GetPointer());
-
-  return thisData;
-}
-
-ExceptionObject &
-ExceptionObject::operator=(const ExceptionObject & orig) noexcept
-{
-  // Note: there is no superclass assignment here, because
-  // std::exception::operator=
-  // appears have a bug on some platforms, including MSVC 2003. The MSVC 2003
-  // bug is
-  // described at the Usenet newsgroup microsoft.public.vc.language, June 2,
-  // 2008,
-  // subject "VC7.1 std::exception assignment operator bug (crash) a known
-  // issue?"
-  //
-  //
-  //
-  // http://groups.google.com/group/microsoft.public.vc.language/msg/15b927c8c1130e88
-
-  // Assigns its smart pointer:
-  m_ExceptionData = orig.m_ExceptionData;
-  return *this;
-}
 
 bool
 ExceptionObject::operator==(const ExceptionObject & orig) const
 {
   // operator== is reimplemented, but it still behaves like the previous
   // version, from ITK 3.6.0.
-  const ExceptionData * const thisData = this->GetExceptionData();
-  const ExceptionData * const origData = orig.GetExceptionData();
+  const ExceptionData * const thisData = m_ExceptionData.get();
+  const ExceptionData * const origData = orig.m_ExceptionData.get();
 
   if (thisData == origData)
   {
@@ -213,24 +98,23 @@ ExceptionObject::operator==(const ExceptionObject & orig) const
 void
 ExceptionObject::SetLocation(const std::string & s)
 {
-  const bool IsNull = m_ExceptionData.IsNull();
+  const bool IsNull = m_ExceptionData == nullptr;
 
-  m_ExceptionData =
-    ReferenceCountedExceptionData::ConstNew(IsNull ? "" : this->GetExceptionData()->m_File.c_str(),
-                                            IsNull ? 0 : this->GetExceptionData()->m_Line,
-                                            IsNull ? "" : this->GetExceptionData()->m_Description.c_str(),
-                                            s);
+  m_ExceptionData = std::make_shared<const ExceptionData>(IsNull ? "" : m_ExceptionData->m_File.c_str(),
+                                                          IsNull ? 0 : m_ExceptionData->m_Line,
+                                                          IsNull ? "" : m_ExceptionData->m_Description.c_str(),
+                                                          s);
 }
 
 void
 ExceptionObject::SetDescription(const std::string & s)
 {
-  const bool IsNull = m_ExceptionData.IsNull();
+  const bool IsNull = m_ExceptionData == nullptr;
 
-  m_ExceptionData = ReferenceCountedExceptionData::ConstNew(IsNull ? "" : this->GetExceptionData()->m_File.c_str(),
-                                                            IsNull ? 0 : this->GetExceptionData()->m_Line,
-                                                            s,
-                                                            IsNull ? "" : this->GetExceptionData()->m_Location.c_str());
+  m_ExceptionData = std::make_shared<const ExceptionData>(IsNull ? "" : m_ExceptionData->m_File.c_str(),
+                                                          IsNull ? 0 : m_ExceptionData->m_Line,
+                                                          s,
+                                                          IsNull ? "" : m_ExceptionData->m_Location.c_str());
 }
 
 void
@@ -260,33 +144,31 @@ ExceptionObject::SetDescription(const char * s)
 const char *
 ExceptionObject::GetLocation() const
 {
-  return m_ExceptionData.IsNull() ? "" : this->GetExceptionData()->m_Location.c_str();
+  return (m_ExceptionData == nullptr) ? "" : m_ExceptionData->m_Location.c_str();
 }
 
 const char *
 ExceptionObject::GetDescription() const
 {
-  return m_ExceptionData.IsNull() ? "" : this->GetExceptionData()->m_Description.c_str();
+  return (m_ExceptionData == nullptr) ? "" : m_ExceptionData->m_Description.c_str();
 }
 
 const char *
 ExceptionObject::GetFile() const
 {
-  return m_ExceptionData.IsNull() ? "" : this->GetExceptionData()->m_File.c_str();
+  return (m_ExceptionData == nullptr) ? "" : m_ExceptionData->m_File.c_str();
 }
 
 unsigned int
 ExceptionObject::GetLine() const
 {
-  return m_ExceptionData.IsNull() ? 0 : this->GetExceptionData()->m_Line;
+  return (m_ExceptionData == nullptr) ? 0 : m_ExceptionData->m_Line;
 }
 
 const char *
 ExceptionObject::what() const noexcept
 {
-  const ExceptionData * const thisData = this->GetExceptionData();
-
-  return thisData ? thisData->m_What.c_str() : "ExceptionObject";
+  return (m_ExceptionData == nullptr) ? "ExceptionObject" : m_ExceptionData->m_What.c_str();
 }
 
 void
@@ -301,9 +183,9 @@ ExceptionObject::Print(std::ostream & os) const
   // Print self
   indent.GetNextIndent();
 
-  if (m_ExceptionData.IsNotNull())
+  if (m_ExceptionData != nullptr)
   {
-    const ExceptionData & data = *(this->GetExceptionData());
+    const ExceptionData & data = *(m_ExceptionData);
 
     if (!data.m_Location.empty())
     {
@@ -334,8 +216,5 @@ InvalidArgumentError::~InvalidArgumentError() noexcept = default;
 IncompatibleOperandsError::~IncompatibleOperandsError() noexcept = default;
 
 ProcessAborted::~ProcessAborted() noexcept = default;
-
-ExceptionObject::ReferenceCounterInterface::ReferenceCounterInterface() = default;
-ExceptionObject::ReferenceCounterInterface::~ReferenceCounterInterface() = default;
 
 } // end namespace itk

--- a/Modules/Core/Common/test/itkExceptionObjectTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectTest.cxx
@@ -18,6 +18,13 @@
 
 #include "itkMacro.h"
 #include <iostream>
+#include <type_traits>
+
+static_assert(std::is_nothrow_default_constructible<itk::ExceptionObject>::value,
+              "ExceptionObject must have a noexcept default-constructor!");
+static_assert(std::is_nothrow_copy_assignable<itk::ExceptionObject>::value &&
+                std::is_nothrow_copy_constructible<itk::ExceptionObject>::value,
+              "An exception type must have noexcept copy semantics!");
 
 class mammal
 {

--- a/Modules/Core/Common/test/itkIntTypesTest.cxx
+++ b/Modules/Core/Common/test/itkIntTypesTest.cxx
@@ -19,6 +19,8 @@
 #include "itkIntTypes.h"
 #include "itkNumericTraits.h"
 
+#include <iostream> // For cout.
+
 namespace
 {
 


### PR DESCRIPTION
A major revision of one of my earliest contributions to ITK 😸  which aimed to make `itk::ExceptionObject` exception-safe, by introducing a rather complicated new internal data structure: 

Commit 8bfd356e80a8a68cf9211b4089dabaafd8eabd35, _"BUG: fixed issue 0007094: itk::ExceptionObject should never cause a crash. Removed ExceptionObject::UpdateWhat(), as discussed with Brad King and Bill Lorensen at [Insight-developers]"_, 28 May 2008.

This pull request proposes to very much simplify the implementation, while preserving its exception-safety.