### PR TITLE
ENH: Make itk::Matrix trivially copyable, following Rule of Zero

### DIFF
--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -210,7 +210,9 @@ public:
   }
 
   /**For every operator=, there should be an equivalent copy constructor. */
-  inline Matrix(const vnl_matrix<T> & matrix) { this->operator=(matrix); }
+  inline Matrix(const vnl_matrix<T> & matrix)
+    : m_Matrix(matrix)
+  {}
 
   /** Comparison operators. */
   inline bool
@@ -246,15 +248,9 @@ public:
   }
 
   /**For every operator=, there should be an equivalent copy constructor. */
-  inline explicit Matrix(const InternalMatrixType & matrix) { this->operator=(matrix); }
-
-  /** Assignment operator. */
-  inline const Self &
-  operator=(const Self & matrix)
-  {
-    m_Matrix = matrix.m_Matrix;
-    return *this;
-  }
+  inline explicit Matrix(const InternalMatrixType & matrix)
+    : m_Matrix(matrix)
+  {}
 
   /** Return the inverse matrix. */
   inline vnl_matrix_fixed<T, NColumns, NRows>
@@ -275,15 +271,12 @@ public:
     return vnl_matrix_fixed<T, NColumns, NRows>{ m_Matrix.transpose().as_matrix() };
   }
 
-  /** Default constructor. */
-  Matrix()
-    : m_Matrix(NumericTraits<T>::ZeroValue())
-  {}
-
-  /** Copy constructor. */
-  Matrix(const Self & matrix)
-    : m_Matrix(matrix.m_Matrix)
-  {}
+  /** Defaulted default-constructor. Zero-initializes all of its elements.
+   * \note The other five "special member functions" (copy-constructor,
+   * copy-assignment operator, move-constructor, move-assignment operator,
+   * and destructor) are implicitly defaulted, following the C++ "Rule of Zero".
+   */
+  Matrix() = default;
 
   void
   swap(Self & other)
@@ -294,7 +287,7 @@ public:
   }
 
 private:
-  InternalMatrixType m_Matrix;
+  InternalMatrixType m_Matrix{};
 };
 
 template <typename T, unsigned int NRows, unsigned int NColumns>

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -616,6 +616,7 @@ set(ITKCommonGTests
       itkImageIORegionGTest.cxx
       itkIndexGTest.cxx
       itkIndexRangeGTest.cxx
+      itkMatrixGTest.cxx
       itkMersenneTwisterRandomVariateGeneratorGTest.cxx
       itkNeighborhoodAllocatorGTest.cxx
       itkNumberToStringGTest.cxx

--- a/Modules/Core/Common/test/itkMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixGTest.cxx
@@ -1,0 +1,54 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkMatrix.h"
+#include <gtest/gtest.h>
+#include <type_traits> // For is_trivially_copyable.
+
+
+namespace
+{
+template <typename TMatrix>
+void
+Expect_Matrix_default_constructor_zero_initializes_all_elements()
+{
+  const TMatrix defaultConstructedMatrix;
+
+  for (unsigned row{}; row < TMatrix::RowDimensions; ++row)
+  {
+    for (unsigned column{}; column < TMatrix::ColumnDimensions; ++column)
+    {
+      EXPECT_EQ(defaultConstructedMatrix(row, column), 0);
+    }
+  }
+}
+} // namespace
+
+
+static_assert(std::is_trivially_copyable<itk::Matrix<float>>() && std::is_trivially_copyable<itk::Matrix<double>>() &&
+                std::is_trivially_copyable<itk::Matrix<double, 2, 2>>(),
+              "Matrix classes of built-in element types should be trivially copyable!");
+
+
+TEST(Matrix, DefaultConstructorZeroInitializesAllElements)
+{
+  Expect_Matrix_default_constructor_zero_initializes_all_elements<itk::Matrix<float>>();
+  Expect_Matrix_default_constructor_zero_initializes_all_elements<itk::Matrix<double>>();
+  Expect_Matrix_default_constructor_zero_initializes_all_elements<itk::Matrix<double, 2, 2>>();
+}


### PR DESCRIPTION
Defaulted the default-constructor of `itk::Matrix`, and added a
GoogleTest, to check that it does properly zero-initialize its elements.

Removed its user-defined copy-constructor and copy-assignment, following
the C++ "Rule of Zero". Tested that `itk::Matrix` has thereby become
"trivially copyable" for built-in element types.