### PR TITLE
BUG: Checkout full depths for clang-format-linter

### DIFF
--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -8,8 +8,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
       with:
         error-message: 'Code is inconsistent with ITK Coding Style. Add the *action:ApplyClangFormat* PR label to correct.'


### PR DESCRIPTION
To address:

reference is not a tree: 670863f3c88fad4d181fe9f59f8b154983c48bd5
lint
Git checkout failed with exit code: 128
lint
Exit code 1 returned from process: file name '/home/runner/runners/2.277.1/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
lint
Git checkout failed on shallow repository, this might because of git fetch with depth '1' doesn't include the checkout commit '670863f3c88fad4d181fe9f59f8b154983c48bd5'.
lint
Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see actions/virtual-environments/issues/1816

https://github.com/InsightSoftwareConsortium/ITK/actions/runs/646656228
