### PR TITLE
COMP: Build PNG arm sources for aarch64 CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/Modules/ThirdParty/PNG/src/itkpng/CMakeLists.txt
+++ b/Modules/ThirdParty/PNG/src/itkpng/CMakeLists.txt
@@ -12,7 +12,7 @@ pngread.c   pngset.c   pngwio.c
 )
 
 # Kitware: added `OR APPLE` to allow Universal Binary builds on Intel Macs.
-if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm" OR APPLE)
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(arm|aarch64)" OR APPLE)
   list(APPEND PNG_SRCS
     arm/arm_init.c
     arm/filter_neon_intrinsics.c


### PR DESCRIPTION
This is the value on the NVIDIA Jetson NX.
