### PR TITLE
ENH: Improve `itk::ResampleInPlaceImageFilter` coverage

### DIFF
--- a/Modules/Core/Transform/test/itkResampleInPlaceImageFilterTest.cxx
+++ b/Modules/Core/Transform/test/itkResampleInPlaceImageFilterTest.cxx
@@ -129,6 +129,10 @@ itkResampleInPlaceImageFilterTest(int argc, char * argv[])
   FilterType::Pointer filter = FilterType::New();
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, ResampleInPlaceImageFilter, ImageToImageFilter);
 
+  // Test the exceptions
+  ITK_TRY_EXPECT_EXCEPTION(filter->Update());
+
+
   filter->SetInputImage(inputImage);
   ITK_TEST_SET_GET_VALUE(inputImage, filter->GetInputImage());
   filter->SetRigidTransform(transform);


### PR DESCRIPTION
Improve `itk::ResampleInPlaceImageFilter` class coverage: test the
exceptions.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)