### PR TITLE
ENH: Add RTTI information to `itk::GaussianDerivativeOperator`

### DIFF
--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -109,6 +109,9 @@ public:
   using Self = GaussianDerivativeOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(GaussianDerivativeOperator, NeighborhoodOperator);
+
   using InterpolationModeEnum = GaussianDerivativeOperatorEnums::InterpolationMode;
 
   /** Neighborhood operator types. */
@@ -239,13 +242,6 @@ private:
    * operator of 0-order respecting the remaining parameters. */
   CoefficientVector
   GenerateGaussianCoefficients() const;
-
-  /** For compatibility with itkWarningMacro */
-  const char *
-  GetNameOfClass() const override
-  {
-    return "itkGaussianDerivativeOperator";
-  }
 
   /** Normalize derivatives across scale space */
   bool m_NormalizeAcrossScale{ true };


### PR DESCRIPTION
Add run-time type information (RTTI) to the
`itk::GaussianDerivativeOperator` class.

Remove its `private` `GetNameOfClass` method: the RTTI macro defines it,
and it should be `public`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)