### PR TITLE
COMP: Fix macOS clang warnings [-Wunused-variable] in test source files

### DIFF
--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -122,7 +122,6 @@ itkAffineTransformTest(int, char *[])
   int any = 0; // Any errors detected in testing?
 
   Matrix2Type matrix2, matrix2Truth;
-  Matrix2Type inverse2;
   Vector2Type vector2, vector2Truth;
 
   /* Create a 2D identity transformation and show its parameters */

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -30,12 +30,12 @@ HDF5ReadWriteTest(const char * fileName)
   std::cout << fileName << std::endl;
   int success(EXIT_SUCCESS);
   using ImageType = typename itk::Image<TPixel, 3>;
-  typename ImageType::RegionType    imageRegion;
-  typename ImageType::SizeType      size;
-  typename ImageType::IndexType     index;
-  typename ImageType::SpacingType   spacing;
-  typename ImageType::PointType     origin;
-  typename ImageType::DirectionType myDirection;
+  typename ImageType::RegionType  imageRegion;
+  typename ImageType::SizeType    size;
+  typename ImageType::IndexType   index;
+  typename ImageType::SpacingType spacing;
+  typename ImageType::PointType   origin;
+
   for (unsigned i = 0; i < 3; i++)
   {
     size[i] = 5;

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -303,11 +303,10 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
 
   using ImageType = typename itk::Image<TPixel, VDimension>;
 
-  typename ImageType::SizeType      size;
-  typename ImageType::IndexType     index;
-  typename ImageType::SpacingType   spacing;
-  typename ImageType::PointType     origin;
-  typename ImageType::DirectionType myDirection;
+  typename ImageType::SizeType    size;
+  typename ImageType::IndexType   index;
+  typename ImageType::SpacingType spacing;
+  typename ImageType::PointType   origin;
 
   std::cout << "Testing:" << fileName << std::endl;
   for (unsigned i = 0; i < VDimension; i++)

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -513,12 +513,12 @@ RGBTest(int ac, char * av[])
   char * tmpImage = *++av;
   int    success(EXIT_SUCCESS);
   using RGBImageType = typename itk::Image<RGBPixelType, 3>;
-  typename RGBImageType::RegionType    imageRegion;
-  typename RGBImageType::SizeType      size;
-  typename RGBImageType::IndexType     index;
-  typename RGBImageType::SpacingType   spacing;
-  typename RGBImageType::PointType     origin;
-  typename RGBImageType::DirectionType myDirection;
+  typename RGBImageType::RegionType  imageRegion;
+  typename RGBImageType::SizeType    size;
+  typename RGBImageType::IndexType   index;
+  typename RGBImageType::SpacingType spacing;
+  typename RGBImageType::PointType   origin;
+
   for (unsigned i = 0; i < 3; i++)
   {
     size[i] = 5;

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
@@ -43,12 +43,11 @@ itkNiftiImageIOTest11(int ac, char * av[])
     return EXIT_FAILURE;
   }
   using ImageType = itk::Image<char, 3>;
-  ImageType::RegionType    imageRegion;
-  ImageType::SizeType      size;
-  ImageType::IndexType     index;
-  ImageType::SpacingType   spacing;
-  ImageType::PointType     origin;
-  ImageType::DirectionType myDirection;
+  ImageType::RegionType  imageRegion;
+  ImageType::SizeType    size;
+  ImageType::IndexType   index;
+  ImageType::SpacingType spacing;
+  ImageType::PointType   origin;
 
   size[0] = static_cast<long int>(itk::NumericTraits<short>::max()) * 2;
   size[1] = 1;


### PR DESCRIPTION
Fixed warnings from ITK.macOS Apple clang version 12.0.0
(clang-1200.0.32.29), saying:

> warning: unused variable 'myDirection' [-Wunused-variable]
> warning: unused variable 'inverse2' [-Wunused-variable]