### PR TITLE
STYLE: Matrix constructors vnl_matrix/vnl_matrix_fixed explicit/implicit

### DIFF
--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -218,8 +218,9 @@ public:
     return *this;
   }
 
-  /**For every operator=, there should be an equivalent copy constructor. */
-  inline Matrix(const vnl_matrix<T> & matrix)
+  /** Explicit constructor. Copies the elements from the specified
+   *  `vnl_matrix` (assuming it has the same dimensions). */
+  inline explicit Matrix(const vnl_matrix<T> & matrix)
     : m_Matrix(matrix)
   {}
 
@@ -256,8 +257,8 @@ public:
     return *this;
   }
 
-  /**For every operator=, there should be an equivalent copy constructor. */
-  inline explicit Matrix(const InternalMatrixType & matrix)
+  /** Converting constructor (implicit). */
+  inline Matrix(const InternalMatrixType & matrix)
     : m_Matrix(matrix)
   {}
 

--- a/Modules/Core/Common/test/itkMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixGTest.cxx
@@ -19,7 +19,7 @@
 // First include the header file to be tested:
 #include "itkMatrix.h"
 #include <gtest/gtest.h>
-#include <type_traits> // For is_trivially_copyable.
+#include <type_traits> // For is_convertible and is_trivially_copyable.
 
 
 namespace
@@ -54,7 +54,33 @@ Expect_GetIdentity_returns_identity_matrix()
   EXPECT_TRUE(TMatrix::GetIdentity().GetVnlMatrix().is_identity());
 }
 
+
+template <typename TMatrix>
+constexpr bool
+vnl_matrix_is_convertible_to_itk_Matrix()
+{
+  return std::is_convertible<vnl_matrix<typename TMatrix::ValueType>, TMatrix>();
+}
+
+template <typename TMatrix>
+constexpr bool
+vnl_matrix_fixed_is_convertible_to_itk_Matrix()
+{
+  return std::is_convertible<
+    vnl_matrix_fixed<typename TMatrix::ValueType, TMatrix::RowDimensions, TMatrix::ColumnDimensions>,
+    TMatrix>();
+}
+
 } // namespace
+
+
+static_assert((!vnl_matrix_is_convertible_to_itk_Matrix<itk::Matrix<float>>()) &&
+                (!vnl_matrix_is_convertible_to_itk_Matrix<itk::Matrix<double, 4, 5>>()),
+              "itk::Matrix should prevent implicit conversion from vnl_matrix");
+
+static_assert(vnl_matrix_fixed_is_convertible_to_itk_Matrix<itk::Matrix<float>>() &&
+                vnl_matrix_fixed_is_convertible_to_itk_Matrix<itk::Matrix<double, 4, 5>>(),
+              "itk::Matrix should allow implicit conversion from vnl_matrix_fixed");
 
 
 // GCC version 4 does not yet support C++11 `std::is_trivially_copyable`, as

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -326,7 +326,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
   {
     principalMoments[i] = pm(i);
   }
-  MatrixType principalAxes = eigen.V.transpose();
+  MatrixType principalAxes(eigen.V.transpose());
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant


### PR DESCRIPTION
Declared the `Matrix(const vnl_matrix &)` constructor `explicit`, while
removing the `explicit` keyword from `Matrix(const InternalMatrixType &)`,
as the latter one is the safest constructor of the two.
(Note that `InternalMatrixType = vnl_matrix_fixed<T, NRows, NColumns>`.)

Added the corresponding static asserts to itkMatrixGTest.