### PR TITLE
ENH: Support 32 bit integer IO in wrapping

### DIFF
--- a/Modules/Core/Common/wrapping/itkImageSource.wrap
+++ b/Modules/Core/Common/wrapping/itkImageSource.wrap
@@ -1,6 +1,6 @@
 itk_wrap_class("itk::ImageSource" POINTER)
   # Force uchar and ulong image sources for saving in 8 bits and watershed filter
-  UNIQUE(image_types "UC;RGBUC;RGBAUC;UL;ULL;${ITKM_IT};${WRAP_ITK_ALL_TYPES}")
+  UNIQUE(image_types "UC;RGBUC;RGBAUC;SI;UI;UL;ULL;${ITKM_IT};${WRAP_ITK_ALL_TYPES}")
   itk_wrap_image_filter("${image_types}" 1)
 
   UNIQUE(to_types "${WRAP_ITK_SCALAR};UC")

--- a/Modules/Core/Common/wrapping/itkImageToImageFilterA.wrap
+++ b/Modules/Core/Common/wrapping/itkImageToImageFilterA.wrap
@@ -1,8 +1,8 @@
 itk_wrap_class("itk::ImageToImageFilter" POINTER)
   # Wrap from each scalar type to each other, and also to uchar (for 8-bit saving)
   # and to ulong (for watershed).
-  UNIQUE(from_types "UC;UL;${ITKM_IT};ULL;${WRAP_ITK_SCALAR}")
-  UNIQUE(to_types "UC;UL;${ITKM_IT};${WRAP_ITK_SCALAR}")
+  UNIQUE(from_types "UC;UL;SI;UI;${ITKM_IT};ULL;${WRAP_ITK_SCALAR}")
+  UNIQUE(to_types "UC;UL;SI;UI;${ITKM_IT};${WRAP_ITK_SCALAR}")
   itk_wrap_image_filter_combinations("${from_types}" "${to_types}")
 
   UNIQUE(to_types "UC;${WRAP_ITK_SCALAR}")

--- a/Modules/Filtering/ImageFilterBase/wrapping/itkCastImageFilter.wrap
+++ b/Modules/Filtering/ImageFilterBase/wrapping/itkCastImageFilter.wrap
@@ -2,7 +2,7 @@ itk_wrap_class("itk::CastImageFilter" POINTER_WITH_SUPERCLASS)
   # Create cast filters between all scalar types. Also force that cast-to-uchar
   # filters are created for all scalar types, and unsigned long for
   # segmentation output casting.
-  UNIQUE(types "${WRAP_ITK_SCALAR};UC;UL")
+  UNIQUE(types "${WRAP_ITK_SCALAR};UC;UI;SI;UL")
   itk_wrap_image_filter_combinations("${types}" "${types}")
 
   # vector <-> vector

--- a/Modules/IO/ImageBase/wrapping/itkImageFileReader.wrap
+++ b/Modules/IO/ImageBase/wrapping/itkImageFileReader.wrap
@@ -1,6 +1,6 @@
 itk_wrap_class("itk::ImageFileReader" POINTER)
   # Force uchar image IO
-  UNIQUE(image_types "ULL;UC;${WRAP_ITK_ALL_TYPES}")
+  UNIQUE(image_types "ULL;SI;UI;UC;${WRAP_ITK_ALL_TYPES}")
   itk_wrap_image_filter("${image_types}" 1)
 
   UNIQUE(to_types "${WRAP_ITK_SCALAR};UC")

--- a/Modules/IO/ImageBase/wrapping/itkImageFileWriter.wrap
+++ b/Modules/IO/ImageBase/wrapping/itkImageFileWriter.wrap
@@ -1,6 +1,6 @@
 itk_wrap_class("itk::ImageFileWriter" POINTER)
   # Force uchar image IO
-  UNIQUE(image_types "ULL;UC;RGBUC;${WRAP_ITK_ALL_TYPES}")
+  UNIQUE(image_types "ULL;UI;SI;UC;RGBUC;${WRAP_ITK_ALL_TYPES}")
   itk_wrap_image_filter("${image_types}" 1)
 
   UNIQUE(to_types "${WRAP_ITK_SCALAR};UC")

--- a/Modules/IO/ImageBase/wrapping/itkImageSeriesReader.wrap
+++ b/Modules/IO/ImageBase/wrapping/itkImageSeriesReader.wrap
@@ -1,5 +1,5 @@
 itk_wrap_class("itk::ImageSeriesReader" POINTER)
   # Force uchar image IO
-  UNIQUE(image_types "UC;${WRAP_ITK_ALL_TYPES}")
+  UNIQUE(image_types "UC;UI;SI;${WRAP_ITK_ALL_TYPES}")
   itk_wrap_image_filter("${image_types}" 1)
 itk_end_wrap_class()

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -160,6 +160,14 @@ except Exception as e:
 image = itk.imread(filename, imageio=itk.PNGImageIO.New())
 assert type(image) == itk.Image[itk.RGBPixel[itk.UC], 2]
 
+# Make sure we can read unsigned short, unsigned int, and cast
+image = itk.imread(filename, itk.UI)
+assert type(image) == itk.Image[itk.UI, 2]
+image = itk.imread(filename, itk.SI)
+assert type(image) == itk.Image[itk.SI, 2]
+as_float = image.astype(np.float32)
+assert type(as_float) == itk.Image[itk.F, 2]
+
 # test mesh read / write
 mesh = itk.meshread(mesh_filename)
 assert type(mesh) == itk.Mesh[itk.F, 3]

--- a/Wrapping/WrapITKTypes.cmake
+++ b/Wrapping/WrapITKTypes.cmake
@@ -203,10 +203,11 @@ WRAP_TYPE("itk::Image" "I" "itkImage.h")
   # Make a list of all of the selected image pixel types and also double (for
   # BSplineDeformableTransform), uchar (for 8-bit image output), ulong
   # (for the watershed and relabel filters), bool for (FlatStructuringElement)
+  # unsigned int and signed int for IO.
 
   # Wrap from ulong to other integral types, even if ulong isn't wrapped. This
   # is needed for the relabel components image filter.
-  UNIQUE(WRAP_ITK_SCALAR_IMAGE_PIXEL_TYPES "${WRAP_ITK_SCALAR};D;UC;UL;ULL;B;${ITKM_IT}")
+  UNIQUE(WRAP_ITK_SCALAR_IMAGE_PIXEL_TYPES "${WRAP_ITK_SCALAR};D;UC;SI;UI;UL;ULL;B;${ITKM_IT}")
   UNIQUE(wrap_image_types "${WRAP_ITK_ALL_TYPES};RGBUC;RGBAUC;VD;${WRAP_ITK_SCALAR_IMAGE_PIXEL_TYPES}")
 
   set(defined_vector_list )


### PR DESCRIPTION
Even though 32 bit integer is often not enabled in the wrapping for the
entire toolkit, add minimial support so we can alway read / write / cast
files with this type in their native type.
