### PR TITLE
BUG: Add run-time type information to FFT filter base classes

### DIFF
--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
@@ -79,6 +79,9 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ForwardFFTImageFilter, ImageToImageFilter);
+
   /** Customized object creation methods that support configuration-based
    * selection of FFT implementation.
    *

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
@@ -73,6 +73,9 @@ public:
 
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(HalfHermitianToRealInverseFFTImageFilter, ImageToImageFilter);
+
   /** Customized object creation methods that support configuration-based
    * selection of FFT implementation.
    *

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
@@ -66,6 +66,9 @@ public:
 
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(InverseFFTImageFilter, ImageToImageFilter);
+
   /** Customized object creation methods that support configuration-based
    * selection of FFT implementation.
    *

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.h
@@ -74,6 +74,9 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(RealToHalfHermitianForwardFFTImageFilter, ImageToImageFilter);
+
   /** Customized object creation methods that support configuration-based
    * selection of FFT implementation.
    *


### PR DESCRIPTION
Without this fix, `ctest` tests on subclasses of these FFTImageFilter base classes will fail their run-time type information checks.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)