### PR TITLE
STYLE: Use `ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION` in Modules/Core

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -232,12 +232,7 @@ public:
     return (m_Index == region.m_Index) && (m_Size == region.m_Size);
   }
 
-  /** Compare two regions. */
-  bool
-  operator!=(const Self & region) const ITK_NOEXCEPT
-  {
-    return !(*this == region);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   /** Test if an index is inside */
   bool

--- a/Modules/Core/ImageAdaptors/include/itkBluePixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkBluePixelAccessor.h
@@ -66,16 +66,12 @@ public:
   }
 
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageAdaptors/include/itkGreenPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkGreenPixelAccessor.h
@@ -67,16 +67,12 @@ public:
   }
 
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageAdaptors/include/itkRedPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkRedPixelAccessor.h
@@ -65,16 +65,12 @@ public:
   }
 
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 };
 } // end namespace itk
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -131,30 +131,13 @@ public:
 
   /** Iteration methods. */
   bool
-  operator==(Self & r)
-  {
-    return ((m_StartEdge == r.m_StartEdge) && (m_Iterator == r.m_Iterator) && (m_OpType == r.m_OpType) &&
-            (m_Start == r.m_Start));
-  }
-
-  bool
   operator==(const Self & r) const
   {
     return ((m_StartEdge == r.m_StartEdge) && (m_Iterator == r.m_Iterator) && (m_OpType == r.m_OpType) &&
             (m_Start == r.m_Start));
   }
 
-  bool
-  operator!=(Self & r)
-  {
-    return (!(this->operator==(r)));
-  }
-
-  bool
-  operator!=(const Self & r) const
-  {
-    return (!(this->operator==(r)));
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   Self &
   operator++()

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -118,11 +118,9 @@ protected:
     {
       return (m_Edge == r.m_Edge);
     }
-    bool
-    operator!=(const FrontAtom & r) const
-    {
-      return (m_Edge != r.m_Edge);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(FrontAtom);
+
     bool
     operator<(const FrontAtom & r) const
     {
@@ -171,28 +169,12 @@ public:
 
   // Iteration methods.
   bool
-  operator==(Self & r) const
-  {
-    return (m_Start == r.m_Start);
-  }
-
-  bool
   operator==(const Self & r) const
   {
     return (m_Start == r.m_Start);
   }
 
-  bool
-  operator!=(Self & r) const
-  {
-    return (!(this->operator==(r)));
-  }
-
-  bool
-  operator!=(const Self & r) const
-  {
-    return (!(this->operator==(r)));
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   Self &
   operator++();


### PR DESCRIPTION
Replaced hand-written definitions of `operator!=` member functions by
`ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION` macro calls, in Modules/Core.

Did some minor adjustments to corresponding `operator==` member
functions, where necessary, and removed non-const operator overloads.

Follow-up to commit 0ad6ef1b558f162e83562a3d420f24aca38fa8d8
"STYLE: Use `ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION` in Core/Common"
