### PR TITLE
COMP: Require Apple Clang 7.0.2 as minimum in itkCompilerChecks.cmake

### DIFF
--- a/CMake/itkCompilerChecks.cmake
+++ b/CMake/itkCompilerChecks.cmake
@@ -10,10 +10,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
   message(FATAL_ERROR "LLVM Clang 3.4 or later is required.")
 endif ()
 
-# Minimum compiler version check: Apple Clang >= 5.1 (Xcode 5.1)
+# Minimum compiler version check: Apple Clang >= 7.0.2 (Xcode 7.2.1)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
-  message(FATAL_ERROR "Apple Clang 5.1 or later is required.")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.2)
+  message(FATAL_ERROR "Apple Clang 7.0.2 or later is required.")
 endif ()
 
 # Minimum compiler version check: Microsoft C/C++ >= 19.10 (MSVC 14.1, Visual Studio 15 2017)


### PR DESCRIPTION
Following commit https://github.com/InsightSoftwareConsortium/ITKSoftwareGuide/commit/f65f786d883a4de033da118908cf06aacb9e7c2b
"ENH: Update Xcode Apple Clang compiler for nightly dashboard"

The new version numbers are based on feedback from Sean McBride (@seanm), at:

Pull request "ENH: Update compiler versions for C++14"
https://github.com/InsightSoftwareConsortium/ITKSoftwareGuide/pull/156

Discussion topic "May we start using C++14 at the master branch?"
https://discourse.itk.org/t/may-we-start-using-c-14-at-the-master-branch/4172/23?u=niels_dekker