### PR TITLE
COMP: Add missing `#include <iostream>` to Deprecated module test

### DIFF
--- a/Modules/Compatibility/Deprecated/test/itkSimpleFastMutexLockTest.cxx
+++ b/Modules/Compatibility/Deprecated/test/itkSimpleFastMutexLockTest.cxx
@@ -19,6 +19,8 @@
 
 #include "itkSimpleFastMutexLock.h"
 
+#include <iostream> // For cout.
+
 
 int
 itkSimpleFastMutexLockTest(int, char *[])


### PR DESCRIPTION
Fixed a Visual C++ 2019 error, saying:

> Deprecated\test\itkSimpleFastMutexLockTest.cxx(48,12): error C2039: 'cout': is not a member of 'std'