### PR TITLE
STYLE: Prefer aliasing template pixel type in `common` operator classes

### DIFF
--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
@@ -55,7 +55,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(BackwardDifferenceOperator, NeighborhoodOperator);
 
-  using PixelType = typename Superclass::PixelType;
+  using PixelType = TPixel;
 
 protected:
   /** Necessary to work around a compiler bug in VC++. */

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.h
@@ -54,7 +54,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ForwardDifferenceOperator, NeighborhoodOperator);
 
-  using PixelType = typename Superclass::PixelType;
+  using PixelType = TPixel;
 
 protected:
   /** Necessary to work around VC++ compiler bug. */

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -135,7 +135,7 @@ protected:
   /** Alias support for coefficient vector type. Necessary to
    * work around compiler bug on VC++. */
   using CoefficientVector = typename Superclass::CoefficientVector;
-  using PixelType = typename Superclass::PixelType;
+  using PixelType = typename TPixel;
 
   /** Calculates operator coefficients. */
   CoefficientVector


### PR DESCRIPTION
Prefer aliasing template pixel type in `common` operator classes over
aliasing the superclass pixel type, which is earlier set to the template
pixel type.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)