### PR TITLE
COMP: fix link error building Universal Binary on Intel Mac

### DIFF
--- a/Modules/ThirdParty/PNG/src/itkpng/CMakeLists.txt
+++ b/Modules/ThirdParty/PNG/src/itkpng/CMakeLists.txt
@@ -11,7 +11,8 @@ pngerror.c  pngpread.c  pngrutil.c  pngwutil.c
 pngread.c   pngset.c   pngwio.c
 )
 
-if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
+# Kitware: added `OR APPLE` to allow Universal Binary builds on Intel Macs.
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm" OR APPLE)
   list(APPEND PNG_SRCS
     arm/arm_init.c
     arm/filter_neon_intrinsics.c


### PR DESCRIPTION
Without this, building Universal Binary on an Intel Mac (but not on an ARM Mac) gives link errors for undefined symbols like _itk_png_do_expand_palette_rgb8_neon and a few others.

Introspecting the CPU type of the build machine is fundamentally incompatible with the idea of Universal Binaries.