### PR TITLE
clang python wrapping

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -450,8 +450,10 @@ ${DO_NOT_WAIT_FOR_THREADS_DECLS}
     endif()
     if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL 3.13.0 AND NOT MSVC)
       include(CheckIPOSupported)
-      check_ipo_supported()
-      set_property(TARGET ${lib} PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+      check_ipo_supported(RESULT ipo_is_supported)
+      if (ipo_is_supported)
+        set_property(TARGET ${lib} PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+      endif()
     endif()
 
     # Link the modules together


### PR DESCRIPTION
- BUG: Add vnl_vector_from_array to extras __all__
- COMP: Do not add IPO to Python wrapping if not supported
