### PR TITLE
ENH: Add MakePoint, MakeVector, MakeIndex, MakeSize function templates

### DIFF
--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -19,6 +19,7 @@
 #define itkIndex_h
 
 #include "itkOffset.h"
+#include <type_traits> // For is_integral.
 
 namespace itk
 {
@@ -567,6 +568,20 @@ swap(Index<VDimension> & one, Index<VDimension> & two)
 {
   std::swap(one.m_InternalArray, two.m_InternalArray);
 }
+
+
+/** Makes an Index object, having the specified index values. */
+template <typename... T>
+auto
+MakeIndex(const T... values)
+{
+  const auto toValueType = [](const auto value) {
+    static_assert(std::is_integral<decltype(value)>::value, "Each value must have an integral type!");
+    return static_cast<IndexValueType>(value);
+  };
+  return Index<sizeof...(T)>{ { toValueType(values)... } };
+}
+
 
 // static constexpr definition explicitly needed in C++11
 template <unsigned int VDimension>

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -348,6 +348,26 @@ swap(Point<TCoordRep, NPointDimension> & a, Point<TCoordRep, NPointDimension> & 
   a.swap(b);
 }
 
+
+/** Makes a Point object, having the specified values as coordinates. */
+template <typename TValue, typename... TVariadic>
+auto
+MakePoint(const TValue firstValue, const TVariadic... otherValues)
+{
+  // Assert that the other values have the same type as the first value.
+  const auto assertSameType = [](const auto value) {
+    static_assert(std::is_same<decltype(value), const TValue>::value, "Each value must have the same type!");
+    return true;
+  };
+  const bool assertions[] = { true, assertSameType(otherValues)... };
+  (void)assertions;
+  (void)assertSameType;
+
+  constexpr unsigned                  dimension{ 1 + sizeof...(TVariadic) };
+  const std::array<TValue, dimension> stdArray{ { firstValue, otherValues... } };
+  return Point<TValue, dimension>{ stdArray };
+}
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -20,8 +20,8 @@
 
 #include "itkIntTypes.h"
 #include "itkMacro.h"
-#include <algorithm> // For copy_n.
-#include <type_traits>
+#include <algorithm>   // For copy_n.
+#include <type_traits> // For is_integral.
 #include <memory>
 
 namespace itk
@@ -470,6 +470,20 @@ swap(Size<VDimension> & one, Size<VDimension> & two)
 {
   std::swap(one.m_InternalArray, two.m_InternalArray);
 }
+
+
+/** Makes a Size object, having the specified size values. */
+template <typename... T>
+auto
+MakeSize(const T... values)
+{
+  const auto toValueType = [](const auto value) {
+    static_assert(std::is_integral<decltype(value)>::value, "Each value must have an integral type!");
+    return static_cast<SizeValueType>(value);
+  };
+  return Size<sizeof...(T)>{ { toValueType(values)... } };
+}
+
 
 // static constexpr definition explicitly needed in C++11
 template <unsigned int VDimension>

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -328,6 +328,26 @@ swap(Vector<T, NVectorDimension> & a, Vector<T, NVectorDimension> & b)
   a.swap(b);
 }
 
+
+/** Makes a Vector object, having the specified values as coordinates. */
+template <typename TValue, typename... TVariadic>
+auto
+MakeVector(const TValue firstValue, const TVariadic... otherValues)
+{
+  // Assert that the other values have the same type as the first value.
+  const auto assertSameType = [](const auto value) {
+    static_assert(std::is_same<decltype(value), const TValue>::value, "Each value must have the same type!");
+    return true;
+  };
+  const bool assertions[] = { true, assertSameType(otherValues)... };
+  (void)assertions;
+  (void)assertSameType;
+
+  constexpr unsigned                  dimension{ 1 + sizeof...(TVariadic) };
+  const std::array<TValue, dimension> stdArray{ { firstValue, otherValues... } };
+  return Vector<TValue, dimension>{ stdArray };
+}
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/test/itkIndexGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexGTest.cxx
@@ -19,6 +19,7 @@
 // First include the header file to be tested:
 #include "itkIndex.h"
 #include <gtest/gtest.h>
+#include <initializer_list>
 #include <limits>
 
 namespace
@@ -55,4 +56,18 @@ TEST(Index, FilledReturnsIndexWithSpecifiedValueForEachElement)
   // Test for 1-D and 3-D.
   Expect_Filled_returns_Index_with_specified_value_for_each_element<1>();
   Expect_Filled_returns_Index_with_specified_value_for_each_element<3>();
+}
+
+
+TEST(Index, Make)
+{
+  static_assert((decltype(itk::MakeIndex(1, 1))::Dimension == 2) && (decltype(itk::MakeIndex(1, 1, 1))::Dimension == 3),
+                "The dimension of the created itk::Size should equal the number of arguments");
+
+  EXPECT_EQ(itk::MakeIndex(0, 0), itk::Index<2>());
+  EXPECT_EQ(itk::MakeIndex(0, 0, 0), itk::Index<3>());
+
+  const auto itkIndex = itk::MakeIndex(1, 2, 3, 4);
+  const auto values = { 1, 2, 3, 4 };
+  EXPECT_TRUE(std::equal(itkIndex.begin(), itkIndex.end(), values.begin(), values.end()));
 }

--- a/Modules/Core/Common/test/itkPointGTest.cxx
+++ b/Modules/Core/Common/test/itkPointGTest.cxx
@@ -20,8 +20,10 @@
 #include "itkPoint.h"
 #include <gtest/gtest.h>
 
-#include <iterator> // For begin and end.
-#include <numeric>  // For iota.
+#include <initializer_list>
+#include <iterator>    // For begin and end.
+#include <numeric>     // For iota.
+#include <type_traits> // For is_same.
 
 namespace
 {
@@ -53,4 +55,22 @@ TEST(Point, CanBeConstructedByStdArray)
   // Test for 2-D and 3-D.
   Expect_Point_can_be_constructed_by_std_array<2>();
   Expect_Point_can_be_constructed_by_std_array<3>();
+}
+
+
+TEST(Point, Make)
+{
+  static_assert(std::is_same<decltype(itk::MakePoint(0))::ValueType, int>::value &&
+                  std::is_same<decltype(itk::MakePoint(0.0))::ValueType, double>::value,
+                "The value type of the created point should be the same as the type of the (first) argument");
+
+  static_assert((decltype(itk::MakePoint(1, 1))::Dimension == 2) && (decltype(itk::MakePoint(1, 1, 1))::Dimension == 3),
+                "The dimension of the created point should equal the number of arguments");
+
+  EXPECT_EQ(itk::MakePoint(0, 0), (itk::Point<int, 2>()));
+  EXPECT_EQ(itk::MakePoint(0, 0, 0), (itk::Point<int, 3>()));
+
+  const auto point = itk::MakePoint(1, 2, 3, 4);
+  const auto values = { 1, 2, 3, 4 };
+  EXPECT_TRUE(std::equal(point.begin(), point.end(), values.begin(), values.end()));
 }

--- a/Modules/Core/Common/test/itkSizeGTest.cxx
+++ b/Modules/Core/Common/test/itkSizeGTest.cxx
@@ -19,6 +19,7 @@
 // First include the header file to be tested:
 #include "itkSize.h"
 #include <gtest/gtest.h>
+#include <initializer_list>
 #include <limits>
 
 namespace
@@ -56,4 +57,18 @@ TEST(Size, FilledReturnsSizeWithSpecifiedValueForEachDimension)
   Expect_Filled_returns_Size_with_specified_value_for_each_element<1>();
   Expect_Filled_returns_Size_with_specified_value_for_each_element<2>();
   Expect_Filled_returns_Size_with_specified_value_for_each_element<3>();
+}
+
+
+TEST(Size, Make)
+{
+  static_assert((decltype(itk::MakeSize(1, 1))::Dimension == 2) && (decltype(itk::MakeSize(1, 1, 1))::Dimension == 3),
+                "The dimension of the created itk::Size should equal the number of arguments");
+
+  EXPECT_EQ(itk::MakeSize(0, 0), itk::Size<2>());
+  EXPECT_EQ(itk::MakeSize(0, 0, 0), itk::Size<3>());
+
+  const auto itkSize = itk::MakeSize(1, 2, 3, 4);
+  const auto values = { 1, 2, 3, 4 };
+  EXPECT_TRUE(std::equal(itkSize.begin(), itkSize.end(), values.begin(), values.end()));
 }

--- a/Modules/Core/Common/test/itkVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGTest.cxx
@@ -20,8 +20,10 @@
 #include "itkVector.h"
 #include <gtest/gtest.h>
 
-#include <iterator> // For begin and end.
-#include <numeric>  // For iota.
+#include <initializer_list>
+#include <iterator>    // For begin and end.
+#include <numeric>     // For iota.
+#include <type_traits> // For is_same.
 
 namespace
 {
@@ -53,4 +55,23 @@ TEST(Vector, CanBeConstructedByStdArray)
   // Test for 2-D and 3-D.
   Expect_itk_Vector_can_be_constructed_by_std_array<2>();
   Expect_itk_Vector_can_be_constructed_by_std_array<3>();
+}
+
+
+TEST(Vector, Make)
+{
+  static_assert(std::is_same<decltype(itk::MakeVector(0))::ValueType, int>::value &&
+                  std::is_same<decltype(itk::MakeVector(0.0))::ValueType, double>::value,
+                "The value type of the created itk::Vector should be the same as the type of the (first) argument");
+
+  static_assert((decltype(itk::MakeVector(1, 1))::Dimension == 2) &&
+                  (decltype(itk::MakeVector(1, 1, 1))::Dimension == 3),
+                "The dimension of the created itk::Vector should equal the number of arguments");
+
+  EXPECT_EQ(itk::MakeVector(0, 0), (itk::Vector<int, 2>()));
+  EXPECT_EQ(itk::MakeVector(0, 0, 0), (itk::Vector<int, 3>()));
+
+  const auto itkVector = itk::MakeVector(1, 2, 3, 4);
+  const auto values = { 1, 2, 3, 4 };
+  EXPECT_TRUE(std::equal(itkVector.begin(), itkVector.end(), values.begin(), values.end()));
 }


### PR DESCRIPTION
Added a templated generalization of the overloaded `MakePoint`,
`MakeVector`, `MakeIndex`, and `MakeSize`, functions from
"itkGTestTypedefsAndConstructors.h", allowing them to be more widely
used.

Placed the function templates directly in the namespace `itk`.