### PR TITLE
ENH: Add `ITK_EXPERIMENTAL_CXX20_REWRITTEN_UNEQUAL_OPERATOR` macro

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorClone.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorClone.h
@@ -96,12 +96,14 @@ public:
     return (m_Pointer == (ObjectType *)(r));
   }
 
+#ifndef ITK_EXPERIMENTAL_CXX20_REWRITTEN_UNEQUAL_OPERATOR
   template <typename TR>
   bool
   operator!=(TR r) const
   {
     return (m_Pointer != (ObjectType *)(r));
   }
+#endif
 
   /** Access function to pointer. */
   ObjectType *

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -281,7 +281,9 @@ public:
   using Superclass::IsAtEnd;
   using Superclass::GetOffset;
   using Superclass::operator==;
+#ifndef ITK_EXPERIMENTAL_CXX20_REWRITTEN_UNEQUAL_OPERATOR
   using Superclass::operator!=;
+#endif
   using Superclass::operator<;
   using Superclass::operator>;
   using Superclass::operator>=;

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -394,18 +394,28 @@ namespace itk
     static_assert(false, "Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE")
 #endif
 
+
+// When ITK_EXPERIMENTAL_CXX20_REWRITTEN_UNEQUAL_OPERATOR is defined, ITK uses
+// the ability for operator!= to be rewritten automatically in terms of
+// operator==, as introduced with C++20. This macro is experimental. It may be
+// modified, renamed, or removed without backward compatibility support.
+#if __cplusplus >= 202002L
+#  define ITK_EXPERIMENTAL_CXX20_REWRITTEN_UNEQUAL_OPERATOR
+#endif
+
 // Note: The following macro, ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TypeName),
 // is only for internal use within the implementation of ITK. It may be
 // modified, renamed, or removed without backward compatibility support.
-#if __cplusplus < 202002L
+#ifdef ITK_EXPERIMENTAL_CXX20_REWRITTEN_UNEQUAL_OPERATOR
+// With C++20, operator!= is automatically rewritten in terms of the
+// corresponding operator==.
+#  define ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TypeName) ITK_MACROEND_NOOP_STATEMENT
+#else
 // For C++14 and C++17, this macro defines an operator!= member function that
 // just calls the corresponding operator== member function.
 #  define ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TypeName)                                                               \
     bool operator!=(const TypeName & other) const { return !(this->operator==(other)); }                               \
     ITK_MACROEND_NOOP_STATEMENT
-#else
-// With C++20, operator!= is defined implicitly, calling the corresponding operator==.
-#  define ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TypeName) ITK_MACROEND_NOOP_STATEMENT
 #endif
 
 /** Macro used to add standard methods to all classes, mainly type

--- a/Modules/Core/Common/include/itkWeakPointer.h
+++ b/Modules/Core/Common/include/itkWeakPointer.h
@@ -76,8 +76,14 @@ public:
     return (m_Pointer == (ObjectType *)r);
   }
 
+#ifndef ITK_EXPERIMENTAL_CXX20_REWRITTEN_UNEQUAL_OPERATOR
   template <typename R>
-  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(R);
+  bool
+  operator!=(R r) const
+  {
+    return !(this->operator==(r));
+  }
+#endif
 
   /** Access function to pointer. */
   ObjectType *


### PR DESCRIPTION
Added an experimental macro to indicate that ITK makes use of C++20
automatically rewritten `operator!=`. Used this macro to fix various
GCC C++20 compile errors reported by Darren Thompson (@darrent1974) at
https://github.com/InsightSoftwareConsortium/ITK/pull/2589#issuecomment-867427430:

> itkWeakPointer.h:80:42: error: expected unqualified-id before ';' token

and:

> itkConstShapedNeighborhoodIterator.h:284:29: error: 'operator!=' has not been declared

Also used the macro for `TreeIteratorClone`.