### PR TITLE
BUG: Resolve warnings with MakeIndex and MakePoint

### DIFF
--- a/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
@@ -198,15 +198,15 @@ TEST_F(StatisticsLabelMapFixture, 2D_ones_with_outliers)
   image->FillBuffer(value);
 
   // Test with outliers outside the label.
-  image->SetPixel(IndexType{ 0, 0 }, 32000);
-  image->SetPixel(IndexType{ 0, 1 }, -32000);
+  image->SetPixel(itk::MakeIndex(0, 0), 32000);
+  image->SetPixel(itk::MakeIndex(0, 1), -32000);
 
 
   auto                  labelImage = Utils ::CreateLabelImage();
   Utils::LabelPixelType label = 1;
   labelImage->FillBuffer(label);
-  labelImage->SetPixel(IndexType{ 0, 0 }, 0);
-  labelImage->SetPixel(IndexType{ 0, 1 }, 0);
+  labelImage->SetPixel(itk::MakeIndex(0, 0), 0);
+  labelImage->SetPixel(itk::MakeIndex(0, 1), 0);
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 16);
 
@@ -233,16 +233,16 @@ TEST_F(StatisticsLabelMapFixture, 2D_rand_with_outliers)
   auto labelImage = Utils ::CreateLabelImage();
 
   // Test with outliers outside the label.
-  image->SetPixel(IndexType{ 0, 0 }, 32000);
-  image->SetPixel(IndexType{ 0, 1 }, -2000);
+  image->SetPixel(itk::MakeIndex(0, 0), 32000);
+  image->SetPixel(itk::MakeIndex(0, 1), -2000);
   // Set min/max in label
-  image->SetPixel(IndexType{ 0, 2 }, 0);
-  image->SetPixel(IndexType{ 0, 3 }, 500);
+  image->SetPixel(itk::MakeIndex(0, 2), 0);
+  image->SetPixel(itk::MakeIndex(0, 3), 500);
 
   Utils::LabelPixelType label = 1;
   labelImage->FillBuffer(label);
-  labelImage->SetPixel(IndexType{ 0, 0 }, 0);
-  labelImage->SetPixel(IndexType{ 0, 1 }, 0);
+  labelImage->SetPixel(itk::MakeIndex(0, 0), 0);
+  labelImage->SetPixel(itk::MakeIndex(0, 1), 0);
 
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 16);
@@ -268,16 +268,16 @@ TEST_F(StatisticsLabelMapFixture, 2D_even)
   auto labelImage = Utils ::CreateLabelImage();
 
   // Set label with two elements far apart, the median should be average
-  image->SetPixel(IndexType{ 0, 0 }, 10);
-  image->SetPixel(IndexType{ 0, 1 }, 100);
-  image->SetPixel(IndexType{ 0, 2 }, 1);
-  image->SetPixel(IndexType{ 0, 3 }, 200);
+  image->SetPixel(itk::MakeIndex(0, 0), 10);
+  image->SetPixel(itk::MakeIndex(0, 1), 100);
+  image->SetPixel(itk::MakeIndex(0, 2), 1);
+  image->SetPixel(itk::MakeIndex(0, 3), 200);
 
   Utils::LabelPixelType label = 1;
-  labelImage->SetPixel(IndexType{ 0, 0 }, label);
-  labelImage->SetPixel(IndexType{ 0, 1 }, label);
-  labelImage->SetPixel(IndexType{ 0, 2 }, label);
-  labelImage->SetPixel(IndexType{ 0, 3 }, label);
+  labelImage->SetPixel(itk::MakeIndex(0, 0), label);
+  labelImage->SetPixel(itk::MakeIndex(0, 1), label);
+  labelImage->SetPixel(itk::MakeIndex(0, 2), label);
+  labelImage->SetPixel(itk::MakeIndex(0, 3), label);
 
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 8);
@@ -306,14 +306,14 @@ TEST_F(StatisticsLabelMapFixture, 2D_three)
   auto labelImage = Utils ::CreateLabelImage();
 
   // Set label with two elements far apart, the median should be average
-  image->SetPixel(IndexType{ 0, 0 }, 1);
-  image->SetPixel(IndexType{ 0, 1 }, 3);
-  image->SetPixel(IndexType{ 0, 2 }, 10);
+  image->SetPixel(itk::MakeIndex(0, 0), 1);
+  image->SetPixel(itk::MakeIndex(0, 1), 3);
+  image->SetPixel(itk::MakeIndex(0, 2), 10);
 
   Utils::LabelPixelType label = 1;
-  labelImage->SetPixel(IndexType{ 0, 0 }, label);
-  labelImage->SetPixel(IndexType{ 0, 1 }, label);
-  labelImage->SetPixel(IndexType{ 0, 2 }, label);
+  labelImage->SetPixel(itk::MakeIndex(0, 0), label);
+  labelImage->SetPixel(itk::MakeIndex(0, 1), label);
+  labelImage->SetPixel(itk::MakeIndex(0, 2), label);
 
 
   Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(labelImage, image, label, 1 << 8);

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
@@ -57,7 +57,7 @@ itkNiftiImageIOTest12(int ac, char * av[])
   ImageType::Pointer image = ImageType::New();
   image->SetRegions(region);
   image->SetNumberOfComponentsPerPixel(3);
-  image->SetOrigin(ImageType::PointType({ -7.0, -13.0, -19.0 }));
+  image->SetOrigin(itk::MakePoint(-7.0, -13.0, -19.0));
   image->Allocate();
 
   { // Fill in entire image

--- a/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
@@ -119,7 +119,7 @@ itkImageToVideoFilterTest(int argc, char * argv[])
       {
         auto idx = it.GetIndex();
         auto frame = videoOutput->GetFrame(idx[frameAxis]);
-        ITK_TEST_EXPECT_EQUAL(frame->GetPixel({ idx[1], idx[2] }), it.Get());
+        ITK_TEST_EXPECT_EQUAL(frame->GetPixel(itk::MakeIndex(idx[1], idx[2])), it.Get());
 
         ++it;
       }


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Resolves nightly exotic build warnings relating to `itk::Index` and `itk::Point` initialization by relying on `itk::MakeIndex` and `itk::MakePoint` helpers.

[Build information](https://open.cdash.org/viewBuildError.php?type=1&buildid=7339831):
Site: RogueResearch7
Build Name: Mac10.11-AppleClang-dbg-x86_64-static
Build Time: 2021-07-14 05:03:37

Warnings resolved:
> [CTest: warning matched] /Users/builder/externalModules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx:201:30: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  image->SetPixel(IndexType{ 0, 0 }, 32000);
...

> CTest: warning matched] /Users/builder/externalModules/Video/Core/test/itkImageToVideoFilterTest.cxx:122:49: warning: suggest braces around initialization of subobject [-Wmissing-braces]
        ITK_TEST_EXPECT_EQUAL(frame->GetPixel({ idx[1], idx[2] }), it.Get());
...

> [CTest: warning matched] /Users/builder/externalModules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx:60:43: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  image->SetOrigin(ImageType::PointType({ -7.0, -13.0, -19.0 }));


## PR Checklist
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
