### PR TITLE
ENH: fix Python multi-processing hang on unix

### DIFF
--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -124,13 +124,23 @@ auto result = pool->AddWork([](int param) { return param; }, 7);
   SetDoNotWaitForThreads(bool doNotWaitForThreads);
 
 protected:
-  /* We need access to the mutex in AddWork, and the variable is only
+  /** We need access to the mutex in AddWork, and the variable is only
    * visible in .cxx file, so this method returns it. */
   std::mutex &
   GetMutex();
 
   ThreadPool();
-  ~ThreadPool() override;
+
+  /** Stop the pool and release threads. To be called by the destructor and atfork. */
+  void
+  CleanUp();
+
+  ~ThreadPool() override { this->CleanUp(); }
+
+  static void
+  PrepareForFork();
+  static void
+  ResumeFromFork();
 
 private:
   /** Only used to synchronize the global variable across static libraries.*/


### PR DESCRIPTION
Closes #2069.

_Initial (**old**) description:_

This turns a hang into:
```text
(pyEnv) dzenan@corista:~/nn_work_dir$ python itkMultiProcessingMONAI.py 
main pid: 2578395 140116265719616
Resampling image_0.nii pid: 2578395 140116265719616...
Resampling image_0.nii pid: 2578404 140116265719616...
Resampling image_1.nii pid: 2578404 140116265719616...
In ThreadPool::atfork_prepareIn ThreadPool::atfork_resumeTraceback (most recent call last):
  File "itkMultiProcessingMONAI.py", line 44, in <module>
    p.map(f, paths)
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 771, in get
    raise self._value
multiprocessing.pool.MaybeEncodingError: Error sending result: '[<itk.itkImagePython.itkImageUC3; proxy of <Swig Object of type 'itkImageUC3 *' at 0x7f6ee94955a0> >]'. Reason: 'TypeError("cannot pickle 'SwigPyObject' object")'
(pyEnv) dzenan@corista:~/nn_work_dir$
```
