### PR TITLE
wrap video

### DIFF
--- a/Modules/Video/Core/wrapping/CMakeLists.txt
+++ b/Modules/Video/Core/wrapping/CMakeLists.txt
@@ -1,4 +1,4 @@
-itk_wrap_module(ITKVideo)
+itk_wrap_module(ITKVideoCore)
 
 set(WRAPPER_SUBMODULE_ORDER
   itkTemporalDataObject

--- a/Modules/Video/Core/wrapping/CMakeLists.txt
+++ b/Modules/Video/Core/wrapping/CMakeLists.txt
@@ -1,0 +1,9 @@
+itk_wrap_module(ITKVideo)
+
+set(WRAPPER_SUBMODULE_ORDER
+  itkVideoStream
+)
+
+itk_auto_load_submodules()
+
+itk_end_wrap_module()

--- a/Modules/Video/Core/wrapping/CMakeLists.txt
+++ b/Modules/Video/Core/wrapping/CMakeLists.txt
@@ -1,6 +1,7 @@
 itk_wrap_module(ITKVideo)
 
 set(WRAPPER_SUBMODULE_ORDER
+  itkTemporalDataObject
   itkVideoStream
 )
 

--- a/Modules/Video/Core/wrapping/itkTemporalDataObject.wrap
+++ b/Modules/Video/Core/wrapping/itkTemporalDataObject.wrap
@@ -1,0 +1,1 @@
+itk_wrap_simple_class("itk::TemporalDataObject" POINTER)

--- a/Modules/Video/Core/wrapping/itkVideoStream.wrap
+++ b/Modules/Video/Core/wrapping/itkVideoStream.wrap
@@ -2,7 +2,7 @@ itk_wrap_include("itkImage.h")
 
 itk_wrap_class("itk::VideoStream" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_REAL})
+    foreach(t ${WRAP_ITK_SCALAR})
       itk_wrap_template("I${ITKM_${t}}${d}" "itk::Image<${ITKT_${t}}, ${d}>")
     endforeach()
   endforeach()

--- a/Modules/Video/Core/wrapping/itkVideoStream.wrap
+++ b/Modules/Video/Core/wrapping/itkVideoStream.wrap
@@ -1,0 +1,9 @@
+itk_wrap_include("itkImage.h")
+
+itk_wrap_class("itk::VideoStream" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("I${ITKM_${t}}${d}" "itk::Image<${ITKT_${t}}, ${d}>")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
- BUG: Fix Python wrapping labeler action regex
- COMP: Update KWStyle to fix compile warnings on Ubuntu 20.04
- BUG: Fix initializing FixedImageMarginalPDF with garbage
- WIP: Wrap ITKVideoStream
- WIP: Add itkTemporalDataObject wrapping
- BUG: Module name wrepping ITKVideoCore
