### PR TITLE
STYLE: Remove dynamic_casts PosteriorImage BayesianClassifierImageFilter

### DIFF
--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -152,7 +152,7 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
       itkExceptionMacro("Second input type does not correspond to expected Priors Image Type");
     }
 
-    auto * posteriorsImage = dynamic_cast<PosteriorsImageType *>(this->GetPosteriorImage());
+    PosteriorsImageType * posteriorsImage = this->GetPosteriorImage();
 
     if (posteriorsImage == nullptr)
     {
@@ -187,7 +187,7 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
   }
   else
   {
-    auto * posteriorsImage = dynamic_cast<PosteriorsImageType *>(this->GetPosteriorImage());
+    PosteriorsImageType * posteriorsImage = this->GetPosteriorImage();
 
     if (posteriorsImage == nullptr)
     {
@@ -329,7 +329,7 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
 
   ImageRegionType imageRegion = labels->GetBufferedRegion();
 
-  auto * posteriorsImage = dynamic_cast<PosteriorsImageType *>(this->GetPosteriorImage());
+  PosteriorsImageType * posteriorsImage = this->GetPosteriorImage();
 
   if (posteriorsImage == nullptr)
   {


### PR DESCRIPTION
Removed the three "no-op" dynamic_casts of `this->GetPosteriorImage()`
from the implementation of `BayesianClassifierImageFilter`.

Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2365
commit 5089a04475583a723a41f92674e8127a265f9250
"STYLE: Remove 9 no-op dynamic_casts (casting T* to T*)"