### PR TITLE
ENH: Add .process_object attribute to functional filters

### DIFF
--- a/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterTest.py
@@ -67,6 +67,9 @@ assert 'return' in type_hints
 result_hints = type_hints['return']
 assert itk.ImageBase in get_args(args_hints)
 
+# Check for process_object attribute pointing to the associated class
+assert itk.median_image_filter.process_object is itk.MedianImageFilter
+
 
 # Test that `__call__()` inside itkTemplate is deprecated. Replaced
 # by snake_case functions

--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -836,6 +836,7 @@ def {snakeCase}_init_docstring():
     from itk.support import template_class
 
     filter_class = itk.{self.moduleName}.{processObject}
+    {snakeCase}.process_object = filter_class
     is_template = isinstance(filter_class, template_class.itkTemplate)
     if is_template:
         filter_object = filter_class.values()[0]


### PR DESCRIPTION
Add an attribute on the functional filter interfaces that points back to
the associated itk.ProcessObject that the filter uses internally.
