### PR TITLE
COMP: Fix deduced type initialization warning and operand mismatch error

### DIFF
--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -282,7 +282,7 @@ private:
       }
       int                  exponent;
       const CoordinateType mantissa{ std::frexp(k, &exponent) };
-      auto                 value{ static_cast<SizeValueType>(std::fabs(mantissa)) };
+      auto                 value = static_cast<SizeValueType>(std::fabs(mantissa));
       value = (2 * value - 1) * ~0U;
       return value;
     }


### PR DESCRIPTION
Fix deduced type initialization warning and operand mismatch error.

Fixes deduced type initialization warning on Apple clang:
```
/Users/builder/externalModules/Filtering/Path/include/itkContourExtractor2DImageFilter.h:285:33:
warning: direct list initialization of a variable with a deduced type will
change meaning in a future version of Clang; insert an '=' to avoid a
change in behavior [-Wfuture-compat]
      auto                 value{ static_cast<SizeValueType>(std::fabs(mantissa)) };
                                ^
				=
```

raised at:
https://open.cdash.org/viewBuildError.php?buildid=7082817

and the operand mismatch error on Apple clang and gcc 4.6:
```
/Users/builder/externalModules/Filtering/Path/include/itkContourExtractor2DImageFilter.h:286:18:
error: invalid operands to binary expression ('int' and 'std::initializer_list<unsigned long>')
      value = (2 * value - 1) * ~0U;
               ~ ^ ~~~~~
```
raised at:
https://open.cdash.org/viewBuildError.php?buildid=7082817
https://open.cdash.org/viewBuildError.php?buildid=7082769
https://open.cdash.org/viewBuildError.php?buildid=7082559

Warning and failure were introduced in commit ad81939.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)