### PR TITLE
ENH: Trigger PR labeler workflows from forks

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,7 @@
 name: Label PRs
 
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   build:


### PR DESCRIPTION
Change the `GitHub` webhook event to a `pull_request_target` event to
trigger the PR labeler workflows from forks.

See documentation:
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
and
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)