### PR TITLE
STYLE: Replace "itk::ERROR" by "ITK ERROR" in description of exception

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -511,7 +511,7 @@ OutputWindowDisplayDebugText(const char *);
 #define itkSpecializedMessageExceptionMacro(ExceptionType, x)                                                          \
   {                                                                                                                    \
     std::ostringstream message;                                                                                        \
-    message << "itk::ERROR: " x;                                                                                       \
+    message << "ITK ERROR: " x;                                                                                        \
     throw ::itk::ExceptionType(                                                                                        \
       std::string{ __FILE__ }, __LINE__, std::string{ message.str() }, std::string{ ITK_LOCATION });                   \
   }                                                                                                                    \

--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -56,7 +56,7 @@ TEST(ExceptionObject, TestDescriptionFromExceptionMacro)
     ASSERT_NE(actualDescription, nullptr);
 
     std::ostringstream expectedDescription;
-    expectedDescription << "itk::ERROR: " << testObject.GetNameOfClass() << "(" << &testObject << "): " << testMessage;
+    expectedDescription << "ITK ERROR: " << testObject.GetNameOfClass() << "(" << &testObject << "): " << testMessage;
 
     EXPECT_EQ(actualDescription, expectedDescription.str());
   }
@@ -74,7 +74,7 @@ TEST(ExceptionObject, TestDescriptionFromSpecializedExceptionMacro)
   {
     const char * const description = exceptionObject.GetDescription();
     ASSERT_NE(description, nullptr);
-    EXPECT_EQ(description, std::string("itk::ERROR: ") + itk::GTest_SpecializedException::default_exception_message);
+    EXPECT_EQ(description, std::string("ITK ERROR: ") + itk::GTest_SpecializedException::default_exception_message);
   }
 }
 


### PR DESCRIPTION
Previously, the description text of an exception thrown by
`itkSpecializedMessageExceptionMacro` would start with the text
"itk::ERROR", which seemed to suggest that it involved an `itk::ERROR`
object, function, or type. However, there is no such `ERROR` in the
`itk` namespace!

It appears clearer to use the text "ITK ERROR" instead, to indicate
that the error involves the ITK library.