### PR TITLE
DOC: Document members in header methods

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.h
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.h
@@ -102,10 +102,8 @@ public:
   itkSetObjectMacro(KernelTransform, KernelTransformType);
   itkGetModifiableObjectMacro(KernelTransform, KernelTransformType);
 
-  /** Set the size of the output image. */
+  /** Set/Get the output image size. */
   itkSetMacro(OutputRegion, OutputImageRegionType);
-
-  /** Get the size of the output image. */
   itkGetConstReferenceMacro(OutputRegion, OutputImageRegionType);
 
   /** Set the output image spacing. */
@@ -121,15 +119,17 @@ public:
   virtual void
   SetOutputOrigin(const double * origin);
 
-  /** Set the output direction cosine matrix. */
+  /** Set/Get the output direction cosine matrix. */
   itkSetMacro(OutputDirection, DirectionType);
   itkGetConstReferenceMacro(OutputDirection, DirectionType);
 
   /** Get the output image origin. */
   itkGetConstReferenceMacro(OutputOrigin, OriginPointType);
 
-  /** Set the list of source landmarks */
+  /** Set the list of source landmarks. */
   itkSetConstObjectMacro(SourceLandmarks, LandmarkContainer);
+
+  /** Set the list of target landmarks. */
   itkSetConstObjectMacro(TargetLandmarks, LandmarkContainer);
 
   /** LandmarkDisplacementFieldSource produces an image which is a different size
@@ -150,33 +150,31 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /**
-   * GenerateData() computes the internal KernelBase spline and resamples
-   * the displacement field.
-   */
+  /** Computes the internal KernelBase spline and resamples
+   * the displacement field. */
   void
   GenerateData() override;
 
   /** Subsample the input displacement field and generate the
-   *  landmarks for the kernel base spline
-   */
+   *  landmarks for the kernel base spline. */
   void
   PrepareKernelBaseSpline();
 
 private:
-  KernelTransformPointerType m_KernelTransform; // Coordinate transform to
-                                                // use
+  /** Coordinate transform to use. */
+  KernelTransformPointerType m_KernelTransform;
 
-  OutputImageRegionType m_OutputRegion; // Region of the output
-                                        // image
-  SpacingType     m_OutputSpacing;      // output image spacing
-  OriginPointType m_OutputOrigin;       // output image origin
-  DirectionType   m_OutputDirection;    // output image direction
-                                        // cosines
+  /** Region of the output image. */
+  OutputImageRegionType m_OutputRegion;
 
-  LandmarkContainerPointer m_SourceLandmarks; // List of source landmarks
-  LandmarkContainerPointer m_TargetLandmarks; // List of target landmarks
+  SpacingType     m_OutputSpacing;
+  OriginPointType m_OutputOrigin;
+  DirectionType   m_OutputDirection;
+
+  LandmarkContainerPointer m_SourceLandmarks;
+  LandmarkContainerPointer m_TargetLandmarks;
 };
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
@@ -24,9 +24,7 @@
 
 namespace itk
 {
-/**
- * Initialize new instance
- */
+
 template <typename TOutputImage>
 LandmarkDisplacementFieldSource<TOutputImage>::LandmarkDisplacementFieldSource()
 {
@@ -39,11 +37,6 @@ LandmarkDisplacementFieldSource<TOutputImage>::LandmarkDisplacementFieldSource()
   m_KernelTransform = DefaultTransformType::New();
 }
 
-/**
- * Print out a description of self
- *
- * \todo Add details about this class
- */
 template <typename TOutputImage>
 void
 LandmarkDisplacementFieldSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -59,9 +52,6 @@ LandmarkDisplacementFieldSource<TOutputImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "Target Landmarks: " << m_TargetLandmarks.GetPointer() << std::endl;
 }
 
-/**
- * Set the output image spacing.
- */
 template <typename TOutputImage>
 void
 LandmarkDisplacementFieldSource<TOutputImage>::SetOutputSpacing(const double * spacing)
@@ -75,9 +65,6 @@ LandmarkDisplacementFieldSource<TOutputImage>::SetOutputSpacing(const double * s
   this->SetOutputSpacing(s);
 }
 
-/**
- * Set the output image origin.
- */
 template <typename TOutputImage>
 void
 LandmarkDisplacementFieldSource<TOutputImage>::SetOutputOrigin(const double * origin)

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
@@ -126,35 +126,23 @@ public:
   /** Pointer Type for the vector distance image. */
   using VectorImagePointer = typename VectorImageType::Pointer;
 
-  /** Set if the distance should be squared. */
+  /** Set/Get if the distance should be squared. */
   itkSetMacro(SquaredDistance, bool);
-
-  /** Get the distance squared. */
   itkGetConstReferenceMacro(SquaredDistance, bool);
-
-  /** Set On/Off if the distance is squared. */
   itkBooleanMacro(SquaredDistance);
 
-  /** Set if the input is binary. If this variable is set, each
+  /** Set/Get if the input is binary. If this variable is set, each
    * nonzero pixel in the input image will be given a unique numeric
    * code to be used by the Voronoi partition.  If the image is binary
    * but you are not interested in the Voronoi regions of the
    * different nonzero pixels, then you need not set this.  */
   itkSetMacro(InputIsBinary, bool);
-
-  /** Get if the input is binary.  See SetInputIsBinary(). */
   itkGetConstReferenceMacro(InputIsBinary, bool);
-
-  /** Set On/Off if the input is binary.  See SetInputIsBinary(). */
   itkBooleanMacro(InputIsBinary);
 
-  /** Set if image spacing should be used in computing distances. */
+  /** Set/Get if image spacing should be used in computing distances. */
   itkSetMacro(UseImageSpacing, bool);
-
-  /** Get whether spacing is used. */
   itkGetConstReferenceMacro(UseImageSpacing, bool);
-
-  /** Set On/Off whether spacing is used. */
   itkBooleanMacro(UseImageSpacing);
 
   /** Get Voronoi Map

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -26,9 +26,7 @@
 
 namespace itk
 {
-/**
- *    Constructor
- */
+
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::DanielssonDistanceMapImageFilter()
 {
@@ -67,9 +65,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Make
   return Superclass::MakeOutput(idx);
 }
 
-/**
- *  Return the distance map Image pointer
- */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 typename DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::OutputImageType *
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetDistanceMap()
@@ -77,9 +72,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetD
   return dynamic_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 }
 
-/**
- *  Return Closest Points Map
- */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 typename DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::VoronoiImageType *
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVoronoiMap()
@@ -87,9 +79,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetV
   return dynamic_cast<VoronoiImageType *>(this->ProcessObject::GetOutput(1));
 }
 
-/**
- *  Return the distance vectors
- */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 typename DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::VectorImageType *
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVectorDistanceMap()
@@ -97,9 +86,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetV
   return dynamic_cast<VectorImageType *>(this->ProcessObject::GetOutput(2));
 }
 
-/**
- *  Prepare data for computation
- */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 void
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::PrepareData()
@@ -219,9 +205,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
   itkDebugMacro(<< "PrepareData End");
 }
 
-/**
- *  Post processing for computing the Voronoi Map
- */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 void
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::ComputeVoronoiMap()
@@ -282,9 +265,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Comp
   itkDebugMacro(<< "ComputeVoronoiMap End");
 }
 
-/**
- *  Locally update the distance.
- */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 void
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::UpdateLocalDistance(
@@ -320,9 +300,6 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Upda
   }
 }
 
-/**
- *  Compute Distance and Voronoi maps
- */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 void
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GenerateData()
@@ -433,11 +410,8 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Gene
   itkDebugMacro(<< "GenerateData: ComputeVoronoiMap");
 
   this->ComputeVoronoiMap();
-} // end GenerateData()
+}
 
-/**
- *  Print Self
- */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 void
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::PrintSelf(std::ostream & os,

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -130,7 +130,7 @@ public:
 
   itkGetConstMacro(NumberOfPrincipalComponentsRequired, unsigned int);
 
-  /** Set/Get the number of training images in the input. */
+  /** Set/Get the number of training images in the input for the PCA. */
   virtual void
   SetNumberOfTrainingImages(unsigned int n);
 
@@ -147,7 +147,7 @@ protected:
 
   /** This filter must produce all of the outputs at once, as such it
    * must override the EnlargeOutputRequestedRegion method to enlarge the
-   * output request region. */
+   * output request region to the largest possible region. */
   void
   EnlargeOutputRequestedRegion(DataObject *) override;
 
@@ -172,24 +172,26 @@ private:
   /** Set up the vector to store the image  data. */
   using InputPixelType = typename TInputImage::PixelType;
 
-  /** Local functions */
-
-  /** A function that generates the cluster centers (model) corresponding to the
-   * estimates of the cluster centers (in the initial codebook).
+  /** Generates the cluster centers (model) corresponding to the estimates of
+   * the cluster centers (in the initial codebook).
    * If no codebook is provided, then use the number of classes to
    * determine the cluster centers or the Shape model. This is the
-   * the base function to call the K-means classifier. */
-
+   * the base function to call the K-means classifier.
+   * Takes the set of training images and internally computes the means and
+   * variance of the various classes defined in the training set.
+   */
   void
   EstimateShapeModels() override;
 
+  /** Estimate shape model parameters using PCA. */
   void
   EstimatePCAShapeModelParameters();
 
+  /** Calculate the inner product between the input training vector
+   * where each image is treated as a vector of n-elements. */
   void
   CalculateInnerProduct();
 
-  /** Local storage variables */
   InputImageIteratorArray m_InputImageIteratorArray;
 
   VectorOfDoubleType m_Means;
@@ -206,10 +208,8 @@ private:
 
   unsigned int m_NumberOfPixels{ 0 };
 
-  // The number of input images for PCA
   unsigned int m_NumberOfTrainingImages{ 0 };
 
-  // The number of output Principal Components
   unsigned int m_NumberOfPrincipalComponentsRequired;
 };
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -32,9 +32,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::ImagePCAShapeModelEstima
   m_NumberOfPrincipalComponentsRequired = 0;
   this->SetNumberOfPrincipalComponentsRequired(1);
 }
-/**
- * PrintSelf
- */
+
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
@@ -56,9 +54,6 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::PrintSelf(std::ostream &
   os << indent << "NumberOfPrincipalComponentsRequired: " << m_NumberOfPrincipalComponentsRequired << std::endl;
 }
 
-/**
- * Enlarge the output requested region to the largest possible region.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * itkNotUsed(output))
@@ -73,16 +68,14 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EnlargeOutputRequestedRe
   }
 }
 
-/**
- * Requires all of the inputs to be in the buffer up to the
- * LargestPossibleRegion of the first input.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {
   Superclass::GenerateInputRequestedRegion();
 
+  // Require all of the inputs to be in the buffer up to the
+  // LargestPossibleRegion of the first input.
   if (this->GetInput(0))
   {
     // Set the requested region of the first input to largest possible region
@@ -113,9 +106,6 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateInputRequestedRe
   }
 }
 
-/**
- * Generate data (start the model building process)
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateData()
@@ -196,11 +186,8 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateData()
   {
     m_EigenVectors.set_size(0, 0);
   }
-} // end Generate data
+}
 
-/**
- * Set the number of required principal components
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::SetNumberOfPrincipalComponentsRequired(unsigned int n)
@@ -237,9 +224,6 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::SetNumberOfPrincipalComp
   }
 }
 
-/**
- * Set the number of training images.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::SetNumberOfTrainingImages(unsigned int n)
@@ -255,11 +239,6 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::SetNumberOfTrainingImage
   }
 }
 
-/**-----------------------------------------------------------------
- * Takes a set of training images and returns the means
- * and variance of the various classes defined in the
- * training set.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimateShapeModels()
@@ -267,12 +246,8 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimateShapeModels()
   this->CalculateInnerProduct();
 
   this->EstimatePCAShapeModelParameters();
-} // end EstimateShapeModels
+}
 
-/**
- * Calculate the inner product between the input training vector
- * where each image is treated as a vector of n-elements
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::CalculateInnerProduct()
@@ -372,12 +347,8 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::CalculateInnerProduct()
   {
     m_InnerProduct.fill(0);
   }
-} // end CalculateInnerProduct
+}
 
-/*-----------------------------------------------------------------
- *Estimage shape models using PCA.
- *-----------------------------------------------------------------
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimatePCAShapeModelParameters()
@@ -432,7 +403,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimatePCAShapeModelPar
   // Normalize the eigen values
   m_EigenVectorNormalizedEnergy = m_EigenValues;
   m_EigenVectorNormalizedEnergy.normalize();
-} // end EstimatePCAShapeModelParameters
+}
 
 } // namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.h
@@ -77,7 +77,7 @@ private:
   virtual void
   EstimateShapeModels() = 0;
 
-  /**Container for holding the training image. */
+  /** Container for holding the training image. */
   InputImagePointer m_InputImage;
 
 }; // class ImageShapeModelEstimator

--- a/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.hxx
@@ -31,9 +31,6 @@ ImageShapeModelEstimatorBase<TInputImage, TOutputImage>::GenerateData()
   this->EstimateShapeModels();
 }
 
-/**
- * PrintSelf
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ImageShapeModelEstimatorBase<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const

--- a/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
@@ -112,12 +112,9 @@ public:
   itkSetMacro(ForegroundValue, PixelType);
   itkGetConstMacro(ForegroundValue, PixelType);
 
-  /** Set the value used as "background". Defaults to
+  /** Set/Get the value used as "background". Defaults to
    * NumericTraits<PixelType>::NonpositiveMin(). */
   itkSetMacro(BackgroundValue, PixelType);
-
-  /** Get the value used as "background". Defaults to
-   * NumericTraits<PixelType>::NonpositiveMin(). */
   itkGetConstMacro(BackgroundValue, PixelType);
 
 protected:

--- a/Modules/IO/MINC/include/itkMINCImageIO.h
+++ b/Modules/IO/MINC/include/itkMINCImageIO.h
@@ -132,16 +132,16 @@ protected:
   void
   WriteSlice(std::string & fileName, const void * buffer);
 
-  // will assign m_NDims and allocate all internal buffers to hold the
-  // information
+  /** Assign m_NDims and allocate all internal buffers to hold the
+   * information. */
   void
   AllocateDimensions(int nDims);
 
-  // cleanup internal buffers
+  /** Cleanup internal buffers. */
   void
   CleanupDimensions();
 
-  // close existing volume, cleanup internal structures
+  /** Close existing volume, cleanup internal structures. */
   void
   CloseVolume();
 

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -197,7 +197,6 @@ MINCImageIO::AllocateDimensions(int nDims)
   }
 }
 
-// close existing volume, cleanup internal structures
 void
 MINCImageIO::CloseVolume()
 {

--- a/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.h
+++ b/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.h
@@ -57,11 +57,11 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(FEMObjectSpatialObject, SpatialObject);
 
-  /** Set the femobject. */
+  /** Set the FEM object in the spatial object. */
   void
   SetFEMObject(FEMObjectType * femobject);
 
-  /** Get a pointer to the femobject currently attached to the object. */
+  /** Get a pointer to the FEM object currently attached to the object. */
   FEMObjectType *
   GetFEMObject()
   {

--- a/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.hxx
@@ -24,7 +24,6 @@
 namespace itk
 {
 
-/** Constructor */
 template <unsigned int TDimension>
 FEMObjectSpatialObject<TDimension>::FEMObjectSpatialObject()
 {
@@ -32,11 +31,9 @@ FEMObjectSpatialObject<TDimension>::FEMObjectSpatialObject()
   m_FEMObject = FEMObjectType::New();
 }
 
-/** Destructor */
 template <unsigned int TDimension>
 FEMObjectSpatialObject<TDimension>::~FEMObjectSpatialObject() = default;
 
-/** Set the femobject in the spatial object */
 template <unsigned int TDimension>
 void
 FEMObjectSpatialObject<TDimension>::SetFEMObject(FEMObjectType * femobject)
@@ -49,7 +46,6 @@ FEMObjectSpatialObject<TDimension>::SetFEMObject(FEMObjectType * femobject)
   m_FEMObject = femobject;
 }
 
-/** Print the object */
 template <unsigned int TDimension>
 void
 FEMObjectSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
@@ -59,7 +55,6 @@ FEMObjectSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) 
   os << indent << m_FEMObject << std::endl;
 }
 
-/** Get the modification time */
 template <unsigned int TDimension>
 ModifiedTimeType
 FEMObjectSpatialObject<TDimension>::GetMTime() const

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
@@ -60,10 +60,10 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** the number of components in a measurement vector */
+  /** The number of components in a measurement vector. */
   static constexpr unsigned int MeasurementVectorSize = TVectorContainer::Element::Dimension;
 
-  /** VectorContainer type alias */
+  /** VectorContainer type alias. */
   using VectorContainerType = TVectorContainer;
   using VectorContainerPointer = typename TVectorContainer::Pointer;
   using VectorContainerConstPointer = typename TVectorContainer::ConstPointer;
@@ -81,22 +81,23 @@ public:
 
   using ValueType = MeasurementVectorType;
 
-  /** Get/Set Method for the point set */
+  /** Get/Set method for the point set container which will be actually used
+   * for storing measurement vectors. */
   itkSetObjectMacro(VectorContainer, VectorContainerType);
   itkGetConstObjectMacro(VectorContainer, VectorContainerType);
 
-  /** returns the number of measurement vectors in this container */
+  /** Returns the number of measurement vectors in this container. */
   InstanceIdentifier
   Size() const override;
 
-  /** returns the measurement vector that is specified by the instance
+  /** Returns the measurement vector that is specified by the instance
    * identifier argument. */
   const MeasurementVectorType & GetMeasurementVector(InstanceIdentifier) const override;
 
-  /** returns 1 as other subclasses of ListSampleBase does */
+  /** Returns 1 as other subclasses of ListSampleBase does. */
   AbsoluteFrequencyType GetFrequency(InstanceIdentifier) const override;
 
-  /** returns the size of this container */
+  /** Returns the size of this container. */
   TotalAbsoluteFrequencyType
   GetTotalFrequency() const override;
 
@@ -213,7 +214,7 @@ public:
     {}
   };
 
-  /** returns an iterator that points to the beginning of the container */
+  /** Returns an iterator that points to the beginning of the container. */
   Iterator
   Begin()
   {
@@ -224,7 +225,7 @@ public:
     return iter;
   }
 
-  /** returns an iterator that points to the end of the container */
+  /** Returns an iterator that points to the end of the container. */
   Iterator
   End()
   {
@@ -236,7 +237,7 @@ public:
     return iter;
   }
 
-  /** returns an iterator that points to the beginning of the container */
+  /** Returns an iterator that points to the beginning of the container. */
   ConstIterator
   Begin() const
   {
@@ -245,7 +246,7 @@ public:
     return iter;
   }
 
-  /** returns an iterator that points to the end of the container */
+  /** Returns an iterator that points to the end of the container. */
   ConstIterator
   End() const
   {
@@ -261,8 +262,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  /** the points container which will be actually used for storing
-   * measurement vectors */
   VectorContainerConstPointer m_VectorContainer;
 }; // end of class VectorContainerToListSampleAdaptor
 } // end of namespace Statistics

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
@@ -47,7 +47,6 @@ VectorContainerToListSampleAdaptor<TVectorContainer>::PrintSelf(std::ostream & o
   }
 }
 
-/** returns the number of measurement vectors in this container*/
 template <typename TVectorContainer>
 typename VectorContainerToListSampleAdaptor<TVectorContainer>::InstanceIdentifier
 VectorContainerToListSampleAdaptor<TVectorContainer>::Size() const

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
@@ -21,9 +21,7 @@
 
 namespace itk
 {
-/**
- * Default constructor
- */
+
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::LevelSetMotionRegistrationFilter()
 {
@@ -50,9 +48,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
      << std::endl;
 }
 
-/*
- * Set the function state values before each iteration
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::InitializeIteration()
@@ -79,9 +74,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   }
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 bool
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::Halt()
@@ -97,9 +89,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   return halt;
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetMetric() const
@@ -114,9 +103,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   return drfp->GetMetric();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetAlpha() const
@@ -131,9 +117,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   return drfp->GetAlpha();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetAlpha(double alpha)
@@ -148,9 +131,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   drfp->SetAlpha(alpha);
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetIntensityDifferenceThreshold() const
@@ -165,9 +145,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   return drfp->GetIntensityDifferenceThreshold();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetIntensityDifferenceThreshold(
@@ -183,9 +160,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   drfp->SetIntensityDifferenceThreshold(threshold);
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetGradientMagnitudeThreshold() const
@@ -200,9 +174,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   return drfp->GetGradientMagnitudeThreshold();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetGradientMagnitudeThreshold(
@@ -218,9 +189,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   drfp->SetGradientMagnitudeThreshold(threshold);
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 double
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
@@ -236,9 +204,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   return drfp->GetGradientSmoothingStandardDeviations();
 }
 
-/**
- *
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::SetGradientSmoothingStandardDeviations(
@@ -254,9 +219,6 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
   drfp->SetGradientSmoothingStandardDeviations(sigma);
 }
 
-/**
- * Get the metric value from the difference function
- */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void
 LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::ApplyUpdate(const TimeStepType & dt)

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
@@ -203,7 +203,9 @@ protected:
   void
   GenerateData() override;
 
-  /** Handle optimization internally */
+  /** Handle optimization internally.
+   * Starts the optimization at each level. Performas a basic gradient descent operation.
+   */
   virtual void
   StartOptimization();
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -32,9 +32,7 @@
 
 namespace itk
 {
-/**
- * Constructor
- */
+
 template <typename TFixedImage,
           typename TMovingImage,
           typename TOutputTransform,
@@ -133,9 +131,6 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
   }
 }
 
-/*
- * Start the optimization at each level.  We just do a basic gradient descent operation.
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TOutputTransform,
@@ -827,9 +822,6 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   return smoothField;
 }
 
-/*
- * Start the registration
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TOutputTransform,
@@ -873,9 +865,6 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
   this->GetTransformOutput()->Set(this->m_OutputTransform);
 }
 
-/*
- * PrintSelf
- */
 template <typename TFixedImage,
           typename TMovingImage,
           typename TOutputTransform,

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
@@ -140,20 +140,22 @@ private:
   /** Dimension of each individual pixel vector. */
   static constexpr unsigned int VectorDimension = InputImagePixelType::Dimension;
 
-  MatrixType   m_NumberOfSamples;
-  MatrixType   m_Means;
-  MatrixType * m_Covariance{ nullptr };
-
-  TrainingImagePointer m_TrainingImage;
-
-  /** A function that generates the
-   * model based on the training input data.
-   * Achieves the goal of training the classifier. */
+  /** Generate the model based on the training input data.
+   * Achieves the goal of training the classifier.
+   * Takes the set of training images and internally computes the means and
+   * variance of the various classes defined in the training set.
+   */
   void
   EstimateModels() override;
 
   void
   EstimateGaussianModelParameters();
+
+  MatrixType   m_NumberOfSamples;
+  MatrixType   m_Means;
+  MatrixType * m_Covariance{ nullptr };
+
+  TrainingImagePointer m_TrainingImage;
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
@@ -31,9 +31,7 @@ ImageGaussianModelEstimator<TInputImage, TMembershipFunction, TTrainingImage>::~
   delete[] m_Covariance;
 }
 
-/**
- * PrintSelf
- */
+
 template <typename TInputImage, typename TMembershipFunction, typename TTrainingImage>
 void
 ImageGaussianModelEstimator<TInputImage, TMembershipFunction, TTrainingImage>::PrintSelf(std::ostream & os,
@@ -53,11 +51,7 @@ void
 ImageGaussianModelEstimator<TInputImage, TMembershipFunction, TTrainingImage>::GenerateData()
 {
   this->EstimateModels();
-} // end Generate data
-
-// Takes a set of training images and returns the means
-// and variance of the various classes defined in the
-// training set.
+}
 
 template <typename TInputImage, typename TMembershipFunction, typename TTrainingImage>
 void
@@ -120,7 +114,7 @@ ImageGaussianModelEstimator<TInputImage, TMembershipFunction, TTrainingImage>::E
 
     this->AddMembershipFunction(membershipFunction);
   }
-} // end train classifier
+}
 
 template <typename TInputImage, typename TMembershipFunction, typename TTrainingImage>
 void
@@ -261,7 +255,6 @@ ImageGaussianModelEstimator<TInputImage, TMembershipFunction, TTrainingImage>::E
     }     // end if loop
   }       // end class index loop
 }
-
 } // end namespace itk
 
 #endif

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
@@ -48,8 +48,8 @@ namespace itk
  * either using user-provided seed points as an initial guess or generating
  * the clusters using a recursive approach when the user provides the
  * number of desired clusters. Each cluster is represented by its cluster
- * center. The two algorithms used are the generalized Lloyd
- * algorithm (GLA) and the Linde-Buzo-Gray algorithm. The cluster centers
+ * center. The two algorithms used are the Generalized Lloyd
+ * algorithm (GLA) and the Linde-Buzo-Gray algorithm (LBG). The cluster centers
  * are also referred to as codewords and a table of cluster centers
  * is referred as a codebook.
  *
@@ -186,28 +186,20 @@ public:
     return m_Codebook;
   }
 
-  /** Set the threshold parameter. */
+  /** Set/Get the threshold parameter. */
   itkSetMacro(Threshold, double);
-
-  /** Get the threshold parameter. */
   itkGetConstMacro(Threshold, double);
 
-  /** Set the offset add parameter. */
+  /** Set/Get the offset add parameter. */
   itkSetMacro(OffsetAdd, double);
-
-  /** Get the offset add parameter. */
   itkGetConstMacro(OffsetAdd, double);
 
-  /** Set the offset multiplication parameter. */
+  /** Set/Get the offset multiplication parameter. */
   itkSetMacro(OffsetMultiply, double);
-
-  /** Get the offset multiplication parameter. */
   itkGetConstMacro(OffsetMultiply, double);
 
-  /** Set the maximum number of attempts to split a codeword. */
+  /** Set/Get the maximum number of attempts to split a codeword. */
   itkSetMacro(MaxSplitAttempts, int);
-
-  /** Get the maximum number of attempts to split a codeword. */
   itkGetConstMacro(MaxSplitAttempts, int);
 
   /** Return the codebook/cluster centers. */
@@ -236,15 +228,18 @@ protected:
   PrintKmeansAlgorithmResults();
 
 private:
-  /** A function that generates the cluster centers (model) corresponding to the
-   * estimates of the cluster centers (in the initial codebook).
+  /** Generates the cluster centers (model) corresponding to the estimates of
+   * the cluster centers (in the initial codebook).
    * If no codebook is provided, then use the number of classes to
    * determine the cluster centers or the Kmeans model. This is the
-   * the base function to call the K-means classifier. */
-
+   * the base function to call the K-means classifier.
+   * Takes the set of training images and internally computes the means and
+   * variance of the various classes defined in the training set.
+   */
   void
   EstimateModels() override;
 
+  /** Estimate K-means models for the core function. */
   void
   EstimateKmeansModelParameters();
 
@@ -253,15 +248,15 @@ private:
   /** Set up the vector to store the image  data. */
   using InputPixelVectorType = typename TInputImage::PixelType::VectorType;
 
+  /**Reallocate various memories and then make a copy of the old data. */
   void
   Reallocate(int oldSize, int newSize);
 
-  // Local functions
   int
-  WithCodebookUseGLA(); // GLA stands for the Generalized Lloyd Algorithm
+  WithCodebookUseGLA();
 
   int
-  WithoutCodebookUseLBG(); // LBG stands for the Lindo Buzo Gray Algorithm
+  WithoutCodebookUseLBG();
 
   void
   NearestNeighborSearchBasic(double * distortion);

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -38,9 +38,6 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::ImageKmeansModelEst
   m_CurrentNumberOfCodewords = 1;
 }
 
-/**
- * PrintSelf
- */
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::PrintSelf(std::ostream & os, Indent indent) const
@@ -97,24 +94,21 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::PrintKmeansAlgorith
   itkDebugMacro(<< "+++++++++++++++++++++++++++++++++++ ");
 
   itkDebugMacro(<< m_CodewordHistogram);
-} // End PrintKmeansAlgorithmResults
+}
 
-/**
- * Generate data (start the model building process)
- */
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::GenerateData()
 {
   this->EstimateModels();
-} // end Generate data
+}
 
-// Set the input codebook and allocate memory
-// for the output codebook and other scratch memory
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::SetCodebook(CodebookMatrixOfDoubleType inCodebook)
 {
+  // Set the input codebook and allocate memory for the output codebook and
+  // other scratch memory
   m_Codebook = inCodebook;
 
   // Check if the input codebook is a valid
@@ -123,9 +117,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::SetCodebook(Codeboo
     m_ValidInCodebook = true;
     this->Allocate();
   }
-} // End SetInCodebook
-
-// Allocate scratch memory
+}
 
 template <typename TInputImage, typename TMembershipFunction>
 void
@@ -177,11 +169,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Allocate()
 
   m_CodewordDistortion.set_size(m_NumberOfCodewords, 1);
   m_CodewordDistortion.fill(0);
-} // end Allocate function
-
-//-----------------------------------------------------------------
-// Reallocate various memories and then make a copy of the old data
-//-----------------------------------------------------------------
+}
 
 template <typename TInputImage, typename TMembershipFunction>
 void
@@ -226,11 +214,6 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Reallocate(int oldS
   }
 }
 
-//-----------------------------------------------------------------
-// Takes a set of training images and returns the means
-// and variance of the various classes defined in the
-// training set.
-//-----------------------------------------------------------------
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::EstimateModels()
@@ -261,11 +244,8 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::EstimateModels()
     membershipFunction->SetCentroid(centroid);
     this->AddMembershipFunction(membershipFunction);
   }
-} // end EstimateModels
+}
 
-//-----------------------------------------------------------------
-// Estimate K-means models (private function) for the core function
-//-----------------------------------------------------------------
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::EstimateKmeansModelParameters()
@@ -410,9 +390,8 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
     }
   } while (pass <= m_MaxSplitAttempts);
   itkExceptionMacro(<< "Lack of convergence");
-} // end WithCodebookUseGLA
+}
 
-//-----------------------------------------------------------------
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSearchBasic(double * distortion)
@@ -539,9 +518,8 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSear
   {
     itkExceptionMacro(<< "Computational overflow");
   }
-} // End nearest_neighbor_search_basic
+}
 
-//-----------------------------------------------------------------
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::SplitCodewords(int currentSize, int numDesired, int scale)
@@ -566,9 +544,8 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::SplitCodewords(int 
 
   delete[] inCodebookData;
   delete[] newCodebookData;
-} // End splitcodewords
+}
 
-//-----------------------------------------------------------------
 template <typename TInputImage, typename TMembershipFunction>
 void
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Perturb(double * oldCodeword,
@@ -614,7 +591,6 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Perturb(double * ol
   }
 }
 
-//-----------------------------------------------------------------
 template <typename TInputImage, typename TMembershipFunction>
 int
 ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithoutCodebookUseLBG()
@@ -685,7 +661,8 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithoutCodebookUseL
   // itkDebugMacro(<<"Done with local function LBG ()");
 
   return LBG_COMPLETED;
-} // End WithoutCodebookUseLBG()
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.h
@@ -155,6 +155,15 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
+  /** Update the filter. It essentially uses a bisection method to search for
+   * the threshold setPt that maximizes the number of connected components in
+   * the image. The ComputeConnectedComponents does the threshold and then a
+   * connected components object count. It is removed from GenerateData
+   * to make this all easier to read.
+   *
+   * Remove the comments on the output statements to see how the search
+   * strategy works.
+   */
   void
   GenerateData() override;
 

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
@@ -26,9 +26,7 @@
 
 namespace itk
 {
-/** Constructor
- *
- */
+
 template <typename TInputImage, typename TOutputImage>
 ThresholdMaximumConnectedComponentsImageFilter<TInputImage,
                                                TOutputImage>::ThresholdMaximumConnectedComponentsImageFilter()
@@ -72,9 +70,6 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage,
   m_NumberOfObjects = 0;
 } // end of the constructor
 
-/**
- *
- */
 template <typename TInputImage, typename TOutputImage>
 SizeValueType
 ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::ComputeConnectedComponents()
@@ -87,17 +82,6 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::Compu
   return m_LabeledComponent->GetNumberOfObjects();
 } //  end of ComputeConnectedComponents()
 
-/**
- * This is the meat of the filter. It essentially uses a bisection
- * method to search for the threshold setPt that maximizes the number
- * of connected components in the image. The
- * "ComputeConnectedComponents" does the threshold and then a
- * connected components object count. It is removed from "GenerateData"
- * to make this all easier to read.
- *
- * Remove the comments on the output statements to see how the search
- * strategy works.
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::GenerateData()
@@ -193,9 +177,6 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::Gener
   this->GraftOutput(m_ThresholdFilter->GetOutput());
 } // end of GenerateData Process
 
-/** Standard Run of the mill PrintSelf
- *
- */
 template <typename TInputImage, typename TOutputImage>
 void
 ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,


### PR DESCRIPTION
Document members in header methods.

Transfer the documentation from the ivar or the method definition to the
header methods where the documentation was incomplete or missing.

Take advantage of the commit to:
- Improve the syntax of the existing documentation to stick to the
  recommendations of the ITK SW Guide to generate the Doxygen
  documentation (i.e. use the `/** <documentation.> */` convention).
- Improve the style of the existing documentation (e.g. capitals,
  punctuation) to stick to the recommendations of the ITK SW Guide.
- Improve the wording of some comments.
- Remove the documentation of methods that are either not documented as
  per the ITK SW Guide (e.g. constructors) or which are inherited members
  whose purpose is not modified (e.g. `PrintSelf`).
- Remove the comments used to mark the end of a method, which are not
  considered as necessary by the ITK SW Guide.
- Remove empty documentation blocks.
- Move the private member methods before the variables.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)