### PR TITLE
COMP: Provide default values for floating point macros

### DIFF
--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -73,6 +73,16 @@ http://graphviz.sourcearchive.com/documentation/2.16/gvrender__pango_8c-source.h
 #  endif
 #endif
 
+// Define used macros with defaults if not available
+#if defined(ITK_FEENABLEEXCEPT_NOOP)
+#  if !defined(FE_DIVBYZERO)
+#    define FE_DIVBYZERO 4
+#  endif
+#  if !defined(FE_INVALID)
+#    define FE_INVALID 1
+#  endif
+#endif
+
 // Considering the following macros:
 //
 // * ITK_FEENABLEEXCEPT_NOOP   : If it applies, defined above


### PR DESCRIPTION
To address:

  In file included from /ITK/Modules/Core/Common/src/itkFloatingPointExceptions.cxx:127:
  /ITK/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx:147:22: error: use of undeclared identifier 'FE_DIVBYZERO'
    itk_feenableexcept(FE_DIVBYZERO);
		       ^
  /ITK/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx:148:22: error: use of undeclared identifier 'FE_INVALID'
    itk_feenableexcept(FE_INVALID);
		       ^
  /ITK/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx:169:23: error: use of undeclared identifier 'FE_DIVBYZERO'
    itk_fedisableexcept(FE_DIVBYZERO);
			^
  /ITK/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx:170:23: error: use of undeclared identifier 'FE_INVALID'
    itk_fedisableexcept(FE_INVALID);
			^
  4 errors generated.

With Emscription 2.

Default values based on Linux.
