### PR TITLE
DOC: fix MutexLock-related broken links in the migration guide

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -69,11 +69,11 @@ Availability of the C++11 standard allows use of many Standard Library
 features. These were previously implemented as portable ITK classes.
 The standard library classes are preferred over ITK's implementations.
 The most notable examples of this are:
- * [atomic integers](https://itk.org/Doxygen/html/classitk_1_1AtomicInt.html) should be replaced by `std::atomic`.
- * [mutex locks](https://itk.org/Doxygen/html/classitk_1_1MutexLock.html)
-and related classes should be replaced by the similarly named classes from
-[<mutex>](https://en.cppreference.com/w/cpp/header/mutex) header.
- * itksys::hash_map should be replaced by [std::unordered_map](https://en.cppreference.com/w/cpp/container/unordered_map).
+ * [atomic integers](https://itk.org/Doxygen413/html/classitk_1_1AtomicInt.html) should be replaced by `std::atomic`.
+ * [mutex locks](https://itk.org/Doxygen413/html/classitk_1_1MutexLock.html)
+and related classes should be replaced by the similarly named classes from STL's
+[`<mutex>`](https://en.cppreference.com/w/cpp/header/mutex) header.
+ * `itksys::hash_map` should be replaced by [std::unordered_map](https://en.cppreference.com/w/cpp/container/unordered_map).
 
 To modernize your code base, replace:
   * `SimpleFastMutexLock` with `std::mutex`, and `#include "itkSimpleFastMutexLock.h"`  with `#include <mutex>`.


### PR DESCRIPTION
## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKExamples) for all new major features (if any)
