### PR TITLE
COMP: CastXML, ITKVtkGlue, include only when property exists

### DIFF
--- a/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
@@ -2,7 +2,9 @@
 if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
   foreach(_vtk_lib IN LISTS ITKVtkGlue_VTK_LIBRARIES)
     get_target_property(_vtk_lib_include_dirs ${_vtk_lib} INTERFACE_INCLUDE_DIRECTORIES)
-    include_directories(${_vtk_lib_include_dirs})
+    if(_vtk_lib_include_dirs)
+      include_directories(${_vtk_lib_include_dirs})
+    endif()
   endforeach()
 endif()
 


### PR DESCRIPTION
Some targets (VTK libraries) didn't have the property INTERFACE_INCLUDE_DIRECTORIES

```bash
CMake Error in Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:
  Found relative path while evaluating include directories of
  "ITKVtkGluePython":

    "_vtk_lib_include_dirs-NOTFOUND"
```

Triggered when compiling Slicer with `Slicer_BUILD_ITKPython:BOOL=ON`
aka `ITK_WRAP_PYTHON:BOOL=ON`.

Full error log with extra printing:

```bash

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:3 (message):
  ITKVtkGlue_VTK_LIBRARIES:
  VTK::IOImage;VTK::ImagingSources;VTK::WrappingPythonCore;VTK::CommonCore;VTK::CommonDataModel;VTK::kwiml;VTK::CommonExecutionModel;VTK::RenderingOpenGL2;VTK::RenderingFreeType;VTK::InteractionStyle;VTK::InteractionWidgets

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs:
  build/VTK-build/Wrapping/PythonCore;build/VTK/Wrapping/PythonCore

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs:
  build/VTK-build/Utilities/KWIML;build/VTK/Utilities/KWIML

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

CMake Warning at Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:6 (message):
  _vtk_lib_include_dirs: _vtk_lib_include_dirs-NOTFOUND

-- ITKVtkGlue: Creating module.
-- ITKVtkGlue: Creating itkImageToVTKImageFilter submodule.
-- ITKVtkGlue: Creating itkVTKImageToImageFilter submodule.
-- ITKVtkGlue: Creating itkViewImage submodule.
-- MGHIO: Creating module.
-- MGHIO: Creating itkMGHImageIO submodule.
-- MorphologicalContourInterpolation: Creating module.
-- MorphologicalContourInterpolation: Creating itkMorphologicalContourInterpolator submodule.
-- ITKPyUtils: Creating module.
-- ITKPyUtils: Creating itkPyCommand submodule.
-- ITKPyUtils: Creating itkPyImageFilter submodule.
-- Configuring done
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
_vtk_lib_include_dirs
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping
   used as include directory in directory build/ITK/Modules/Bridge/VtkGlue/wrapping

CMake Error in Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt:
  Found relative path while evaluating include directories of
  "ITKVtkGluePython":

    "_vtk_lib_include_dirs-NOTFOUND"

```

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
