### PR TITLE
STYLE: Replace postfix by prefix increment in `for` loops in Core/Common

### DIFF
--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -104,7 +104,7 @@ public:
   {
     this->m_LetArrayManageMemory = true;
     this->SetSize(r.GetSize());
-    for (SizeValueType i = 0; i < r.GetSize(); i++)
+    for (SizeValueType i = 0; i < r.GetSize(); ++i)
     {
       this->operator[](i) = static_cast<TValue>(r[i]);
     }

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -44,7 +44,7 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::BS
 
   for (const IndexType index : ZeroBasedIndexRange<VSpaceDimension>(m_SupportSize))
   {
-    for (unsigned int j = 0; j < SpaceDimension; j++)
+    for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
       m_OffsetToIndexTable[counter][j] = index[j];
     }
@@ -95,7 +95,7 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Ev
   unsigned int j, k;
 
   // Find the starting index of the support region
-  for (j = 0; j < SpaceDimension; j++)
+  for (j = 0; j < SpaceDimension; ++j)
   {
     // Note that the expression passed to Math::Floor is adapted to work around
     // a compiler bug which caused endless compilations (apparently), by
@@ -105,22 +105,22 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Ev
 
   // Compute the weights
   Matrix<double, SpaceDimension, SplineOrder + 1> weights1D;
-  for (j = 0; j < SpaceDimension; j++)
+  for (j = 0; j < SpaceDimension; ++j)
   {
     double x = index[j] - static_cast<double>(startIndex[j]);
 
-    for (k = 0; k <= SplineOrder; k++)
+    for (k = 0; k <= SplineOrder; ++k)
     {
       weights1D[j][k] = m_Kernel->Evaluate(x);
       x -= 1.0;
     }
   }
 
-  for (k = 0; k < m_NumberOfWeights; k++)
+  for (k = 0; k < m_NumberOfWeights; ++k)
   {
     weights[k] = 1.0;
 
-    for (j = 0; j < SpaceDimension; j++)
+    for (j = 0; j < SpaceDimension; ++j)
     {
       weights[k] *= weights1D[j][m_OffsetToIndexTable[k][j]];
     }

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -42,7 +42,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Pri
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Bounding Box: ( ";
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     os << m_Bounds[2 * i] << "," << m_Bounds[2 * i + 1] << " ";
   }
@@ -85,15 +85,15 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
   PointType center = this->GetCenter();
   PointType radius;
 
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     radius[i] = m_Bounds[2 * i + 1] - center[i];
   }
 
-  for (SizeValueType j = 0; j < NumberOfCorners; j++)
+  for (SizeValueType j = 0; j < NumberOfCorners; ++j)
   {
     PointType pnt;
-    for (unsigned int i = 0; i < PointDimension; i++)
+    for (unsigned int i = 0; i < PointDimension; ++i)
     {
       pnt[i] = center[i] + std::pow(-1.0, ((double)(j / (int(std::pow(2.0, (double)i)))))) * radius[i];
     }
@@ -158,7 +158,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
 
     PointsContainerConstIterator      ci = m_PointsContainer->Begin();
     Point<TCoordRep, VPointDimension> point = ci->Value(); // point value
-    for (unsigned int i = 0; i < PointDimension; i++)
+    for (unsigned int i = 0; i < PointDimension; ++i)
     {
       m_Bounds[2 * i] = point[i];
       m_Bounds[2 * i + 1] = point[i];
@@ -170,7 +170,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
     while (ci != m_PointsContainer->End())
     {
       point = ci->Value(); // point value
-      for (unsigned int i = 0; i < PointDimension; i++)
+      for (unsigned int i = 0; i < PointDimension; ++i)
       {
         if (point[i] < m_Bounds[2 * i])
         {
@@ -197,7 +197,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
   this->ComputeBoundingBox();
 
   PointType center;
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     center[i] = (m_Bounds[2 * i] + m_Bounds[2 * i + 1]) / 2.0;
   }
@@ -212,7 +212,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
   this->ComputeBoundingBox();
 
   PointType minimum;
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     minimum[i] = m_Bounds[2 * i];
   }
@@ -224,7 +224,7 @@ template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoo
 void
 BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::SetMinimum(const PointType & point)
 {
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     m_Bounds[2 * i] = point[i];
   }
@@ -239,7 +239,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
   this->ComputeBoundingBox();
 
   PointType maximum;
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     maximum[i] = m_Bounds[2 * i + 1];
   }
@@ -251,7 +251,7 @@ template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoo
 void
 BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::SetMaximum(const PointType & point)
 {
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     m_Bounds[2 * i + 1] = point[i];
   }
@@ -265,7 +265,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Con
 {
   bool changed = false;
 
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     if (point[i] < m_Bounds[2 * i])
     {
@@ -293,7 +293,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
 
   if (this->ComputeBoundingBox())
   {
-    for (unsigned int i = 0; i < PointDimension; i++)
+    for (unsigned int i = 0; i < PointDimension; ++i)
     {
       dist2 += (m_Bounds[2 * i] - m_Bounds[2 * i + 1]) * (m_Bounds[2 * i] - m_Bounds[2 * i + 1]);
     }
@@ -367,7 +367,7 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Dee
 #endif
 
   // Copy the bounds into the clone
-  for (unsigned int i = 0; i < 2 * PointDimension; i++)
+  for (unsigned int i = 0; i < 2 * PointDimension; ++i)
   {
     clone->m_Bounds[i] = this->m_Bounds[i];
   }

--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -60,14 +60,14 @@ BresenhamLine<VDimension>::BuildLine(LType Direction, unsigned int length)
   // we are going to start at 0
   m_CurrentImageIndex.Fill(0);
   StartIndex.Fill(0);
-  for (unsigned i = 0; i < VDimension; i++)
+  for (unsigned i = 0; i < VDimension; ++i)
   {
     LastIndex[i] = (IndexValueType)(length * Direction[i]);
   }
   // Find the dominant direction
   IndexValueType maxDistance = 0;
   unsigned int   maxDistanceDimension = 0;
-  for (unsigned i = 0; i < VDimension; i++)
+  for (unsigned i = 0; i < VDimension; ++i)
   {
     auto distance = static_cast<long>(itk::Math::abs(LastIndex[i]));
     if (distance > maxDistance)
@@ -118,7 +118,7 @@ BresenhamLine<VDimension>::BuildLine(IndexType p0, IndexType p1)
 {
   itk::Point<float, VDimension> point0;
   itk::Point<float, VDimension> point1;
-  for (unsigned int i = 0; i < VDimension; i++)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     point0[i] = p0[i];
     point1[i] = p1[i];
@@ -128,7 +128,7 @@ BresenhamLine<VDimension>::BuildLine(IndexType p0, IndexType p1)
   OffsetArray offsets = this->BuildLine(point1 - point0, distance);
 
   IndexArray indices(offsets.size());
-  for (unsigned int i = 0; i < offsets.size(); i++)
+  for (unsigned int i = 0; i < offsets.size(); ++i)
   {
     indices[i] = p0 + offsets[i];
   }

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -287,7 +287,7 @@ void
 ByteSwapper<T>::Swap2Range(void * ptr, BufferSizeType num)
 {
   auto * pos = static_cast<char *>(ptr);
-  for (BufferSizeType i = 0; i < num; i++)
+  for (BufferSizeType i = 0; i < num; ++i)
   {
     const char one_byte = pos[0];
     pos[0] = pos[1];
@@ -312,7 +312,7 @@ ByteSwapper<T>::SwapWrite2Range(void * ptr, BufferSizeType num, OStreamType * fp
     memcpy(cpy, ptr, chunkSize * 2);
 
     char * pos = cpy;
-    for (BufferSizeType i = 0; i < chunkSize; i++)
+    for (BufferSizeType i = 0; i < chunkSize; ++i)
     {
       const char one_byte = pos[0];
       pos[0] = pos[1];
@@ -356,7 +356,7 @@ ByteSwapper<T>::Swap4Range(void * ptr, BufferSizeType num)
 {
   auto * pos = static_cast<char *>(ptr);
 
-  for (BufferSizeType i = 0; i < num; i++)
+  for (BufferSizeType i = 0; i < num; ++i)
   {
     char one_byte = pos[0];
     pos[0] = pos[3];
@@ -387,7 +387,7 @@ ByteSwapper<T>::SwapWrite4Range(void * ptr, BufferSizeType num, OStreamType * fp
     memcpy(cpy, ptr, chunkSize * 4);
 
     char * pos = cpy;
-    for (BufferSizeType i = 0; i < chunkSize; i++)
+    for (BufferSizeType i = 0; i < chunkSize; ++i)
     {
       char one_byte = pos[0];
       pos[0] = pos[3];
@@ -443,7 +443,7 @@ ByteSwapper<T>::Swap8Range(void * ptr, BufferSizeType num)
 {
   auto * pos = static_cast<char *>(ptr);
 
-  for (BufferSizeType i = 0; i < num; i++)
+  for (BufferSizeType i = 0; i < num; ++i)
   {
     char one_byte = pos[0];
     pos[0] = pos[7];

--- a/Modules/Core/Common/include/itkCellInterface.hxx
+++ b/Modules/Core/Common/include/itkCellInterface.hxx
@@ -66,7 +66,7 @@ template <typename TPixelType, typename TCellTraits>
 void
 CellInterface<TPixelType, TCellTraits>::SetPointIdsContainer(const PointIdentifierContainerType & container)
 {
-  for (unsigned int i = 0; i < container.Size(); i++)
+  for (unsigned int i = 0; i < container.Size(); ++i)
   {
     this->SetPointId(i, container[i]);
   }

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -137,7 +137,7 @@ ColorTable<TPixel>::UseGrayColors(unsigned int n)
   // Converting from TPixel to RealType may introduce a rounding error, so do static_cast
   constexpr auto max_value_converted =
     static_cast<typename NumericTraits<TPixel>::RealType>(NumericTraits<TPixel>::max());
-  for (i = 0; i < m_NumberOfColors; i++)
+  for (i = 0; i < m_NumberOfColors; ++i)
   {
     typename NumericTraits<TPixel>::RealType realGray(minimum + i * delta);
 
@@ -182,7 +182,7 @@ ColorTable<TPixel>::UseHeatColors(unsigned int n)
   // Converting from TPixel to RealType may introduce a rounding error, so do static_cast
   constexpr auto max_value_converted =
     static_cast<typename NumericTraits<TPixel>::RealType>(NumericTraits<TPixel>::max());
-  for (i = 0; i < n / 2.0; i++)
+  for (i = 0; i < n / 2.0; ++i)
   {
     //
     // avoid overflow
@@ -200,7 +200,7 @@ ColorTable<TPixel>::UseHeatColors(unsigned int n)
     m_ColorName[i] = name.str();
   }
 
-  for (i = 0; i < n / 2; i++)
+  for (i = 0; i < n / 2; ++i)
   {
     typename NumericTraits<TPixel>::RealType rdouble(1.0 * scale + shift);
     TPixel                                   r(NumericTraits<TPixel>::max());
@@ -240,7 +240,7 @@ ColorTable<TPixel>::UseRandomColors(unsigned int n)
     minimum = NumericTraits<TPixel>::ZeroValue();
     maximum = NumericTraits<TPixel>::OneValue();
   }
-  for (i = 0; i < n; i++)
+  for (i = 0; i < n; ++i)
   {
     r = static_cast<TPixel>(vnl_sample_uniform(minimum, maximum));
     m_Color[i][0] = r;
@@ -346,7 +346,7 @@ ColorTable<TPixel>::GetClosestColorTableId(TPixel r, TPixel g, TPixel b)
   double       bestMatch = 0.0;
   unsigned int bestMatchColor = 0;
 
-  for (unsigned int i = 0; i < m_NumberOfColors; i++)
+  for (unsigned int i = 0; i < m_NumberOfColors; ++i)
   {
     double match;
     match = (r - (double)m_Color[i].GetRed()) * (r - (double)m_Color[i].GetRed());
@@ -368,7 +368,7 @@ ColorTable<TPixel>::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 
   os << indent << "NumberOfColors = " << m_NumberOfColors << std::endl;
-  for (unsigned int i = 0; i < m_NumberOfColors; i++)
+  for (unsigned int i = 0; i < m_NumberOfColors; ++i)
   {
     os << indent << "ColorName[" << i << "] = " << m_ColorName[i] << ", "
        << "Color[" << i << "] = " << m_Color[i] << std::endl;

--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
@@ -95,14 +95,14 @@ ConicShellInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::os
 
   unsigned int i;
   os << indent << "Origin: [";
-  for (i = 0; i < VDimension - 1; i++)
+  for (i = 0; i < VDimension - 1; ++i)
   {
     os << m_Origin[i] << ", ";
   }
   os << "]" << std::endl;
 
   os << indent << "Gradient at origin: [";
-  for (i = 0; i < VDimension - 1; i++)
+  for (i = 0; i < VDimension - 1; ++i)
   {
     os << m_OriginGradient[i] << ", ";
   }

--- a/Modules/Core/Common/include/itkConnectedComponentAlgorithm.h
+++ b/Modules/Core/Common/include/itkConnectedComponentAlgorithm.h
@@ -48,7 +48,7 @@ setConnectivity(TIterator * it, bool fullyConnected = false)
     // activate all neighbors that are face+edge+vertex
     // connected to the current pixel. do not include the center pixel
     unsigned int centerIndex = it->GetCenterNeighborhoodIndex();
-    for (unsigned int d = 0; d < centerIndex * 2 + 1; d++)
+    for (unsigned int d = 0; d < centerIndex * 2 + 1; ++d)
     {
       offset = it->GetOffset(d);
       it->ActivateOffset(offset);
@@ -83,7 +83,7 @@ setConnectivityPrevious(TIterator * it, bool fullyConnected = false)
     // activate all neighbors that are face+edge+vertex
     // connected to the current pixel. do not include the center pixel
     unsigned int centerIndex = it->GetCenterNeighborhoodIndex();
-    for (unsigned int d = 0; d < centerIndex; d++)
+    for (unsigned int d = 0; d < centerIndex; ++d)
     {
       offset = it->GetOffset(d);
       it->ActivateOffset(offset);
@@ -118,7 +118,7 @@ setConnectivityLater(TIterator * it, bool fullyConnected = false)
     // activate all neighbors that are face+edge+vertex
     // connected to the current pixel. do not include the center pixel
     unsigned int centerIndex = it->GetCenterNeighborhoodIndex();
-    for (unsigned int d = centerIndex + 1; d < 2 * centerIndex + 1; d++)
+    for (unsigned int d = centerIndex + 1; d < 2 * centerIndex + 1; ++d)
     {
       offset = it->GetOffset(d);
       it->ActivateOffset(offset);

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -111,7 +111,7 @@ public:
   ConstNeighborhoodIterator(const SizeType & radius, const ImageType * ptr, const RegionType & region)
   {
     this->Initialize(radius, ptr, region);
-    for (DimensionValueType i = 0; i < Dimension; i++)
+    for (DimensionValueType i = 0; i < Dimension; ++i)
     {
       m_InBounds[i] = false;
     }

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -30,7 +30,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::InBounds() const
   }
 
   bool ans = true;
-  for (DimensionValueType i = 0; i < Dimension; i++)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     if (m_Loop[i] < m_InnerBoundsLow[i] || m_Loop[i] >= m_InnerBoundsHigh[i])
     {
@@ -229,7 +229,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::ConstNeighborhoodIterator
 
   m_WrapOffset.Fill(0);
 
-  for (DimensionValueType i = 0; i < Dimension; i++)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     m_InBounds[i] = false;
   }
@@ -327,7 +327,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetNeighborhood() const
   else
   {
     // Calculate overlap & initialize index
-    for (DimensionValueType i = 0; i < Dimension; i++)
+    for (DimensionValueType i = 0; i < Dimension; ++i)
     {
       OverlapLow[i] = m_InnerBoundsLow[i] - m_Loop[i];
       OverlapHigh[i] = static_cast<OffsetValueType>(this->GetSize(i)) - ((m_Loop[i] + 2) - m_InnerBoundsHigh[i]);
@@ -640,12 +640,12 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PrintSelf(std::ostream & 
   os << "}" << std::endl;
 
   os << indent << ",  m_InnerBoundsLow = { ";
-  for (i = 0; i < Dimension; i++)
+  for (i = 0; i < Dimension; ++i)
   {
     os << m_InnerBoundsLow[i] << " ";
   }
   os << "}, m_InnerBoundsHigh = { ";
-  for (i = 0; i < Dimension; i++)
+  for (i = 0; i < Dimension; ++i)
   {
     os << m_InnerBoundsHigh[i] << " ";
   }

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -32,7 +32,7 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::InBounds() const
   }
 
   bool ans = true;
-  for (DimensionValueType i = 0; i < Dimension; i++)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     if (m_Loop[i] < m_InnerBoundsLow[i] || m_Loop[i] >= m_InnerBoundsHigh[i])
     {
@@ -145,7 +145,7 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnl
   m_Region.SetIndex(zeroIndex);
   m_Region.SetSize(zeroSize);
 
-  for (DimensionValueType i = 0; i < Dimension; i++)
+  for (DimensionValueType i = 0; i < Dimension; ++i)
   {
     m_InBounds[i] = false;
   }
@@ -184,7 +184,7 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnl
                                                                                        const RegionType & region)
 {
   this->Initialize(radius, ptr, region);
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     m_InBounds[i] = false;
   }
@@ -301,7 +301,7 @@ template <typename TImage>
 bool
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::operator<(const Self & it) const
 {
-  for (DimensionValueType i = 1; i <= Dimension; i++)
+  for (DimensionValueType i = 1; i <= Dimension; ++i)
   {
     if (this->GetIndex()[Dimension - i] < it.GetIndex()[Dimension - i])
     {
@@ -330,7 +330,7 @@ template <typename TImage>
 bool
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::operator>(const Self & it) const
 {
-  for (DimensionValueType i = 1; i <= Dimension; i++)
+  for (DimensionValueType i = 1; i <= Dimension; ++i)
   {
     if (this->GetIndex()[Dimension - i] > it.GetIndex()[Dimension - i])
     {
@@ -470,12 +470,12 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::PrintSelf(std::ostream & os, Ind
   os << "}, m_IsInBoundsValid = {" << m_IsInBoundsValid;
 
   os << indent << ",  m_InnerBoundsLow = { ";
-  for (i = 0; i < Dimension; i++)
+  for (i = 0; i < Dimension; ++i)
   {
     os << m_InnerBoundsLow[i] << " ";
   }
   os << "}, m_InnerBoundsHigh = { ";
-  for (i = 0; i < Dimension; i++)
+  for (i = 0; i < Dimension; ++i)
   {
     os << m_InnerBoundsHigh[i] << " ";
   }

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -165,7 +165,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::operator++()
     }
 
     // Increment pointers for only the active pixels.
-    for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); it++)
+    for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
     {
       (this->GetElement(*it))++;
     }
@@ -181,7 +181,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::operator++()
         {
           this->GetElement(this->GetCenterNeighborhoodIndex()) += this->m_WrapOffset[ii];
         }
-        for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); it++)
+        for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
         {
           (this->GetElement(*it)) += this->m_WrapOffset[ii];
         }
@@ -223,7 +223,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::operator--()
     }
 
     // Decrement pointers for only the active pixels.
-    for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); it++)
+    for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
     {
       (this->GetElement(*it))--;
     }
@@ -238,7 +238,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::operator--()
         {
           this->GetElement(this->GetCenterNeighborhoodIndex()) -= this->m_WrapOffset[i];
         }
-        for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); it++)
+        for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
         {
           (this->GetElement(*it)) -= this->m_WrapOffset[i];
         }
@@ -296,7 +296,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::operator+=(const Of
     }
 
     // Increment pointers only for those active pixels
-    for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); it++)
+    for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
     {
       (this->GetElement(*it)) += accumulator;
     }
@@ -350,7 +350,7 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::operator-=(const Of
     }
 
     // Increment pointers only for those active pixels
-    for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); it++)
+    for (it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
     {
       (this->GetElement(*it)) -= accumulator;
     }

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -87,7 +87,7 @@ public:
   /** Construct from discrete index type */
   ContinuousIndex(const IndexType & index)
   {
-    for (unsigned int i = 0; i < VIndexDimension; i++)
+    for (unsigned int i = 0; i < VIndexDimension; ++i)
     {
       (*this)[i] = static_cast<TCoordRep>(index[i]);
     }

--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -152,7 +152,7 @@ public:
   inline const Self &
   operator*=(const Tt & value)
   {
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       (*this)[i] = static_cast<ValueType>((*this)[i] * value);
     }
@@ -164,7 +164,7 @@ public:
   const Self &
   operator/=(const Tt & value)
   {
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       (*this)[i] = static_cast<ValueType>((*this)[i] / value);
     }
@@ -208,7 +208,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       result[i] = static_cast<ValueType>((*this)[i] * val);
     }
@@ -223,7 +223,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       result[i] = static_cast<ValueType>((*this)[i] / val);
     }
@@ -255,7 +255,7 @@ public:
   void
   CastFrom(const CovariantVector<TCoordRepB, NVectorDimension> & pa)
   {
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       (*this)[i] = static_cast<T>(pa[i]);
     }

--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -41,7 +41,7 @@ template <typename T, unsigned int NVectorDimension>
 const typename CovariantVector<T, NVectorDimension>::Self &
 CovariantVector<T, NVectorDimension>::operator+=(const Self & vec)
 {
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     (*this)[i] += vec[i];
   }
@@ -52,7 +52,7 @@ template <typename T, unsigned int NVectorDimension>
 const typename CovariantVector<T, NVectorDimension>::Self &
 CovariantVector<T, NVectorDimension>::operator-=(const Self & vec)
 {
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     (*this)[i] -= vec[i];
   }
@@ -65,7 +65,7 @@ CovariantVector<T, NVectorDimension>::operator-() const
 {
   Self result;
 
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     result[i] = -(*this)[i];
   }
@@ -78,7 +78,7 @@ CovariantVector<T, NVectorDimension>::operator+(const Self & vec) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     result[i] = (*this)[i] + vec[i];
   }
@@ -91,7 +91,7 @@ CovariantVector<T, NVectorDimension>::operator-(const Self & vec) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     result[i] = (*this)[i] - vec[i];
   }
@@ -103,7 +103,7 @@ typename CovariantVector<T, NVectorDimension>::ValueType CovariantVector<T, NVec
   const Self & other) const
 {
   typename NumericTraits<T>::AccumulateType value = NumericTraits<T>::ZeroValue();
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];
   }
@@ -115,7 +115,7 @@ typename CovariantVector<T, NVectorDimension>::ValueType CovariantVector<T, NVec
   const Vector<T, NVectorDimension> & other) const
 {
   typename NumericTraits<T>::AccumulateType value = NumericTraits<T>::ZeroValue();
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];
   }
@@ -128,7 +128,7 @@ CovariantVector<T, NVectorDimension>::GetSquaredNorm() const
 {
   RealValueType sum = NumericTraits<RealValueType>::ZeroValue();
 
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     const RealValueType value = (*this)[i];
     sum += value * value;
@@ -149,7 +149,7 @@ CovariantVector<T, NVectorDimension>::Normalize()
 {
   const RealValueType norm = this->GetNorm();
 
-  for (unsigned int i = 0; i < NVectorDimension; i++)
+  for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
     (*this)[i] /= norm;
   }
@@ -161,7 +161,7 @@ template <typename T, unsigned int NVectorDimension>
 void
 CovariantVector<T, NVectorDimension>::SetVnlVector(const vnl_vector<T> & v)
 {
-  for (unsigned int i = 0; i < v.size(); i++)
+  for (unsigned int i = 0; i < v.size(); ++i)
   {
     (*this)[i] = v(i);
   }

--- a/Modules/Core/Common/include/itkCrossHelper.h
+++ b/Modules/Core/Common/include/itkCrossHelper.h
@@ -59,7 +59,7 @@ public:
 
       if (Dimension > 3)
       {
-        for (unsigned int dim = 3; dim < Dimension; dim++)
+        for (unsigned int dim = 3; dim < Dimension; ++dim)
         {
           oCross[dim] = 0.0;
         }

--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
@@ -67,7 +67,7 @@ public:
   {
     InternalType * truePixel = (&output) + offset * m_OffsetMultiplier;
 
-    for (VectorLengthType i = 0; i < m_VectorLength; i++)
+    for (VectorLengthType i = 0; i < m_VectorLength; ++i)
     {
       truePixel[i] = input[i];
     }

--- a/Modules/Core/Common/include/itkDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkDerivativeOperator.hxx
@@ -35,10 +35,10 @@ DerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
   CoefficientVector  coeff(w);
 
   coeff[w / 2] = 1.0;
-  for (i = 0; i < m_Order / 2; i++)
+  for (i = 0; i < m_Order / 2; ++i)
   {
     previous = coeff[1] - 2 * coeff[0];
-    for (j = 1; j < w - 1; j++)
+    for (j = 1; j < w - 1; ++j)
     {
       next = coeff[j - 1] + coeff[j + 1] - 2 * coeff[j];
       coeff[j - 1] = previous;
@@ -48,10 +48,10 @@ DerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
     coeff[j - 1] = previous;
     coeff[j] = next;
   }
-  for (i = 0; i < m_Order % 2; i++)
+  for (i = 0; i < m_Order % 2; ++i)
   {
     previous = 0.5 * coeff[1];
-    for (j = 1; j < w - 1; j++)
+    for (j = 1; j < w - 1; ++j)
     {
       next = -0.5 * coeff[j - 1] + 0.5 * coeff[j + 1];
       coeff[j - 1] = previous;

--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -38,7 +38,7 @@ EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::~EllipsoidInterior
 
   if (m_Orientations)
   {
-    for (i = 0; i < VDimension; i++)
+    for (i = 0; i < VDimension; ++i)
     {
       delete[] m_Orientations[i];
     }
@@ -58,14 +58,14 @@ EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const Inp
   // Project the position onto each of the axes, normalize by axis length,
   // and determine whether position is inside ellipsoid. The length of axis0,
   // m_Axis[0] is orientated in the direction of m_Orientations[0].
-  for (unsigned int i = 0; i < VDimension; i++)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     pointVector[i] = position[i] - m_Center[i];
   }
 
-  for (unsigned int i = 0; i < VDimension; i++)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    for (unsigned int j = 0; j < VDimension; j++)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       orientationVector[j] = m_Orientations[i][j];
     }
@@ -90,22 +90,22 @@ EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::SetOrientations(co
   // Initialize orientation vectors.
   if (m_Orientations)
   {
-    for (i = 0; i < VDimension; i++)
+    for (i = 0; i < VDimension; ++i)
     {
       delete[] m_Orientations[i];
     }
     delete[] m_Orientations;
   }
   m_Orientations = new double *[VDimension];
-  for (i = 0; i < VDimension; i++)
+  for (i = 0; i < VDimension; ++i)
   {
     m_Orientations[i] = new double[VDimension];
   }
 
   // Set orientation vectors (must be orthogonal).
-  for (i = 0; i < VDimension; i++)
+  for (i = 0; i < VDimension; ++i)
   {
-    for (j = 0; j < VDimension; j++)
+    for (j = 0; j < VDimension; ++j)
     {
       m_Orientations[i][j] = orientations[i][j];
     }
@@ -125,9 +125,9 @@ EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::ost
   if (m_Orientations)
   {
     os << indent << "Orientations: " << std::endl;
-    for (i = 0; i < VDimension; i++)
+    for (i = 0; i < VDimension; ++i)
     {
-      for (j = 0; j < VDimension; j++)
+      for (j = 0; j < VDimension; ++j)
       {
         os << indent << indent << m_Orientations[i][j] << " ";
       }

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -125,13 +125,13 @@ FiniteCylinderSpatialFunction<VDimension, TInput>::PrintSelf(std::ostream & os, 
   os << indent << "Radius: " << m_Radius << std::endl;
   os << indent << "Origin of Cylinder: " << m_Center << std::endl;
   os << indent << "Orientation: " << std::endl;
-  for (i = 0; i < VDimension; i++)
+  for (i = 0; i < VDimension; ++i)
   {
     os << indent << indent << m_Orientation[i] << " ";
   }
   os << std::endl;
   os << indent << "Normalized Orientation: " << std::endl;
-  for (i = 0; i < VDimension; i++)
+  for (i = 0; i < VDimension; ++i)
   {
     os << indent << indent << m_NormalizedOrientation[i] << " ";
   }

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
@@ -204,7 +204,7 @@ public:
     // Initialize the temporary image
     m_TemporaryPointer->FillBuffer(NumericTraits<typename TTempImage::PixelType>::ZeroValue());
 
-    for (unsigned int i = 0; i < m_Seeds.size(); i++)
+    for (unsigned int i = 0; i < m_Seeds.size(); ++i)
     {
       if (this->m_Image->GetBufferedRegion().IsInside(m_Seeds[i]) && this->IsPixelIncluded(m_Seeds[i]))
       {

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -46,7 +46,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FloodFilledFunct
   this->m_Image = imagePtr;
   m_Function = fnPtr;
   unsigned int i;
-  for (i = 0; i < startIndex.size(); i++)
+  for (i = 0; i < startIndex.size(); ++i)
   {
     m_Seeds.push_back(startIndex[i]);
   }
@@ -94,7 +94,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::InitializeIterat
   // position later (using FindSeedPixel).  Must make sure that the
   // seed is inside the buffer before touching pixels.
   this->m_IsAtEnd = true;
-  for (unsigned int i = 0; i < m_Seeds.size(); i++)
+  for (unsigned int i = 0; i < m_Seeds.size(); ++i)
   {
     if (m_ImageRegion.IsInside(m_Seeds[i]))
     {
@@ -170,7 +170,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::DoFloodStep()
 
   // Iterate through all possible dimensions
   // NOTE: Replace this with a ShapeNeighborhoodIterator
-  for (unsigned int i = 0; i < NDimensions; i++)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
     // The j loop establishes either left or right neighbor (+-1)
     for (int j = -1; j <= 1; j += 2)
@@ -178,7 +178,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::DoFloodStep()
       IndexType tempIndex;
 
       // build the index of a neighbor
-      for (unsigned int k = 0; k < NDimensions; k++)
+      for (unsigned int k = 0; k < NDimensions; ++k)
       {
         if (i != k)
         {

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
@@ -70,7 +70,7 @@ FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIn
       // along each dimension
       ContinuousIndex<double, TImage::ImageDimension> contIndex;
 
-      for (unsigned int i = 0; i < TImage::ImageDimension; i++)
+      for (unsigned int i = 0; i < TImage::ImageDimension; ++i)
       {
         contIndex[i] = (double)index[i] + 0.5;
       }
@@ -118,11 +118,11 @@ FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIn
       IndexType tempIndex;
 
       // First we loop over the binary counter
-      for (counter = 0; counter < numReps; counter++)
+      for (counter = 0; counter < numReps; ++counter)
       {
         // Next we use the binary values in the counter to form
         // an index to look at
-        for (unsigned int i = 0; i < dim; i++)
+        for (unsigned int i = 0; i < dim; ++i)
         {
           counterCopy = counter;
           tempIndex[i] = index[i] + static_cast<int>((counterCopy >> i) & 0x0001);
@@ -162,11 +162,11 @@ FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIn
       IndexType    tempIndex;
 
       // First we loop over the binary counter
-      for (counter = 0; counter < numReps; counter++)
+      for (counter = 0; counter < numReps; ++counter)
       {
         // Next we use the binary values in the counter to form
         // an index to look at
-        for (unsigned int i = 0; i < dim; i++)
+        for (unsigned int i = 0; i < dim; ++i)
         {
           counterCopy = counter;
           tempIndex[i] = index[i] + static_cast<int>((counterCopy >> i) & 0x0001);

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -121,7 +121,7 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateGaussianCoef
   coeff.push_back(et * ModifiedBesselI1(pixelVariance));
   sum += coeff[1] * 2.0;
 
-  for (int i = 2; sum.GetSum() < cap; i++)
+  for (int i = 2; sum.GetSum() < cap; ++i)
   {
     coeff.push_back(et * ModifiedBesselI(i, pixelVariance));
     sum += coeff[i] * 2.0;

--- a/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
@@ -47,7 +47,7 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(co
   {
     prefixDenom = m_Sigma[m_Direction] * m_Sigma[m_Direction];
 
-    for (unsigned int i = 0; i < VImageDimension; i++)
+    for (unsigned int i = 0; i < VImageDimension; ++i)
     {
       prefixDenom *= m_Sigma[i];
     }
@@ -61,7 +61,7 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(co
 
   double suffixExp = 0;
 
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     suffixExp += (position[m_Direction] - m_Mean[m_Direction]) * (position[m_Direction] - m_Mean[m_Direction]) /
                  (2 * m_Sigma[m_Direction] * m_Sigma[m_Direction]);
@@ -80,7 +80,7 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::EvaluateVec
 {
   VectorType gradient;
 
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     m_Direction = i;
     gradient[i] = this->Evaluate(position);

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -43,7 +43,7 @@ GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
   coeff.push_back(et * ModifiedBesselI1(m_Variance));
   sum += coeff[1] * 2.0;
 
-  for (i = 2; sum < cap; i++)
+  for (i = 2; sum < cap; ++i)
   {
     coeff.push_back(et * ModifiedBesselI(i, m_Variance));
     sum += coeff[i] * 2.0;

--- a/Modules/Core/Common/include/itkHexahedronCell.h
+++ b/Modules/Core/Common/include/itkHexahedronCell.h
@@ -172,7 +172,7 @@ protected:
 public:
   HexahedronCell()
   {
-    for (unsigned int i = 0; i < Self::NumberOfPoints; i++)
+    for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
     {
       m_PointIds[i] = NumericTraits<PointIdentifier>::max();
     }

--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -386,7 +386,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
       }
     }
 
-    for (unsigned int i = 0; i < Self::PointDimension3D; i++)
+    for (unsigned int i = 0; i < Self::PointDimension3D; ++i)
     {
       fcol[i] -= x[i];
     }
@@ -680,11 +680,11 @@ HexahedronCell<TCellInterface>::EvaluateLocation(int &                     itkNo
     // NOTE: Avoid compiler warning.  The code below only runs if PointType::Dimension == Self::PointDimension3D
     constexpr unsigned int PREVENT_OVERRUN_OF_INVALID_INSTANTIATIONS =
       hexahedron_constexpr_min(PointType::Dimension, Self::PointDimension3D);
-    for (unsigned int i = 0; i < Self::NumberOfPoints; i++)
+    for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
     {
       const PointType pt{ points->GetElement(m_PointIds[i]) };
 
-      for (unsigned int j = 0; j < PREVENT_OVERRUN_OF_INVALID_INSTANTIATIONS; j++)
+      for (unsigned int j = 0; j < PREVENT_OVERRUN_OF_INVALID_INSTANTIATIONS; ++j)
       {
         const CoordRepType t = pt[j] * weights[i];
         x[j] += t;

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -446,10 +446,10 @@ public:
   {
     IndexType index;
 
-    for (unsigned int i = 0; i < VImageDimension; i++)
+    for (unsigned int i = 0; i < VImageDimension; ++i)
     {
       TCoordRep sum = NumericTraits<TCoordRep>::ZeroValue();
-      for (unsigned int j = 0; j < VImageDimension; j++)
+      for (unsigned int j = 0; j < VImageDimension; ++j)
       {
         sum += this->m_PhysicalPointToIndex[i][j] * (point[j] - this->m_Origin[j]);
       }

--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -70,7 +70,7 @@ template <unsigned int VImageDimension>
 void
 ImageBase<VImageDimension>::SetSpacing(const SpacingType & spacing)
 {
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     if (this->m_Spacing[i] < 0.0)
     {
@@ -132,9 +132,9 @@ ImageBase<VImageDimension>::SetDirection(const DirectionType & direction)
 {
   bool modified = false;
 
-  for (unsigned int r = 0; r < VImageDimension; r++)
+  for (unsigned int r = 0; r < VImageDimension; ++r)
   {
-    for (unsigned int c = 0; c < VImageDimension; c++)
+    for (unsigned int c = 0; c < VImageDimension; ++c)
     {
       if (Math::NotExactlyEquals(m_Direction[r][c], direction[r][c]))
       {
@@ -158,7 +158,7 @@ ImageBase<VImageDimension>::ComputeIndexToPhysicalPointMatrices()
 {
   DirectionType scale;
 
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     if (this->m_Spacing[i] == 0.0)
     {
@@ -189,7 +189,7 @@ ImageBase<VImageDimension>::ComputeOffsetTable()
 
   // m_OffsetTable[0] = (OffsetValueType)num;
   m_OffsetTable[0] = num;
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     num *= bufferSize[i];
     // m_OffsetTable[i+1] = (OffsetValueType)num;
@@ -347,7 +347,7 @@ ImageBase<VImageDimension>::RequestedRegionIsOutsideOfTheBufferedRegion()
   const SizeType & requestedRegionSize = this->GetRequestedRegion().GetSize();
   const SizeType & bufferedRegionSize = this->GetBufferedRegion().GetSize();
 
-  for (i = 0; i < VImageDimension; i++)
+  for (i = 0; i < VImageDimension; ++i)
   {
     if ((requestedRegionIndex[i] < bufferedRegionIndex[i]) ||
         ((requestedRegionIndex[i] + static_cast<OffsetValueType>(requestedRegionSize[i])) >
@@ -377,7 +377,7 @@ ImageBase<VImageDimension>::VerifyRequestedRegion()
   const SizeType & requestedRegionSize = this->GetRequestedRegion().GetSize();
   const SizeType & largestPossibleRegionSize = this->GetLargestPossibleRegion().GetSize();
 
-  for (i = 0; i < VImageDimension; i++)
+  for (i = 0; i < VImageDimension; ++i)
   {
     if ((requestedRegionIndex[i] < largestPossibleRegionIndex[i]) ||
         ((requestedRegionIndex[i] + static_cast<OffsetValueType>(requestedRegionSize[i])) >

--- a/Modules/Core/Common/include/itkImageKernelOperator.hxx
+++ b/Modules/Core/Common/include/itkImageKernelOperator.hxx
@@ -66,7 +66,7 @@ ImageKernelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
   }
 
   // Check that the size of the kernel is odd in all dimensions.
-  for (unsigned int i = 0; i < VDimension; i++)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     if (m_ImageKernel->GetLargestPossibleRegion().GetSize()[i] % 2 == 0)
     {

--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
@@ -246,7 +246,7 @@ ImageLinearConstIteratorWithIndex<TImage>::NextLine()
 
   this->m_PositionIndex[m_Direction] = this->m_BeginIndex[m_Direction];
 
-  for (unsigned int n = 0; n < TImage::ImageDimension; n++)
+  for (unsigned int n = 0; n < TImage::ImageDimension; ++n)
   {
     this->m_Remaining = false;
 
@@ -282,7 +282,7 @@ ImageLinearConstIteratorWithIndex<TImage>::PreviousLine()
 
   this->m_PositionIndex[m_Direction] = this->m_EndIndex[m_Direction] - 1;
 
-  for (unsigned int n = 0; n < TImage::ImageDimension; n++)
+  for (unsigned int n = 0; n < TImage::ImageDimension; ++n)
   {
     this->m_Remaining = false;
 

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
@@ -95,7 +95,7 @@ ImageRandomConstIteratorWithIndex<TImage>::RandomJump()
   PositionValueType position = randomPosition;
   PositionValueType residual;
 
-  for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
   {
     const SizeValueType sizeInThisDimension = this->m_Region.GetSize()[dim];
     residual = position % sizeInThisDimension;

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
@@ -89,7 +89,7 @@ ImageRandomConstIteratorWithOnlyIndex<TImage>::RandomJump()
   PositionValueType position = randomPosition;
   PositionValueType residual;
 
-  for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
   {
     const SizeValueType sizeInThisDimension = this->m_Region.GetSize()[dim];
     residual = position % sizeInThisDimension;

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -113,7 +113,7 @@ public:
   void
   Shuffle() const
   {
-    for (SizeValueType i = 0; i < m_Size; i++)
+    for (SizeValueType i = 0; i < m_Size; ++i)
     {
       m_Permutation[i].m_Value = m_Generator->GetVariateWithClosedRange(1.0);
       m_Permutation[i].m_Index = i;

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
@@ -119,11 +119,11 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SetPriorityImage(const Pr
   // image is the right size
   using PositionValueType = SizeValueType;
 
-  for (PositionValueType pixel = 0; pixel < m_NumberOfPixelsInRegion; pixel++)
+  for (PositionValueType pixel = 0; pixel < m_NumberOfPixelsInRegion; ++pixel)
   {
     PositionValueType position = pixel;
     IndexType         positionIndex;
-    for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+    for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
     {
       const SizeValueType     sizeInThisDimension = this->m_Region.GetSize()[dim];
       const PositionValueType residual = position % sizeInThisDimension;
@@ -146,7 +146,7 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::UpdatePosition()
   using PositionValueType = IndexValueType;
 
   PositionValueType position = (*(this->m_Permutation))[m_NumberOfSamplesDone % m_NumberOfSamplesRequested];
-  for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+  for (unsigned int dim = 0; dim < TImage::ImageDimension; ++dim)
   {
     const SizeValueType     sizeInThisDimension = this->m_Region.GetSize()[dim];
     const PositionValueType residual = position % sizeInThisDimension;

--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -243,7 +243,7 @@ public:
   bool
   IsInside(const IndexType & index) const
   {
-    for (unsigned int i = 0; i < ImageDimension; i++)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       if (index[i] < m_Index[i])
       {
@@ -265,7 +265,7 @@ public:
   bool
   IsInside(const ContinuousIndex<TCoordRepType, VImageDimension> & index) const
   {
-    for (unsigned int i = 0; i < ImageDimension; i++)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       if (Math::RoundHalfIntegerUp<IndexValueType>(index[i]) < static_cast<IndexValueType>(m_Index[i]))
       {
@@ -303,7 +303,7 @@ public:
     }
     IndexType        endCorner;
     const SizeType & size = region.GetSize();
-    for (unsigned int i = 0; i < ImageDimension; i++)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       endCorner[i] = beginCorner[i] + static_cast<OffsetValueType>(size[i]) - 1;
     }

--- a/Modules/Core/Common/include/itkImageRegion.hxx
+++ b/Modules/Core/Common/include/itkImageRegion.hxx
@@ -37,7 +37,7 @@ typename ImageRegion<VImageDimension>::IndexType
 ImageRegion<VImageDimension>::GetUpperIndex() const
 {
   IndexType idx;
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     idx[i] = m_Index[i] + m_Size[i] - 1;
   }
@@ -49,7 +49,7 @@ template <unsigned int VImageDimension>
 void
 ImageRegion<VImageDimension>::SetUpperIndex(const IndexType & idx)
 {
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     m_Size[i] = idx[i] - m_Index[i] + 1;
   }
@@ -62,7 +62,7 @@ ImageRegion<VImageDimension>::ComputeOffsetTable(OffsetTableType offsetTable) co
   OffsetValueType num = 1;
 
   offsetTable[0] = num;
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     num *= m_Size[i];
     offsetTable[i + 1] = num;
@@ -75,7 +75,7 @@ ImageRegion<VImageDimension>::GetNumberOfPixels() const
 {
   SizeValueType numPixels = 1;
 
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     numPixels *= m_Size[i];
   }
@@ -112,7 +112,7 @@ template <unsigned int VImageDimension>
 void
 ImageRegion<VImageDimension>::PadByRadius(const SizeType & radius)
 {
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     m_Size[i] += 2 * radius[i];
     m_Index[i] -= static_cast<OffsetValueType>(radius[i]);
@@ -123,7 +123,7 @@ template <unsigned int VImageDimension>
 void
 ImageRegion<VImageDimension>::PadByRadius(const IndexValueArrayType radius)
 {
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     m_Size[i] += 2 * radius[i];
     m_Index[i] -= static_cast<OffsetValueType>(radius[i]);
@@ -149,7 +149,7 @@ bool
 ImageRegion<VImageDimension>::ShrinkByRadius(const SizeType & radius)
 {
   bool shrunkSuccessfully = true;
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     if (m_Size[i] <= 2 * radius[i])
     {
@@ -169,7 +169,7 @@ bool
 ImageRegion<VImageDimension>::ShrinkByRadius(const IndexValueArrayType radius)
 {
   bool shrunkSuccessfully = true;
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     if (static_cast<IndexValueType>(m_Size[i]) <= 2 * radius[i])
     {
@@ -193,7 +193,7 @@ ImageRegion<VImageDimension>::Crop(const Self & region)
   bool            cropPossible = true;
 
   // Can we crop?
-  for (i = 0; i < VImageDimension && cropPossible; i++)
+  for (i = 0; i < VImageDimension && cropPossible; ++i)
   {
     // Is left edge of current region to the right of the right edge
     // of the region to crop with? (if so, we cannot crop)
@@ -216,7 +216,7 @@ ImageRegion<VImageDimension>::Crop(const Self & region)
   }
 
   // we can crop, so crop
-  for (i = 0; i < VImageDimension; i++)
+  for (i = 0; i < VImageDimension; ++i)
   {
     // first check the start index
     if (m_Index[i] < region.GetIndex()[i])
@@ -260,7 +260,7 @@ ImageRegion<VImageDimension>::Slice(const unsigned int dim) const
   sliceIndex.Fill(0);
   sliceSize.Fill(0);
   unsigned int ii = 0;
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     if (i != dim)
     {

--- a/Modules/Core/Common/include/itkImageRegionConstIterator.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIterator.hxx
@@ -49,7 +49,7 @@ ImageRegionConstIterator<TImage>::Increment()
   // Note that ++ind[0] moves to the next pixel along the row.
   ++ind[0];
   bool done = (ind[0] == startIndex[0] + static_cast<IndexValueType>(size[0]));
-  for (unsigned int i = 1; done && i < ImageIteratorDimension; i++)
+  for (unsigned int i = 1; done && i < ImageIteratorDimension; ++i)
   {
     done = (ind[i] == startIndex[i] + static_cast<IndexValueType>(size[i]) - 1);
   }
@@ -95,7 +95,7 @@ ImageRegionConstIterator<TImage>::Decrement()
   // Check to see if we are past the first pixel in the region
   // Note that --ind[0] moves to the previous pixel along the row.
   bool done = (--ind[0] == startIndex[0] - 1);
-  for (unsigned int i = 1; done && i < ImageIteratorDimension; i++)
+  for (unsigned int i = 1; done && i < ImageIteratorDimension; ++i)
   {
     done = (ind[i] == startIndex[i]);
   }

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
@@ -30,7 +30,7 @@ ImageRegionConstIteratorWithIndex<TImage> &
 ImageRegionConstIteratorWithIndex<TImage>::operator++()
 {
   this->m_Remaining = false;
-  for (unsigned int in = 0; in < TImage::ImageDimension; in++)
+  for (unsigned int in = 0; in < TImage::ImageDimension; ++in)
   {
     const IndexValueType positionIndex = ++this->m_PositionIndex[in];
     if (positionIndex < this->m_EndIndex[in])
@@ -62,7 +62,7 @@ ImageRegionConstIteratorWithIndex<TImage> &
 ImageRegionConstIteratorWithIndex<TImage>::operator--()
 {
   this->m_Remaining = false;
-  for (unsigned int in = 0; in < TImage::ImageDimension; in++)
+  for (unsigned int in = 0; in < TImage::ImageDimension; ++in)
   {
     if (this->m_PositionIndex[in] > this->m_BeginIndex[in])
     {

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.hxx
@@ -30,7 +30,7 @@ ImageRegionConstIteratorWithOnlyIndex<TImage> &
 ImageRegionConstIteratorWithOnlyIndex<TImage>::operator++()
 {
   this->m_Remaining = false;
-  for (unsigned int in = 0; in < TImage::ImageDimension; in++)
+  for (unsigned int in = 0; in < TImage::ImageDimension; ++in)
   {
     this->m_PositionIndex[in]++;
     if (this->m_PositionIndex[in] < this->m_EndIndex[in])
@@ -55,7 +55,7 @@ ImageRegionConstIteratorWithOnlyIndex<TImage> &
 ImageRegionConstIteratorWithOnlyIndex<TImage>::operator--()
 {
   this->m_Remaining = false;
-  for (unsigned int in = 0; in < TImage::ImageDimension; in++)
+  for (unsigned int in = 0; in < TImage::ImageDimension; ++in)
   {
     if (this->m_PositionIndex[in] > this->m_BeginIndex[in])
     {

--- a/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.hxx
@@ -103,7 +103,7 @@ ImageRegionExclusionConstIteratorWithIndex<TImage>::GoToBegin()
   this->Superclass::GoToBegin();
 
   // If inside the exclusion region to begin with, jump past it.
-  for (unsigned int in = 0; in < TImage::ImageDimension; in++)
+  for (unsigned int in = 0; in < TImage::ImageDimension; ++in)
   {
     if (m_ExclusionRegion.IsInside(this->m_PositionIndex))
     {
@@ -138,7 +138,7 @@ ImageRegionExclusionConstIteratorWithIndex<TImage>::GoToReverseBegin()
   this->Superclass::GoToReverseBegin();
 
   // If inside the exclusion region to begin with, jump past it.
-  for (unsigned int in = 0; in < TImage::ImageDimension; in++)
+  for (unsigned int in = 0; in < TImage::ImageDimension; ++in)
   {
     if (m_ExclusionRegion.IsInside(this->m_PositionIndex))
     {

--- a/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
@@ -272,7 +272,7 @@ public:
       // Check to see if we are past the first pixel in the region
       // Note that --ind[0] moves to the previous pixel along the row.
       done = (--ind[0] == startIndex[0] - 1);
-      for (unsigned int i = 1; done && i < this->ImageIteratorDimension; i++)
+      for (unsigned int i = 1; done && i < this->ImageIteratorDimension; ++i)
       {
         done = (ind[i] == startIndex[i]);
       }
@@ -328,7 +328,7 @@ public:
       // Check to see if we are past the last pixel in the region
       // Note that ++ind[0] moves to the next pixel along the row.
       done = (++ind[0] == startIndex[0] + static_cast<OffsetValueType>(size[0]));
-      for (unsigned int i = 1; done && i < this->ImageIteratorDimension; i++)
+      for (unsigned int i = 1; done && i < this->ImageIteratorDimension; ++i)
       {
         done = (ind[i] == startIndex[i] + static_cast<OffsetValueType>(size[i]) - 1);
       }

--- a/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
@@ -77,7 +77,7 @@ ImageSliceConstIteratorWithIndex<TImage>::NextSlice()
   this->m_Position -= m_LineJump * (this->m_PositionIndex[m_Direction_B] - this->m_BeginIndex[m_Direction_B]);
   this->m_PositionIndex[m_Direction_B] = this->m_BeginIndex[m_Direction_B];
 
-  for (unsigned int n = 0; n < TImage::ImageDimension; n++)
+  for (unsigned int n = 0; n < TImage::ImageDimension; ++n)
   {
     this->m_Remaining = false;
 
@@ -112,7 +112,7 @@ ImageSliceConstIteratorWithIndex<TImage>::PreviousSlice()
   this->m_PositionIndex[m_Direction_B] = this->m_EndIndex[m_Direction_B] - 1;
   this->m_Position += m_LineJump * (this->m_EndIndex[m_Direction_B] - this->m_BeginIndex[m_Direction_B]);
 
-  for (unsigned int n = 0; n < TImage::ImageDimension; n++)
+  for (unsigned int n = 0; n < TImage::ImageDimension; ++n)
   {
     this->m_Remaining = false;
 

--- a/Modules/Core/Common/include/itkImageToImageFilterDetail.h
+++ b/Modules/Core/Common/include/itkImageToImageFilterDetail.h
@@ -389,7 +389,7 @@ ImageToImageFilterDefaultCopyInformation(const typename BinaryUnsignedIntDispatc
   {
     destSpacing[i] = inputSpacing[i];
     destOrigin[i] = inputOrigin[i];
-    for (unsigned int j = 0; j < DestinationImageType::ImageDimension; j++)
+    for (unsigned int j = 0; j < DestinationImageType::ImageDimension; ++j)
     {
       if (j < SourceImageType::ImageDimension)
       {
@@ -405,7 +405,7 @@ ImageToImageFilterDefaultCopyInformation(const typename BinaryUnsignedIntDispatc
   {
     destSpacing[i] = 1.0;
     destOrigin[i] = 0.0;
-    for (unsigned int j = 0; j < DestinationImageType::ImageDimension; j++)
+    for (unsigned int j = 0; j < DestinationImageType::ImageDimension; ++j)
     {
       if (j == i)
       {

--- a/Modules/Core/Common/include/itkImportImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImportImageFilter.hxx
@@ -71,14 +71,14 @@ ImportImageFilter<TPixel, VImageDimension>::PrintSelf(std::ostream & os, Indent 
   }
 
   os << indent << "Spacing: [";
-  for (i = 0; i < static_cast<int>(VImageDimension) - 1; i++)
+  for (i = 0; i < static_cast<int>(VImageDimension) - 1; ++i)
   {
     os << m_Spacing[i] << ", ";
   }
   os << m_Spacing[i] << "]" << std::endl;
 
   os << indent << "Origin: [";
-  for (i = 0; i < static_cast<int>(VImageDimension) - 1; i++)
+  for (i = 0; i < static_cast<int>(VImageDimension) - 1; ++i)
   {
     os << m_Origin[i] << ", ";
   }
@@ -186,9 +186,9 @@ ImportImageFilter<TPixel, VImageDimension>::SetDirection(const DirectionType & d
 {
   bool modified = false;
 
-  for (unsigned int r = 0; r < VImageDimension; r++)
+  for (unsigned int r = 0; r < VImageDimension; ++r)
   {
-    for (unsigned int c = 0; c < VImageDimension; c++)
+    for (unsigned int c = 0; c < VImageDimension; ++c)
     {
       if (Math::NotExactlyEquals(m_Direction[r][c], direction[r][c]))
       {

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
@@ -68,7 +68,7 @@ InPlaceImageFilter<TInputImage, TOutputImage>::InternalAllocateOutputs(const Tru
   bool rMatch = true;
   if (inputPtr != nullptr && (unsigned int)InputImageDimension == (unsigned int)OutputImageDimension)
   {
-    for (unsigned int i = 0; i < (unsigned int)InputImageDimension; i++)
+    for (unsigned int i = 0; i < (unsigned int)InputImageDimension; ++i)
     {
       if (inputPtr->GetBufferedRegion().GetIndex(i) != outputPtr->GetRequestedRegion().GetIndex(i))
       {
@@ -102,7 +102,7 @@ InPlaceImageFilter<TInputImage, TOutputImage>::InternalAllocateOutputs(const Tru
     using ImageBaseType = ImageBase<OutputImageDimension>;
 
     // If there are more than one outputs, allocate the remaining outputs
-    for (unsigned int i = 1; i < this->GetNumberOfIndexedOutputs(); i++)
+    for (unsigned int i = 1; i < this->GetNumberOfIndexedOutputs(); ++i)
     {
       // Check whether the output is an image of the appropriate
       // dimension (use ProcessObject's version of the GetInput()

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -99,7 +99,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] + static_cast<IndexValueType>(sz[i]);
     }
@@ -110,7 +110,7 @@ public:
   const Self &
   operator+=(const SizeType & sz)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] += static_cast<IndexValueType>(sz[i]);
     }
@@ -124,7 +124,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] - static_cast<IndexValueType>(sz[i]);
     }
@@ -135,7 +135,7 @@ public:
   const Self &
   operator-=(const SizeType & sz)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] -= static_cast<IndexValueType>(sz[i]);
     }
@@ -148,7 +148,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] + offset[i];
     }
@@ -159,7 +159,7 @@ public:
   const Self &
   operator+=(const OffsetType & offset)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] += offset[i];
     }
@@ -170,7 +170,7 @@ public:
   const Self &
   operator-=(const OffsetType & offset)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] -= offset[i];
     }
@@ -183,7 +183,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] - off.m_InternalArray[i];
     }
@@ -196,7 +196,7 @@ public:
   {
     OffsetType result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] - vec.m_InternalArray[i];
     }
@@ -210,7 +210,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] * static_cast<IndexValueType>(vec.m_InternalArray[i]);
     }

--- a/Modules/Core/Common/include/itkLineCell.h
+++ b/Modules/Core/Common/include/itkLineCell.h
@@ -112,7 +112,7 @@ public:
 
   LineCell()
   {
-    for (unsigned int i = 0; i < Self::NumberOfPoints; i++)
+    for (unsigned int i = 0; i < Self::NumberOfPoints; ++i)
     {
       m_PointIds[i] = NumericTraits<PointIdentifier>::max();
     }

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1160,7 +1160,7 @@ compilers.
   virtual void Set##name(type data[])                                                                                  \
   {                                                                                                                    \
     unsigned int i;                                                                                                    \
-    for (i = 0; i < count; i++)                                                                                        \
+    for (i = 0; i < count; ++i)                                                                                        \
     {                                                                                                                  \
       CLANG_PRAGMA_PUSH                                                                                                \
       CLANG_SUPPRESS_Wfloat_equal                                                                                      \
@@ -1173,7 +1173,7 @@ compilers.
     if (i < count)                                                                                                     \
     {                                                                                                                  \
       this->Modified();                                                                                                \
-      for (i = 0; i < count; i++)                                                                                      \
+      for (i = 0; i < count; ++i)                                                                                      \
       {                                                                                                                \
         this->m_##name[i] = data[i];                                                                                   \
       }                                                                                                                \

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -229,9 +229,9 @@ public:
   {
     bool equal = true;
 
-    for (unsigned int r = 0; r < NRows; r++)
+    for (unsigned int r = 0; r < NRows; ++r)
     {
-      for (unsigned int c = 0; c < NColumns; c++)
+      for (unsigned int c = 0; c < NColumns; ++c)
       {
         if (Math::NotExactlyEquals(m_Matrix(r, c), matrix.m_Matrix(r, c)))
         {

--- a/Modules/Core/Common/include/itkMatrix.hxx
+++ b/Modules/Core/Common/include/itkMatrix.hxx
@@ -30,10 +30,10 @@ template <typename T, unsigned int NRows, unsigned int NColumns>
 Vector<T, NRows> Matrix<T, NRows, NColumns>::operator*(const Vector<T, NColumns> & vect) const
 {
   Vector<T, NRows> result;
-  for (unsigned int r = 0; r < NRows; r++)
+  for (unsigned int r = 0; r < NRows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < NColumns; c++)
+    for (unsigned int c = 0; c < NColumns; ++c)
     {
       sum += m_Matrix(r, c) * vect[c];
     }
@@ -49,10 +49,10 @@ template <typename T, unsigned int NRows, unsigned int NColumns>
 Point<T, NRows> Matrix<T, NRows, NColumns>::operator*(const Point<T, NColumns> & pnt) const
 {
   Point<T, NRows> result;
-  for (unsigned int r = 0; r < NRows; r++)
+  for (unsigned int r = 0; r < NRows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < NColumns; c++)
+    for (unsigned int c = 0; c < NColumns; ++c)
     {
       sum += m_Matrix(r, c) * pnt[c];
     }
@@ -68,10 +68,10 @@ template <typename T, unsigned int NRows, unsigned int NColumns>
 vnl_vector_fixed<T, NRows> Matrix<T, NRows, NColumns>::operator*(const vnl_vector_fixed<T, NColumns> & inVNLvect) const
 {
   vnl_vector_fixed<T, NRows> result;
-  for (unsigned int r = 0; r < NRows; r++)
+  for (unsigned int r = 0; r < NRows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < NColumns; c++)
+    for (unsigned int c = 0; c < NColumns; ++c)
     {
       sum += m_Matrix(r, c) * inVNLvect[c];
     }
@@ -87,10 +87,10 @@ template <typename T, unsigned int NRows, unsigned int NColumns>
 CovariantVector<T, NRows> Matrix<T, NRows, NColumns>::operator*(const CovariantVector<T, NColumns> & covect) const
 {
   CovariantVector<T, NRows> result;
-  for (unsigned int r = 0; r < NRows; r++)
+  for (unsigned int r = 0; r < NRows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < NColumns; c++)
+    for (unsigned int c = 0; c < NColumns; ++c)
     {
       sum += m_Matrix(r, c) * covect[c];
     }
@@ -118,9 +118,9 @@ Matrix<T, NRows, NColumns>::operator+(const Self & matrix) const
 {
   Self result;
 
-  for (unsigned int r = 0; r < NRows; r++)
+  for (unsigned int r = 0; r < NRows; ++r)
   {
-    for (unsigned int c = 0; c < NColumns; c++)
+    for (unsigned int c = 0; c < NColumns; ++c)
     {
       result.m_Matrix(r, c) = m_Matrix(r, c) + matrix.m_Matrix(r, c);
     }
@@ -135,9 +135,9 @@ template <typename T, unsigned int NRows, unsigned int NColumns>
 const Matrix<T, NRows, NColumns> &
 Matrix<T, NRows, NColumns>::operator+=(const Self & matrix)
 {
-  for (unsigned int r = 0; r < NRows; r++)
+  for (unsigned int r = 0; r < NRows; ++r)
   {
-    for (unsigned int c = 0; c < NColumns; c++)
+    for (unsigned int c = 0; c < NColumns; ++c)
     {
       m_Matrix(r, c) += matrix.m_Matrix(r, c);
     }
@@ -154,9 +154,9 @@ Matrix<T, NRows, NColumns>::operator-(const Self & matrix) const
 {
   Self result;
 
-  for (unsigned int r = 0; r < NRows; r++)
+  for (unsigned int r = 0; r < NRows; ++r)
   {
-    for (unsigned int c = 0; c < NColumns; c++)
+    for (unsigned int c = 0; c < NColumns; ++c)
     {
       result.m_Matrix(r, c) = m_Matrix(r, c) - matrix.m_Matrix(r, c);
     }
@@ -171,9 +171,9 @@ template <typename T, unsigned int NRows, unsigned int NColumns>
 const Matrix<T, NRows, NColumns> &
 Matrix<T, NRows, NColumns>::operator-=(const Self & matrix)
 {
-  for (unsigned int r = 0; r < NRows; r++)
+  for (unsigned int r = 0; r < NRows; ++r)
   {
-    for (unsigned int c = 0; c < NColumns; c++)
+    for (unsigned int c = 0; c < NColumns; ++c)
     {
       m_Matrix(r, c) -= matrix.m_Matrix(r, c);
     }

--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -100,7 +100,7 @@ public:
   {
     m_Radius.Fill(0);
     m_Size.Fill(0);
-    for (DimensionValueType i = 0; i < VDimension; i++)
+    for (DimensionValueType i = 0; i < VDimension; ++i)
     {
       m_StrideTable[i] = 0;
     }

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -44,7 +44,7 @@ Neighborhood<TPixel, VDimension, TContainer>::ComputeNeighborhoodOffsetTable()
   m_OffsetTable.reserve(this->Size());
   OffsetType         o;
   DimensionValueType i, j;
-  for (j = 0; j < VDimension; j++)
+  for (j = 0; j < VDimension; ++j)
   {
     o[j] = -(static_cast<OffsetValueType>(this->GetRadius(j)));
   }
@@ -52,7 +52,7 @@ Neighborhood<TPixel, VDimension, TContainer>::ComputeNeighborhoodOffsetTable()
   for (i = 0; i < this->Size(); ++i)
   {
     m_OffsetTable.push_back(o);
-    for (j = 0; j < VDimension; j++)
+    for (j = 0; j < VDimension; ++j)
     {
       o[j] = o[j] + 1;
       if (o[j] > static_cast<OffsetValueType>(this->GetRadius(j)))
@@ -73,7 +73,7 @@ Neighborhood<TPixel, VDimension, TContainer>::SetRadius(const SizeValueType s)
 {
   SizeType k;
 
-  for (DimensionValueType i = 0; i < VDimension; i++)
+  for (DimensionValueType i = 0; i < VDimension; ++i)
   {
     k[i] = s;
   }
@@ -88,7 +88,7 @@ Neighborhood<TPixel, VDimension, TContainer>::SetRadius(const SizeType & r)
   this->SetSize();
 
   SizeValueType cumul = NumericTraits<SizeValueType>::OneValue();
-  for (DimensionValueType i = 0; i < VDimension; i++)
+  for (DimensionValueType i = 0; i < VDimension; ++i)
   {
     cumul *= m_Size[i];
   }

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
@@ -124,7 +124,7 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetPixel(const unsigned n, con
     // Here, we are checking whether the particular pixel in the
     // neighborhood is within the bounds (when the neighborhood is not
     // completely in bounds, it is usually partly in bounds)
-    for (i = 0; i < Superclass::Dimension; i++)
+    for (i = 0; i < Superclass::Dimension; ++i)
     {
       if (!this->m_InBounds[i]) // Part of dimension spills out of bounds
       {
@@ -168,14 +168,14 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetNeighborhood(const Neighbor
 
   if (this->m_NeedToUseBoundaryCondition == false)
   {
-    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; this_it++, N_it++)
+    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; ++this_it, ++N_it)
     {
       this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
     }
   }
   else if (this->InBounds())
   {
-    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; this_it++, N_it++)
+    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; ++this_it, ++N_it)
     {
       this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
     }
@@ -183,7 +183,7 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetNeighborhood(const Neighbor
   else
   {
     // Calculate overlap & initialize index
-    for (i = 0; i < Superclass::Dimension; i++)
+    for (i = 0; i < Superclass::Dimension; ++i)
     {
       OverlapLow[i] = this->m_InnerBoundsLow[i] - this->m_Loop[i];
       OverlapHigh[i] =
@@ -192,7 +192,7 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetNeighborhood(const Neighbor
     }
 
     // Iterate through neighborhood
-    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; N_it++, this_it++)
+    for (N_it = N.Begin(), this_it = this->Begin(); this_it < _end; ++N_it, ++this_it)
     {
       flag = true;
       for (i = 0; i < Superclass::Dimension; ++i)

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.hxx
@@ -27,7 +27,7 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 void
 NeighborhoodOperator<TPixel, VDimension, TAllocator>::ScaleCoefficients(PixelRealType s)
 {
-  for (unsigned i = 0; i < this->Size(); i++)
+  for (unsigned i = 0; i < this->Size(); ++i)
   {
     this->operator[](i) = static_cast<TPixel>(this->operator[](i) * s);
   }
@@ -93,7 +93,7 @@ NeighborhoodOperator<TPixel, VDimension, TAllocator>::CreateToRadius(const SizeV
 {
   SizeType k;
 
-  for (unsigned int i = 0; i < VDimension; i++)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     k[i] = sz;
   }

--- a/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
@@ -141,7 +141,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < GetLength(v); i++)
+    for (unsigned int i = 0; i < GetLength(v); ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -184,7 +184,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < D; i++)
+    for (unsigned int i = 0; i < D; ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -187,7 +187,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < 6; i++)
+    for (unsigned int i = 0; i < 6; ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -180,7 +180,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < D; i++)
+    for (unsigned int i = 0; i < D; ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -171,7 +171,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < D; i++)
+    for (unsigned int i = 0; i < D; ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -212,7 +212,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < 4; i++)
+    for (unsigned int i = 0; i < 4; ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -212,7 +212,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < 3; i++)
+    for (unsigned int i = 0; i < 3; ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsStdVector.h
+++ b/Modules/Core/Common/include/itkNumericTraitsStdVector.h
@@ -162,7 +162,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < GetLength(v); i++)
+    for (unsigned int i = 0; i < GetLength(v); ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -187,7 +187,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < GetLength(); i++)
+    for (unsigned int i = 0; i < GetLength(); ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
@@ -140,7 +140,7 @@ public:
   IsPositive(const Self & a)
   {
     bool flag = false;
-    for (unsigned int i = 0; i < GetLength(a); i++)
+    for (unsigned int i = 0; i < GetLength(a); ++i)
     {
       if (a[i] > NumericTraits<ValueType>::ZeroValue())
       {
@@ -154,7 +154,7 @@ public:
   IsNonpositive(const Self & a)
   {
     bool flag = false;
-    for (unsigned int i = 0; i < GetLength(a); i++)
+    for (unsigned int i = 0; i < GetLength(a); ++i)
     {
       if (!(a[i] > 0.0))
       {
@@ -168,7 +168,7 @@ public:
   IsNegative(const Self & a)
   {
     bool flag = false;
-    for (unsigned int i = 0; i < GetLength(a); i++)
+    for (unsigned int i = 0; i < GetLength(a); ++i)
     {
       if (a[i] < NumericTraits<ValueType>::ZeroValue())
       {
@@ -182,7 +182,7 @@ public:
   IsNonnegative(const Self & a)
   {
     bool flag = false;
-    for (unsigned int i = 0; i < GetLength(a); i++)
+    for (unsigned int i = 0; i < GetLength(a); ++i)
     {
       if (!(a[i] < 0.0))
       {
@@ -222,7 +222,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < GetLength(v); i++)
+    for (unsigned int i = 0; i < GetLength(v); ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -133,7 +133,7 @@ public:
   IsPositive(const Self & a)
   {
     bool flag = false;
-    for (unsigned int i = 0; i < GetLength(a); i++)
+    for (unsigned int i = 0; i < GetLength(a); ++i)
     {
       if (a[i] > NumericTraits<ValueType>::ZeroValue())
       {
@@ -147,7 +147,7 @@ public:
   IsNonpositive(const Self & a)
   {
     bool flag = false;
-    for (unsigned int i = 0; i < GetLength(a); i++)
+    for (unsigned int i = 0; i < GetLength(a); ++i)
     {
       if (!(a[i] > 0.0))
       {
@@ -161,7 +161,7 @@ public:
   IsNegative(const Self & a)
   {
     bool flag = false;
-    for (unsigned int i = 0; i < GetLength(a); i++)
+    for (unsigned int i = 0; i < GetLength(a); ++i)
     {
       if (a[i] < 0.0)
       {
@@ -175,7 +175,7 @@ public:
   IsNonnegative(const Self & a)
   {
     bool flag = false;
-    for (unsigned int i = 0; i < GetLength(a); i++)
+    for (unsigned int i = 0; i < GetLength(a); ++i)
     {
       if (!(a[i] < 0.0))
       {
@@ -226,7 +226,7 @@ public:
   static void
   AssignToArray(const Self & v, TArray & mv)
   {
-    for (unsigned int i = 0; i < D; i++)
+    for (unsigned int i = 0; i < D; ++i)
     {
       mv[i] = v[i];
     }

--- a/Modules/Core/Common/include/itkObjectStore.hxx
+++ b/Modules/Core/Common/include/itkObjectStore.hxx
@@ -52,7 +52,7 @@ ObjectStore<TObjectType>::Reserve(SizeValueType n)
   m_Store.push_back(new_block);
 
   m_FreeList.reserve(n);
-  for (ObjectType * ptr = new_block.Begin; ptr < new_block.Begin + new_block.Size; ptr++)
+  for (ObjectType * ptr = new_block.Begin; ptr < new_block.Begin + new_block.Size; ++ptr)
   {
     m_FreeList.push_back(ptr);
   }

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -276,13 +276,13 @@ Octree<TPixel, ColorTableSize, MappingFunctionType>::GetImage()
   img->SetRequestedRegion(region);
   img->Allocate();
   typename ImageType::IndexType setIndex;
-  for (unsigned int i = 0; i < m_TrueDims[0]; i++)
+  for (unsigned int i = 0; i < m_TrueDims[0]; ++i)
   {
     setIndex[0] = i;
-    for (unsigned int j = 0; j < m_TrueDims[0]; j++)
+    for (unsigned int j = 0; j < m_TrueDims[0]; ++j)
     {
       setIndex[1] = j;
-      for (unsigned int k = 0; k < m_TrueDims[0]; k++)
+      for (unsigned int k = 0; k < m_TrueDims[0]; ++k)
       {
         setIndex[2] = k;
         img->SetPixel(setIndex, (TPixel)this->GetValue(i, j, k));

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -93,7 +93,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] + vec.m_InternalArray[i];
     }
@@ -106,7 +106,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] + sz[i];
     }
@@ -117,7 +117,7 @@ public:
   const Self &
   operator+=(const Size<VDimension> & sz)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] += sz[i];
     }
@@ -128,7 +128,7 @@ public:
   const Self &
   operator-=(const Size<VDimension> & sz)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] -= sz[i];
     }
@@ -141,7 +141,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] - vec.m_InternalArray[i];
     }
@@ -152,7 +152,7 @@ public:
   const Self &
   operator+=(const Self & vec)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] += vec.m_InternalArray[i];
     }
@@ -163,7 +163,7 @@ public:
   const Self &
   operator-=(const Self & vec)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] -= vec.m_InternalArray[i];
     }

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -262,7 +262,7 @@ public:
   void
   CastFrom(const Point<TCoordRepB, NPointDimension> & pa)
   {
-    for (unsigned int i = 0; i < NPointDimension; i++)
+    for (unsigned int i = 0; i < NPointDimension; ++i)
     {
       (*this)[i] = static_cast<TCoordRep>(pa[i]);
     }
@@ -278,7 +278,7 @@ public:
   {
     RealType sum = NumericTraits<RealType>::ZeroValue();
 
-    for (unsigned int i = 0; i < NPointDimension; i++)
+    for (unsigned int i = 0; i < NPointDimension; ++i)
     {
       const auto     component = static_cast<RealType>(pa[i]);
       const RealType difference = static_cast<RealType>((*this)[i]) - component;

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -42,7 +42,7 @@ template <typename T, unsigned int TPointDimension>
 const Point<T, TPointDimension> &
 Point<T, TPointDimension>::operator+=(const VectorType & vec)
 {
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     (*this)[i] += vec[i];
   }
@@ -56,7 +56,7 @@ template <typename T, unsigned int TPointDimension>
 const Point<T, TPointDimension> &
 Point<T, TPointDimension>::operator-=(const VectorType & vec)
 {
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     (*this)[i] -= vec[i];
   }
@@ -72,7 +72,7 @@ Point<T, TPointDimension>::operator+(const VectorType & vec) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     result[i] = (*this)[i] + vec[i];
   }
@@ -88,7 +88,7 @@ Point<T, TPointDimension>::operator-(const VectorType & vec) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     result[i] = (*this)[i] - vec[i];
   }
@@ -104,7 +104,7 @@ Point<T, TPointDimension>::operator-(const Self & pnt) const
 {
   VectorType result;
 
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     result[i] = (*this)[i] - pnt[i];
   }
@@ -150,7 +150,7 @@ template <typename T, unsigned int TPointDimension>
 void
 Point<T, TPointDimension>::SetToMidPoint(const Self & A, const Self & B)
 {
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     (*this)[i] = (A[i] + B[i]) / 2.0;
   }
@@ -166,7 +166,7 @@ Point<T, TPointDimension>::SetToBarycentricCombination(const Self & A, const Sel
   const double wa = alpha;
   const double wb = 1.0 - alpha;
 
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     (*this)[i] = wa * A[i] + wb * B[i];
   }
@@ -185,7 +185,7 @@ Point<T, TPointDimension>::SetToBarycentricCombination(const Self & A,
 {
   const double weightForC = 1.0 - weightForA - weightForB;
 
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     (*this)[i] = weightForA * A[i] + weightForB * B[i] + weightForC * C[i];
   }
@@ -200,17 +200,17 @@ Point<T, TPointDimension>::SetToBarycentricCombination(const Self * P, const dou
 {
   this->Fill(NumericTraits<T>::ZeroValue()); // put this point to null
   double weightSum = 0.0;
-  for (unsigned int j = 0; j < N - 1; j++)
+  for (unsigned int j = 0; j < N - 1; ++j)
   {
     const double weight = weights[j];
     weightSum += weight;
-    for (unsigned int i = 0; i < TPointDimension; i++)
+    for (unsigned int i = 0; i < TPointDimension; ++i)
     {
       (*this)[i] += weight * P[j][i];
     }
   }
   const double weight = (1.0 - weightSum);
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     (*this)[i] += weight * P[N - 1][i];
   }
@@ -242,7 +242,7 @@ BarycentricCombination<TPointContainer, TWeightContainer>::Evaluate(const PointC
   {
     const double weight = weights[j++];
     weightSum += weight;
-    for (unsigned int i = 0; i < PointDimension; i++)
+    for (unsigned int i = 0; i < PointDimension; ++i)
     {
       barycentre[i] += weight * (point->Value())[i];
     }
@@ -252,7 +252,7 @@ BarycentricCombination<TPointContainer, TWeightContainer>::Evaluate(const PointC
   // Compute directly the last one
   // to make sure that the weights sum 1
   const double weight = (1.0 - weightSum);
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     barycentre[i] += weight * (last->Value())[i];
   }
@@ -274,7 +274,7 @@ operator<<(std::ostream & os, const Point<T, TPointDimension> & vct)
   }
   else
   {
-    for (unsigned int i = 0; i + 1 < TPointDimension; i++)
+    for (unsigned int i = 0; i + 1 < TPointDimension; ++i)
     {
       os << vct[i] << ", ";
     }
@@ -291,7 +291,7 @@ template <typename T, unsigned int TPointDimension>
 std::istream &
 operator>>(std::istream & is, Point<T, TPointDimension> & vct)
 {
-  for (unsigned int i = 0; i < TPointDimension; i++)
+  for (unsigned int i = 0; i < TPointDimension; ++i)
   {
     is >> vct[i];
   }

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
@@ -128,7 +128,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
   bb->SetPoints(InputPointSet->GetPoints());
   bb->ComputeBoundingBox();
 
-  for (i = 0; i < InputPointSetDimension; i++)
+  for (i = 0; i < InputPointSetDimension; ++i)
   {
     size[i] = static_cast<SizeValueType>(bb->GetBounds()[2 * i + 1] - bb->GetBounds()[2 * i]);
     origin[i] = 0; // bb->GetBounds()[2*i];
@@ -142,7 +142,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
   // PointSet's bounding box will be used as default.
 
   bool specified = false;
-  for (i = 0; i < OutputImageDimension; i++)
+  for (i = 0; i < OutputImageDimension; ++i)
   {
     if (m_Size[i] != NumericTraits<SizeValueType>::ZeroValue())
     {
@@ -168,7 +168,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
   // the point-set is used as default.
 
   specified = false;
-  for (i = 0; i < OutputImageDimension; i++)
+  for (i = 0; i < OutputImageDimension; ++i)
   {
     if (Math::NotExactlyEquals(m_Spacing[i],
                                NumericTraits<typename NumericTraits<SpacingType>::ValueType>::ZeroValue()))
@@ -184,7 +184,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
   }
 
   specified = false;
-  for (i = 0; i < OutputImageDimension; i++)
+  for (i = 0; i < OutputImageDimension; ++i)
   {
     if (Math::NotExactlyEquals(m_Origin[i], NumericTraits<typename NumericTraits<PointType>::ValueType>::ZeroValue()))
     {
@@ -195,7 +195,7 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::GenerateData()
 
   if (specified)
   {
-    for (i = 0; i < OutputImageDimension; i++)
+    for (i = 0; i < OutputImageDimension; ++i)
     {
       origin[i] = m_Origin[i]; // set origin
     }

--- a/Modules/Core/Common/include/itkPolygonCell.h
+++ b/Modules/Core/Common/include/itkPolygonCell.h
@@ -147,7 +147,7 @@ public:
   PolygonCell() = default;
   PolygonCell(PointIdentifier NumberOfPoints)
   {
-    for (PointIdentifier i = 0; i < NumberOfPoints; i++)
+    for (PointIdentifier i = 0; i < NumberOfPoints; ++i)
     {
       m_PointIds.push_back(NumericTraits<PointIdentifier>::max());
     }

--- a/Modules/Core/Common/include/itkPolygonCell.hxx
+++ b/Modules/Core/Common/include/itkPolygonCell.hxx
@@ -166,7 +166,7 @@ PolygonCell<TCellInterface>::BuildEdges()
   {
     m_Edges.resize(m_PointIds.size());
     const auto numberOfPoints = static_cast<unsigned int>(m_PointIds.size());
-    for (unsigned int i = 1; i < numberOfPoints; i++)
+    for (unsigned int i = 1; i < numberOfPoints; ++i)
     {
       m_Edges[i - 1][0] = i - 1;
       m_Edges[i - 1][1] = i;

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.h
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.h
@@ -107,7 +107,7 @@ public:
 
   QuadraticEdgeCell()
   {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; i++)
+    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
     {
       m_PointIds[i] = NumericTraits<PointIdentifier>::max();
     }

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.h
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.h
@@ -128,7 +128,7 @@ public:
 public:
   QuadraticTriangleCell()
   {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; i++)
+    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
     {
       m_PointIds[i] = NumericTraits<PointIdentifier>::max();
     }

--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -132,7 +132,7 @@ public:
   /** Constructor and destructor */
   QuadrilateralCell()
   {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; i++)
+    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
     {
       m_PointIds[i] = NumericTraits<PointIdentifier>::max();
     }

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -304,7 +304,7 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   // See vtkQuad for this:  ComputeNormal (this, pt1, pt2, pt3, n);  vtkPlane::ProjectPoint(x,pt1,n,cp);
 
   //  enter iteration loop
-  for (iteration = converged = 0; !converged && (iteration < ITK_QUAD_MAX_ITERATION); iteration++)
+  for (iteration = converged = 0; !converged && (iteration < ITK_QUAD_MAX_ITERATION); ++iteration)
   {
     //  calculate element interpolation functions and derivatives
     this->InterpolationFunctions(pcoords, weights);

--- a/Modules/Core/Common/include/itkRGBAPixel.hxx
+++ b/Modules/Core/Common/include/itkRGBAPixel.hxx
@@ -38,7 +38,7 @@ RGBAPixel<T>::operator+(const Self & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     result[i] = (*this)[i] + r[i];
   }
@@ -51,7 +51,7 @@ RGBAPixel<T>::operator-(const Self & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     result[i] = (*this)[i] - r[i];
   }
@@ -62,7 +62,7 @@ template <typename T>
 const RGBAPixel<T> &
 RGBAPixel<T>::operator+=(const Self & r)
 {
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     (*this)[i] += r[i];
   }
@@ -73,7 +73,7 @@ template <typename T>
 const RGBAPixel<T> &
 RGBAPixel<T>::operator-=(const Self & r)
 {
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     (*this)[i] -= r[i];
   }
@@ -84,7 +84,7 @@ template <typename T>
 const RGBAPixel<T> &
 RGBAPixel<T>::operator*=(const ComponentType & r)
 {
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     (*this)[i] *= r;
   }
@@ -96,7 +96,7 @@ template <typename T>
 const RGBAPixel<T> &
 RGBAPixel<T>::operator/=(const ComponentType & r)
 {
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     (*this)[i] /= r;
   }
@@ -108,7 +108,7 @@ RGBAPixel<T> RGBAPixel<T>::operator*(const ComponentType & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     result[i] = (*this)[i] * r;
   }
@@ -121,7 +121,7 @@ RGBAPixel<T>::operator/(const ComponentType & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     result[i] = (*this)[i] / r;
   }
@@ -132,7 +132,7 @@ template <typename T>
 bool
 RGBAPixel<T>::operator==(const Self & r) const
 {
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     if ((*this)[i] != r[i])
     {

--- a/Modules/Core/Common/include/itkRGBPixel.hxx
+++ b/Modules/Core/Common/include/itkRGBPixel.hxx
@@ -38,7 +38,7 @@ RGBPixel<T>::operator+(const Self & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     result[i] = (*this)[i] + r[i];
   }
@@ -51,7 +51,7 @@ RGBPixel<T>::operator-(const Self & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     result[i] = (*this)[i] - r[i];
   }
@@ -62,7 +62,7 @@ template <typename T>
 const RGBPixel<T> &
 RGBPixel<T>::operator+=(const Self & r)
 {
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     (*this)[i] += r[i];
   }
@@ -73,7 +73,7 @@ template <typename T>
 const RGBPixel<T> &
 RGBPixel<T>::operator-=(const Self & r)
 {
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     (*this)[i] -= r[i];
   }
@@ -84,7 +84,7 @@ template <typename T>
 const RGBPixel<T> &
 RGBPixel<T>::operator*=(const ComponentType & r)
 {
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     (*this)[i] *= r;
   }
@@ -96,7 +96,7 @@ template <typename T>
 const RGBPixel<T> &
 RGBPixel<T>::operator/=(const ComponentType & r)
 {
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     (*this)[i] /= r;
   }
@@ -108,7 +108,7 @@ RGBPixel<T> RGBPixel<T>::operator*(const ComponentType & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     result[i] = (*this)[i] * r;
   }
@@ -121,7 +121,7 @@ RGBPixel<T>::operator/(const ComponentType & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     result[i] = (*this)[i] / r;
   }
@@ -132,7 +132,7 @@ template <typename T>
 bool
 RGBPixel<T>::operator==(const Self & r) const
 {
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     if (Math::NotExactlyEquals((*this)[i], r[i]))
     {

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -196,7 +196,7 @@ public:
     // Initialize the temporary image
     m_TempPtr->FillBuffer(NumericTraits<typename TTempImage::PixelType>::ZeroValue());
 
-    for (unsigned int i = 0; i < m_Seeds.size(); i++)
+    for (unsigned int i = 0; i < m_Seeds.size(); ++i)
     {
       if (this->m_Image->GetBufferedRegion().IsInside(m_Seeds[i]) && this->IsPixelIncluded(m_Seeds[i]))
       {

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -49,7 +49,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloo
   this->m_Image = imagePtr; // can not be done in the initialization list
 
   unsigned int i;
-  for (i = 0; i < startIndex.size(); i++)
+  for (i = 0; i < startIndex.size(); ++i)
   {
     m_Seeds.push_back(startIndex[i]);
   }
@@ -104,7 +104,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::Initialize
   // position later (using FindSeedPixel).  Must make sure that the
   // seed is inside the buffer before touching pixels.
   this->m_IsAtEnd = true;
-  for (unsigned int i = 0; i < m_Seeds.size(); i++)
+  for (unsigned int i = 0; i < m_Seeds.size(); ++i)
   {
     if (m_ImageRegion.IsInside(m_Seeds[i]))
     {

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -83,7 +83,7 @@ namespace itk
    // etc..
    ...
    ShapedNeighborhoodIterator<ImageType>::Iterator i;
-   for (i = it.Begin(); ! i.IsAtEnd(); i++)
+   for (i = it.Begin(); ! i.IsAtEnd(); ++i)
    { i.Set(i.Get() + 1.0); }
    // you may also use i != i.End(), but IsAtEnd() may be slightly faster.
    \endcode

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -94,7 +94,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] + vec.m_InternalArray[i];
     }
@@ -105,7 +105,7 @@ public:
   const Self &
   operator+=(const Self & vec)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] += vec.m_InternalArray[i];
     }
@@ -118,7 +118,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] - vec.m_InternalArray[i];
     }
@@ -129,7 +129,7 @@ public:
   const Self &
   operator-=(const Self & vec)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] -= vec.m_InternalArray[i];
     }
@@ -141,7 +141,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] = m_InternalArray[i] * vec.m_InternalArray[i];
     }
@@ -152,7 +152,7 @@ public:
   const Self &
   operator*=(const Self & vec)
   {
-    for (unsigned int i = 0; i < VDimension; i++)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       m_InternalArray[i] *= vec.m_InternalArray[i];
     }

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -38,11 +38,11 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
   if (VDimension == 3)
   {
     i = 0;
-    for (z = -1; z <= 1; z++)
+    for (z = -1; z <= 1; ++z)
     {
-      for (y = -1; y <= 1; y++)
+      for (y = -1; y <= 1; ++y)
       {
-        for (x = -1; x <= 1; x++)
+        for (x = -1; x <= 1; ++x)
         {
           pos = center + z * this->GetStride(2) + y * this->GetStride(1) + x * this->GetStride(0);
           this->operator[](pos) = static_cast<TPixel>(coeff[i]);
@@ -55,9 +55,9 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
   else if (VDimension == 2)
   {
     i = 0;
-    for (y = -1; y <= 1; y++)
+    for (y = -1; y <= 1; ++y)
     {
-      for (x = -1; x <= 1; x++)
+      for (x = -1; x <= 1; ++x)
       {
         pos = center + y * this->GetStride(1) + x * this->GetStride(0);
         this->operator[](pos) = static_cast<TPixel>(coeff[i]);

--- a/Modules/Core/Common/include/itkSparseFieldLayer.hxx
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.hxx
@@ -65,7 +65,7 @@ SparseFieldLayer<TNodeType>::SplitRegions(int num) const
   ConstIterator position = Begin();
   ConstIterator last = End();
 
-  for (int i = 0; i < num; i++)
+  for (int i = 0; i < num; ++i)
   {
     unsigned int j = 0;
     RegionType   region;

--- a/Modules/Core/Common/include/itkSpecialCoordinatesImage.hxx
+++ b/Modules/Core/Common/include/itkSpecialCoordinatesImage.hxx
@@ -75,7 +75,7 @@ SpecialCoordinatesImage<TPixel, VImageDimension>::FillBuffer(const TPixel & valu
 {
   const SizeValueType numberOfPixels = this->GetBufferedRegion().GetNumberOfPixels();
 
-  for (unsigned int i = 0; i < numberOfPixels; i++)
+  for (unsigned int i = 0; i < numberOfPixels; ++i)
   {
     (*m_Buffer)[i] = value;
   }

--- a/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
@@ -36,7 +36,7 @@ SphereSpatialFunction<VImageDimension, TInput>::Evaluate(const InputType & posit
 {
   double acc = 0;
 
-  for (unsigned int i = 0; i < VImageDimension; i++)
+  for (unsigned int i = 0; i < VImageDimension; ++i)
   {
     acc += (position[i] - m_Center[i]) * (position[i] - m_Center[i]);
   }
@@ -61,7 +61,7 @@ SphereSpatialFunction<VImageDimension, TInput>::PrintSelf(std::ostream & os, Ind
 
   unsigned int i;
   os << indent << "Center: [";
-  for (i = 0; i < VImageDimension - 1; i++)
+  for (i = 0; i < VImageDimension - 1; ++i)
   {
     os << m_Center[i] << ", ";
   }

--- a/Modules/Core/Common/include/itkStreamingImageFilter.hxx
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.hxx
@@ -167,7 +167,7 @@ StreamingImageFilter<TInputImage, TOutputImage>::UpdateOutputData(DataObject * i
    * piece, and copy the results into the output image.
    */
   unsigned int piece = 0;
-  for (; piece < numDivisions && !this->GetAbortGenerateData(); piece++)
+  for (; piece < numDivisions && !this->GetAbortGenerateData(); ++piece)
   {
     InputImageRegionType streamRegion = outputRegion;
     m_RegionSplitter->GetSplit(piece, numDivisions, streamRegion);

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -43,7 +43,7 @@ SymmetricEllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(
 
   // Project the position onto the major axis, normalize by axis length,
   // and determine whether position is inside ellipsoid.
-  for (unsigned int i = 0; i < VDimension; i++)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     pointVector[i] = position[i] - m_Center[i];
   }

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
@@ -53,7 +53,7 @@ SymmetricSecondRankTensor<T, NDimension>::operator+(const Self & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < InternalDimension; i++)
+  for (unsigned int i = 0; i < InternalDimension; ++i)
   {
     result[i] = (*this)[i] + r[i];
   }
@@ -69,7 +69,7 @@ SymmetricSecondRankTensor<T, NDimension>::operator-(const Self & r) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < InternalDimension; i++)
+  for (unsigned int i = 0; i < InternalDimension; ++i)
   {
     result[i] = (*this)[i] - r[i];
   }
@@ -83,7 +83,7 @@ template <typename T, unsigned int NDimension>
 const SymmetricSecondRankTensor<T, NDimension> &
 SymmetricSecondRankTensor<T, NDimension>::operator+=(const Self & r)
 {
-  for (unsigned int i = 0; i < InternalDimension; i++)
+  for (unsigned int i = 0; i < InternalDimension; ++i)
   {
     (*this)[i] += r[i];
   }
@@ -97,7 +97,7 @@ template <typename T, unsigned int NDimension>
 const SymmetricSecondRankTensor<T, NDimension> &
 SymmetricSecondRankTensor<T, NDimension>::operator-=(const Self & r)
 {
-  for (unsigned int i = 0; i < InternalDimension; i++)
+  for (unsigned int i = 0; i < InternalDimension; ++i)
   {
     (*this)[i] -= r[i];
   }
@@ -111,7 +111,7 @@ template <typename T, unsigned int NDimension>
 const SymmetricSecondRankTensor<T, NDimension> &
 SymmetricSecondRankTensor<T, NDimension>::operator*=(const RealValueType & r)
 {
-  for (unsigned int i = 0; i < InternalDimension; i++)
+  for (unsigned int i = 0; i < InternalDimension; ++i)
   {
     (*this)[i] *= r;
   }
@@ -125,7 +125,7 @@ template <typename T, unsigned int NDimension>
 const SymmetricSecondRankTensor<T, NDimension> &
 SymmetricSecondRankTensor<T, NDimension>::operator/=(const RealValueType & r)
 {
-  for (unsigned int i = 0; i < InternalDimension; i++)
+  for (unsigned int i = 0; i < InternalDimension; ++i)
   {
     (*this)[i] /= r;
   }
@@ -141,7 +141,7 @@ SymmetricSecondRankTensor<T, NDimension> SymmetricSecondRankTensor<T, NDimension
 {
   Self result;
 
-  for (unsigned int i = 0; i < InternalDimension; i++)
+  for (unsigned int i = 0; i < InternalDimension; ++i)
   {
     result[i] = (*this)[i] * r;
   }
@@ -157,7 +157,7 @@ SymmetricSecondRankTensor<T, NDimension>::operator/(const RealValueType & r) con
 {
   Self result;
 
-  for (unsigned int i = 0; i < InternalDimension; i++)
+  for (unsigned int i = 0; i < InternalDimension; ++i)
   {
     result[i] = (*this)[i] / r;
   }
@@ -225,7 +225,7 @@ void
 SymmetricSecondRankTensor<T, NDimension>::SetIdentity()
 {
   this->Fill(NumericTraits<T>::ZeroValue());
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     (*this)(i, i) = NumericTraits<T>::OneValue();
   }
@@ -241,7 +241,7 @@ SymmetricSecondRankTensor<T, NDimension>::GetTrace() const
   AccumulateValueType trace = NumericTraits<AccumulateValueType>::ZeroValue();
   unsigned int        k = 0;
 
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     trace += (*this)[k];
     k += (Dimension - i);
@@ -260,9 +260,9 @@ SymmetricSecondRankTensor<T, NDimension>::ComputeEigenValues(EigenValuesArrayTyp
 
   MatrixType tensorMatrix;
 
-  for (unsigned int row = 0; row < Dimension; row++)
+  for (unsigned int row = 0; row < Dimension; ++row)
   {
-    for (unsigned int col = 0; col < Dimension; col++)
+    for (unsigned int col = 0; col < Dimension; ++col)
     {
       tensorMatrix[row][col] = (*this)(row, col);
     }
@@ -284,9 +284,9 @@ SymmetricSecondRankTensor<T, NDimension>::ComputeEigenAnalysis(EigenValuesArrayT
 
   MatrixType tensorMatrix;
 
-  for (unsigned int row = 0; row < Dimension; row++)
+  for (unsigned int row = 0; row < Dimension; ++row)
   {
-    for (unsigned int col = 0; col < Dimension; col++)
+    for (unsigned int col = 0; col < Dimension; ++col)
     {
       tensorMatrix[row][col] = (*this)(row, col);
     }
@@ -308,12 +308,12 @@ SymmetricSecondRankTensor<T, NDimension>::Rotate(const Matrix<TMatrixValueType, 
   Self result;
   using RotationMatrixType = Matrix<double, NDimension, NDimension>;
   RotationMatrixType SCT; // self * Transpose(m)
-  for (unsigned int r = 0; r < NDimension; r++)
+  for (unsigned int r = 0; r < NDimension; ++r)
   {
-    for (unsigned int c = 0; c < NDimension; c++)
+    for (unsigned int c = 0; c < NDimension; ++c)
     {
       double sum = 0.0;
-      for (unsigned int t = 0; t < NDimension; t++)
+      for (unsigned int t = 0; t < NDimension; ++t)
       {
         sum += (*this)(r, t) * m(c, t);
       }
@@ -321,12 +321,12 @@ SymmetricSecondRankTensor<T, NDimension>::Rotate(const Matrix<TMatrixValueType, 
     }
   }
   // self = m * sct;
-  for (unsigned int r = 0; r < NDimension; r++)
+  for (unsigned int r = 0; r < NDimension; ++r)
   {
-    for (unsigned int c = 0; c < NDimension; c++)
+    for (unsigned int c = 0; c < NDimension; ++c)
     {
       double sum = 0.0;
-      for (unsigned int t = 0; t < NDimension; t++)
+      for (unsigned int t = 0; t < NDimension; ++t)
       {
         sum += m(r, t) * SCT(t, c);
       }
@@ -346,12 +346,12 @@ SymmetricSecondRankTensor<T, NDimension>::PreMultiply(const MatrixType & m) cons
   MatrixType result;
 
   using AccumulateType = typename NumericTraits<T>::AccumulateType;
-  for (unsigned int r = 0; r < NDimension; r++)
+  for (unsigned int r = 0; r < NDimension; ++r)
   {
-    for (unsigned int c = 0; c < NDimension; c++)
+    for (unsigned int c = 0; c < NDimension; ++c)
     {
       AccumulateType sum = NumericTraits<AccumulateType>::ZeroValue();
-      for (unsigned int t = 0; t < NDimension; t++)
+      for (unsigned int t = 0; t < NDimension; ++t)
       {
         sum += m(r, t) * (*this)(t, c);
       }
@@ -371,12 +371,12 @@ SymmetricSecondRankTensor<T, NDimension>::PostMultiply(const MatrixType & m) con
   MatrixType result;
 
   using AccumulateType = typename NumericTraits<T>::AccumulateType;
-  for (unsigned int r = 0; r < NDimension; r++)
+  for (unsigned int r = 0; r < NDimension; ++r)
   {
-    for (unsigned int c = 0; c < NDimension; c++)
+    for (unsigned int c = 0; c < NDimension; ++c)
     {
       AccumulateType sum = NumericTraits<AccumulateType>::ZeroValue();
-      for (unsigned int t = 0; t < NDimension; t++)
+      for (unsigned int t = 0; t < NDimension; ++t)
       {
         sum += (*this)(r, t) * m(t, c);
       }
@@ -393,7 +393,7 @@ template <typename T, unsigned int NDimension>
 std::ostream &
 operator<<(std::ostream & os, const SymmetricSecondRankTensor<T, NDimension> & c)
 {
-  for (unsigned int i = 0; i < c.GetNumberOfComponents(); i++)
+  for (unsigned int i = 0; i < c.GetNumberOfComponents(); ++i)
   {
     os << static_cast<typename NumericTraits<T>::PrintType>(c[i]) << "  ";
   }
@@ -407,7 +407,7 @@ template <typename T, unsigned int NDimension>
 std::istream &
 operator>>(std::istream & is, SymmetricSecondRankTensor<T, NDimension> & dt)
 {
-  for (unsigned int i = 0; i < dt.GetNumberOfComponents(); i++)
+  for (unsigned int i = 0; i < dt.GetNumberOfComponents(); ++i)
   {
     is >> dt[i];
   }

--- a/Modules/Core/Common/include/itkTetrahedronCell.h
+++ b/Modules/Core/Common/include/itkTetrahedronCell.h
@@ -138,7 +138,7 @@ public:
 public:
   TetrahedronCell()
   {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; i++)
+    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
     {
       m_PointIds[i] = NumericTraits<PointIdentifier>::max();
     }

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -107,7 +107,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   PointType pt3 = points->GetElement(m_PointIds[2]);
   PointType pt4 = points->GetElement(m_PointIds[3]);
 
-  for (i = 0; i < PointDimension; i++)
+  for (i = 0; i < PointDimension; ++i)
   {
     rhs[i] = x[i] - pt4[i];
     c1[i] = pt1[i] - pt4[i];
@@ -118,7 +118,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   // Create a vnl_matrix so that the determinant can be computed
   // for any PointDimension
   vnl_matrix_fixed<CoordRepType, 3, PointDimension> mat;
-  for (i = 0; i < PointDimension; i++)
+  for (i = 0; i < PointDimension; ++i)
   {
     mat.put(0, i, c1[i]);
     mat.put(1, i, c2[i]);
@@ -130,7 +130,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
     return false;
   }
 
-  for (i = 0; i < PointDimension; i++)
+  for (i = 0; i < PointDimension; ++i)
   {
     mat.put(0, i, rhs[i]);
     mat.put(1, i, c2[i]);
@@ -139,7 +139,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
 
   pcoords[0] = vnl_determinant(mat) / det;
 
-  for (i = 0; i < PointDimension; i++)
+  for (i = 0; i < PointDimension; ++i)
   {
     mat.put(0, i, c1[i]);
     mat.put(1, i, rhs[i]);
@@ -148,7 +148,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
 
   pcoords[1] = vnl_determinant(mat) / det;
 
-  for (i = 0; i < PointDimension; i++)
+  for (i = 0; i < PointDimension; ++i)
   {
     mat.put(0, i, c1[i]);
     mat.put(1, i, c2[i]);
@@ -179,7 +179,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   {
     if (closestPoint)
     {
-      for (unsigned int ii = 0; ii < PointDimension; ii++)
+      for (unsigned int ii = 0; ii < PointDimension; ++ii)
       {
         closestPoint[ii] = x[ii];
       }
@@ -199,14 +199,14 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
     {
       FaceAutoPointer triangle;
       *minDist2 = NumericTraits<double>::max();
-      for (i = 0; i < 4; i++)
+      for (i = 0; i < 4; ++i)
       {
         this->GetFace(i, triangle);
         triangle->EvaluatePosition(x, points, closest, pc, &dist2, nullptr);
 
         if (dist2 < *minDist2)
         {
-          for (unsigned int dim = 0; dim < PointDimension; dim++)
+          for (unsigned int dim = 0; dim < PointDimension; ++dim)
           {
             closestPoint[dim] = closest[dim];
           }

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
@@ -58,7 +58,7 @@ TorusInteriorExteriorSpatialFunction<VDimension, TInput>::PrintSelf(std::ostream
   unsigned int i;
 
   os << indent << "Origin: [";
-  for (i = 0; i < VDimension - 1; i++)
+  for (i = 0; i < VDimension - 1; ++i)
   {
     os << m_Origin[i] << ", ";
   }

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -279,7 +279,7 @@ TriangleCell<TCellInterface>::DistanceToLine(PointType      x,
 {
   // convert from CoordRepType * to PointType:
   PointType temp(closestPoint);
-  //   for (unsigned int i = 0; i < PointDimension; i++)
+  //   for (unsigned int i = 0; i < PointDimension; ++i)
   //     {
   //     temp[i] = closestPoint[i];
   //     }
@@ -288,7 +288,7 @@ TriangleCell<TCellInterface>::DistanceToLine(PointType      x,
   const double distance2 = this->DistanceToLine(x, p1, p2, t, temp);
 
   // convert from PointType to CoordRepType * :
-  for (unsigned int j = 0; j < PointDimension; j++)
+  for (unsigned int j = 0; j < PointDimension; ++j)
   {
     closestPoint[j] = temp[j];
   }
@@ -311,7 +311,7 @@ TriangleCell<TCellInterface>::DistanceToLine(PointType   x,
   double num(0);
   double denom(0);
 
-  for (unsigned int i = 0; i < PointDimension; i++)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     num += static_cast<double>(v21[i] * (x[i] - p1[i]));
     denom += static_cast<double>(v21[i] * v21[i]);
@@ -374,7 +374,7 @@ TriangleCell<TCellInterface>::ComputeBarycenter(CoordRepType * iWeights, PointsC
   CoordRepType sum_weights(0.);
   unsigned int i(0);
 
-  for (; i < 3; i++)
+  for (; i < 3; ++i)
   {
     sum_weights += iWeights[i];
     p[i] = iPoints->GetElement(m_PointIds[i]);
@@ -385,7 +385,7 @@ TriangleCell<TCellInterface>::ComputeBarycenter(CoordRepType * iWeights, PointsC
   if (sum_weights != 0.)
   {
     oP.Fill(0.);
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < 3; ++i)
     {
       oP += p[i].GetVectorFromOrigin() * iWeights[i] / sum_weights;
     }
@@ -414,7 +414,7 @@ TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints)
   PointType    p[3];
   unsigned int i;
 
-  for (i = 0; i < 3; i++)
+  for (i = 0; i < 3; ++i)
   {
     p[i] = iPoints->GetElement(m_PointIds[i]);
   }
@@ -434,7 +434,7 @@ TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints)
     PointType oP;
     oP.Fill(0.);
 
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < 3; ++i)
     {
       oP += p[i].GetVectorFromOrigin() * weights[i] / sum_weights;
     }
@@ -547,7 +547,7 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
     if (closestPoint)
     { // Compute the Distance 2 Between Points
       *minDist2 = 0;
-      for (i = 0; i < PointDimension; i++)
+      for (i = 0; i < PointDimension; ++i)
       {
         const double val = cp[i] - x[i];
         *minDist2 += val * val;
@@ -579,7 +579,7 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
       if (b1 < 0.0 && b2 < 0.0)
       {
         dist2Point = 0;
-        for (i = 0; i < PointDimension; i++)
+        for (i = 0; i < PointDimension; ++i)
         {
           dist2Point += (x[i] - pt3[i]) * (x[i] - pt3[i]);
         }
@@ -600,11 +600,11 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
           *minDist2 = dist2Line2;
           closest = closestPoint2;
         }
-        for (i = 0; i < PointDimension; i++)
+        for (i = 0; i < PointDimension; ++i)
         {
           closestPoint[i] = closest[i];
         }
-        for (; i < 3; i++)
+        for (; i < 3; ++i)
         {
           closestPoint[i] = 0.;
         }
@@ -612,7 +612,7 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
       else if (b2 < 0.0 && b3 < 0.0)
       {
         dist2Point = 0;
-        for (i = 0; i < PointDimension; i++)
+        for (i = 0; i < PointDimension; ++i)
         {
           dist2Point += (x[i] - pt1[i]) * (x[i] - pt1[i]);
         }
@@ -633,11 +633,11 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
           *minDist2 = dist2Line2;
           closest = closestPoint2;
         }
-        for (i = 0; i < PointDimension; i++)
+        for (i = 0; i < PointDimension; ++i)
         {
           closestPoint[i] = closest[i];
         }
-        for (; i < 3; i++)
+        for (; i < 3; ++i)
         {
           closestPoint[i] = 0.;
         }
@@ -645,7 +645,7 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
       else if (b1 < 0.0 && b3 < 0.0)
       {
         dist2Point = 0;
-        for (i = 0; i < PointDimension; i++)
+        for (i = 0; i < PointDimension; ++i)
         {
           dist2Point += (x[i] - pt2[i]) * (x[i] - pt2[i]);
         }
@@ -666,11 +666,11 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
           *minDist2 = dist2Line2;
           closest = closestPoint2;
         }
-        for (i = 0; i < PointDimension; i++)
+        for (i = 0; i < PointDimension; ++i)
         {
           closestPoint[i] = closest[i];
         }
-        for (; i < 3; i++)
+        for (; i < 3; ++i)
         {
           closestPoint[i] = 0.;
         }

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -759,7 +759,7 @@ public:
   Self &
   operator--()
   {
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       this->m_Data[i] -= static_cast<ValueType>(1.0);
     }
@@ -770,7 +770,7 @@ public:
   Self &
   operator++() // prefix operator ++v;
   {
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       this->m_Data[i] += static_cast<ValueType>(1.0);
     }
@@ -811,7 +811,7 @@ public:
   operator-=(const VariableLengthVector<T> & v)
   {
     itkAssertInDebugAndIgnoreInReleaseMacro(m_NumElements == v.GetSize());
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       m_Data[i] -= static_cast<ValueType>(v[i]);
     }
@@ -822,7 +822,7 @@ public:
   Self &
   operator-=(TValue s)
   {
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       m_Data[i] -= s;
     }
@@ -842,7 +842,7 @@ public:
   operator+=(const VariableLengthVector<T> & v)
   {
     itkAssertInDebugAndIgnoreInReleaseMacro(m_NumElements == v.GetSize());
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       m_Data[i] += static_cast<ValueType>(v[i]);
     }
@@ -853,7 +853,7 @@ public:
   Self &
   operator+=(TValue s)
   {
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       m_Data[i] += s;
     }
@@ -912,7 +912,7 @@ public:
   operator*=(T s)
   {
     const ValueType & sc = static_cast<ValueType>(s);
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       m_Data[i] *= sc;
     }
@@ -925,7 +925,7 @@ public:
   Self &
   operator*=(TValue s)
   {
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       m_Data[i] *= s;
     }
@@ -943,7 +943,7 @@ public:
   operator/=(T s)
   {
     const RealValueType sc = s;
-    for (ElementIdentifier i = 0; i < m_NumElements; i++)
+    for (ElementIdentifier i = 0; i < m_NumElements; ++i)
     {
       m_Data[i] = static_cast<ValueType>(static_cast<RealValueType>(m_Data[i]) / sc);
     }

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -384,7 +384,7 @@ template <typename TValue>
 VariableLengthVector<TValue> &
 VariableLengthVector<TValue>::operator-()
 {
-  for (ElementIdentifier i = 0; i < m_NumElements; i++)
+  for (ElementIdentifier i = 0; i < m_NumElements; ++i)
   {
     m_Data[i] = -m_Data[i];
   }

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.h
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.h
@@ -272,9 +272,9 @@ VariableSizeMatrix<T>::operator==(const Self & matrix) const
   }
   bool equal = true;
 
-  for (unsigned int r = 0; r < this->Rows(); r++)
+  for (unsigned int r = 0; r < this->Rows(); ++r)
   {
-    for (unsigned int c = 0; c < this->Cols(); c++)
+    for (unsigned int c = 0; c < this->Cols(); ++c)
     {
       if (Math::NotExactlyEquals(m_Matrix(r, c), matrix.m_Matrix(r, c)))
       {

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
@@ -44,10 +44,10 @@ Array<T> VariableSizeMatrix<T>::operator*(const Array<T> & vect) const
   }
 
   Array<T> result(rows);
-  for (unsigned int r = 0; r < rows; r++)
+  for (unsigned int r = 0; r < rows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < cols; c++)
+    for (unsigned int c = 0; c < cols; ++c)
     {
       sum += m_Matrix(r, c) * vect[c];
     }
@@ -88,9 +88,9 @@ VariableSizeMatrix<T>::operator+(const Self & matrix) const
   }
 
   Self result(this->Rows(), this->Cols());
-  for (unsigned int r = 0; r < this->Rows(); r++)
+  for (unsigned int r = 0; r < this->Rows(); ++r)
   {
-    for (unsigned int c = 0; c < this->Cols(); c++)
+    for (unsigned int c = 0; c < this->Cols(); ++c)
     {
       result.m_Matrix(r, c) = m_Matrix(r, c) + matrix.m_Matrix(r, c);
     }
@@ -112,9 +112,9 @@ VariableSizeMatrix<T>::operator+=(const Self & matrix)
                              << ")");
   }
 
-  for (unsigned int r = 0; r < this->Rows(); r++)
+  for (unsigned int r = 0; r < this->Rows(); ++r)
   {
-    for (unsigned int c = 0; c < this->Cols(); c++)
+    for (unsigned int c = 0; c < this->Cols(); ++c)
     {
       m_Matrix(r, c) += matrix.m_Matrix(r, c);
     }
@@ -137,9 +137,9 @@ VariableSizeMatrix<T>::operator-(const Self & matrix) const
   }
 
   Self result(this->Rows(), this->Cols());
-  for (unsigned int r = 0; r < this->Rows(); r++)
+  for (unsigned int r = 0; r < this->Rows(); ++r)
   {
-    for (unsigned int c = 0; c < this->Cols(); c++)
+    for (unsigned int c = 0; c < this->Cols(); ++c)
     {
       result.m_Matrix(r, c) = m_Matrix(r, c) - matrix.m_Matrix(r, c);
     }
@@ -161,9 +161,9 @@ VariableSizeMatrix<T>::operator-=(const Self & matrix)
                              << ")");
   }
 
-  for (unsigned int r = 0; r < this->Rows(); r++)
+  for (unsigned int r = 0; r < this->Rows(); ++r)
   {
-    for (unsigned int c = 0; c < this->Cols(); c++)
+    for (unsigned int c = 0; c < this->Cols(); ++c)
     {
       m_Matrix(r, c) -= matrix.m_Matrix(r, c);
     }
@@ -175,9 +175,9 @@ template <typename T>
 VariableSizeMatrix<T> &
 VariableSizeMatrix<T>::operator-()
 {
-  for (unsigned int r = 0; r < this->Rows(); r++)
+  for (unsigned int r = 0; r < this->Rows(); ++r)
   {
-    for (unsigned int c = 0; c < this->Cols(); c++)
+    for (unsigned int c = 0; c < this->Cols(); ++c)
     {
       m_Matrix(r, c) = -m_Matrix(r, c);
     }

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -159,7 +159,7 @@ public:
   inline const Self &
   operator*=(const Tt & value)
   {
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       (*this)[i] = static_cast<ValueType>((*this)[i] * value);
     }
@@ -171,7 +171,7 @@ public:
   inline const Self &
   operator/=(const Tt & value)
   {
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       (*this)[i] = static_cast<ValueType>((*this)[i] / value);
     }
@@ -209,7 +209,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       result[i] = static_cast<ValueType>((*this)[i] * value);
     }
@@ -224,7 +224,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       result[i] = static_cast<ValueType>((*this)[i] / value);
     }
@@ -278,7 +278,7 @@ public:
   void
   CastFrom(const Vector<TCoordRepB, NVectorDimension> & pa)
   {
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       (*this)[i] = static_cast<T>(pa[i]);
     }
@@ -288,7 +288,7 @@ public:
   operator Vector<TCoordRepB, NVectorDimension>()
   {
     Vector<TCoordRepB, NVectorDimension> r;
-    for (unsigned int i = 0; i < NVectorDimension; i++)
+    for (unsigned int i = 0; i < NVectorDimension; ++i)
     {
       r[i] = static_cast<TCoordRepB>((*this)[i]);
     }

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -42,7 +42,7 @@ template <typename T, unsigned int TVectorDimension>
 const typename Vector<T, TVectorDimension>::Self &
 Vector<T, TVectorDimension>::operator+=(const Self & vec)
 {
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     (*this)[i] += vec[i];
   }
@@ -53,7 +53,7 @@ template <typename T, unsigned int TVectorDimension>
 const typename Vector<T, TVectorDimension>::Self &
 Vector<T, TVectorDimension>::operator-=(const Self & vec)
 {
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     (*this)[i] -= vec[i];
   }
@@ -66,7 +66,7 @@ Vector<T, TVectorDimension>::operator-() const
 {
   Self result;
 
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     result[i] = -(*this)[i];
   }
@@ -79,7 +79,7 @@ Vector<T, TVectorDimension>::operator+(const Self & vec) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     result[i] = (*this)[i] + vec[i];
   }
@@ -92,7 +92,7 @@ Vector<T, TVectorDimension>::operator-(const Self & vec) const
 {
   Self result;
 
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     result[i] = (*this)[i] - vec[i];
   }
@@ -104,7 +104,7 @@ typename Vector<T, TVectorDimension>::RealValueType
 Vector<T, TVectorDimension>::GetSquaredNorm() const
 {
   typename NumericTraits<RealValueType>::AccumulateType sum = NumericTraits<T>::ZeroValue();
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     const RealValueType value = (*this)[i];
     sum += value * value;
@@ -130,7 +130,7 @@ Vector<T, TVectorDimension>::Normalize()
   }
 
   const RealValueType inversedNorm = 1.0 / norm;
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     (*this)[i] = static_cast<T>(static_cast<RealValueType>((*this)[i] * inversedNorm));
   }
@@ -159,7 +159,7 @@ template <typename T, unsigned int TVectorDimension>
 void
 Vector<T, TVectorDimension>::SetVnlVector(const vnl_vector<T> & v)
 {
-  for (unsigned int i = 0; i < v.size(); i++)
+  for (unsigned int i = 0; i < v.size(); ++i)
   {
     (*this)[i] = v(i);
   }
@@ -176,7 +176,7 @@ operator<<(std::ostream & os, const Vector<T, TVectorDimension> & vct)
   }
   else
   {
-    for (unsigned int i = 0; i + 1 < TVectorDimension; i++)
+    for (unsigned int i = 0; i + 1 < TVectorDimension; ++i)
     {
       os << vct[i] << ", ";
     }
@@ -190,7 +190,7 @@ template <typename T, unsigned int TVectorDimension>
 std::istream &
 operator>>(std::istream & is, Vector<T, TVectorDimension> & vct)
 {
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     is >> vct[i];
   }
@@ -201,7 +201,7 @@ template <typename T, unsigned int TVectorDimension>
 typename Vector<T, TVectorDimension>::ValueType Vector<T, TVectorDimension>::operator*(const Self & other) const
 {
   typename NumericTraits<T>::AccumulateType value = NumericTraits<T>::ZeroValue();
-  for (unsigned int i = 0; i < TVectorDimension; i++)
+  for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];
   }

--- a/Modules/Core/Common/include/itkVectorImage.h
+++ b/Modules/Core/Common/include/itkVectorImage.h
@@ -225,7 +225,7 @@ public:
   {
     OffsetValueType offset = m_VectorLength * this->FastComputeOffset(index);
 
-    for (VectorLengthType i = 0; i < m_VectorLength; i++)
+    for (VectorLengthType i = 0; i < m_VectorLength; ++i)
     {
       (*m_Buffer)[offset + i] = value[i];
     }

--- a/Modules/Core/Common/include/itkVectorImage.hxx
+++ b/Modules/Core/Common/include/itkVectorImage.hxx
@@ -85,9 +85,9 @@ VectorImage<TPixel, VImageDimension>::FillBuffer(const PixelType & value)
 
   SizeValueType ctr = 0;
 
-  for (SizeValueType i = 0; i < numberOfPixels; i++)
+  for (SizeValueType i = 0; i < numberOfPixels; ++i)
   {
-    for (VectorLengthType j = 0; j < m_VectorLength; j++)
+    for (VectorLengthType j = 0; j < m_VectorLength; ++j)
     {
       (*m_Buffer)[ctr++] = value[j];
     }

--- a/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
@@ -96,7 +96,7 @@ public:
   {
     InternalPixelType * const truePixelPointer = pixelPointer + (pixelPointer - m_Begin) * m_OffsetMultiplier;
 
-    for (VectorLengthType i = 0; i < m_VectorLength; i++)
+    for (VectorLengthType i = 0; i < m_VectorLength; ++i)
     {
       truePixelPointer[i] = p[i];
     }

--- a/Modules/Core/Common/include/itkVertexCell.h
+++ b/Modules/Core/Common/include/itkVertexCell.h
@@ -112,7 +112,7 @@ public:
 public:
   VertexCell()
   {
-    for (PointIdentifier i = 0; i < Self::NumberOfPoints; i++)
+    for (PointIdentifier i = 0; i < Self::NumberOfPoints; ++i)
     {
       m_PointIds[i] = NumericTraits<PointIdentifier>::max();
     }

--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -181,7 +181,7 @@ VertexCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
 
   if (closestPoint)
   {
-    for (unsigned int i = 0; i < PointDimension; i++)
+    for (unsigned int i = 0; i < PointDimension; ++i)
     {
       closestPoint[i] = X[i];
     }
@@ -189,7 +189,7 @@ VertexCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
 
   double dist2 = 0;
   {
-    for (unsigned int i = 0; i < PointDimension; i++)
+    for (unsigned int i = 0; i < PointDimension; ++i)
     {
       dist2 += (X[i] - x[i]) * (X[i] - x[i]);
     }

--- a/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
@@ -96,7 +96,7 @@ ZeroFluxNeumannBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRe
   SizeType   requestSize;
   RegionType requestRegion;
 
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     // Check if the output region is entirely below the low index of
     // the image region.

--- a/Modules/Core/Common/src/itkImageIORegion.cxx
+++ b/Modules/Core/Common/src/itkImageIORegion.cxx
@@ -119,7 +119,7 @@ ImageIORegion::GetRegionDimension() const
 {
   unsigned int dim = 0;
 
-  for (unsigned int i = 0; i < m_ImageDimension; i++)
+  for (unsigned int i = 0; i < m_ImageDimension; ++i)
   {
     if (m_Size[i] > 1)
     {
@@ -176,7 +176,7 @@ ImageIORegion::IsInside(const IndexType & index) const
   {
     return false;
   }
-  for (unsigned int i = 0; i < m_ImageDimension; i++)
+  for (unsigned int i = 0; i < m_ImageDimension; ++i)
   {
     if (index[i] < m_Index[i])
     {
@@ -202,7 +202,7 @@ ImageIORegion::IsInside(const Self & region) const
   }
   IndexType endCorner(region.m_ImageDimension);
   SizeType  size = region.GetSize();
-  for (unsigned int i = 0; i < m_ImageDimension; i++)
+  for (unsigned int i = 0; i < m_ImageDimension; ++i)
   {
     endCorner[i] = beginCorner[i] + size[i] - 1;
   }

--- a/Modules/Core/Common/src/itkImageRegionSplitterMultidimensional.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterMultidimensional.cxx
@@ -78,7 +78,7 @@ ImageRegionSplitterMultidimensional::GetSplitInternal(unsigned int   dim,
 
 
   // Assign the output split region to the input region in-place
-  for (unsigned int i = 0; i < dim; i++)
+  for (unsigned int i = 0; i < dim; ++i)
   {
     const SizeValueType inputRegionSize = regionSize[i];
     const auto          indexOffset =

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -509,7 +509,7 @@ MultiThreaderBase::ParallelizeArrayHelper(void * arg)
 
   TotalProgressReporter reporter(acParams->filter, range);
 
-  for (SizeValueType i = first; i < afterLast; i++)
+  for (SizeValueType i = first; i < afterLast; ++i)
   {
     acParams->functor(i);
 
@@ -536,7 +536,7 @@ MultiThreaderBase::ParallelizeImageRegion(unsigned int                          
   ProgressReporter progress(filter, 0, 1);
 
   SizeValueType pixelCount = 1;
-  for (unsigned d = 0; d < dimension; d++)
+  for (unsigned d = 0; d < dimension; ++d)
   {
     pixelCount *= size[d];
   }
@@ -559,7 +559,7 @@ MultiThreaderBase::ParallelizeImageRegionHelper(void * arg)
 
   const ImageRegionSplitterBase * splitter = ImageSourceCommon::GetGlobalDefaultSplitter();
   ImageIORegion                   region(rnc->dimension);
-  for (unsigned d = 0; d < rnc->dimension; d++)
+  for (unsigned d = 0; d < rnc->dimension; ++d)
   {
     region.SetIndex(d, rnc->index[d]);
     region.SetSize(d, rnc->size[d]);

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -436,7 +436,7 @@ ObjectFactoryBase::LoadLibrariesInPath(const char * path)
   /**
    * Attempt to load each file in the directory as a shared library
    */
-  for (unsigned int i = 0; i < dir->GetNumberOfFiles(); i++)
+  for (unsigned int i = 0; i < dir->GetNumberOfFiles(); ++i)
   {
     const char * file = dir->GetFile(i);
     /**

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
@@ -44,7 +44,7 @@ PlatformMultiThreader::MultipleMethodExecute()
     m_NumberOfWorkUnits = m_GlobalMaximumNumberOfThreads;
   }
 
-  for (thread_loop = 0; thread_loop < m_NumberOfWorkUnits; thread_loop++)
+  for (thread_loop = 0; thread_loop < m_NumberOfWorkUnits; ++thread_loop)
   {
     if (m_MultipleMethod[thread_loop] == (ThreadFunctionType)0)
     {

--- a/Modules/Core/Common/src/itkPoolMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPoolMultiThreader.cxx
@@ -173,7 +173,7 @@ PoolMultiThreader::ParallelizeArray(SizeValueType             firstIndex,
     }
 
     auto lambda = [aFunc](SizeValueType start, SizeValueType end) {
-      for (SizeValueType ii = start; ii < end; ii++)
+      for (SizeValueType ii = start; ii < end; ++ii)
       {
         aFunc(ii);
       }
@@ -198,7 +198,7 @@ PoolMultiThreader::ParallelizeArray(SizeValueType             firstIndex,
     });
 
     // now wait for the other computations to finish
-    for (SizeValueType i = 1; i < workUnit; i++)
+    for (SizeValueType i = 1; i < workUnit; ++i)
     {
       exceptionHandler.TryAndCatch([this, i, &reporter, &filter] {
         std::future_status status;
@@ -244,7 +244,7 @@ PoolMultiThreader::ParallelizeImageRegion(unsigned int         dimension,
   else
   {
     ImageIORegion region(dimension);
-    for (unsigned d = 0; d < dimension; d++)
+    for (unsigned d = 0; d < dimension; ++d)
     {
       region.SetIndex(d, index[d]);
       region.SetSize(d, size[d]);
@@ -261,7 +261,7 @@ PoolMultiThreader::ParallelizeImageRegion(unsigned int         dimension,
       itkAssertOrThrowMacro(splitCount <= m_NumberOfWorkUnits, "Split count is greater than number of work units!");
       ImageIORegion iRegion;
       ThreadIdType  total;
-      for (ThreadIdType i = 1; i < splitCount; i++)
+      for (ThreadIdType i = 1; i < splitCount; ++i)
       {
         iRegion = region;
         total = splitter->GetSplit(i, splitCount, iRegion);
@@ -290,7 +290,7 @@ PoolMultiThreader::ParallelizeImageRegion(unsigned int         dimension,
       });
 
       // now wait for the other computations to finish
-      for (ThreadIdType i = 1; i < splitCount; i++)
+      for (ThreadIdType i = 1; i < splitCount; ++i)
       {
         exceptionHandler.TryAndCatch([this, i, &reporter, &filter] {
           std::future_status status;

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -177,7 +177,7 @@ ProcessObject::GetNumberOfValidRequiredInputs() const
    * Get the number of specified inputs
    */
   DataObjectPointerArraySizeType count = 0;
-  for (DataObjectPointerArraySizeType i = 0; i < m_NumberOfRequiredInputs; i++)
+  for (DataObjectPointerArraySizeType i = 0; i < m_NumberOfRequiredInputs; ++i)
   {
     if (this->GetInput(i))
     {
@@ -347,7 +347,7 @@ ProcessObject::PopFrontInput()
   DataObjectPointerArraySizeType nb = this->GetNumberOfIndexedInputs();
   if (nb > 0)
   {
-    for (DataObjectPointerArraySizeType i = 1; i < nb; i++)
+    for (DataObjectPointerArraySizeType i = 1; i < nb; ++i)
     {
       this->SetNthInput(i - 1, this->GetInput(i));
     }
@@ -722,7 +722,7 @@ ProcessObject::DataObjectPointerArray
 ProcessObject::GetIndexedOutputs()
 {
   DataObjectPointerArray res(this->GetNumberOfIndexedOutputs());
-  for (DataObjectPointerArraySizeType i = 0; i < this->GetNumberOfIndexedOutputs(); i++)
+  for (DataObjectPointerArraySizeType i = 0; i < this->GetNumberOfIndexedOutputs(); ++i)
   {
     res[i] = this->GetOutput(i);
   }
@@ -1015,7 +1015,7 @@ ProcessObject::DataObjectPointerArray
 ProcessObject::GetIndexedInputs()
 {
   DataObjectPointerArray res(this->GetNumberOfIndexedInputs());
-  for (DataObjectPointerArraySizeType i = 0; i < this->GetNumberOfIndexedInputs(); i++)
+  for (DataObjectPointerArraySizeType i = 0; i < this->GetNumberOfIndexedInputs(); ++i)
   {
     res[i] = this->GetInput(i);
   }

--- a/Modules/Core/Common/src/itkSpatialOrientationAdapter.cxx
+++ b/Modules/Core/Common/src/itkSpatialOrientationAdapter.cxx
@@ -46,7 +46,7 @@ SpatialOrientationAdapter::FromDirectionCosines(const DirectionType & Dir)
                                                    SpatialOrientation::ITK_COORDINATE_UNKNOWN,
                                                    SpatialOrientation::ITK_COORDINATE_UNKNOWN };
 
-  for (unsigned i = 0; i < 3; i++)
+  for (unsigned i = 0; i < 3; ++i)
   {
     if (int(axes[(i * 3)]) == 1)
     {
@@ -98,7 +98,7 @@ SpatialOrientationAdapter::ToDirectionCosines(const OrientationType & Or)
   terms[2] = static_cast<CoordinateTerms>((Or >> SpatialOrientation::ITK_COORDINATE_TertiaryMinor) & 0xff);
   DirectionType direction;
   direction.Fill(0.0);
-  for (unsigned int i = 0; i < DirectionType::ColumnDimensions; i++)
+  for (unsigned int i = 0; i < DirectionType::ColumnDimensions; ++i)
   {
     switch (terms[i])
     {

--- a/Modules/Core/Common/src/itkStreamingProcessObject.cxx
+++ b/Modules/Core/Common/src/itkStreamingProcessObject.cxx
@@ -42,7 +42,7 @@ StreamingProcessObject::GenerateData()
   // Loop over the number of pieces, execute the upstream pipeline on each
   // piece, and execute StreamedGenerateData on each region
   //
-  for (unsigned int piece = 0; piece < numberOfInputRequestRegion && !this->GetAbortGenerateData(); piece++)
+  for (unsigned int piece = 0; piece < numberOfInputRequestRegion && !this->GetAbortGenerateData(); ++piece)
   {
     this->m_CurrentRequestNumber = piece;
 

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -211,7 +211,7 @@ struct TBBImageRegionSplitter : public itk::ImageIORegion
   bool
   empty() const
   {
-    for (unsigned d = 0; d < this->GetImageDimension(); d++)
+    for (unsigned d = 0; d < this->GetImageDimension(); ++d)
     {
       if (this->GetSize(d) == 0)
       {
@@ -224,7 +224,7 @@ struct TBBImageRegionSplitter : public itk::ImageIORegion
   bool
   is_divisible() const
   {
-    for (unsigned d = 0; d < this->GetImageDimension(); d++)
+    for (unsigned d = 0; d < this->GetImageDimension(); ++d)
     {
       if (this->GetSize(d) > 1)
       {
@@ -259,7 +259,7 @@ TBBMultiThreader::ParallelizeImageRegion(unsigned int         dimension,
   else
   {
     ImageIORegion region(dimension);
-    for (unsigned d = 0; d < dimension; d++)
+    for (unsigned d = 0; d < dimension; ++d)
     {
       region.SetIndex(d, index[d]);
       region.SetSize(d, size[d]);

--- a/Modules/Core/Common/test/VNLSparseLUSolverTraitsTest.cxx
+++ b/Modules/Core/Common/test/VNLSparseLUSolverTraitsTest.cxx
@@ -32,7 +32,7 @@ VectorsEquals(const TVector & v1, const TVector & v2, const typename TVector::el
     return false;
   }
 
-  for (unsigned int i = 0; i < v1.size(); i++)
+  for (unsigned int i = 0; i < v1.size(); ++i)
   {
     if (itk::Math::abs(v1(i) - v2(i)) > tolerance)
     {

--- a/Modules/Core/Common/test/itkArray2DTest.cxx
+++ b/Modules/Core/Common/test/itkArray2DTest.cxx
@@ -34,9 +34,9 @@ itkArray2DTest(int, char *[])
   ArrayType     a(rows, cols);
   VnlMatrixType vm(rows, cols);
 
-  for (unsigned int r = 0; r < rows; r++)
+  for (unsigned int r = 0; r < rows; ++r)
   {
-    for (unsigned int c = 0; c < cols; c++)
+    for (unsigned int c = 0; c < cols; ++c)
     {
       const auto value = static_cast<double>(r + c);
       a.SetElement(r, c, value);
@@ -49,9 +49,9 @@ itkArray2DTest(int, char *[])
   // test copy constructor
   ArrayType b(a);
 
-  for (unsigned int r = 0; r < rows; r++)
+  for (unsigned int r = 0; r < rows; ++r)
   {
-    for (unsigned int c = 0; c < cols; c++)
+    for (unsigned int c = 0; c < cols; ++c)
     {
       double diff = a.GetElement(r, c) - b(r, c);
       diff = (diff > 0.0) ? diff : -diff; // take abs value
@@ -66,9 +66,9 @@ itkArray2DTest(int, char *[])
   // test construction from vnl_matrix
   ArrayType d(vm);
 
-  for (unsigned int r = 0; r < rows; r++)
+  for (unsigned int r = 0; r < rows; ++r)
   {
-    for (unsigned int c = 0; c < cols; c++)
+    for (unsigned int c = 0; c < cols; ++c)
     {
       double diff = d(r, c) - vm(r, c);
       diff = (diff > 0.0) ? diff : -diff; // take abs value
@@ -85,9 +85,9 @@ itkArray2DTest(int, char *[])
 
   e = a;
 
-  for (unsigned int r = 0; r < rows; r++)
+  for (unsigned int r = 0; r < rows; ++r)
   {
-    for (unsigned int c = 0; c < cols; c++)
+    for (unsigned int c = 0; c < cols; ++c)
     {
       double diff = a(r, c) - e(r, c);
       diff = (diff > 0.0) ? diff : -diff; // take abs value
@@ -104,9 +104,9 @@ itkArray2DTest(int, char *[])
 
   f = vm;
 
-  for (unsigned int r = 0; r < rows; r++)
+  for (unsigned int r = 0; r < rows; ++r)
   {
-    for (unsigned int c = 0; c < cols; c++)
+    for (unsigned int c = 0; c < cols; ++c)
     {
       double diff = f(r, c) - vm(r, c);
       diff = (diff > 0.0) ? diff : -diff; // take abs value

--- a/Modules/Core/Common/test/itkAtanRegularizedHeavisideStepFunctionTest1.cxx
+++ b/Modules/Core/Common/test/itkAtanRegularizedHeavisideStepFunctionTest1.cxx
@@ -48,7 +48,7 @@ itkAtanRegularizedHeavisideStepFunctionTest1(int, char *[])
 
   constexpr InputType incValue = 0.1;
 
-  for (signed int x = minValue; x < maxValue; x++)
+  for (signed int x = minValue; x < maxValue; ++x)
   {
     const InputType ix = x * incValue;
     OutputType      f = functionBase0->Evaluate(ix);

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -80,7 +80,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
       const double tolerance = 1e-6;
       bool         symmetryForXBroken = false;
 
-      for (unsigned int nw = 0; nw < numberOfWeigts - indexDifference; nw++)
+      for (unsigned int nw = 0; nw < numberOfWeigts - indexDifference; ++nw)
       {
         if (itk::Math::abs(weights1[nw] - weights2[numberOfWeigts - nw - 1 - indexDifference]) > tolerance)
         {
@@ -94,22 +94,22 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
         std::cerr << "Error in weights symmetry for X = " << x << std::endl;
         testFailed = true;
         std::cerr << "indexDifference= " << indexDifference << std::endl;
-        for (unsigned int nw = 0; nw < numberOfWeigts; nw++)
+        for (unsigned int nw = 0; nw < numberOfWeigts; ++nw)
         {
           std::cerr << weights1[nw] << "\t";
         }
         std::cerr << std::endl;
-        for (unsigned int nw = 0; nw < numberOfWeigts; nw++)
+        for (unsigned int nw = 0; nw < numberOfWeigts; ++nw)
         {
           std::cerr << weights2[nw] << "\t";
         }
         std::cerr << std::endl;
-        for (unsigned int sd = 0; sd < SpaceDimension; sd++)
+        for (unsigned int sd = 0; sd < SpaceDimension; ++sd)
         {
           std::cerr << startIndex1[sd] << "\t";
         }
         std::cerr << std::endl;
-        for (unsigned int sd = 0; sd < SpaceDimension; sd++)
+        for (unsigned int sd = 0; sd < SpaceDimension; ++sd)
         {
           std::cerr << startIndex2[sd] << "\t";
         }
@@ -170,7 +170,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
       const double tolerance = 1e-6;
       bool         symmetryForXBroken = false;
 
-      for (unsigned int nw = 0; nw < numberOfWeigts - indexDifference; nw++)
+      for (unsigned int nw = 0; nw < numberOfWeigts - indexDifference; ++nw)
       {
         if (itk::Math::abs(weights1[nw] - weights2[numberOfWeigts - nw - 1 - indexDifference]) > tolerance)
         {
@@ -184,22 +184,22 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
         std::cerr << "Error in weights symmetry for X = " << x << std::endl;
         testFailed = true;
         std::cerr << "indexDifference= " << indexDifference << std::endl;
-        for (unsigned int nw = 0; nw < numberOfWeigts; nw++)
+        for (unsigned int nw = 0; nw < numberOfWeigts; ++nw)
         {
           std::cerr << weights1[nw] << "\t";
         }
         std::cerr << std::endl;
-        for (unsigned int nw = 0; nw < numberOfWeigts; nw++)
+        for (unsigned int nw = 0; nw < numberOfWeigts; ++nw)
         {
           std::cerr << weights2[nw] << "\t";
         }
         std::cerr << std::endl;
-        for (unsigned int sd = 0; sd < SpaceDimension; sd++)
+        for (unsigned int sd = 0; sd < SpaceDimension; ++sd)
         {
           std::cerr << startIndex1[sd] << "\t";
         }
         std::cerr << std::endl;
-        for (unsigned int sd = 0; sd < SpaceDimension; sd++)
+        for (unsigned int sd = 0; sd < SpaceDimension; ++sd)
         {
           std::cerr << startIndex2[sd] << "\t";
         }
@@ -273,7 +273,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     {
 
       double value = 1.0;
-      for (unsigned int j = 0; j < SpaceDimension; j++)
+      for (unsigned int j = 0; j < SpaceDimension; ++j)
       {
         value *= kernel->Evaluate(static_cast<double>(iter.GetIndex()[j]) - position[j]);
       }

--- a/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
@@ -67,7 +67,7 @@ itkBSplineKernelFunctionTest(int, char *[])
     FunctionType::Pointer function = FunctionType::New();                                                              \
                                                                                                                        \
     function->Print(std::cout);                                                                                        \
-    for (unsigned j = 0; j < npoints; j++)                                                                             \
+    for (unsigned j = 0; j < npoints; ++j)                                                                             \
     {                                                                                                                  \
       double results = function->Evaluate(x[j]);                                                                       \
       /* compare with external results */                                                                              \

--- a/Modules/Core/Common/test/itkBoundingBoxTest.cxx
+++ b/Modules/Core/Common/test/itkBoundingBoxTest.cxx
@@ -36,7 +36,7 @@ itkBoundingBoxTest(int, char *[])
   std::cout << "Testing Bounding Box" << std::endl;
   {
     const BB::BoundsArrayType & bounds = myBox->GetBounds();
-    for (unsigned int i = 0; i < bounds.Size(); i++)
+    for (unsigned int i = 0; i < bounds.Size(); ++i)
     {
       if (itk::Math::NotExactlyEquals(bounds[i], itk::NumericTraits<BB::CoordRepType>::ZeroValue()))
       {
@@ -50,7 +50,7 @@ itkBoundingBoxTest(int, char *[])
 
   {
     BB::PointType center = myBox->GetCenter();
-    for (unsigned int i = 0; i < 1; i++)
+    for (unsigned int i = 0; i < 1; ++i)
     {
       if (itk::Math::NotExactlyEquals(center[i], itk::NumericTraits<BB::CoordRepType>::ZeroValue()))
       {
@@ -75,7 +75,7 @@ itkBoundingBoxTest(int, char *[])
   std::cout << "Null GetPoints test passed" << std::endl;
 
 
-  for (unsigned int i = 0; i < 10; i++)
+  for (unsigned int i = 0; i < 10; ++i)
   {
     P[0] = (double)i;
     Points->InsertElement(i, P);
@@ -104,7 +104,7 @@ itkBoundingBoxTest(int, char *[])
 
   {
     BB::PointType center = myBox->GetCenter();
-    for (unsigned int i = 0; i < 1; i++)
+    for (unsigned int i = 0; i < 1; ++i)
     {
       if (center[i] != 4.5)
       {
@@ -176,7 +176,7 @@ itkBoundingBoxTest(int, char *[])
   unsigned int j = 0;
   while (it != corners.end())
   {
-    for (unsigned int i = 0; i < 3; i++)
+    for (unsigned int i = 0; i < 3; ++i)
     {
       if ((*it)[i] != std::pow(-1.0, (double)(j / (int(std::pow(2.0, (double)i))))))
       {
@@ -195,7 +195,7 @@ itkBoundingBoxTest(int, char *[])
     CC::Pointer                 clone = my3DBox->DeepCopy();
     const CC::BoundsArrayType & originalBounds = my3DBox->GetBounds();
     const CC::BoundsArrayType & clonedbounds = clone->GetBounds();
-    for (unsigned int i = 0; i < originalBounds.Size(); i++)
+    for (unsigned int i = 0; i < originalBounds.Size(); ++i)
     {
       if (std::fabs(originalBounds[i] - clonedbounds[i]) > tolerance)
       {

--- a/Modules/Core/Common/test/itkBresenhamLineTest.cxx
+++ b/Modules/Core/Common/test/itkBresenhamLineTest.cxx
@@ -39,7 +39,7 @@ itkBresenhamLineTest(int, char *[])
       return EXIT_FAILURE;
     }
 
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 4; ++i)
     {
       if (offsets[i][0] != i || offsets[i][1] != i)
       {
@@ -69,7 +69,7 @@ itkBresenhamLineTest(int, char *[])
       return EXIT_FAILURE;
     }
 
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 4; ++i)
     {
       if (indices[i][0] != i || indices[i][1] != i)
       {

--- a/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
@@ -72,7 +72,7 @@ public:
     ThreadedExecution(const DomainType & subdomain, const itk::ThreadIdType threadId) override
     {
       itk::CompensatedSummation<double> compensatedSum;
-      for (DomainType::IndexValueType i = subdomain[0]; i <= subdomain[1]; i++)
+      for (DomainType::IndexValueType i = subdomain[0]; i <= subdomain[1]; ++i)
       {
         double value = itk::NumericTraits<double>::OneValue() / 7;
         this->m_PerThreadCompensatedSum[threadId].AddElement(value);

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -256,7 +256,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
     std::cerr << "IndexInBounds failed for index 0, expected false." << std::endl;
     return EXIT_FAILURE;
   }
-  for (unsigned int n = 0; n < 4; n++)
+  for (unsigned int n = 0; n < 4; ++n)
   {
     if (resultOffset[n] != static_cast<itk::OffsetValueType>(radius[n]))
     {
@@ -271,7 +271,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
     std::cerr << "IndexInBounds failed for index size-1, expected true." << std::endl;
     return EXIT_FAILURE;
   }
-  for (unsigned int n = 0; n < 4; n++)
+  for (unsigned int n = 0; n < 4; ++n)
   {
     if (resultOffset[n] != 0)
     {
@@ -282,7 +282,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
 
   // Test min boundary by dimension
   int result = EXIT_SUCCESS;
-  for (unsigned int n = 0; n < 4; n++)
+  for (unsigned int n = 0; n < 4; ++n)
   {
     IteratorType::IndexType boundaryLoc = centerLoc;
     boundaryLoc[n] = 0;
@@ -296,7 +296,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
   }
 
   // Test max boundary by dimension
-  for (unsigned int n = 0; n < 4; n++)
+  for (unsigned int n = 0; n < 4; ++n)
   {
     IteratorType::IndexType boundaryLoc = centerLoc;
     boundaryLoc[n] = dims[n] - 1;

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
@@ -94,7 +94,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
     return EXIT_FAILURE;
   }
   IndexType truthIndex;
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     truthIndex[i] = loc[i] - radius[i];
   }
@@ -149,7 +149,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   // fwd iterate by a line
   it.GoToBegin();
   index = it.GetIndex();
-  for (unsigned int i = 0; i < sz[0]; i++)
+  for (unsigned int i = 0; i < sz[0]; ++i)
   {
     ++it;
   }
@@ -161,7 +161,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
 
   // fwd iterate by a slice
   index = it.GetIndex();
-  for (unsigned int i = 0; i < sz[0] * sz[1]; i++)
+  for (unsigned int i = 0; i < sz[0] * sz[1]; ++i)
   {
     ++it;
   }
@@ -182,7 +182,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   }
 
   index = it.GetIndex();
-  for (unsigned int i = 0; i < sz[0]; i++)
+  for (unsigned int i = 0; i < sz[0]; ++i)
   {
     --it;
   }
@@ -193,7 +193,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   }
 
   index = it.GetIndex();
-  for (unsigned int i = 0; i < sz[0] * sz[1]; i++)
+  for (unsigned int i = 0; i < sz[0] * sz[1]; ++i)
   {
     --it;
   }
@@ -249,7 +249,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   OffsetType a_off;
   a_off.Fill(1);
   ra_it += a_off;
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     IndexType ind = ra_it.GetIndex();
     if (ind[i] != loc[i] + 1)
@@ -273,7 +273,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
 
   std::cout << "Subtracting [1, 1, 1, 1]" << std::endl;
   ra_it -= a_off;
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     IndexType ind = ra_it.GetIndex();
     if (ind[i] != loc[i])
@@ -291,7 +291,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   ra_it += a_off;
   IndexType truth = loc;
   truth += a_off;
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     IndexType ind = ra_it.GetIndex();
     if (ind[i] != truth[i])
@@ -314,7 +314,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   a_off[1] = 8;
   ra_it += a_off;
   truth += a_off;
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     IndexType ind = ra_it.GetIndex();
     if (ind[i] != truth[i])
@@ -341,7 +341,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   a_off[3] = -1;
   ra_it += a_off;
   truth += a_off;
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     IndexType ind = ra_it.GetIndex();
     if (ind[i] != truth[i])
@@ -388,7 +388,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
     std::cerr << "IndexInBounds failed for index 0, expected false." << std::endl;
     return EXIT_FAILURE;
   }
-  for (unsigned int n = 0; n < 4; n++)
+  for (unsigned int n = 0; n < 4; ++n)
   {
     if (resultOffset[n] != static_cast<itk::OffsetValueType>(radius[n]))
     {
@@ -403,7 +403,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
     std::cerr << "IndexInBounds failed for index size-1, expected true." << std::endl;
     return EXIT_FAILURE;
   }
-  for (unsigned int n = 0; n < 4; n++)
+  for (unsigned int n = 0; n < 4; ++n)
   {
     if (resultOffset[n] != 0)
     {
@@ -414,7 +414,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
 
   // Test min boundary by dimension
   int result = EXIT_SUCCESS;
-  for (unsigned int n = 0; n < 4; n++)
+  for (unsigned int n = 0; n < 4; ++n)
   {
     typename IteratorType::IndexType boundaryLoc = centerLoc;
     boundaryLoc[n] = 0;
@@ -428,7 +428,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
   }
 
   // Test max boundary by dimension
-  for (unsigned int n = 0; n < 4; n++)
+  for (unsigned int n = 0; n < 4; ++n)
   {
     typename IteratorType::IndexType boundaryLoc = centerLoc;
     boundaryLoc[n] = dims[n] - 1;

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -128,7 +128,7 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
   it.ActivateOffset(off);
   it.Print(std::cout);
 
-  for (unsigned int r = 0; r < 1; r++)
+  for (unsigned int r = 0; r < 1; ++r)
   {
     println("...turn on [1,0,0,0]");
     off[0] = 1;

--- a/Modules/Core/Common/test/itkCovariantVectorGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkCovariantVectorGeometryTest.cxx
@@ -104,7 +104,7 @@ itkCovariantVectorGeometryTest(int, char *[])
   vnl_vector_ref<ValueType> vnlVector = va.GetVnlVector();
   {
     std::cout << "vnl_vector_ref = va ";
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       std::cout << vnlVector[i] << ", ";
     }
@@ -121,7 +121,7 @@ itkCovariantVectorGeometryTest(int, char *[])
   vnl_vector<ValueType> vnlVector2 = vf.GetVnlVector();
   {
     std::cout << "vnl_vector = va ";
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       std::cout << vnlVector2[i] << ", ";
     }
@@ -156,7 +156,7 @@ itkCovariantVectorGeometryTest(int, char *[])
     fp.CastFrom(dp);
 
     std::cout << std::endl;
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       auto val = static_cast<FloatCovariantVectorType::ValueType>(dp[i]);
 
@@ -247,7 +247,7 @@ itkCovariantVectorGeometryTest(int, char *[])
     }
     auto * compp = reinterpret_cast<char *>(&comp);
     auto * xp = reinterpret_cast<char *>(&x);
-    for (unsigned i = 0; i < sizeof(CovariantVectorType::ComponentType); i++)
+    for (unsigned i = 0; i < sizeof(CovariantVectorType::ComponentType); ++i)
     {
       if (compp[i] != xp[i])
       {

--- a/Modules/Core/Common/test/itkDataTypeTest.cxx
+++ b/Modules/Core/Common/test/itkDataTypeTest.cxx
@@ -30,7 +30,7 @@ itkDataTypeTest(int, char *[])
   v[2] = 3;
   v[3] = 4;
   std::cout << "Vector value = ";
-  for (unsigned int i = 0; i < v.GetVectorDimension(); i++)
+  for (unsigned int i = 0; i < v.GetVectorDimension(); ++i)
   {
     if (v[i] != static_cast<int>(i + 1))
     {

--- a/Modules/Core/Common/test/itkDerivativeOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkDerivativeOperatorTest.cxx
@@ -42,7 +42,7 @@ public:
       return false;
     }
 
-    for (unsigned int i = 0; i < expected.size(); i++)
+    for (unsigned int i = 0; i < expected.size(); ++i)
     {
       if (itk::Math::NotAlmostEquals(expected[i], coefficients[i]))
       {

--- a/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -72,11 +72,11 @@ itkEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
   bool functionValue;            // Value of pixel at a given position
   int  interiorPixelCounter = 0; // Count pixels inside ellipsoid
 
-  for (int x = 0; x < xExtent; x++)
+  for (int x = 0; x < xExtent; ++x)
   {
-    for (int y = 0; y < yExtent; y++)
+    for (int y = 0; y < yExtent; ++y)
     {
-      for (int z = 0; z < zExtent; z++)
+      for (int z = 0; z < zExtent; ++z)
       {
         testPosition[0] = x;
         testPosition[1] = y;

--- a/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
@@ -63,11 +63,11 @@ itkFiniteCylinderSpatialFunctionTest(int, char *[])
   bool functionValue;            // Value of pixel at a given position
   int  interiorPixelCounter = 0; // Count pixels inside cylinder
 
-  for (int x = 0; x < xExtent; x++)
+  for (int x = 0; x < xExtent; ++x)
   {
-    for (int y = 0; y < yExtent; y++)
+    for (int y = 0; y < yExtent; ++y)
     {
-      for (int z = 0; z < zExtent; z++)
+      for (int z = 0; z < zExtent; ++z)
       {
         testPosition[0] = x;
         testPosition[1] = y;

--- a/Modules/Core/Common/test/itkFixedArrayTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest.cxx
@@ -83,12 +83,12 @@ itkFixedArrayTest(int, char *[])
   // Test Get/Set element
   constexpr unsigned int           n = 20;
   itk::FixedArray<unsigned int, n> array20;
-  for (unsigned int i = 0; i < n; i++)
+  for (unsigned int i = 0; i < n; ++i)
   {
     array20.SetElement(i, i);
   }
 
-  for (unsigned int k = 0; k < n; k++)
+  for (unsigned int k = 0; k < n; ++k)
   {
     if (array20.GetElement(k) != k)
     {

--- a/Modules/Core/Common/test/itkFloodFilledSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFilledSpatialFunctionTest.cxx
@@ -73,7 +73,7 @@ itkFloodFilledSpatialFunctionTest(int, char *[])
   sourceImage->Allocate();
 
   // Loop over all available iterator strategies
-  for (int strat = 0; strat < 4; strat++)
+  for (int strat = 0; strat < 4; ++strat)
   {
     // Initialize the image to hold all 0's
     itk::ImageRegionIterator<ImageType> it = itk::ImageRegionIterator<ImageType>(sourceImage, largestPossibleRegion);

--- a/Modules/Core/Common/test/itkHeavisideStepFunctionTest1.cxx
+++ b/Modules/Core/Common/test/itkHeavisideStepFunctionTest1.cxx
@@ -36,7 +36,7 @@ itkHeavisideStepFunctionTest1(int, char *[])
 
   constexpr InputType incValue = 0.1;
 
-  for (signed int x = minValue; x < maxValue; x++)
+  for (signed int x = minValue; x < maxValue; ++x)
   {
     const InputType ix = x * incValue;
     OutputType      f = functionBase0->Evaluate(ix);

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -26,9 +26,9 @@ void
 ComputeIndex(TImage * image, unsigned int count, unsigned int repeat)
 {
   typename TImage::IndexType index;
-  for (unsigned j = 0; j < repeat; j++)
+  for (unsigned j = 0; j < repeat; ++j)
   {
-    for (unsigned int i = 0; i < count; i++)
+    for (unsigned int i = 0; i < count; ++i)
     {
       index = image->ComputeIndex(i);
     }
@@ -45,9 +45,9 @@ ComputeFastIndex(TImage * image, unsigned int count, unsigned int repeat)
   const typename TImage::IndexType &       bufferedRegionIndex = image->GetBufferedRegion().GetIndex();
   const typename TImage::OffsetValueType * offsetTable = image->GetOffsetTable();
 
-  for (unsigned int j = 0; j < repeat; j++)
+  for (unsigned int j = 0; j < repeat; ++j)
   {
-    for (unsigned int i = 0; i < count; i++)
+    for (unsigned int i = 0; i < count; ++i)
     {
       itk::ImageHelper<TImage::ImageDimension, TImage::ImageDimension>::ComputeIndex(
         bufferedRegionIndex, i, offsetTable, index);
@@ -66,10 +66,10 @@ ComputeOffset(TImage * image, unsigned int count, unsigned int repeat)
   typename TImage::OffsetType      indexIncr;
   indexIncr.Fill(1);
 
-  for (unsigned j = 0; j < repeat; j++)
+  for (unsigned j = 0; j < repeat; ++j)
   {
     index.Fill(0);
-    for (unsigned int i = 0; i < count; i++)
+    for (unsigned int i = 0; i < count; ++i)
     {
 
       offset = image->ComputeOffset(index);
@@ -92,10 +92,10 @@ ComputeFastOffset(TImage * image, unsigned int count, unsigned int repeat)
 
   const typename TImage::OffsetValueType * offsetTable = image->GetOffsetTable();
 
-  for (unsigned j = 0; j < repeat; j++)
+  for (unsigned j = 0; j < repeat; ++j)
   {
     index.Fill(0);
-    for (unsigned int i = 0; i < count; i++)
+    for (unsigned int i = 0; i < count; ++i)
     {
       offset = 0;
       itk::ImageHelper<TImage::ImageDimension, TImage::ImageDimension>::ComputeOffset(
@@ -131,7 +131,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     myImage->Allocate();                                                                                               \
     collector.Start("ComputeIndexFast " #dim "D");                                                                     \
     unsigned int totalSize = 1;                                                                                        \
-    for (unsigned int i = 0; i < dim; i++)                                                                             \
+    for (unsigned int i = 0; i < dim; ++i)                                                                             \
       totalSize *= size[i];                                                                                            \
     unsigned int repeat = 1000;                                                                                        \
     if (dim > 2)                                                                                                       \
@@ -163,7 +163,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     myImage->Allocate();                                                                                               \
     collector.Start("ComputeIndex " #dim "D");                                                                         \
     unsigned int totalSize = 1;                                                                                        \
-    for (unsigned int i = 0; i < dim; i++)                                                                             \
+    for (unsigned int i = 0; i < dim; ++i)                                                                             \
       totalSize *= size[i];                                                                                            \
     unsigned int repeat = 1000;                                                                                        \
     if (dim > 2)                                                                                                       \
@@ -198,7 +198,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     if (dim < 4)                                                                                                       \
       repeat = 100;                                                                                                    \
     unsigned int totalSize = 1;                                                                                        \
-    for (unsigned int i = 0; i < dim; i++)                                                                             \
+    for (unsigned int i = 0; i < dim; ++i)                                                                             \
       totalSize *= size[i];                                                                                            \
     ComputeFastOffset<ImageType>(myImage, size[0], totalSize * repeat);                                                \
     collector.Stop("ComputeOffsetFast " #dim "D");                                                                     \
@@ -225,7 +225,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
     if (dim < 4)                                                                                                       \
       repeat = 100;                                                                                                    \
     unsigned int totalSize = 1;                                                                                        \
-    for (unsigned int i = 0; i < dim; i++)                                                                             \
+    for (unsigned int i = 0; i < dim; ++i)                                                                             \
       totalSize *= size[i];                                                                                            \
     ComputeOffset<ImageType>(myImage, size[0], totalSize * repeat);                                                    \
     collector.Stop("ComputeOffset " #dim "D");                                                                         \

--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -251,7 +251,7 @@ itkImageDuplicatorTest(int, char *[])
 
     VectorImageType::Pointer             vectorImage = VectorImageType::New();
     itk::VariableLengthVector<PixelType> f(VectorLength);
-    for (unsigned int i = 0; i < VectorLength; i++)
+    for (unsigned int i = 0; i < VectorLength; ++i)
     {
       f[i] = i;
     }

--- a/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
@@ -46,7 +46,7 @@ itkImageDuplicatorTest2(int argc, char * argv[])
 
     ImageType::RegionType lpr = inImage->GetLargestPossibleRegion();
     ImageType::RegionType region = lpr;
-    for (unsigned d = 0; d < Dimension; d++)
+    for (unsigned d = 0; d < Dimension; ++d)
     {
       itk::IndexValueType size = region.GetSize(d);
       region.SetIndex(d, size / 4);

--- a/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
@@ -436,7 +436,7 @@ itkImageLinearIteratorTest(int, char *[])
     std::cout << "    GetIndex(): " << cbot.GetIndex() << std::endl;
     // go to the middle of the first line
     std::cout << "    for(unsigned int i=0; ..." << std::endl;
-    for (unsigned int i = 0; i < size[0] / 2; i++)
+    for (unsigned int i = 0; i < size[0] / 2; ++i)
     {
       std::cout << "      ++cbot;" << std::endl;
       ++cbot;
@@ -489,7 +489,7 @@ itkImageLinearIteratorTest(int, char *[])
     std::cout << "    GetIndex(): " << cbot.GetIndex() << std::endl;
     // go to the middle of the second line
     std::cout << "    for(unsigned int i=0; ..." << std::endl;
-    for (unsigned int i = 0; i < size[0] + size[0] / 2; i++)
+    for (unsigned int i = 0; i < size[0] + size[0] / 2; ++i)
     {
       std::cout << "      ++cbot;" << std::endl;
       ++cbot;
@@ -544,7 +544,7 @@ itkImageLinearIteratorTest(int, char *[])
     cbot.GoToBegin();
 
     // go to the middle of the first line
-    for (unsigned int i = 0; i < size[0] / 2; i++)
+    for (unsigned int i = 0; i < size[0] / 2; ++i)
     {
       ++cbot;
     }
@@ -587,7 +587,7 @@ itkImageLinearIteratorTest(int, char *[])
     cbot.GoToBegin();
 
     // go to the middle of the second line
-    for (unsigned int i = 0; i < size[0] + size[0] / 2; i++)
+    for (unsigned int i = 0; i < size[0] + size[0] / 2; ++i)
     {
       ++cbot;
       if (cbot.IsAtEndOfLine())

--- a/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
@@ -131,7 +131,7 @@ public:
     IndexType index;
     it.GoToBegin();
     index = it.GetIndex();
-    for (unsigned int i = 0; i < region.GetSize()[0]; i++)
+    for (unsigned int i = 0; i < region.GetSize()[0]; ++i)
     {
       ++it;
     }
@@ -141,7 +141,7 @@ public:
     }
 
     // iterate back
-    for (unsigned int i = 0; i < region.GetSize()[0]; i++)
+    for (unsigned int i = 0; i < region.GetSize()[0]; ++i)
     {
       --it;
     }
@@ -155,7 +155,7 @@ public:
     {
       it.GoToBegin();
       index = it.GetIndex();
-      for (unsigned int i = 0; i < region.GetSize()[0] * region.GetSize()[1]; i++)
+      for (unsigned int i = 0; i < region.GetSize()[0] * region.GetSize()[1]; ++i)
       {
         ++it;
       }
@@ -166,7 +166,7 @@ public:
       }
 
       // iterate back
-      for (unsigned int i = 0; i < region.GetSize()[0] * region.GetSize()[1]; i++)
+      for (unsigned int i = 0; i < region.GetSize()[0] * region.GetSize()[1]; ++i)
       {
         --it;
       }

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -129,7 +129,7 @@ itkImageRegionIteratorTest(int, char *[])
 
     itk::Image<itk::Vector<unsigned short, 5>, 3>::IndexType index = backIt.GetIndex();
     std::cout << "Simple iterator backwards loop: ";
-    for (unsigned int i = 0; i < index.GetIndexDimension(); i++)
+    for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
       std::cout << index[i] << " ";
     }

--- a/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
@@ -108,7 +108,7 @@ itkImageReverseIteratorTest(int, char *[])
   {
     ImageType::IndexType index = it.GetIndex();
     std::cout << "Simple iterator loop: ";
-    for (unsigned int i = 0; i < index.GetIndexDimension(); i++)
+    for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
       std::cout << index[i] << " ";
     }
@@ -124,7 +124,7 @@ itkImageReverseIteratorTest(int, char *[])
 
     ImageType::IndexType index = backIt.GetIndex();
     std::cout << "Simple iterator backwards loop: ";
-    for (unsigned int i = 0; i < index.GetIndexDimension(); i++)
+    for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
       std::cout << index[i] << " ";
     }
@@ -139,7 +139,7 @@ itkImageReverseIteratorTest(int, char *[])
   {
     ImageType::IndexType index = reverseIt.GetIndex();
     std::cout << "Reverse iterator: ";
-    for (unsigned int i = 0; i < index.GetIndexDimension(); i++)
+    for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
       std::cout << index[i] << " ";
     }
@@ -161,7 +161,7 @@ itkImageReverseIteratorTest(int, char *[])
 
     ImageType::IndexType index = backReverseIt.GetIndex();
     std::cout << "Reverse iterator backwards loop: ";
-    for (unsigned int i = 0; i < index.GetIndexDimension(); i++)
+    for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
       std::cout << index[i] << " ";
     }
@@ -174,7 +174,7 @@ itkImageReverseIteratorTest(int, char *[])
   {
     ImageType::IndexType index = reverseConstIt.GetIndex();
     std::cout << "Reverse const iterator: ";
-    for (unsigned int i = 0; i < index.GetIndexDimension(); i++)
+    for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
       std::cout << index[i] << " ";
     }
@@ -192,7 +192,7 @@ itkImageReverseIteratorTest(int, char *[])
     --castBackReverseIt;
     itk::Image<itk::Vector<unsigned short, 5>, 3>::IndexType index = it.GetIndex();
     itk::Image<itk::Vector<unsigned short, 5>, 3>::IndexType rindex = castBackReverseIt.GetIndex();
-    for (unsigned int i = 0; i < index.GetIndexDimension(); i++)
+    for (unsigned int i = 0; i < index.GetIndexDimension(); ++i)
     {
       if (index[i] != rindex[i])
       {

--- a/Modules/Core/Common/test/itkImageTransformTest.cxx
+++ b/Modules/Core/Common/test/itkImageTransformTest.cxx
@@ -32,7 +32,7 @@ TestTransform()
 
   typename ImageType::PointType origin;
 
-  for (unsigned int i = 0; i < TDimension; i++)
+  for (unsigned int i = 0; i < TDimension; ++i)
   {
     origin[i] = static_cast<double>(i * 100);
   }

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -43,9 +43,9 @@ testMemoryAccess(OptimizerParametersType & params, ImageVectorPointer imageOfVec
 {
   int result = EXIT_SUCCESS;
 
-  for (itk::SizeValueType y = 0; y < dimLength; y++)
+  for (itk::SizeValueType y = 0; y < dimLength; ++y)
   {
-    for (itk::SizeValueType x = 0; x < dimLength; x++)
+    for (itk::SizeValueType x = 0; x < dimLength; ++x)
     {
       IndexType index;
       index[0] = x;
@@ -55,7 +55,7 @@ testMemoryAccess(OptimizerParametersType & params, ImageVectorPointer imageOfVec
       // element against the values returned by parameter object.
       itk::OffsetValueType offset = (x + y * dimLength) * VectorDimension;
       VectorPixelType      vectorpixel = imageOfVectors->GetPixel(index);
-      for (itk::SizeValueType ind = 0; ind < VectorDimension; ind++)
+      for (itk::SizeValueType ind = 0; ind < VectorDimension; ++ind)
       {
         ValueType paramsValue = params[offset + ind];
         if (itk::Math::NotExactlyEquals(vectorpixel[ind], paramsValue))
@@ -114,9 +114,9 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
   //   Intensity = f(x,y) = x + 3 * y
   //
   //
-  for (int y = 0; y < dimLength; y++)
+  for (int y = 0; y < dimLength; ++y)
   {
-    for (int x = 0; x < dimLength; x++)
+    for (int x = 0; x < dimLength; ++x)
     {
       IndexType index;
       index[0] = x;

--- a/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
@@ -65,7 +65,7 @@ itkMathRoundProfileTest1(int, char *[])
   std::cout << "Initial Value   = " << initialValue << std::endl;
   std::cout << "Value Increment = " << valueIncrement << std::endl;
 
-  for (unsigned long i = 0; i < numberOfValues; i++)
+  for (unsigned long i = 0; i < numberOfValues; ++i)
   {
     const double inputValue = initialValue + i * valueIncrement;
     input.push_back(inputValue);
@@ -75,7 +75,7 @@ itkMathRoundProfileTest1(int, char *[])
   //
   // Make sure that entries in the .5 locations are included
   //
-  for (signed int k = -10; k <= 10; k++)
+  for (signed int k = -10; k <= 10; ++k)
   {
     const double value = k + 0.5;
     input.push_back(value);
@@ -87,7 +87,7 @@ itkMathRoundProfileTest1(int, char *[])
   output3.resize(input.size());
   output4.resize(input.size());
 
-  for (unsigned int tours = 0; tours < 100; tours++)
+  for (unsigned int tours = 0; tours < 100; ++tours)
   {
     //
     // Count the time of simply assigning values in an std::vector

--- a/Modules/Core/Common/test/itkMatrixTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixTest.cxx
@@ -124,9 +124,9 @@ itkMatrixTest(int, char *[])
     itk::Matrix<double, 2, 2> m1;
     itk::Matrix<double, 2, 2> m2;
 
-    for (unsigned int i = 0; i < 2; i++)
+    for (unsigned int i = 0; i < 2; ++i)
     {
-      for (unsigned int j = 0; j < 2; j++)
+      for (unsigned int j = 0; j < 2; ++j)
       {
         m1[i][j] = i + j;
       }
@@ -136,9 +136,9 @@ itkMatrixTest(int, char *[])
     std::cout << m1 << std::endl;
 
 
-    for (unsigned int i = 0; i < 2; i++)
+    for (unsigned int i = 0; i < 2; ++i)
     {
-      for (unsigned int j = 0; j < 2; j++)
+      for (unsigned int j = 0; j < 2; ++j)
       {
         m2[i][j] = i + j;
       }
@@ -157,9 +157,9 @@ itkMatrixTest(int, char *[])
     itk::Matrix<double, 2, 2> m3;
     itk::Matrix<double, 2, 3> m4;
 
-    for (unsigned int i = 0; i < 2; i++)
+    for (unsigned int i = 0; i < 2; ++i)
     {
-      for (unsigned int j = 0; j < 2; j++)
+      for (unsigned int j = 0; j < 2; ++j)
       {
         m3[i][j] = i + j;
       }
@@ -169,9 +169,9 @@ itkMatrixTest(int, char *[])
     std::cout << m3 << std::endl;
 
 
-    for (unsigned int i = 0; i < 2; i++)
+    for (unsigned int i = 0; i < 2; ++i)
     {
-      for (unsigned int j = 0; j < 3; j++)
+      for (unsigned int j = 0; j < 3; ++j)
       {
         m4[i][j] = i + j;
       }
@@ -206,9 +206,9 @@ itkMatrixTest(int, char *[])
 
     // fill the matrices with something
     {
-      for (unsigned int r = 0; r < nr; r++)
+      for (unsigned int r = 0; r < nr; ++r)
       {
-        for (unsigned int c = 0; c < nc; c++)
+        for (unsigned int c = 0; c < nc; ++c)
         {
           const auto fr = (double)r;
           const auto fc = (double)c;
@@ -233,9 +233,9 @@ itkMatrixTest(int, char *[])
     // Check the addition and subtraction values
     {
       const double tolerance = 1e-7;
-      for (unsigned int r = 0; r < nr; r++)
+      for (unsigned int r = 0; r < nr; ++r)
       {
-        for (unsigned int c = 0; c < nc; c++)
+        for (unsigned int c = 0; c < nc; ++c)
         {
           if (std::fabs(m3[r][c] - 2 * r) > tolerance)
           {
@@ -259,9 +259,9 @@ itkMatrixTest(int, char *[])
     // Check the in-place addition and subtraction values
     {
       const double tolerance = 1e-7;
-      for (unsigned int r = 0; r < nr; r++)
+      for (unsigned int r = 0; r < nr; ++r)
       {
-        for (unsigned int c = 0; c < nc; c++)
+        for (unsigned int c = 0; c < nc; ++c)
         {
           if (std::fabs(m3[r][c] - m1[r][c]) > tolerance)
           {
@@ -285,9 +285,9 @@ itkMatrixTest(int, char *[])
     MatrixType matrixA;
 
     int counter = 0;
-    for (unsigned int row = 0; row < 3; row++)
+    for (unsigned int row = 0; row < 3; ++row)
     {
-      for (unsigned int col = 0; col < 3; col++)
+      for (unsigned int col = 0; col < 3; ++col)
       {
         matrixA[row][col] = counter++;
       }
@@ -299,9 +299,9 @@ itkMatrixTest(int, char *[])
 
     { // verify values
       const double tolerance = 1e-7;
-      for (unsigned int row = 0; row < 3; row++)
+      for (unsigned int row = 0; row < 3; ++row)
       {
-        for (unsigned int col = 0; col < 3; col++)
+        for (unsigned int col = 0; col < 3; ++col)
         {
           if (std::abs(matrixB[row][col] - matrixA[row][col]) > tolerance)
           {
@@ -317,9 +317,9 @@ itkMatrixTest(int, char *[])
 
     { // verify values
       const double tolerance = 1e-7;
-      for (unsigned int row = 0; row < 3; row++)
+      for (unsigned int row = 0; row < 3; ++row)
       {
-        for (unsigned int col = 0; col < 3; col++)
+        for (unsigned int col = 0; col < 3; ++col)
         {
           if (std::abs(matrixC[row][col] - matrixA[row][col]) > tolerance)
           {

--- a/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
@@ -48,7 +48,7 @@ itkMemoryProbesCollecterBaseTest(int, char *[])
   mcollecter.Start("Update");
   probe.Start();
   auto * buf = new char[bufsize];
-  for (unsigned int i = 0; i < bufsize; i++)
+  for (unsigned int i = 0; i < bufsize; ++i)
   {
     buf[i] = static_cast<char>(i & 0xff);
   }

--- a/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorTest.cxx
+++ b/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorTest.cxx
@@ -49,7 +49,7 @@ itkMersenneTwisterRandomVariateGeneratorTest(int, char *[])
   twister->SetSeed(Twister::GetInstance()->GetSeed());
 
   // Check that we get the same series of numbers from the two.  Use integers.
-  for (int i = 0; i < 200; i++)
+  for (int i = 0; i < 200; ++i)
   {
     if (Twister::GetInstance()->GetIntegerVariate() != twister->GetIntegerVariate())
     {
@@ -85,7 +85,7 @@ itkMersenneTwisterRandomVariateGeneratorTest(int, char *[])
   double sum = 0.0;
   double sum2 = 0.0;
   int    count = 500000;
-  for (int i = 0; i < count; i++)
+  for (int i = 0; i < count; ++i)
   {
     double v = twister->GetNormalVariate();
     sum += v;

--- a/Modules/Core/Common/test/itkMultiThreaderParallelizeArrayTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderParallelizeArrayTest.cxx
@@ -80,7 +80,7 @@ itkMultiThreaderParallelizeArrayTest(int argc, char * argv[])
     result = EXIT_FAILURE;
   }
 
-  for (unsigned i = 1; i < size; i++)
+  for (unsigned i = 1; i < size; ++i)
   {
     if (vec[i] != i)
     {

--- a/Modules/Core/Common/test/itkMultithreadingTest.cxx
+++ b/Modules/Core/Common/test/itkMultithreadingTest.cxx
@@ -43,10 +43,10 @@ execute(void * ptr)
   int    m = *data;
   double sum = 1.0;
 
-  for (int j = 0; j < m; j++)
+  for (int j = 0; j < m; ++j)
   {
     sum = 1.0;
-    for (int i = 1; i <= n; i++)
+    for (int i = 1; i <= n; ++i)
     {
       sum = sum + i + j;
     }
@@ -82,7 +82,7 @@ itkMultithreadingTest(int argc, char * argv[])
   itk::TimeProbe                timeProbe;
   itk::TimeProbe::TimeStampType startTime = timeProbe.GetInstantValue();
   int                           data = 123;
-  for (int i = 0; i < count; i++)
+  for (int i = 0; i < count; ++i)
   {
     threader->SetSingleMethod(&execute, &data);
     threader->SingleMethodExecute();

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
@@ -83,9 +83,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   it3.Print(std::cout);
   unsigned x, y, i;
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }
@@ -100,9 +100,9 @@ itkNeighborhoodIteratorTest(int, char *[])
   z[3] = 0;
   it3.SetNext(0, 2, z);
 
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }
@@ -111,9 +111,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetNext(1, 2, [0,0,0,0])");
   it3.SetNext(1, 2, z);
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }
@@ -122,9 +122,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetNext(0, [0,0,0,0])");
   it3.SetNext(0, z);
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }
@@ -133,9 +133,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetNext(1, [0,0,0,0])");
   it3.SetNext(1, z);
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }
@@ -146,9 +146,9 @@ itkNeighborhoodIteratorTest(int, char *[])
   println("Testing SetPrevious(0, 2, [0,0,0,0])");
   it3.SetPrevious(0, 2, z);
 
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }
@@ -157,9 +157,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetPrevious(1, 2, [0,0,0,0])");
   it3.SetPrevious(1, 2, z);
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }
@@ -168,9 +168,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetPrevious(0, [0,0,0,0])");
   it3.SetPrevious(0, z);
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }
@@ -179,9 +179,9 @@ itkNeighborhoodIteratorTest(int, char *[])
 
   println("Testing SetPrevious(1, [0,0,0,0])");
   it3.SetPrevious(1, z);
-  for (y = 0, i = 0; y < 5; y++)
+  for (y = 0, i = 0; y < 5; ++y)
   {
-    for (x = 0; x < 5; x++, i++)
+    for (x = 0; x < 5; ++x, ++i)
     {
       std::cout << it3.GetPixel(i) << " ";
     }

--- a/Modules/Core/Common/test/itkNumericsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericsTest.cxx
@@ -24,9 +24,9 @@ void
 print_vnl_matrix(T & mat)
 {
   std::cout << mat;
-  for (unsigned int r = 0; r < mat.rows(); r++)
+  for (unsigned int r = 0; r < mat.rows(); ++r)
   {
-    for (unsigned int c = 0; c < mat.columns(); c++)
+    for (unsigned int c = 0; c < mat.columns(); ++c)
       std::cout << mat(r, c) << " ";
     std::cout << std::endl;
   }
@@ -69,9 +69,9 @@ itkNumericsTest(int, char *[])
   double             data[] = { 1, 1, 1, 1, 2, 3, 1, 3, 6 };
   vnl_matrix<double> mat(data, 3, 3);
   std::cout << std::endl << "A matrix" << std::endl;
-  for (unsigned int r = 0; r < mat.rows(); r++)
+  for (unsigned int r = 0; r < mat.rows(); ++r)
   {
-    for (unsigned int c = 0; c < mat.rows(); c++)
+    for (unsigned int c = 0; c < mat.rows(); ++c)
     {
       std::cout << mat(r, c) << " ";
     }

--- a/Modules/Core/Common/test/itkObjectFactoryTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest.cxx
@@ -165,7 +165,7 @@ itkObjectFactoryTest(int, char *[])
     std::list<std::string>::const_iterator n = names.begin();
     std::list<std::string>::const_iterator d = descriptions.begin();
     std::list<bool>::const_iterator        e = enableflags.begin();
-    for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, e++)
+    for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
     {
       std::cout << "    Override " << *o << " with " << *n << std::endl
                 << "      described as \"" << *d << "\"" << std::endl

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -103,7 +103,7 @@ itkObjectFactoryTest2(int argc, char * argv[])
   std::string pathSeparator = ":";
 #endif
   std::string path = "";
-  for (int ac = 1; ac < argc - 1; ac++)
+  for (int ac = 1; ac < argc - 1; ++ac)
   {
     path += argv[ac];
 #ifdef CMAKE_INTDIR
@@ -139,7 +139,7 @@ itkObjectFactoryTest2(int argc, char * argv[])
       std::list<std::string>::const_iterator n = names.begin();
       std::list<std::string>::const_iterator d = descriptions.begin();
       std::list<bool>::const_iterator        e = enableflags.begin();
-      for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, e++)
+      for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
       {
         std::cout << "    Override " << *o << " with " << *n << std::endl
                   << "      described as \"" << *d << "\"" << std::endl

--- a/Modules/Core/Common/test/itkObjectStoreTest.cxx
+++ b/Modules/Core/Common/test/itkObjectStoreTest.cxx
@@ -41,21 +41,21 @@ itkObjectStoreTest(int, char *[])
   store->SetGrowthStrategy(store->GetGrowthStrategy());
 
 
-  for (j = 0; j < 2; j++)
+  for (j = 0; j < 2; ++j)
   {
     std::cout << "_______________________" << std::endl;
     store->Print(std::cout);
 
 
     // Borrow some items
-    for (i = 0; i < 30000; i++)
+    for (i = 0; i < 30000; ++i)
     {
       borrowed_list.push_back(store->Borrow());
     }
     store->Print(std::cout);
 
     // Force allocation of a more memory
-    for (i = 0; i < 1000000; i++)
+    for (i = 0; i < 1000000; ++i)
     {
       borrowed_list.push_back(store->Borrow());
     }

--- a/Modules/Core/Common/test/itkOptimizerParametersTest.cxx
+++ b/Modules/Core/Common/test/itkOptimizerParametersTest.cxx
@@ -47,7 +47,7 @@ runTestByType()
   // Copy constructor
   {
     itk::OptimizerParameters<TValue> paramsCopy(params);
-    for (itk::SizeValueType i = 0; i < params.GetSize(); i++)
+    for (itk::SizeValueType i = 0; i < params.GetSize(); ++i)
     {
       if (itk::Math::NotExactlyEquals(params[i], paramsCopy[i]))
       {
@@ -59,13 +59,13 @@ runTestByType()
 
   // Constructor from array
   itk::Array<TValue> array(dim);
-  for (itk::SizeValueType i = 0; i < dim; i++)
+  for (itk::SizeValueType i = 0; i < dim; ++i)
   {
     array[i] = i * 3.19;
   }
   {
     itk::OptimizerParameters<TValue> paramsCopy(array);
-    for (itk::SizeValueType i = 0; i < params.GetSize(); i++)
+    for (itk::SizeValueType i = 0; i < params.GetSize(); ++i)
     {
       if (itk::Math::NotExactlyEquals(array[i], paramsCopy[i]))
       {
@@ -80,7 +80,7 @@ runTestByType()
   // Assign from Array
   itk::OptimizerParameters<TValue> paramsArray;
   paramsArray = array;
-  for (itk::SizeValueType i = 0; i < array.GetSize(); i++)
+  for (itk::SizeValueType i = 0; i < array.GetSize(); ++i)
   {
     if (itk::Math::NotExactlyEquals(paramsArray[i], array[i]))
     {
@@ -91,14 +91,14 @@ runTestByType()
 
   // Assign from VnlVector
   vnl_vector<TValue> vector(dim);
-  for (itk::SizeValueType i = 0; i < dim; i++)
+  for (itk::SizeValueType i = 0; i < dim; ++i)
   {
     vector[i] = i * 0.123;
   }
   {
     itk::OptimizerParameters<TValue> paramsVnl;
     paramsVnl = vector;
-    for (itk::SizeValueType i = 0; i < paramsVnl.GetSize(); i++)
+    for (itk::SizeValueType i = 0; i < paramsVnl.GetSize(); ++i)
     {
       if (itk::Math::NotExactlyEquals(vector[i], paramsVnl[i]))
       {
@@ -111,7 +111,7 @@ runTestByType()
   /* Test MoveDataPointer to point to different memory block */
   TValue block[10] = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
   params.MoveDataPointer(block);
-  for (int i = 0; i < 10; i++)
+  for (int i = 0; i < 10; ++i)
   {
     if (itk::Math::NotExactlyEquals(params[i], 10 - i))
     {
@@ -135,7 +135,7 @@ runTestByType()
   itk::OptimizerParameters<TValue> params2(4);
   params1.Fill(1.23);
   params2 = params1;
-  for (itk::SizeValueType i = 0; i < params1.GetSize(); i++)
+  for (itk::SizeValueType i = 0; i < params1.GetSize(); ++i)
   {
     if (itk::Math::NotExactlyEquals(params1[i], params2[i]))
     {

--- a/Modules/Core/Common/test/itkPointGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkPointGeometryTest.cxx
@@ -101,7 +101,7 @@ itkPointGeometryTest(int, char *[])
   auto vnlVector = pa.GetVnlVector();
   std::cout << "vnl_vector = ";
   {
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       std::cout << vnlVector[i] << ", ";
     }
@@ -133,7 +133,7 @@ itkPointGeometryTest(int, char *[])
     fp.CastFrom(dp); // Here is the call !
 
     // Verification...
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       auto val = static_cast<FloatPointType::ValueType>(dp[i]);
       if (std::fabs(val - fp[i]) > tolerance)
@@ -159,7 +159,7 @@ itkPointGeometryTest(int, char *[])
     std::cout << "PA = " << A << std::endl;
     std::cout << "PB = " << B << std::endl;
     std::cout << "MidPoint = " << midpoint << std::endl;
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       if (itk::Math::NotAlmostEquals(midpoint[i], (A[i] + B[i]) / 2.0))
       {
@@ -186,7 +186,7 @@ itkPointGeometryTest(int, char *[])
     std::cout << "PB = " << B << std::endl;
     std::cout << "Alpha = " << alpha << std::endl;
     std::cout << "Combination = " << combination << std::endl;
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       const double value = (alpha * A[i] + (1.0 - alpha) * B[i]);
       if (std::fabs(combination[i] - value) > tolerance)
@@ -218,7 +218,7 @@ itkPointGeometryTest(int, char *[])
     std::cout << "Alpha = " << alpha << std::endl;
     std::cout << "Beta  = " << beta << std::endl;
     std::cout << "Combination = " << combination << std::endl;
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       const double value = alpha * A[i] + beta * B[i] + (1.0 - alpha - beta) * C[i];
       if (std::fabs(combination[i] - value) > tolerance)
@@ -248,7 +248,7 @@ itkPointGeometryTest(int, char *[])
     w[1] = 1 / 3.0;
     combination.SetToBarycentricCombination(A, w, N);
     std::cout << "Test for Barycentric combination of an array of Points" << std::endl;
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       if (std::fabs(combination[i] - (K / 3.0)) > tolerance)
       {
@@ -287,7 +287,7 @@ itkPointGeometryTest(int, char *[])
     using BarycentricCalculatorType = itk::BarycentricCombination<VectorOfPoints, double *>;
     combination = BarycentricCalculatorType::Evaluate(points, w);
     std::cout << "Test for Barycentric combination of a VectorContainer of Points" << std::endl;
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       if (std::fabs(combination[i] - (K / 3.0)) > tolerance)
       {

--- a/Modules/Core/Common/test/itkPriorityQueueTest.cxx
+++ b/Modules/Core/Common/test/itkPriorityQueueTest.cxx
@@ -52,7 +52,7 @@ itkPriorityQueueTest(int, char *[])
 
   std::list<double>::const_iterator it = sequence.begin();
   size_t                            i = 0;
-  for (; it != sequence.end(); ++it, i++)
+  for (; it != sequence.end(); ++it, ++i)
   {
     min_priority_queue->Push(MinPQElementType(i, *it));
     max_priority_queue->Push(MaxPQElementType(i, *it));

--- a/Modules/Core/Common/test/itkRGBPixelTest.cxx
+++ b/Modules/Core/Common/test/itkRGBPixelTest.cxx
@@ -43,7 +43,7 @@ itkRGBPixelTest(int, char *[])
   std::cout << "pixel.GetNumberOfComponents = " << pixel.GetNumberOfComponents() << std::endl;
   std::cout << "pixel.GetScalarValue() = " << pixel.GetScalarValue() << std::endl;
   std::cout << "pixel.GetNthComponent()" << std::endl;
-  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); i++)
+  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); ++i)
   {
     std::cout << "\tpixel[" << i << "] = " << pixel.GetNthComponent(i) << std::endl;
   }
@@ -51,7 +51,7 @@ itkRGBPixelTest(int, char *[])
   pixel.SetGreen(22.0);
   pixel.SetBlue(33.0);
   std::cout << "pixel.SetRed (11.0); pixel.SetGreen (22.0); pixel.SetBlue (33.0);" << std::endl;
-  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); i++)
+  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); ++i)
   {
     std::cout << "\tpixel[" << i << "] = " << pixel.GetNthComponent(i) << std::endl;
   }
@@ -64,7 +64,7 @@ itkRGBPixelTest(int, char *[])
   pixel[0] = 111;
   pixel[1] = 222;
   pixel[2] = 333;
-  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); i++)
+  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); ++i)
   {
     std::cout << "\tpixel[" << i << "] = " << pixel.GetNthComponent(i) << std::endl;
   }
@@ -72,14 +72,14 @@ itkRGBPixelTest(int, char *[])
   std::cout << "std::cout << pixel << std::endl;" << std::endl;
   std::cout << "\t" << pixel << std::endl;
 
-  for (unsigned int j = 0; j < 2; j++)
+  for (unsigned int j = 0; j < 2; ++j)
   {
     std::cout << "pixelArray[" << j << "].GetNumberOfComponents = " << pixelArray[j].GetNumberOfComponents()
               << std::endl;
     std::cout << "pixelArray[" << j << "].GetScalarValue() = " << static_cast<int>(pixelArray[j].GetScalarValue())
               << std::endl;
     std::cout << "pixelArray[" << j << "].GetNthComponent()" << std::endl;
-    for (unsigned int i = 0; i < pixelArray[j].GetNumberOfComponents(); i++)
+    for (unsigned int i = 0; i < pixelArray[j].GetNumberOfComponents(); ++i)
     {
       std::cout << "\tpixelArray[" << j << "].GetNthComponent(" << i
                 << ") = " << static_cast<int>(pixelArray[j].GetNthComponent(i)) << std::endl;

--- a/Modules/Core/Common/test/itkRealTimeIntervalTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeIntervalTest.cxx
@@ -67,7 +67,7 @@ itkRealTimeIntervalTest(int, char *[])
   itk::RealTimeInterval intervalX = interval0;
 
   itk::RealTimeInterval oneSecond(1, 0);
-  for (unsigned int i = 0; i < 1000000L; i++)
+  for (unsigned int i = 0; i < 1000000L; ++i)
   {
     intervalX += oneSecond;
   }
@@ -85,7 +85,7 @@ itkRealTimeIntervalTest(int, char *[])
 
   itk::RealTimeInterval interval3 = interval0;
 
-  for (unsigned int i = 0; i < 1000000L; i++)
+  for (unsigned int i = 0; i < 1000000L; ++i)
   {
     interval3 += fiveMicroseconds;
   }
@@ -96,7 +96,7 @@ itkRealTimeIntervalTest(int, char *[])
 
   CHECK_FOR_VALUE(timeInSeconds, 5.0);
 
-  for (unsigned int i = 0; i < 1000000L; i++)
+  for (unsigned int i = 0; i < 1000000L; ++i)
   {
     interval3 -= fiveMicroseconds;
   }

--- a/Modules/Core/Common/test/itkRealTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeStampTest.cxx
@@ -65,7 +65,7 @@ itkRealTimeStampTest(int, char *[])
   itk::RealTimeStamp    stamp2 = stamp0;
   itk::RealTimeInterval oneSecond(1, 0);
 
-  for (unsigned int i = 0; i < 1000000L; i++)
+  for (unsigned int i = 0; i < 1000000L; ++i)
   {
     stamp2 += oneSecond;
   }
@@ -83,7 +83,7 @@ itkRealTimeStampTest(int, char *[])
 
   itk::RealTimeStamp stamp3 = stamp0;
 
-  for (unsigned int i = 0; i < 1000000L; i++)
+  for (unsigned int i = 0; i < 1000000L; ++i)
   {
     stamp3 += fiveMicroseconds;
   }
@@ -94,7 +94,7 @@ itkRealTimeStampTest(int, char *[])
 
   CHECK_FOR_VALUE(timeInSeconds, 5.0);
 
-  for (unsigned int i = 0; i < 1000000L; i++)
+  for (unsigned int i = 0; i < 1000000L; ++i)
   {
     stamp3 -= fiveMicroseconds;
   }

--- a/Modules/Core/Common/test/itkSTLContainerAdaptorTest.cxx
+++ b/Modules/Core/Common/test/itkSTLContainerAdaptorTest.cxx
@@ -45,7 +45,7 @@ itkSTLContainerAdaptorTest(int, char *[])
 
     STLVectorType vectorSource;
 
-    for (unsigned int i = 0; i < containerSize; i++)
+    for (unsigned int i = 0; i < containerSize; ++i)
     {
       vectorSource.push_back(containerSize - i);
     }
@@ -90,7 +90,7 @@ itkSTLContainerAdaptorTest(int, char *[])
 
       // Test of index access
       std::cout << "Testing index access... ";
-      for (unsigned int i = 0; i < containerSize; i++)
+      for (unsigned int i = 0; i < containerSize; ++i)
       {
         if (vectorSource[i] != vectorContainer->GetElement(i))
         {
@@ -138,7 +138,7 @@ itkSTLContainerAdaptorTest(int, char *[])
 
       // Test of index access
       std::cout << "Testing index access... ";
-      for (unsigned int i = 0; i < containerSize; i++)
+      for (unsigned int i = 0; i < containerSize; ++i)
       {
         if (destination[i] != vectorContainer->GetElement(i))
         {
@@ -167,7 +167,7 @@ itkSTLContainerAdaptorTest(int, char *[])
     using STLMapType = std::map<int, ElementType>;
     STLMapType mapSource;
 
-    for (unsigned int i = 0; i < containerSize; i++)
+    for (unsigned int i = 0; i < containerSize; ++i)
     {
       mapSource[i] = containerSize - i;
     }
@@ -188,7 +188,7 @@ itkSTLContainerAdaptorTest(int, char *[])
 
       std::cout << "Testing assignment... ";
 
-      for (unsigned int i = 0; i < containerSize; i++)
+      for (unsigned int i = 0; i < containerSize; ++i)
       {
         targetRef[i] = mapSource[i];
       }
@@ -215,7 +215,7 @@ itkSTLContainerAdaptorTest(int, char *[])
 
       // Test of index access
       std::cout << "Testing index access... ";
-      for (unsigned int j = 0; j < containerSize; j++)
+      for (unsigned int j = 0; j < containerSize; ++j)
       {
         if (mapSource[j] != mapContainer->GetElement(j))
         {
@@ -239,7 +239,7 @@ itkSTLContainerAdaptorTest(int, char *[])
       STLMapType destination;
 
       std::cout << "Testing reading assignment... ";
-      for (unsigned int i = 0; i < containerSize; i++)
+      for (unsigned int i = 0; i < containerSize; ++i)
       {
         destination[i] = constTargetRef.find(i)->second;
       }
@@ -266,7 +266,7 @@ itkSTLContainerAdaptorTest(int, char *[])
 
       // Test of index access
       std::cout << "Testing index access... ";
-      for (unsigned int j = 0; j < containerSize; j++)
+      for (unsigned int j = 0; j < containerSize; ++j)
       {
         if (destination[j] != mapContainer->GetElement(j))
         {

--- a/Modules/Core/Common/test/itkSinRegularizedHeavisideStepFunctionTest1.cxx
+++ b/Modules/Core/Common/test/itkSinRegularizedHeavisideStepFunctionTest1.cxx
@@ -48,7 +48,7 @@ itkSinRegularizedHeavisideStepFunctionTest1(int, char *[])
 
   constexpr InputType incValue = 0.1;
 
-  for (signed int x = minValue; x < maxValue; x++)
+  for (signed int x = minValue; x < maxValue; ++x)
   {
     const InputType ix = x * incValue;
     OutputType      f = functionBase0->Evaluate(ix);

--- a/Modules/Core/Common/test/itkSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkSliceIteratorTest.cxx
@@ -131,7 +131,7 @@ void
 PrintSlice(TContainer s)
 {
   std::cout << "[";
-  for (s = s.Begin(); s < s.End(); s++)
+  for (s = s.Begin(); s < s.End(); ++s)
   {
     std::cout << *s << " ";
   }

--- a/Modules/Core/Common/test/itkSparseFieldLayerTest.cxx
+++ b/Modules/Core/Common/test/itkSparseFieldLayerTest.cxx
@@ -37,10 +37,10 @@ itkSparseFieldLayerTest(int, char *[])
 
   itk::SparseFieldLayer<node_type>::Pointer layer = itk::SparseFieldLayer<node_type>::New();
 
-  for (j = 0; j < 2; j++)
+  for (j = 0; j < 2; ++j)
   {
     std::cout << "---------------" << std::endl;
-    for (i = 0; i < 4000; i++)
+    for (i = 0; i < 4000; ++i)
     {
       (store + i)->value = i;
     }
@@ -48,7 +48,7 @@ itkSparseFieldLayerTest(int, char *[])
     layer->Print(std::cout);
     std::cout << layer->Size() << std::endl;
 
-    for (i = 0; i < 4000; i++)
+    for (i = 0; i < 4000; ++i)
     {
       layer->PushFront(store + i);
     }
@@ -57,7 +57,7 @@ itkSparseFieldLayerTest(int, char *[])
     std::cout << layer->Size() << std::endl;
 
     rlist = layer->SplitRegions(5);
-    for (int k = 0; k < 5; k++)
+    for (int k = 0; k < 5; ++k)
     {
       std::cout << "Region begin:" << (rlist[k].first)->value << std::endl;
     }
@@ -86,18 +86,18 @@ itkSparseFieldLayerTest(int, char *[])
       --i;
     }
 
-    for (i = 0; i < 5000; i++)
+    for (i = 0; i < 5000; ++i)
     {
       layer->PopFront();
     }
     layer->Print(std::cout);
     std::cout << layer->Size() << std::endl;
 
-    for (i = 0; i < 4000; i++)
+    for (i = 0; i < 4000; ++i)
     {
       layer->PushFront(store + i);
     }
-    for (i = 0; i < 5000; i++)
+    for (i = 0; i < 5000; ++i)
     {
       layer->Unlink(layer->Front());
     }

--- a/Modules/Core/Common/test/itkSparseImageTest.cxx
+++ b/Modules/Core/Common/test/itkSparseImageTest.cxx
@@ -62,8 +62,8 @@ itkSparseImageTest(int, char *[])
   NodeType *           node;
   int                  cnt = 0;
 
-  for (index[0] = 0; index[0] < 24; index[0]++)
-    for (index[1] = 0; index[1] < 24; index[1]++)
+  for (index[0] = 0; index[0] < 24; ++index[0])
+    for (index[1] = 0; index[1] < 24; ++index[1])
     {
       if ((index[0] >= 6) && (index[0] <= 12) && (index[1] >= 6) && (index[1] <= 12))
       {

--- a/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
@@ -103,7 +103,7 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
       double eigvals[6] = { 0.170864, 2.16934, 3.79272, 15.435, 24.6083, 78.2994 };
 
       double tolerance = 0.01;
-      for (unsigned int i = 0; i < 6; i++)
+      for (unsigned int i = 0; i < 6; ++i)
       {
         if (itk::Math::abs(eigvals[i] - eigenvalues[i]) > tolerance)
         {
@@ -138,9 +138,9 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
 
     InputMatrixType S;
 
-    for (unsigned int row = 0; row < 6; row++)
+    for (unsigned int row = 0; row < 6; ++row)
     {
-      for (unsigned int col = 0; col < 6; col++)
+      for (unsigned int col = 0; col < 6; ++col)
       {
         S[row][col] = Sdata[row * 6 + col];
       }
@@ -166,7 +166,7 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
       double eigvals[6] = { 0.170864, 2.16934, 3.79272, 15.435, 24.6083, 78.2994 };
 
       double tolerance = 0.01;
-      for (unsigned int i = 0; i < 6; i++)
+      for (unsigned int i = 0; i < 6; ++i)
       {
         if (itk::Math::abs(eigvals[i] - eigenvalues[i]) > tolerance)
         {
@@ -201,9 +201,9 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
 
     InputMatrixType S;
 
-    for (unsigned int row = 0; row < 6; row++)
+    for (unsigned int row = 0; row < 6; ++row)
     {
-      for (unsigned int col = 0; col < 6; col++)
+      for (unsigned int col = 0; col < 6; ++col)
       {
         S[row][col] = Sdata[row * 6 + col];
       }
@@ -223,7 +223,7 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
     double eigvals[6] = { 0.170864, 2.16934, 3.79272, 15.435, 24.6083, 78.2994 };
 
     double tolerance = 0.01;
-    for (unsigned int i = 0; i < 6; i++)
+    for (unsigned int i = 0; i < 6; ++i)
     {
       if (itk::Math::abs(eigvals[i] - eigenvalues[i]) > tolerance)
       {
@@ -259,9 +259,9 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
 
     InputMatrixType S;
 
-    for (unsigned int row = 0; row < 6; row++)
+    for (unsigned int row = 0; row < 6; ++row)
     {
-      for (unsigned int col = 0; col < 6; col++)
+      for (unsigned int col = 0; col < 6; ++col)
       {
         S(row, col) = Sdata[row * 6 + col];
       }
@@ -286,7 +286,7 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
       double eigvals[6] = { 0.170864, 2.16934, 3.79272, 15.435, 24.6083, 78.2994 };
 
       double tolerance = 0.01;
-      for (unsigned int i = 0; i < 6; i++)
+      for (unsigned int i = 0; i < 6; ++i)
       {
         if (itk::Math::abs(eigvals[i] - eigenvalues[i]) > tolerance)
         {
@@ -319,9 +319,9 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
 
     InputMatrixType S;
 
-    for (unsigned int row = 0; row < 3; row++)
+    for (unsigned int row = 0; row < 3; ++row)
     {
-      for (unsigned int col = 0; col < 3; col++)
+      for (unsigned int col = 0; col < 3; ++col)
       {
         S(row, col) = Sdata[row * 3 + col];
       }
@@ -347,7 +347,7 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
       double eigvals[3] = { -1.0, -3.0, 5.0 };
 
       double tolerance = 0.01;
-      for (unsigned int i = 0; i < 3; i++)
+      for (unsigned int i = 0; i < 3; ++i)
       {
         if (itk::Math::abs(eigvals[i] - eigenvalues[i]) > tolerance)
         {
@@ -380,9 +380,9 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
 
     InputMatrixType S;
 
-    for (unsigned int row = 0; row < 3; row++)
+    for (unsigned int row = 0; row < 3; ++row)
     {
-      for (unsigned int col = 0; col < 3; col++)
+      for (unsigned int col = 0; col < 3; ++col)
       {
         S(row, col) = Sdata[row * 3 + col];
       }
@@ -408,7 +408,7 @@ itkSymmetricEigenAnalysisTest(int argc, char * argv[])
       float eigvals[3] = { -3.26256000e-06f, 1.96703376e+01f, -2.74458376e+01f };
 
       float tolerance = 0.01;
-      for (unsigned int i = 0; i < 3; i++)
+      for (unsigned int i = 0; i < 3; ++i)
       {
         if (itk::Math::abs(eigvals[i] - eigenvalues[i]) > tolerance)
         {

--- a/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -68,11 +68,11 @@ itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
   bool functionValue;            // Value of pixel at a given position
   int  interiorPixelCounter = 0; // Count pixels inside ellipsoid
 
-  for (int x = 0; x < xExtent; x++)
+  for (int x = 0; x < xExtent; ++x)
   {
-    for (int y = 0; y < yExtent; y++)
+    for (int y = 0; y < yExtent; ++y)
     {
-      for (int z = 0; z < zExtent; z++)
+      for (int z = 0; z < zExtent; ++z)
       {
         testPosition[0] = x;
         testPosition[1] = y;

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -72,9 +72,9 @@ itkSymmetricSecondRankTensorImageReadTest(int ac, char * av[])
   while (!itr.IsAtEnd())
   {
     itr.Set(matrixPixel);
-    for (unsigned int i = 0; i < 3; i++)
+    for (unsigned int i = 0; i < 3; ++i)
     {
-      for (unsigned int j = 0; j < 3; j++)
+      for (unsigned int j = 0; j < 3; ++j)
       {
         matrixPixel[i][j]++;
       }
@@ -101,9 +101,9 @@ itkSymmetricSecondRankTensorImageReadTest(int ac, char * av[])
       matrixPixel = mItr.Get();
       const TensorPixelType tensorPixel = tItr.Get();
 
-      for (unsigned int i = 0; i < 3; i++)
+      for (unsigned int i = 0; i < 3; ++i)
       {
-        for (unsigned int j = 0; j < 3; j++)
+        for (unsigned int j = 0; j < 3; ++j)
         {
           if (std::abs(matrixPixel[i][j] - tensorPixel(i, j)) > tolerance)
           {

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -62,7 +62,7 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int ac, char * av[])
   while (!itr.IsAtEnd())
   {
     itr.Set(tensorPixelInput);
-    for (unsigned int i = 0; i < 3; i++)
+    for (unsigned int i = 0; i < 3; ++i)
       tensorPixelInput[i]++;
     ++itr;
   }
@@ -86,7 +86,7 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int ac, char * av[])
       tensorPixelInput = inIt.Get();
       const TensorPixelType tensorPixelOutput = outIt.Get();
 
-      for (unsigned int i = 0; i < 3; i++)
+      for (unsigned int i = 0; i < 3; ++i)
       {
         if (std::abs(tensorPixelInput[i] - tensorPixelOutput[i]) > tolerance)
         {

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
@@ -50,7 +50,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
   }
   std::cout << "pixel.GetNumberOfComponents = " << pixel.GetNumberOfComponents() << std::endl;
   std::cout << "pixel.GetNthComponent()" << std::endl;
-  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); i++)
+  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); ++i)
   {
     std::cout << "\tpixel[" << i << "] = " << pixel.GetNthComponent(i) << std::endl;
   }
@@ -66,7 +66,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
   pixel(2, 2) = 14.0;
 
   std::cout << "testing the pixel(i,j) APID" << std::endl;
-  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); i++)
+  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); ++i)
   {
     std::cout << "\tpixel[" << i << "] = " << pixel.GetNthComponent(i) << std::endl;
   }
@@ -81,7 +81,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
   pixel[4] = 555;
   pixel[5] = 666;
 
-  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); i++)
+  for (unsigned int i = 0; i < pixel.GetNumberOfComponents(); ++i)
   {
     std::cout << "\tpixel[" << i << "] = " << pixel.GetNthComponent(i) << std::endl;
   }
@@ -89,12 +89,12 @@ itkSymmetricSecondRankTensorTest(int, char *[])
   std::cout << "std::cout << pixel << std::endl;" << std::endl;
   std::cout << "\t" << pixel << std::endl;
 
-  for (unsigned int j = 0; j < 2; j++)
+  for (unsigned int j = 0; j < 2; ++j)
   {
     std::cout << "pixelArray[" << j << "].GetNumberOfComponents = " << pixelArray[j].GetNumberOfComponents()
               << std::endl;
     std::cout << "pixelArray[" << j << "].GetNthComponent()" << std::endl;
-    for (unsigned int i = 0; i < pixelArray[j].GetNumberOfComponents(); i++)
+    for (unsigned int i = 0; i < pixelArray[j].GetNumberOfComponents(); ++i)
     {
       std::cout << "\tpixelArray[" << j << "].GetNthComponent(" << i
                 << ") = " << static_cast<int>(pixelArray[j].GetNthComponent(i)) << std::endl;
@@ -240,7 +240,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
       expectedValues[1] = v[1];
       expectedValues[2] = v[2];
 
-      for (unsigned int i = 0; i < 3; i++)
+      for (unsigned int i = 0; i < 3; ++i)
       {
         if (std::fabs(expectedValues[i] - eigenValues[i]) > tolerance)
         {
@@ -251,7 +251,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
         }
       }
 
-      for (unsigned int j = 0; j < 3; j++)
+      for (unsigned int j = 0; j < 3; ++j)
       {
         if (std::fabs(expectedValues[j] - eigenValues2[j]) > tolerance)
         {
@@ -292,7 +292,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
       expectedValues[1] = 4.0;
       expectedValues[2] = 10.0;
 
-      for (unsigned int i = 0; i < 3; i++)
+      for (unsigned int i = 0; i < 3; ++i)
       {
         if (std::fabs(expectedValues[i] - eigenValues[i]) > tolerance)
         {
@@ -303,7 +303,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
         }
       }
 
-      for (unsigned int j = 0; j < 3; j++)
+      for (unsigned int j = 0; j < 3; ++j)
       {
         if (std::fabs(expectedValues[j] - eigenValues2[j]) > tolerance)
         {
@@ -344,7 +344,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
       expectedValues[1] = 0.00000;
       expectedValues[2] = 13.61580;
 
-      for (unsigned int i = 0; i < 3; i++)
+      for (unsigned int i = 0; i < 3; ++i)
       {
         if (std::fabs(expectedValues[i] - eigenValues[i]) > tolerance)
         {
@@ -355,7 +355,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
         }
       }
 
-      for (unsigned int j = 0; j < 3; j++)
+      for (unsigned int j = 0; j < 3; ++j)
       {
         if (std::fabs(expectedValues[j] - eigenValues2[j]) > tolerance)
         {

--- a/Modules/Core/Common/test/itkTimeProbesTest.cxx
+++ b/Modules/Core/Common/test/itkTimeProbesTest.cxx
@@ -30,13 +30,13 @@ TestTransformIndexToPhysicalPoint(T * image)
   typename T::IndexType index3D;
   typename T::PointType point3D;
 
-  for (int k = 0; k < 10; k++)
+  for (int k = 0; k < 10; ++k)
   {
     index3D[2] = k;
-    for (int j = 0; j < 1000; j++)
+    for (int j = 0; j < 1000; ++j)
     {
       index3D[1] = j;
-      for (int i = 0; i < 1000; i++)
+      for (int i = 0; i < 1000; ++i)
       {
         index3D[0] = i;
         image->TransformIndexToPhysicalPoint(index3D, point3D);
@@ -53,13 +53,13 @@ TestTransformPhysicalPointToIndex(T * image)
   typename T::IndexType index3D;
   typename T::PointType point3D;
 
-  for (int k = 0; k < 10; k++)
+  for (int k = 0; k < 10; ++k)
   {
     point3D[2] = static_cast<typename itk::NumericTraits<typename T::PointType>::ValueType>(k);
-    for (int j = 0; j < 1000; j++)
+    for (int j = 0; j < 1000; ++j)
     {
       point3D[1] = static_cast<typename itk::NumericTraits<typename T::PointType>::ValueType>(j);
-      for (int i = 0; i < 1000; i++)
+      for (int i = 0; i < 1000; ++i)
       {
         point3D[0] = static_cast<typename itk::NumericTraits<typename T::PointType>::ValueType>(i);
         image->TransformPhysicalPointToIndex(point3D, index3D);
@@ -91,10 +91,10 @@ itkTimeProbesTest(int, char *[])
 
     // Do slow stuff here...
     {
-      for (unsigned int i = 0; i < N; i++)
+      for (unsigned int i = 0; i < N; ++i)
       {
         auto * dummy = new unsigned int[M];
-        for (unsigned int j = 0; j < M; j++)
+        for (unsigned int j = 0; j < M; ++j)
         {
           dummy[j] = j;
         }
@@ -107,10 +107,10 @@ itkTimeProbesTest(int, char *[])
 
     // Do other slow stuff here...
     {
-      for (unsigned int i = 0; i < M; i++)
+      for (unsigned int i = 0; i < M; ++i)
       {
         auto * dummy = new unsigned int[N];
-        for (unsigned int j = 0; j < N; j++)
+        for (unsigned int j = 0; j < N; ++j)
         {
           dummy[j] = j;
         }

--- a/Modules/Core/Common/test/itkTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkTimeStampTest.cxx
@@ -76,7 +76,7 @@ itkTimeStampTest(int, char *[])
     // Set up the helper class
     helper.counters.resize(numberOfWorkUnits);
     helper.timestamps.resize(numberOfWorkUnits);
-    for (itk::ThreadIdType k = 0; k < numberOfWorkUnits; k++)
+    for (itk::ThreadIdType k = 0; k < numberOfWorkUnits; ++k)
     {
       helper.counters[k] = 0;
     }
@@ -95,13 +95,13 @@ itkTimeStampTest(int, char *[])
 
     constexpr unsigned int num_exp = 500;
 
-    for (unsigned int i = 0; i < num_exp; i++)
+    for (unsigned int i = 0; i < num_exp; ++i)
     {
       multithreader->SingleMethodExecute();
 
       itk::ModifiedTimeType min_mtime = helper.timestamps[0].GetMTime();
       itk::ModifiedTimeType max_mtime = helper.timestamps[0].GetMTime();
-      for (itk::ThreadIdType k = 0; k < numberOfWorkUnits; k++)
+      for (itk::ThreadIdType k = 0; k < numberOfWorkUnits; ++k)
       {
         const itk::ModifiedTimeType & mtime = helper.timestamps[k].GetMTime();
         if (mtime > max_mtime)
@@ -121,7 +121,7 @@ itkTimeStampTest(int, char *[])
 
       if (iter_success)
       {
-        for (itk::ThreadIdType k = 0; k < numberOfWorkUnits; k++)
+        for (itk::ThreadIdType k = 0; k < numberOfWorkUnits; ++k)
         {
           // Test whether the all modified times have
           // been used

--- a/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
@@ -64,7 +64,7 @@ itkVNLRoundProfileTest1(int, char *[])
   std::cout << "Initial Value   = " << initialValue << std::endl;
   std::cout << "Value Increment = " << valueIncrement << std::endl;
 
-  for (unsigned long i = 0; i < numberOfValues; i++)
+  for (unsigned long i = 0; i < numberOfValues; ++i)
   {
     const double inputValue = initialValue + i * valueIncrement;
     input.push_back(inputValue);
@@ -74,7 +74,7 @@ itkVNLRoundProfileTest1(int, char *[])
   //
   // Make sure that entries in the .5 locations are included
   //
-  for (signed int k = -10; k <= 10; k++)
+  for (signed int k = -10; k <= 10; ++k)
   {
     const double value = k + 0.5;
     input.push_back(value);
@@ -86,7 +86,7 @@ itkVNLRoundProfileTest1(int, char *[])
   output3.resize(input.size());
   output4.resize(input.size());
 
-  for (unsigned int tours = 0; tours < 100; tours++)
+  for (unsigned int tours = 0; tours < 100; ++tours)
   {
     //
     // Count the time of simply assigning values in an std::vector

--- a/Modules/Core/Common/test/itkVariableSizeMatrixTest.cxx
+++ b/Modules/Core/Common/test/itkVariableSizeMatrixTest.cxx
@@ -81,11 +81,11 @@ itkVariableSizeMatrixTest(int, char *[])
   }
 
   // Get each row separately
-  for (unsigned int i = 0; i < h.Rows(); i++)
+  for (unsigned int i = 0; i < h.Rows(); ++i)
   {
     float * row = h[i];
     std::cout << "h[" << i << "] = ";
-    for (unsigned int j = 0; j < h.Cols(); j++)
+    for (unsigned int j = 0; j < h.Cols(); ++j)
     {
       std::cout << *(row + j) << ", ";
     }
@@ -93,11 +93,11 @@ itkVariableSizeMatrixTest(int, char *[])
   }
 
   // Get each row separately, const version
-  for (unsigned int i = 0; i < h.Rows(); i++)
+  for (unsigned int i = 0; i < h.Rows(); ++i)
   {
     const float * row = h[i];
     std::cout << "h[" << i << "] = ";
-    for (unsigned int j = 0; j < h.Cols(); j++)
+    for (unsigned int j = 0; j < h.Cols(); ++j)
     {
       std::cout << *(row + j) << ", ";
     }

--- a/Modules/Core/Common/test/itkVectorGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGeometryTest.cxx
@@ -115,7 +115,7 @@ itkVectorGeometryTest(int, char *[])
   vnl_vector_ref<ValueType> vnlVector = va.GetVnlVector();
   {
     std::cout << "vnl_vector_ref = va ";
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       std::cout << vnlVector[i] << ", ";
     }
@@ -132,7 +132,7 @@ itkVectorGeometryTest(int, char *[])
   vnl_vector<ValueType> vnlVector2 = vf.GetVnlVector();
   {
     std::cout << "vnl_vector = va ";
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       std::cout << vnlVector2[i] << ", ";
     }
@@ -213,7 +213,7 @@ itkVectorGeometryTest(int, char *[])
     fp.CastFrom(dp);
 
 
-    for (unsigned int i = 0; i < N; i++)
+    for (unsigned int i = 0; i < N; ++i)
     {
       auto val = static_cast<FloatVectorType::ValueType>(dp[i]);
       if (itk::Math::abs(val - fp[i]) > tolerance)


### PR DESCRIPTION
Followed common C++ guidelines, including:

Google C++ Style Guide: "Use the prefix form (++i) of the increment and
decrement operators unless you need postfix semantics."
https://google.github.io/styleguide/cppguide.html#Preincrement_and_Predecrement

Herb Sutter, Andrei Alexandrescu - C++ Coding Standards: 101 Rules,
Guidelines, and Best Practices: "Prefer the canonical form of ++ and --.
Prefer calling the prefix forms"
https://www.oreilly.com/library/view/c-coding-standards/0321113586/ch29.html

Applied at GNU bash, by the following command:

	find . \( -iname *.cxx -or -iname *.hxx -or -iname *.h \) -exec perl -pi -w -e 's/(\s+for \(.*; .+); (\w+)\+\+\)/$1; ++$2)/g;' {} \;

Manually replaced a few more postfix increments, which were not detected
by this regex command, as remarked by Mikhail Isakov (@issakomi).