### PR TITLE
STYLE: C++11 inheriting constructors and Rule of Zero for ExceptionObject derived classes

### DIFF
--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -143,29 +143,8 @@ operator<<(std::ostream & os, const ExceptionObject & e)
 class ITKCommon_EXPORT MemoryAllocationError : public ExceptionObject
 {
 public:
-  /** Default constructor.  Needed to ensure the exception object can be
-   * copied. */
-  MemoryAllocationError() noexcept
-    : ExceptionObject()
-  {}
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  MemoryAllocationError(const char * file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {}
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  MemoryAllocationError(const std::string & file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {}
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  MemoryAllocationError(const std::string & file,
-                        unsigned int        lineNumber,
-                        const std::string & desc,
-                        const std::string & loc)
-    : ExceptionObject(file, lineNumber, desc, loc)
-  {}
+  // Inherit the constructors from its base class.
+  using ExceptionObject::ExceptionObject;
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~MemoryAllocationError() noexcept override;
@@ -185,21 +164,8 @@ public:
 class ITKCommon_EXPORT RangeError : public ExceptionObject
 {
 public:
-  /** Default constructor.  Needed to ensure the exception object can be
-   * copied. */
-  RangeError() noexcept
-    : ExceptionObject()
-  {}
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  RangeError(const char * file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {}
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  RangeError(const std::string & file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {}
+  // Inherit the constructors from its base class.
+  using ExceptionObject::ExceptionObject;
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~RangeError() noexcept override;
@@ -220,27 +186,8 @@ public:
 class ITKCommon_EXPORT InvalidArgumentError : public ExceptionObject
 {
 public:
-  /**
-   * Default constructor.  Needed to ensure the exception object can be
-   * copied.
-   */
-  InvalidArgumentError() noexcept
-    : ExceptionObject()
-  {}
-
-  /**
-   * Constructor. Needed to ensure the exception object can be copied.
-   */
-  InvalidArgumentError(const char * file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {}
-
-  /**
-   * Constructor. Needed to ensure the exception object can be copied.
-   */
-  InvalidArgumentError(const std::string & file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {}
+  // Inherit the constructors from its base class.
+  using ExceptionObject::ExceptionObject;
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~InvalidArgumentError() noexcept override;
@@ -260,21 +207,8 @@ public:
 class ITKCommon_EXPORT IncompatibleOperandsError : public ExceptionObject
 {
 public:
-  /** Default constructor.  Needed to ensure the exception object can be
-   * copied. */
-  IncompatibleOperandsError() noexcept
-    : ExceptionObject()
-  {}
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  IncompatibleOperandsError(const char * file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {}
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  IncompatibleOperandsError(const std::string & file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {}
+  // Inherit the constructors from its base class.
+  using ExceptionObject::ExceptionObject;
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~IncompatibleOperandsError() noexcept override;

--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -146,9 +146,6 @@ public:
   // Inherit the constructors from its base class.
   using ExceptionObject::ExceptionObject;
 
-  /** Virtual destructor needed for subclasses. Has to have empty throw(). */
-  ~MemoryAllocationError() noexcept override;
-
   const char *
   GetNameOfClass() const override
   {
@@ -166,9 +163,6 @@ class ITKCommon_EXPORT RangeError : public ExceptionObject
 public:
   // Inherit the constructors from its base class.
   using ExceptionObject::ExceptionObject;
-
-  /** Virtual destructor needed for subclasses. Has to have empty throw(). */
-  ~RangeError() noexcept override;
 
   const char *
   GetNameOfClass() const override
@@ -189,9 +183,6 @@ public:
   // Inherit the constructors from its base class.
   using ExceptionObject::ExceptionObject;
 
-  /** Virtual destructor needed for subclasses. Has to have empty throw(). */
-  ~InvalidArgumentError() noexcept override;
-
   const char *
   GetNameOfClass() const override
   {
@@ -209,9 +200,6 @@ class ITKCommon_EXPORT IncompatibleOperandsError : public ExceptionObject
 public:
   // Inherit the constructors from its base class.
   using ExceptionObject::ExceptionObject;
-
-  /** Virtual destructor needed for subclasses. Has to have empty throw(). */
-  ~IncompatibleOperandsError() noexcept override;
 
   const char *
   GetNameOfClass() const override
@@ -249,9 +237,6 @@ public:
   {
     this->SetDescription("Filter execution was aborted by an external request");
   }
-
-  /** Virtual destructor needed for subclasses. Has to have empty throw(). */
-  ~ProcessAborted() noexcept override;
 
   const char *
   GetNameOfClass() const override

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -207,14 +207,4 @@ ExceptionObject::Print(std::ostream & os) const
   os << indent << std::endl;
 }
 
-MemoryAllocationError::~MemoryAllocationError() noexcept = default;
-
-RangeError::~RangeError() noexcept = default;
-
-InvalidArgumentError::~InvalidArgumentError() noexcept = default;
-
-IncompatibleOperandsError::~IncompatibleOperandsError() noexcept = default;
-
-ProcessAborted::~ProcessAborted() noexcept = default;
-
 } // end namespace itk


### PR DESCRIPTION
`MemoryAllocationError`, `RangeError`, `InvalidArgumentError`, and
`IncompatibleOperandsError` may simply inherit the constructors from
their base class, `itk::ExceptionObject`.