### PR TITLE
COMP: Restore generation of static runtime library on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach(pnew "") # Currently Empty
     cmake_policy(SET ${pnew} NEW)
   endif()
 endforeach()
-foreach(pold "CMP0120") # CMP0120 will require non-trivial effort to address
+foreach(pold "CMP0120" "CMP0091") # CMP0120 will require non-trivial effort to address
   if(POLICY ${pold})
     cmake_policy(SET ${pold} OLD)
   endif()


### PR DESCRIPTION
ce2efb1b9eeb439465ab0355a2445091fc2f2e52 broke runtime library setting
due to implicitly using `NEW` value for CMake policy CMP0091.
This caused dynamic runtime library even if /MT was present in
CMAKE_CXX_FLAGS_RELEASE and friends in CMake cache.

This a `release` branch clone of #2609.
