### PR TITLE
Avoid "message" naming conflicts exception macro, inherit constructors, remove ITK_MACROEND_NOOP_STATEMENT calls

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -508,25 +508,15 @@ OutputWindowDisplayDebugText(const char *);
   ITK_MACROEND_NOOP_STATEMENT
 
 #define itkSpecializedExceptionMacro(ExceptionType)                                                                    \
-  {                                                                                                                    \
-    itkSpecializedMessageExceptionMacro(ExceptionType, << ::itk::ExceptionType::default_exception_message);            \
-  }                                                                                                                    \
-  ITK_MACROEND_NOOP_STATEMENT
+  itkSpecializedMessageExceptionMacro(ExceptionType, << ::itk::ExceptionType::default_exception_message)
 
 /** The itkExceptionMacro macro is used to print error information (i.e., usually
  * a condition that results in program failure). Example usage looks like:
  * itkExceptionMacro(<< "this is error info" << this->SomeVariable); */
 #define itkExceptionMacro(x)                                                                                           \
-  {                                                                                                                    \
-    itkSpecializedMessageExceptionMacro(ExceptionObject, << this->GetNameOfClass() << "(" << this << "): " x);         \
-  }                                                                                                                    \
-  ITK_MACROEND_NOOP_STATEMENT
+  itkSpecializedMessageExceptionMacro(ExceptionObject, << this->GetNameOfClass() << "(" << this << "): " x)
 
-#define itkGenericExceptionMacro(x)                                                                                    \
-  {                                                                                                                    \
-    itkSpecializedMessageExceptionMacro(ExceptionObject, x);                                                           \
-  }                                                                                                                    \
-  ITK_MACROEND_NOOP_STATEMENT
+#define itkGenericExceptionMacro(x) itkSpecializedMessageExceptionMacro(ExceptionObject, x)
 
 #define itkGenericOutputMacro(x)                                                                                       \
   {                                                                                                                    \

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -490,18 +490,8 @@ OutputWindowDisplayDebugText(const char *);
   public:                                                                                                              \
     /* default message provides backward compatibility for a given exception type */                                   \
     static constexpr const char * const default_exception_message = whatmessage;                                       \
-    explicit newexcp(const char * file,                                                                                \
-                     unsigned int lineNumber = 0,                                                                      \
-                     const char * desc = "None",                                                                       \
-                     const char * loc = "Unknown")                                                                     \
-      : parentexcp(std::string{ file }, lineNumber, std::string{ desc }, std::string{ loc })                           \
-    {}                                                                                                                 \
-    explicit newexcp(std::string  file,                                                                                \
-                     unsigned int lineNumber = 0,                                                                      \
-                     std::string  desc = std::string{ "None" },                                                        \
-                     std::string  loc = std::string{ "Unknown" })                                                      \
-      : parentexcp(std::move(file), lineNumber, std::move(desc), std::move(loc))                                       \
-    {}                                                                                                                 \
+    /* Inherit the constructors from its base class. */                                                                \
+    using parentexcp::parentexcp;                                                                                      \
     itkTypeMacro(newexcp, parentexcp);                                                                                 \
   };                                                                                                                   \
   }                                                                                                                    \

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -510,10 +510,10 @@ OutputWindowDisplayDebugText(const char *);
 
 #define itkSpecializedMessageExceptionMacro(ExceptionType, x)                                                          \
   {                                                                                                                    \
-    std::ostringstream message;                                                                                        \
-    message << "ITK ERROR: " x;                                                                                        \
+    std::ostringstream exceptionDescriptionOutputStringStream;                                                         \
+    exceptionDescriptionOutputStringStream << "ITK ERROR: " x;                                                         \
     throw ::itk::ExceptionType(                                                                                        \
-      std::string{ __FILE__ }, __LINE__, std::string{ message.str() }, std::string{ ITK_LOCATION });                   \
+      std::string{ __FILE__ }, __LINE__, exceptionDescriptionOutputStringStream.str(), std::string{ ITK_LOCATION });   \
   }                                                                                                                    \
   ITK_MACROEND_NOOP_STATEMENT
 

--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -41,18 +41,18 @@ TEST(ExceptionObject, TestDescriptionFromExceptionMacro)
     itkTypeMacroNoParent(TestClass);
 
     void
-    CallExceptionMacro(const std::string & testMessage) const
+    CallExceptionMacro(const std::string & message) const
     {
-      itkExceptionMacro(<< testMessage);
+      itkExceptionMacro(<< message);
     }
   };
 
-  const std::string testMessage = "test message";
+  const std::string message = "test message";
   const TestClass   testObject{};
 
   try
   {
-    testObject.CallExceptionMacro(testMessage);
+    testObject.CallExceptionMacro(message);
   }
   catch (const itk::ExceptionObject & exceptionObject)
   {
@@ -60,7 +60,7 @@ TEST(ExceptionObject, TestDescriptionFromExceptionMacro)
     ASSERT_NE(actualDescription, nullptr);
 
     std::ostringstream expectedDescription;
-    expectedDescription << "ITK ERROR: " << testObject.GetNameOfClass() << "(" << &testObject << "): " << testMessage;
+    expectedDescription << "ITK ERROR: " << testObject.GetNameOfClass() << "(" << &testObject << "): " << message;
 
     EXPECT_EQ(actualDescription, expectedDescription.str());
   }


### PR DESCRIPTION
Replaced the very general term "message" inside the definition of
`itkSpecializedMessageExceptionMacro` by a much more specific
identifier, "exceptionDescriptionOutputStringStream", to avoid naming
conflicts in user code.

Removed the unnecessary `std::string{ ... }` construction for the result
of `std::ostringstream::str()`, as it is an `std::string` already.

Did inherit the exception constructors inside `itkDeclareExceptionMacro`,
as a follow-up to pull request #2398 commit e41b2ef92196805ccac076115468d3d7d54f0cf5
"STYLE: C++11 inheriting constructors from ExceptionObject for 4 classes"

Removed unnecessary `ITK_MACROEND_NOOP_STATEMENT` calls from exception macro definitions.
