### PR TITLE
Use `ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION` in Numerics, Segmentation, Video 

### DIFF
--- a/Modules/Core/Common/include/itkSliceIterator.h
+++ b/Modules/Core/Common/include/itkSliceIterator.h
@@ -110,12 +110,7 @@ public:
            orig.m_Slice.start() == this->m_Slice.start();
   }
 
-  /** Returns the logical inverse of the boolean == of two slice iterators. */
-  bool
-  operator!=(const SliceIterator & orig)
-  {
-    return !operator==(orig);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(SliceIterator);
 
   /** Returns the boolean < of two slice iterator positions.  Result
    * is only true if the slice iterators have the same stride and

--- a/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
+++ b/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
@@ -31,20 +31,12 @@ public:
   TanHelper() = default;
   ~TanHelper() = default;
   bool
-  operator!=(const TanHelper & rhs) const
+  operator==(const TanHelper & rhs) const
   {
-    return this != &rhs;
+    return this == &rhs;
   }
 
-  bool
-  operator==(const TanHelper & other) const = delete;
-  /* NOTE: operator== NOT defined. It is not required
-   * as part of the defined specification for a Function.
-  bool operator==(const TanHelper & other) const
-  {
-    return !( *this != other );
-  }
-  */
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TanHelper);
 
   inline TOutput
   operator()(const TInput & A) const

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
@@ -193,16 +193,12 @@ private:
     }
 
     bool
-    operator==(const UnsharpMaskingFunctor & other)
+    operator==(const UnsharpMaskingFunctor & other) const
     {
       return (m_Amount == other.m_Amount) && (m_Threshold == other.m_Threshold) && (m_Clamp == other.m_Clamp);
     }
 
-    bool
-    operator!=(const UnsharpMaskingFunctor & other)
-    {
-      return !(*this == other);
-    }
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(UnsharpMaskingFunctor);
 
     inline OutPixelType
     operator()(const InPixelType & v, const FunctorRealType & s) const

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -402,16 +402,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Id != it.m_Id);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (m_Id == it.m_Id);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
   protected:
     ConstIterator(InstanceIdentifier id, const Self * histogram)

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
@@ -195,16 +195,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iter != it.m_Iter);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iter == it.m_Iter);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
   protected:
     // This method should only be available to the ListSample class

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
@@ -209,16 +209,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_MeasurementVectorCache[0] != it.m_MeasurementVectorCache[0]);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (m_MeasurementVectorCache[0] == it.m_MeasurementVectorCache[0]);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
   protected:
     // This method should only be available to the ListSample class

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
@@ -234,16 +234,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_InstanceIdentifier != it.m_InstanceIdentifier);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (m_InstanceIdentifier == it.m_InstanceIdentifier);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
   protected:
     // This method should only be available to the ListSample class

--- a/Modules/Numerics/Statistics/include/itkListSample.h
+++ b/Modules/Numerics/Statistics/include/itkListSample.h
@@ -183,16 +183,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iter != it.m_Iter);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iter == it.m_Iter);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
   protected:
     // This method should only be available to the ListSample class

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.h
@@ -176,16 +176,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_InstanceIdentifier != it.m_InstanceIdentifier);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (m_InstanceIdentifier == it.m_InstanceIdentifier);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
     ConstIterator &
     operator++()

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
@@ -160,16 +160,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iter != it.m_Iter);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iter == it.m_Iter);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
   protected:
     // This method should only be available to the ListSample class

--- a/Modules/Numerics/Statistics/include/itkSubsample.h
+++ b/Modules/Numerics/Statistics/include/itkSubsample.h
@@ -174,16 +174,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iter != it.m_Iter);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iter == it.m_Iter);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
     ConstIterator &
     operator++()

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
@@ -154,16 +154,12 @@ public:
     }
 
     bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (this->m_Iter != it.m_Iter);
-    }
-
-    bool
     operator==(const ConstIterator & it) const
     {
       return (this->m_Iter == it.m_Iter);
     }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
   protected:
     // This method should only be available to the ListSample class

--- a/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
@@ -59,20 +59,12 @@ public:
   ~SimilarPixelsFunctor() = default;
 
   bool
-  operator!=(const SimilarPixelsFunctor & other) const
-  {
-    if (m_Threshold != other.m_Threshold)
-    {
-      return true;
-    }
-    return false;
-  }
-
-  bool
   operator==(const SimilarPixelsFunctor & other) const
   {
-    return !(*this != other);
+    return m_Threshold == other.m_Threshold;
   }
+
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(SimilarPixelsFunctor);
 
   void
   SetDistanceThreshold(const TInput & thresh)

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.h
@@ -143,21 +143,16 @@ public:
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const Iterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Iterator);
+
     bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
     LevelSetIdentifierType
     GetIdentifier() const
@@ -224,21 +219,16 @@ public:
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const Iterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Iterator);
+
     bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
 
     LevelSetIdentifierType
     GetIdentifier() const

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.h
@@ -171,21 +171,17 @@ public:
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const Iterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Iterator);
+
     bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
+
     LevelSetIdentifierType
     GetIdentifier() const
     {
@@ -250,21 +246,17 @@ public:
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const Iterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Iterator);
+
     bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
+
     LevelSetIdentifierType
     GetIdentifier() const
     {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.h
@@ -188,21 +188,17 @@ public:
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const Iterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Iterator);
+
     bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
+
     TermIdType
     GetIdentifier() const
     {
@@ -267,21 +263,17 @@ public:
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const Iterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Iterator);
+
     bool
     operator==(const ConstIterator & it) const
     {
       return (m_Iterator == it.m_Iterator);
     }
-    bool
-    operator!=(const ConstIterator & it) const
-    {
-      return (m_Iterator != it.m_Iterator);
-    }
+
+    ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstIterator);
+
     TermIdType
     GetIdentifier() const
     {

--- a/Modules/Video/Core/include/itkTemporalRegion.h
+++ b/Modules/Video/Core/include/itkTemporalRegion.h
@@ -98,8 +98,7 @@ public:
   bool
   operator==(const Self & region) const;
 
-  bool
-  operator!=(const Self & region) const;
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
 protected:
   void

--- a/Modules/Video/Core/src/itkTemporalRegion.cxx
+++ b/Modules/Video/Core/src/itkTemporalRegion.cxx
@@ -118,13 +118,6 @@ TemporalRegion::operator==(const Self & region) const
 }
 
 // ---------------------------------------------------------------------------
-bool
-TemporalRegion::operator!=(const Self & region) const
-{
-  return !(operator==(region));
-}
-
-// ---------------------------------------------------------------------------
 void
 TemporalRegion::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -181,11 +181,7 @@ public:
             m_MethodType == other.GetMethodType());
   }
 
-  bool
-  operator!=(const CallRecord & other) const
-  {
-    return !(*this == other);
-  }
+  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(CallRecord);
 
 protected:
   SizeValueType  m_CallerId;


### PR DESCRIPTION
And also used this macro in `UnsharpMaskingFunctor`, `SliceIterator`, and `TanHelper`.

Note: This should be the last "bulk PR" to add those `ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION` macro calls.