### PR TITLE
COMP: Replace np.bool with np.bool8

### DIFF
--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -137,7 +137,7 @@ class itkCType:
         _SS: "itkCType" = itkCType("signed short", "SS", np.int16)
         _SI: "itkCType" = itkCType("signed int", "SI", np.int32)
         _SLL: "itkCType" = itkCType("signed long long", "SLL", np.int64)
-        _B: "itkCType" = itkCType("bool", "B", np.bool)
+        _B: "itkCType" = itkCType("bool", "B", np.bool8)
         return _F, _D, _UC, _US, _UI, _UL, _SL, _LD, _ULL, _SC, _SS, _SI, _SLL, _B
 
 


### PR DESCRIPTION
To address:

  itk/support/types.py:137
  `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
