### PR TITLE
ENH: Wrap ITKVideoStream

### DIFF
--- a/Modules/Video/Core/include/itkVideoStream.h
+++ b/Modules/Video/Core/include/itkVideoStream.h
@@ -187,9 +187,9 @@ public:
    * Head of the ring buffer in place and just use the frame number as an
    * offset. This allows all references to frames to be processed by an
    * explicit frame number rather than a potentially confusing offset. */
-  FramePointer
+  FrameType *
   GetFrame(SizeValueType frameNumber);
-  FrameConstPointer
+  const FrameType *
   GetFrame(SizeValueType frameNumber) const;
 
   /** Get/Set the LargestPossibleRegion of a frame */

--- a/Modules/Video/Core/include/itkVideoStream.hxx
+++ b/Modules/Video/Core/include/itkVideoStream.hxx
@@ -332,7 +332,7 @@ VideoStream<TFrameType>::SetFrame(SizeValueType frameNumber, FramePointer frame)
 
 
 template <typename TFrameType>
-typename VideoStream<TFrameType>::FramePointer
+typename VideoStream<TFrameType>::FrameType *
 VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber)
 {
 
@@ -344,7 +344,7 @@ VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber)
 
 
 template <typename TFrameType>
-typename VideoStream<TFrameType>::FrameConstPointer
+const typename VideoStream<TFrameType>::FrameType *
 VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber) const
 {
   typename BufferType::ElementPointer element = m_DataObjectBuffer->GetBufferContents(frameNumber);

--- a/Modules/Video/Core/wrapping/CMakeLists.txt
+++ b/Modules/Video/Core/wrapping/CMakeLists.txt
@@ -1,0 +1,12 @@
+itk_wrap_module(ITKVideoCore)
+
+set(WRAPPER_SUBMODULE_ORDER
+  itkTemporalRegion
+  itkRingBuffer
+  itkTemporalDataObject
+  itkVideoStream
+)
+
+itk_auto_load_submodules()
+
+itk_end_wrap_module()

--- a/Modules/Video/Core/wrapping/itkRingBuffer.wrap
+++ b/Modules/Video/Core/wrapping/itkRingBuffer.wrap
@@ -1,0 +1,10 @@
+itk_wrap_include("itkImage.h")
+
+itk_wrap_class("itk::RingBuffer" POINTER)
+  itk_wrap_template("DO" "itk::DataObject")
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_SCALAR})
+      itk_wrap_template("I${ITKM_${t}}${d}" "itk::Image<${ITKT_${t}}, ${d}>")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/Modules/Video/Core/wrapping/itkTemporalDataObject.wrap
+++ b/Modules/Video/Core/wrapping/itkTemporalDataObject.wrap
@@ -1,0 +1,6 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
+
+itk_wrap_include("itkDataObject.h")
+itk_wrap_include("itkTemporalDataObject.h")
+itk_wrap_simple_class("itk::TemporalDataObjectEnums")
+itk_wrap_simple_class("itk::TemporalDataObject" POINTER)

--- a/Modules/Video/Core/wrapping/itkTemporalRegion.wrap
+++ b/Modules/Video/Core/wrapping/itkTemporalRegion.wrap
@@ -1,0 +1,2 @@
+itk_wrap_include("itkTemporalRegion.h")
+itk_wrap_simple_class("itk::TemporalRegion")

--- a/Modules/Video/Core/wrapping/itkVideoStream.wrap
+++ b/Modules/Video/Core/wrapping/itkVideoStream.wrap
@@ -1,0 +1,9 @@
+itk_wrap_include("itkImage.h")
+
+itk_wrap_class("itk::VideoStream" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_SCALAR})
+      itk_wrap_template("I${ITKM_${t}}${d}" "itk::Image<${ITKT_${t}}, ${d}>")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
Wraps `itk::VideoStream` and related components in `ITKVideoCore` for Python.

## PR Checklist
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

<!-- **Thanks for contributing to ITK!** -->
