### PR TITLE
BUG: Remove unused virtual operator!=, operator== from ColormapFunction

### DIFF
--- a/Modules/Filtering/Colormap/include/itkColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkColormapFunction.h
@@ -72,18 +72,6 @@ public:
   itkSetMacro(MaximumInputValue, ScalarType);
   itkGetConstMacro(MaximumInputValue, ScalarType);
 
-  virtual bool
-  operator!=(const ColormapFunction &) const
-  {
-    return false;
-  }
-
-  virtual bool
-  operator==(const ColormapFunction & other) const
-  {
-    return !(*this != other);
-  }
-
   virtual RGBPixelType
   operator()(const ScalarType &) const = 0;
 


### PR DESCRIPTION
The `virtual` `ColormapFunction` member functions `operator!=` and
`operator==` appear incorrect, as they always just return `false` or
`true`, respectively, even while `ColormapFunction` has four values as
data members, and corresponding setters and getters.

The two member functions aren't used elsewhere in ITK, and they aren't
overridden by derived ITK classes. So instead of fixing them, it appears
preferable to just remove them.
