### PR TITLE
Fix HDF5 installed find package

### DIFF
--- a/Modules/ThirdParty/HDF5/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/CMakeLists.txt
@@ -23,15 +23,19 @@ if(ITK_USE_SYSTEM_HDF5)
   if(HDF5_DIR)
     set(_HDF5_DIR_CODE "set(HDF5_DIR \"${HDF5_DIR}\")")
   endif()
+  if(HDF5_NO_MODULE)
+    set(_HDF5_NO_MODULE_ARG "NO_MODULE")
+  endif()
+
   # When ITK's config is loaded, load HDF5 too.
   set(ITKHDF5_EXPORT_CODE_INSTALL "
 ${_HDF5_DIR_CODE}
-find_package(HDF5 REQUIRED COMPONENTS CXX C)
+find_package(HDF5 ${_HDF5_NO_MODULE_ARG} REQUIRED COMPONENTS CXX C)
 ")
     set(ITKHDF5_EXPORT_CODE_BUILD "
 if(NOT ITK_BINARY_DIR)
   ${_HDF5_DIR_CODE}
-  find_package(HDF5 REQUIRED COMPONENTS CXX C)
+  find_package(HDF5 ${_HDF5_NO_MODULE_ARG} REQUIRED COMPONENTS CXX C)
 endif()
 ")
 

--- a/Modules/ThirdParty/HDF5/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/CMakeLists.txt
@@ -21,18 +21,19 @@ endif()
 if(ITK_USE_SYSTEM_HDF5)
 
   if(HDF5_DIR)
-    # When ITK's config is loaded, load HDF5 too.
-    set(ITKHDF5_EXPORT_CODE_INSTALL "
-set(HDF5_DIR \"${HDF5_DIR}\")
-find_package(HDF5 REQUIRED NO_MODULE)
+    set(_HDF5_DIR_CODE "set(HDF5_DIR \"${HDF5_DIR}\")")
+  endif()
+  # When ITK's config is loaded, load HDF5 too.
+  set(ITKHDF5_EXPORT_CODE_INSTALL "
+${_HDF5_DIR_CODE}
+find_package(HDF5 REQUIRED COMPONENTS CXX C)
 ")
     set(ITKHDF5_EXPORT_CODE_BUILD "
 if(NOT ITK_BINARY_DIR)
-  set(HDF5_DIR \"${HDF5_DIR}\")
-  find_package(HDF5 REQUIRED NO_MODULE)
+  ${_HDF5_DIR_CODE}
+  find_package(HDF5 REQUIRED COMPONENTS CXX C)
 endif()
 ")
-  endif()
 
   if(BUILD_SHARED_LIBS)
     if (TARGET hdf5-shared)

--- a/Modules/ThirdParty/HDF5/itk-module-init.cmake
+++ b/Modules/ThirdParty/HDF5/itk-module-init.cmake
@@ -2,6 +2,7 @@ option(ITK_USE_SYSTEM_HDF5 "Use an outside build of HDF5." ${ITK_USE_SYSTEM_LIBR
 mark_as_advanced(ITK_USE_SYSTEM_HDF5)
 
 if(ITK_USE_SYSTEM_HDF5)
+  set(HDF5_NO_MODULE 1)
   if(ITK_BUILD_SHARED_LIBS)
     find_package(HDF5 QUIET NO_MODULE COMPONENTS CXX C shared)
   else()
@@ -10,5 +11,6 @@ if(ITK_USE_SYSTEM_HDF5)
 
   if(NOT HDF5_FOUND)
     find_package(HDF5 REQUIRED COMPONENTS CXX C)
+    set(HDF5_NO_MODULE 0)
   endif()
 endif()


### PR DESCRIPTION
Addresses instalation issue with ITK_USE_SYSTEM_HDF5 with a system HDF5 that does not provide a HDF5Config.cmake file. The wrong find_package signature was being generated in the ITKHDF5.cmake file.


This change is also needed in the release branch.