### PR TITLE
STYLE: Replace postfix by prefix increment in `for` loops in Examples

### DIFF
--- a/Examples/DataRepresentation/Image/Image5.cxx
+++ b/Examples/DataRepresentation/Image/Image5.cxx
@@ -184,15 +184,15 @@ main(int argc, char * argv[])
   constexpr double radius2 = radius * radius;
   PixelType *      it = localBuffer;
 
-  for (unsigned int z = 0; z < size[2]; z++)
+  for (unsigned int z = 0; z < size[2]; ++z)
   {
     const double dz =
       static_cast<double>(z) - static_cast<double>(size[2]) / 2.0;
-    for (unsigned int y = 0; y < size[1]; y++)
+    for (unsigned int y = 0; y < size[1]; ++y)
     {
       const double dy =
         static_cast<double>(y) - static_cast<double>(size[1]) / 2.0;
-      for (unsigned int x = 0; x < size[0]; x++)
+      for (unsigned int x = 0; x < size[0]; ++x)
       {
         const double dx =
           static_cast<double>(x) - static_cast<double>(size[0]) / 2.0;

--- a/Examples/DataRepresentation/Mesh/Mesh3.cxx
+++ b/Examples/DataRepresentation/Mesh/Mesh3.cxx
@@ -103,7 +103,7 @@ main(int, char *[])
   PointType point;
 
   constexpr unsigned int numberOfPoints = 10;
-  for (unsigned int id = 0; id < numberOfPoints; id++)
+  for (unsigned int id = 0; id < numberOfPoints; ++id)
   {
     point[0] = static_cast<PointType::ValueType>(id);              // x
     point[1] = std::log(static_cast<double>(id) + itk::Math::eps); // y
@@ -129,7 +129,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   CellType::CellAutoPointer line;
   const unsigned int        numberOfCells = numberOfPoints - 1;
-  for (unsigned int cellId = 0; cellId < numberOfCells; cellId++)
+  for (unsigned int cellId = 0; cellId < numberOfCells; ++cellId)
   {
     line.TakeOwnership(new LineType);
     line->SetPointId(0, cellId);     // first point
@@ -155,7 +155,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  for (unsigned int cellId = 0; cellId < numberOfCells; cellId++)
+  for (unsigned int cellId = 0; cellId < numberOfCells; ++cellId)
   {
     mesh->SetCellData(cellId, static_cast<PixelType>(cellId * cellId));
   }

--- a/Examples/DataRepresentation/Mesh/MeshKComplex.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshKComplex.cxx
@@ -599,7 +599,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   dimension = 0;
-  for (unsigned int b0 = 0; b0 < n0; b0++)
+  for (unsigned int b0 = 0; b0 < n0; ++b0)
   {
     MeshType::CellIdentifier id;
     bool found = mesh->GetBoundaryAssignment(dimension, cellId, b0, &id);
@@ -610,7 +610,7 @@ main(int, char *[])
 
   dimension = 1;
   std::cout << "Boundary features of dimension " << dimension << std::endl;
-  for (unsigned int b1 = 0; b1 < n1; b1++)
+  for (unsigned int b1 = 0; b1 < n1; ++b1)
   {
     MeshType::CellIdentifier id;
     bool found = mesh->GetBoundaryAssignment(dimension, cellId, b1, &id);
@@ -622,7 +622,7 @@ main(int, char *[])
 
   dimension = 2;
   std::cout << "Boundary features of dimension " << dimension << std::endl;
-  for (unsigned int b2 = 0; b2 < n2; b2++)
+  for (unsigned int b2 = 0; b2 < n2; ++b2)
   {
     MeshType::CellIdentifier id;
     bool found = mesh->GetBoundaryAssignment(dimension, cellId, b2, &id);
@@ -654,7 +654,7 @@ main(int, char *[])
   std::cout << "Boundary features of dimension " << dimension;
   n1 = mesh->GetNumberOfCellBoundaryFeatures(dimension, cellId);
   std::cout << " = " << n1 << std::endl;
-  for (unsigned int b1 = 0; b1 < n1; b1++)
+  for (unsigned int b1 = 0; b1 < n1; ++b1)
   {
     MeshType::CellIdentifier id;
     bool found = mesh->GetBoundaryAssignment(dimension, cellId, b1, &id);

--- a/Examples/DataRepresentation/Mesh/MeshTraits.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshTraits.cxx
@@ -161,7 +161,7 @@ main(int, char *[])
   PointType point;
 
   constexpr unsigned int numberOfPoints = 10;
-  for (unsigned int id = 0; id < numberOfPoints; id++)
+  for (unsigned int id = 0; id < numberOfPoints; ++id)
   {
     point[0] = 1.565; // Initialize points here
     point[1] = 3.647; // with arbitrary values
@@ -190,7 +190,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   CellType::CellAutoPointer line;
   const unsigned int        numberOfCells = numberOfPoints - 1;
-  for (unsigned int cellId = 0; cellId < numberOfCells; cellId++)
+  for (unsigned int cellId = 0; cellId < numberOfCells; ++cellId)
   {
     line.TakeOwnership(new LineType);
     line->SetPointId(0, cellId);     // first point
@@ -214,7 +214,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  for (unsigned int cellId = 0; cellId < numberOfCells; cellId++)
+  for (unsigned int cellId = 0; cellId < numberOfCells; ++cellId)
   {
     CellDataType value;
     mesh->SetCellData(cellId, value);

--- a/Examples/DataRepresentation/Mesh/PointSetWithCovariantVectors.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSetWithCovariantVectors.cxx
@@ -105,7 +105,7 @@ main(int, char *[])
   unsigned int     pointId = 0;
   constexpr double radius = 300.0;
 
-  for (unsigned int i = 0; i < 360; i++)
+  for (unsigned int i = 0; i < 360; ++i)
   {
     const double angle = i * std::atan(1.0) / 45.0;
     point[0] = radius * std::sin(angle);
@@ -150,7 +150,7 @@ main(int, char *[])
   {
     point = pointIterator.Value();
     gradient = pixelIterator.Value();
-    for (unsigned int i = 0; i < Dimension; i++)
+    for (unsigned int i = 0; i < Dimension; ++i)
     {
       point[i] += gradient[i];
     }

--- a/Examples/DataRepresentation/Mesh/PointSetWithVectors.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSetWithVectors.cxx
@@ -102,7 +102,7 @@ main(int, char *[])
   unsigned int     pointId = 0;
   constexpr double radius = 300.0;
 
-  for (unsigned int i = 0; i < 360; i++)
+  for (unsigned int i = 0; i < 360; ++i)
   {
     const double angle = i * itk::Math::pi / 180.0;
     point[0] = radius * std::sin(angle);

--- a/Examples/DataRepresentation/Mesh/RGBPointSet.cxx
+++ b/Examples/DataRepresentation/Mesh/RGBPointSet.cxx
@@ -80,7 +80,7 @@ main(int, char *[])
   unsigned int            pointId = 0;
   constexpr double        radius = 3.0;
 
-  for (unsigned int i = 0; i < 360; i++)
+  for (unsigned int i = 0; i < 360; ++i)
   {
     const double angle = i * itk::Math::pi / 180.0;
     point[0] = radius * std::sin(angle);

--- a/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
@@ -214,7 +214,7 @@ main(int argc, char * argv[])
   // In this for loop, we will extract the 'n' gradient images + 1 reference
   // image from the DWI Vector image.
   //
-  for (unsigned int i = 0; i < numberOfImages; i++)
+  for (unsigned int i = 0; i < numberOfImages; ++i)
   {
     GradientImageType::Pointer image = GradientImageType::New();
     image->CopyInformation(img);
@@ -242,7 +242,7 @@ main(int argc, char * argv[])
   {
     unsigned int referenceImageIndex = 0;
     using GradientWriterType = itk::ImageFileWriter<GradientImageType>;
-    for (unsigned int i = 0; i < numberOfImages; i++)
+    for (unsigned int i = 0; i < numberOfImages; ++i)
     {
       GradientWriterType::Pointer gradientWriter = GradientWriterType::New();
       gradientWriter->SetInput(imageContainer[i]);

--- a/Examples/Filtering/DigitallyReconstructedRadiograph1.cxx
+++ b/Examples/Filtering/DigitallyReconstructedRadiograph1.cxx
@@ -469,7 +469,7 @@ main(int argc, char * argv[])
     region.Print(std::cout);
 
     std::cout << "  Resolution: [";
-    for (i = 0; i < Dimension; i++)
+    for (i = 0; i < Dimension; ++i)
     {
       std::cout << spacing[i];
       if (i < Dimension - 1)
@@ -479,7 +479,7 @@ main(int argc, char * argv[])
 
     const InputImageType::PointType origin = image->GetOrigin();
     std::cout << "  Origin: [";
-    for (i = 0; i < Dimension; i++)
+    for (i = 0; i < Dimension; ++i)
     {
       std::cout << origin[i];
       if (i < Dimension - 1)

--- a/Examples/Filtering/FFTDirectInverse.cxx
+++ b/Examples/Filtering/FFTDirectInverse.cxx
@@ -87,7 +87,7 @@ main(int argc, char * argv[])
   inputsize = inputreader->GetOutput()->GetLargestPossibleRegion().GetSize();
 
   // worksize is the nearest multiple of 2 larger than the input
-  for (unsigned int i = 0; i < 2; i++)
+  for (unsigned int i = 0; i < 2; ++i)
   {
     unsigned int n = 0;
     worksize[i] = inputsize[i];

--- a/Examples/Filtering/ScaleSpaceGenerator2D.cxx
+++ b/Examples/Filtering/ScaleSpaceGenerator2D.cxx
@@ -86,7 +86,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   int numberOfSlices = std::stoi(argv[3]);
-  for (int slice = 0; slice < numberOfSlices; slice++)
+  for (int slice = 0; slice < numberOfSlices; ++slice)
   {
     std::ostringstream filename;
     filename << argv[2] << std::setfill('0') << std::setw(3) << slice

--- a/Examples/Filtering/SpatialObjectToImage3.cxx
+++ b/Examples/Filtering/SpatialObjectToImage3.cxx
@@ -159,7 +159,7 @@ main(int argc, char * argv[])
 
   typename PolygonType::PolygonPointType polygonPoint;
 
-  for (unsigned int i = 0; i < numberOfPoints; i++)
+  for (unsigned int i = 0; i < numberOfPoints; ++i)
   {
     const double angle = 2.0 * itk::Math::pi * i / numberOfPoints;
     radial[0] = radius * std::cos(angle);

--- a/Examples/IO/XML/itkParticleSwarmOptimizerDOMReader.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerDOMReader.cxx
@@ -111,7 +111,7 @@ ParticleSwarmOptimizerDOMReader::GenerateData(const DOMNodeType * inputdom,
     s.ToData(ubound); // read all data elements in the string
     // combine the two
     ParticleSwarmOptimizer::ParameterBoundsType bounds;
-    for (size_t i = 0; i < lbound.size(); i++)
+    for (size_t i = 0; i < lbound.size(); ++i)
     {
       std::pair<double, double> value;
       value.first = lbound[i];

--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.cxx
@@ -97,7 +97,7 @@ ParticleSwarmOptimizerSAXReader::EndElement(const char * name)
     // all children have been read, now incorporate them into the output
     // object
     ParticleSwarmOptimizer::ParameterBoundsType bounds;
-    for (size_t i = 0; i < this->m_LowerBound.size(); i++)
+    for (size_t i = 0; i < this->m_LowerBound.size(); ++i)
     {
       std::pair<double, double> value;
       value.first = this->m_LowerBound[i];
@@ -146,7 +146,7 @@ ParticleSwarmOptimizerSAXReader::CharacterDataHandler(const char * inData,
 
     Array<double> ptols(
       static_cast<Array<double>::SizeValueType>(data.size()));
-    for (unsigned int i = 0; i < data.size(); i++)
+    for (unsigned int i = 0; i < data.size(); ++i)
     {
       ptols[i] = data[i];
     }

--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.cxx
@@ -127,7 +127,7 @@ ParticleSwarmOptimizerSAXWriter::WriteFile()
     // Note: The data-cast to unsigned int is required
     //       because itk::Array only supports 'unsigned int' number of
     //       elements.
-    for (unsigned int i = 0; i < ptols.GetSize(); i++)
+    for (unsigned int i = 0; i < ptols.GetSize(); ++i)
     {
       ofs << " " << ptols[i];
     }

--- a/Examples/Iterators/ImageLinearIteratorWithIndex2.cxx
+++ b/Examples/Iterators/ImageLinearIteratorWithIndex2.cxx
@@ -121,7 +121,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     size3D[i] = size4D[i];
     index3D[i] = index4D[i];

--- a/Examples/Iterators/ImageRegionIterator.cxx
+++ b/Examples/Iterators/ImageRegionIterator.cxx
@@ -174,7 +174,7 @@ main(int argc, char * argv[])
   const ImageType::PointType & inputOrigin = reader->GetOutput()->GetOrigin();
   double                       outputOrigin[Dimension];
 
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     outputOrigin[i] = inputOrigin[i] + spacing[i] * inputStart[i];
   }

--- a/Examples/Iterators/NeighborhoodIterators6.cxx
+++ b/Examples/Iterators/NeighborhoodIterators6.cxx
@@ -173,7 +173,7 @@ main(int argc, char ** argv)
     flag = false;
 
     PixelType min = it.GetCenterPixel();
-    for (unsigned i = 0; i < it.Size(); i++)
+    for (unsigned i = 0; i < it.Size(); ++i)
     {
       if (it.GetPixel(i) < min)
       {

--- a/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
@@ -174,9 +174,9 @@ main(int argc, char ** argv)
     // Creates a circular structuring element by activating all the pixels
     // less than radius distance from the center of the neighborhood.
 
-    for (float y = -rad; y <= rad; y++)
+    for (float y = -rad; y <= rad; ++y)
     {
-      for (float x = -rad; x <= rad; x++)
+      for (float x = -rad; x <= rad; ++x)
       {
         ShapedNeighborhoodIteratorType::OffsetType off;
 
@@ -211,7 +211,7 @@ main(int argc, char ** argv)
       ShapedNeighborhoodIteratorType::ConstIterator ci;
 
       bool flag = true;
-      for (ci = it.Begin(); ci != it.End(); ci++)
+      for (ci = it.Begin(); ci != it.End(); ++ci)
       {
         if (ci.Get() == background_value)
         {

--- a/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
@@ -95,9 +95,9 @@ main(int argc, char ** argv)
 
     // Creates a circular structuring element by activating all the pixels
     // less than radius distance from the center of the neighborhood.
-    for (float y = -rad; y <= rad; y++)
+    for (float y = -rad; y <= rad; ++y)
     {
-      for (float x = -rad; x <= rad; x++)
+      for (float x = -rad; x <= rad; ++x)
       {
         ShapedNeighborhoodIteratorType::OffsetType off;
 
@@ -126,7 +126,7 @@ main(int argc, char ** argv)
       ShapedNeighborhoodIteratorType::ConstIterator ci;
 
       bool flag = false;
-      for (ci = it.Begin(); ci != it.End(); ci++)
+      for (ci = it.Begin(); ci != it.End(); ++ci)
       {
         if (ci.Get() != background_value)
         {

--- a/Examples/Numerics/FourierDescriptors1.cxx
+++ b/Examples/Numerics/FourierDescriptors1.cxx
@@ -132,7 +132,7 @@ main(int argc, char * argv[])
   PointIterator pointItr = points->Begin();
 
   PointType point;
-  for (unsigned int pt = 0; pt < numberOfPoints; pt++)
+  for (unsigned int pt = 0; pt < numberOfPoints; ++pt)
   {
     inputFile >> point[0] >> point[1];
     pointItr.Value() = point;
@@ -182,7 +182,7 @@ main(int argc, char * argv[])
   FFTSpectrumType signal(spectrumSize);
 
   pointItr = points->Begin();
-  for (unsigned int p = 0; p < numberOfPoints; p++)
+  for (unsigned int p = 0; p < numberOfPoints; ++p)
   {
     signal[p] = FFTCoefficientType(pointItr.Value()[0], pointItr.Value()[1]);
     ++pointItr;
@@ -199,7 +199,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  for (unsigned int pad = numberOfPoints; pad < spectrumSize; pad++)
+  for (unsigned int pad = numberOfPoints; pad < spectrumSize; ++pad)
   {
     signal[pad] = 0.0;
   }
@@ -213,7 +213,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   std::cout << "Input to the FFT transform" << std::endl;
-  for (unsigned int s = 0; s < spectrumSize; s++)
+  for (unsigned int s = 0; s < spectrumSize; ++s)
   {
     std::cout << s << " : ";
     std::cout << signal[s] << std::endl;
@@ -240,7 +240,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   std::cout << std::endl;
   std::cout << "Result from the FFT transform" << std::endl;
-  for (unsigned int k = 0; k < spectrumSize; k++)
+  for (unsigned int k = 0; k < spectrumSize; ++k)
   {
     const double real = signal[k].real();
     const double imag = signal[k].imag();

--- a/Examples/RegistrationITKv4/BSplineWarping1.cxx
+++ b/Examples/RegistrationITKv4/BSplineWarping1.cxx
@@ -210,7 +210,7 @@ main(int argc, char * argv[])
   TransformType::PhysicalDimensionsType fixedPhysicalDimensions;
   TransformType::MeshSizeType           meshSize;
 
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     fixedPhysicalDimensions[i] =
       fixedSpacing[i] * static_cast<double>(fixedSize[i] - 1);

--- a/Examples/RegistrationITKv4/BSplineWarping2.cxx
+++ b/Examples/RegistrationITKv4/BSplineWarping2.cxx
@@ -208,7 +208,7 @@ main(int argc, char * argv[])
   TransformType::PhysicalDimensionsType fixedPhysicalDimensions;
   TransformType::MeshSizeType           meshSize;
 
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     fixedPhysicalDimensions[i] =
       fixedSpacing[i] * static_cast<double>(fixedSize[i] - 1);
@@ -259,7 +259,7 @@ main(int argc, char * argv[])
 
   infile.open(argv[1]);
 
-  for (unsigned int n = 0; n < numberOfNodes; n++)
+  for (unsigned int n = 0; n < numberOfNodes; ++n)
   {
     infile >> parameters[n];                     // X coordinate
     infile >> parameters[n + numberOfNodes];     // Y coordinate

--- a/Examples/RegistrationITKv4/ChangeInformationImageFilter.cxx
+++ b/Examples/RegistrationITKv4/ChangeInformationImageFilter.cxx
@@ -126,7 +126,7 @@ main(int argc, char * argv[])
   if (argc > 3)
   {
     double scale = std::stod(argv[3]);
-    for (unsigned int i = 0; i < Dimension; i++)
+    for (unsigned int i = 0; i < Dimension; ++i)
     {
       spacing[i] *= scale;
     }

--- a/Examples/RegistrationITKv4/DeformableRegistration12.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration12.cxx
@@ -195,7 +195,7 @@ main(int argc, char * argv[])
   TransformType::MeshSizeType           meshSize;
   TransformType::OriginType             fixedOrigin;
 
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     fixedOrigin[i] = fixedImage->GetOrigin()[i];
     fixedPhysicalDimensions[i] =

--- a/Examples/RegistrationITKv4/DeformableRegistration13.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration13.cxx
@@ -207,7 +207,7 @@ main(int argc, char * argv[])
   TransformType::MeshSizeType           meshSize;
   TransformType::OriginType             fixedOrigin;
 
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     fixedOrigin[i] = fixedImage->GetOrigin()[i];
     fixedPhysicalDimensions[i] =

--- a/Examples/RegistrationITKv4/DeformableRegistration14.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration14.cxx
@@ -182,7 +182,7 @@ main(int argc, char * argv[])
   TransformType::MeshSizeType           meshSize;
   TransformType::OriginType             fixedOrigin;
 
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     fixedOrigin[i] = fixedImage->GetOrigin()[i];
     fixedPhysicalDimensions[i] =

--- a/Examples/RegistrationITKv4/DeformableRegistration15.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration15.cxx
@@ -420,7 +420,7 @@ main(int argc, char * argv[])
   DeformableTransformType::MeshSizeType           meshSize;
   DeformableTransformType::OriginType             fixedOrigin;
 
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     fixedOrigin[i] = fixedImage->GetOrigin()[i];
     fixedPhysicalDimensions[i] =
@@ -575,7 +575,7 @@ main(int argc, char * argv[])
 
   unsigned int counter = 0;
 
-  for (unsigned int k = 0; k < SpaceDimension; k++)
+  for (unsigned int k = 0; k < SpaceDimension; ++k)
   {
     using ParametersImageType = DeformableTransformType::ImageType;
     using ResamplerType =

--- a/Examples/RegistrationITKv4/DeformableRegistration6.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration6.cxx
@@ -286,7 +286,7 @@ main(int argc, char * argv[])
 
   // First, get fixed image physical dimensions
   TransformType::PhysicalDimensionsType fixedPhysicalDimensions;
-  for (unsigned int i = 0; i < SpaceDimension; i++)
+  for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
     fixedPhysicalDimensions[i] =
       fixedImage->GetSpacing()[i] *
@@ -295,7 +295,7 @@ main(int argc, char * argv[])
   }
 
   // Create the transform adaptors specific to B-splines
-  for (unsigned int level = 0; level < numberOfLevels; level++)
+  for (unsigned int level = 0; level < numberOfLevels; ++level)
   {
     using ShrinkFilterType =
       itk::ShrinkImageFilter<FixedImageType, FixedImageType>;
@@ -308,7 +308,7 @@ main(int argc, char * argv[])
     // level
     //
     TransformType::MeshSizeType requiredMeshSize;
-    for (unsigned int d = 0; d < ImageDimension; d++)
+    for (unsigned int d = 0; d < ImageDimension; ++d)
     {
       requiredMeshSize[d] = meshSize[d] << level;
     }

--- a/Examples/RegistrationITKv4/MeanSquaresImageMetric1.cxx
+++ b/Examples/RegistrationITKv4/MeanSquaresImageMetric1.cxx
@@ -193,9 +193,9 @@ main(int argc, char * argv[])
   constexpr int rangex = 50;
   constexpr int rangey = 50;
 
-  for (int dx = -rangex; dx <= rangex; dx++)
+  for (int dx = -rangex; dx <= rangex; ++dx)
   {
-    for (int dy = -rangey; dy <= rangey; dy++)
+    for (int dy = -rangey; dy <= rangey; ++dy)
     {
       displacement[0] = dx;
       displacement[1] = dy;

--- a/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
@@ -782,7 +782,7 @@ main(int argc, char * argv[])
   parametersScale.set_size(3);
   parametersScale[0] = 1000; // angle scale
 
-  for (unsigned int i = 1; i < 3; i++)
+  for (unsigned int i = 1; i < 3; ++i)
   {
     parametersScale[i] = 2; // offset scale
   }

--- a/Examples/RegistrationITKv4/ModelToImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/ModelToImageRegistration2.cxx
@@ -115,7 +115,7 @@ public:
 
     double magnitude2 = 0.0;
 
-    for (unsigned int i = 0; i < gradient.size(); i++)
+    for (unsigned int i = 0; i < gradient.size(); ++i)
     {
       const double fc = gradient[i] / scales[i];
       magnitude2 += fc * fc;

--- a/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
+++ b/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
@@ -208,7 +208,7 @@ main(int argc, char * argv[])
     index = fi.GetIndex();
     field->TransformIndexToPhysicalPoint(index, point1);
     point2 = tps->TransformPoint(point1);
-    for (unsigned int i = 0; i < ImageDimension; i++)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       displacement[i] = point2[i] - point1[i];
     }

--- a/Examples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx
@@ -825,7 +825,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   OptimizerType::ScalesType scales(shape->GetNumberOfParameters());
   scales.Fill(1.0);
-  for (unsigned int k = 0; k < numberOfPCAModes; k++)
+  for (unsigned int k = 0; k < numberOfPCAModes; ++k)
   {
     scales[k] = 20.0; // scales for the pca mode multiplier
   }

--- a/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
@@ -280,7 +280,7 @@ main(int argc, char * argv[])
       localOutputImage->GetLargestPossibleRegion().GetSize();
     float diag = std::sqrt((float)(size[0] * size[0] + size[1] * size[1]));
 
-    for (auto i = static_cast<int>(-diag); i < static_cast<int>(diag); i++)
+    for (auto i = static_cast<int>(-diag); i < static_cast<int>(diag); ++i)
     {
       localIndex[0] = (long int)(u[0] + i * v[0]);
       localIndex[1] = (long int)(u[1] + i * v[1]);

--- a/Examples/SpatialObjects/BlobSpatialObject.cxx
+++ b/Examples/SpatialObjects/BlobSpatialObject.cxx
@@ -79,7 +79,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   BlobType::BlobPointListType list;
 
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 4; ++i)
   {
     BlobPointType p;
     PointType     pnt;

--- a/Examples/SpatialObjects/DTITubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/DTITubeSpatialObject.cxx
@@ -99,7 +99,7 @@ main(int, char *[])
     p.AddField("Lambda2", 5 * i);
     p.AddField("Lambda3", 6 * i);
     auto * v = new float[6];
-    for (unsigned int k = 0; k < 6; k++)
+    for (unsigned int k = 0; k < 6; ++k)
     {
       v[k] = k;
     }

--- a/Examples/SpatialObjects/SurfaceSpatialObject.cxx
+++ b/Examples/SpatialObjects/SurfaceSpatialObject.cxx
@@ -67,7 +67,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   SurfaceType::SurfacePointListType list;
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     SurfacePointType p;
     PointType        pnt;
@@ -77,7 +77,7 @@ main(int, char *[])
     p.SetPositionInObjectSpace(pnt);
     p.SetColor(1, 0, 0, 1);
     CovariantVectorType normal;
-    for (unsigned int j = 0; j < 3; j++)
+    for (unsigned int j = 0; j < 3; ++j)
     {
       normal[j] = j;
     }

--- a/Examples/Statistics/ExpectationMaximizationMixtureModelEstimator.cxx
+++ b/Examples/Statistics/ExpectationMaximizationMixtureModelEstimator.cxx
@@ -201,7 +201,7 @@ main()
     itk::Statistics::GaussianMixtureModelComponent<SampleType>;
 
   std::vector<ComponentType::Pointer> components;
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     components.push_back(ComponentType::New());
     (components[i])->SetSample(sample);

--- a/Examples/Statistics/ImageHistogram2.cxx
+++ b/Examples/Statistics/ImageHistogram2.cxx
@@ -177,7 +177,7 @@ main(int argc, char * argv[])
   std::cout << "Histogram size " << histogramSize << std::endl;
 
   unsigned int bin;
-  for (bin = 0; bin < histogramSize; bin++)
+  for (bin = 0; bin < histogramSize; ++bin)
   {
     std::cout << "bin = " << bin << " frequency = ";
     std::cout << histogram->GetFrequency(bin, 0) << std::endl;

--- a/Examples/Statistics/KdTreeBasedKMeansClustering.cxx
+++ b/Examples/Statistics/KdTreeBasedKMeansClustering.cxx
@@ -361,13 +361,13 @@ main()
     membershipFunctionVectorObject->Get();
 
   int index = 0;
-  for (unsigned int i = 0; i < 2; i++)
+  for (unsigned int i = 0; i < 2; ++i)
   {
     MembershipFunctionType::Pointer membershipFunction =
       MembershipFunctionType::New();
     MembershipFunctionType::CentroidType centroid(
       sample->GetMeasurementVectorSize());
-    for (unsigned int j = 0; j < sample->GetMeasurementVectorSize(); j++)
+    for (unsigned int j = 0; j < sample->GetMeasurementVectorSize(); ++j)
     {
       centroid[j] = estimatedMeans[index++];
     }

--- a/Examples/Statistics/ScalarImageKmeansClassifier.cxx
+++ b/Examples/Statistics/ScalarImageKmeansClassifier.cxx
@@ -146,7 +146,7 @@ main(int argc, char * argv[])
 
 
   // Software Guide : BeginCodeSnippet
-  for (unsigned k = 0; k < numberOfInitialClasses; k++)
+  for (unsigned k = 0; k < numberOfInitialClasses; ++k)
   {
     const double userProvidedInitialMean = std::stod(argv[k + argoffset]);
     kmeansFilter->AddClassWithInitialMean(userProvidedInitialMean);

--- a/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
+++ b/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
@@ -279,7 +279,7 @@ main(int argc, char * argv[])
 
   double                               meanDistance = 0;
   MembershipFunctionType::CentroidType centroid(1);
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     MembershipFunctionPointer membershipFunction =
       MembershipFunctionType::New();


### PR DESCRIPTION
Applied to the root of ITK, at the GNU bash prompt:

    find . \( -iname *.cxx -or -iname *.hxx -or -iname *.h \) -exec perl -pi -w -e 's/(\s+for \(.*;.*); (\w+)\+\+\)/$1; ++$2)/g;' {} \;

(Excluded ITK/Modules/ThirdParty.)

Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2499
commit 971aef211cad336ba75cb2da114fc86e873444e5
"STYLE: Replace postfix by prefix increment in for loops in ITK/Modules"