### PR TITLE
COMP: Avoid creating a copy variable

### DIFF
--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -544,7 +544,7 @@ TEST(ShapedImageNeighborhoodRange, IteratorRetrievesSamePixelValuesAsConstNeighb
 
     itk::SizeValueType i = 0;
 
-    for (const auto pixel : range)
+    for (const PixelType pixel : range)
     {
       EXPECT_EQ(pixel, constNeighborhoodIterator.GetPixel(i));
       ++i;


### PR DESCRIPTION
Avoid creating a copy variable.

Fixes:

```
[CTest: warning matched]
/Users/builder/externalModules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx:547:21:
warning: loop variable 'pixel' of type 'const
itk::ShapedImageNeighborhoodRange<const itk::Image<unsigned char,
2>, itk::ZeroFluxNeumannImageNeighborhoodPixelAccessPolicy<const
itk::Image<unsigned char, 2> > >::PixelProxy<true, void>' creates
a copy from type 'const itk::ShapedImageNeighborhoodRange<const
itk::Image<unsigned char, 2>,
itk::ZeroFluxNeumannImageNeighborhoodPixelAccessPolicy<const
itk::Image<unsigned char, 2> > >::PixelProxy<true, void>'
[-Wrange-loop-analysis]
    for (const auto pixel : range)
                    ^
[CTest: warning matched]
/Users/builder/externalModules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx:547:10:
note: use reference type 'const
itk::ShapedImageNeighborhoodRange<const
itk::Image<unsigned char, 2>,
itk::ZeroFluxNeumannImageNeighborhoodPixelAccessPolicy<const
itk::Image<unsigned char, 2> >
>::PixelProxy<true, void> &' to prevent
>copying
    for (const auto pixel : range)
        ^~~~~~~~~~~~~~~~~~
[CTest: warning suppressed] 1 warning generated.
```

raised at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=7103973

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
