### PR TITLE
STYLE: Add default member initializer `true` to `m_LetArrayManageMemory`

### DIFF
--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -90,11 +90,9 @@ public:
 
 #else // defined ( ITK_LEGACY_REMOVE )
   /** Constructor that initializes array with contents from a user supplied
-   * buffer. The pointer to the buffer and the length is specified. By default,
-   * the array does not manage the memory of the buffer. It merely points to
-   * that location and it is the user's responsibility to delete it.
-   * If "LetArrayManageMemory" is true, then this class will free the
-   * memory when this object is destroyed. */
+   * buffer. The pointer to the buffer and the length is specified. The array
+   * does a deep copy of the const pointer data, so the array class also
+   * manages memory. The 3rd argument is only for backward compatibility. */
   Array(const ValueType * datain, SizeValueType sz, bool LetArrayManageMemory = false);
 #endif
 
@@ -102,7 +100,6 @@ public:
   template <typename TArrayValue>
   Array(const Array<TArrayValue> & r)
   {
-    this->m_LetArrayManageMemory = true;
     this->SetSize(r.GetSize());
     for (SizeValueType i = 0; i < r.GetSize(); ++i)
     {
@@ -207,7 +204,8 @@ public:
   }
 
 private:
-  bool m_LetArrayManageMemory;
+  /** Indicates whether this array manages the memory of its data. */
+  bool m_LetArrayManageMemory{ true };
 };
 
 template <typename TValue>

--- a/Modules/Core/Common/include/itkArray.hxx
+++ b/Modules/Core/Common/include/itkArray.hxx
@@ -27,44 +27,35 @@ namespace itk
 template <typename TValue>
 Array<TValue>::Array()
   : vnl_vector<TValue>()
-{
-  m_LetArrayManageMemory = true;
-}
+{}
 
 /** Copy constructor */
 template <typename TValue>
 Array<TValue>::Array(const Self & rhs)
   : vnl_vector<TValue>(rhs)
-  ,
-  // The vnl vector copy constructor creates new memory
-  // no matter the setting of let array manage memory of rhs
-  m_LetArrayManageMemory(true)
+// The copy constructor creates new memory, no matter
+// the setting of let array manage memory of rhs
 {}
 
 template <typename TValue>
 Array<TValue>::Array(const VnlVectorType & rhs)
   : vnl_vector<TValue>(rhs)
-  ,
-  // The vnl vector copy constructor creates new memory
-  // no matter the setting of let array manage memory of rhs
-  m_LetArrayManageMemory(true)
+// The vnl vector copy constructor creates new memory
+// no matter the setting of let array manage memory of rhs
 {}
 
 /** Constructor with size */
 template <typename TValue>
 Array<TValue>::Array(SizeValueType dimension)
   : vnl_vector<TValue>(dimension)
-  ,
-  // The vnl vector copy constructor creates new memory
-  // no matter the setting of let array manage memory of rhs
-  m_LetArrayManageMemory(true)
+// The vnl vector copy constructor creates new memory
+// no matter the setting of let array manage memory of rhs
 {}
 
 /** Constructor with size and initial value for each element. */
 template <typename TValue>
 Array<TValue>::Array(const SizeValueType dimension, const TValue & value)
   : vnl_vector<TValue>(dimension, value)
-  , m_LetArrayManageMemory{ true }
 {}
 
 /** Constructor with user specified data */
@@ -81,10 +72,8 @@ Array<TValue>::Array(ValueType * datain, SizeValueType sz, bool LetArrayManageMe
 template <typename TValue>
 Array<TValue>::Array(const ValueType * datain, SizeValueType sz)
   : vnl_vector<TValue>(datain, sz)
-  ,
-  // The vnl vector copy constructor creates new memory
-  // no matter the setting of let array manage memory of rhs
-  m_LetArrayManageMemory(true)
+// The vnl vector copy constructor creates new memory
+// no matter the setting of let array manage memory of rhs
 {}
 
 #else // defined ( ITK_LEGACY_REMOVE )
@@ -94,10 +83,8 @@ Array<TValue>::Array(const ValueType * datain, SizeValueType sz, bool /* LetArra
   : /* NOTE: The 3rd argument "LetArrayManageMemory, was never valid to use, but is
      * preserved to maintain backwards compatibility*/
   vnl_vector<TValue>(datain, sz)
-  ,
-  // The vnl vector copy constructor creates new memory
-  // no matter the setting of let array manage memory of rhs
-  m_LetArrayManageMemory(true)
+// The vnl vector copy constructor creates new memory
+// no matter the setting of let array manage memory of rhs
 {}
 #endif
 


### PR DESCRIPTION
Most of the eight `Array` constructors initialize
`m_LetArrayManageMemory` as `true` anyway. Only
`Array(ValueType *, SizeValueType, bool = false)`
allows a different initial value.

Also somewhat fixed the documentation.