### PR TITLE
ENH: Add static member function, `itk::Matrix::GetIdentity()`

### DIFF
--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -786,7 +786,7 @@ public:
   SetNumberOfComponentsPerPixel(unsigned int);
 
 protected:
-  ImageBase();
+  ImageBase() = default;
   ~ImageBase() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -810,15 +810,15 @@ protected:
   /** Origin, spacing, and direction in physical coordinates. This variables are
    * protected for efficiency.  They are referenced frequently by
    * inner loop calculations. */
-  SpacingType   m_Spacing;
-  PointType     m_Origin;
-  DirectionType m_Direction;
-  DirectionType m_InverseDirection;
+  SpacingType   m_Spacing{ 1.0 };
+  PointType     m_Origin{};
+  DirectionType m_Direction{ DirectionType::GetIdentity() };
+  DirectionType m_InverseDirection{ DirectionType::GetIdentity() };
 
   /** Matrices intended to help with the conversion of Index coordinates
    *  to PhysicalPoint coordinates */
-  DirectionType m_IndexToPhysicalPoint;
-  DirectionType m_PhysicalPointToIndex;
+  DirectionType m_IndexToPhysicalPoint{ DirectionType::GetIdentity() };
+  DirectionType m_PhysicalPointToIndex{ DirectionType::GetIdentity() };
 
   /** Restores the buffered region to it's default state
    *  This method does not call Modify because Initialization is

--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -40,18 +40,6 @@ namespace itk
 {
 
 template <unsigned int VImageDimension>
-ImageBase<VImageDimension>::ImageBase()
-{
-  m_Spacing.Fill(1.0);
-  m_Origin.Fill(0.0);
-  m_Direction.SetIdentity();
-  m_InverseDirection.SetIdentity();
-  m_IndexToPhysicalPoint.SetIdentity();
-  m_PhysicalPointToIndex.SetIdentity();
-}
-
-
-template <unsigned int VImageDimension>
 void
 ImageBase<VImageDimension>::Allocate(bool)
 {}

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -194,6 +194,15 @@ public:
     m_Matrix.set_identity();
   }
 
+  /** Get an identity matrix. */
+  static Self
+  GetIdentity()
+  {
+    InternalMatrixType internalMatrix;
+    internalMatrix.set_identity();
+    return Self{ internalMatrix };
+  }
+
   /** Fill the matrix with a value. */
   inline void
   Fill(const T & value)

--- a/Modules/Core/Common/test/itkImageBaseGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBaseGTest.cxx
@@ -98,6 +98,27 @@ Expect_by_default_Transform_result_equals_default_constructed_value(const typena
                                    CovariantVectorType());
 }
 
+
+template <unsigned int VImageDimension>
+void
+Check_New_ImageBase()
+{
+  const auto imageBase = itk::ImageBase<VImageDimension>::New();
+  ASSERT_NE(imageBase, nullptr);
+
+  for (const auto spacingValue : imageBase->GetSpacing())
+  {
+    EXPECT_FLOAT_EQ(spacingValue, 1.0);
+  }
+  for (const auto originValue : imageBase->GetOrigin())
+  {
+    EXPECT_FLOAT_EQ(originValue, 0.0);
+  }
+
+  EXPECT_TRUE(imageBase->GetDirection().GetVnlMatrix().is_identity());
+  EXPECT_TRUE(imageBase->GetInverseDirection().GetVnlMatrix().is_identity());
+}
+
 } // end namespace
 
 
@@ -111,4 +132,10 @@ TEST(ImageBase, ByDefaultTransformResultEqualsDefaultConstructedValue)
   // Test both 2D and 3D, for different pixel types and sizes:
   Expect_by_default_Transform_result_equals_default_constructed_value<itk::Image<double>>({ { 2, 2 } });
   Expect_by_default_Transform_result_equals_default_constructed_value<itk::Image<unsigned char, 3>>({ { 2, 3, 4 } });
+}
+
+TEST(ImageBase, New)
+{
+  Check_New_ImageBase<2>();
+  Check_New_ImageBase<3>();
 }

--- a/Modules/Core/Common/test/itkMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixGTest.cxx
@@ -38,6 +38,14 @@ Expect_Matrix_default_constructor_zero_initializes_all_elements()
     }
   }
 }
+
+template <typename TMatrix>
+void
+Expect_GetIdentity_returns_identity_matrix()
+{
+  EXPECT_TRUE(TMatrix::GetIdentity().GetVnlMatrix().is_identity());
+}
+
 } // namespace
 
 
@@ -51,4 +59,12 @@ TEST(Matrix, DefaultConstructorZeroInitializesAllElements)
   Expect_Matrix_default_constructor_zero_initializes_all_elements<itk::Matrix<float>>();
   Expect_Matrix_default_constructor_zero_initializes_all_elements<itk::Matrix<double>>();
   Expect_Matrix_default_constructor_zero_initializes_all_elements<itk::Matrix<double, 2, 2>>();
+}
+
+
+TEST(Matrix, GetIdentity)
+{
+  Expect_GetIdentity_returns_identity_matrix<itk::Matrix<float>>();
+  Expect_GetIdentity_returns_identity_matrix<itk::Matrix<double>>();
+  Expect_GetIdentity_returns_identity_matrix<itk::Matrix<double, 2, 2>>();
 }


### PR DESCRIPTION
Used `itk::Matrix::GetIdentity()` to simplify and modernize the default-constructor of `ImageBase`.