### PR TITLE
COMP: Use numpy==1.20.3 for CI testing

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -31,7 +31,7 @@ jobs:
 
     - bash: |
         set -x
-        python3 -m pip install ninja numpy>=1.20 typing-extensions
+        python3 -m pip install ninja numpy==1.20.3 typing-extensions
         python3 -m pip install --upgrade setuptools
         python3 -m pip install lxml scikit-ci-addons dask distributed
       displayName: 'Install dependencies'

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -26,8 +26,7 @@ jobs:
 
     - bash: |
         set -x
-        sudo pip3 install ninja numpy
-        sudo pip3 install ninja numpy>=1.20 typing-extensions
+        sudo pip3 install ninja numpy==1.20.3 typing-extensions
         sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install scikit-ci-addons
         sudo python3 -m pip install lxml dask distributed

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -28,7 +28,7 @@ jobs:
         architecture: 'x64'
 
     - script: |
-        python -m pip install ninja numpy>=1.20 typing-extensions
+        python -m pip install ninja numpy==1.20.3 typing-extensions
         python -m pip install --upgrade setuptools
         python -m pip install scikit-ci-addons dask distributed lxml
       displayName: 'Install dependencies'


### PR DESCRIPTION
With numpy 1.21.0, PythonMedianImageFilterTest fails with:

  2916: Traceback (most recent call last):
  2916:   File "/home/matt/src/ITK/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterTest.py", line 56, in <module>
  2916:     type_hints = get_type_hints(itk.median_image_filter, globalns= { 'itk': itk })
  2916:   File "/home/matt/bin/miniconda/lib/python3.8/typing.py", line 1266, in get_type_hints
  2916:     value = _eval_type(value, globalns, localns)
  2916:   File "/home/matt/bin/miniconda/lib/python3.8/typing.py", line 272, in _eval_type
  2916:     ev_args = tuple(_eval_type(a, globalns, localns) for a in t.__args__)
  2916:   File "/home/matt/bin/miniconda/lib/python3.8/typing.py", line 272, in <genexpr>
  2916:     ev_args = tuple(_eval_type(a, globalns, localns) for a in t.__args__)
  2916:   File "/home/matt/bin/miniconda/lib/python3.8/typing.py", line 272, in _eval_type
  2916:     ev_args = tuple(_eval_type(a, globalns, localns) for a in t.__args__)
  2916:   File "/home/matt/bin/miniconda/lib/python3.8/typing.py", line 272, in <genexpr>
  2916:     ev_args = tuple(_eval_type(a, globalns, localns) for a in t.__args__)
  2916:   File "/home/matt/bin/miniconda/lib/python3.8/typing.py", line 270, in _eval_type
  2916:     return t._evaluate(globalns, localns)
  2916:   File "/home/matt/bin/miniconda/lib/python3.8/typing.py", line 520, in _evaluate
  2916:     eval(self.__forward_code__, globalns, localns),
  2916:   File "<string>", line 1, in <module>
  2916: NameError: name 'dtype' is not defined
  2916: itkTestDriver: Process exited with return value: 1

Use 1.20.3 until this is addressed, issue is tracked in #2613.

