### PR TITLE
STYLE: ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION when `==` just returns true

### DIFF
--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -70,16 +70,12 @@ public:
   }
 
   bool
-  operator!=(const PostProcessCorrelation &) const
+  operator==(const PostProcessCorrelation &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const PostProcessCorrelation & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(PostProcessCorrelation);
 
   inline TImage
   operator()(const TImage & NCC, const TImage & denominator, const TImage & numberOfOverlapPixels) const

--- a/Modules/Filtering/Deconvolution/include/itkInverseDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkInverseDeconvolutionImageFilter.h
@@ -130,15 +130,13 @@ public:
   ~InverseDeconvolutionFunctor() = default;
 
   bool
-  operator!=(const InverseDeconvolutionFunctor &) const
+  operator==(const InverseDeconvolutionFunctor &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const InverseDeconvolutionFunctor & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(InverseDeconvolutionFunctor);
+
   inline TOutput
   operator()(const TInput1 & I, const TInput2 & H) const
   {

--- a/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.h
@@ -40,16 +40,12 @@ public:
   ~LandweberMethod() = default;
 
   bool
-  operator!=(const LandweberMethod &) const
+  operator==(const LandweberMethod &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const LandweberMethod & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(LandweberMethod);
 
   inline TOutput
   operator()(const TInput1 & estimateFT, const TInput2 & kernelFT, const TInput2 & inputFT) const

--- a/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
@@ -130,17 +130,14 @@ public:
     , m_KernelZeroMagnitudeThreshold(f.m_KernelZeroMagnitudeThreshold)
   {}
 
+  bool
+  operator==(const TikhonovDeconvolutionFunctor &) const
+  {
+    return true;
+  }
 
-  bool
-  operator!=(const TikhonovDeconvolutionFunctor &) const
-  {
-    return false;
-  }
-  bool
-  operator==(const TikhonovDeconvolutionFunctor & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TikhonovDeconvolutionFunctor);
+
   inline TOutput
   operator()(const TInput1 & I, const TInput2 & H) const
   {

--- a/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
@@ -154,15 +154,13 @@ public:
   {}
 
   bool
-  operator!=(const WienerDeconvolutionFunctor &) const
+  operator==(const WienerDeconvolutionFunctor &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const WienerDeconvolutionFunctor & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(WienerDeconvolutionFunctor);
+
   inline TPixel
   operator()(const TPixel & I, const TPixel & H) const
   {

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
@@ -35,16 +35,12 @@ public:
   TensorFractionalAnisotropyFunction() = default;
   ~TensorFractionalAnisotropyFunction() = default;
   bool
-  operator!=(const TensorFractionalAnisotropyFunction &) const
+  operator==(const TensorFractionalAnisotropyFunction &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const TensorFractionalAnisotropyFunction & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TensorFractionalAnisotropyFunction);
 
   inline RealValueType
   operator()(const TInput & x) const

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
@@ -35,16 +35,12 @@ public:
   TensorRelativeAnisotropyFunction() = default;
   ~TensorRelativeAnisotropyFunction() = default;
   bool
-  operator!=(const TensorRelativeAnisotropyFunction &) const
+  operator==(const TensorRelativeAnisotropyFunction &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const TensorRelativeAnisotropyFunction & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TensorRelativeAnisotropyFunction);
 
   inline RealValueType
   operator()(const TInput & x) const

--- a/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
@@ -61,16 +61,12 @@ public:
   AbsoluteValueDifference2() = default;
   ~AbsoluteValueDifference2() = default;
   bool
-  operator!=(const AbsoluteValueDifference2 &) const
+  operator==(const AbsoluteValueDifference2 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const AbsoluteValueDifference2 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(AbsoluteValueDifference2);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
@@ -60,16 +60,12 @@ public:
   SquaredDifference2() = default;
   ~SquaredDifference2() = default;
   bool
-  operator!=(const SquaredDifference2 &) const
+  operator==(const SquaredDifference2 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const SquaredDifference2 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(SquaredDifference2);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
@@ -68,16 +68,12 @@ public:
   using JoinType = Vector<JoinValueType, Self::JoinDimension>;
 
   bool
-  operator!=(const JoinFunctor &) const
+  operator==(const JoinFunctor &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const JoinFunctor & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(JoinFunctor);
 
   /** operator().  This is the "call" method of the functor. */
   inline JoinType

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
@@ -42,16 +42,12 @@ public:
   Cast() = default;
   virtual ~Cast() = default;
   bool
-  operator!=(const Cast &) const
+  operator==(const Cast &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Cast & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Cast);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
@@ -36,16 +36,12 @@ public:
   Abs() = default;
   ~Abs() = default;
   bool
-  operator!=(const Abs &) const
+  operator==(const Abs &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Abs & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Abs);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
@@ -37,16 +37,12 @@ public:
   Acos() = default;
   ~Acos() = default;
   bool
-  operator!=(const Acos &) const
+  operator==(const Acos &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Acos & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Acos);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -37,16 +37,12 @@ public:
   Add2() = default;
   ~Add2() = default;
   bool
-  operator!=(const Add2 &) const
+  operator==(const Add2 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Add2 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Add2);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -68,16 +64,12 @@ public:
   Add3() = default;
   ~Add3() = default;
   bool
-  operator!=(const Add3 &) const
+  operator==(const Add3 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Add3 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Add3);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B, const TInput3 & C) const
@@ -99,16 +91,12 @@ public:
   Sub2() = default;
   ~Sub2() = default;
   bool
-  operator!=(const Sub2 &) const
+  operator==(const Sub2 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Sub2 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Sub2);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -130,16 +118,12 @@ public:
   Mult() = default;
   ~Mult() = default;
   bool
-  operator!=(const Mult &) const
+  operator==(const Mult &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Mult & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Mult);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -161,16 +145,12 @@ public:
   Div() = default;
   ~Div() = default;
   bool
-  operator!=(const Div &) const
+  operator==(const Div &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Div & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Div);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -245,16 +225,12 @@ public:
   ~Modulus() = default;
 
   bool
-  operator!=(const Modulus &) const
+  operator==(const Modulus &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Modulus & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Modulus);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -336,16 +312,12 @@ class DivFloor
 {
 public:
   bool
-  operator!=(const DivFloor &) const
+  operator==(const DivFloor &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const DivFloor & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(DivFloor);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -383,16 +355,12 @@ class DivReal
 public:
   // Use default copy, assigned and destructor
   bool
-  operator!=(const DivReal &) const
+  operator==(const DivReal &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const DivReal & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(DivReal);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -415,16 +383,12 @@ public:
   UnaryMinus() = default;
   ~UnaryMinus() = default;
   bool
-  operator!=(const UnaryMinus &) const
+  operator==(const UnaryMinus &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const UnaryMinus & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(UnaryMinus);
 
   inline TOutput
   operator()(const TInput1 & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
@@ -37,16 +37,12 @@ public:
   Asin() = default;
   ~Asin() = default;
   bool
-  operator!=(const Asin &) const
+  operator==(const Asin &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Asin & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Asin);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
@@ -37,16 +37,12 @@ public:
   Atan2() = default;
   ~Atan2() = default;
   bool
-  operator!=(const Atan2 &) const
+  operator==(const Atan2 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Atan2 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Atan2);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
@@ -37,16 +37,12 @@ public:
   Atan() = default;
   ~Atan() = default;
   bool
-  operator!=(const Atan &) const
+  operator==(const Atan &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Atan & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Atan);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
@@ -36,16 +36,12 @@ public:
   Modulus2() = default;
   ~Modulus2() = default;
   bool
-  operator!=(const Modulus2 &) const
+  operator==(const Modulus2 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Modulus2 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Modulus2);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkBitwiseOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBitwiseOpsFunctors.h
@@ -37,16 +37,12 @@ public:
   AND() = default;
   ~AND() = default;
   bool
-  operator!=(const AND &) const
+  operator==(const AND &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const AND & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(AND);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -67,16 +63,12 @@ public:
   OR() = default;
   ~OR() = default;
   bool
-  operator!=(const OR &) const
+  operator==(const OR &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const OR & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(OR);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -97,16 +89,12 @@ public:
   XOR() = default;
   ~XOR() = default;
   bool
-  operator!=(const XOR &) const
+  operator==(const XOR &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const XOR & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(XOR);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
@@ -128,16 +116,12 @@ public:
   // BitwiseNot() {} default constructor OK
 
   bool
-  operator!=(const BitwiseNot &) const
+  operator==(const BitwiseNot &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const BitwiseNot & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(BitwiseNot);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
@@ -50,16 +50,12 @@ public:
   BoundedReciprocal() = default;
   ~BoundedReciprocal() = default;
   bool
-  operator!=(const BoundedReciprocal &) const
+  operator==(const BoundedReciprocal &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const BoundedReciprocal & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(BoundedReciprocal);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
@@ -39,16 +39,12 @@ public:
   ComplexToImaginary() = default;
   ~ComplexToImaginary() = default;
   bool
-  operator!=(const ComplexToImaginary &) const
+  operator==(const ComplexToImaginary &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const ComplexToImaginary & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ComplexToImaginary);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
@@ -38,16 +38,12 @@ public:
   ComplexToModulus() = default;
   ~ComplexToModulus() = default;
   bool
-  operator!=(const ComplexToModulus &) const
+  operator==(const ComplexToModulus &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const ComplexToModulus & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ComplexToModulus);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
@@ -39,16 +39,12 @@ public:
   ComplexToPhase() = default;
   ~ComplexToPhase() = default;
   bool
-  operator!=(const ComplexToPhase &) const
+  operator==(const ComplexToPhase &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const ComplexToPhase & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ComplexToPhase);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
@@ -38,16 +38,12 @@ public:
   ComplexToReal() = default;
   ~ComplexToReal() = default;
   bool
-  operator!=(const ComplexToReal &) const
+  operator==(const ComplexToReal &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const ComplexToReal & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ComplexToReal);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
@@ -37,16 +37,12 @@ public:
   ConstrainedValueAddition() = default;
   ~ConstrainedValueAddition() = default;
   bool
-  operator!=(const ConstrainedValueAddition &) const
+  operator==(const ConstrainedValueAddition &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const ConstrainedValueAddition & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstrainedValueAddition);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueDifferenceImageFilter.h
@@ -61,16 +61,12 @@ public:
   ConstrainedValueDifference() = default;
   ~ConstrainedValueDifference() = default;
   bool
-  operator!=(const ConstrainedValueDifference &) const
+  operator==(const ConstrainedValueDifference &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const ConstrainedValueDifference & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstrainedValueDifference);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
@@ -37,16 +37,12 @@ public:
   Cos() = default;
   ~Cos() = default;
   bool
-  operator!=(const Cos &) const
+  operator==(const Cos &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Cos & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Cos);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
@@ -46,16 +46,12 @@ public:
   EdgePotential() = default;
   ~EdgePotential() = default;
   bool
-  operator!=(const EdgePotential &) const
+  operator==(const EdgePotential &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const EdgePotential & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(EdgePotential);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
@@ -37,16 +37,12 @@ public:
   Exp() = default;
   ~Exp() = default;
   bool
-  operator!=(const Exp &) const
+  operator==(const Exp &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Exp & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Exp);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
@@ -37,16 +37,12 @@ public:
   Log10() = default;
   ~Log10() = default;
   bool
-  operator!=(const Log10 &) const
+  operator==(const Log10 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Log10 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Log10);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
@@ -37,16 +37,12 @@ public:
   Log() = default;
   ~Log() = default;
   bool
-  operator!=(const Log &) const
+  operator==(const Log &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Log & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Log);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
@@ -68,17 +68,13 @@ public:
 
   ~LogicOpBase() = default;
 
+  bool
+  operator==(const Self &) const
+  {
+    return true;
+  }
 
-  bool
-  operator!=(const Self &) const
-  {
-    return false;
-  }
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   void
   SetForegroundValue(const TOutput & FG)
@@ -127,15 +123,13 @@ public:
   ~Equal() = default;
 
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
+
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
   {
@@ -164,16 +158,15 @@ public:
 
   NotEqual() = default;
   ~NotEqual() = default;
+
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
+
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
   {
@@ -204,15 +197,13 @@ public:
   ~GreaterEqual() = default;
 
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
+
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
   {
@@ -241,16 +232,15 @@ public:
   using Self = Greater;
   Greater() = default;
   ~Greater() = default;
+
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
+
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
   {
@@ -280,16 +270,15 @@ public:
 
   LessEqual() = default;
   ~LessEqual() = default;
+
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
+
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
   {
@@ -318,16 +307,15 @@ public:
   using Self = Less;
   Less() = default;
   ~Less() = default;
+
   bool
-  operator!=(const Self &) const
+  operator==(const Self &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const Self & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
+
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const
   {
@@ -351,17 +339,14 @@ class ITK_TEMPLATE_EXPORT NOT : public LogicOpBase<TInput, TInput, TOutput>
 public:
   NOT() = default;
   ~NOT() = default;
-  bool
-  operator!=(const NOT &) const
-  {
-    return false;
-  }
 
   bool
-  operator==(const NOT & other) const
+  operator==(const NOT &) const
   {
-    return !(*this != other);
+    return true;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(NOT);
 
   inline TOutput
   operator()(const TInput & A) const
@@ -385,17 +370,14 @@ class ITK_TEMPLATE_EXPORT TernaryOperator
 public:
   TernaryOperator() = default;
   ~TernaryOperator() = default;
-  bool
-  operator!=(const TernaryOperator &) const
-  {
-    return false;
-  }
 
   bool
-  operator==(const TernaryOperator & other) const
+  operator==(const TernaryOperator &) const
   {
-    return !(*this != other);
+    return true;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TernaryOperator);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B, const TInput3 & C) const

--- a/Modules/Filtering/ImageIntensity/include/itkMagnitudeAndPhaseToComplexImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMagnitudeAndPhaseToComplexImageFilter.h
@@ -61,16 +61,12 @@ public:
   MagnitudeAndPhaseToComplex() = default;
   ~MagnitudeAndPhaseToComplex() = default;
   bool
-  operator!=(const MagnitudeAndPhaseToComplex &) const
+  operator==(const MagnitudeAndPhaseToComplex &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const MagnitudeAndPhaseToComplex & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(MagnitudeAndPhaseToComplex);
 
   inline std::complex<TOutput>
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -45,16 +45,12 @@ public:
   }
   ~MaskInput() = default;
   bool
-  operator!=(const MaskInput &) const
+  operator==(const MaskInput &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const MaskInput & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(MaskInput);
 
   inline TOutput
   operator()(const TInput & A, const TMask & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -43,16 +43,12 @@ public:
   {}
   ~MaskNegatedInput() = default;
   bool
-  operator!=(const MaskNegatedInput &) const
+  operator==(const MaskNegatedInput &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const MaskNegatedInput & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(MaskNegatedInput);
 
   inline TOutput
   operator()(const TInput & A, const TMask & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
@@ -36,16 +36,12 @@ public:
   Maximum() = default;
   ~Maximum() = default;
   bool
-  operator!=(const Maximum &) const
+  operator==(const Maximum &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Maximum & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Maximum);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
@@ -36,16 +36,12 @@ public:
   Minimum() = default;
   ~Minimum() = default;
   bool
-  operator!=(const Minimum &) const
+  operator==(const Minimum &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Minimum & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Minimum);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
@@ -55,11 +55,7 @@ public:
     return true;
   }
 
-  bool
-  operator!=(const Add1 &) const
-  {
-    return false;
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Add1);
 };
 } // namespace Functor
 

--- a/Modules/Filtering/ImageIntensity/include/itkNaryMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryMaximumImageFilter.h
@@ -61,11 +61,7 @@ public:
     return true;
   }
 
-  bool
-  operator!=(const Maximum1 &) const
-  {
-    return false;
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Maximum1);
 };
 } // namespace Functor
 

--- a/Modules/Filtering/ImageIntensity/include/itkPowImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPowImageFilter.h
@@ -35,18 +35,14 @@ class Pow
 {
 public:
   Pow() = default;
-  bool
-  operator!=(const Pow &) const
-  {
-    // we contain no data, so we are always the same
-    return false;
-  }
 
   bool
-  operator==(const Pow & other) const
+  operator==(const Pow &) const
   {
-    return !(*this != other);
+    return true;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Pow);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
@@ -46,16 +46,12 @@ public:
   RGBToLuminance() = default;
   ~RGBToLuminance() = default;
   bool
-  operator!=(const RGBToLuminance &) const
+  operator==(const RGBToLuminance &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const RGBToLuminance & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(RGBToLuminance);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkRoundImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRoundImageFilter.h
@@ -37,16 +37,12 @@ public:
   Round() = default;
   ~Round() = default;
   bool
-  operator!=(const Round &) const
+  operator==(const Round &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Round & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Round);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
@@ -37,16 +37,12 @@ public:
   Sin() = default;
   ~Sin() = default;
   bool
-  operator!=(const Sin &) const
+  operator==(const Sin &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Sin & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Sin);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
@@ -37,16 +37,12 @@ public:
   Sqrt() = default;
   ~Sqrt() = default;
   bool
-  operator!=(const Sqrt &) const
+  operator==(const Sqrt &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Sqrt & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Sqrt);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
@@ -44,16 +44,12 @@ public:
   Square() = default;
   ~Square() = default;
   bool
-  operator!=(const Square &) const
+  operator==(const Square &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Square & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Square);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
@@ -48,16 +48,12 @@ public:
   ~SymmetricEigenAnalysisFunction() = default;
   using CalculatorType = SymmetricEigenAnalysis<TInput, TOutput>;
   bool
-  operator!=(const SymmetricEigenAnalysisFunction &) const
+  operator==(const SymmetricEigenAnalysisFunction &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const SymmetricEigenAnalysisFunction & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(SymmetricEigenAnalysisFunction);
 
   inline TOutput
   operator()(const TInput & x) const
@@ -139,16 +135,12 @@ public:
   ~SymmetricEigenAnalysisFixedDimensionFunction() = default;
   using CalculatorType = SymmetricEigenAnalysisFixedDimension<TMatrixDimension, TInput, TOutput>;
   bool
-  operator!=(const SymmetricEigenAnalysisFixedDimensionFunction &) const
+  operator==(const SymmetricEigenAnalysisFixedDimensionFunction &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const SymmetricEigenAnalysisFixedDimensionFunction & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(SymmetricEigenAnalysisFixedDimensionFunction);
 
   inline TOutput
   operator()(const TInput & x) const

--- a/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
@@ -37,16 +37,12 @@ public:
   Tan() = default;
   ~Tan() = default;
   bool
-  operator!=(const Tan &) const
+  operator==(const Tan &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Tan & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Tan);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeImageFilter.h
@@ -36,16 +36,12 @@ public:
   Modulus3() = default;
   ~Modulus3() = default;
   bool
-  operator!=(const Modulus3 &) const
+  operator==(const Modulus3 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const Modulus3 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Modulus3);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B, const TInput3 & C) const

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeSquaredImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeSquaredImageFilter.h
@@ -36,16 +36,12 @@ public:
   ModulusSquare3() = default;
   ~ModulusSquare3() = default;
   bool
-  operator!=(const ModulusSquare3 &) const
+  operator==(const ModulusSquare3 &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const ModulusSquare3 & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ModulusSquare3);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B, const TInput3 & C) const

--- a/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
@@ -52,16 +52,12 @@ public:
   ~VectorMagnitude() = default;
 
   bool
-  operator!=(const VectorMagnitude &) const
+  operator==(const VectorMagnitude &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const VectorMagnitude & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(VectorMagnitude);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
@@ -61,15 +61,13 @@ public:
   BinaryNot() = default;
   ~BinaryNot() = default;
   bool
-  operator!=(const BinaryNot &) const
+  operator==(const BinaryNot &) const
   {
-    return false;
+    return true;
   }
-  bool
-  operator==(const BinaryNot & other) const
-  {
-    return !(*this != other);
-  }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(BinaryNot);
+
   inline TPixel
   operator()(const TPixel & A) const
   {

--- a/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
@@ -67,16 +67,12 @@ public:
   }
 
   bool
-  operator!=(const SimilarVectorsFunctor &) const
+  operator==(const SimilarVectorsFunctor &) const
   {
-    return false;
+    return true;
   }
 
-  bool
-  operator==(const SimilarVectorsFunctor & other) const
-  {
-    return !(*this != other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(SimilarVectorsFunctor);
 
   bool
   operator()(const TInput & a, const TInput & b) const


### PR DESCRIPTION
Replaced hand-written definitions of `operator!=` member functions by
`ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION` macro calls, and adjusted the
corresponding `operator==` member functions whenever those `==`
operators would simple just always return `true`. (These are member
functions of classes whose instances are all considered equal.)

Did find and replace in Visual Studio, using regular expressions like:

Find:

    bool\r?\n  operator!=\(const (.+) \&\) const\r?\n  {\r?\n    return false;\r?\n  }\r?\n\r?\n  bool\r?\n  operator==\(const (.+) \& other\) const\r?\n  {\r?\n    return !\(\*this != other\);\r?\n  }

Replace by:

    bool operator==(const $1 &) const { return true; }\r\n\r\ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION($1);

Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2597
commit 27f26685cc10be8bee74989a1c03639cd89705ce
"STYLE: Use ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION in Modules/Core"