### PR TITLE
BUG: Fix Python wrapping labeler action regex

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -58,7 +58,7 @@ area:Python wrapping:
     - "Modules/Generators/Python/*"
     - "Modules/.*/wrapping/*"
     - ".*.notwrapped"
-    - ".*.py*"
+    - ".*.py.*"
     - ".*.wrap"
 
 area:Registration:


### PR DESCRIPTION
Fix Python wrapping labeler action regex: make filename extensions
contain the `.py` string.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)KSphinxExamples) for all new major features (if any)