### PR TITLE
Revert "COMP: Use CMake 3.18.4 in macOS CI builds"

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -60,10 +60,6 @@ jobs:
     - bash: |
         set -x
 
-        curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/de946dd0c0a91ecf6c78c843a4580bd7116c6bf0/Formula/cmake.rb
-        brew unlink cmake
-        brew install ./cmake.rb
-
         c++ --version
         cmake --version
 

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -68,10 +68,6 @@ jobs:
     - bash: |
         set -x
 
-        curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/de946dd0c0a91ecf6c78c843a4580bd7116c6bf0/Formula/cmake.rb
-        brew unlink cmake
-        brew install ./cmake.rb
-
         c++ --version
         cmake --version
 


### PR DESCRIPTION
This reverts commit 414d4c05025236521f02141da096f022cc8ee7e8.

This is a PR for release branch.