### PR TITLE
COMP: Change ::uint32_t to std::uint32_t, uint32 to uint32_t, etc.

### DIFF
--- a/Modules/Core/Common/include/itkIntTypes.h
+++ b/Modules/Core/Common/include/itkIntTypes.h
@@ -25,38 +25,38 @@
 
 namespace itk
 {
-using int8_t = ::int8_t;
-using uint8_t = ::uint8_t;
-using int16_t = ::int16_t;
-using uint16_t = ::uint16_t;
-using int32_t = ::int32_t;
-using uint32_t = ::uint32_t;
-using int64_t = ::int64_t;
-using uint64_t = ::uint64_t;
+using int8_t = std::int8_t;
+using uint8_t = std::uint8_t;
+using int16_t = std::int16_t;
+using uint16_t = std::uint16_t;
+using int32_t = std::int32_t;
+using uint32_t = std::uint32_t;
+using int64_t = std::int64_t;
+using uint64_t = std::uint64_t;
 
-using int_least8_t = ::int_least8_t;
-using uint_least8_t = ::uint_least8_t;
-using int_least16_t = ::int_least16_t;
-using uint_least16_t = ::uint_least16_t;
-using int_least32_t = ::int_least32_t;
-using uint_least32_t = ::uint_least32_t;
-using int_least64_t = ::int_least64_t;
-using uint_least64_t = ::uint_least64_t;
+using int_least8_t = std::int_least8_t;
+using uint_least8_t = std::uint_least8_t;
+using int_least16_t = std::int_least16_t;
+using uint_least16_t = std::uint_least16_t;
+using int_least32_t = std::int_least32_t;
+using uint_least32_t = std::uint_least32_t;
+using int_least64_t = std::int_least64_t;
+using uint_least64_t = std::uint_least64_t;
 
-using int_fast8_t = ::int_fast8_t;
-using uint_fast8_t = ::uint_fast8_t;
-using int_fast16_t = ::int_fast16_t;
-using uint_fast16_t = ::uint_fast16_t;
-using int_fast32_t = ::int_fast32_t;
-using uint_fast32_t = ::uint_fast32_t;
-using int_fast64_t = ::int_fast64_t;
-using uint_fast64_t = ::uint_fast64_t;
+using int_fast8_t = std::int_fast8_t;
+using uint_fast8_t = std::uint_fast8_t;
+using int_fast16_t = std::int_fast16_t;
+using uint_fast16_t = std::uint_fast16_t;
+using int_fast32_t = std::int_fast32_t;
+using uint_fast32_t = std::uint_fast32_t;
+using int_fast64_t = std::int_fast64_t;
+using uint_fast64_t = std::uint_fast64_t;
 
-using intmax_t = ::intmax_t;
-using uintmax_t = ::uintmax_t;
+using intmax_t = std::intmax_t;
+using uintmax_t = std::uintmax_t;
 
-using intptr_t = ::intptr_t;
-using uintptr_t = ::uintptr_t;
+using intptr_t = std::intptr_t;
+using uintptr_t = std::uintptr_t;
 
 
 #if defined(ITK_USE_64BITS_IDS) && ((ULLONG_MAX != ULONG_MAX) || (LLONG_MAX != LONG_MAX))

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -53,7 +53,7 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDat
   }
   typename Statistics::NormalVariateGenerator::Pointer randn = Statistics::NormalVariateGenerator::New();
   const uint32_t                                       seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
-  // Convert the seed bit for bit to int32
+  // Convert the seed bit for bit to int32_t
   randn->Initialize(*reinterpret_cast<const int32_t *>(&seed));
 
   // Define the portion of the input to walk for this thread, using

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -313,7 +313,7 @@ DCMTKImageIO ::ReorderRGBValues(void * buffer, const void * data, size_t count, 
   {
     // DCMTK only supports unsigned integer types for RGB(A) images.
     // see DCMTK file dcmimage/libsrc/dicoimg.cc (function const void *DiColorImage::getData(...) )
-    // DCMTK only supports uint8, uint16, and uint32, but we leave LONG (at least 32bits but
+    // DCMTK only supports uint8_t, uint16_t, and uint32_t, but we leave LONG (at least 32bits but
     // could be 64bits) for future support.
     case IOComponentEnum::UCHAR:
       ReorderRGBValues<unsigned char>(buffer, data, count, voxel_size);

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1059,7 +1059,7 @@ TIFFImageIO::AllocateTiffPalette(uint16_t bps)
     itkExceptionMacro("Can't allocate space for Blue channel of component tables.");
   }
   // TIFF palette length is fixed for a given bpp
-  uint64_t TIFFPaletteLength = uint64{ 1 } << bps;
+  uint64_t TIFFPaletteLength = uint64_t{ 1 } << bps;
   for (size_t i = 0; i < TIFFPaletteLength; ++i)
   {
     if (i < m_ColorPalette.size())


### PR DESCRIPTION
Change itk namespace aliases from, for example,
```c++
using uint64_t = ::uint64_t;
```
to
```c++
using uint64_t = std::uint64_t;
```

Also, the version `uint64` is deprecated in favor of `uint64_t`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
