### PR TITLE
ENH: Propagate StatisticsLabelMapFilter's default NumberOfBins

### DIFF
--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
@@ -31,7 +31,7 @@ BinaryImageToStatisticsLabelMapFilter<TInputImage, TFeatureImage, TOutputImage>:
   m_FullyConnected = false;
   m_ComputeFeretDiameter = false;
   m_ComputePerimeter = true;
-  m_NumberOfBins = 128;
+  m_NumberOfBins = LabelObjectValuatorType::GetDefaultNumberOfBins();
   m_ComputeHistogram = true;
   this->SetNumberOfRequiredInputs(2);
 }

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.hxx
@@ -29,7 +29,7 @@ LabelImageToStatisticsLabelMapFilter<TInputImage, TFeatureImage, TOutputImage>::
   m_BackgroundValue = NumericTraits<OutputImagePixelType>::NonpositiveMin();
   m_ComputeFeretDiameter = false;
   m_ComputePerimeter = true;
-  m_NumberOfBins = 128;
+  m_NumberOfBins = LabelObjectValuatorType::GetDefaultNumberOfBins();
   m_ComputeHistogram = true;
   this->SetNumberOfRequiredInputs(2);
 }

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -133,6 +133,15 @@ public:
   itkSetMacro(NumberOfBins, unsigned int);
   itkGetConstReferenceMacro(NumberOfBins, unsigned int);
 
+  // Set the default number of bins to match the number of values for 8 or 16-bit integers; otherwise 128
+  static constexpr unsigned int
+  GetDefaultNumberOfBins()
+  {
+    return NumericTraits<FeatureImagePixelType>::IsInteger && sizeof(FeatureImagePixelType) <= 2
+             ? 1 << (8 * sizeof(FeatureImagePixelType))
+             : 128;
+  }
+
 protected:
   StatisticsLabelMapFilter();
   ~StatisticsLabelMapFilter() override = default;
@@ -149,13 +158,8 @@ protected:
 private:
   FeatureImagePixelType m_Minimum{ NumericTraits<FeatureImagePixelType>::ZeroValue() };
   FeatureImagePixelType m_Maximum{ NumericTraits<FeatureImagePixelType>::ZeroValue() };
-  // Set the number of bins to match the number of values for 8,16-bit integers.
-  static constexpr bool m_DefaultNumberOfBinsToNumberOfValues =
-    NumericTraits<typename Self::FeatureImagePixelType>::IsInteger && sizeof(typename Self::FeatureImagePixelType) <= 2;
-  unsigned int m_NumberOfBins{ m_DefaultNumberOfBinsToNumberOfValues
-                                 ? 1 << (8 * sizeof(typename Self::FeatureImagePixelType))
-                                 : 128 };
-  bool         m_ComputeHistogram{ true };
+  unsigned int          m_NumberOfBins{ GetDefaultNumberOfBins() };
+  bool                  m_ComputeHistogram{ true };
 }; // end of class
 } // end namespace itk
 


### PR DESCRIPTION
Addresses https://github.com/InsightSoftwareConsortium/ITK/pull/2514#issuecomment-830062366.  This pull request propagates the new behavior for the default `NumberOfBins` from `itk::StatisticsLabelMapFilter` to `itk::BinaryImageToStatisticsLabelMapFilter` and `itk::LabelImageToStatisticsLabelMapFilter`.


## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)