### PR TITLE
ENH: Add missing getter method to `itk::GaussianDerivativeOperator` ivar

### DIFF
--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -188,6 +188,7 @@ public:
   {
     m_MaximumKernelWidth = n;
   }
+  itkGetConstMacro(MaximumKernelWidth, unsigned int);
 
   /** Sets/Get the order of the derivative. */
   void


### PR DESCRIPTION
Add missing getter method to `itk::GaussianDerivativeOperator` ivar.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)