### PR TITLE
ENH: Upgrade ITK from C++11 to C++14

### DIFF
--- a/CMake/itkCompilerChecks.cmake
+++ b/CMake/itkCompilerChecks.cmake
@@ -28,13 +28,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND
   message(FATAL_ERROR "Intel C++ (ICC) 14.0 or later is required.")
 endif ()
 
-# Make sure we have C++11 enabled.
-if(NOT ITK_IGNORE_CMAKE_CXX11_CHECKS)
+# Make sure we have C++14 enabled.
+if(NOT ITK_IGNORE_CMAKE_CXX14_CHECKS)
   # Needed to make sure libraries and executables not built by the
-  # itkModuleMacros still have the C++11 compiler flags enabled
+  # itkModuleMacros still have the C++14 compiler flags enabled
   # Wrap this in an escape hatch for unknown compilers
   if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11) # Supported values are ``11``, ``14``, and ``17``.
+    set(CMAKE_CXX_STANDARD 14) # Supported values are 14, 17, 20, and 23.
   endif()
   if(NOT CMAKE_CXX_STANDARD_REQUIRED)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMake/itkCompilerChecks.cmake
+++ b/CMake/itkCompilerChecks.cmake
@@ -1,31 +1,31 @@
-# Minimum compiler version check: GCC >= 4.8
+# Minimum compiler version check: GCC
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
-  message(FATAL_ERROR "GCC 4.8 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
+  message(FATAL_ERROR "GCC 5.1 or later is required.")
 endif ()
 
-# Minimum compiler version check: LLVM Clang >= 3.3
+# Minimum compiler version check: LLVM Clang
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.3)
-  message(FATAL_ERROR "LLVM Clang 3.3 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4)
+  message(FATAL_ERROR "LLVM Clang 3.4 or later is required.")
 endif ()
 
-# Minimum compiler version check: Apple Clang >= 5.0 (Xcode 5.0)
+# Minimum compiler version check: Apple Clang >= 5.1 (Xcode 5.1)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-  message(FATAL_ERROR "Apple Clang 5.0 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
+  message(FATAL_ERROR "Apple Clang 5.1 or later is required.")
 endif ()
 
-# Minimum compiler version check: Microsoft C/C++ >= 19.0 (aka VS 2015 aka VS 14.0)
+# Minimum compiler version check: Microsoft C/C++ >= 19.10 (MSVC 14.1, Visual Studio 15 2017)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0)
-  message(FATAL_ERROR "Microsoft Visual Studio 2015 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
+  message(FATAL_ERROR "Microsoft Visual Studio 2017 or later is required.")
 endif ()
 
-# Minimum compiler version check: Intel C++ (ICC) >= 14
+# Minimum compiler version check: Intel C++ (ICC)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
-  message(FATAL_ERROR "Intel C++ (ICC) 14.0 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17.0)
+  message(FATAL_ERROR "Intel C++ (ICC) 17.0 or later is required.")
 endif ()
 
 # Make sure we have C++14 enabled.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,15 @@ foreach(pold "CMP0120") # CMP0120 will require non-trivial effort to address
   endif()
 endforeach()
 
-# ==== Define language standard configurations requiring at least c++11 standard
-if(CMAKE_CXX_STANDARD EQUAL "98" )
-   message(FATAL_ERROR "CMAKE_CXX_STANDARD:STRING=98 is not supported in ITK version 5 and greater.")
+# ==== Define language standard configurations requiring at least c++14 standard
+if(CMAKE_CXX_STANDARD EQUAL "98" OR CMAKE_CXX_STANDARD LESS "14")
+   message(FATAL_ERROR "C++98 to C++11 are no longer supported in ITK version 5.3 and greater.")
 endif()
 
 #####
 ##  Set the default target properties for ITK
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11) # Supported values are ``11``, ``14``, and ``17``.
+  set(CMAKE_CXX_STANDARD 14) # Supported values are 14, 17, 20, and 23.
 endif()
 if(NOT CMAKE_CXX_STANDARD_REQUIRED)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/Documentation/SupportedCompilers.md
+++ b/Documentation/SupportedCompilers.md
@@ -1,22 +1,21 @@
-ITK requires a compiler with C++11 support.
+ITK requires a compiler with C++14 support.
 
 # Visual Studio
-* VS2013 and earlier: **NOT supported**
-* MSVC toolset v140 (first shipped with VS2015): supported
+* VS2015 and earlier: **NOT supported**
 * MSVC toolset v141 (first shipped with VS2017): supported
 * MSVC toolset v142 (first shipped with VS2019): supported
 
 # GNU Compile Collection
-* GCC 4.8.1 and later [should be supported](https://www.gnu.org/software/gcc/projects/cxx-status.html).
+* GCC 5.1 and later [should be supported](https://www.gnu.org/software/gcc/projects/cxx-status.html).
 
 # LLVM Clang
-* Clang 3.3 and later [should be supported](https://clang.llvm.org/cxx_status.html)
+* Clang 3.4 and later [should be supported](https://clang.llvm.org/cxx_status.html)
 
 # AppleClang
 * AppleClang 7.0.2 and later (from Xcode 7.2.1) [should be supported](https://en.wikipedia.org/wiki/Xcode#Version_history)
 
 # Intel C++ Compiler
-* Intel C++ 15.0.4 and later
+* Intel C++ 17.0 and later
 
 # Future versions
 Future versions of these compilers should be backwards compatible, and thus ITK is expected to work with them.

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -162,8 +162,8 @@ namespace itk
  * MSVC++ 14.16 _MSC_VER == 1916 (Visual Studio 2017 version 15.9)
  * MSVC++ 14.2 _MSC_VER == 1920 (Visual Studio 2019 Version 16.0)
  */
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-#  error "Visual Studio < 2015 is not supported under ITKv5"
+#if defined(_MSC_VER) && (_MSC_VER < 1910)
+#  error "Visual Studio < 2017 is not supported under ITKv5.3"
 #endif
 #if defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x5140)
 #  error "SUNPro C++ < 5.14.0 is not supported under ITKv5 and above"
@@ -178,8 +178,8 @@ namespace itk
 #  error "The MetroWerks compiler is not supported in ITKv4 and above"
 #endif
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) &&                                          \
-  ((__GNUC__ < 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ < 8)))
-#  error "GCC < 4.8 is not supported under ITKv5"
+  ((__GNUC__ < 5) || ((__GNUC__ == 5) && (__GNUC_MINOR__ < 1)))
+#  error "GCC < 5.1 is not supported under ITKv5.3"
 #endif
 #if defined(__sgi)
 // This is true for IRIX 6.5.18m with MIPSPro 7.3.1.3m.
@@ -188,14 +188,14 @@ namespace itk
 #  error "The SGI compiler is not supported under ITKv4 and above"
 #endif
 #if defined(__APPLE__)
-#  if defined(__clang__) && (__cplusplus < 201103L)
-#    error "Apple LLVM < 5.0 (clang < 3.3) is not supported under ITKv5"
+#  if defined(__clang__) && (__cplusplus < 201402L)
+#    error "Apple LLVM < 5.1 (clang < 3.4) is not supported under ITKv5.3"
 #  endif
-#elif defined(__clang__) && ((__clang_major__ < 3) || ((__clang_major__ == 3) && (__clang_minor__ < 3)))
-#  error "Clang < 3.3 is not supported under ITKv5"
+#elif defined(__clang__) && ((__clang_major__ < 3) || ((__clang_major__ == 3) && (__clang_minor__ < 4)))
+#  error "Clang < 3.4 is not supported under ITKv5.3"
 #endif
-#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1504)
-#  error "Intel C++ < 15.0.4 is not supported under ITKv5"
+#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1700)
+#  error "Intel C++ < 17.0 is not supported under ITKv5.3"
 #endif
 
 // Setup symbol exports

--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -218,9 +218,9 @@ macro(itk_end_wrap_submodule_castxml module)
   set(_castxml_cc_flags ${CMAKE_CXX_FLAGS})
   # Avoid missing omp.h include
   if(CMAKE_CXX_EXTENSIONS)
-    set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX11_EXTENSION_COMPILE_OPTION}")
+    set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX14_EXTENSION_COMPILE_OPTION}")
   else()
-    set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX11_STANDARD_COMPILE_OPTION}")
+    set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX14_STANDARD_COMPILE_OPTION}")
   endif()
 
   # Agressive optimization flags cause cast_xml to give invalid error conditions


### PR DESCRIPTION
Follow-up to commit babb6779b67a4b14f14cc5629da95105c8df4c83
"COMP: Enforce building ITK with C++11", Hans Johnson (@hjmjohnson), 19 January 2018

Discussion item: https://discourse.itk.org/t/may-we-start-using-c-14-at-the-master-branch/4172 