### PR TITLE
ENH: Add missing getter method to `itk::LaplacianOperator` ivar

### DIFF
--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -99,6 +99,7 @@ public:
    *  default. This method must be called BEFORE CreateOperator */
   void
   SetDerivativeScalings(const double * s);
+  itkGetConstMacro(DerivativeScalings, const double *);
 
 protected:
   /** Alias support for coefficient vector type. Necessary to


### PR DESCRIPTION
Add missing getter method to `itk::LaplacianOperator` class ivar.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)