### PR TITLE
ENH: Add wrappings for video IO

### DIFF
--- a/Modules/Video/IO/wrapping/itkFileListVideoIO.wrap
+++ b/Modules/Video/IO/wrapping/itkFileListVideoIO.wrap
@@ -1,0 +1,1 @@
+itk_wrap_simple_class("itk::FileListVideoIO" POINTER)

--- a/Modules/Video/IO/wrapping/itkVideoFileReader.wrap
+++ b/Modules/Video/IO/wrapping/itkVideoFileReader.wrap
@@ -1,0 +1,12 @@
+itk_wrap_include("itkImage.h")
+itk_wrap_include("itkVideoStream.h")
+
+UNIQUE(image_types "UC;ULL;D;${WRAP_ITK_ALL_TYPES}")
+itk_wrap_class("itk::VideoFileReader" POINTER)
+  foreach(t ${image_types})
+    foreach(d ${ITK_WRAP_IMAGE_DIMS})
+      itk_wrap_template("VSI${ITKM_${t}}${d}"
+                        "itk::VideoStream<itk::Image<${ITKT_${t}},${d}>>")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/Modules/Video/IO/wrapping/itkVideoFileWriter.wrap
+++ b/Modules/Video/IO/wrapping/itkVideoFileWriter.wrap
@@ -1,0 +1,12 @@
+itk_wrap_include("itkImage.h")
+itk_wrap_include("itkVideoStream.h")
+
+UNIQUE(image_types "UC;ULL;D;${WRAP_ITK_ALL_TYPES}")
+itk_wrap_class("itk::VideoFileWriter" POINTER)
+  foreach(t ${image_types})
+    foreach(d ${ITK_WRAP_IMAGE_DIMS})
+      itk_wrap_template("VSI${ITKM_${t}}${d}"
+                        "itk::VideoStream<itk::Image<${ITKT_${t}},${d}>>")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/Modules/Video/IO/wrapping/itkVideoIOBase.wrap
+++ b/Modules/Video/IO/wrapping/itkVideoIOBase.wrap
@@ -1,0 +1,5 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
+itk_wrap_include("itkVideoIOBase.h")
+itk_wrap_simple_class("itk::VideoIOBaseEnums")
+
+itk_wrap_simple_class("itk::VideoIOBase" POINTER)


### PR DESCRIPTION
Adding Python wrappings for `itkVideoFileReader`, `itkVideoFileWriter`, and `itkFileListVideoIO`.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
