### PR TITLE
ENH: Add support for long long pixel types to ImageDuplicator wrapping

### DIFF
--- a/Modules/Core/Common/wrapping/itkImageDuplicator.wrap
+++ b/Modules/Core/Common/wrapping/itkImageDuplicator.wrap
@@ -10,7 +10,7 @@ endmacro()
 itk_wrap_class("itk::ImageDuplicator" POINTER)
   # Making sure that all types wrapped in PyBuffer are also wrapped for ImageDuplicator
   # as this filter is used in the Python NumPy  bridge.
-  UNIQUE(types "${WRAP_ITK_SCALAR};UC;D;US;UI;UL;SC;SS;SI;SL;F")
+  UNIQUE(types "${WRAP_ITK_SCALAR};UC;D;US;UI;UL;ULL;SC;SS;SI;SL;SLL;F")
   foreach(t ${types})
     string(REGEX MATCHALL "(V${t}|CV${t})" VectorTypes ${WRAP_ITK_VECTOR})
     set(PixelType ${t})


### PR DESCRIPTION
This is a follow-up to #2554, suggested in
https://github.com/InsightSoftwareConsortium/ITK/pull/2578#issuecomment-855014914


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

