### PR TITLE
STYLE: Replace `new` by C++14 `std::make_unique`

### DIFF
--- a/Modules/Core/Common/include/itkOptimizerParameters.h
+++ b/Modules/Core/Common/include/itkOptimizerParameters.h
@@ -96,7 +96,7 @@ public:
   Initialize()
   {
     // Set the default OptimizerParametersHelper
-    this->m_Helper.reset(new OptimizerParametersHelperType);
+    this->m_Helper = std::make_unique<OptimizerParametersHelperType>();
   }
 
 
@@ -182,8 +182,7 @@ public:
   ~OptimizerParameters() override = default;
 
 private:
-  std::unique_ptr<OptimizerParametersHelperType> m_Helper =
-    std::unique_ptr<OptimizerParametersHelperType>{ new OptimizerParametersHelperType };
+  std::unique_ptr<OptimizerParametersHelperType> m_Helper{ std::make_unique<OptimizerParametersHelperType>() };
 };
 
 } // namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -200,13 +200,13 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
   {
     progressPerDimension = 0.67f / (static_cast<float>(ImageDimension) + 1);
   }
-  std::unique_ptr<ProgressReporter> progress(
-    new ProgressReporter(this,
-                         threadId,
-                         NumberOfRows[m_CurrentDimension],
-                         30,
-                         0.33f + static_cast<float>(m_CurrentDimension * progressPerDimension),
-                         progressPerDimension));
+  auto progress =
+    std::make_unique<ProgressReporter>(this,
+                                       threadId,
+                                       NumberOfRows[m_CurrentDimension],
+                                       30,
+                                       0.33f + static_cast<float>(m_CurrentDimension * progressPerDimension),
+                                       progressPerDimension);
 
   // This variable provides the amount by which to divide the dimensionless index in order to get the index for each
   // dimension.

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.hxx
@@ -262,9 +262,9 @@ TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputIma
 
   if (inputPtr1 && inputPtr2 && inputPtr3)
   {
-    inputIt1.reset(new ImageScanlineConstIterator<TInputImage1>(inputPtr1, outputRegionForThread));
-    inputIt2.reset(new ImageScanlineConstIterator<TInputImage2>(inputPtr2, outputRegionForThread));
-    inputIt3.reset(new ImageScanlineConstIterator<TInputImage3>(inputPtr3, outputRegionForThread));
+    inputIt1 = std::make_unique<ImageScanlineConstIterator<TInputImage1>>(inputPtr1, outputRegionForThread);
+    inputIt2 = std::make_unique<ImageScanlineConstIterator<TInputImage2>>(inputPtr2, outputRegionForThread);
+    inputIt3 = std::make_unique<ImageScanlineConstIterator<TInputImage3>>(inputPtr3, outputRegionForThread);
 
     while (!outputIt.IsAtEnd())
     {
@@ -287,15 +287,15 @@ TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputIma
   {
     if (inputPtr1)
     {
-      inputIt1.reset(new ImageScanlineConstIterator<TInputImage1>(inputPtr1, outputRegionForThread));
+      inputIt1 = std::make_unique<ImageScanlineConstIterator<TInputImage1>>(inputPtr1, outputRegionForThread);
     }
     if (inputPtr2)
     {
-      inputIt2.reset(new ImageScanlineConstIterator<TInputImage2>(inputPtr2, outputRegionForThread));
+      inputIt2 = std::make_unique<ImageScanlineConstIterator<TInputImage2>>(inputPtr2, outputRegionForThread);
     }
     if (inputPtr3)
     {
-      inputIt3.reset(new ImageScanlineConstIterator<TInputImage3>(inputPtr3, outputRegionForThread));
+      inputIt3 = std::make_unique<ImageScanlineConstIterator<TInputImage3>>(inputPtr3, outputRegionForThread);
     }
 
 

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -290,7 +290,7 @@ HDF5TransformIOTemplate<TParametersValueType>::Read()
   // happens in a big try/catch clause
   try
   {
-    this->m_H5File.reset(new H5::H5File(this->GetFileName(), H5F_ACC_RDONLY));
+    this->m_H5File = std::make_unique<H5::H5File>(this->GetFileName(), H5F_ACC_RDONLY);
     // open /TransformGroup
     H5::Group transformGroup = this->m_H5File->openGroup(transformGroupName);
 
@@ -420,7 +420,8 @@ HDF5TransformIOTemplate<TParametersValueType>::Write()
 #  error The selected version of HDF5 library does not support setting backwards compatibility at run-time.\
   Please use a different version of HDF5, e.g. the one bundled with ITK (by setting ITK_USE_SYSTEM_HDF5 to OFF).
 #endif
-    this->m_H5File.reset(new H5::H5File(this->GetFileName(), H5F_ACC_TRUNC, H5::FileCreatPropList::DEFAULT, fapl));
+    this->m_H5File =
+      std::make_unique<H5::H5File>(this->GetFileName(), H5F_ACC_TRUNC, H5::FileCreatPropList::DEFAULT, fapl);
 
     this->WriteString(ItkVersion, Version::GetITKVersion());
     this->WriteString(HDFVersion, H5_VERS_INFO);

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
@@ -166,7 +166,7 @@ LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::SetMetric(MetricType * metric)
 
   this->SetCostFunctionAdaptor(adaptor);
 
-  m_VnlOptimizer.reset(new InternalOptimizerType(*adaptor, this));
+  m_VnlOptimizer = std::make_unique<InternalOptimizerType>(*adaptor, this);
 }
 
 template <typename TInternalVnlOptimizerType>

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -176,7 +176,7 @@ LBFGSBOptimizerv4 ::SetMetric(MetricType * metric)
 
   CostFunctionAdaptorType * adaptor = this->GetCostFunctionAdaptor();
 
-  m_VnlOptimizer.reset(new InternalOptimizerType(*adaptor, this));
+  m_VnlOptimizer = std::make_unique<InternalOptimizerType>(*adaptor, this);
 
   // set the optimizer parameters
   m_VnlOptimizer->set_trace(m_Trace);


### PR DESCRIPTION
According to Clang-Tidy `modernize-make-unique`:
https://clang.llvm.org/extra/clang-tidy/checks/modernize-make-unique.html

C++ Core Guidelines, March 11, 2021, R.23: Use make_unique() to make unique_ptrs
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-make_unique