### PR TITLE
COMP: Workaround Clang 3 error default initialization const MatrixGTest

### DIFF
--- a/Modules/Core/Common/test/itkMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixGTest.cxx
@@ -28,7 +28,15 @@ template <typename TMatrix>
 void
 Expect_Matrix_default_constructor_zero_initializes_all_elements()
 {
-  const TMatrix defaultConstructedMatrix;
+#ifndef __clang__
+  // Clang versions before 3.9.0 reject the `const` here (erroneously).
+  // Mac10.10-AppleClang-dbg-x86_64-static produced an error message on an
+  // attempt to build ITK 5 from the master branch (2021-03-31), saying:
+  // > error: default initialization of an object of const type
+  // > 'const itk::Matrix' without a user-provided default constructor
+  const
+#endif
+    TMatrix defaultConstructedMatrix;
 
   for (unsigned row{}; row < TMatrix::RowDimensions; ++row)
   {


### PR DESCRIPTION
Worked around a compiler bug encountered with Clang 3.8.1 and
Mac10.10-AppleClang (which appears fixed with more recent Clang
compiler versions), saying:

> error: default initialization of an object of const type
> 'const itk::Matrix' without a user-provided default constructor

Reported by Jon Haitz Legarreta Gorroño (@jhlegarreta) at pull request
"ENH: Make itk::Matrix trivially copyable, following Rule of Zero"
https://github.com/InsightSoftwareConsortium/ITK/pull/2449