### PR TITLE
STYLE: Use C++14 <type_traits> template aliases instead of nested types

### DIFF
--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -85,7 +85,7 @@ private:
   constexpr static bool SupportsDirectPixelAccess =
     std::is_same<PixelType, InternalPixelType>::value &&
     std::is_same<typename TImage::AccessorType, DefaultPixelAccessor<PixelType>>::value &&
-    std::is_same<AccessorFunctorType, DefaultPixelAccessorFunctor<typename std::remove_const<TImage>::type>>::value;
+    std::is_same<AccessorFunctorType, DefaultPixelAccessorFunctor<std::remove_const_t<TImage>>>::value;
 
   // Tells whether or not this range is using a pointer as iterator.
   constexpr static bool UsingPointerAsIterator = SupportsDirectPixelAccess;
@@ -94,7 +94,7 @@ private:
   {};
 
   using OptionalAccessorFunctorType =
-    typename std::conditional<SupportsDirectPixelAccess, EmptyAccessorFunctor, AccessorFunctorType>::type;
+    std::conditional_t<SupportsDirectPixelAccess, EmptyAccessorFunctor, AccessorFunctorType>;
 
   // PixelProxy: internal class that aims to act like a reference to a pixel:
   // It acts either like 'PixelType &' or like 'const PixelType &', depending
@@ -237,15 +237,14 @@ private:
     friend class ImageBufferRange;
 
     // Image type class that is either 'const' or non-const qualified, depending on QualifiedIterator and TImage.
-    using QualifiedImageType = typename std::conditional<VIsConst, const ImageType, ImageType>::type;
+    using QualifiedImageType = std::conditional_t<VIsConst, const ImageType, ImageType>;
 
     static constexpr bool IsImageTypeConst = std::is_const<QualifiedImageType>::value;
 
-    using QualifiedInternalPixelType =
-      typename std::conditional<IsImageTypeConst, const InternalPixelType, InternalPixelType>::type;
+    using QualifiedInternalPixelType = std::conditional_t<IsImageTypeConst, const InternalPixelType, InternalPixelType>;
 
     // Pixel type class that is either 'const' or non-const qualified, depending on QualifiedImageType.
-    using QualifiedPixelType = typename std::conditional<IsImageTypeConst, const PixelType, PixelType>::type;
+    using QualifiedPixelType = std::conditional_t<IsImageTypeConst, const PixelType, PixelType>;
 
 
     // Wraps a reference to a pixel.
@@ -292,8 +291,7 @@ private:
     // Types conforming the iterator requirements of the C++ standard library:
     using difference_type = std::ptrdiff_t;
     using value_type = PixelType;
-    using reference =
-      typename std::conditional<SupportsDirectPixelAccess, QualifiedPixelType &, PixelProxy<IsImageTypeConst>>::type;
+    using reference = std::conditional_t<SupportsDirectPixelAccess, QualifiedPixelType &, PixelProxy<IsImageTypeConst>>;
     using pointer = QualifiedPixelType *;
     using iterator_category = std::random_access_iterator_tag;
 
@@ -326,7 +324,7 @@ private:
     {
       assert(m_InternalPixelPointer != nullptr);
 
-      using PixelWrapper = typename std::conditional<SupportsDirectPixelAccess, PixelReferenceWrapper, reference>::type;
+      using PixelWrapper = std::conditional_t<SupportsDirectPixelAccess, PixelReferenceWrapper, reference>;
 
       return PixelWrapper{ *m_InternalPixelPointer, m_OptionalAccessorFunctor };
     }
@@ -487,8 +485,7 @@ private:
 
   static constexpr bool IsImageTypeConst = std::is_const<TImage>::value;
 
-  using QualifiedInternalPixelType =
-    typename std::conditional<IsImageTypeConst, const InternalPixelType, InternalPixelType>::type;
+  using QualifiedInternalPixelType = std::conditional_t<IsImageTypeConst, const InternalPixelType, InternalPixelType>;
 
   class AccessorFunctorInitializer final
   {
@@ -549,10 +546,9 @@ private:
   SizeValueType m_NumberOfPixels = 0;
 
 public:
-  using const_iterator =
-    typename std::conditional<UsingPointerAsIterator, const InternalPixelType *, QualifiedIterator<true>>::type;
-  using iterator = typename std::
-    conditional<UsingPointerAsIterator, QualifiedInternalPixelType *, QualifiedIterator<IsImageTypeConst>>::type;
+  using const_iterator = std::conditional_t<UsingPointerAsIterator, const InternalPixelType *, QualifiedIterator<true>>;
+  using iterator =
+    std::conditional_t<UsingPointerAsIterator, QualifiedInternalPixelType *, QualifiedIterator<IsImageTypeConst>>;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -112,9 +112,9 @@ private:
     friend class ImageRegionRange;
 
     // Use either a const or a non-const qualified image buffer iterator.
-    using QualifiedBufferIteratorType = typename std::conditional<VIsConst,
-                                                                  typename ImageBufferRange<TImage>::const_iterator,
-                                                                  typename ImageBufferRange<TImage>::iterator>::type;
+    using QualifiedBufferIteratorType = std::conditional_t<VIsConst,
+                                                           typename ImageBufferRange<TImage>::const_iterator,
+                                                           typename ImageBufferRange<TImage>::iterator>;
 
     // QualifiedIterator data members (strictly private):
 

--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -258,7 +258,7 @@ public:
 
 
     // When BeginAtZero is true, use zero as minimum index, otherwise use itk::Index<N>.
-    using MinIndexType = typename std::conditional<VBeginAtZero, ZeroIndex, IndexType>::type;
+    using MinIndexType = std::conditional_t<VBeginAtZero, ZeroIndex, IndexType>;
 
     // Private constructor, only used by friend class IndexRange.
     const_iterator(const IndexType & index, const MinIndexType & minIndex, const IndexType & maxIndex) ITK_NOEXCEPT
@@ -310,7 +310,7 @@ public:
    * case there is a substitution failure, and C++ "SFINAE" kicks in).
    */
   template <bool VIsSubstitutionFailure = VBeginAtZero,
-            typename TVoid = typename std::enable_if<!VIsSubstitutionFailure>::type>
+            typename TVoid = std::enable_if_t<!VIsSubstitutionFailure>>
   explicit IndexRange(const ImageRegion<VDimension> & imageRegion)
     : // Note: Use parentheses instead of curly braces to initialize data members,
       // to avoid AppleClang 6.0.0.6000056 compile errors, "no viable conversion..."

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -294,15 +294,14 @@ private:
     friend class ShapedImageNeighborhoodRange;
 
     // Image type class that is either 'const' or non-const qualified, depending on QualifiedIterator and TImage.
-    using QualifiedImageType = typename std::conditional<VIsConst, const ImageType, ImageType>::type;
+    using QualifiedImageType = std::conditional_t<VIsConst, const ImageType, ImageType>;
 
     static constexpr bool IsImageTypeConst = std::is_const<QualifiedImageType>::value;
 
-    using QualifiedInternalPixelType =
-      typename std::conditional<IsImageTypeConst, const InternalPixelType, InternalPixelType>::type;
+    using QualifiedInternalPixelType = std::conditional_t<IsImageTypeConst, const InternalPixelType, InternalPixelType>;
 
     // Pixel type class that is either 'const' or non-const qualified, depending on QualifiedImageType.
-    using QualifiedPixelType = typename std::conditional<IsImageTypeConst, const PixelType, PixelType>::type;
+    using QualifiedPixelType = std::conditional_t<IsImageTypeConst, const PixelType, PixelType>;
 
     // Pointer to the buffer of the image. Only null when the iterator is default-constructed.
     QualifiedInternalPixelType * m_ImageBufferPointer = nullptr;
@@ -579,8 +578,7 @@ private:
 
   static constexpr bool IsImageTypeConst = std::is_const<TImage>::value;
 
-  using QualifiedInternalPixelType =
-    typename std::conditional<IsImageTypeConst, const InternalPixelType, InternalPixelType>::type;
+  using QualifiedInternalPixelType = std::conditional_t<IsImageTypeConst, const InternalPixelType, InternalPixelType>;
 
 
   // Just the data from itk::ImageRegion (not the virtual table)

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -613,8 +613,8 @@ private:
   {
     auto pointerToData = GetPointerToMatrixData(A);
     using PointerType = decltype(pointerToData);
-    using ValueTypeCV = typename std::remove_pointer<PointerType>::type;
-    using ValueType = typename std::remove_cv<ValueTypeCV>::type;
+    using ValueTypeCV = std::remove_pointer_t<PointerType>;
+    using ValueType = std::remove_cv_t<ValueTypeCV>;
     using EigenLibMatrixType = Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
     using EigenConstMatrixMap = Eigen::Map<const EigenLibMatrixType>;
     EigenConstMatrixMap inputMatrix(pointerToData, m_Dimension, m_Dimension);
@@ -715,8 +715,8 @@ private:
   {
     auto pointerToData = GetPointerToMatrixData(A);
     using PointerType = decltype(pointerToData);
-    using ValueTypeCV = typename std::remove_pointer<PointerType>::type;
-    using ValueType = typename std::remove_cv<ValueTypeCV>::type;
+    using ValueTypeCV = std::remove_pointer_t<PointerType>;
+    using ValueType = std::remove_cv_t<ValueTypeCV>;
     using EigenLibMatrixType = Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
     using EigenConstMatrixMap = Eigen::Map<const EigenLibMatrixType>;
     EigenConstMatrixMap inputMatrix(pointerToData, m_Dimension, m_Dimension);
@@ -910,8 +910,8 @@ private:
   {
     auto pointerToData = GetPointerToMatrixData(A);
     using PointerType = decltype(pointerToData);
-    using ValueTypeCV = typename std::remove_pointer<PointerType>::type;
-    using ValueType = typename std::remove_cv<ValueTypeCV>::type;
+    using ValueTypeCV = std::remove_pointer_t<PointerType>;
+    using ValueType = std::remove_cv_t<ValueTypeCV>;
     using EigenLibMatrixType = Eigen::Matrix<ValueType, VDimension, VDimension, Eigen::RowMajor>;
     using EigenConstMatrixMap = Eigen::Map<const EigenLibMatrixType>;
     EigenConstMatrixMap inputMatrix(pointerToData);
@@ -1067,8 +1067,8 @@ private:
   {
     auto pointerToData = GetPointerToMatrixData(A);
     using PointerType = decltype(pointerToData);
-    using ValueTypeCV = typename std::remove_pointer<PointerType>::type;
-    using ValueType = typename std::remove_cv<ValueTypeCV>::type;
+    using ValueTypeCV = std::remove_pointer_t<PointerType>;
+    using ValueType = std::remove_cv_t<ValueTypeCV>;
     using EigenLibMatrixType = Eigen::Matrix<ValueType, VDimension, VDimension, Eigen::RowMajor>;
     using EigenConstMatrixMap = Eigen::Map<const EigenLibMatrixType>;
     EigenConstMatrixMap inputMatrix(pointerToData);

--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -84,10 +84,9 @@ auto result = pool->AddWork([](int param) { return param; }, 7);
    * std::cout << result.get() << std::endl; */
   template <class Function, class... Arguments>
   auto
-  AddWork(Function && function, Arguments &&... arguments)
-    -> std::future<typename std::result_of<Function(Arguments...)>::type>
+  AddWork(Function && function, Arguments &&... arguments) -> std::future<std::result_of_t<Function(Arguments...)>>
   {
-    using return_type = typename std::result_of<Function(Arguments...)>::type;
+    using return_type = std::result_of_t<Function(Arguments...)>;
 
     auto task = std::make_shared<std::packaged_task<return_type()>>(
       std::bind(std::forward<Function>(function), std::forward<Arguments>(arguments)...));

--- a/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
@@ -31,8 +31,8 @@ Expect_data_returns_pointer_to_first_element(T & container)
 {
   static_assert(std::is_pointer<decltype(container.data())>::value, "data() must return a pointer");
 
-  static_assert(std::is_const<typename std::remove_reference<decltype(*(container.data()))>::type>::value ==
-                  std::is_const<typename std::remove_reference<decltype(container[0])>::type>::value,
+  static_assert(std::is_const<std::remove_reference_t<decltype(*(container.data()))>>::value ==
+                  std::is_const<std::remove_reference_t<decltype(container[0])>>::value,
                 "*container.data() and container[0] must have the same const-ness");
 
   EXPECT_EQ(container.data(), &container[0]);

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -553,12 +553,10 @@ public:
    * The image parameter may be either a SmartPointer or a raw pointer.
    * */
   template <typename TImage>
-  typename std::enable_if<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions,
-                          void>::type
+  std::enable_if_t<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions, void>
   ApplyToImageMetadata(TImage * image) const;
   template <typename TImage>
-  typename std::enable_if<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions,
-                          void>::type
+  std::enable_if_t<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions, void>
   ApplyToImageMetadata(SmartPointer<TImage> image) const
   {
     this->ApplyToImageMetadata(image.GetPointer()); // Delegate to the raw pointer signature

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -473,8 +473,7 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformS
 
 template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 template <typename TImage>
-typename std::enable_if<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions,
-                        void>::type
+std::enable_if_t<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions, void>
 Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::ApplyToImageMetadata(TImage * image) const
 {
   using ImageType = TImage;

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
@@ -141,13 +141,13 @@ protected:
 
   template <typename TInputPixelType,
             typename TOutputPixelType,
-            typename std::enable_if<mpl::is_static_castable<TInputPixelType, TOutputPixelType>::value, int>::type = 0>
+            std::enable_if_t<mpl::is_static_castable<TInputPixelType, TOutputPixelType>::value, int> = 0>
   void
   DynamicThreadedGenerateDataDispatched(const OutputImageRegionType & outputRegionForThread);
 
   template <typename TInputPixelType,
             typename TOutputPixelType,
-            typename std::enable_if<!mpl::is_static_castable<TInputPixelType, TOutputPixelType>::value, int>::type = 0>
+            std::enable_if_t<!mpl::is_static_castable<TInputPixelType, TOutputPixelType>::value, int> = 0>
   void
   DynamicThreadedGenerateDataDispatched(const OutputImageRegionType & outputRegionForThread);
 

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
@@ -90,7 +90,7 @@ CastImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 template <typename TInputImage, typename TOutputImage>
 template <typename TInputPixelType,
           typename TOutputPixelType,
-          typename std::enable_if<mpl::is_static_castable<TInputPixelType, TOutputPixelType>::value, int>::type>
+          std::enable_if_t<mpl::is_static_castable<TInputPixelType, TOutputPixelType>::value, int>>
 void
 CastImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDataDispatched(
   const OutputImageRegionType & outputRegionForThread)
@@ -112,7 +112,7 @@ CastImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDataDispatche
 template <typename TInputImage, typename TOutputImage>
 template <typename TInputPixelType,
           typename TOutputPixelType,
-          typename std::enable_if<!mpl::is_static_castable<TInputPixelType, TOutputPixelType>::value, int>::type>
+          std::enable_if_t<!mpl::is_static_castable<TInputPixelType, TOutputPixelType>::value, int>>
 void
 CastImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDataDispatched(
   const OutputImageRegionType & outputRegionForThread)

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -94,24 +94,25 @@ GetCastTypeName()
 // static_cast_is_well_defined function returns true if the result of the static cast is well defined
 // and false if the result is undefined.
 template <typename TInput, typename TOutput>
-static typename std::enable_if<std::is_integral<TOutput>::value && std::is_integral<TInput>::value, bool>::type
+static std::enable_if_t<std::is_integral<TOutput>::value && std::is_integral<TInput>::value, bool>
   static_cast_is_well_defined(TInput)
 {
   return true; // casting from int to int types employes deterministic 2's complement behavior
 }
 
 template <typename TInput, typename TOutput>
-static typename std::enable_if<std::is_floating_point<TOutput>::value &&
-                                 (std::is_floating_point<TInput>::value || std::is_integral<TInput>::value),
-                               bool>::type static_cast_is_well_defined(TInput)
+static std::enable_if_t<std::is_floating_point<TOutput>::value &&
+                          (std::is_floating_point<TInput>::value || std::is_integral<TInput>::value),
+                        bool>
+  static_cast_is_well_defined(TInput)
 {
   return true; // Floating point to floating point static casts are always consistently defined.
 }
 
 template <typename TInput, typename TOutput>
-static typename std::enable_if<std::is_integral<TOutput>::value && std::is_unsigned<TOutput>::value &&
-                                 std::is_floating_point<TInput>::value,
-                               bool>::type
+static std::enable_if_t<std::is_integral<TOutput>::value && std::is_unsigned<TOutput>::value &&
+                          std::is_floating_point<TInput>::value,
+                        bool>
 static_cast_is_well_defined(TInput value)
 {
   if (value < 0.0 || value > static_cast<TInput>(std::numeric_limits<TOutput>::max()))
@@ -122,9 +123,9 @@ static_cast_is_well_defined(TInput value)
 }
 
 template <typename TInput, typename TOutput>
-static typename std::enable_if<std::is_integral<TOutput>::value && std::is_signed<TOutput>::value &&
-                                 std::is_floating_point<TInput>::value,
-                               bool>::type
+static std::enable_if_t<std::is_integral<TOutput>::value && std::is_signed<TOutput>::value &&
+                          std::is_floating_point<TInput>::value,
+                        bool>
 static_cast_is_well_defined(TInput value)
 {
   if (value < static_cast<TInput>(std::numeric_limits<TOutput>::min()) ||

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.h
@@ -136,7 +136,7 @@ private:
 
   /** Round different pixel types. */
   template <class TOutputType, class TInputType>
-  typename std::enable_if<std::numeric_limits<TOutputType>::is_integer, TOutputType>::type
+  std::enable_if_t<std::numeric_limits<TOutputType>::is_integer, TOutputType>
   RoundIfInteger(TInputType input)
   {
     return Math::Round<TOutputType>(input);
@@ -145,7 +145,7 @@ private:
   // For Non-fundamental types numeric_limits is not specialized, and
   // is_integer defaults to false.
   template <class TOutputType, class TInputType>
-  typename std::enable_if<!std::numeric_limits<TOutputType>::is_integer, TOutputType>::type
+  std::enable_if_t<!std::numeric_limits<TOutputType>::is_integer, TOutputType>
   RoundIfInteger(const TInputType & input, ...)
   {
     return static_cast<TOutputType>(input);

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -246,12 +246,12 @@ template <typename TImagePointer>
 ITK_TEMPLATE_EXPORT void
 WriteImage(TImagePointer && image, const std::string & filename, bool compress = false)
 {
-  using NonReferenceImagePointer = typename std::remove_reference<TImagePointer>::type;
+  using NonReferenceImagePointer = std::remove_reference_t<TImagePointer>;
   static_assert(std::is_pointer<NonReferenceImagePointer>::value ||
                   mpl::IsSmartPointer<NonReferenceImagePointer>::Value,
                 "WriteImage requires a raw pointer or SmartPointer.");
 
-  using ImageType = typename std::remove_const<typename std::remove_reference<decltype(*image)>::type>::type;
+  using ImageType = std::remove_const_t<std::remove_reference_t<decltype(*image)>>;
   auto writer = ImageFileWriter<ImageType>::New();
   writer->SetInput(image);
   writer->SetFileName(filename);


### PR DESCRIPTION
Replaced uses of nested types from `<type_traits>` (from C++11) by the
corresponding C++14 template aliases. Removed the corresponding `typename`
keywords that were originally necessary. Did so by running the following
command, at the GNU bash prompt, from the root of the ITK source tree:

    find . \( -iname itk*.cxx -or -iname itk*.hxx -or -iname itk*.h \) -exec perl -pi -w -e 's/typename std::(\w+)<(.+)>::type/std::$1_t<$2>/g;' {} \;
