### PR TITLE
COMP: Fix macOS clang warning [-Wunused-variable] in itkMINCImageIOTest

### DIFF
--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -558,11 +558,10 @@ MINCReadWriteTestVector(const char * fileName,
   using ImageType = typename itk::VectorImage<TPixel, VDimension>;
   using InternalPixelType = typename itk::VectorImage<TPixel, VDimension>::PixelType;
 
-  typename ImageType::SizeType      size;
-  typename ImageType::IndexType     index;
-  typename ImageType::SpacingType   spacing;
-  typename ImageType::PointType     origin;
-  typename ImageType::DirectionType myDirection;
+  typename ImageType::SizeType    size;
+  typename ImageType::IndexType   index;
+  typename ImageType::SpacingType spacing;
+  typename ImageType::PointType   origin;
 
   std::cout << "Testing:" << fileName << std::endl;
 


### PR DESCRIPTION
Fixed a warning from ITK.macOS Apple clang version 12.0.0
(clang-1200.0.32.29), saying:

> itkMINCImageIOTest.cxx:565:37: warning: unused variable 'myDirection' [-Wunused-variable]

Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2451
commit 24744f9ef427a05aa29175670a6ef9ac9ad04196
"COMP: Fix macOS clang warnings [-Wunused-variable] in test source files"