### PR TITLE
COMP: Define ExceptionObject destructor out-of-line (doing Rule of Five)

### DIFF
--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -50,12 +50,7 @@ public:
   static constexpr const char * const default_exception_message = "Generic ExceptionObject";
   using Superclass = std::exception;
 
-  /** Explicitly-defaulted default-constructor. Creates an empty exception object.
-   * \note The other five "special member functions" (copy-constructor,
-   * copy-assignment operator, move-constructor, move-assignment operator,
-   * and destructor) are defaulted implicitly, following the C++ "Rule of Zero".
-   * All of these special member functions are `noexcept`.
-   */
+  /** Explicitly-defaulted default-constructor. Creates an empty exception object. */
   ExceptionObject() noexcept = default;
 
   explicit ExceptionObject(const char * file,
@@ -66,6 +61,24 @@ public:
                            unsigned int lineNumber = 0,
                            std::string  desc = "None",
                            std::string  loc = "Unknown");
+
+  /** Copy-constructor. */
+  ExceptionObject(const ExceptionObject &) noexcept = default;
+
+  /** Move-constructor. */
+  ExceptionObject(ExceptionObject &&) noexcept = default;
+
+  /** Copy-assignment operator. */
+  ExceptionObject &
+  operator=(const ExceptionObject &) noexcept = default;
+
+  /** Move-assignment operator. */
+  ExceptionObject &
+  operator=(ExceptionObject &&) noexcept = default;
+
+  /** Destructor.
+   * \note It appears necessary to define the destructor "out-of-line" for external linkage. */
+  ~ExceptionObject() override;
 
   /** Equivalence operator. */
   virtual bool

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -75,6 +75,10 @@ ExceptionObject::ExceptionObject(std::string file, unsigned int lineNumber, std:
 {}
 
 
+// Note: It appears necessary to define the destructor "out-of-line" for external linkage.
+ExceptionObject::~ExceptionObject() = default;
+
+
 bool
 ExceptionObject::operator==(const ExceptionObject & orig) const
 {


### PR DESCRIPTION
Followed the C++ Rule of Five, instead of the Rule of Zero, for
`ExceptionObject`, and added the definition of its destructor to its CXX
file.

Aims to fix Visual C++ link errors (error LNK2005 "symbol was defined
more than once", fatal error LNK1169) reported by @SimonRit, and
confirmed by @LucasGandel, at "Modernize the implementation of
ExceptionObject", pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2374