### PR TITLE
COMP: No longer test `is_trivially_copyable` in itkMatrixGTest on GCC 4

### DIFF
--- a/Modules/Core/Common/test/itkMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixGTest.cxx
@@ -41,9 +41,15 @@ Expect_Matrix_default_constructor_zero_initializes_all_elements()
 } // namespace
 
 
+// GCC version 4 does not yet support C++11 `std::is_trivially_copyable`, as
+// GCC 4.8.5 produced an error message on an attempt to build ITK 5 from the
+// master branch (CentOS Coverage, 2021-03-30), saying:
+// > error: 'is_trivially_copyable' is not a member of 'std'
+#if (!defined(__GNUC__)) || (__GNUC__ > 4)
 static_assert(std::is_trivially_copyable<itk::Matrix<float>>() && std::is_trivially_copyable<itk::Matrix<double>>() &&
                 std::is_trivially_copyable<itk::Matrix<double, 2, 2>>(),
               "Matrix classes of built-in element types should be trivially copyable!");
+#endif
 
 
 TEST(Matrix, DefaultConstructorZeroInitializesAllElements)


### PR DESCRIPTION
Worked around:

> ITK/Modules/Core/Common/test/itkMatrixGTest.cxx:44:15: error:
> 'is_trivially_copyable' is not a member of 'std'

From CDash (https://open.cdash.org/viewBuildError.php?buildid=7131131):
> Site: AWS-BATCH-88ede920-9899-42aa-8b05-b6d829ac45d3
> Build Name: CentOS Coverage
> Build Time: 2021-03-30 04:52:57

Reported by Matt McCormick at pull request
"ENH: Make itk::Matrix trivially copyable, following Rule of Zero"
https://github.com/InsightSoftwareConsortium/ITK/pull/2449