### PR TITLE
COMP: Do not explicitly instantiate Array in itkArrayTest

### DIFF
--- a/Modules/Core/Common/test/itkArrayTest.cxx
+++ b/Modules/Core/Common/test/itkArrayTest.cxx
@@ -21,9 +21,6 @@
 #include "itkArray.h"
 #include "itkNumericTraits.h"
 
-// Explicit instantiation to make sure all methods are compiled.
-template class itk::Array<float>;
-
 int
 itkArrayTest(int, char *[])
 {


### PR DESCRIPTION
Array is intantiated and used throughout the toolkit and this
instantiation conflicts on macOS arm64 in symbol exports resulting in:

  ld: warning: direct access in function 'itk::MetaDataObject<itk::Array<float> >::GetMetaDataObjectTypeName() const' from file 'lib/libITKCommon-5.2.a(itkMetaDataObject.cxx.o)' to global weak symbol 'typeinfo name for itk::Array<float>' from file 'Modules/Core/Common/test/CMakeFiles/ITKCommon1TestDriver.dir/itkArrayTest.cxx.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
  ld: warning: direct access in function 'itk::MetaDataObject<itk::Array<float> >::GetMetaDataObjectTypeName() const' from file 'lib/libITKCommon-5.2.a(itkMetaDataObject.cxx.o)' to global weak symbol 'typeinfo name for itk::Array<float>' from file 'Modules/Core/Common/test/CMakeFiles/ITKCommon1TestDriver.dir/itkArrayTest.cxx.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
  ld: warning: direct access in function 'itk::MetaDataObject<itk::Array<float> >::GetMetaDataObjectTypeInfo() const' from file 'lib/libITKCommon-5.2.a(itkMetaDataObject.cxx.o)' to global weak symbol 'typeinfo for itk::Array<float>' from file 'Modules/Core/Common/test/CMakeFiles/ITKCommon1TestDriver.dir/itkArrayTest.cxx.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
  ld: warning: direct access in function 'itk::MetaDataObject<itk::Array<float> >::GetMetaDataObjectTypeInfo() const' from file 'lib/libITKCommon-5.2.a(itkMetaDataObject.cxx.o)' to global weak symbol 'typeinfo for itk::Array<float>' from file 'Modules/Core/Common/test/CMakeFiles/ITKCommon1TestDriver.dir/itkArrayTest.cxx.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
