### PR TITLE
BUG: Ellipsis is not iterable

### DIFF
--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -825,7 +825,7 @@ def {snakeCase}(*args{args_typehint}, {kwargs_typehints}**kwargs){return_typehin
     import itk
 
     kwarg_typehints = {{ {kwarg_dict} }}
-    specified_kwarg_typehints = {{ k:v for (k,v) in kwarg_typehints.items() if kwarg_typehints[k] != ... }}
+    specified_kwarg_typehints = {{ k:v for (k,v) in kwarg_typehints.items() if kwarg_typehints[k] is not ... }}
     kwargs.update(specified_kwarg_typehints)
 
     instance = itk.{processObject}.New(*args, **kwargs)


### PR DESCRIPTION
Addresses #2520.

A `__eq__` method test for inequality with `...` (ellipsis) was failing because the test in question was implemented with `tuple(self) == tuple(other)`; and `tuple(...)` is an illegal operation because ellipsis is not an iterable.  This pull request replaces the test `!= ...` with `is not ...`.  This is in generated Python code for wrapping ITK objects and is part of the type hints mechanism.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)