### PR TITLE
vtk version

### DIFF
--- a/Modules/Bridge/VtkGlue/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/CMakeLists.txt
@@ -80,16 +80,11 @@ if(NOT VTK_RENDERING_BACKEND STREQUAL \"None\")
     ${_target_prefix}InteractionWidgets
   )
 endif()
-if(${VTK_VERSION} VERSION_LESS 6.0.0)
-  set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
-  set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
-else()
-  vtk_module_config(ITKVtkGlue_VTK
-    \${_required_vtk_libraries}
-    )
-  set(ITKVtkGlue_VTK_LIBRARIES \${_required_vtk_libraries})
-  set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS \${ITKVtkGlue_VTK_DEFINITIONS})
-endif()
+vtk_module_config(ITKVtkGlue_VTK
+  \${_required_vtk_libraries}
+  )
+set(ITKVtkGlue_VTK_LIBRARIES \${_required_vtk_libraries})
+set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS \${ITKVtkGlue_VTK_DEFINITIONS})
 ")
 set(ITKVtkGlue_EXPORT_CODE_BUILD "
 if(NOT ITK_BINARY_DIR)
@@ -140,16 +135,11 @@ if(NOT ITK_BINARY_DIR)
       ${_target_prefix}InteractionWidgets
     )
   endif()
-  if( ${VTK_VERSION} VERSION_LESS 6.0.0 )
-    set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
-    set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
-  else()
-    vtk_module_config(ITKVtkGlue_VTK
-      \${_required_vtk_libraries}
-      )
-    set(ITKVtkGlue_VTK_LIBRARIES \${_required_vtk_libraries})
-    set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS \${ITKVtkGlue_VTK_DEFINITIONS})
-  endif()
+  vtk_module_config(ITKVtkGlue_VTK
+    \${_required_vtk_libraries}
+    )
+  set(ITKVtkGlue_VTK_LIBRARIES \${_required_vtk_libraries})
+  set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS \${ITKVtkGlue_VTK_DEFINITIONS})
 endif()
 ")
 

--- a/Modules/Bridge/VtkGlue/itk-module-init.cmake
+++ b/Modules/Bridge/VtkGlue/itk-module-init.cmake
@@ -3,7 +3,7 @@
 #
 
 # Needed VTK version
-set(VERSION_MIN "5.10.0")
+set(VERSION_MIN "8.1.0")
 
 # Look for VTK
 find_package(VTK NO_MODULE REQUIRED)
@@ -65,9 +65,6 @@ if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
 endif()
 if (${VTK_VERSION} VERSION_LESS ${VERSION_MIN})
   message(ERROR " VtkGlue requires VTK version ${VERSION_MIN} or newer but the current version is ${VTK_VERSION}")
-elseif( ${VTK_VERSION} VERSION_LESS 6.0.0 )
-  set(ITKVtkGlue_VTK_INCLUDE_DIRS ${VTK_INCLUDE_DIRS})
-  set(ITKVtkGlue_VTK_LIBRARIES ${VTK_LIBRARIES})
 else()
   vtk_module_config(ITKVtkGlue_VTK
     ${_required_vtk_libraries}

--- a/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
+++ b/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
@@ -41,6 +41,7 @@ exclude = [
     "ScalarImageToTextureFeaturesFilter",
     # These classes are just ignored.
     "ScanlineFilterCommon",  # Segfault
+    "ImageToVTKImageFilter",
     "templated_class",
     "auto_pipeline",
     "pipeline",


### PR DESCRIPTION
- BUG: Ignore ImageToVTKImageFilter in VerifyGetOutputAPIConsistency test
- ENH: Required VTK 8 or newer
