### PR TITLE
ENH: Add Python wrapping for `itk::ResampleInPlaceImageFilter`

### DIFF
--- a/Modules/Core/Transform/wrapping/itkResampleInPlaceImageFilter.wrap
+++ b/Modules/Core/Transform/wrapping/itkResampleInPlaceImageFilter.wrap
@@ -1,0 +1,8 @@
+itk_wrap_filter_dims(d3 3)
+if(d3)
+  itk_wrap_class("itk::ResampleInPlaceImageFilter" POINTER)
+    foreach(t ${WRAP_ITK_SCALAR})
+      itk_wrap_template("${ITKM_I${t}${d3}}${ITKM_I${t}${d3}}" "${ITKT_I${t}${d3}},${ITKT_I${t}${d3}}")
+    endforeach()
+  itk_end_wrap_class()
+endif()


### PR DESCRIPTION
Add Python wrapping for `itk::ResampleInPlaceImageFilter`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5