### PR TITLE
BUG: Set ElementType for wrapping PyVectorContainer

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyVectorContainerBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyVectorContainerBuffer.i.in
@@ -14,14 +14,14 @@
         itksize = vector_container.Size()
         container_type = itk.template(vector_container)
         if isinstance(container_type[1][1], type):
-            element_type = itk.template(container_type[1][1])
-            dimension = element_type[1][1]
+            container_element_type = itk.template(container_type[1][1])
+            dimension = container_element_type[1][1]
             shape   = (itksize, dimension)
         else:
             shape   = (itksize,)
 
-        pixelType     = "@PixelType@"
-        numpydatatype = _get_numpy_pixelid(pixelType)
+        element_type     = "@ElementType@"
+        numpydatatype = _get_numpy_pixelid(element_type)
         memview       = itkPyVectorContainer@PyVectorContainerTypes@._array_view_from_vector_container(vector_container)
         ndarrview  = np.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(np.ndarray)
 

--- a/Modules/Bridge/NumPy/wrapping/itkPyVectorContainer.wrap
+++ b/Modules/Bridge/NumPy/wrapping/itkPyVectorContainer.wrap
@@ -6,6 +6,7 @@ itk_wrap_class("itk::PyVectorContainer")
   UNIQUE(index_types "IT;UC")
   foreach(tt ${index_types})
     foreach(t ${scalar_types})
+      set(ElementType ${t})
       # These are wrapped below with "vectypes"
       if(NOT t IN_LIST WRAP_ITK_USIGN_INT)
         itk_wrap_template("${ITKM_${tt}}${ITKM_${t}}" "${ITKT_${tt}},${ITKT_${t}}")
@@ -23,6 +24,7 @@ itk_wrap_class("itk::PyVectorContainer")
   UNIQUE(real_types "${WRAP_ITK_REAL};D")
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${real_types})
+      set(ElementType ${t})
       itk_wrap_template("${ITKM_IT}${ITKM_V${t}${d}}" "${ITKT_IT},${ITKT_V${t}${d}}")
       set(PyVectorContainerTypes ${ITKM_IT}${ITKM_V${t}${d}})
       configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/PyVectorContainerBuffer.i.in
@@ -57,6 +59,7 @@ itk_wrap_class("itk::PyVectorContainer")
   endforeach()
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     itk_wrap_template("${ITKM_UC}${ITKM_O${d}}"  "${ITKT_UC},${ITKT_O${d}}")
+      set(ElementType ${ITKM_OT})
       set(PyVectorContainerTypes ${ITKM_UC}${ITKM_O${d}})
       configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/PyVectorContainerBuffer.i.in
                       ${CMAKE_CURRENT_BINARY_DIR}/PyVectorContainerBuffer.i.temp
@@ -79,6 +82,7 @@ itk_wrap_class("itk::PyVectorContainer")
   endforeach()
   # used in FastMarchingExtensionImageFilter
   itk_wrap_template("${ITKM_UI}${ITKM_VUC1}"    "${ITKT_UI},${ITKT_VUC1}")
+    set(ElementType UC)
     set(PyVectorContainerTypes ${ITKM_UI}${ITKM_VUC1})
     configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/PyVectorContainerBuffer.i.in
                     ${CMAKE_CURRENT_BINARY_DIR}/PyVectorContainerBuffer.i.temp
@@ -89,6 +93,7 @@ itk_wrap_class("itk::PyVectorContainer")
                 ${PyBufferInterfaceTemp})
 
 itk_wrap_template("${ITKM_IT}S${ITKM_IT}"    "${ITKT_IT}, std::set< ${ITKT_IT} >")
+    set(ElementType IT)
     set(PyVectorContainerTypes ${ITKM_IT}S${ITKM_IT})
     configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/PyVectorContainerBuffer.i.in
                     ${CMAKE_CURRENT_BINARY_DIR}/PyVectorContainerBuffer.i.temp
@@ -101,6 +106,7 @@ itk_wrap_template("${ITKM_IT}S${ITKM_IT}"    "${ITKT_IT}, std::set< ${ITKT_IT} >
   UNIQUE(vectypes "${ITKM_IT};UI;${WRAP_ITK_USIGN_INT}")
   foreach(t1 ${vectypes})
     foreach(t2 ${vectypes})
+      set(ElementType ${t2})
       itk_wrap_template("${ITKM_${t1}}${ITKM_${t2}}" "${ITKT_${t1}}, ${ITKT_${t2}}")
 
       set(PyVectorContainerTypes ${ITKM_${t1}}${ITKM_${t2}})

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py
@@ -51,6 +51,7 @@ class TestNumpyVectorContainerMemoryviewInterface(unittest.TestCase):
         v1.SetElement(2, 4)
         v1.SetElement(3, 5)
         arr = itk.array_view_from_vector_container(v1)
+        assert arr.dtype == np.float32
         v2 = itk.vector_container_from_array(arr)
         self.assertEqual(v1.Size(), arr.shape[0])
         self.assertEqual(v1.Size(), v2.Size())

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -392,7 +392,8 @@ def array_from_vector_container(container, ttype=None):
     """Get an Array with the content of the vector container"""
     import itk
 
-    IndexType = itk.template(container)[1][0]
+    container_template = itk.template(container)
+    IndexType = container_template[1][0]
 
     # Find container data type
     if ttype is not None:
@@ -403,7 +404,7 @@ def array_from_vector_container(container, ttype=None):
         else:
             DataType = ttype
     else:
-        DataType = itk.template(container)[1][1]
+        DataType = container_template[1][1]
     keys = [k for k in itk.PyVectorContainer.keys() if k == (IndexType, DataType)]
     if len(keys) == 0:
         raise RuntimeError("No suitable template parameter can be found.")
@@ -415,7 +416,8 @@ def array_view_from_vector_container(container, ttype=None):
     """Get an Array view with the content of the vector container"""
     import itk
 
-    IndexType = itk.template(container)[1][0]
+    container_template = itk.template(container)
+    IndexType = container_template[1][0]
 
     # Find container type
     if ttype is not None:
@@ -426,7 +428,7 @@ def array_view_from_vector_container(container, ttype=None):
         else:
             DataType = ttype
     else:
-        DataType = itk.template(container)[1][1]
+        DataType = container_template[1][1]
     keys = [k for k in itk.PyVectorContainer.keys() if k == (IndexType, DataType)]
     if len(keys) == 0:
         raise RuntimeError("No suitable template parameter can be found.")


### PR DESCRIPTION
This is required in the CMake configure_file template to produce the
correct return type.