### PR TITLE
COMP: Fix missing initializer warning

### DIFF
--- a/Modules/Core/Common/include/itkImage.hxx
+++ b/Modules/Core/Common/include/itkImage.hxx
@@ -148,7 +148,7 @@ Image<TPixel, VImageDimension>::GetNumberOfComponentsPerPixel() const
 {
   // use the GetLength() method which works with variable length arrays,
   // to make it work with as much pixel types as possible
-  const PixelType p{};
+  const auto p = PixelType();
   return NumericTraits<PixelType>::GetLength(p);
 }
 


### PR DESCRIPTION
Fix missing initializer warning.

Fixes:
```
/tmp/bld/ITK/Modules/Core/Common/include/itkImage.hxx: In instantiation of
'unsigned int itk::Image<TPixel,
VImageDimension>::GetNumberOfComponentsPerPixel() const [with TPixel =
itk::Index<4u>; unsigned int VImageDimension = 4u]':
bld/ITK/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx:427:1:
required from here
[CTest: warning matched]
bld/ITK/Modules/Core/Common/include/itkImage.hxx:151:21: warning: missing
initializer for member 'itk::Index<4u>::m_InternalArray'
[-Wmissing-field-initializers]
   const PixelType p{};
                     ^
```

raised at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=7088974
https://open.cdash.org/viewBuildError.php?type=1&buildid=7089276
https://open.cdash.org/viewBuildError.php?type=1&buildid=7089222

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)