### PR TITLE
DOC: Remove indication NarrowBandCurvesLevelSetImageFilter not wrapped

### DIFF
--- a/Modules/Segmentation/LevelSets/wrapping/wrap_itkNarrowBandCurvesLevelSetImageFilter.cmake.notwrapped
+++ b/Modules/Segmentation/LevelSets/wrapping/wrap_itkNarrowBandCurvesLevelSetImageFilter.cmake.notwrapped
@@ -1,5 +1,0 @@
-itk_wrap_class("itk::NarrowBandCurvesLevelSetImageFilter")
-#   itk_wrap_image_filter("${WRAP_ITK_USIGN_INT}" 2)
-#   itk_wrap_image_filter("${WRAP_ITK_SIGN_INT}" 2)
-  itk_wrap_image_filter("${WRAP_ITK_REAL}" 2)
-WRITE_CLASS_POINTER_WRAPPER()


### PR DESCRIPTION
It is wrapped at:

  Modules/Segmentation/LevelSets/wrapping/itkNarrowBandCurvesLevelSetImageFilter.wrap
