### PR TITLE
STYLE: Use MakePoint, MakeVector, MakeIndex, MakeSize from itk namespace

### DIFF
--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -111,14 +111,14 @@ TEST(ITKBSplineTransform, Copying_Clone)
 
   ASSERT_EQ(coeffImageArray.Size(), 2);
 
-  SizeType      imageSize = MakeSize(10, 10);
+  SizeType      imageSize = itk::MakeSize(10, 10);
   DirectionType imageDirection; // filled with zeros
   imageDirection(0, 1) = -1;
   imageDirection(1, 0) = 1;
 
-  VectorType imageSpacing = MakeVector(1.1, 1.2);
+  VectorType imageSpacing = itk::MakeVector(1.1, 1.2);
 
-  PointType imageOrigin = MakePoint(0.9, 0.8);
+  PointType imageOrigin = itk::MakePoint(0.9, 0.8);
 
   coeffImageArray[0] = ImageType::New();
 
@@ -153,10 +153,10 @@ TEST(ITKBSplineTransform, Copying_Clone)
 
   bspline_eq(bspline1.GetPointer(), bspline1.GetPointer(), "Check after initialization by coefficient images.");
 
-  ITK_EXPECT_VECTOR_NEAR(bspline1->GetTransformDomainOrigin(), MakePoint(-0.3, 1.9), 1e-15);
+  ITK_EXPECT_VECTOR_NEAR(bspline1->GetTransformDomainOrigin(), itk::MakePoint(-0.3, 1.9), 1e-15);
   EXPECT_EQ(bspline1->GetTransformDomainDirection(), imageDirection);
-  EXPECT_EQ(bspline1->GetTransformDomainMeshSize(), MakeSize(7, 7));
-  ITK_EXPECT_VECTOR_NEAR(bspline1->GetTransformDomainPhysicalDimensions(), MakeVector(7.7, 8.4), 1e-15);
+  EXPECT_EQ(bspline1->GetTransformDomainMeshSize(), itk::MakeSize(7, 7));
+  ITK_EXPECT_VECTOR_NEAR(bspline1->GetTransformDomainPhysicalDimensions(), itk::MakeVector(7.7, 8.4), 1e-15);
 
   BSplineType::Pointer bspline2 = BSplineType::New();
   bspline2->SetFixedParameters(bspline1->GetFixedParameters());

--- a/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
@@ -314,7 +314,7 @@ TEST(SliceImageFilterTests, Sizes)
 
   using namespace itk::GTest::TypedefsAndConstructors::Dimension3;
 
-  source->SetSize(MakeSize(19, 17, 11));
+  source->SetSize(itk::MakeSize(19, 17, 11));
 
   filter = FilterType::New();
   filter->SetInput(source->GetOutput());
@@ -324,7 +324,7 @@ TEST(SliceImageFilterTests, Sizes)
   EXPECT_EQ(9, filter->GetOutput()->GetLargestPossibleRegion().GetSize(1));
   EXPECT_EQ(6, filter->GetOutput()->GetLargestPossibleRegion().GetSize(2));
 
-  source->SetSize(MakeSize(5, 2, 3));
+  source->SetSize(itk::MakeSize(5, 2, 3));
 
   std::cout << "CHECK" << std::endl;
 

--- a/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
@@ -118,7 +118,7 @@ TEST_F(TileImageFixture, VectorImage)
 
   auto image = ImageType::New();
 
-  typename ImageType::SizeType imageSize = MakeSize(10, 10);
+  typename ImageType::SizeType imageSize = itk::MakeSize(10, 10);
 
   const unsigned int numberOfComponents = 5;
 

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -113,30 +113,30 @@ TEST_F(ShapeLabelMapFixture, 3D_T1x1x1)
 
   Utils::ImageType::Pointer image(Utils::CreateImage());
 
-  image->SetPixel(MakeIndex(5, 7, 9), 1);
+  image->SetPixel(itk::MakeIndex(5, 7, 9), 1);
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5, 7, 9), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakeSize(1, 1, 1), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(5.0, 7.0, 9.0), labelObject->GetCentroid(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeIndex(5, 7, 9), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(1, 1, 1), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(5.0, 7.0, 9.0), labelObject->GetCentroid(), 1e-10);
   EXPECT_EQ(0.0, labelObject->GetElongation());
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(0.0, 0.0, 0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(0.0, 0.0, 0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
   EXPECT_NEAR(4.83598, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
   EXPECT_NEAR(0.62035, labelObject->GetEquivalentSphericalRadius(), 1e-4);    // resulting value
   EXPECT_EQ(0.0, labelObject->GetFeretDiameter());
   EXPECT_EQ(0.0, labelObject->GetFlatness());
   EXPECT_EQ(1u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(1u, 1u, 1u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(4.5, 6.5, 8.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(1u, 1u, 1u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(4.5, 6.5, 8.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
   EXPECT_NEAR(3.004, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_EQ(1.0, labelObject->GetPhysicalSize());
   // labelObject->GetPrincipalAxes();  degenerate case
-  EXPECT_EQ(MakeVector(0.0, 0.0, 0.0), labelObject->GetPrincipalMoments());
+  EXPECT_EQ(itk::MakeVector(0.0, 0.0, 0.0), labelObject->GetPrincipalMoments());
   EXPECT_NEAR(1.6098, labelObject->GetRoundness(), 0.0001); // resulting value
 
   EXPECT_EQ(labelObject->GetBoundingBox(), labelObject->GetRegion());
@@ -157,32 +157,32 @@ TEST_F(ShapeLabelMapFixture, 3D_T3x2x1)
 
   for (unsigned int i = 5; i < 8; ++i)
   {
-    image->SetPixel(MakeIndex(i, 9, 11), 1);
-    image->SetPixel(MakeIndex(i, 10, 11), 1);
+    image->SetPixel(itk::MakeIndex(i, 9, 11), 1);
+    image->SetPixel(itk::MakeIndex(i, 10, 11), 1);
   }
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakeSize(3, 2, 1), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  EXPECT_EQ(MakePoint(6, 9.5, 11.0), labelObject->GetCentroid());
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(3, 2, 1), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  EXPECT_EQ(itk::MakePoint(6.0, 9.5, 11.0), labelObject->GetCentroid());
   EXPECT_NEAR(1.63299, labelObject->GetElongation(), 1e-4);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(0.0, 0.0, 0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(0.0, 0.0, 0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
   EXPECT_NEAR(15.96804, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
   EXPECT_NEAR(1.12725, labelObject->GetEquivalentSphericalRadius(), 1e-4);     // resulting value
   EXPECT_NEAR(2.23606, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_EQ(0.0, labelObject->GetFlatness());
   EXPECT_EQ(6u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(1u, 2u, 3u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(7.5, 8.5, 10.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(1u, 2u, 3u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(7.5, 8.5, 10.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
   EXPECT_NEAR(14.62414, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_EQ(6.0, labelObject->GetPhysicalSize());
   // labelObject->GetPrincipalAxes(); omitted
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(0, 0.25, 0.666667), labelObject->GetPrincipalMoments(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.0, 0.25, 0.666667), labelObject->GetPrincipalMoments(), 1e-4);
   EXPECT_NEAR(1.09189, labelObject->GetRoundness(), 1e-4); // resulting value
 
   EXPECT_EQ(labelObject->GetBoundingBox(), labelObject->GetRegion());
@@ -204,8 +204,8 @@ TEST_F(ShapeLabelMapFixture, 3D_T3x2x1_Direction)
 
   for (unsigned int i = 5; i < 8; ++i)
   {
-    image->SetPixel(MakeIndex(i, 9, 11), 1);
-    image->SetPixel(MakeIndex(i, 10, 11), 1);
+    image->SetPixel(itk::MakeIndex(i, 9, 11), 1);
+    image->SetPixel(itk::MakeIndex(i, 10, 11), 1);
   }
 
   DirectionType direction;
@@ -221,25 +221,26 @@ TEST_F(ShapeLabelMapFixture, 3D_T3x2x1_Direction)
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakeSize(3, 2, 1), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(5.06906, -3.25286, -14.5249), labelObject->GetCentroid(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(3, 2, 1), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(5.06906, -3.25286, -14.5249), labelObject->GetCentroid(), 1e-4);
   EXPECT_NEAR(1.63299, labelObject->GetElongation(), 1e-4);
-  // ITK_EXPECT_VECTOR_NEAR(MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
+  // ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
   EXPECT_NEAR(15.96804, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
   EXPECT_NEAR(1.12725, labelObject->GetEquivalentSphericalRadius(), 1e-4);     // resulting value
   EXPECT_NEAR(2.23606, labelObject->GetFeretDiameter(), 1e-4);
   // EXPECT_EQ(0.0, labelObject->GetFlatness()); unstable due to division near zero
   EXPECT_EQ(6u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(1u, 2u, 3u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(3.22524, -3.19685, -14.83670), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(1u, 2u, 3u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(
+    itk::MakePoint(3.22524, -3.19685, -14.83670), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
   EXPECT_NEAR(14.62414, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_EQ(6.0, labelObject->GetPhysicalSize());
   // labelObject->GetPrincipalAxes(); omitted
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(0, 0.25, 0.666667), labelObject->GetPrincipalMoments(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.0, 0.25, 0.666667), labelObject->GetPrincipalMoments(), 1e-4);
   EXPECT_NEAR(1.09189, labelObject->GetRoundness(), 1e-4); // resulting value
 
   if (::testing::Test::HasFailure())
@@ -261,29 +262,29 @@ TEST_F(ShapeLabelMapFixture, 3D_T2x2x2_Spacing)
   {
     for (unsigned int j = 0; j < 2; ++j)
     {
-      image->SetPixel(MakeIndex(5 + j, 9 + i, 11), 1);
-      image->SetPixel(MakeIndex(5 + j, 9 + i, 12), 1);
+      image->SetPixel(itk::MakeIndex(5 + j, 9 + i, 11), 1);
+      image->SetPixel(itk::MakeIndex(5 + j, 9 + i, 12), 1);
     }
   }
 
-  image->SetSpacing(MakeVector(1.0, 1.1, 2.2));
+  image->SetSpacing(itk::MakeVector(1.0, 1.1, 2.2));
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakeSize(2, 2, 2), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(5.5, 10.45, 25.3), labelObject->GetCentroid(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(2, 2, 2), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(5.5, 10.45, 25.3), labelObject->GetCentroid(), 1e-4);
   EXPECT_NEAR(2.0, labelObject->GetElongation(), 1e-4);
   ITK_EXPECT_VECTOR_NEAR(
-    MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
-  EXPECT_NEAR(34.86751, labelObject->GetEquivalentSphericalPerimeter(), 1e-4);                 // resulting value
-  EXPECT_NEAR(1.66573, labelObject->GetEquivalentSphericalRadius(), 1e-4);                     // resulting value
+    itk::MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
+  EXPECT_NEAR(34.86751, labelObject->GetEquivalentSphericalPerimeter(), 1e-4);                      // resulting value
+  EXPECT_NEAR(1.66573, labelObject->GetEquivalentSphericalRadius(), 1e-4);                          // resulting value
   EXPECT_NEAR(2.65518, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_NEAR(1.1, labelObject->GetFlatness(), 1e-4);
   EXPECT_EQ(8u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(2, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(2.0, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
   EXPECT_NEAR(28.3919, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
@@ -291,9 +292,9 @@ TEST_F(ShapeLabelMapFixture, 3D_T2x2x2_Spacing)
   // Because the sign of the Eigen vectors is not
   // unique, therefore the axes may not always point in the same
   // direction making origin not unique. Therefore we check the expected origin the the list of vertices.
-  EXPECT_TRUE(Utils::TestListHasPoint(labelObject->GetOrientedBoundingBoxVertices(), MakePoint(4.5, 9.35, 23.1)));
+  EXPECT_TRUE(Utils::TestListHasPoint(labelObject->GetOrientedBoundingBoxVertices(), itk::MakePoint(4.5, 9.35, 23.1)));
   // labelObject->GetPrincipalAxes(); omitted
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(), 1e-4);
   EXPECT_NEAR(1.22808, labelObject->GetRoundness(), 1e-4); // resulting value
 
   if (::testing::Test::HasFailure())
@@ -325,37 +326,38 @@ TEST_F(ShapeLabelMapFixture, 3D_T2x2x2_Spacing_Direction)
   {
     for (unsigned int j = 0; j < 2; ++j)
     {
-      image->SetPixel(MakeIndex(5 + j, 9 + i, 11), 1);
-      image->SetPixel(MakeIndex(5 + j, 9 + i, 12), 1);
+      image->SetPixel(itk::MakeIndex(5 + j, 9 + i, 11), 1);
+      image->SetPixel(itk::MakeIndex(5 + j, 9 + i, 12), 1);
     }
   }
 
-  image->SetSpacing(MakeVector(1.0, 1.1, 2.2));
+  image->SetSpacing(itk::MakeVector(1.0, 1.1, 2.2));
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
 
-  ITK_EXPECT_VECTOR_NEAR(MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakeSize(2, 2, 2), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(10.13655, 4.21035, -25.67227), labelObject->GetCentroid(), 1e-4); // resulting value
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(2, 2, 2), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(
+    itk::MakePoint(10.13655, 4.21035, -25.67227), labelObject->GetCentroid(), 1e-4); // resulting value
   EXPECT_NEAR(2.0, labelObject->GetElongation(), 1e-4);
   ITK_EXPECT_VECTOR_NEAR(
-    MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
-  EXPECT_NEAR(34.86751, labelObject->GetEquivalentSphericalPerimeter(), 1e-4);                 // resulting value
-  EXPECT_NEAR(1.66573, labelObject->GetEquivalentSphericalRadius(), 1e-4);                     // resulting value
+    itk::MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
+  EXPECT_NEAR(34.86751, labelObject->GetEquivalentSphericalPerimeter(), 1e-4);                      // resulting value
+  EXPECT_NEAR(1.66573, labelObject->GetEquivalentSphericalRadius(), 1e-4);                          // resulting value
   EXPECT_NEAR(2.65518, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_NEAR(1.1, labelObject->GetFlatness(), 1e-4);
   EXPECT_EQ(8u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(2, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(2.0, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
   ITK_EXPECT_VECTOR_NEAR(
-    MakePoint(8.92548, 4.27240, -23.31018), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4); // resulting value
-  EXPECT_NEAR(28.3919, labelObject->GetPerimeter(), 1e-4);                                      // resulting value
+    itk::MakePoint(8.92548, 4.27240, -23.31018), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4); // resulting value
+  EXPECT_NEAR(28.3919, labelObject->GetPerimeter(), 1e-4);                                           // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_NEAR(19.36, labelObject->GetPhysicalSize(), 1e-10);
   // labelObject->GetPrincipalAxes(); omitted
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(), 1e-4);
   EXPECT_NEAR(1.22808, labelObject->GetRoundness(), 1e-4); // resulting value
 
   if (::testing::Test::HasFailure())
@@ -373,12 +375,12 @@ TEST_F(ShapeLabelMapFixture, 2D_T1x1)
 
   Utils::ImageType::Pointer image(Utils::CreateImage());
 
-  image->SetPixel(MakeIndex(5, 7), 1);
+  image->SetPixel(itk::MakeIndex(5, 7), 1);
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(1.0, 1.0), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(4.5, 6.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(1.0, 1.0), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(4.5, 6.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
 
   if (::testing::Test::HasFailure())
   {
@@ -395,14 +397,15 @@ TEST_F(ShapeLabelMapFixture, 2D_T1_1)
 
   Utils::ImageType::Pointer image(Utils::CreateImage());
 
-  image->SetPixel(MakeIndex(5, 7), 1);
-  image->SetPixel(MakeIndex(6, 8), 1);
+  image->SetPixel(itk::MakeIndex(5, 7), 1);
+  image->SetPixel(itk::MakeIndex(6, 8), 1);
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
-  ITK_EXPECT_VECTOR_NEAR(MakeSize(2, 2), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(Math::sqrt2, 2.0 * Math::sqrt2), labelObject->GetOrientedBoundingBoxSize(), 1e-4);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(4.0, 7.0), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(2, 2), labelObject->GetBoundingBox().GetSize(), 1e-99);
+  ITK_EXPECT_VECTOR_NEAR(
+    itk::MakeVector(Math::sqrt2, 2.0 * Math::sqrt2), labelObject->GetOrientedBoundingBoxSize(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(4.0, 7.0), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
 
   if (::testing::Test::HasFailure())
   {
@@ -419,8 +422,8 @@ TEST_F(ShapeLabelMapFixture, 2D_T1_1_FlipDirection)
 
   Utils::ImageType::Pointer image(Utils::CreateImage());
 
-  image->SetPixel(MakeIndex(5, 7), 1);
-  image->SetPixel(MakeIndex(6, 8), 1);
+  image->SetPixel(itk::MakeIndex(5, 7), 1);
+  image->SetPixel(itk::MakeIndex(6, 8), 1);
 
   DirectionType direction;
 
@@ -433,8 +436,9 @@ TEST_F(ShapeLabelMapFixture, 2D_T1_1_FlipDirection)
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(Math::sqrt2, 2.0 * Math::sqrt2), labelObject->GetOrientedBoundingBoxSize(), 1e-4);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(6.0, 5.0), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(
+    itk::MakeVector(Math::sqrt2, 2.0 * Math::sqrt2), labelObject->GetOrientedBoundingBoxSize(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(6.0, 5.0), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
 
 
   if (::testing::Test::HasFailure())
@@ -452,8 +456,8 @@ TEST_F(ShapeLabelMapFixture, 2D_T1_2_Direction)
 
   Utils::ImageType::Pointer image(Utils::CreateImage());
 
-  image->SetPixel(MakeIndex(5, 7), 1);
-  image->SetPixel(MakeIndex(5, 8), 1);
+  image->SetPixel(itk::MakeIndex(5, 7), 1);
+  image->SetPixel(itk::MakeIndex(5, 8), 1);
 
   DirectionType direction;
 
@@ -471,10 +475,10 @@ TEST_F(ShapeLabelMapFixture, 2D_T1_2_Direction)
 
   EXPECT_EQ(obbVertices.Size(), 4);
 
-  EXPECT_TRUE(Utils::TestListHasPoint(obbVertices, MakePoint(8.5, 4.5)));
-  EXPECT_TRUE(Utils::TestListHasPoint(obbVertices, MakePoint(8.5, 5.5)));
-  EXPECT_TRUE(Utils::TestListHasPoint(obbVertices, MakePoint(6.5, 4.5)));
-  EXPECT_TRUE(Utils::TestListHasPoint(obbVertices, MakePoint(6.5, 5.5)));
+  EXPECT_TRUE(Utils::TestListHasPoint(obbVertices, itk::MakePoint(8.5, 4.5)));
+  EXPECT_TRUE(Utils::TestListHasPoint(obbVertices, itk::MakePoint(8.5, 5.5)));
+  EXPECT_TRUE(Utils::TestListHasPoint(obbVertices, itk::MakePoint(6.5, 4.5)));
+  EXPECT_TRUE(Utils::TestListHasPoint(obbVertices, itk::MakePoint(6.5, 5.5)));
 
 
   if (::testing::Test::HasFailure())
@@ -496,14 +500,14 @@ TEST_F(ShapeLabelMapFixture, 2D_T2x4)
   {
     for (unsigned int j = 3; j < 7; ++j)
     {
-      image->SetPixel(MakeIndex(i, j), 1);
+      image->SetPixel(itk::MakeIndex(i, j), 1);
     }
   }
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image);
 
-  ITK_EXPECT_VECTOR_NEAR(MakeVector(2.0, 4.0), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(MakePoint(3.5, 2.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(2.0, 4.0), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(3.5, 2.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
 
   if (::testing::Test::HasFailure())
   {

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
@@ -39,7 +39,7 @@ CreateTestImageA()
   using ImageType = itk::Image<PixelType, Dimension>;
 
   auto image = ImageType::New();
-  image->SetRegions(ImageType::RegionType(MakeSize(2u, 2u, 2u)));
+  image->SetRegions(ImageType::RegionType(itk::MakeSize(2u, 2u, 2u)));
   image->Allocate(true);
 
   for (size_t i = 0; i < 8; ++i)

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -41,7 +41,7 @@ CreateTestImageA()
   using ImageType = itk::Image<PixelType, Dimension>;
 
   auto image = ImageType::New();
-  image->SetRegions(ImageType::RegionType(MakeSize(3u, 3u)));
+  image->SetRegions(ImageType::RegionType(itk::MakeSize(3u, 3u)));
   image->Allocate();
   image->FillBuffer(0);
 


### PR DESCRIPTION
Replaced calls to the `Make` functions from the namespace
`itk::GTest::TypedefsAndConstructors` by calls to the function templates
from `itk`, that were added by:

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2633
commit 8aed68490b733ba45b36b2e8e84e99980db45948
"ENH: Add MakePoint, MakeVector, MakeIndex, MakeSize function templates"