### PR TITLE
ENH: Add explicit `itk::Vector(const std::array &)` constructor

### DIFF
--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -137,6 +137,11 @@ public:
     : BaseArray(r)
   {}
 
+  /** Explicit constructor for std::array. */
+  explicit Vector(const std::array<ValueType, NVectorDimension> & stdArray)
+    : BaseArray(stdArray)
+  {}
+
   /** Pass-through assignment operator for the Array base class. */
   template <typename TVectorValueType>
   Vector &

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -626,6 +626,7 @@ set(ITKCommonGTests
       itkSizeGTest.cxx
       itkSmartPointerGTest.cxx
       itkVectorContainerGTest.cxx
+      itkVectorGTest.cxx
       itkWeakPointerGTest.cxx
       itkCommonTypeTraitsGTest.cxx
       itkMetaDataDictionaryGTest.cxx

--- a/Modules/Core/Common/test/itkVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGTest.cxx
@@ -1,0 +1,56 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkVector.h"
+#include <gtest/gtest.h>
+
+#include <iterator> // For begin and end.
+#include <numeric>  // For iota.
+
+namespace
+{
+template <unsigned VDimension>
+void
+Expect_itk_Vector_can_be_constructed_by_std_array()
+{
+  using ValueType = double;
+  using VectorType = itk::Vector<ValueType, VDimension>;
+
+  std::array<ValueType, VDimension> stdArray;
+
+  // Assign a different value (0, 1, 2, ...) to each element.
+  std::iota(std::begin(stdArray), std::end(stdArray), 0.0);
+
+  // Now construct the vector (using the explicit Vector constructor for std::array).
+  const VectorType itkVector(stdArray);
+
+  // Check that the values of all element are copied.
+  EXPECT_TRUE(std::equal(itkVector.cbegin(), itkVector.cend(), stdArray.cbegin()));
+}
+} // namespace
+
+
+// Tests that an itk::Vector can be constructed by specifying
+// its coordinates by an std::array<ValueType, VDimension>.
+TEST(Vector, CanBeConstructedByStdArray)
+{
+  // Test for 2-D and 3-D.
+  Expect_itk_Vector_can_be_constructed_by_std_array<2>();
+  Expect_itk_Vector_can_be_constructed_by_std_array<3>();
+}


### PR DESCRIPTION
Added `itk::Vector` constructor, allowing to specify its elements by a
C++11 `std::array`. Added `itkVectorGTest` to test this constructor.

Follow-up to:
"ENH: Add explicit constructors Point and FixedArray for C++11 std::array"
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/748
commit 8080e037bc76755c5c5ac8d62ae2daf980542227