### PR TITLE
COMP: Remove MultiThreaderBase pixelCount

### DIFF
--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -535,11 +535,6 @@ MultiThreaderBase::ParallelizeImageRegion(unsigned int                          
   }
   ProgressReporter progress(filter, 0, 1);
 
-  SizeValueType pixelCount = 1;
-  for (unsigned d = 0; d < dimension; ++d)
-  {
-    pixelCount *= size[d];
-  }
   struct RegionAndCallback rnc
   {
     funcP, dimension, index, size, 0, filter


### PR DESCRIPTION
To address:

  /ITK/Modules/Core/Common/src/itkMultiThreaderBase.cxx:538:17: warning:
  variable 'pixelCount' set but not used [-Wunused-but-set-variable]
    SizeValueType pixelCount = 1;
