### PR TITLE
STYLE: Use equal_to on pixel containers DenseFiniteDifferenceImageFilter

### DIFF
--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -19,10 +19,12 @@
 #define itkDenseFiniteDifferenceImageFilter_hxx
 #include "itkDenseFiniteDifferenceImageFilter.h"
 
-#include <list>
 #include "itkImageRegionIterator.h"
 #include "itkNumericTraits.h"
 #include "itkNeighborhoodAlgorithm.h"
+
+#include <functional> // For equal_to.
+
 
 namespace itk
 {
@@ -39,15 +41,11 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CopyInputToOutput()
   }
 
   // Check if we are doing in-place filtering
-  if (this->GetInPlace() && this->CanRunInPlace())
+  if (this->GetInPlace() && this->CanRunInPlace() &&
+      std::equal_to<const void *>{}(input->GetPixelContainer(), output->GetPixelContainer()))
   {
-    const void * const inputPixelContainer = input->GetPixelContainer();
-    const auto * const tempPtr = output.GetPointer();
-    if (tempPtr != nullptr && tempPtr->GetPixelContainer() == inputPixelContainer)
-    {
-      // the input and output container are the same - no need to copy
-      return;
-    }
+    // the input and output container are the same - no need to copy
+    return;
   }
 
   ImageRegionConstIterator<TInputImage> in(input, output->GetRequestedRegion());


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2386
commit 1c25350c93c33578b11c83bce501496c306ff3b1
"COMP: Fix image pointer casting error"

Also removed an unused `#include <list>`.