### PR TITLE
DOC: Improve documentation in `Common` operator classes

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -72,19 +72,19 @@ template <typename TPixel, unsigned int TDimension = 2, typename TAllocator = Ne
 class ITK_TEMPLATE_EXPORT AnnulusOperator : public NeighborhoodOperator<TPixel, TDimension, TAllocator>
 {
 public:
-  /** Standard type alias */
+  /** Standard class type aliases. */
   using Self = AnnulusOperator;
   using Superclass = NeighborhoodOperator<TPixel, TDimension, TAllocator>;
 
-  /** Additional type alias */
+  /** Additional type aliases. */
   using SizeType = typename Superclass::SizeType;
   using OffsetType = typename Superclass::OffsetType;
   using SpacingType = Vector<double, TDimension>;
 
+  /** Run-time type information (and related methods). */
   itkTypeMacro(AnnulusOperator, NeighborhoodOperator);
 
-  /** This function is called to create the operator.  The radius of
-   * the operator is determine automatically.  */
+  /** Create the operator. The radius of the operator is determined automatically. */
   void
   CreateOperator();
 

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -235,8 +235,8 @@ protected:
   }
 
 private:
-  /* methods for generations of the coefficients for a gaussian
-   * operator of 0-order respecting the remaining parameters */
+  /* Methods for generations of the coefficients for a Gaussian
+   * operator of 0-order respecting the remaining parameters. */
   CoefficientVector
   GenerateGaussianCoefficients() const;
 

--- a/Modules/Core/Common/include/itkGaussianOperator.h
+++ b/Modules/Core/Common/include/itkGaussianOperator.h
@@ -73,6 +73,7 @@ public:
   using Self = GaussianOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
+  /** Run-time type information (and related methods). */
   itkTypeMacro(GaussianOperator, NeighborhoodOperator);
 
   /** Sets the desired variance of the Gaussian kernel. */

--- a/Modules/Core/Common/include/itkImageKernelOperator.h
+++ b/Modules/Core/Common/include/itkImageKernelOperator.h
@@ -57,6 +57,7 @@ public:
   using SizeType = typename Superclass::SizeType;
   using CoefficientVector = typename Superclass::CoefficientVector;
 
+  /** Run-time type information (and related methods). */
   itkTypeMacro(ImageKernelOperator, NeighborhoodOperator);
 
   /** Set the image kernel. Only images with odd size in all

--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -67,16 +67,13 @@ template <typename TPixel, unsigned int VDimension = 2, typename TAllocator = Ne
 class ITK_TEMPLATE_EXPORT LaplacianOperator : public NeighborhoodOperator<TPixel, VDimension, TAllocator>
 {
 public:
-  /** Standard "Self" type alias support   */
+  /** Standard class type aliases. */
   using Self = LaplacianOperator;
-
-  /** Standard "Superclass" type alias.   */
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
   using PixelType = typename Superclass::PixelType;
   using SizeType = typename Superclass::SizeType;
 
-  /**  Default constructor  */
   LaplacianOperator()
   {
     for (unsigned i = 0; i < VDimension; ++i)
@@ -85,7 +82,7 @@ public:
     }
   }
 
-  /** This function is called to create the operator  */
+  /** Create the operator. */
   void
   CreateOperator();
 
@@ -104,16 +101,16 @@ public:
   SetDerivativeScalings(const double * s);
 
 protected:
-  /** Typedef support for coefficient vector type.  Necessary to
-   * work around compiler bug on VC++.   */
+  /** Alias support for coefficient vector type. Necessary to
+   * work around compiler bug on VC++. */
   using CoefficientVector = typename Superclass::CoefficientVector;
 
-  /** Calculates operator coefficients.   */
+  /** Calculates operator coefficients. */
   CoefficientVector
   GenerateCoefficients() override;
 
   /** Arranges coefficients spatially in the memory buffer, default
-   * function was NOT used.   */
+   * function was NOT used. */
   void
   Fill(const CoefficientVector &) override;
 

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.h
@@ -72,7 +72,7 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator = Neighb
 class ITK_TEMPLATE_EXPORT NeighborhoodOperator : public Neighborhood<TPixel, VDimension, TAllocator>
 {
 public:
-  /**  Standard class type aliases. */
+  /** Standard class type aliases. */
   using Self = NeighborhoodOperator;
   using Superclass = Neighborhood<TPixel, VDimension, TAllocator>;
 

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -98,14 +98,13 @@ template <typename TPixel, unsigned int VDimension = 2, typename TAllocator = Ne
 class ITK_TEMPLATE_EXPORT SobelOperator : public NeighborhoodOperator<TPixel, VDimension, TAllocator>
 {
 public:
-  /** Standard type alias */
+  /** Standard class type aliases. */
   using Self = SobelOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
   itkTypeMacro(SobelOperator, NeighborhoodOperator);
 
-  /** Creates the operator with length only in the specified direction.  For
-   * the Sobel operator, this
+  /** Creates the operator with length only in the specified direction.
    * The radius of the operator will be 0 except along the axis on which
    * the operator will work.
    * \sa CreateToRadius \sa FillCenteredDirectional \sa SetDirection() \sa GetDirection() */
@@ -133,22 +132,16 @@ public:
   }
 
 protected:
-  /**
-   * Typedef support for coefficient vector type.  Necessary to
-   * work around compiler bug on VC++.
-   */
+  /** Alias support for coefficient vector type. Necessary to
+   * work around compiler bug on VC++. */
   using CoefficientVector = typename Superclass::CoefficientVector;
   using PixelType = typename Superclass::PixelType;
 
-  /**
-   * Calculates operator coefficients.
-   */
+  /** Calculates operator coefficients. */
   CoefficientVector
   GenerateCoefficients() override;
 
-  /**
-   * Arranges coefficients spatially in the memory buffer.
-   */
+  /** Arranges coefficients spatially in the memory buffer. */
   void
   Fill(const CoefficientVector & coeff) override;
 };


### PR DESCRIPTION
Improve documentation in `Common` operator classes:
- Add documentation to type aliases/methods that are usually documented in
  the same manner.
- Remove documentation from methods not needing it (e.g. the default
  constructor).
- Remove excessive white spaces.
- Fix typos.
- Reduce the documentation block span if the documentation fits into a
  single line.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)