### PR TITLE
Use non-deprecated ITK_DISALLOW_COPY_AND_MOVE in ResampleInPlace

### DIFF
--- a/Modules/Core/Transform/include/itkResampleInPlaceImageFilter.h
+++ b/Modules/Core/Transform/include/itkResampleInPlaceImageFilter.h
@@ -97,7 +97,7 @@ template <typename TInputImage, typename TOutputImage>
 class ResampleInPlaceImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ResampleInPlaceImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ResampleInPlaceImageFilter);
 
   /** Standard class type alias */
   using Self = ResampleInPlaceImageFilter;

--- a/Modules/Core/Transform/include/itkResampleInPlaceImageFilter.h
+++ b/Modules/Core/Transform/include/itkResampleInPlaceImageFilter.h
@@ -40,7 +40,7 @@ namespace itk
  * as well as eliminating the expense of accessing the physical memory of the image.
  * We need to compose all the transforms beforehand to make use of this filter.
  *
- * \param RigidTransform -- Currently must be a \class VersorRigid3D
+ * \param RigidTransform -- Currently must be a VersorRigid3D
  * \param InputImage -- The image to be duplicated and modified to incorporate the
  * rigid transform
  * \return -- An image with the same voxels values as the input, but with differnt


### PR DESCRIPTION
## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Fixes:
```text
In file included from /Users/builder/externalModules/Core/Transform/test/itkResampleInPlaceImageFilterTest.cxx:19:
/Users/builder/externalModules/Core/Transform/include/itkResampleInPlaceImageFilter.h:100:3: error: static_assert failed "Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE"
  ITK_DISALLOW_COPY_AND_ASSIGN(ResampleInPlaceImageFilter);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[CTest: warning matched] /Users/builder/externalModules/Core/Common/include/itkMacro.h:394:5: note: expanded from macro 'ITK_DISALLOW_COPY_AND_ASSIGN'
    static_assert(false, "Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE")
    ^             ~~~~~
```