### PR TITLE
BUG: Fix crash in itk.image_from_xarray if is_vector and Dimension==4

### DIFF
--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -345,7 +345,6 @@ def _GetImageFromArray(arr, function_name: str, is_vector: bool, ttype):
     else:
         PixelType = _get_itk_pixelid(arr)
         Dimension = arr.ndim
-        ImageType = itk.Image[PixelType, Dimension]
         if is_vector:
             Dimension = arr.ndim - 1
             if arr.flags["C_CONTIGUOUS"]:
@@ -361,6 +360,8 @@ def _GetImageFromArray(arr, function_name: str, is_vector: bool, ttype):
                     ImageType = itk.VectorImage[PixelType, Dimension]
             else:
                 ImageType = itk.VectorImage[PixelType, Dimension]
+        else:
+            ImageType = itk.Image[PixelType, Dimension]
     keys = [k for k in itk.PyBuffer.keys() if k[0] == ImageType]
     if len(keys) == 0:
         raise RuntimeError(


### PR DESCRIPTION
```text
Traceback (most recent call last):
  File "M:\Dev\ITK-py\Wrapping\Generators\Python\itk\support\template_class.py", line 525, in __getitem__
    this_item = self.__template__[key]
KeyError: (<itkCType float>, 4)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Program Files\JetBrains\PyCharm Community Edition 2020.2.3\plugins\python-ce\helpers\pydev\pydevd.py", line 1477, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "C:\Program Files\JetBrains\PyCharm Community Edition 2020.2.3\plugins\python-ce\helpers\pydev\_pydev_imps\_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "M:/Dev/Plus/UltrasoundPhantomSegmentation/ml_spect_supervised.py", line 100, in <module>
    save_spectra(filename, in_label, out_file)
  File "M:/Dev/Plus/UltrasoundPhantomSegmentation/ml_spect_supervised.py", line 87, in save_spectra
    spectra = itk.image_from_xarray(spectra_da)
  File "M:\Dev\ITK-py\Wrapping\Generators\Python\itk\support\extras.py", line 646, in image_from_xarray
    itk_image = itk.image_view_from_array(values, is_vector=is_vector)
  File "M:\Dev\ITK-py\Wrapping\Generators\Python\itk\support\extras.py", line 385, in GetImageViewFromArray
    return _GetImageFromArray(arr, "GetImageViewFromArray", is_vector, ttype)
  File "M:\Dev\ITK-py\Wrapping\Generators\Python\itk\support\extras.py", line 348, in _GetImageFromArray
    ImageType = itk.Image[PixelType, Dimension]
  File "M:\Dev\ITK-py\Wrapping\Generators\Python\itk\support\template_class.py", line 529, in __getitem__
    raise itk.TemplateTypeError(self, key)
itk.support.extras.TemplateTypeError: itk.Image is not wrapped for input type `itk.F, int`.

To limit the size of the package, only a limited number of
types are available in ITK Python. To print the supported
types, run the following command in your python environment:

    itk.Image.GetTypes()

Possible solutions:
* If you are an application user:
** Convert your input image into a supported format (see below).
** Contact developer to report the issue.
* If you are an application developer, force input images to be
loaded in a supported pixel type.

    e.g.: instance = itk.Image[itk.RGBPixel[itk.UC], int].New(my_input)

* (Advanced) If you are an application developer, build ITK Python yourself and
turned to `ON` the corresponding CMake option to wrap the pixel type or image
dimension you need. When configuring ITK with CMake, you can set
`ITK_WRAP_${type}` (replace ${type} with appropriate pixel type such as
`double`). If you need to support images with 4 or 5 dimensions, you can add
these dimensions to the list of dimensions in the CMake variable
`ITK_WRAP_IMAGE_DIMS`.

Supported input types:

itk.RGBPixel[itk.UC]
itk.RGBAPixel[itk.UC]
itk.Vector[itk.F,2]
itk.Vector[itk.F,3]
itk.Vector[itk.F,4]
itk.CovariantVector[itk.F,2]
itk.CovariantVector[itk.F,3]
itk.CovariantVector[itk.F,4]
itk.SS
itk.UC
itk.F
itk.complex[itk.F]
itk.Vector[itk.D,2]
itk.Vector[itk.D,3]
itk.Vector[itk.D,4]
itk.D
itk.SI
itk.UI
itk.UL
itk.ULL
itk.B
itk.FixedArray[itk.F,2]
itk.Offset[2]
itk.SymmetricSecondRankTensor[itk.D,2]
itk.RGBPixel[itk.UC]
itk.RGBAPixel[itk.UC]
itk.Vector[itk.F,2]
itk.Vector[itk.F,3]
itk.Vector[itk.F,4]
itk.CovariantVector[itk.F,2]
itk.CovariantVector[itk.F,3]
itk.CovariantVector[itk.F,4]
itk.SS
itk.UC
itk.F
itk.complex[itk.F]
itk.Vector[itk.D,2]
itk.Vector[itk.D,3]
itk.Vector[itk.D,4]
itk.D
itk.SI
itk.UI
itk.UL
itk.ULL
itk.B
itk.FixedArray[itk.F,3]
itk.Offset[3]
itk.SymmetricSecondRankTensor[itk.D,3]
itk.Vector[itk.F,1]
itk.Vector[itk.D,2]
itk.Vector[itk.D,3]
itk.Vector[itk.D,4]
itk.Vector[itk.F,1]
itk.CovariantVector[itk.D,2]
itk.CovariantVector[itk.D,3]
itk.CovariantVector[itk.D,4]
itk.CovariantVector[itk.D,2]
itk.CovariantVector[itk.D,3]
itk.CovariantVector[itk.D,4]
itk.NormalBandNode[itk.Image[itk.F,2]]
itk.NormalBandNode[itk.Image[itk.F,3]]
itk.list[itk.Index[2]]
itk.list[itk.Index[3]]

python-BaseException

Process finished with exit code -1
```