### PR TITLE
STYLE: Combine code `MatrixOffsetTransformBase` constructors

### DIFF
--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -503,8 +503,7 @@ protected:
    * omitted, then the MatrixOffsetTransformBase is initialized to an identity
    * transformation in the appropriate number of dimensions. */
   MatrixOffsetTransformBase(const MatrixType & matrix, const OutputVectorType & offset);
-  MatrixOffsetTransformBase(unsigned int paramDims);
-  MatrixOffsetTransformBase();
+  explicit MatrixOffsetTransformBase(unsigned int paramDims = ParametersDimension);
 
   /** Destroy an MatrixOffsetTransformBase object */
   ~MatrixOffsetTransformBase() override = default;
@@ -577,13 +576,13 @@ protected:
   itkGetConstMacro(Singular, bool);
 
 private:
-  MatrixType                m_Matrix;        // Matrix of the transformation
-  OutputVectorType          m_Offset;        // Offset of the transformation
-  mutable InverseMatrixType m_InverseMatrix; // Inverse of the matrix
-  mutable bool              m_Singular;      // Is m_Inverse singular?
+  MatrixType                m_Matrix{ MatrixType::GetIdentity() };               // Matrix of the transformation
+  OutputVectorType          m_Offset{};                                          // Offset of the transformation
+  mutable InverseMatrixType m_InverseMatrix{ InverseMatrixType::GetIdentity() }; // Inverse of the matrix
+  mutable bool              m_Singular{ false };                                 // Is m_Inverse singular?
 
-  InputPointType   m_Center;
-  OutputVectorType m_Translation;
+  InputPointType   m_Center{};
+  OutputVectorType m_Translation{};
 
   /** To avoid recomputation of the inverse if not needed */
   TimeStamp         m_MatrixMTime;

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -28,34 +28,11 @@ namespace itk
 {
 
 template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::MatrixOffsetTransformBase()
-  : Superclass(ParametersDimension)
-{
-  m_Matrix.SetIdentity();
-  m_MatrixMTime.Modified();
-  m_Offset.Fill(0);
-  m_Center.Fill(0);
-  m_Translation.Fill(0);
-  m_Singular = false;
-  m_InverseMatrix.SetIdentity();
-  m_InverseMatrixMTime = m_MatrixMTime;
-  this->m_FixedParameters.SetSize(NInputDimensions);
-  this->m_FixedParameters.Fill(0.0);
-}
-
-
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::MatrixOffsetTransformBase(
   unsigned int paramDims)
   : Superclass(paramDims)
 {
-  m_Matrix.SetIdentity();
   m_MatrixMTime.Modified();
-  m_Offset.Fill(0);
-  m_Center.Fill(0);
-  m_Translation.Fill(0);
-  m_Singular = false;
-  m_InverseMatrix.SetIdentity();
   m_InverseMatrixMTime = m_MatrixMTime;
   this->m_FixedParameters.SetSize(NInputDimensions);
   this->m_FixedParameters.Fill(0.0);
@@ -66,16 +43,11 @@ template <typename TParametersValueType, unsigned int NInputDimensions, unsigned
 MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::MatrixOffsetTransformBase(
   const MatrixType &       matrix,
   const OutputVectorType & offset)
+  : m_Matrix(matrix)
+  , m_Offset(offset)
 {
-  m_Matrix = matrix;
   m_MatrixMTime.Modified();
-  m_Offset = offset;
-  m_Center.Fill(0);
-  m_Translation.Fill(0);
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
-  {
-    m_Translation[i] = offset[i];
-  }
+  std::copy_n(offset.begin(), NOutputDimensions, m_Translation.begin());
   this->ComputeMatrixParameters();
 }
 

--- a/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
+++ b/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
@@ -24,6 +24,23 @@
 
 namespace
 {
+
+template <typename TParametersValueType, unsigned NDimensions>
+void
+Check_New_MatrixOffsetTransformBase()
+{
+  const auto transformBase = itk::MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>::New();
+
+  EXPECT_TRUE(transformBase->GetMatrix().GetVnlMatrix().is_identity());
+
+  const auto zeroFilledFixedArray = itk::FixedArray<double, NDimensions>::Filled(0.0);
+
+  EXPECT_EQ(zeroFilledFixedArray, transformBase->GetOffset());
+  EXPECT_EQ(zeroFilledFixedArray, transformBase->GetCenter());
+  EXPECT_EQ(zeroFilledFixedArray, transformBase->GetTranslation());
+}
+
+
 template <unsigned int NDimensions>
 void
 Assert_SetFixedParameters_throws_when_size_is_less_than_NDimensions()
@@ -40,6 +57,14 @@ Assert_SetFixedParameters_throws_when_size_is_less_than_NDimensions()
 }
 
 } // namespace
+
+
+// Checks the object created by MatrixOffsetTransformBase::New().
+TEST(MatrixOffsetTransformBase, CheckNew)
+{
+  Check_New_MatrixOffsetTransformBase<float, 2>();
+  Check_New_MatrixOffsetTransformBase<double, 3>();
+}
 
 
 TEST(MatrixOffsetTransformBase, SetFixedParametersThrowsWhenSizeIsLessThanNDimensions)


### PR DESCRIPTION
Replaced separate (`protected`) default-constructor and converting
constructor (from `unsigned int paramDims`) by a single `explicit`
constructor with default argument (still `protected` anyway).

Used C++11 in-class data member initializers.

Added extra GTest unit test to check `MatrixOffsetTransformBase::New()`.