### PR TITLE
BUG: Fixes for median calculation

### DIFF
--- a/Modules/Filtering/LabelMap/ITKKWStyleOverwrite.txt
+++ b/Modules/Filtering/LabelMap/ITKKWStyleOverwrite.txt
@@ -1,4 +1,5 @@
 test/*\.cxx Namespace Disable
 test/itkAttributePositionLabelMapFilterTest1.cxx Namespace Disable
 test/itkShapeLabelMapFilterGTest.cxx Namespace Disable
+test/itkStatisticsLabelMapFilterGTest.cxx Namespace Disable
 test/itkShapeLabelObjectAccessorsTest1.cxx SemicolonSpace Disable

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
@@ -31,7 +31,7 @@ BinaryImageToStatisticsLabelMapFilter<TInputImage, TFeatureImage, TOutputImage>:
   m_FullyConnected = false;
   m_ComputeFeretDiameter = false;
   m_ComputePerimeter = true;
-  m_NumberOfBins = 128;
+  m_NumberOfBins = LabelObjectValuatorType::GetDefaultNumberOfBins();
   m_ComputeHistogram = true;
   this->SetNumberOfRequiredInputs(2);
 }

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.hxx
@@ -29,7 +29,7 @@ LabelImageToStatisticsLabelMapFilter<TInputImage, TFeatureImage, TOutputImage>::
   m_BackgroundValue = NumericTraits<OutputImagePixelType>::NonpositiveMin();
   m_ComputeFeretDiameter = false;
   m_ComputePerimeter = true;
-  m_NumberOfBins = 128;
+  m_NumberOfBins = LabelObjectValuatorType::GetDefaultNumberOfBins();
   m_ComputeHistogram = true;
   this->SetNumberOfRequiredInputs(2);
 }

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -133,6 +133,15 @@ public:
   itkSetMacro(NumberOfBins, unsigned int);
   itkGetConstReferenceMacro(NumberOfBins, unsigned int);
 
+  // Set the default number of bins to match the number of values for 8 or 16-bit integers; otherwise 128
+  static constexpr unsigned int
+  GetDefaultNumberOfBins()
+  {
+    return NumericTraits<FeatureImagePixelType>::IsInteger && sizeof(FeatureImagePixelType) <= 2
+             ? 1 << (8 * sizeof(FeatureImagePixelType))
+             : 128;
+  }
+
 protected:
   StatisticsLabelMapFilter();
   ~StatisticsLabelMapFilter() override = default;
@@ -149,13 +158,8 @@ protected:
 private:
   FeatureImagePixelType m_Minimum{ NumericTraits<FeatureImagePixelType>::ZeroValue() };
   FeatureImagePixelType m_Maximum{ NumericTraits<FeatureImagePixelType>::ZeroValue() };
-  // Set the number of bins to match the number of values for 8,16-bit integers.
-  static constexpr bool m_DefaultNumberOfBinsToNumberOfValues =
-    NumericTraits<typename Self::FeatureImagePixelType>::IsInteger && sizeof(typename Self::FeatureImagePixelType) <= 2;
-  unsigned int m_NumberOfBins{ m_DefaultNumberOfBinsToNumberOfValues
-                                 ? 1 << (8 * sizeof(typename Self::FeatureImagePixelType))
-                                 : 128 };
-  bool         m_ComputeHistogram{ true };
+  unsigned int          m_NumberOfBins{ GetDefaultNumberOfBins() };
+  bool                  m_ComputeHistogram{ true };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -147,10 +147,15 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  FeatureImagePixelType m_Minimum;
-  FeatureImagePixelType m_Maximum;
-  unsigned int          m_NumberOfBins;
-  bool                  m_ComputeHistogram;
+  FeatureImagePixelType m_Minimum{ NumericTraits<FeatureImagePixelType>::ZeroValue() };
+  FeatureImagePixelType m_Maximum{ NumericTraits<FeatureImagePixelType>::ZeroValue() };
+  // Set the number of bins to match the number of values for 8,16-bit integers.
+  static constexpr bool m_DefaultNumberOfBinsToNumberOfValues =
+    NumericTraits<typename Self::FeatureImagePixelType>::IsInteger && sizeof(typename Self::FeatureImagePixelType) <= 2;
+  unsigned int m_NumberOfBins{ m_DefaultNumberOfBinsToNumberOfValues
+                                 ? 1 << (8 * sizeof(typename Self::FeatureImagePixelType))
+                                 : 128 };
+  bool         m_ComputeHistogram{ true };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -177,15 +177,28 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
   }
 
   // the median
-  double median = 0;
-  double count = 0; // will not be fully set, so do not use later !
-  for (SizeValueType i = 0; i < histogram->Size(); i++)
+  double median = 0.0;
+  double count = 0.0; // will not be fully set, so do not use later !
+  for (SizeValueType i = 0; i < histogram->Size(); ++i)
   {
     count += histogram->GetFrequency(i);
 
     if (count >= (totalFreq / 2))
     {
       median = histogram->GetMeasurementVector(i)[0];
+      // If there are an even number of elements average with the next bin with elements
+      if (labelObject->Size() % 2 == 0 && count == totalFreq / 2)
+      {
+        while (++i < histogram->Size())
+        {
+          if (histogram->GetFrequency(i) > 0)
+          {
+            median += histogram->GetMeasurementVector(i)[0];
+            median *= 0.5;
+            break;
+          }
+        }
+      }
       break;
     }
   }

--- a/Modules/Filtering/LabelMap/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/test/CMakeLists.txt
@@ -273,7 +273,7 @@ itk_add_test(NAME itkLabelImageToStatisticsLabelMapFilterTest1
       COMMAND ITKLabelMapTestDriver
     --compare DATA{${ITK_DATA_ROOT}/Input/Spots.png}
               ${ITK_TEST_OUTPUT_DIR}/Spots-labelimage-to-statisticslabel.png
-    itkLabelImageToStatisticsLabelMapFilterTest1 DATA{${ITK_DATA_ROOT}/Input/Spots.png} DATA{${ITK_DATA_ROOT}/Input/Spots.png} ${ITK_TEST_OUTPUT_DIR}/Spots-labelimage-to-statisticslabel.png 0 1 1 1 128)
+    itkLabelImageToStatisticsLabelMapFilterTest1 DATA{${ITK_DATA_ROOT}/Input/Spots.png} DATA{${ITK_DATA_ROOT}/Input/Spots.png} ${ITK_TEST_OUTPUT_DIR}/Spots-labelimage-to-statisticslabel.png 0 1 1 1 256)
 itk_add_test(NAME itkLabelMapFilterTest
       COMMAND ITKLabelMapTestDriver itkLabelMapFilterTest)
 itk_add_test(NAME itkLabelMapMaskImageFilterTest-0-0-0
@@ -598,6 +598,7 @@ itk_add_test(NAME itkStatisticsUniqueLabelMapFilterTest2
       1 100)
 
 set(ITKLabelMapGTests
-  itkShapeLabelMapFilterGTest.cxx)
+  itkShapeLabelMapFilterGTest.cxx
+  itkStatisticsLabelMapFilterGTest.cxx)
 
 CreateGoogleTestDriver(ITKLabelMap "${ITKLabelMap-Test_LIBRARIES}" "${ITKLabelMapGTests}")

--- a/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
@@ -1,0 +1,251 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+
+#include "itkImage.h"
+#include "itkLabelImageToStatisticsLabelMapFilter.h"
+#include "itkImageRegionIterator.h"
+#include <algorithm>
+
+
+namespace
+{
+
+class StatisticsLabelMapFixture : public ::testing::Test
+{
+public:
+  StatisticsLabelMapFixture() = default;
+  ~StatisticsLabelMapFixture() override = default;
+
+protected:
+  void
+  SetUp() override
+  {}
+  void
+  TearDown() override
+  {}
+
+  template <unsigned int D, typename TPixelType = unsigned short>
+  struct FixtureUtilities
+  {
+    static const unsigned int Dimension = D;
+
+    using PixelType = TPixelType;
+    using ImageType = itk::Image<PixelType, Dimension>;
+
+    using LabelPixelType = unsigned char;
+    using LabelImageType = itk::Image<LabelPixelType, Dimension>;
+
+    using LabelObjectType = itk::StatisticsLabelObject<LabelPixelType, Dimension>;
+    using StatisticsLabelMapType = itk::LabelMap<LabelObjectType>;
+
+
+    static typename ImageType::Pointer
+    CreateImage()
+    {
+      typename ImageType::Pointer image = ImageType::New();
+
+      typename ImageType::SizeType imageSize;
+      imageSize.Fill(25);
+      image->SetRegions(typename ImageType::RegionType(imageSize));
+      image->Allocate();
+      image->FillBuffer(0);
+
+      return image;
+    }
+
+    static typename ImageType::Pointer
+    CreateImageRandom(PixelType randMax = 500, unsigned int randSeed = 0)
+    {
+      typename ImageType::Pointer image = ImageType::New();
+
+      typename ImageType::SizeType imageSize;
+      imageSize.Fill(25);
+      image->SetRegions(typename ImageType::RegionType(imageSize));
+      image->Allocate();
+      image->FillBuffer(0);
+
+      srand(randSeed);
+
+      itk::ImageRegionIterator<ImageType> it(image, image->GetLargestPossibleRegion());
+      while (!it.IsAtEnd())
+      {
+        it.Set(rand() % randMax);
+        ++it;
+      }
+      return image;
+    }
+
+
+    static typename LabelImageType::Pointer
+    CreateLabelImage()
+    {
+      auto image = LabelImageType::New();
+
+      typename LabelImageType::SizeType imageSize;
+      imageSize.Fill(25);
+      image->SetRegions(typename ImageType::RegionType(imageSize));
+      image->Allocate();
+      image->FillBuffer(0);
+
+      return image;
+    }
+
+
+    static typename LabelObjectType::ConstPointer
+    ComputeLabelObject(const LabelImageType * labelImage,
+                       const ImageType *      image,
+                       const PixelType        label = 1,
+                       const size_t           numberOfBins = 0)
+    {
+
+      auto l2s = itk::LabelImageToStatisticsLabelMapFilter<LabelImageType, ImageType>::New();
+      l2s->SetInput1(labelImage);
+      l2s->SetFeatureImage(image);
+      l2s->ComputeFeretDiameterOn();
+      l2s->ComputePerimeterOn();
+      // l2s->ComputeOrientedBoundingBoxOn();
+      l2s->ComputeHistogramOn();
+      if (numberOfBins != 0)
+      {
+        l2s->SetNumberOfBins(numberOfBins);
+      }
+      l2s->Update();
+      return l2s->GetOutput()->GetLabelObject(label);
+    }
+
+    static double
+    ComputeExactMedian(const LabelObjectType * labelObject, const ImageType * image)
+    {
+      std::vector<PixelType>                       values;
+      typename LabelObjectType::ConstIndexIterator it(labelObject);
+
+      while (!it.IsAtEnd())
+      {
+        const typename ImageType::IndexType & idx = it.GetIndex();
+        values.push_back(image->GetPixel(idx));
+        ++it;
+      }
+
+      std::sort(values.begin(), values.end());
+
+      auto n1 = values.size() / 2;
+      if (values.size() % 2 == 0)
+      {
+        return 0.5 * (double(values[n1]) + double(values[n1 - 1]));
+      }
+      return values[n1];
+    }
+  };
+};
+} // namespace
+
+
+TEST_F(StatisticsLabelMapFixture, 2D_zero)
+{
+  using Utils = FixtureUtilities<2, unsigned char>;
+
+  auto image = Utils::CreateImage();
+  auto labelImage = Utils ::CreateLabelImage();
+
+  Utils::LabelPixelType label = 1;
+  labelImage->FillBuffer(label);
+
+
+  Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, 1, 1 << 8);
+
+  EXPECT_NEAR(0.0, labelObject->GetMinimum(), 1e-12);
+  EXPECT_NEAR(0.0, labelObject->GetMaximum(), 1e-12);
+  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
+  EXPECT_NEAR(0.0, labelObject->GetSum(), 1e-12);
+  EXPECT_NEAR(0.0, labelObject->GetVariance(), 1e-12);
+  EXPECT_NEAR(0.0, labelObject->GetStandardDeviation(), 1e-12);
+
+  if (::testing::Test::HasFailure())
+  {
+    labelObject->Print(std::cout);
+  }
+}
+
+
+TEST_F(StatisticsLabelMapFixture, 2D_ones_with_outliers)
+{
+  using Utils = FixtureUtilities<2, signed short>;
+
+  auto             image = Utils::CreateImage();
+  Utils::PixelType value = 1;
+  image->FillBuffer(value);
+
+  // Test with outliers outside the label.
+  image->SetPixel({ 0, 0 }, 32000);
+  image->SetPixel({ 0, 1 }, -32000);
+
+
+  auto                  labelImage = Utils ::CreateLabelImage();
+  Utils::LabelPixelType label = 1;
+  labelImage->FillBuffer(label);
+  labelImage->SetPixel({ 0, 0 }, 0);
+  labelImage->SetPixel({ 0, 1 }, 0);
+
+  Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 16);
+
+  EXPECT_NEAR(value, labelObject->GetMinimum(), 1e-12);
+  EXPECT_NEAR(value, labelObject->GetMaximum(), 1e-12);
+  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 0.5);
+  EXPECT_NEAR(25 * 25 - 2, labelObject->GetSum(), 1e-12);
+  EXPECT_NEAR(0.0, labelObject->GetVariance(), 1e-12);
+  EXPECT_NEAR(0.0, labelObject->GetStandardDeviation(), 1e-12);
+
+  if (::testing::Test::HasFailure())
+  {
+    labelObject->Print(std::cout);
+  }
+}
+
+TEST_F(StatisticsLabelMapFixture, 2D_rand_with_outliers)
+{
+  using Utils = FixtureUtilities<2, signed short>;
+
+  auto image = Utils::CreateImageRandom(500, 0);
+  auto labelImage = Utils ::CreateLabelImage();
+
+  // Test with outliers outside the label.
+  image->SetPixel({ 0, 0 }, 32000);
+  image->SetPixel({ 0, 1 }, -2000);
+  // Set min/max in label
+  image->SetPixel({ 0, 2 }, 0);
+  image->SetPixel({ 0, 3 }, 500);
+
+  Utils::LabelPixelType label = 1;
+  labelImage->FillBuffer(label);
+  labelImage->SetPixel({ 0, 0 }, 0);
+  labelImage->SetPixel({ 0, 1 }, 0);
+
+
+  Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 16);
+
+  EXPECT_NEAR(0.0, labelObject->GetMinimum(), 1e-12);
+  EXPECT_NEAR(500.0, labelObject->GetMaximum(), 1e-12);
+  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 0.5);
+
+  if (::testing::Test::HasFailure())
+  {
+    labelObject->Print(std::cout);
+  }
+}

--- a/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
@@ -175,7 +175,7 @@ TEST_F(StatisticsLabelMapFixture, 2D_zero)
   EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
   EXPECT_NEAR(0.0, labelObject->GetSum(), 1e-12);
   EXPECT_NEAR(0.0, labelObject->GetVariance(), 1e-12);
-  EXPECT_NEAR(0.0, labelObject->GetStandardDeviation(), 1e-12);
+  EXPECT_NEAR(0.0, labelObject->GetStandardDeviation(), 0.5);
 
   if (::testing::Test::HasFailure())
   {
@@ -207,7 +207,7 @@ TEST_F(StatisticsLabelMapFixture, 2D_ones_with_outliers)
 
   EXPECT_NEAR(value, labelObject->GetMinimum(), 1e-12);
   EXPECT_NEAR(value, labelObject->GetMaximum(), 1e-12);
-  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 0.5);
+  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
   EXPECT_NEAR(25 * 25 - 2, labelObject->GetSum(), 1e-12);
   EXPECT_NEAR(0.0, labelObject->GetVariance(), 1e-12);
   EXPECT_NEAR(0.0, labelObject->GetStandardDeviation(), 1e-12);
@@ -242,7 +242,7 @@ TEST_F(StatisticsLabelMapFixture, 2D_rand_with_outliers)
 
   EXPECT_NEAR(0.0, labelObject->GetMinimum(), 1e-12);
   EXPECT_NEAR(500.0, labelObject->GetMaximum(), 1e-12);
-  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 0.5);
+  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
 
   if (::testing::Test::HasFailure())
   {
@@ -275,10 +275,44 @@ TEST_F(StatisticsLabelMapFixture, 2D_even)
 
   EXPECT_NEAR(1.0, labelObject->GetMinimum(), 1e-12);
   EXPECT_NEAR(200.0, labelObject->GetMaximum(), 1e-12);
-  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 0.5);
+  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
   EXPECT_NEAR(311.0, labelObject->GetSum(), 1e-12);
   EXPECT_NEAR(8640.25, labelObject->GetVariance(), 1e-10);
   EXPECT_NEAR(92.95294, labelObject->GetStandardDeviation(), 1e-5);
+
+  if (::testing::Test::HasFailure())
+  {
+    labelObject->Print(std::cout);
+  }
+}
+
+
+TEST_F(StatisticsLabelMapFixture, 2D_three)
+{
+  using Utils = FixtureUtilities<2, unsigned char>;
+
+  auto image = Utils::CreateImage();
+  auto labelImage = Utils ::CreateLabelImage();
+
+  // Set label with two elements far apart, the median should be average
+  image->SetPixel({ 0, 0 }, 1);
+  image->SetPixel({ 0, 1 }, 3);
+  image->SetPixel({ 0, 2 }, 10);
+
+  Utils::LabelPixelType label = 1;
+  labelImage->SetPixel({ 0, 0 }, label);
+  labelImage->SetPixel({ 0, 1 }, label);
+  labelImage->SetPixel({ 0, 2 }, label);
+
+
+  Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 8);
+
+  EXPECT_NEAR(1.0, labelObject->GetMinimum(), 1e-12);
+  EXPECT_NEAR(10.0, labelObject->GetMaximum(), 1e-12);
+  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
+  EXPECT_NEAR(14.0, labelObject->GetSum(), 1e-12);
+  EXPECT_NEAR(22.33333, labelObject->GetVariance(), 1e-5);
+  EXPECT_NEAR(4.725815, labelObject->GetStandardDeviation(), 1e-5);
 
   if (::testing::Test::HasFailure())
   {

--- a/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
@@ -145,6 +145,8 @@ protected:
 
       std::sort(values.begin(), values.end());
 
+      assert(!values.empty());
+
       auto n1 = values.size() / 2;
       if (values.size() % 2 == 0)
       {
@@ -170,6 +172,7 @@ TEST_F(StatisticsLabelMapFixture, 2D_zero)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, 1, 1 << 8);
 
+  ASSERT_GT(labelObject->Size(), 0);
   EXPECT_NEAR(0.0, labelObject->GetMinimum(), 1e-12);
   EXPECT_NEAR(0.0, labelObject->GetMaximum(), 1e-12);
   EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
@@ -205,6 +208,7 @@ TEST_F(StatisticsLabelMapFixture, 2D_ones_with_outliers)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 16);
 
+  ASSERT_GT(labelObject->Size(), 0);
   EXPECT_NEAR(value, labelObject->GetMinimum(), 1e-12);
   EXPECT_NEAR(value, labelObject->GetMaximum(), 1e-12);
   EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
@@ -240,6 +244,7 @@ TEST_F(StatisticsLabelMapFixture, 2D_rand_with_outliers)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 16);
 
+  ASSERT_GT(labelObject->Size(), 0);
   EXPECT_NEAR(0.0, labelObject->GetMinimum(), 1e-12);
   EXPECT_NEAR(500.0, labelObject->GetMaximum(), 1e-12);
   EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
@@ -273,6 +278,7 @@ TEST_F(StatisticsLabelMapFixture, 2D_even)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 8);
 
+  ASSERT_GT(labelObject->Size(), 0);
   EXPECT_NEAR(1.0, labelObject->GetMinimum(), 1e-12);
   EXPECT_NEAR(200.0, labelObject->GetMaximum(), 1e-12);
   EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);
@@ -307,6 +313,7 @@ TEST_F(StatisticsLabelMapFixture, 2D_three)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 8);
 
+  ASSERT_GT(labelObject->Size(), 0);
   EXPECT_NEAR(1.0, labelObject->GetMinimum(), 1e-12);
   EXPECT_NEAR(10.0, labelObject->GetMaximum(), 1e-12);
   EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 1e-12);

--- a/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
@@ -249,3 +249,39 @@ TEST_F(StatisticsLabelMapFixture, 2D_rand_with_outliers)
     labelObject->Print(std::cout);
   }
 }
+
+
+TEST_F(StatisticsLabelMapFixture, 2D_even)
+{
+  using Utils = FixtureUtilities<2, unsigned char>;
+
+  auto image = Utils::CreateImage();
+  auto labelImage = Utils ::CreateLabelImage();
+
+  // Set label with two elements far apart, the median should be average
+  image->SetPixel({ 0, 0 }, 10);
+  image->SetPixel({ 0, 1 }, 100);
+  image->SetPixel({ 0, 2 }, 1);
+  image->SetPixel({ 0, 3 }, 200);
+
+  Utils::LabelPixelType label = 1;
+  labelImage->SetPixel({ 0, 0 }, label);
+  labelImage->SetPixel({ 0, 1 }, label);
+  labelImage->SetPixel({ 0, 2 }, label);
+  labelImage->SetPixel({ 0, 3 }, label);
+
+
+  Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 8);
+
+  EXPECT_NEAR(1.0, labelObject->GetMinimum(), 1e-12);
+  EXPECT_NEAR(200.0, labelObject->GetMaximum(), 1e-12);
+  EXPECT_NEAR(Utils::ComputeExactMedian(labelObject, image), labelObject->GetMedian(), 0.5);
+  EXPECT_NEAR(311.0, labelObject->GetSum(), 1e-12);
+  EXPECT_NEAR(8640.25, labelObject->GetVariance(), 1e-10);
+  EXPECT_NEAR(92.95294, labelObject->GetStandardDeviation(), 1e-5);
+
+  if (::testing::Test::HasFailure())
+  {
+    labelObject->Print(std::cout);
+  }
+}


### PR DESCRIPTION
This pull request cherry picks the commits of Pull Requests #2514 and #2521 (from oldest to newest):

- c6da8be54ccff5ac4ca01813d8a17b1089f484f0 BUG: Add tests demonstration current behavior of histogram based median
- 208d7e32d75efe87df4c1537887f4b7ec8fd0c9a BUG: Fix StatisticsLabelMap median for even number of pixels
- 54675f3fbf7f7fd95c0fa15b8c3efafcdc1892e2 ENH: StatisticsLabelMapFilter use improve integer histogram
- bc95f51d9f2d17c0bbdfe16e9ed9c3b6baca9c76 ENH: Add additional testing for zero sized label object
- bb54bad6933f9c08f0882926573289c7f86fdba9 ENH: Propagate StatisticsLabelMapFilter's default NumberOfBins

from the master branch to the release branch.  The first four are from @blowekamp; the last is from @Leengit.