### PR TITLE
STYLE: Remove `Make` functions from itk::GTest::TypedefsAndConstructors

### DIFF
--- a/Modules/Core/TestKernel/include/itkGTestTypedefsAndConstructors.h
+++ b/Modules/Core/TestKernel/include/itkGTestTypedefsAndConstructors.h
@@ -53,36 +53,6 @@ using DirectionType = ImageBaseType::DirectionType;
 using VectorType = ImageBaseType::SpacingType;
 using RegionType = ImageBaseType::RegionType;
 
-inline static PointType
-MakePoint(PointType::ValueType p1, PointType::ValueType p2)
-{
-  const PointType::ValueType a[] = { p1, p2 };
-  PointType                  point(a);
-  return point;
-}
-
-inline static VectorType
-MakeVector(VectorType::ValueType v1, VectorType::ValueType v2)
-{
-  const VectorType::ValueType a[] = { v1, v2 };
-  VectorType                  vector(a);
-  return vector;
-}
-
-inline static IndexType
-MakeIndex(IndexType::IndexValueType i1, IndexType::IndexValueType i2)
-{
-  IndexType idx = { { i1, i2 } };
-  return idx;
-}
-
-inline static SizeType
-MakeSize(SizeType::SizeValueType s1, SizeType::SizeValueType s2)
-{
-  SizeType size = { { s1, s2 } };
-  return size;
-}
-
 } // end namespace Dimension2
 
 
@@ -104,36 +74,6 @@ using PointType = ImageBaseType::PointType;
 using DirectionType = ImageBaseType::DirectionType;
 using VectorType = ImageBaseType::SpacingType;
 using RegionType = ImageBaseType::RegionType;
-
-inline static PointType
-MakePoint(PointType::ValueType p1, PointType::ValueType p2, PointType::ValueType p3)
-{
-  const PointType::ValueType a[] = { p1, p2, p3 };
-  PointType                  point(a);
-  return point;
-}
-
-inline static VectorType
-MakeVector(VectorType::ValueType v1, VectorType::ValueType v2, VectorType::ValueType v3)
-{
-  const VectorType::ValueType a[] = { v1, v2, v3 };
-  VectorType                  vector(a);
-  return vector;
-}
-
-inline static IndexType
-MakeIndex(IndexType::IndexValueType i1, IndexType::IndexValueType i2, IndexType::IndexValueType i3)
-{
-  IndexType idx = { { i1, i2, i3 } };
-  return idx;
-}
-
-inline static SizeType
-MakeSize(SizeType::SizeValueType s1, SizeType::SizeValueType s2, SizeType::SizeValueType s3)
-{
-  SizeType size = { { s1, s2, s3 } };
-  return size;
-}
 
 } // end namespace Dimension3
 

--- a/Modules/Core/TestKernel/test/itkGoogleTest.cxx
+++ b/Modules/Core/TestKernel/test/itkGoogleTest.cxx
@@ -36,30 +36,30 @@ TEST(GoogleTest, TypedefsAndConstructors_Dimension2)
   PointType pt1;
   pt1[0] = 1.1;
   pt1[1] = 2.2;
-  const PointType pt2 = MakePoint(1.1, 2.2);
+  const PointType pt2 = itk::MakePoint(1.1, 2.2);
   EXPECT_TRUE(pt1 == pt2);
   ITK_EXPECT_VECTOR_NEAR(pt1, pt2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(pt1, MakePoint(1.1, 2.2), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(pt1, itk::MakePoint(1.1, 2.2), 1e-10);
 
   VectorType vec1;
   vec1[0] = 1.1;
   vec1[1] = 2.2;
-  const VectorType vec2 = MakeVector(1.1, 2.2);
+  const VectorType vec2 = itk::MakeVector(1.1, 2.2);
   EXPECT_TRUE(vec1 == vec2);
   ITK_EXPECT_VECTOR_NEAR(vec1, vec2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(vec1, MakeVector(1.1, 2.2), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(vec1, itk::MakeVector(1.1, 2.2), 1e-10);
 
   const IndexType idx1 = { { 0, 1 } };
-  const IndexType idx2 = MakeIndex(0, 1);
+  const IndexType idx2 = itk::MakeIndex(0, 1);
   EXPECT_TRUE(idx1 == idx2);
   ITK_EXPECT_VECTOR_NEAR(idx1, idx2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(idx1, MakeIndex(0, 1), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(idx1, itk::MakeIndex(0, 1), 1e-10);
 
   const SizeType sz1 = { { 0u, 1u } };
-  const SizeType sz2 = MakeSize(0u, 1u);
+  const SizeType sz2 = itk::MakeSize(0u, 1u);
   EXPECT_TRUE(sz1 == sz2);
   ITK_EXPECT_VECTOR_NEAR(sz1, sz2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(sz1, MakeSize(0u, 1u), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(sz1, itk::MakeSize(0u, 1u), 1e-10);
 }
 
 
@@ -73,27 +73,27 @@ TEST(GoogleTest, TypedefsAndConstructors_Dimension3)
   pt1[0] = 1.1;
   pt1[1] = 2.2;
   pt1[2] = 3.3;
-  const PointType pt2 = MakePoint(1.1, 2.2, 3.3);
+  const PointType pt2 = itk::MakePoint(1.1, 2.2, 3.3);
   EXPECT_TRUE(pt1 == pt2);
   ITK_EXPECT_VECTOR_NEAR(pt1, pt2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(pt1, MakePoint(1.1, 2.2, 3.3), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(pt1, itk::MakePoint(1.1, 2.2, 3.3), 1e-10);
 
   VectorType vec1;
   vec1[0] = 1.1;
   vec1[1] = 2.2;
   vec1[2] = 3.3;
-  const VectorType vec2 = MakeVector(1.1, 2.2, 3.3);
+  const VectorType vec2 = itk::MakeVector(1.1, 2.2, 3.3);
   EXPECT_TRUE(vec1 == vec2);
   ITK_EXPECT_VECTOR_NEAR(vec1, vec2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(vec1, MakeVector(1.1, 2.2, 3.3), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(vec1, itk::MakeVector(1.1, 2.2, 3.3), 1e-10);
 
   const IndexType idx1 = { { 0, 1, 2 } };
-  const IndexType idx2 = MakeIndex(0, 1, 2);
+  const IndexType idx2 = itk::MakeIndex(0, 1, 2);
   EXPECT_TRUE(idx1 == idx2);
   ITK_EXPECT_VECTOR_NEAR(idx1, idx2, 1e-10);
 
   const SizeType sz1 = { { 0u, 1u, 2u } };
-  const SizeType sz2 = MakeSize(0u, 1u, 2u);
+  const SizeType sz2 = itk::MakeSize(0u, 1u, 2u);
   EXPECT_TRUE(sz1 == sz2);
-  ITK_EXPECT_VECTOR_NEAR(sz1, MakeSize(0u, 1u, 2u), 1e-10);
+  ITK_EXPECT_VECTOR_NEAR(sz1, itk::MakeSize(0u, 1u, 2u), 1e-10);
 }


### PR DESCRIPTION
Removed the `Make` functions from the namespace
`itk::GTest::TypedefsAndConstructors` as they are superseded by:

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2633
commit 8aed68490b733ba45b36b2e8e84e99980db45948
"ENH: Add MakePoint, MakeVector, MakeIndex, MakeSize function templates"

Adjusted itkGoogleTest.cxx accordingly.