### PR TITLE
ENH: Increase pixel type alias consistency in common operators

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -77,6 +77,7 @@ public:
   using Superclass = NeighborhoodOperator<TPixel, TDimension, TAllocator>;
 
   /** Additional type aliases. */
+  using PixelType = typename Superclass::PixelType;
   using SizeType = typename Superclass::SizeType;
   using OffsetType = typename Superclass::OffsetType;
   using SpacingType = Vector<double, TDimension>;
@@ -224,8 +225,6 @@ protected:
   /** Typedef support for coefficient vector type.  Necessary to
    *  work around compiler bug on VC++. */
   using CoefficientVector = typename Superclass::CoefficientVector;
-
-  using PixelType = typename Superclass::PixelType;
 
   /** Calculates operator coefficients. */
   CoefficientVector

--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -77,7 +77,7 @@ public:
   using Superclass = NeighborhoodOperator<TPixel, TDimension, TAllocator>;
 
   /** Additional type aliases. */
-  using PixelType = typename Superclass::PixelType;
+  using PixelType = TPixel;
   using SizeType = typename Superclass::SizeType;
   using OffsetType = typename Superclass::OffsetType;
   using SpacingType = Vector<double, TDimension>;

--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -73,7 +73,7 @@ public:
   using Self = DerivativeOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
-  using PixelType = typename Superclass::PixelType;
+  using PixelType = TPixel;
   using PixelRealType = typename Superclass::PixelRealType;
 
   /** Sets the order of the derivative. */

--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -71,7 +71,7 @@ public:
   using Self = LaplacianOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
-  using PixelType = typename Superclass::PixelType;
+  using PixelType = TPixel;
   using SizeType = typename Superclass::SizeType;
 
   LaplacianOperator()


### PR DESCRIPTION
Increase pixel type alias consistency in common operators:
- Make `PixelType` alias be public in `itk::AnnulusOperator`
- Prefer aliasing template pixel type in `common` operator classes

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)