### PR TITLE
COMP: add missing wrapping for MeshFileWriter

### DIFF
--- a/Modules/Core/Mesh/wrapping/itkMeshToMeshFilter.wrap
+++ b/Modules/Core/Mesh/wrapping/itkMeshToMeshFilter.wrap
@@ -3,7 +3,7 @@ itk_wrap_include("itkDefaultStaticMeshTraits.h")
 
 itk_wrap_class("itk::MeshToMeshFilter" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_REAL})
+    foreach(t ${WRAP_ITK_SCALAR})
       itk_wrap_template("M${ITKM_${t}}${d}M${ITKM_${t}}${d}"
         "itk::Mesh< ${ITKT_${t}},${d} >, itk::Mesh< ${ITKT_${t}},${d} >")
     endforeach()

--- a/Modules/Core/Mesh/wrapping/itkTransformMeshFilter.wrap
+++ b/Modules/Core/Mesh/wrapping/itkTransformMeshFilter.wrap
@@ -6,7 +6,7 @@ itk_wrap_class("itk::TransformMeshFilter" POINTER)
   # Transform parameter types
   UNIQUE(transform_type "D;${WRAP_ITK_REAL}")
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_REAL})
+    foreach(t ${WRAP_ITK_SCALAR})
       foreach(tt ${transform_type})
         itk_wrap_template("M${ITKM_${t}}${d}M${ITKM_${t}}${d}T${ITKM_${tt}}${d}${d}"
             "itk::Mesh< ${ITKT_${t}},${d} >, itk::Mesh< ${ITKT_${t}},${d} >, itk::Transform< ${ITKT_${tt}}, ${d}, ${d} >")

--- a/Modules/IO/MeshBase/wrapping/itkMeshFileWriter.wrap
+++ b/Modules/IO/MeshBase/wrapping/itkMeshFileWriter.wrap
@@ -3,7 +3,7 @@ itk_wrap_include("itkDefaultStaticMeshTraits.h")
 itk_wrap_include("itkDefaultDynamicMeshTraits.h")
 
 itk_wrap_class("itk::MeshFileWriter" POINTER)
-  UNIQUE(types "${WRAP_ITK_REAL};D")
+  UNIQUE(types "${WRAP_ITK_SCALAR};D")
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${types})
       itk_wrap_template("M${ITKM_${t}}${d}" "itk::Mesh< ${ITKT_${t}},${d} >")


### PR DESCRIPTION
MeshFileWriter was erroneously wrapped for
WRAP_ITK_REAL instead of WRAP_ITK_SCALAR.

```text
   itk.meshwrite(mesh, file_path)
     ...
itk.support.extras.TemplateTypeError: itk.MeshFileWriter is not wrapped for input type `itk.Mesh[itk.UC,3]`.
To limit the size of the package, only a limited number of
types are available in ITK Python.
...
Supported input types:
itk.Mesh[itk.F,2]
itk.Mesh[itk.D,2]
itk.Mesh[itk.F,3]
itk.Mesh[itk.D,3]
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

