### PR TITLE
BUG: Avoid crash TranslationTransform::SetParameters when too few params

### DIFF
--- a/Modules/Core/Transform/include/itkTranslationTransform.hxx
+++ b/Modules/Core/Transform/include/itkTranslationTransform.hxx
@@ -46,6 +46,12 @@ template <typename TParametersValueType, unsigned int NDimensions>
 void
 TranslationTransform<TParametersValueType, NDimensions>::SetParameters(const ParametersType & parameters)
 {
+  if (parameters.Size() < SpaceDimension)
+  {
+    itkExceptionMacro(<< "Error setting parameters: parameters array size (" << parameters.Size()
+                      << ") is less than expected (SpaceDimension = " << SpaceDimension << ")");
+  }
+
   // Save parameters. Needed for proper operation of TransformUpdateParameters.
   if (&parameters != &(this->m_Parameters))
   {

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -189,5 +189,6 @@ set(ITKTransformGTests
   itkBSplineTransformGTest.cxx
   itkEuler3DTransformGTest.cxx
   itkMatrixOffsetTransformBaseGTest.cxx
+  itkTranslationTransformGTest.cxx
 )
 CreateGoogleTestDriver(ITKTransform "${ITKTransform-Test_LIBRARIES}" "${ITKTransformGTests}")

--- a/Modules/Core/Transform/test/itkTranslationTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkTranslationTransformGTest.cxx
@@ -1,0 +1,80 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkTranslationTransform.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm> // For equal.
+#include <numeric>   // For iota.
+
+
+namespace
+{
+
+template <unsigned NDimensions>
+void
+Expect_SetParameters_throws_when_size_is_less_than_SpaceDimension()
+{
+  using TransformType = itk::TranslationTransform<double, NDimensions>;
+  const auto transform = TransformType::New();
+
+  for (unsigned size{}; size < TransformType::SpaceDimension; ++size)
+  {
+    const typename TransformType::ParametersType parameters(size, 0.0);
+    EXPECT_THROW(transform->SetParameters(parameters), itk::ExceptionObject);
+  }
+}
+
+
+template <unsigned NDimensions>
+void
+Expect_SetParameters_sets_translation_offset()
+{
+  using TransformType = itk::TranslationTransform<double, NDimensions>;
+  using ParametersType = typename TransformType::ParametersType;
+
+  const auto transform = TransformType::New();
+
+  // Check setting the offset to (0, 0, 0, ...).
+  transform->SetParameters(ParametersType(NDimensions, 0.0));
+  EXPECT_EQ(transform->GetOffset(), typename TransformType::OutputVectorType());
+
+  // Check setting the offset to (1, 2, 3, ...).
+  ParametersType parameters(NDimensions);
+  std::iota(parameters.begin(), parameters.end(), 1.0);
+  transform->SetParameters(parameters);
+  EXPECT_TRUE(std::equal(parameters.begin(), parameters.end(), transform->GetOffset().begin()));
+}
+
+} // namespace
+
+
+TEST(TranslationTransform, SetParametersThrowsWhenSizeIsLessThanSpaceDimension)
+{
+  Expect_SetParameters_throws_when_size_is_less_than_SpaceDimension<2>();
+  Expect_SetParameters_throws_when_size_is_less_than_SpaceDimension<3>();
+}
+
+
+TEST(TranslationTransform, SetParametersSetsOffset)
+{
+  Expect_SetParameters_sets_translation_offset<2>();
+  Expect_SetParameters_sets_translation_offset<3>();
+}


### PR DESCRIPTION
When the argument passed to `TranslationTransform` member function
`SetParameters` would contain less than `SpaceDimension` values,
the member function would have undefined behavior, which would typically
just cause a crash.

This commit avoids such undefined behavior by throwing an exception, in
this case. GoogleTest unit tests are included.

Follow-up to:
"BUG: Fix MatrixOffsetTransformBase SetFixedParameters if too few params"
Pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2118
Commit fcb85b3a1e4f78d3c9c3742f213e7acefb87314f