### PR TITLE
DOC: Improve `itk::ResampleInPlaceImageFilter` documentation

### DIFF
--- a/Modules/Core/Transform/include/itkResampleInPlaceImageFilter.h
+++ b/Modules/Core/Transform/include/itkResampleInPlaceImageFilter.h
@@ -27,69 +27,74 @@ namespace itk
 /** \class ResampleInPlaceImageFilter
  * \brief Resample an image in place.
  *
- * The current ITK resample image filter will generate a physical memory-
- * modified version of the input image if the input transform is not identity.
- * The abuse use of the resample filter can be a source of problems.
- * It can exhaust memory if the image is very large.
- * It WILL reduce image quality when there are lots of transforms to be
- * superimposed for the input image. We usually don't even care
- * about those intermediate transformed images!
+ * The ResampleImageFilter will generate a physical memory-modified version of
+ * the input image if the input transform is not identity. Its neglectful use
+ * can be a source of problems: e.g. it can exhaust the memory if the image is
+ * very large, and it WILL reduce the image quality when there are lots of
+ * transforms to be superimposed for the input image. Often times, we are not
+ * interested in the intermediate transformed images.
  *
  * If all the transforms are rigid, there is a far superior way to achieve a similar result.
  * Updating image metadata in-place removes the accumulated resampling errors
  * as well as eliminating the expense of accessing the physical memory of the image.
  * We need to compose all the transforms beforehand to make use of this filter.
  *
- * \param RigidTransform -- Currently must be a VersorRigid3D
- * \param InputImage -- The image to be duplicated and modified to incorporate the
- * rigid transform
- * \return -- An image with the same voxels values as the input, but with differnt
+ * \param \c RigidTransform Currently must be a VersorRigid3DTransform.
+ * \param \c InputImage The image to be duplicated and modified to incorporate the
+ * rigid transform.
+ * \return An image with the same voxel values as the input, but with different
  * physical space representation affected by the rigid transform.
  *
- * The purpose of this code is to generate the new origin and direction
+ * The purpose of this class is to generate the new origin and direction
  * that will remove the need for using the transform.
  *
- * Given a set of PhysicalFixedImagePoints (i.e. from the fixedImage space)
- * those points are converted to PhysicalMovingImagePoints = TfmF2M( PhysicalFixedImagePoints )
- * and then MovingContinuousIndexPoints = movingImage->TransformPhysicalPointToContinuousIndex(
- * PhysicalMovingImagePoints ) to get image values.
+ * Let us call the transform operation from the fixed image to moving image <tt>TfmF2M</tt>.
+ * Given a set of points from the fixed image in physical space (i.e. <tt>physicalFixedImagePoints</tt>),
+ * the aim is to convert those points into the moving image physical space as
+ * <tt>physicalMovingImagePoints = TfmF2M( physicalFixedImagePoints )</tt>, and
+ * then be able to get the image values as
+ * <tt>movingContinuousIndexPoints = movingImage->TransformPhysicalPointToContinuousIndex( physicalMovingImagePoints
+ * )</tt>.
  *
- * We desire to change the moving image DirectionCosine [DC] and Origin [O] such that
- * we can compute the:
- * MovingContinuousIndexPoints = newMovingImage->TransformPhysicalPointToContinuousIndex( PhysicalFixedImagePoints )
+ * We desire to change the moving image direction cosine \f$\mathbf{D}\f$ and origin \f$\mathbf{o}\f$
+ * such that we can compute the moving image points as
+ * <tt>movingContinuousIndexPoints = newMovingImage->TransformPhysicalPointToContinuousIndex( physicalFixedImagePoints
+ * )</tt>
  *
- * Image Notations:
- *   \f$\mathbf{D}\f$: Direction cosine matrix
- *   \f$\mathbf{o}\f$: Origin vector
- *   \f$\mathbf{S}\f$: Spacing
- *   \f$\mathbf{ci}\f$: Continouos index
- *   \f$\mathbf{D}^{'}\f$: New direction cosine matrix
- *   \f$\mathbf{o}^{'}\f$: New origin vector
+ * Let us introduce the notation that will be used to formalize the transformation:
+ *  - Image-related parameters:
+ *    - \f$\mathbf{D}\f$: direction cosine matrix
+ *    - \f$\mathbf{o}\f$: origin vector
+ *    - \f$\mathbf{S}\f$: spacing
+ *    - \f$\mathbf{ci}\f$: continouos index
+ *    - \f$\mathbf{D}^{'}\f$: new direction cosine matrix
+ *    - \f$\mathbf{o}^{'}\f$: new origin vector
  *
- * Rigid Transform Notations:
- *   \f$\mathbf{R}\f$: Rotation matrix
- *   \f$\mathbf{c}\f$: Center of rotation vector
- *   \f$\mathbf{t}\f$: Translation vector
+ *  - Image content in corresponding space:
+ *    - \f$\mathbf{f}_{p}\f$: fixed image points in physical space
+ *    - \f$\mathbf{m}_{p}\f$: moving image points in physical space
  *
- *   \f$\mathbf{f}_{p}\f$: fixed image points in physical space
- *   \f$\mathbf{m}_{p}\f$: moving image points in physical space
+ *  - Rigid transform-related parameters:
+ *     - \f$\mathbf{R}\f$: rotation matrix
+ *     - \f$\mathbf{c}\f$: center of rotation vector
+ *     - \f$\mathbf{t}\f$: translation vector
  *
- * TransformPhysicalPointToContinuousIndex:
- * \f[
- *   \mathbf{ci} = \mathbf{S}^{-1}\mathbf{D}^{-1}( \mathbf{m}_{p} - \mathbf{o} ) \\
- *   \mathbf{m}_{p} = \mathbf{R}(\mathbf{f}_{p} - \mathbf{c}) + \mathbf{c} + \mathbf{T}
- * \f]
+ * The <tt>TransformPhysicalPointToContinuousIndex</tt> method performs then:
+ * \f{eqnarray*}{
+ *   \mathbf{ci} &= \mathbf{S}^{-1}\mathbf{D}^{-1}( \mathbf{m}_{p} - \mathbf{o} ) \\
+ *   \mathbf{m}_{p} &= \mathbf{R}(\mathbf{f}_{p} - \mathbf{c}) + \mathbf{c} + \mathbf{t}
+ * \f}
  *
- * After substitutions:
+ * After substitution:
  *
- * \f[
- * \mathbf{m}_{c} = \underbrace{\mathbf{R}^{-1}\mathbf{D}}_\text{new cosine}\mathbf{S} * \mathbf{i} +
- * \underbrace{\mathbf{R}^{-1} * \mathbf{o} - \mathbf{R}^{-1} * \mathbf{c} - \mathbf{R}^{-1}*T}_\text{new origin} +
- * \mathbf{c} \\
- * \\
- * \mathbf{D}^{'} = \mathbf{R}^{-1}\mathbf{D} \\
- * \mathbf{o}^{'} = \mathbf{R}^{-1} * ( \mathbf{o} - \mathbf{c} - \mathbf{t} ) + \mathbf{c}
- * \f]
+ * \f{eqnarray*}{
+ *   \mathbf{m}_{c} &= \underbrace{\mathbf{R}^{-1}\mathbf{D}}_\text{new cosine}\mathbf{S} * \mathbf{i} +
+ *   \underbrace{\mathbf{R}^{-1} * \mathbf{o} - \mathbf{R}^{-1} * \mathbf{c} - \mathbf{R}^{-1}*t}_\text{new origin} +
+ *   \mathbf{c} \\
+ *   \\
+ *   \mathbf{D}^{'} &= \mathbf{R}^{-1}\mathbf{D} \\
+ *   \mathbf{o}^{'} &= \mathbf{R}^{-1} * ( \mathbf{o} - \mathbf{c} - \mathbf{t} ) + \mathbf{c}
+ * \f}
  *
  * \ingroup ITKTransform
  */


### PR DESCRIPTION
Improve `itk::ResampleInPlaceImageFilter` documentation:
- Name itk filters with their classname so that Doxygen can automatically
  generate links.
- Make use of Doxygen syntax to improve the readability of the code.
- Use the appropriate LaTeX equation environments to accept line breaks.
- Improve the layout of the documentation.

Take advantage of the commit to:
- Re-phrase some sentences.
- Fix some typos and inconsistencies in notation.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)