### PR TITLE
Add `NthElementPixelAccessor::operator==`, use `ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION` in Filtering 

### DIFF
--- a/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
@@ -91,13 +91,15 @@ public:
     m_ElementNumber = nth;
   }
 
-  /** operator!=. This is needed to convert a pixel accessor to a functor.
+  /** This is needed to convert a pixel accessor to a functor.
    * \sa AdaptImageFilter */
   bool
-  operator!=(const Self & accessor) const
+  operator==(const Self & accessor) const
   {
-    return (m_ElementNumber != accessor.m_ElementNumber);
+    return m_ElementNumber == accessor.m_ElementNumber;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   /** Assignment operator */
   NthElementPixelAccessor &
@@ -197,13 +199,15 @@ public:
 
   NthElementPixelAccessor(unsigned int length = 1) { Superclass::SetVectorLength(length); }
 
-  /** operator!=. This is needed to convert a pixel accessor to a functor.
+  /** This is needed to convert a pixel accessor to a functor.
    * \sa AdaptImageFilter */
   bool
-  operator!=(const Self & accessor) const
+  operator==(const Self & accessor) const
   {
-    return (m_ElementNumber != accessor.m_ElementNumber);
+    return m_ElementNumber == accessor.m_ElementNumber;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   /** Assignment operator */
   NthElementPixelAccessor &

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
@@ -88,18 +88,13 @@ public:
   }
 
   bool
-  operator!=(const LabelOverlayFunctor & l) const
+  operator==(const LabelOverlayFunctor & other) const
   {
-    bool areDifferent = Math::NotExactlyEquals(l.m_Opacity, m_Opacity) || l.m_BackgroundValue != m_BackgroundValue ||
-                        l.m_RGBFunctor != m_RGBFunctor;
-    return areDifferent;
+    return Math::ExactlyEquals(m_Opacity, other.m_Opacity) && m_BackgroundValue == other.m_BackgroundValue &&
+           m_RGBFunctor == other.m_RGBFunctor;
   }
 
-  bool
-  operator==(const LabelOverlayFunctor & l) const
-  {
-    return !(*this != l);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(LabelOverlayFunctor);
 
   ~LabelOverlayFunctor() = default;
 

--- a/Modules/Filtering/ImageFusion/include/itkLabelToRGBFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelToRGBFunctor.h
@@ -134,30 +134,13 @@ public:
   }
 
   bool
-  operator!=(const Self & l) const
-  {
-    if (m_BackgroundColor != l.m_BackgroundColor || m_BackgroundValue != l.m_BackgroundValue ||
-        m_Colors.size() != l.m_Colors.size())
-    {
-      return true;
-    }
-
-    // We need to check each color to see if it's different
-    for (typename std::vector<TRGBPixel>::size_type i = 0; i < m_Colors.size(); ++i)
-    {
-      if (m_Colors[i] != l.m_Colors[i])
-      {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  bool
   operator==(const Self & other) const
   {
-    return !(*this != other);
+    return m_BackgroundColor == other.m_BackgroundColor && m_BackgroundValue == other.m_BackgroundValue &&
+           m_Colors == other.m_Colors;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   void
   SetBackgroundValue(TLabel v)

--- a/Modules/Filtering/ImageIntensity/include/itkAdaptImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAdaptImageFilter.h
@@ -83,18 +83,14 @@ public:
     m_Accessor = accessor;
   }
 
-  /** operator!=.  Needed to determine if two accessors are the same. */
-  bool
-  operator!=(const Self & functor) const
-  {
-    return (m_Accessor != functor.m_Accessor);
-  }
-
+  /** Needed to determine if two accessors are the same. */
   bool
   operator==(const Self & other) const
   {
-    return !(*this != other);
+    return m_Accessor == other.m_Accessor;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
 private:
   AccessorType m_Accessor;

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -185,18 +185,14 @@ public:
   ~DivideOrZeroOut() = default;
 
   bool
-  operator!=(const DivideOrZeroOut & other) const
-  {
-    return !(*this == other);
-  }
-
-  bool
   operator==(const DivideOrZeroOut & itkNotUsed(other)) const
   {
     // Always return true for now.  Do a comparison to m_Threshold if it is
     // every made set-able.
     return true;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(DivideOrZeroOut);
 
   inline TOutput
   operator()(const TNumerator & n, const TDenominator & d) const
@@ -269,20 +265,12 @@ public:
   }
 
   bool
-  operator!=(const ModulusTransform & other) const
-  {
-    if (m_Dividend != other.m_Dividend)
-    {
-      return true;
-    }
-    return false;
-  }
-
-  bool
   operator==(const ModulusTransform & other) const
   {
-    return !(*this != other);
+    return m_Dividend == other.m_Dividend;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ModulusTransform);
 
   inline TOutput
   operator()(const TInput & x) const

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
@@ -68,9 +68,9 @@ public:
   SetBounds(const OutputType lowerBound, const OutputType upperBound);
 
   bool
-  operator!=(const Self & other) const;
-  bool
   operator==(const Self & other) const;
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   OutputType
   operator()(const InputType & A) const;

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
@@ -63,16 +63,9 @@ Clamp<TInput, TOutput>::SetBounds(const OutputType lowerBound, const OutputType 
 
 template <typename TInput, typename TOutput>
 bool
-Clamp<TInput, TOutput>::operator!=(const Self & other) const
-{
-  return m_UpperBound != other.m_UpperBound || m_LowerBound != other.m_LowerBound;
-}
-
-template <typename TInput, typename TOutput>
-bool
 Clamp<TInput, TOutput>::operator==(const Self & other) const
 {
-  return !(*this != other);
+  return m_UpperBound == other.m_UpperBound && m_LowerBound == other.m_LowerBound;
 }
 
 } // end namespace Functor

--- a/Modules/Filtering/ImageIntensity/include/itkExpNegativeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkExpNegativeImageFilter.h
@@ -38,21 +38,14 @@ public:
   ExpNegative() { m_Factor = 1.0; }
   ~ExpNegative() = default;
 
-  bool
-  operator!=(const ExpNegative & other) const
-  {
-    if (Math::NotExactlyEquals(m_Factor, other.m_Factor))
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const ExpNegative & other) const
   {
-    return !(*this != other);
+    return Math::ExactlyEquals(m_Factor, other.m_Factor);
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ExpNegative);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.h
@@ -41,25 +41,18 @@ public:
     , m_WindowMinimum(0)
   {}
   ~IntensityWindowingTransform() = default;
-  bool
-  operator!=(const IntensityWindowingTransform & other) const
-  {
-    if (Math::NotExactlyEquals(m_Factor, other.m_Factor) || Math::NotExactlyEquals(m_Offset, other.m_Offset) ||
-        Math::NotExactlyEquals(m_OutputMaximum, other.m_OutputMaximum) ||
-        Math::NotExactlyEquals(m_OutputMinimum, other.m_OutputMinimum) ||
-        Math::NotExactlyEquals(m_WindowMaximum, other.m_WindowMaximum) ||
-        Math::NotExactlyEquals(m_WindowMinimum, other.m_WindowMinimum))
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const IntensityWindowingTransform & other) const
   {
-    return !(*this != other);
+    return Math::ExactlyEquals(m_Factor, other.m_Factor) && Math::ExactlyEquals(m_Offset, other.m_Offset) &&
+           Math::ExactlyEquals(m_OutputMaximum, other.m_OutputMaximum) &&
+           Math::ExactlyEquals(m_OutputMinimum, other.m_OutputMinimum) &&
+           Math::ExactlyEquals(m_WindowMaximum, other.m_WindowMaximum) &&
+           Math::ExactlyEquals(m_WindowMinimum, other.m_WindowMinimum);
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(IntensityWindowingTransform);
 
   void
   SetFactor(RealType a)

--- a/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.h
@@ -43,21 +43,14 @@ public:
     m_Maximum = max;
   }
 
-  bool
-  operator!=(const InvertIntensityTransform & other) const
-  {
-    if (m_Maximum != other.m_Maximum)
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const InvertIntensityTransform & other) const
   {
-    return !(*this != other);
+    return m_Maximum == other.m_Maximum;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(InvertIntensityTransform);
 
   inline TOutput
   operator()(const TInput & x) const

--- a/Modules/Filtering/ImageIntensity/include/itkMatrixIndexSelectionImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMatrixIndexSelectionImageFilter.h
@@ -45,20 +45,12 @@ public:
   }
 
   bool
-  operator!=(const MatrixIndexSelection & other) const
-  {
-    if (m_I != other.m_I || m_J != other.m_J)
-    {
-      return true;
-    }
-    return false;
-  }
-
-  bool
   operator==(const MatrixIndexSelection & other) const
   {
-    return !(*this != other);
+    return m_I == other.m_I && m_J == other.m_J;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(MatrixIndexSelection);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
@@ -68,22 +68,15 @@ public:
   {
     m_Maximum = max;
   }
-  bool
-  operator!=(const IntensityLinearTransform & other) const
-  {
-    if (Math::NotExactlyEquals(m_Factor, other.m_Factor) || Math::NotExactlyEquals(m_Offset, other.m_Offset) ||
-        Math::NotExactlyEquals(m_Maximum, other.m_Maximum) || Math::NotExactlyEquals(m_Minimum, other.m_Minimum))
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const IntensityLinearTransform & other) const
   {
-    return !(*this != other);
+    return Math::ExactlyEquals(m_Factor, other.m_Factor) && Math::ExactlyEquals(m_Offset, other.m_Offset) &&
+           Math::ExactlyEquals(m_Maximum, other.m_Maximum) && Math::ExactlyEquals(m_Minimum, other.m_Minimum);
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(IntensityLinearTransform);
 
   inline TOutput
   operator()(const TInput & x) const

--- a/Modules/Filtering/ImageIntensity/include/itkSigmoidImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSigmoidImageFilter.h
@@ -61,23 +61,17 @@ public:
   }
 
   ~Sigmoid() = default;
-  bool
-  operator!=(const Sigmoid & other) const
-  {
-    if (Math::NotExactlyEquals(m_Alpha, other.m_Alpha) || Math::NotExactlyEquals(m_Beta, other.m_Beta) ||
-        Math::NotExactlyEquals(m_OutputMaximum, other.m_OutputMaximum) ||
-        Math::NotExactlyEquals(m_OutputMinimum, other.m_OutputMinimum))
-    {
-      return true;
-    }
-    return false;
-  }
+
 
   bool
   operator==(const Sigmoid & other) const
   {
-    return !(*this != other);
+    return Math::ExactlyEquals(m_Alpha, other.m_Alpha) && Math::ExactlyEquals(m_Beta, other.m_Beta) &&
+           Math::ExactlyEquals(m_OutputMaximum, other.m_OutputMaximum) &&
+           Math::ExactlyEquals(m_OutputMinimum, other.m_OutputMinimum);
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Sigmoid);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkVectorIndexSelectionCastImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorIndexSelectionCastImageFilter.h
@@ -43,20 +43,12 @@ public:
   }
 
   bool
-  operator!=(const VectorIndexSelectionCast & other) const
-  {
-    if (m_Index != other.m_Index)
-    {
-      return true;
-    }
-    return false;
-  }
-
-  bool
   operator==(const VectorIndexSelectionCast & other) const
   {
-    return !(*this != other);
+    return m_Index == other.m_Index;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(VectorIndexSelectionCast);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.h
@@ -42,21 +42,14 @@ public:
     m_Factor = a;
   }
   static constexpr unsigned int VectorDimension = TInput::Dimension;
-  bool
-  operator!=(const VectorMagnitudeLinearTransform & other) const
-  {
-    if (Math::NotExactlyEquals(m_Factor, other.m_Factor))
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const VectorMagnitudeLinearTransform & other) const
   {
-    return !(*this != other);
+    return Math::ExactlyEquals(m_Factor, other.m_Factor);
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(VectorMagnitudeLinearTransform);
 
   inline TOutput
   operator()(const TInput & x) const

--- a/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
@@ -42,21 +42,14 @@ public:
     , m_Beta(0.0)
   {}
   ~WeightedAdd2() = default;
-  bool
-  operator!=(const WeightedAdd2 & other) const
-  {
-    if (Math::NotExactlyEquals(m_Alpha, other.m_Alpha))
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const WeightedAdd2 & other) const
   {
-    return !(*this != other);
+    return Math::ExactlyEquals(m_Alpha, other.m_Alpha);
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(WeightedAdd2);
 
   inline TOutput
   operator()(const TInput1 & A, const TInput2 & B) const

--- a/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
@@ -59,21 +59,14 @@ public:
 
   using ChangeMapType = std::map<TInput, TOutput>;
 
-  bool
-  operator!=(const ChangeLabel & other) const
-  {
-    if (m_ChangeMap != other.m_ChangeMap)
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const ChangeLabel & other) const
   {
-    return !(*this != other);
+    return m_ChangeMap == other.m_ChangeMap;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ChangeLabel);
 
   TOutput
   GetChange(const TInput & original)

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.h
@@ -372,11 +372,7 @@ public:
       return m_Iterator == iter.m_Iterator && m_Begin == iter.m_Begin && m_End == iter.m_End;
     }
 
-    bool
-    operator!=(const ConstIterator & iter) const
-    {
-      return !(*this == iter);
-    }
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
     void
     GoToBegin()
@@ -463,11 +459,7 @@ public:
       return m_Iterator == iter.m_Iterator && m_Begin == iter.m_Begin && m_End == iter.m_End;
     }
 
-    bool
-    operator!=(const Iterator & iter) const
-    {
-      return !(*this == iter);
-    }
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Iterator);
 
     void
     GoToBegin()

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.h
@@ -263,11 +263,7 @@ public:
       return m_Iterator == iter.m_Iterator && m_Begin == iter.m_Begin && m_End == iter.m_End;
     }
 
-    bool
-    operator!=(const ConstLineIterator & iter) const
-    {
-      return !(*this == iter);
-    }
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstLineIterator);
 
     void
     GoToBegin()
@@ -363,11 +359,7 @@ public:
       return m_Index == iter.m_Index && m_Iterator == iter.m_Iterator && m_Begin == iter.m_Begin && m_End == iter.m_End;
     }
 
-    bool
-    operator!=(const ConstIndexIterator & iter) const
-    {
-      return !(*this == iter);
-    }
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIndexIterator);
 
     void
     GoToBegin()

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
@@ -98,23 +98,16 @@ public:
     m_OutsideValue = value;
   }
 
-  bool
-  operator!=(const BinaryThreshold & other) const
-  {
-    if (m_LowerThreshold != other.m_LowerThreshold || m_UpperThreshold != other.m_UpperThreshold ||
-        Math::NotExactlyEquals(m_InsideValue, other.m_InsideValue) ||
-        Math::NotExactlyEquals(m_OutsideValue, other.m_OutsideValue))
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const BinaryThreshold & other) const
   {
-    return !(*this != other);
+    return m_LowerThreshold == other.m_LowerThreshold && m_UpperThreshold == other.m_UpperThreshold &&
+           Math::ExactlyEquals(m_InsideValue, other.m_InsideValue) &&
+           Math::ExactlyEquals(m_OutsideValue, other.m_OutsideValue);
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(BinaryThreshold);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
@@ -66,21 +66,14 @@ public:
     m_LabelOffset = labelOffset;
   }
 
-  bool
-  operator!=(const ThresholdLabeler & other) const
-  {
-    if (m_Thresholds != other.m_Thresholds || m_LabelOffset != other.m_LabelOffset)
-    {
-      return true;
-    }
-    return false;
-  }
 
   bool
   operator==(const ThresholdLabeler & other) const
   {
-    return !(*this != other);
+    return m_Thresholds == other.m_Thresholds && m_LabelOffset == other.m_LabelOffset;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ThresholdLabeler);
 
   inline TOutput
   operator()(const TInput & A) const


### PR DESCRIPTION
Two related commits:
- ENH: Add `NthElementPixelAccessor::operator==` 
- STYLE: Use ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION in Modules/Filtering

The `NthElementPixelAccessor::operator==` overloads appear necessary in order to implement `AccessorFunctor::operator==` by a simple `return m_Accessor == other.m_Accessor`.
