### PR TITLE
COMP: Fix image pointer casting error

### DIFF
--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -41,8 +41,9 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CopyInputToOutput()
   // Check if we are doing in-place filtering
   if (this->GetInPlace() && this->CanRunInPlace())
   {
-    typename TInputImage::Pointer tempPtr = output.GetPointer();
-    if (tempPtr && tempPtr->GetPixelContainer() == input->GetPixelContainer())
+    const void * const inputPixelContainer = input->GetPixelContainer();
+    const auto * const tempPtr = output.GetPointer();
+    if (tempPtr != nullptr && tempPtr->GetPixelContainer() == inputPixelContainer)
     {
       // the input and output container are the same - no need to copy
       return;


### PR DESCRIPTION
Fix image pointer casting error.

Fixes
```
In file included from
ITK/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h:194:0,
from
ITK/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.h:21,
from
ITK/Modules/Filtering/AnisotropicSmoothing/include/itkGradientAnisotropicDiffusionImageFilter.h:21,
from
src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/Code.cxx:22:
/.../ITKExamples-build/ITK/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx:
In instantiation of
'void itk::DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CopyInputToOutput()
[with TInputImage = itk::Image<unsigned char, 2>; TOutputImage = itk::Image<float, 2>]':
src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/Code.cxx:72:1:
required from here

ITK/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx:44:35:
error: conversion from 'itk::SmartPointer<itk::Image<float, 2> >::ObjectType*
{aka itk::Image<float, 2>*}' to non-scalar type
'itk::Image<unsigned char, 2>::Pointer
{aka itk::SmartPointer<itk::Image<unsigned char, 2> >}' requested

typename TInputImage::Pointer tempPtr =	output.GetPointer();
                              ^~~~~~~
```

raised at:
https://open.cdash.org/viewBuildError.php?buildid=7083938

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)