### PR TITLE
ENH: Add RTTI information to `Common` operator classes

### DIFF
--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
@@ -52,7 +52,9 @@ public:
   using Self = BackwardDifferenceOperator;
   using Superclass = NeighborhoodOperator<TPixel, TDimension, TAllocator>;
 
-  /** From Superclass */
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(BackwardDifferenceOperator, NeighborhoodOperator);
+
   using PixelType = typename Superclass::PixelType;
 
 protected:

--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -73,6 +73,9 @@ public:
   using Self = DerivativeOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DerivativeOperator, NeighborhoodOperator);
+
   using PixelType = TPixel;
   using PixelRealType = typename Superclass::PixelRealType;
 

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.h
@@ -51,6 +51,9 @@ public:
   using Self = ForwardDifferenceOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ForwardDifferenceOperator, NeighborhoodOperator);
+
   using PixelType = typename Superclass::PixelType;
 
 protected:

--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -71,6 +71,9 @@ public:
   using Self = LaplacianOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(LaplacianOperator, NeighborhoodOperator);
+
   using PixelType = TPixel;
   using SizeType = typename Superclass::SizeType;
 


### PR DESCRIPTION
Add run-time type information (RTTI) to `Common` operator classes.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)