### PR TITLE
STYLE: Use macros to Set/Get ivars in `Common` operators

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -96,11 +96,7 @@ public:
   {
     m_InnerRadius = r;
   }
-  double
-  GetInnerRadius() const
-  {
-    return m_InnerRadius;
-  }
+  itkGetConstNonVirtualMacro(InnerRadius, double);
 
   /** Set/Get the thickness of the annulus.  The outer radius of the
    * annulus is defined as r = InnerRadius + Thickness. Thickness is
@@ -110,47 +106,26 @@ public:
   {
     m_Thickness = t;
   }
-  double
-  GetThickness() const
-  {
-    return m_Thickness;
-  }
+  itkGetConstNonVirtualMacro(Thickness, double);
 
-  /** Set/Get the pixel spacings.  Setting these ensures the annulus
+  /** Set/Get the pixel spacings. Setting these ensures the annulus
    * is round in physical space. Defaults to 1. */
   void
   SetSpacing(SpacingType & s)
   {
     m_Spacing = s;
   }
-  const SpacingType &
-  GetSpacing() const
-  {
-    return m_Spacing;
-  }
+  itkGetConstNonVirtualReferenceMacro(Spacing, SpacingType);
 
   /** Set/Get whether kernel values are computed automatically or
-   * specified manually */
+   * specified manually. */
   void
   SetNormalize(bool b)
   {
     m_Normalize = b;
   }
-  bool
-  GetNormalize() const
-  {
-    return m_Normalize;
-  }
-  void
-  NormalizeOn()
-  {
-    this->SetNormalize(true);
-  }
-  void
-  NormalizeOff()
-  {
-    this->SetNormalize(false);
-  }
+  itkGetConstNonVirtualMacro(Normalize, bool);
+  itkBooleanNonVirtualMacro(Normalize);
 
   /** If Normalize is on, you define the annulus to have a bright
    * center or a dark center. */
@@ -159,21 +134,8 @@ public:
   {
     m_BrightCenter = b;
   }
-  bool
-  GetBrightCenter() const
-  {
-    return m_BrightCenter;
-  }
-  void
-  BrightCenterOn()
-  {
-    this->SetBrightCenter(true);
-  }
-  void
-  BrightCenterOff()
-  {
-    this->SetBrightCenter(false);
-  }
+  itkGetConstNonVirtualMacro(BrightCenter, bool);
+  itkBooleanNonVirtualMacro(BrightCenter);
 
   /** If Normalize is off, the interior to annulus, the
    * annulus (region between the two circles), and the region exterior to the
@@ -184,31 +146,19 @@ public:
   {
     m_InteriorValue = v;
   }
-  TPixel
-  GetInteriorValue() const
-  {
-    return m_InteriorValue;
-  }
+  itkGetConstNonVirtualMacro(InteriorValue, TPixel);
   void
   SetAnnulusValue(TPixel v)
   {
     m_AnnulusValue = v;
   }
-  TPixel
-  GetAnnulusValue() const
-  {
-    return m_AnnulusValue;
-  }
+  itkGetConstNonVirtualMacro(AnnulusValue, TPixel);
   void
   SetExteriorValue(TPixel v)
   {
     m_ExteriorValue = v;
   }
-  TPixel
-  GetExteriorValue() const
-  {
-    return m_ExteriorValue;
-  }
+  itkGetConstNonVirtualMacro(ExteriorValue, TPixel);
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override

--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -78,19 +78,13 @@ public:
   /** Type alias support for pixel real type.*/
   using typename Superclass::PixelRealType;
 
-  /** Sets the order of the derivative. */
+  /** Set/Get the order of the derivative. */
   void
   SetOrder(const unsigned int order)
   {
     this->m_Order = order;
   }
-
-  /** Returns the order of the derivative. */
-  unsigned int
-  GetOrder() const
-  {
-    return m_Order;
-  }
+  itkGetConstNonVirtualMacro(Order, unsigned int);
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override
@@ -116,7 +110,6 @@ protected:
   }
 
 private:
-  /** Order of the derivative. */
   unsigned int m_Order{ 1 };
 };
 } // namespace itk

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -130,26 +130,16 @@ public:
   {
     m_NormalizeAcrossScale = flag;
   }
-  bool
-  GetNormalizeAcrossScale() const
-  {
-    return m_NormalizeAcrossScale;
-  }
+  itkGetConstNonVirtualMacro(NormalizeAcrossScale, bool);
   itkBooleanMacro(NormalizeAcrossScale);
 
-  /** Set/Get the variance of the Gaussian kernel.
-   *
-   */
+  /** Set/Get the variance of the Gaussian kernel. */
   void
   SetVariance(const double variance)
   {
     m_Variance = variance;
   }
-  double
-  GetVariance() const
-  {
-    return m_Variance;
-  }
+  itkGetConstNonVirtualMacro(Variance, double);
 
   /** Set/Get the spacing for the direction of this kernel. */
   void
@@ -157,16 +147,13 @@ public:
   {
     m_Spacing = spacing;
   }
-  double
-  GetSpacing() const
-  {
-    return m_Spacing;
-  }
+  itkGetConstNonVirtualMacro(Spacing, double);
 
-  /** Set/Get the desired maximum error of the gaussian approximation.  Maximum
-   * error is the difference between the area under the discrete Gaussian curve
-   * and the area under the continuous Gaussian. Maximum error affects the
-   * Gaussian operator size. The value is clamped between 0.00001 and 0.99999. */
+  /** Set/Get the desired maximum error of the Gaussian approximation.
+   * The maximum error is the difference between the area under the discrete
+   * Gaussian curve and the area under the continuous Gaussian. Maximum error
+   * affects the Gaussian operator size. The value is clamped between 0.00001
+   * and 0.99999. */
   void
   SetMaximumError(const double maxerror)
   {
@@ -175,16 +162,12 @@ public:
 
     m_MaximumError = std::clamp(maxerror, Min, Max);
   }
-  double
-  GetMaximumError()
-  {
-    return m_MaximumError;
-  }
+  itkGetNonVirtualMacro(MaximumError, double);
 
-  /** Sets/Get a limit for growth of the kernel.  Small maximum error values with
-   *  large variances will yield very large kernel sizes.  This value can be
-   *  used to truncate a kernel in such instances.  A warning will be given on
-   *  truncation of the kernel. */
+  /** Set/Get a limit for growth of the kernel. Small maximum error values with
+   *  large variances will yield very large kernel sizes. This value can be
+   *  used to truncate a kernel in such instances. A warning will be given when
+   *  the specified maximum error causes the kernel to exceed this size. */
   void
   SetMaximumKernelWidth(unsigned int n)
   {
@@ -192,17 +175,13 @@ public:
   }
   itkGetConstMacro(MaximumKernelWidth, unsigned int);
 
-  /** Sets/Get the order of the derivative. */
+  /** Set/Get the order of the derivative. */
   void
   SetOrder(const unsigned int order)
   {
     m_Order = order;
   }
-  unsigned int
-  GetOrder() const
-  {
-    return m_Order;
-  }
+  itkGetConstNonVirtualMacro(Order, unsigned int);
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -243,26 +222,12 @@ private:
   CoefficientVector
   GenerateGaussianCoefficients() const;
 
-  /** Normalize derivatives across scale space */
-  bool m_NormalizeAcrossScale{ true };
-
-  /** Desired variance of the discrete Gaussian function. */
-  double m_Variance{ 1.0 };
-
-  /** Difference between the areas under the curves of the continuous and
-   * discrete Gaussian functions. */
-  double m_MaximumError{ 0.005 };
-
-  /** Maximum kernel size allowed.  This value is used to truncate a kernel
-   *  that has grown too large.  A warning is given when the specified maximum
-   *  error causes the kernel to exceed this size. */
+  bool         m_NormalizeAcrossScale{ true };
+  double       m_Variance{ 1.0 };
+  double       m_MaximumError{ 0.005 };
   unsigned int m_MaximumKernelWidth{ 30 };
-
-  /** Order of the derivative. */
   unsigned int m_Order{ 1 };
-
-  /** Spacing in the direction of this kernel. */
-  double m_Spacing{ 1.0 };
+  double       m_Spacing{ 1.0 };
 };
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkGaussianOperator.h
+++ b/Modules/Core/Common/include/itkGaussianOperator.h
@@ -76,16 +76,17 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(GaussianOperator);
 
-  /** Sets the desired variance of the Gaussian kernel. */
+  /** Set/Get the desired variance of the Gaussian kernel. */
   void
   SetVariance(const double variance)
   {
     m_Variance = variance;
   }
+  itkGetNonVirtualMacro(Variance, double);
 
-  /** Sets the desired maximum error of the gaussian approximation.  Maximum
+  /** Set/Get the desired maximum error of the Gaussian approximation. The maximum
    * error is the difference between the area under the discrete Gaussian curve
-   * and the area under the continuous Gaussian. Maximum error affects the
+   * and the area under the continuous Gaussian. The maximum error affects the
    * Gaussian operator size. The value must be between 0.0 and 1.0. */
   void
   SetMaximumError(const double max_error)
@@ -97,40 +98,18 @@ public:
 
     m_MaximumError = max_error;
   }
+  itkGetNonVirtualMacro(MaximumError, double);
 
-  /** Returns the variance of the Gaussian (scale) for the operator. */
-  double
-  GetVariance()
-  {
-    return m_Variance;
-  }
-
-  /** Returns the maximum error of the gaussian approximation.  Maximum error is
-   * the difference between the area under the discrete Gaussian curve and the
-   * area under the continuous Gaussian. Maximum error affects the Gaussian
-   * operator size. */
-  double
-  GetMaximumError()
-  {
-    return m_MaximumError;
-  }
-
-  /** Sets a limit for growth of the kernel.  Small maximum error values with
-   *  large variances will yield very large kernel sizes.  This value can be
-   *  used to truncate a kernel in such instances.  A warning will be given on
-   *  truncation of the kernel. */
+  /** Set/Get a limit for growth of the kernel. Small maximum error values with
+   *  large variances will yield very large kernel sizes. This value can be
+   *  used to truncate a kernel in such instances. A warning will be given when
+   *  the specified maximum error causes the kernel to exceed this size. */
   void
   SetMaximumKernelWidth(unsigned int n)
   {
     m_MaximumKernelWidth = n;
   }
-
-  /** Returns the maximum allowed kernel width. */
-  unsigned int
-  GetMaximumKernelWidth() const
-  {
-    return m_MaximumKernelWidth;
-  }
+  itkGetConstNonVirtualMacro(MaximumKernelWidth, unsigned int);
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override
@@ -201,16 +180,8 @@ protected:
   }
 
 private:
-  /** Desired variance of the discrete Gaussian function. */
-  double m_Variance{ 1 };
-
-  /** Difference between the areas under the curves of the continuous and
-   * discrete Gaussian functions. */
-  double m_MaximumError{ .01 };
-
-  /** Maximum kernel size allowed.  This value is used to truncate a kernel
-   *  that has grown too large.  A warning is given when the specified maximum
-   *  error causes the kernel to exceed this size. */
+  double       m_Variance{ 1 };
+  double       m_MaximumError{ .01 };
   unsigned int m_MaximumKernelWidth{ 30 };
 
   /** Enable/disable kernel generation debug warnings */

--- a/Modules/Core/Common/include/itkImageKernelOperator.h
+++ b/Modules/Core/Common/include/itkImageKernelOperator.h
@@ -58,13 +58,11 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ImageKernelOperator);
 
-  /** Set the image kernel. Only images with odd size in all
+  /** Set/Get the image kernel. Only images with odd size in all
    * dimensions are allowed. If an image with an even size is passed
    * as an argument, an exception will be thrown. */
   void
   SetImageKernel(const ImageType * kernel);
-
-  /** Get the image kernel. */
   const ImageType *
   GetImageKernel() const;
 

--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -96,8 +96,8 @@ public:
     os << indent << "DerivativeScalings: " << m_DerivativeScalings << std::endl;
   }
 
-  /** Sets the weights that are applied to the derivative in each axial
-   *  direction when the kernel is computed.  These weights are all 1.0 by
+  /** Set/Get the weights that are applied to the derivative in each axial
+   *  direction when the kernel is computed. These weights are all 1.0 by
    *  default. This method must be called BEFORE CreateOperator */
   void
   SetDerivativeScalings(const double * s);

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1019,7 +1019,7 @@ compilers.
 /** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility());
  * This is the "const" form of the itkGetMacro.  It should be used unless
  * the member can be changed through the "Get" access routine.
- * This versions returns a const reference to the variable. */
+ * This version returns a const reference to the variable. */
 #define itkGetConstReferenceMacro(name, type)                       \
   virtual const type & Get##name() const { return this->m_##name; } \
   ITK_MACROEND_NOOP_STATEMENT

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1008,12 +1008,36 @@ compilers.
   virtual type Get##name() const { return this->m_##name; } \
   ITK_MACROEND_NOOP_STATEMENT
 
+/** Get built-in type.  Creates a non-virtual member Get"name"() (e.g., GetVisibility());
+ * This is the "non-virtual, const" form of the itkGetMacro. It should be used unless
+ * the member can be changed through the "Get" access routine and in situations where the
+ * method is not required to be overriden. */
+#define itkGetConstNonVirtualMacro(name, type)                                                                         \
+  type Get##name() const { return this->m_##name; }                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
+
 /** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility());
  * This is the "const" form of the itkGetMacro.  It should be used unless
  * the member can be changed through the "Get" access routine.
  * This versions returns a const reference to the variable. */
 #define itkGetConstReferenceMacro(name, type)                       \
   virtual const type & Get##name() const { return this->m_##name; } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+/** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility());
+ * This is the "non-virtual, const" form of the itkGetMacro. It should be used unless
+ * the member can be changed through the "Get" access routine and in situations where the
+ * method is not required to be overriden.
+ * This version returns a const reference to the variable. */
+#define itkGetConstNonVirtualReferenceMacro(name, type)                                                                \
+  const type & Get##name() const { return this->m_##name; }                                                            \
+  ITK_MACROEND_NOOP_STATEMENT
+
+/** Get built-in type.  Creates a non-virtual member Get"name"() (e.g., GetVisibility());
+ * This is the "non-virtual" form of the itkGetMacro. It should be used in situations where the
+ * method is not required to be overriden. */
+#define itkGetNonVirtualMacro(name, type)                                                                              \
+  type Get##name() { return this->m_##name; }                                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Set built-in type.  Creates member Set"name"() (e.g., SetVisibility());
@@ -1199,6 +1223,12 @@ compilers.
   virtual void name##On() { this->Set##name(true); }   \
   virtual void name##Off() { this->Set##name(false); } \
   ITK_MACROEND_NOOP_STATEMENT
+
+/** Create non-virtual members "name"On() and "name"Off() (e.g., DebugOn() DebugOff()).
+ * Set method must be defined to use this macro. */
+#define itkBooleanNonVirtualMacro(name)                                                                                \
+  void name##On() { this->Set##name(true); }                                                                           \
+  void name##Off() { this->Set##name(false); }
 
 // clang-format off
 /** General set vector macro creates a single method that copies specified

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.h
@@ -89,7 +89,7 @@ public:
 
   using PixelRealType = typename NumericTraits<TPixel>::RealType;
 
-  /** Sets the dimensional direction of a directional operator. */
+  /** Set/Get the direction (dimension number) of a directional operator. */
   void
   SetDirection(const unsigned long direction)
   {
@@ -100,13 +100,7 @@ public:
     }
     m_Direction = direction;
   }
-
-  /** Returns the direction (dimension number) of a directional operator. */
-  unsigned long
-  GetDirection() const
-  {
-    return m_Direction;
-  }
+  itkGetConstNonVirtualMacro(Direction, unsigned long);
 
   /** Creates the operator with length only in the specified direction.
    * The radius of the operator will be 0 except along the axis on which
@@ -180,7 +174,6 @@ protected:
   }
 
 private:
-  /** Direction (dimension number) of the derivative. */
   unsigned long m_Direction{ 0 };
 };
 } // namespace itk


### PR DESCRIPTION
Use macros to Set/Get ivars in `Common` operators.

Take advantage of the commit to leave the documentation of the ivars only
in their corresponding Set/Get methods, as dictated by the ITK SW Guide.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)