### PR TITLE
DOC: Fix description of SpatialObjectToImage registration

### DIFF
--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
@@ -38,18 +38,17 @@ namespace itk
  *  Moving object. This direction of the transform is the one that makes easier
  *  to resample the Moving object into the space of the Fixed object.
  *
- *  In the particular case of the ImageToSpatialObject registration, the
+ *  In the particular case of ImageToSpatialObject registration, the
  *  Transform to be computed is the one mapping points from the SpatialObject
- *  into the Image, despite the fact that the SpatialObject is called the
- *  "Moving" object and the image is called the "Fixed" object. This change of
- *  reference system is the consequence of using this type of registration in
- *  applications that are based on Visualization. In the context of such
- *  visualizations it is simpler to think in terms of the Transform that can be
- *  used for displaying the SpatialObject in the appropriate position with
- *  respect to the image. Since this process does not involve resampling, but
- *  providing a Transform to a visualization routine, it is usually more
- *  natural to use the Transform that maps points from the SpatialObject space
- *  the image space.
+ *  into the Image.  This allows the SpatialObject to drive the location and
+ *  geometry of the measurements made in the image - thereby if the spatial
+ *  object is sparse and/or contains varying geometric features, the metric
+ *  applied to measure how well that object matches with the image can be
+ *  rapidly computed only at the sparse locations and using measures that
+ *  match the local geometry that should be at those locations in the image.
+ *  This is particularly useful for fast intra-operative registration when the
+ *  pre-operative data is used to define a SpatialObject and can anticipate
+ *  how that object will appear in the intra-operative images.
  *
  *  A full discussion of the Transform directions in the ITK registration
  *  framework can be found in the ITK Software Guide.

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.h
@@ -62,18 +62,17 @@ namespace itk
  * Moving object. This direction of the transform is the one that makes easier
  * to resample the Moving object into the space of the Fixed object.
  *
- * In the particular case of the ImageToSpatialObject registration, the
+ * In the particular case of ImageToSpatialObject registration, the
  * Transform to be computed is the one mapping points from the SpatialObject
- * into the Image, despite the fact that the SpatialObject is called the
- * "Moving" object and the image is called the "Fixed" object. This change of
- * reference system is the consequence of using this type of registration in
- * applications that are based on Visualization. In the context of such
- * visualizations it is simpler to think in terms of the Transform that can be
- * used for displaying the SpatialObject in the appropriate position with
- * respect to the image. Since this process does not involve resampling, but
- * providing a Transform to a visualization routine, it is usually more
- * natural to use the Transform that maps points from the SpatialObject space
- * the image space.
+ * into the Image.  This allows the SpatialObject to drive the location and
+ * geometry of the measurements made in the image - thereby if the spatial
+ * object is sparse and/or contains varying geometric features, the metric
+ * applied to measure how well that object matches with the image can be
+ * rapidly computed only at the sparse locations and using measures that
+ * match the local geometry that should be at those locations in the image.
+ * This is particularly useful for fast intra-operative registration when the
+ * pre-operative data is used to define a SpatialObject and can anticipate
+ * how that object will appear in the intra-operative images.
  *
  * A full discussion of the Transform directions in the ITK registration
  * framework can be found in the ITK Software Guide.


### PR DESCRIPTION
Corrects the description of the motivation for SpatialObject registration.

In the particular case of ImageToSpatialObject registration, the
Transform to be computed is the one mapping points from the SpatialObject
into the Image.  This allows the SpatialObject to drive the location and
geometry of the measurements made in the image - thereby if the spatial
object is sparse and/or contains varying geometric features, the metric
applied to measure how well that object matches with the image can be
rapidly computed only at the sparse locations and using measures that
match the local geometry that should be at those locations in the image.
This is particularly useful for fast intra-operative registration when the
pre-operative data is used to define a SpatialObject and can anticipate
how that object will appear in the intra-operative images.
