### PR TITLE
STYLE: Add Python-formatting commit's hash to .git-blame-ignore-revs.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -80,3 +80,5 @@ e94ba003e6d27b0c70c114a7f1177ba7bbe7f538
 030c92003ba82f103b481c8af1fdf7eab84dda47
 # STYLE: Removed trailing whitespace.
 452a3298169c95fcb59a0410883496d63a48ecaf
+# Apply black to format Python
+fbbc7aa38cf23d0966b1dbd0f9825797e84c2502


### PR DESCRIPTION
This is the followup pull request to Pull Request #2608 that is described there.   To `.git-blame-ignore-revs`, add the hash for the commit that reformats Python code with `black`.
