### PR TITLE
BUG: LabelImageToStatisticsLabelMapFilter median computation

### DIFF
--- a/Modules/Filtering/LabelMap/wrapping/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/wrapping/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+# some tests will fail if dim=2 and unsigned short are not wrapped
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_unsigned_short AND wrap_2_index GREATER -1)
+    itk_python_add_test(NAME LabelImageToStatisticsLabelMapFilterTest2
+                        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/LabelImageToStatisticsLabelMapFilterTest2.py)
+endif()

--- a/Modules/Filtering/LabelMap/wrapping/test/LabelImageToStatisticsLabelMapFilterTest2.py
+++ b/Modules/Filtering/LabelMap/wrapping/test/LabelImageToStatisticsLabelMapFilterTest2.py
@@ -1,0 +1,69 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+
+import copy
+import numpy as np
+
+import itk
+
+itk.auto_progress(2)
+
+
+def calculate_features(lbl_img, int_img):
+    filt = itk.LabelImageToStatisticsLabelMapFilter[type(lbl_img), type(int_img), itk.LabelMap.x3].New()
+    filt.SetInput1(lbl_img)
+    filt.SetInput2(int_img)
+    filt.SetComputeHistogram(False)
+    filt.SetComputeFeretDiameter(True)
+    filt.SetComputePerimeter(True)
+    filt.Update()
+    features = filt.GetOutput()
+    computed_means = np.array([features[l].GetMean() for l in features.GetLabels()])
+    computed_medians = np.array([features[l].GetMedian() for l in features.GetLabels()])
+    assert np.array_equal(computed_means, np.array([254.48, 257.0, 232.56, 239.16, 258.2, 224.36,]),)
+    assert np.array_equal(computed_medians, np.array([267.0, 231.0, 172.0, 203.0, 209.0, 237.0,]),)
+
+
+shape = (50, 50, 1)
+# Define a dummy label image
+lbl_img_np = np.zeros(shape).astype("uint16")
+lbl_img_np[5:10, 5:10, 0] = 1
+lbl_img_np[15:20, 5:10, 0] = 2
+lbl_img_np[25:30, 5:10, 0] = 3
+lbl_img_np[5:10, 15:20, 0] = 4
+lbl_img_np[15:20, 15:20, 0] = 5
+lbl_img_np[25:30, 15:20, 0] = 6
+
+# Define a dummy intensity image
+np.random.seed(20210413)
+int_img_np = np.random.randint(500, size=shape).astype("uint16")
+
+# Set some values very high to see if that causes the bug to reproduce
+int_img_np_outlier = copy.deepcopy(int_img_np)
+int_img_np_outlier[1, 1, 0] = 62000
+int_img_np[1, 1, 0] = 100
+
+lbl_img = itk.GetImageFromArray(lbl_img_np)
+int_img = itk.GetImageFromArray(int_img_np)
+int_img_outlier = itk.GetImageFromArray(int_img_np_outlier)
+
+# print("Regular image")
+calculate_features(lbl_img, int_img)
+
+# print("Image with 1 outlier pixel (outside the measurement area)")
+calculate_features(lbl_img, int_img_outlier)


### PR DESCRIPTION
Addresses #2482, where the calculation of a median using values represented by counts in histogram buckets depends significantly on the choice of the histogram buckets.  Instead we are now calculating the median from the direct values themselves regardless of the histogram buckets.

Does this constitute a change in functionality or API that should be documented?

I can run the script supplied with Issue #2482 -- thanks @jluethi -- without trouble on installed ITK.  However, all _builds_ on my local system (whether master branch or this pull request's branch, with or without `-DITK_WRAP_unsigned_short:BOOL=ON`) are failing to run the script due to Python wrapping errors associated with `unsigned short`.  I am submitting this pull request now to see how GitHub handles it.

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
