### PR TITLE
BUG: Remove duplicate "itk::ERROR: " from itkSpecializedExceptionMacro

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -519,8 +519,7 @@ OutputWindowDisplayDebugText(const char *);
 
 #define itkSpecializedExceptionMacro(ExceptionType)                                                                    \
   {                                                                                                                    \
-    itkSpecializedMessageExceptionMacro(ExceptionType,                                                                 \
-                                        "itk::ERROR: " << ::itk::ExceptionType::default_exception_message);            \
+    itkSpecializedMessageExceptionMacro(ExceptionType, << ::itk::ExceptionType::default_exception_message);            \
   }                                                                                                                    \
   ITK_MACROEND_NOOP_STATEMENT
 

--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -23,6 +23,11 @@
 #include <string>
 
 
+itkDeclareExceptionMacro(GTest_SpecializedException,
+                         ExceptionObject,
+                         "GTest specific specialized exception (for unit test purposes only)");
+
+
 // Tests the description of an exception object thrown by `itkExceptionMacro(x)`.
 TEST(ExceptionObject, TestDescriptionFromExceptionMacro)
 {
@@ -54,6 +59,22 @@ TEST(ExceptionObject, TestDescriptionFromExceptionMacro)
     expectedDescription << "itk::ERROR: " << testObject.GetNameOfClass() << "(" << &testObject << "): " << testMessage;
 
     EXPECT_EQ(actualDescription, expectedDescription.str());
+  }
+}
+
+
+// Tests the description of an exception object thrown by `itkSpecializedExceptionMacro(x)`.
+TEST(ExceptionObject, TestDescriptionFromSpecializedExceptionMacro)
+{
+  try
+  {
+    itkSpecializedExceptionMacro(GTest_SpecializedException);
+  }
+  catch (const itk::ExceptionObject & exceptionObject)
+  {
+    const char * const description = exceptionObject.GetDescription();
+    ASSERT_NE(description, nullptr);
+    EXPECT_EQ(description, std::string("itk::ERROR: ") + itk::GTest_SpecializedException::default_exception_message);
   }
 }
 


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2380
commit df0a977dd47467a82bfbfc76ed301c159d020a4c
"BUG: Remove duplicate "itk::ERROR: itk::ERROR: " from itkExceptionMacro"