### PR TITLE
COMP: Add virtual destructor to TestClass in ExceptionObject unit test

### DIFF
--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -34,6 +34,10 @@ TEST(ExceptionObject, TestDescriptionFromExceptionMacro)
   class TestClass
   {
   public:
+    ITK_DISALLOW_COPY_AND_MOVE(TestClass);
+    TestClass() = default;
+    virtual ~TestClass() = default;
+
     itkTypeMacroNoParent(TestClass);
 
     void


### PR DESCRIPTION
Addressed Mac10.14-AppleClang-dbg-ASanUBSan warning:

> itkExceptionObjectGTest.cxx:29:9: warning: 'TestClass' has virtual
> functions but non-virtual destructor [-Wnon-virtual-dtor]

From https://open.cdash.org/viewBuildError.php?type=1&buildid=7093971

Reported by Jon Haitz Legarreta Gorroño (@jhlegarreta) at
https://github.com/InsightSoftwareConsortium/ITK/pull/2374#issuecomment-797546665

Also added an explicit default-constructor, and disallowed copy and move.