### PR TITLE
STYLE: Increase tests style consistency

### DIFF
--- a/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
@@ -21,13 +21,16 @@
 #include "itkImageFileWriter.h"
 #include "itkImageDuplicator.h"
 #include "itkAbsImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageDuplicatorTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " Input Output\n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " Input Output" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
 #include "itkTestingComparisonImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -29,9 +30,9 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Missing arguments " << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  outputImageFile" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "  outputImageFile" << std::endl;
     std::cerr << "[baselineImage  differenceImage]" << std::endl;
     return EXIT_FAILURE;
   }
@@ -103,15 +104,8 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
 
     writer2->SetInput(difference->GetOutput());
 
-    try
-    {
-      writer2->Update();
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(writer2->Update());
+
 
     std::cout << "Number of pixels with differences = ";
     std::cout << difference->GetNumberOfPixelsWithDifferences() << std::endl;

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -19,6 +19,7 @@
 #include "itkImage.h"
 #include "itkRGBPixel.h"
 #include "itkTextOutput.h" // Needed to see warnings
+#include "itkTestingMacros.h"
 
 using myPointer = itk::ImportImageContainer<unsigned long, short>::Pointer;
 bool
@@ -89,7 +90,9 @@ itkObjectFactoryTest2(int argc, char * argv[])
   itk::ObjectFactoryBase::UnRegisterAllFactories();
   if (argc < 2)
   {
-    std::cout << "Usage: " << argv[0] << " FactoryPath [FactoryPath [FactoryPath ..." << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " FactoryPath [FactoryPath [FactoryPath ..." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest3.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest3.cxx
@@ -23,6 +23,7 @@
 #include "itkStreamingImageFilter.h"
 #include "itkImageRegionSplitterMultidimensional.h"
 #include "itkPipelineMonitorImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -30,8 +31,9 @@ itkStreamingImageFilterTest3(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile outputImageFile numberOfStreamDivisions" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "  inputImageFile outputImageFile numberOfStreamDivisions" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
@@ -19,6 +19,7 @@
 #include "itkQuadEdgeMesh.h"
 #include "itkRegularSphereMeshSource.h"
 #include "itkQuadEdgeMeshScalarDataVTKPolyDataWriter.h"
+#include "itkTestingMacros.h"
 
 #include <iostream>
 
@@ -27,9 +28,9 @@ itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Usage" << std::endl;
-    std::cerr << argv[0] << " outputFileName.vtk" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " outputFileName.vtk" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -54,16 +55,8 @@ itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1(int argc, char * argv[])
 
   mySphereMeshSource->Modified();
 
-  try
-  {
-    mySphereMeshSource->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error during source Update() " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(mySphereMeshSource->Update());
+
 
   std::cout << "mySphereMeshSource: " << mySphereMeshSource;
 
@@ -107,16 +100,7 @@ itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1(int argc, char * argv[])
   writer->SetInput(mySphereMeshSource->GetOutput());
   writer->SetFileName(argv[1]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error during writer Update() " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   return EXIT_SUCCESS;

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkResampleImageFilter.h"
 
 #include "itkBSplineDeformableTransform.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -78,16 +79,7 @@ public:
     typename FixedReaderType::Pointer fixedReader = FixedReaderType::New();
     fixedReader->SetFileName(argv[2]);
 
-    try
-    {
-      fixedReader->Update();
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(fixedReader->Update());
 
 
     typename MovingReaderType::Pointer movingReader = MovingReaderType::New();
@@ -196,16 +188,7 @@ public:
 
     resampler->SetTransform(bsplineTransform);
 
-    try
-    {
-      itk::WriteImage(resampler->GetOutput(), argv[4]);
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(resampler->GetOutput(), argv[4]));
 
 
     using VectorType = itk::Vector<float, ImageDimension>;
@@ -241,16 +224,7 @@ public:
 
     if (argc >= 6)
     {
-      try
-      {
-        itk::WriteImage(field, argv[5]);
-      }
-      catch (const itk::ExceptionObject & excp)
-      {
-        std::cerr << "Exception thrown " << std::endl;
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-      }
+      ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(field, argv[5]));
     }
     return EXIT_SUCCESS;
   }
@@ -263,8 +237,8 @@ itkBSplineDeformableTransformTest2(int argc, char * argv[])
 
   if (argc < 5)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " coefficientsFile fixedImage ";
     std::cerr << "movingImage deformedMovingImage" << std::endl;
     std::cerr << "[deformationField][spline order 2,3]" << std::endl;

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest3.cxx
@@ -23,6 +23,7 @@
 
 #include "itkBSplineDeformableTransform.h"
 #include "itkSimilarity2DTransform.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -79,16 +80,7 @@ public:
     typename FixedReaderType::Pointer fixedReader = FixedReaderType::New();
     fixedReader->SetFileName(argv[2]);
 
-    try
-    {
-      fixedReader->Update();
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(fixedReader->Update());
 
 
     typename MovingReaderType::Pointer movingReader = MovingReaderType::New();
@@ -210,16 +202,7 @@ public:
 
     resampler->SetTransform(bsplineTransform);
 
-    try
-    {
-      itk::WriteImage(resampler->GetOutput(), argv[4]);
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(resampler->GetOutput(), argv[4]));
 
 
     using VectorType = itk::Vector<float, ImageDimension>;
@@ -255,16 +238,7 @@ public:
 
     if (argc >= 6)
     {
-      try
-      {
-        itk::WriteImage(field, argv[5]);
-      }
-      catch (const itk::ExceptionObject & excp)
-      {
-        std::cerr << "Exception thrown " << std::endl;
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-      }
+      ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(field, argv[5]));
     }
     return EXIT_SUCCESS;
   }
@@ -277,8 +251,8 @@ itkBSplineDeformableTransformTest3(int argc, char * argv[])
 
   if (argc < 7)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " coefficientsFile fixedImage ";
     std::cerr << "movingImage deformedMovingImage" << std::endl;
     std::cerr << "[deformationField][multithreader use #threads]" << std::endl;

--- a/Modules/Core/Transform/test/itkBSplineTransformInitializerTest1.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformInitializerTest1.cxx
@@ -35,8 +35,8 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
 
   if (argc < 5)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " coefficientsFile fixedImage";
     std::cerr << " movingImage deformedMovingImage" << std::endl;
     std::cerr << " [deformationField]" << std::endl;
@@ -55,16 +55,8 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
   FixedReaderType::Pointer fixedReader = FixedReaderType::New();
   fixedReader->SetFileName(argv[2]);
 
-  try
-  {
-    fixedReader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(fixedReader->Update());
+
 
   MovingReaderType::Pointer movingReader = MovingReaderType::New();
 
@@ -146,16 +138,8 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
 
   resampler->SetTransform(bsplineTransform);
 
-  try
-  {
-    itk::WriteImage(resampler->GetOutput(), argv[4]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(resampler->GetOutput(), argv[4]));
+
 
   using VectorType = itk::Vector<float, ImageDimension>;
   using DeformationFieldType = itk::Image<VectorType, ImageDimension>;
@@ -192,16 +176,7 @@ itkBSplineTransformInitializerTest1(int argc, char * argv[])
 
   if (argc >= 6)
   {
-    try
-    {
-      itk::WriteImage(field, argv[5]);
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(field, argv[5]));
   }
 
   return EXIT_SUCCESS;

--- a/Modules/Core/Transform/test/itkBSplineTransformInitializerTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformInitializerTest2.cxx
@@ -46,8 +46,9 @@ itkBSplineTransformInitializerTest2(int argc, char * argv[])
 
   if (argc < 2)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0] << " fixedImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " fixedImage ";
     return EXIT_FAILURE;
   }
 
@@ -60,16 +61,8 @@ itkBSplineTransformInitializerTest2(int argc, char * argv[])
   FixedReaderType::Pointer fixedReader = FixedReaderType::New();
   fixedReader->SetFileName(argv[1]);
 
-  try
-  {
-    fixedReader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(fixedReader->Update());
+
 
   // We first use the passed fixed image to construct the control point
   // grid and save the control point locations.

--- a/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkResampleImageFilter.h"
 
 #include "itkBSplineTransform.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -78,16 +79,7 @@ public:
     typename FixedReaderType::Pointer fixedReader = FixedReaderType::New();
     fixedReader->SetFileName(argv[2]);
 
-    try
-    {
-      fixedReader->Update();
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(fixedReader->Update());
 
 
     typename MovingReaderType::Pointer movingReader = MovingReaderType::New();
@@ -172,16 +164,7 @@ public:
 
     resampler->SetTransform(bsplineTransform);
 
-    try
-    {
-      itk::WriteImage(resampler->GetOutput(), argv[4]);
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(resampler->GetOutput(), argv[4]));
 
 
     using VectorType = itk::Vector<float, ImageDimension>;
@@ -217,16 +200,7 @@ public:
 
     if (argc >= 6)
     {
-      try
-      {
-        itk::WriteImage(field, argv[5]);
-      }
-      catch (const itk::ExceptionObject & excp)
-      {
-        std::cerr << "Exception thrown " << std::endl;
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-      }
+      ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(field, argv[5]));
     }
     return EXIT_SUCCESS;
   }
@@ -239,8 +213,8 @@ itkBSplineTransformTest2(int argc, char * argv[])
 
   if (argc < 5)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " coefficientsFile fixedImage ";
     std::cerr << "movingImage deformedMovingImage" << std::endl;
     std::cerr << "[deformationField][spline order 2,3]" << std::endl;

--- a/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
@@ -22,6 +22,7 @@
 #include "itkResampleImageFilter.h"
 
 #include "itkBSplineTransform.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -78,16 +79,7 @@ public:
     typename FixedReaderType::Pointer fixedReader = FixedReaderType::New();
     fixedReader->SetFileName(argv[2]);
 
-    try
-    {
-      fixedReader->Update();
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(fixedReader->Update());
 
 
     typename MovingReaderType::Pointer movingReader = MovingReaderType::New();
@@ -197,16 +189,7 @@ public:
 
     resampler->SetTransform(bsplineTransform);
 
-    try
-    {
-      itk::WriteImage(resampler->GetOutput(), argv[4]);
-    }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << "Exception thrown " << std::endl;
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(resampler->GetOutput(), argv[4]));
 
 
     using VectorType = itk::Vector<float, ImageDimension>;
@@ -242,16 +225,7 @@ public:
 
     if (argc >= 6)
     {
-      try
-      {
-        itk::WriteImage(field, argv[5]);
-      }
-      catch (const itk::ExceptionObject & excp)
-      {
-        std::cerr << "Exception thrown " << std::endl;
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-      }
+      ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(field, argv[5]));
     }
     return EXIT_SUCCESS;
   }
@@ -264,8 +238,8 @@ itkBSplineTransformTest3(int argc, char * argv[])
 
   if (argc < 7)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " coefficientsFile fixedImage ";
     std::cerr << "movingImage deformedMovingImage" << std::endl;
     std::cerr << "[deformationField][multithreader use #threads]" << std::endl;

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest3.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest3.cxx
@@ -21,14 +21,15 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkBinaryDilateImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkBinaryDilateImageFilterTest3(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage Foreground Background BoundaryToForeground Radius" << std::endl;
     return EXIT_FAILURE;
   }
@@ -110,15 +111,8 @@ itkBinaryDilateImageFilterTest3(int argc, char * argv[])
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest3.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest3.cxx
@@ -21,14 +21,15 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkBinaryErodeImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkBinaryErodeImageFilterTest3(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " InputImage OutputImage Foreground Background BoundaryToForeground Radius" << std::endl;
     return EXIT_FAILURE;
   }
@@ -110,15 +111,8 @@ itkBinaryErodeImageFilterTest3(int argc, char * argv[])
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
@@ -30,9 +30,10 @@ itkBinaryOpeningByReconstructionImageFilterTest(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output conn fg kernelSize" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output conn fg kernelSize" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;
@@ -64,6 +65,9 @@ itkBinaryOpeningByReconstructionImageFilterTest(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(reconstruction->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
-  return 0;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTestInt.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTestInt.cxx
@@ -22,6 +22,7 @@
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkStreamingImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkConvolutionImageFilterTestInt(int argc, char * argv[])
@@ -29,8 +30,9 @@ itkConvolutionImageFilterTestInt(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cout << "Usage: " << argv[0] << " inputImage kernelImage outputImage [normalizeImage] [outputRegionMode]"
-              << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImage kernelImage outputImage [normalizeImage] [outputRegionMode]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -95,15 +97,8 @@ itkConvolutionImageFilterTestInt(int argc, char * argv[])
   writer->SetFileName(argv[3]);
   writer->SetInput(streamingFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   if (!monitor->VerifyAllInputCanStream(numberOfStreamDivisions))
   {

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTestInt.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTestInt.cxx
@@ -28,8 +28,9 @@ itkFFTConvolutionImageFilterTestInt(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cout << "Usage: " << argv[0] << " inputImage kernelImage outputImage [normalizeImage] [outputRegionMode]"
-              << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImage kernelImage outputImage [normalizeImage] [outputRegionMode]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest1.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileWriter.h"
 
 #include "itkSignedDanielssonDistanceMapImageFilter.h"
+#include "itkTestingMacros.h"
 
 // Convenience function to template over dimension and avoid code duplication.
 template <unsigned int ImageDimension>
@@ -61,7 +62,9 @@ itkSignedDanielssonDistanceMapImageFilterTest1(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " InputImage OutputImage [ImageDimension]\n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " InputImage OutputImage [ImageDimension]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest2.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest2.cxx
@@ -21,14 +21,17 @@
 #include "itkRescaleIntensityImageFilter.h"
 
 #include "itkSignedDanielssonDistanceMapImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkSignedDanielssonDistanceMapImageFilterTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " InputImage OutputImage\n";
-    return -1;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " InputImage OutputImage" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr unsigned int ImageDimension = 2;
@@ -67,7 +70,9 @@ itkSignedDanielssonDistanceMapImageFilterTest2(int argc, char * argv[])
   writer->SetInput(rescaler->GetOutput());
   writer->SetFileName(argv[2]);
   writer->UseCompressionOn();
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest2.cxx
@@ -29,7 +29,9 @@ itkCannyEdgeDetectionImageFilterTest2(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Usage: " << argv[0] << " InputImage OutputImage1 OutputImage2" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " InputImage OutputImage1 OutputImage2" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest1.cxx
@@ -20,6 +20,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkLabelMapContourOverlayImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -27,8 +28,9 @@ itkLabelMapContourOverlayImageFilterTest1(int argc, char * argv[])
 {
   if (argc != 9)
   {
-    std::cerr << "usage: " << argv[0] << " input input output opacity type thickness dilation priority sliceDim"
-              << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input input output opacity type thickness dilation priority sliceDim" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -67,6 +69,9 @@ itkLabelMapContourOverlayImageFilterTest1(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(colorizer->GetOutput());
   writer->SetFileName(argv[3]);
-  writer->Update();
-  return 0;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest2.cxx
@@ -20,6 +20,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkLabelMapContourOverlayImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -27,10 +28,10 @@ itkLabelMapContourOverlayImageFilterTest2(int argc, char * argv[])
 {
   if (argc != 9)
   {
-    std::cerr << "usage: " << argv[0] << " input input output opacity type thickness dilation priority sliceDim"
-              << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input input output opacity type thickness dilation priority sliceDim" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;
@@ -72,6 +73,9 @@ itkLabelMapContourOverlayImageFilterTest2(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(colorizer->GetOutput());
   writer->SetFileName(argv[3]);
-  writer->Update();
-  return 0;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest3.cxx
@@ -20,6 +20,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkLabelMapContourOverlayImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -27,8 +28,9 @@ itkLabelMapContourOverlayImageFilterTest3(int argc, char * argv[])
 {
   if (argc != 9)
   {
-    std::cerr << "usage: " << argv[0] << " input input output opacity type thickness dilation priority sliceDim"
-              << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input input output opacity type thickness dilation priority sliceDim" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -75,15 +77,9 @@ itkLabelMapContourOverlayImageFilterTest3(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(colorizer->GetOutput());
   writer->SetFileName(argv[3]);
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "Unexpected exception." << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
-  return 0;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest1.cxx
@@ -21,6 +21,7 @@
 
 #include "itkLabelImageToLabelMapFilter.h"
 #include "itkLabelMapOverlayImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -28,9 +29,10 @@ itkLabelMapOverlayImageFilterTest1(int argc, char * argv[])
 {
   if (argc != 5)
   {
-    std::cerr << "usage: " << argv[0] << " input input output opacity" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input input output opacity" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest2.cxx
@@ -21,6 +21,7 @@
 
 #include "itkLabelImageToLabelMapFilter.h"
 #include "itkLabelMapOverlayImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -28,8 +29,10 @@ itkLabelMapOverlayImageFilterTest2(int argc, char * argv[])
 {
   if (argc != 5)
   {
-    std::cerr << "usage: " << argv[0] << " input input output opacity" << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input input output opacity" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;
@@ -61,6 +64,9 @@ itkLabelMapOverlayImageFilterTest2(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(colorizer->GetOutput());
   writer->SetFileName(argv[3]);
-  writer->Update();
-  return 0;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest3.cxx
@@ -21,6 +21,7 @@
 
 #include "itkLabelImageToLabelMapFilter.h"
 #include "itkLabelMapOverlayImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -28,7 +29,9 @@ itkLabelMapOverlayImageFilterTest3(int argc, char * argv[])
 {
   if (argc != 5)
   {
-    std::cerr << "usage: " << argv[0] << " input input output opacity" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input input output opacity" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -68,14 +71,9 @@ itkLabelMapOverlayImageFilterTest3(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(colorizer->GetOutput());
   writer->SetFileName(argv[3]);
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "Unexpected exception." << std::endl;
-    std::cerr << err << std::endl;
-  }
-  return 0;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapToRGBImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapToRGBImageFilterTest1.cxx
@@ -29,9 +29,10 @@ itkLabelMapToRGBImageFilterTest1(int argc, char * argv[])
 {
   if (argc != 3)
   {
-    std::cerr << "usage: " << argv[0] << " input output" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;
@@ -71,5 +72,5 @@ itkLabelMapToRGBImageFilterTest1(int argc, char * argv[])
   colorizer->GetFunctor().AddColor(0, 255, 0);
   ITK_TEST_EXPECT_TRUE(colorizer->GetFunctor() != functor);
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapToRGBImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapToRGBImageFilterTest2.cxx
@@ -21,6 +21,7 @@
 
 #include "itkLabelImageToLabelMapFilter.h"
 #include "itkLabelMapToRGBImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -28,8 +29,10 @@ itkLabelMapToRGBImageFilterTest2(int argc, char * argv[])
 {
   if (argc != 3)
   {
-    std::cerr << "usage: " << argv[0] << " input output" << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;
@@ -55,6 +58,9 @@ itkLabelMapToRGBImageFilterTest2(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(colorizer->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
-  return 0;
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
@@ -100,8 +100,9 @@ itkGradientImageFilterTest2(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " Inputimage OutputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " Inputimage OutputImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -21,6 +21,7 @@
 #include "itkVariableLengthVector.h"
 #include "itkVectorImage.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 /*
  * Test itkGradientRecursiveGaussianFilter with various types
@@ -144,8 +145,6 @@ itkGradientRecursiveGaussianFilterTest3Run(typename TImageType::PixelType &   my
   return EXIT_SUCCESS;
 }
 
-////////////////////////////////////////////////////////////////////
-
 template <typename TGradImage1DType, typename TGradImageVectorType>
 int
 itkGradientRecursiveGaussianFilterTest3Compare(typename TGradImage1DType::Pointer     scalarPixelGradImage,
@@ -185,15 +184,13 @@ itkGradientRecursiveGaussianFilterTest3Compare(typename TGradImage1DType::Pointe
   return EXIT_SUCCESS;
 }
 
-////////////////////////////////////////////////////////////////////
-
 int
 itkGradientRecursiveGaussianFilterTest3(int argc, char * argv[])
 {
   if (argc != 8)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputImageFile1 outputImageFile2 outputImageFile3 outputImageFile4 outputImageFile5 "
                  "outputImageFile6 outputImageFile7"
               << std::endl;

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
@@ -32,9 +32,9 @@ itkBSplineScatteredDataPointSetToImageFilterTest2(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage:" << std::endl;
-    std::cerr << argv[0] << "outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
@@ -34,9 +34,9 @@ itkBSplineScatteredDataPointSetToImageFilterTest3(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage:" << std::endl;
-    std::cerr << argv[0] << "inputPointsFile.txt outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "inputPointsFile.txt outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
@@ -35,9 +35,9 @@ itkBSplineScatteredDataPointSetToImageFilterTest5(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage:" << std::endl;
-    std::cerr << argv[0] << "outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
@@ -323,7 +323,7 @@ itkBinShrinkImageFilterTest1(int, char *[])
           if (lfailed)
           {
             monitor2->GetOutput()->Print(std::cout);
-            exit(1);
+            return EXIT_FAILURE;
           }
         }
         catch (const itk::ExceptionObject & e)

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
@@ -65,8 +65,7 @@ itkResampleImageTest2(int argc, char * argv[])
   if (argc < 8)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << "inputImage "
               << " referenceImage"
               << " resampledImageLinear"

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -64,9 +64,9 @@ itkResampleImageTest2Streaming(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cerr << "Missing arguments ! " << std::endl;
-    std::cerr << "Usage : " << std::endl;
-    std::cerr << argv[0] << "inputImage referenceImage "
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "inputImage referenceImage "
               << "resampledImageLinear resampledImageNonLinear "
               << "resampledImageLinearNearestExtrapolate"
               << "resampledImageNonLinearNearestExtrapolate";

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest3.cxx
@@ -37,7 +37,8 @@ itkResampleImageTest3(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImage resampledImage" << std::endl;
     return EXIT_FAILURE;
   }
@@ -108,16 +109,8 @@ itkResampleImageTest3(int argc, char * argv[])
   writer1->SetFileName(argv[2]);
   writer1->SetInput(resample->GetOutput());
 
-  // Run the resampling filter
-  try
-  {
-    writer1->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer1->Update());
+
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
@@ -28,6 +28,14 @@ int
 itkResampleImageTest5(int argc, char * argv[])
 {
 
+  if (argc < 2)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cout << " scaling outputFilename" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Resample an RGB image
   constexpr unsigned int NDimensions = 2;
 
@@ -45,12 +53,6 @@ itkResampleImageTest5(int argc, char * argv[])
   using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
-
-  if (argc < 2)
-  {
-    std::cout << "Usage: " << argv[0] << " scaling outputFilename" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   float scaling = std::stod(argv[1]);
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
@@ -28,6 +28,15 @@ int
 itkResampleImageTest6(int argc, char * argv[])
 {
 
+  if (argc < 2)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cout << " scaling outputFilename" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+
   // Resample a Vector image
   constexpr unsigned int NDimensions = 2;
 
@@ -46,12 +55,6 @@ itkResampleImageTest6(int argc, char * argv[])
   using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
-
-  if (argc < 2)
-  {
-    std::cout << "Usage: " << argv[0] << " scaling outputFilename" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   float scaling = std::stod(argv[1]);
 

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest2.cxx
@@ -28,8 +28,9 @@ itkAddImageFilterTest2(int argc, char * argv[])
 {
   if (argc != 3)
   {
-    std::cerr << "Usage: " << argv[0] << " <InputImage>"
-              << " <OutputImage>" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " <InputImage> <OutputImage>" << std::endl;
     return EXIT_FAILURE;
   }
   const char * inputImage = argv[1];

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculatorTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculatorTest.cxx
@@ -32,8 +32,7 @@ itkPeakSignalToNoiseRatioCalculatorTest(int argc, char * argv[])
               << std::endl;
     std::cerr << " input: the input image" << std::endl;
     std::cerr << " noisy: noise with the input image" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;
@@ -71,5 +70,5 @@ itkPeakSignalToNoiseRatioCalculatorTest(int argc, char * argv[])
     }
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToEntropyImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToEntropyImageFilterTest1.cxx
@@ -21,14 +21,17 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkHistogramToEntropyImageFilter.h"
+#include "itkTestingMacros.h"
+
 int
 itkHistogramToEntropyImageFilterTest1(int argc, char * argv[])
 {
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -41,16 +44,8 @@ itkHistogramToEntropyImageFilterTest1(int argc, char * argv[])
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encoutered while reading image file : " << argv[1] << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   itk::MinimumMaximumImageFilter<ScalarImageType>::Pointer minmaxFilter =
     itk::MinimumMaximumImageFilter<ScalarImageType>::New();
@@ -92,15 +87,8 @@ itkHistogramToEntropyImageFilterTest1(int argc, char * argv[])
 
   writer->SetInput(histogramToImageFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToEntropyImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToEntropyImageFilterTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkJoinImageFilter.h"
 #include "itkHistogramToEntropyImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkHistogramToEntropyImageFilterTest2(int argc, char * argv[])
@@ -29,8 +30,9 @@ itkHistogramToEntropyImageFilterTest2(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -47,17 +49,9 @@ itkHistogramToEntropyImageFilterTest2(int argc, char * argv[])
   reader1->SetFileName(argv[1]);
   reader2->SetFileName(argv[2]);
 
-  try
-  {
-    reader1->Update();
-    reader2->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encoutered while reading image file : " << argv[1] << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader1->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader2->Update());
+
 
   using JoinFilterType = itk::JoinImageFilter<ScalarImageType, ScalarImageType>;
 
@@ -81,7 +75,8 @@ itkHistogramToEntropyImageFilterTest2(int argc, char * argv[])
   HistogramMeasurementVectorType imageMax(NumberOfComponents);
 
   minmaxFilter->SetInput(reader1->GetOutput());
-  minmaxFilter->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(minmaxFilter->Update());
 
   imageMin[0] = minmaxFilter->GetMinimum();
   imageMax[0] = minmaxFilter->GetMaximum();
@@ -109,7 +104,7 @@ itkHistogramToEntropyImageFilterTest2(int argc, char * argv[])
   histogramFilter->SetHistogramBinMinimum(imageMin);
   histogramFilter->SetHistogramBinMaximum(imageMax);
 
-  histogramFilter->Update();
+  ITK_TRY_EXPECT_NO_EXCEPTION(histogramFilter->Update());
 
 
   using HistogramType = HistogramFilterType::HistogramType;
@@ -129,15 +124,8 @@ itkHistogramToEntropyImageFilterTest2(int argc, char * argv[])
 
   writer->SetInput(histogramToImageFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToIntensityImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToIntensityImageFilterTest1.cxx
@@ -21,14 +21,17 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkHistogramToIntensityImageFilter.h"
+#include "itkTestingMacros.h"
+
 int
 itkHistogramToIntensityImageFilterTest1(int argc, char * argv[])
 {
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -41,21 +44,16 @@ itkHistogramToIntensityImageFilterTest1(int argc, char * argv[])
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encoutered while reading image file : " << argv[1] << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   itk::MinimumMaximumImageFilter<ScalarImageType>::Pointer minmaxFilter =
     itk::MinimumMaximumImageFilter<ScalarImageType>::New();
   minmaxFilter->SetInput(reader->GetOutput());
-  minmaxFilter->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(minmaxFilter->Update());
+
+
   const ScalarImageType::PixelType imageMin = minmaxFilter->GetMinimum();
   const ScalarImageType::PixelType imageMax = minmaxFilter->GetMaximum();
 
@@ -91,15 +89,8 @@ itkHistogramToIntensityImageFilterTest1(int argc, char * argv[])
 
   writer->SetInput(histogramToImageFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToIntensityImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToIntensityImageFilterTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkJoinImageFilter.h"
 #include "itkHistogramToIntensityImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkHistogramToIntensityImageFilterTest2(int argc, char * argv[])
@@ -29,8 +30,9 @@ itkHistogramToIntensityImageFilterTest2(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -47,17 +49,9 @@ itkHistogramToIntensityImageFilterTest2(int argc, char * argv[])
   reader1->SetFileName(argv[1]);
   reader2->SetFileName(argv[2]);
 
-  try
-  {
-    reader1->Update();
-    reader2->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encoutered while reading image file : " << argv[1] << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader1->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader2->Update());
+
 
   using JoinFilterType = itk::JoinImageFilter<ScalarImageType, ScalarImageType>;
 
@@ -87,7 +81,9 @@ itkHistogramToIntensityImageFilterTest2(int argc, char * argv[])
   imageMax[0] = minmaxFilter->GetMaximum();
 
   minmaxFilter->SetInput(reader2->GetOutput());
-  minmaxFilter->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(minmaxFilter->Update());
+
 
   imageMin[1] = minmaxFilter->GetMinimum();
   imageMax[1] = minmaxFilter->GetMaximum();
@@ -109,7 +105,7 @@ itkHistogramToIntensityImageFilterTest2(int argc, char * argv[])
   histogramFilter->SetHistogramBinMinimum(imageMin);
   histogramFilter->SetHistogramBinMaximum(imageMax);
 
-  histogramFilter->Update();
+  ITK_TRY_EXPECT_NO_EXCEPTION(histogramFilter->Update());
 
 
   using HistogramType = HistogramFilterType::HistogramType;
@@ -129,15 +125,8 @@ itkHistogramToIntensityImageFilterTest2(int argc, char * argv[])
 
   writer->SetInput(histogramToImageFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToLogProbabilityImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToLogProbabilityImageFilterTest1.cxx
@@ -21,14 +21,17 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkHistogramToLogProbabilityImageFilter.h"
+#include "itkTestingMacros.h"
+
 int
 itkHistogramToLogProbabilityImageFilterTest1(int argc, char * argv[])
 {
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -41,21 +44,16 @@ itkHistogramToLogProbabilityImageFilterTest1(int argc, char * argv[])
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encoutered while reading image file : " << argv[1] << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   itk::MinimumMaximumImageFilter<ScalarImageType>::Pointer minmaxFilter =
     itk::MinimumMaximumImageFilter<ScalarImageType>::New();
   minmaxFilter->SetInput(reader->GetOutput());
-  minmaxFilter->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(minmaxFilter->Update());
+
+
   const ScalarImageType::PixelType imageMin = minmaxFilter->GetMinimum();
   const ScalarImageType::PixelType imageMax = minmaxFilter->GetMaximum();
 
@@ -92,15 +90,8 @@ itkHistogramToLogProbabilityImageFilterTest1(int argc, char * argv[])
 
   writer->SetInput(histogramToImageFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToLogProbabilityImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToLogProbabilityImageFilterTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkJoinImageFilter.h"
 #include "itkHistogramToLogProbabilityImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkHistogramToLogProbabilityImageFilterTest2(int argc, char * argv[])
@@ -29,8 +30,9 @@ itkHistogramToLogProbabilityImageFilterTest2(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -47,17 +49,9 @@ itkHistogramToLogProbabilityImageFilterTest2(int argc, char * argv[])
   reader1->SetFileName(argv[1]);
   reader2->SetFileName(argv[2]);
 
-  try
-  {
-    reader1->Update();
-    reader2->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encoutered while reading image file : " << argv[1] << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader1->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader2->Update());
+
 
   using JoinFilterType = itk::JoinImageFilter<ScalarImageType, ScalarImageType>;
 
@@ -81,7 +75,8 @@ itkHistogramToLogProbabilityImageFilterTest2(int argc, char * argv[])
   HistogramMeasurementVectorType imageMax(NumberOfComponents);
 
   minmaxFilter->SetInput(reader1->GetOutput());
-  minmaxFilter->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(minmaxFilter->Update());
 
   imageMin[0] = minmaxFilter->GetMinimum();
   imageMax[0] = minmaxFilter->GetMaximum();
@@ -109,7 +104,7 @@ itkHistogramToLogProbabilityImageFilterTest2(int argc, char * argv[])
   histogramFilter->SetHistogramBinMinimum(imageMin);
   histogramFilter->SetHistogramBinMaximum(imageMax);
 
-  histogramFilter->Update();
+  ITK_TRY_EXPECT_NO_EXCEPTION(histogramFilter->Update());
 
 
   using HistogramType = HistogramFilterType::HistogramType;
@@ -129,15 +124,8 @@ itkHistogramToLogProbabilityImageFilterTest2(int argc, char * argv[])
 
   writer->SetInput(histogramToImageFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest1.cxx
@@ -21,14 +21,17 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkHistogramToProbabilityImageFilter.h"
+#include "itkTestingMacros.h"
+
 int
 itkHistogramToProbabilityImageFilterTest1(int argc, char * argv[])
 {
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -41,16 +44,8 @@ itkHistogramToProbabilityImageFilterTest1(int argc, char * argv[])
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encoutered while reading image file : " << argv[1] << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   itk::MinimumMaximumImageFilter<ScalarImageType>::Pointer minmaxFilter =
     itk::MinimumMaximumImageFilter<ScalarImageType>::New();
@@ -93,15 +88,8 @@ itkHistogramToProbabilityImageFilterTest1(int argc, char * argv[])
 
   writer->SetInput(histogramToImageFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkJoinImageFilter.h"
 #include "itkHistogramToProbabilityImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkHistogramToProbabilityImageFilterTest2(int argc, char * argv[])
@@ -29,8 +30,9 @@ itkHistogramToProbabilityImageFilterTest2(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -129,15 +131,8 @@ itkHistogramToProbabilityImageFilterTest2(int argc, char * argv[])
 
   writer->SetInput(histogramToImageFilter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageMomentsCalculator.h"
 
 #include "itkImageMaskSpatialObject.h"
+#include "itkTestingMacros.h"
 
 using PixelType = unsigned short;
 using VectorType = itk::Vector<double, 3>;
@@ -33,7 +34,9 @@ itkImageMomentsTest(int argc, char * argv[])
 {
   if (argc != 2)
   {
-    std::cerr << "Usage: " << argv[0] << " <mask|nomask>" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " <mask|nomask>" << std::endl;
     return EXIT_FAILURE;
   }
   const std::string maskCondition{ argv[1] };

--- a/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest2.cxx
@@ -21,15 +21,15 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkMaximumProjectionImageFilter.h"
-
+#include "itkTestingMacros.h"
 
 int
 itkMaximumProjectionImageFilterTest2(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << "Dimension Inputimage Outputimage " << std::endl;
     return EXIT_FAILURE;
   }
@@ -61,15 +61,8 @@ itkMaximumProjectionImageFilterTest2(int argc, char * argv[])
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[3]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest3.cxx
@@ -20,6 +20,7 @@
 #include "itkSimpleFilterWatcher.h"
 
 #include "itkMaximumProjectionImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -27,8 +28,8 @@ itkMaximumProjectionImageFilterTest3(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << "Dimension Inputimage Outputimage " << std::endl;
     return EXIT_FAILURE;
   }
@@ -57,33 +58,14 @@ itkMaximumProjectionImageFilterTest3(int argc, char * argv[])
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[3]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   // Set ProjectionDimension to a bad value
-  bool caught = false;
-  try
-  {
-    filter->SetProjectionDimension(100);
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << std::endl << "Caught expected exception!";
-    std::cerr << excp << std::endl;
-    caught = true;
-  }
-  if (!caught)
-  {
-    std::cerr << "Failed to catch expected exception!" << std::endl;
-    return EXIT_FAILURE;
-  }
+  filter->SetProjectionDimension(100);
+
+  ITK_TRY_EXPECT_EXCEPTION(writer->Update());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkAttributeKeepNObjectsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeKeepNObjectsLabelMapFilterTest1.cxx
@@ -31,7 +31,8 @@ itkAttributeKeepNObjectsLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 5)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input output";
     std::cerr << " nbOfObjects reverseOrdering(0/1)";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkAttributeLabelObjectAccessorsTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeLabelObjectAccessorsTest1.cxx
@@ -28,9 +28,10 @@ itkAttributeLabelObjectAccessorsTest1(int argc, char * argv[])
 
   if (argc != 3)
   {
-    std::cerr << "usage: " << argv[0] << " label input" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " label input" << std::endl;
+    return EXIT_FAILURE;
   }
 
   // declare the dimension used, and the type of the input image
@@ -76,6 +77,9 @@ itkAttributeLabelObjectAccessorsTest1(int argc, char * argv[])
     // the label object
     LabelObjectType * labelObject = it.GetLabelObject();
 
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(labelObject, AttributeLabelObject, LabelObject);
+
+
     // init the vars
     double        mean = 0;
     unsigned long size = 0;
@@ -100,9 +104,7 @@ itkAttributeLabelObjectAccessorsTest1(int argc, char * argv[])
     // make sure that the accessor provide the same values than the GetAttribute() method
     itk::Functor::AttributeLabelObjectAccessor<LabelObjectType> accessor;
     ITK_TEST_SET_GET_VALUE(accessor(labelObject), labelObject->GetAttribute());
-    // exercise the print self method
-    labelObject->Print(std::cout);
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkAttributeOpeningLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeOpeningLabelMapFilterTest1.cxx
@@ -31,7 +31,8 @@ itkAttributeOpeningLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 5)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input output";
     std::cerr << " lambda reverseOrdering(0/1)";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkAttributePositionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributePositionLabelMapFilterTest1.cxx
@@ -21,6 +21,7 @@
 
 #include "itkLabelImageToShapeLabelMapFilter.h"
 #include "itkAttributePositionLabelMapFilter.h"
+#include "itkTestingMacros.h"
 
 /**
  *\class TestLabelObjectAccessor
@@ -47,9 +48,10 @@ itkAttributePositionLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 3)
   {
-    std::cerr << "usage: " << argv[0] << " input output" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output" << std::endl;
+    return EXIT_FAILURE;
   }
 
   // declare the dimension used, and the type of the input image
@@ -86,7 +88,9 @@ itkAttributePositionLabelMapFilterTest1(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(l2i->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
 
-  return 0;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkAttributeRelabelLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeRelabelLabelMapFilterTest1.cxx
@@ -31,7 +31,8 @@ itkAttributeRelabelLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 4)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input output";
     std::cerr << " reverseOrdering(0/1)";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkAttributeUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeUniqueLabelMapFilterTest1.cxx
@@ -26,6 +26,7 @@
 
 #include "itkBinaryDilateImageFilter.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -34,9 +35,10 @@ itkAttributeUniqueLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 4)
   {
-    std::cerr << "usage: " << argv[0] << " input output reverse" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output reverse" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;
@@ -82,7 +84,9 @@ itkAttributeUniqueLabelMapFilterTest1(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(l2i->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
 
-  return 0;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkAutoCropLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAutoCropLabelMapFilterTest1.cxx
@@ -41,7 +41,8 @@ itkAutoCropLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputLabelImage outputLabelImage inputBackgroundValue sizeX sizeY" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/LabelMap/test/itkAutoCropLabelMapFilterTest2.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAutoCropLabelMapFilterTest2.cxx
@@ -42,7 +42,8 @@ itkAutoCropLabelMapFilterTest2(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputLabelImage outputLabelImage1 outputLabelImage2 label1 label2" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/LabelMap/test/itkBinaryGrindPeakImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryGrindPeakImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkBinaryGrindPeakImageFilterTest1(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "Usage: " << argv[0] << " input output fullyConnected foreground background" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output fullyConnected foreground background" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest2.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest2.cxx
@@ -29,7 +29,8 @@ itkBinaryImageToLabelMapFilterTest2(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << "inputBinaryImage outputLabelImage";
     std::cerr << "foregroundValue backgroundValue NumThreads";
     std::cerr << std::endl;
@@ -71,7 +72,9 @@ itkBinaryImageToLabelMapFilterTest2(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(labelToImage->GetOutput());
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToShapeLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToShapeLabelMapFilterTest1.cxx
@@ -29,7 +29,8 @@ itkBinaryImageToShapeLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 8)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputBinaryImage outputShapeLabelMap";
     std::cerr << " fullyConnected(0/1) foregroundValue backgroundValue";
     std::cerr << " feretDiameter, perimeter";

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToStatisticsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToStatisticsLabelMapFilterTest1.cxx
@@ -29,7 +29,8 @@ itkBinaryImageToStatisticsLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 11)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputBinaryImage inputGrayscaleImage outputStatisticsLabelMap";
     std::cerr << " fullyConnected(0/1) foregroundValue backgroundValue";
     std::cerr << " feretDiameter, perimeter, histogram, numberOfBins";

--- a/Modules/Filtering/LabelMap/test/itkBinaryShapeKeepNObjectsImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryShapeKeepNObjectsImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkBinaryShapeKeepNObjectsImageFilterTest1(int argc, char * argv[])
 
   if (argc != 9)
   {
-    std::cerr << "Usage: " << argv[0] << " input output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output";
     std::cerr << " foreground background numberOfObjectsToKeep";
     std::cerr << " reverseOrdering connectivity attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkBinaryShapeOpeningImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryShapeOpeningImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkBinaryShapeOpeningImageFilterTest1(int argc, char * argv[])
 
   if (argc != 9)
   {
-    std::cerr << "Usage: " << argv[0] << " input output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output";
     std::cerr << " foreground background lambda";
     std::cerr << "reverseOrdering connectivity attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkBinaryStatisticsKeepNObjectsImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryStatisticsKeepNObjectsImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkBinaryStatisticsKeepNObjectsImageFilterTest1(int argc, char * argv[])
 
   if (argc != 10)
   {
-    std::cerr << "Usage: " << argv[0] << " input feature output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input feature output";
     std::cerr << " foreground background numberOfObjectsToKeep";
     std::cerr << "reverseOrdering connectivity attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkBinaryStatisticsOpeningImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryStatisticsOpeningImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkBinaryStatisticsOpeningImageFilterTest1(int argc, char * argv[])
 
   if (argc != 10)
   {
-    std::cerr << "Usage: " << argv[0] << " input feature output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input feature output";
     std::cerr << " foreground background lambda";
     std::cerr << "reverseOrdering connectivity attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkChangeRegionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkChangeRegionLabelMapFilterTest1.cxx
@@ -31,7 +31,9 @@ itkChangeRegionLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 7)
   {
-    std::cerr << "usage: " << argv[0] << " input output idx0 idx1 size0 size1" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output idx0 idx1 size0 size1" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkConvertLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkConvertLabelMapFilterTest1.cxx
@@ -28,7 +28,8 @@ itkConvertLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 3)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputLabelImage outputLabelImage";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkConvertLabelMapFilterTest2.cxx
+++ b/Modules/Filtering/LabelMap/test/itkConvertLabelMapFilterTest2.cxx
@@ -30,7 +30,8 @@ itkConvertLabelMapFilterTest2(int argc, char * argv[])
 {
   if (argc != 3)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputLabelImage outputLabelImage";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkCropLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkCropLabelMapFilterTest1.cxx
@@ -41,7 +41,9 @@ itkCropLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 5)
   {
-    std::cerr << "usage: " << argv[0] << " input output size0 size1" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output size0 size1" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToShapeLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToShapeLabelMapFilterTest1.cxx
@@ -26,7 +26,8 @@ itkLabelImageToShapeLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 6)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputBinaryImage outputShapeLabelMap";
     std::cerr << " backgroundValue computeFeretDiameter computePerimeter";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToStatisticsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToStatisticsLabelMapFilterTest1.cxx
@@ -29,7 +29,8 @@ itkLabelImageToStatisticsLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 9)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputLabelImage inputGrayscaleImage outputStatisticsLabelMap";
     std::cerr << " backgroundValue";
     std::cerr << " feretDiameter, perimeter, histogram, numberOfBins";

--- a/Modules/Filtering/LabelMap/test/itkLabelMapTest2.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapTest2.cxx
@@ -19,16 +19,11 @@
 #include <iostream>
 #include "itkLabelMap.h"
 #include "itkLabelObject.h"
+#include "itkTestingMacros.h"
 
 int
-itkLabelMapTest2(int argc, char * argv[])
+itkLabelMapTest2(int, char *[])
 {
-  if (argc != 1)
-  {
-    std::cerr << "usage: " << argv[0] << "" << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int dim = 3;
 
   using LabelObjectType = itk::LabelObject<unsigned long, dim>;

--- a/Modules/Filtering/LabelMap/test/itkLabelMapToAttributeImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapToAttributeImageFilterTest1.cxx
@@ -32,7 +32,9 @@ itkLabelMapToAttributeImageFilterTest1(int argc, char * argv[])
 
   if (argc != 3)
   {
-    std::cerr << "usage: " << argv[0] << " input output" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkLabelSelectionLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelSelectionLabelMapFilterTest.cxx
@@ -31,9 +31,10 @@ itkLabelSelectionLabelMapFilterTest(int argc, char * argv[])
 
   if (argc != 5)
   {
-    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output exclude label" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output exclude label" << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr int dim = 2;
@@ -66,7 +67,9 @@ itkLabelSelectionLabelMapFilterTest(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(l2i->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
 
-  return 0;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkLabelShapeKeepNObjectsImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelShapeKeepNObjectsImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkLabelShapeKeepNObjectsImageFilterTest1(int argc, char * argv[])
 
   if (argc != 7)
   {
-    std::cerr << "Usage: " << argv[0] << " input output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output";
     std::cerr << " background numberOfObjectsToKeep";
     std::cerr << "reverseOrdering attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkLabelShapeOpeningImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelShapeOpeningImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkLabelShapeOpeningImageFilterTest1(int argc, char * argv[])
 
   if (argc != 7)
   {
-    std::cerr << "Usage: " << argv[0] << " input output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output";
     std::cerr << " background lambda";
     std::cerr << "reverseOrdering attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkLabelStatisticsKeepNObjectsImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelStatisticsKeepNObjectsImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkLabelStatisticsKeepNObjectsImageFilterTest1(int argc, char * argv[])
 
   if (argc != 8)
   {
-    std::cerr << "Usage: " << argv[0] << " input feature output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input feature output";
     std::cerr << " background numberOfObjectsToKeep";
     std::cerr << " reverseOrdering attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkLabelStatisticsOpeningImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelStatisticsOpeningImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkLabelStatisticsOpeningImageFilterTest1(int argc, char * argv[])
 
   if (argc != 8)
   {
-    std::cerr << "Usage: " << argv[0] << " input feature output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input feature output";
     std::cerr << " background lambda";
     std::cerr << " reverseOrdering attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkLabelUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelUniqueLabelMapFilterTest1.cxx
@@ -25,6 +25,7 @@
 
 #include "itkBinaryDilateImageFilter.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -33,9 +34,10 @@ itkLabelUniqueLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 4)
   {
-    std::cerr << "usage: " << argv[0] << " input output reverse" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output reverse" << std::endl;
+    return EXIT_SUCCESS;
   }
 
   constexpr int dim = 2;
@@ -80,7 +82,9 @@ itkLabelUniqueLabelMapFilterTest1(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(l2i->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
 
-  return 0;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkMergeLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkMergeLabelMapFilterTest1.cxx
@@ -30,7 +30,8 @@ itkMergeLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 8)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input1 input2 output background1 background2 method expectfailure" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/LabelMap/test/itkPadLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkPadLabelMapFilterTest1.cxx
@@ -42,7 +42,9 @@ itkPadLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 5)
   {
-    std::cerr << "usage: " << argv[0] << " input output size0 size1" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output size0 size1" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkRegionFromReferenceLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkRegionFromReferenceLabelMapFilterTest1.cxx
@@ -41,7 +41,9 @@ itkRegionFromReferenceLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 4)
   {
-    std::cerr << "usage: " << argv[0] << " input reference output" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input reference output" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkRelabelLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkRelabelLabelMapFilterTest1.cxx
@@ -32,7 +32,9 @@ itkRelabelLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 3)
   {
-    std::cerr << "usage: " << argv[0] << " input output" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkShapeKeepNObjectsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeKeepNObjectsLabelMapFilterTest1.cxx
@@ -30,7 +30,8 @@ itkShapeKeepNObjectsLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 6)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input output";
     std::cerr << " reverseOrdering attribute numberOfObjectsToKeep";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelObjectAccessorsTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelObjectAccessorsTest1.cxx
@@ -21,6 +21,7 @@
 #include "itkShapeKeepNObjectsLabelMapFilter.h"
 #include "itkLabelImageToShapeLabelMapFilter.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -28,7 +29,8 @@ itkShapeLabelObjectAccessorsTest1(int argc, char * argv[])
 {
   if (argc != 2)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input ";
     std::cerr << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkShapeOpeningLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeOpeningLabelMapFilterTest1.cxx
@@ -30,7 +30,8 @@ itkShapeOpeningLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 6)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input output";
     std::cerr << " lambda reverseOrdering(0/1) attribute";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkShapePositionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapePositionLabelMapFilterTest1.cxx
@@ -21,7 +21,7 @@
 
 #include "itkLabelImageToShapeLabelMapFilter.h"
 #include "itkShapePositionLabelMapFilter.h"
-
+#include "itkTestingMacros.h"
 
 int
 itkShapePositionLabelMapFilterTest1(int argc, char * argv[])
@@ -29,9 +29,10 @@ itkShapePositionLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 4)
   {
-    std::cerr << "usage: " << argv[0] << " input output attribute" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output attribute" << std::endl;
+    return EXIT_FAILURE;
   }
 
   // declare the dimension used, and the type of the input image
@@ -66,7 +67,9 @@ itkShapePositionLabelMapFilterTest1(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(l2i->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
 
-  return 0;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkShapeRelabelImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeRelabelImageFilterTest1.cxx
@@ -29,7 +29,8 @@ itkShapeRelabelImageFilterTest1(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "Usage: " << argv[0] << " input output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " background";
     std::cerr << " reverseOrdering attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkShapeRelabelLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeRelabelLabelMapFilterTest1.cxx
@@ -31,7 +31,9 @@ itkShapeRelabelLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 5)
   {
-    std::cerr << "usage: " << argv[0] << " input output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output";
     std::cerr << "background reverseOrdering attribute" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/LabelMap/test/itkShapeUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeUniqueLabelMapFilterTest1.cxx
@@ -30,7 +30,8 @@ itkShapeUniqueLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 5)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input output";
     std::cerr << " reverseOrdering(0/1) attribute";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkShiftScaleLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShiftScaleLabelMapFilterTest1.cxx
@@ -42,7 +42,9 @@ itkShiftScaleLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "usage: " << argv[0] << " input output shift scale change_bg" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output shift scale change_bg" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/LabelMap/test/itkStatisticsKeepNObjectsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsKeepNObjectsLabelMapFilterTest1.cxx
@@ -30,7 +30,8 @@ itkStatisticsKeepNObjectsLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 7)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input feature output";
     std::cerr << " reverseOrdering attribute numberOfObjectsToKeep";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkStatisticsOpeningLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsOpeningLabelMapFilterTest1.cxx
@@ -31,7 +31,8 @@ itkStatisticsOpeningLabelMapFilterTest1(int argc, char * argv[])
 {
   if (argc != 7)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input feature output";
     std::cerr << " lambda reverseOrdering(0/1) attribute";
     std::cerr << std::endl;

--- a/Modules/Filtering/LabelMap/test/itkStatisticsPositionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsPositionLabelMapFilterTest1.cxx
@@ -21,6 +21,7 @@
 
 #include "itkLabelImageToStatisticsLabelMapFilter.h"
 #include "itkStatisticsPositionLabelMapFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -29,9 +30,10 @@ itkStatisticsPositionLabelMapFilterTest1(int argc, char * argv[])
 
   if (argc != 5)
   {
-    std::cerr << "usage: " << argv[0] << " input feature output attribute" << std::endl;
-    // std::cerr << "  : " << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input feature output attribute" << std::endl;
+    return EXIT_FAILURE;
   }
 
   // declare the dimension used, and the type of the input image
@@ -70,7 +72,9 @@ itkStatisticsPositionLabelMapFilterTest1(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(l2i->GetOutput());
   writer->SetFileName(argv[3]);
-  writer->Update();
 
-  return 0;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkStatisticsRelabelImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsRelabelImageFilterTest1.cxx
@@ -29,7 +29,9 @@ itkStatisticsRelabelImageFilterTest1(int argc, char * argv[])
 
   if (argc != 7)
   {
-    std::cerr << "Usage: " << argv[0] << " input feature output";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input feature output";
     std::cerr << " background";
     std::cerr << " reverseOrdering attribute" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
@@ -36,7 +36,8 @@ itkStatisticsUniqueLabelMapFilterTest1(int argc, char * argv[])
   // Then, argc != 6
   if (argc != 7)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " input feature output dilationOutput";
     std::cerr << " reverseOrdering attribute";
     std::cerr << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
@@ -18,6 +18,7 @@
 
 #include "itkFlatStructuringElement.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 template <class TSEType>
 void
@@ -66,8 +67,9 @@ itkFlatStructuringElementTest3(int argc, char * argv[])
   // test polygon SEs
   if (argc < 4)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << argv[0] << " OutputImage Radius Lines Dimension" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " OutputImage Radius Lines Dimension" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest2.cxx
@@ -20,6 +20,7 @@
 #include "itkMorphologicalGradientImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 #include <fstream>
 
 int
@@ -27,9 +28,9 @@ itkMorphologicalGradientImageFilterTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImage outputImage " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -61,56 +62,42 @@ itkMorphologicalGradientImageFilterTest2(int argc, char * argv[])
   writer->SetInput(gradient->GetOutput());
   writer->SetFileName(argv[2]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception caught ! " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
-  try
-  {
-    structuringElement.SetRadius(4);
-    gradient->SetAlgorithm(GradientType::AlgorithmEnum::BASIC);
-    gradient->Update();
-    const GradientType::AlgorithmEnum algorithmType1 = gradient->GetAlgorithm();
-    std::cout << "algorithmType1 : " << algorithmType1 << std::endl;
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return EXIT_FAILURE;
-  }
 
-  try
-  {
-    using SRType = itk::FlatStructuringElement<dim>;
-    SRType::RadiusType elementRadius;
-    elementRadius.Fill(4);
-    SRType structuringElement2 = SRType::Box(elementRadius);
-    using Gradient1Type = itk::MorphologicalGradientImageFilter<IType, IType, SRType>;
-    Gradient1Type::Pointer gradient1 = Gradient1Type::New();
-    gradient1->SetInput(reader->GetOutput());
-    gradient1->SetKernel(structuringElement2);
-    gradient1->SetAlgorithm(GradientType::AlgorithmEnum::VHGW);
-    gradient1->Update();
-    const GradientType::AlgorithmEnum algorithmType2 = gradient1->GetAlgorithm();
-    std::cout << "algorithmType : " << algorithmType2 << std::endl;
+  structuringElement.SetRadius(4);
+  gradient->SetAlgorithm(GradientType::AlgorithmEnum::BASIC);
 
-    gradient1->SetAlgorithm(GradientType::AlgorithmEnum::ANCHOR);
-    gradient1->Update();
-    const GradientType::AlgorithmEnum algorithmType3 = gradient1->GetAlgorithm();
-    std::cout << "algorithmType : " << algorithmType3 << std::endl;
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(gradient->Update());
+
+
+  const GradientType::AlgorithmEnum algorithmType1 = gradient->GetAlgorithm();
+  std::cout << "algorithmType1 : " << algorithmType1 << std::endl;
+
+
+  using SRType = itk::FlatStructuringElement<dim>;
+  SRType::RadiusType elementRadius;
+  elementRadius.Fill(4);
+  SRType structuringElement2 = SRType::Box(elementRadius);
+
+  using Gradient1Type = itk::MorphologicalGradientImageFilter<IType, IType, SRType>;
+  Gradient1Type::Pointer gradient1 = Gradient1Type::New();
+  gradient1->SetInput(reader->GetOutput());
+  gradient1->SetKernel(structuringElement2);
+  gradient1->SetAlgorithm(GradientType::AlgorithmEnum::VHGW);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(gradient1->Update());
+
+
+  const GradientType::AlgorithmEnum algorithmType2 = gradient1->GetAlgorithm();
+  std::cout << "algorithmType : " << algorithmType2 << std::endl;
+
+  gradient1->SetAlgorithm(GradientType::AlgorithmEnum::ANCHOR);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(gradient1->Update());
+
+  const GradientType::AlgorithmEnum algorithmType3 = gradient1->GetAlgorithm();
+  std::cout << "algorithmType : " << algorithmType3 << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/MathematicalMorphology/test/itkRemoveBoundaryObjectsTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRemoveBoundaryObjectsTest2.cxx
@@ -23,14 +23,15 @@
 
 #include "itkGrayscaleGrindPeakImageFilter.h"
 #include "itkXorImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkRemoveBoundaryObjectsTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile  ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputImageFile  " << std::endl;
     return EXIT_FAILURE;
   }
@@ -84,7 +85,9 @@ itkRemoveBoundaryObjectsTest2(int argc, char * argv[])
 
   // Run the filter
   writer->SetInput(xorfilter->GetOutput());
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/BMP/test/itkBMPImageIOTest2.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest2.cxx
@@ -28,7 +28,9 @@ itkBMPImageIOTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " input output" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/BMP/test/itkBMPImageIOTest3.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest3.cxx
@@ -32,7 +32,9 @@ itkBMPImageIOTest3(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " lowerLeftImage upperLeftImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " lowerLeftImage upperLeftImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/BMP/test/itkBMPImageIOTest4.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest4.cxx
@@ -33,7 +33,9 @@ itkBMPImageIOTest4(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " lowerLeftImage upperLeftImage" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " lowerLeftImage upperLeftImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/BMP/test/itkBMPImageIOTest5.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest5.cxx
@@ -34,7 +34,9 @@ itkBMPImageIOTest5(int argc, char * argv[])
 
   if (argc != 3)
   {
-    std::cerr << "Usage: " << argv[0] << " compressedImage"
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " compressedImage"
               << " uncompressedImage" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
@@ -31,7 +31,9 @@ itkBMPImageIOTestPalette(int argc, char * argv[])
 {
   if (argc != 5)
   {
-    std::cerr << "Usage: " << argv[0] << " input"
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input"
               << " output"
               << " expandRGBPalette"
               << " isPaletteImage" << std::endl;

--- a/Modules/IO/GDCM/test/itkGDCMImageIONoPreambleTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoPreambleTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkGDCMImageIO.h"
 #include "itkImageFileReader.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -29,7 +30,9 @@ itkGDCMImageIONoPreambleTest(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " DicomImage\n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " DicomImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
@@ -18,6 +18,7 @@
 #include "itkGDCMImageIO.h"
 #include "itkImageSeriesReader.h"
 #include "itkImageSeriesWriter.h"
+#include "itkTestingMacros.h"
 
 #include <sstream>
 
@@ -30,7 +31,9 @@ itkGDCMImageIOTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " InputFile OutputDicomRoot\n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " InputFile OutputDicomRoot" << std::endl;
     return EXIT_FAILURE;
   }
   const char * input = argv[1];
@@ -149,16 +152,9 @@ itkGDCMImageIOTest2(int argc, char * argv[])
   // Save as raw
   writer->UseCompressionOff();
   writer->SetFileName(output_raw.c_str());
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file writer " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest2.cxx
@@ -23,6 +23,7 @@
 
 #include "itkTestingComparisonImageFilter.h"
 #include "itkExtractImageFilter.h"
+#include "itkTestingMacros.h"
 
 using PixelType = unsigned char;
 using ImageType = itk::Image<PixelType, 3>;
@@ -71,7 +72,9 @@ itkImageFileReaderStreamingTest2(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " input " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest1.cxx
@@ -19,13 +19,16 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageFileWriterPastingTest1(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " input output" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -93,16 +96,8 @@ itkImageFileWriterPastingTest1(int argc, char * argv[])
     writer->SetIORegion(ioregion);
     writer->SetInput(reader->GetOutput());
 
-    try
-    {
-      writer->Update();
-    }
-    catch (const itk::ExceptionObject & err)
-    {
-      std::cerr << "ExceptionObject caught !" << std::endl;
-      std::cerr << err << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
   } // end for pieces
 
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest2.cxx
@@ -22,6 +22,7 @@
 #include "itkTestingComparisonImageFilter.h"
 #include "itkExtractImageFilter.h"
 #include "itkPipelineMonitorImageFilter.h"
+#include "itkTestingMacros.h"
 
 using PixelType = unsigned char;
 using ImageType = itk::Image<PixelType, 3>;
@@ -57,7 +58,9 @@ itkImageFileWriterPastingTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " input output [existingFile]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output [existingFile]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest3.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest3.cxx
@@ -21,6 +21,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTestingComparisonImageFilter.h"
 #include "itkExtractImageFilter.h"
+#include "itkTestingMacros.h"
 
 using PixelType = unsigned char;
 using ImageType = itk::Image<PixelType, 3>;
@@ -60,7 +61,9 @@ itkImageFileWriterPastingTest3(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " input output" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -123,21 +126,7 @@ itkImageFileWriterPastingTest3(int argc, char * argv[])
     image->GetBufferedRegion(), ioRegion, image->GetLargestPossibleRegion().GetIndex());
   writer->SetIORegion(ioRegion);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    if (argc > 3)
-    {
-      return EXIT_SUCCESS;
-    }
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   ReaderType::Pointer reader = ReaderType::New();

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
@@ -22,6 +22,7 @@
 #include "itkTestingComparisonImageFilter.h"
 #include "itkExtractImageFilter.h"
 #include "itkPipelineMonitorImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 constexpr unsigned int VDimension = 3;
@@ -240,7 +241,9 @@ itkImageFileWriterStreamingPastingCompressingTest1(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " input outputBase outputExtension [expect exception (0|1)] ..." << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input outputBase outputExtension [expect exception (0|1)] ..." << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest1.cxx
@@ -20,13 +20,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkPipelineMonitorImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageFileWriterStreamingTest1(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " input output [existingFile [ no-streaming 1|0] ]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output [existingFile [ no-streaming 1|0] ]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -79,17 +82,7 @@ itkImageFileWriterStreamingTest1(int argc, char * argv[])
   writer->SetInput(monitor->GetOutput());
   writer->SetNumberOfStreamDivisions(numberOfDataPieces);
 
-
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   bool passed = true;

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest2.cxx
@@ -21,7 +21,7 @@
 #include "itkImageFileWriter.h"
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkTestingComparisonImageFilter.h"
-
+#include "itkTestingMacros.h"
 
 using PixelType = unsigned char;
 using ImageType = itk::Image<PixelType, 3>;
@@ -63,10 +63,11 @@ int
 itkImageFileWriterStreamingTest2(int argc, char * argv[])
 {
 
-
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0] << " input output " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -97,18 +98,9 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
   if (numberOfDataPieces != writer->GetNumberOfStreamDivisions())
     return EXIT_FAILURE;
 
-  // write the whole image
-  try
-  {
-    std::cout << "=== Updating ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Write the whole image
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   if (!monitor->VerifyAllInputCanStream(4))
   {
@@ -140,17 +132,8 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
   writer->SetIORegion(ioregion);
 
-  try
-  {
-    std::cout << "=== Updating 1x1x1 IORegion ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << "=== Updating 1x1x1 IORegion ==" << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   if (!monitor->VerifyAllInputCanStream(1))
@@ -174,17 +157,8 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
   writer->SetIORegion(ioregion);
 
-  try
-  {
-    std::cout << "=== Updating 2x2x2 IORegion with odd offset ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << "=== Updating 2x2x2 IORegion with odd offset ==" << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   if (!monitor->VerifyAllInputCanStream(-1))
@@ -209,17 +183,9 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
   writer->SetIORegion(ioregion);
 
-  try
-  {
-    std::cout << "=== Updating 1x1xlong IORegion ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << "=== Updating 1x1xlong IORegion ==" << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   if (!monitor->VerifyAllInputCanStream(-1))
   {
@@ -243,17 +209,9 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
   writer->SetIORegion(ioregion);
 
-  try
-  {
-    std::cout << "=== Updating 1xlongx1 IORegion ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << "=== Updating 1xlongx1 IORegion ==" << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   if (!monitor->VerifyAllInputCanStream(-1))
   {
@@ -278,17 +236,8 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
   writer->SetIORegion(ioregion);
 
-  try
-  {
-    std::cout << "=== Updating Full IORegion ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << "=== Updating Full IORegion ==" << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   if (!monitor->VerifyAllInputCanStream(4))
   {
@@ -302,9 +251,8 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
   }
 
   reader->Modified();
-  bool thrownException = false;
-  ////////////////////////////////////////////////
-  // test out of bounds region
+
+  // Test out of bounds region
   ioregion.SetIndex(0, largestRegion.GetIndex()[0] - 1);
   ioregion.SetIndex(1, largestRegion.GetIndex()[1]);
   ioregion.SetIndex(2, largestRegion.GetIndex()[2]);
@@ -314,26 +262,13 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
   writer->SetIORegion(ioregion);
 
-  try
-  {
-    std::cout << "=== Updating out of bounds IORegion ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught expected exception" << std::endl;
-    std::cout << err << std::endl;
-    thrownException = true;
-  }
-
-  if (!thrownException)
-    return EXIT_FAILURE;
+  std::cout << "=== Updating out of bounds IORegion ==" << std::endl;
+  ITK_TRY_EXPECT_EXCEPTION(writer->Update());
 
 
   reader->Modified();
-  thrownException = false;
-  ////////////////////////////////////////////////
-  // test out of bounds region
+
+  // Test out of bounds region
   ioregion.SetIndex(0, largestRegion.GetIndex()[0] + largestRegion.GetSize()[0] / 2 + 1);
   ioregion.SetIndex(1, largestRegion.GetIndex()[1] + largestRegion.GetSize()[1] / 2 + 1);
   ioregion.SetIndex(2, largestRegion.GetIndex()[2] + largestRegion.GetSize()[2] / 2 + 1);
@@ -343,26 +278,13 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
   writer->SetIORegion(ioregion);
 
-  try
-  {
-    std::cout << "=== Updating out of bounds IORegion ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught expected exception" << std::endl;
-    std::cout << err << std::endl;
-    thrownException = true;
-  }
+  std::cout << "=== Updating out of bounds IORegion ==" << std::endl;
+  ITK_TRY_EXPECT_EXCEPTION(writer->Update());
 
-  if (!thrownException)
-  {
-    return EXIT_FAILURE;
-  }
 
   reader->Modified();
-  ////////////////////////////////////////////////
-  // test when regions aren't matching
+
+  // Test when regions aren't matching
   ImageType::RegionType halfLargestRegion;
   halfLargestRegion.SetIndex(largestRegion.GetIndex());
   halfLargestRegion.SetSize(0, largestRegion.GetSize()[0] / 2);
@@ -382,20 +304,12 @@ itkImageFileWriterStreamingTest2(int argc, char * argv[])
 
   writer->SetIORegion(ioregion);
 
-  try
-  {
-    std::cout << "=== Preparing mismatched IORegion ==" << std::endl;
-    monitor->Update();
-    monitor->VerifyAllInputCanStream(1);
-    std::cout << "=== Updating mismatched IORegion ==" << std::endl;
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(monitor->Update());
+  monitor->VerifyAllInputCanStream(1);
+
+  std::cout << "=== Updating mismatched IORegion ==" << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   if (!monitor->VerifyAllNoUpdate())
   {

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int
 itkJPEGImageIOTest2(int argc, char * argv[])
@@ -24,7 +25,9 @@ itkJPEGImageIOTest2(int argc, char * argv[])
 
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " outputFilename " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " outputFilename " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -65,29 +68,15 @@ itkJPEGImageIOTest2(int argc, char * argv[])
 
   writer->SetInput(image);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   const ImageType * readImage = reader->GetOutput();
 

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIORegionOfInterest.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIORegionOfInterest.cxx
@@ -20,15 +20,17 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkRegionOfInterestImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkJPEG2000ImageIORegionOfInterest(int argc, char * argv[])
 {
-  // Verify the number of parameters in the command line
+
   if (argc < 7)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile  outputImageFile " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImageFile  outputImageFile " << std::endl;
     std::cerr << " startX startY sizeX sizeY " << std::endl;
     return EXIT_FAILURE;
   }
@@ -87,15 +89,8 @@ itkJPEG2000ImageIORegionOfInterest(int argc, char * argv[])
   filter->SetInput(reader->GetOutput());
   writer->SetInput(filter->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest01.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest01.cxx
@@ -19,16 +19,18 @@
 #include "itkJPEG2000ImageIOFactory.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 int
 itkJPEG2000ImageIOTest01(int argc, char * argv[])
 {
-  // Verify the number of parameters in the command line
+
   if (argc < 3)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile  outputImageFile " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImageFile  outputImageFile " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -58,15 +60,8 @@ itkJPEG2000ImageIOTest01(int argc, char * argv[])
 
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest02.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest02.cxx
@@ -19,16 +19,18 @@
 #include "itkJPEG2000ImageIOFactory.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 int
 itkJPEG2000ImageIOTest02(int argc, char * argv[])
 {
-  // Verify the number of parameters in the command line
+
   if (argc < 3)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile  outputImageFile " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImageFile  outputImageFile " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -58,15 +60,8 @@ itkJPEG2000ImageIOTest02(int argc, char * argv[])
 
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest03.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest03.cxx
@@ -19,7 +19,7 @@
 #include "itkJPEG2000ImageIOFactory.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-
+#include "itkTestingMacros.h"
 
 int
 itkJPEG2000ImageIOTest03(int argc, char * argv[])
@@ -27,8 +27,9 @@ itkJPEG2000ImageIOTest03(int argc, char * argv[])
   // Verify the number of parameters in the command line
   if (argc < 3)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile  outputImageFile " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImageFile  outputImageFile " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -57,15 +58,8 @@ itkJPEG2000ImageIOTest03(int argc, char * argv[])
 
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest04.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest04.cxx
@@ -20,7 +20,7 @@
 #include "itkJPEG2000ImageIO.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-
+#include "itkTestingMacros.h"
 
 int
 itkJPEG2000ImageIOTest04(int argc, char * argv[])
@@ -28,8 +28,9 @@ itkJPEG2000ImageIOTest04(int argc, char * argv[])
   // Verify the number of parameters in the command line
   if (argc < 5)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile J2KOutputImageFile tileSizeX tileSizeY" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImageFile J2KOutputImageFile tileSizeX tileSizeY" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -62,15 +63,9 @@ itkJPEG2000ImageIOTest04(int argc, char * argv[])
 
   writer->SetInput(reader->GetOutput());
   writer->SetImageIO(base);
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest05.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest05.cxx
@@ -19,6 +19,7 @@
 #include "itkImageSeriesWriter.h"
 #include "itkNumericSeriesFileNames.h"
 #include "itkJPEG2000ImageIOFactory.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -27,7 +28,9 @@ itkJPEG2000ImageIOTest05(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " input outputdir extension" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input outputdir extension" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -41,16 +44,10 @@ itkJPEG2000ImageIOTest05(int argc, char * argv[])
   reader->SetFileName(argv[1]);
   // reader->SetUseStreaming( true );
 
-  try
-  {
-    reader->Update();
-    reader->GetOutput()->Print(std::cout);
-  }
-  catch (const itk::ExceptionObject & ex)
-  {
-    std::cout << ex;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+
+  reader->GetOutput()->Print(std::cout);
 
   //  Register the factory
   itk::JPEG2000ImageIOFactory::RegisterOneFactory();
@@ -78,16 +75,8 @@ itkJPEG2000ImageIOTest05(int argc, char * argv[])
   writer->SetInput(reader->GetOutput());
   writer->SetFileNames(fit->GetFileNames());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Error while writing the series with SeriesFileNames generator" << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest06.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest06.cxx
@@ -19,16 +19,18 @@
 #include "itkJPEG2000ImageIOFactory.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 int
 itkJPEG2000ImageIOTest06(int argc, char * argv[])
 {
-  // Verify the number of parameters in the command line
+
   if (argc < 3)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile  outputImageFile " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImageFile  outputImageFile " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -57,15 +59,8 @@ itkJPEG2000ImageIOTest06(int argc, char * argv[])
 
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "ExceptionObject caught !" << std::endl;
-    std::cerr << err << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/MINC/test/itkMINCImageIOTest4.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest4.cxx
@@ -26,6 +26,7 @@
 
 #include "itkImageMomentsCalculator.h"
 #include "itkStdStreamStateSave.h"
+#include "itkTestingMacros.h"
 
 template <typename ImageType>
 int
@@ -106,9 +107,9 @@ itkMINCImageIOTest4(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing Arguments " << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputfile outputfile [sum mx my mz ]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputfile outputfile [sum mx my mz ]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -133,9 +134,9 @@ itkMINCImageIOTest4(int argc, char * argv[])
     }
     else
     {
-      std::cerr << "Incorrecte number of additional arguments " << std::endl;
-      std::cerr << "Usage: " << std::endl;
-      std::cerr << argv[0] << " inputfile outputfile [sum mx my mz ]" << std::endl;
+      std::cerr << "Missing parameters." << std::endl;
+      std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+      std::cerr << " inputfile outputfile [sum mx my mz ]" << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/IO/NIFTI/test/itkExtractSlice.cxx
+++ b/Modules/IO/NIFTI/test/itkExtractSlice.cxx
@@ -20,54 +20,52 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkExtractImageFilter.h"
-
-using PixelType = float;
-using ImageType = itk::Image<PixelType, 3>;
-using SliceType = itk::Image<PixelType, 2>;
-using ReaderType = itk::ImageFileReader<ImageType>;
-using ExtractType = itk::ExtractImageFilter<ImageType, SliceType>;
-using WriterType = itk::ImageFileWriter<SliceType>;
+#include "itkTestingMacros.h"
 
 int
 itkExtractSlice(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cout << "Usage:\n" << argv[0] << " in.nii out.nrrd";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cout << " in.nii out.nrrd";
     return EXIT_FAILURE;
   }
 
-  try
-  {
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->UpdateOutputInformation();
+  using PixelType = float;
+  using ImageType = itk::Image<PixelType, 3>;
+  using SliceType = itk::Image<PixelType, 2>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using ExtractType = itk::ExtractImageFilter<ImageType, SliceType>;
+  using WriterType = itk::ImageFileWriter<SliceType>;
 
-    ImageType::RegionType inRegion = reader->GetOutput()->GetLargestPossibleRegion();
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->UpdateOutputInformation();
 
-    ImageType::SizeType outSize = inRegion.GetSize();
-    outSize[1] = 0;
-    ImageType::IndexType outIndex = inRegion.GetIndex();
-    outIndex[1] = inRegion.GetSize()[1] / 2;
-    ImageType::RegionType outRegion;
-    outRegion.SetSize(outSize);
-    outRegion.SetIndex(outIndex);
+  ImageType::RegionType inRegion = reader->GetOutput()->GetLargestPossibleRegion();
 
-    ExtractType::Pointer extractFilter = ExtractType::New();
-    extractFilter->SetDirectionCollapseToSubmatrix();
-    extractFilter->InPlaceOn();
-    extractFilter->SetInput(reader->GetOutput());
-    extractFilter->SetExtractionRegion(outRegion);
+  ImageType::SizeType outSize = inRegion.GetSize();
+  outSize[1] = 0;
+  ImageType::IndexType outIndex = inRegion.GetIndex();
+  outIndex[1] = inRegion.GetSize()[1] / 2;
+  ImageType::RegionType outRegion;
+  outRegion.SetSize(outSize);
+  outRegion.SetIndex(outIndex);
 
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput(extractFilter->GetOutput());
-    writer->SetFileName(argv[2]);
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cerr << exc;
-    return EXIT_FAILURE;
-  }
+  ExtractType::Pointer extractFilter = ExtractType::New();
+  extractFilter->SetDirectionCollapseToSubmatrix();
+  extractFilter->InPlaceOn();
+  extractFilter->SetInput(reader->GetOutput());
+  extractFilter->SetExtractionRegion(outRegion);
+
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(extractFilter->GetOutput());
+  writer->SetFileName(argv[2]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
@@ -50,7 +50,9 @@ itkPNGImageIOTest2(int argc, char * argv[])
   // Test the reading of an image as grayscale image and writing of grayscale image
   if (argc < 5)
   {
-    std::cerr << "Usage: " << argv[0] << " input"
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input"
               << " output"
               << " useCompression"
               << " compressionLevel"

--- a/Modules/IO/PNG/test/itkPNGImageIOTest3.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest3.cxx
@@ -28,7 +28,9 @@ itkPNGImageIOTest3(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " input" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
@@ -32,7 +32,9 @@ itkPNGImageIOTestPalette(int argc, char * argv[])
 {
   if (argc != 5)
   {
-    std::cerr << "Usage: " << argv[0] << " input"
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input"
               << " output"
               << " expandRGBPalette"
               << " isPaletteImage" << std::endl;

--- a/Modules/IO/Stimulate/test/itkStimulateImageIOTest2.cxx
+++ b/Modules/IO/Stimulate/test/itkStimulateImageIOTest2.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkImageFileReader.h"
 #include "itkStimulateImageIO.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -30,7 +31,9 @@ itkStimulateImageIOTest2(int argc, char * argv[])
   // Insight/Testing/Data/Input/BigEndian.spr
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " filename\n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " filename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
@@ -26,7 +26,9 @@ itkTIFFImageIOTest2(int argc, char * argv[])
 
   if (argc != 2)
   {
-    std::cerr << "Usage: " << argv[0] << " outputFilename" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
@@ -40,7 +40,9 @@ itkTIFFImageIOTestPalette(int argc, char * argv[])
 
   if (argc != 5)
   {
-    std::cerr << "Usage: " << argv[0] << " input"
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input"
               << " output"
               << " expandRGBPalette: request palette expanding"
               << " isPaletteImage: is image palette type" << std::endl;

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test2.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test2.cxx
@@ -22,6 +22,7 @@
 
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkStreamingImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkVTKImageIO2Test2(int argc, char * argv[])
@@ -31,10 +32,11 @@ itkVTKImageIO2Test2(int argc, char * argv[])
   // VTKImageIO with tensors
   //
 
-
   if (argc < 2)
   {
-    std::cerr << "Usage: " << argv[0] << " outputFileName" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " outputFileName" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/VTK/test/itkVTKImageIOTest2.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOTest2.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -28,8 +29,9 @@ itkVTKImageIOTest2(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  output1 output2 " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "  output1 output2 " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -52,15 +54,8 @@ itkVTKImageIOTest2(int argc, char * argv[])
 
   writer->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/VTK/test/itkVTKImageIOTest3.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOTest3.cxx
@@ -28,9 +28,10 @@ itkVTKImageIOTest3(int argc, char * argv[])
 
   if (argc != 2)
   {
+
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  polyDataFile" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "  polyDataFile" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/Review/test/itkAreaClosingImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkAreaClosingImageFilterTest.cxx
@@ -21,6 +21,7 @@
 
 #include "itkSimpleFilterWatcher.h"
 #include "itkAreaClosingImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkAreaClosingImageFilterTest(int argc, char * argv[])
@@ -28,7 +29,9 @@ itkAreaClosingImageFilterTest(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "usage: " << argv[0] << " inputImage outputImage lambda conn use_spacing" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImage outputImage lambda conn use_spacing" << std::endl;
     std::cerr << "  inputImage: The input image." << std::endl;
     std::cerr << "  outputImage: The output image." << std::endl;
     return EXIT_SUCCESS;
@@ -108,15 +111,8 @@ itkAreaClosingImageFilterTest(int argc, char * argv[])
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/Review/test/itkAreaOpeningImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkAreaOpeningImageFilterTest.cxx
@@ -21,6 +21,7 @@
 
 #include "itkSimpleFilterWatcher.h"
 #include "itkAreaOpeningImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkAreaOpeningImageFilterTest(int argc, char * argv[])
@@ -28,7 +29,9 @@ itkAreaOpeningImageFilterTest(int argc, char * argv[])
 
   if (argc != 6)
   {
-    std::cerr << "usage: " << argv[0] << " inputImage outputImage lambda conn use_spacing" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImage outputImage lambda conn use_spacing" << std::endl;
     std::cerr << "  inputImage: The input image." << std::endl;
     std::cerr << "  outputImage: The output image." << std::endl;
     return EXIT_FAILURE;
@@ -108,15 +111,8 @@ itkAreaOpeningImageFilterTest(int argc, char * argv[])
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/Review/test/itkConformalFlatteningMeshFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkConformalFlatteningMeshFilterTest.cxx
@@ -19,14 +19,16 @@
 #include "itkMeshFileReader.h"
 #include "itkMeshFileWriter.h"
 #include "itkConformalFlatteningMeshFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkConformalFlatteningMeshFilterTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Usage: " << argv[0] << "vtkInputFilename vtkOutputFilename mapToSphere[0:1] [polarCellId]\n";
-
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "vtkInputFilename vtkOutputFilename mapToSphere[0:1] [polarCellId]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -39,34 +41,17 @@ itkConformalFlatteningMeshFilterTest(int argc, char * argv[])
 
   using CellIdentifier = MeshType::CellIdentifier;
 
-  //
   // Read mesh file
-  //
-
-  std::cout << "Read " << argv[1] << std::endl;
-
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   MeshType::Pointer mesh = reader->GetOutput();
 
-  //
-  // Test itkConformalFlatteningMeshFilter
-  //
-
   FilterType::Pointer filter = FilterType::New();
 
-  // Connect the input
   filter->SetInput(mesh);
 
   CellIdentifier polarCellId = 0; // default set to the first cell
@@ -92,42 +77,20 @@ itkConformalFlatteningMeshFilterTest(int argc, char * argv[])
   //  double scale = std::stod( argv[4] );
   //  filter->SetScale( scale );
 
-  // Execute the filter
 
-  std::cout << "Execute the filter" << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-  try
-  {
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
 
   // Get the Smart Pointer to the Filter Output
   MeshType::Pointer newMesh = filter->GetOutput();
 
-  //
   // Write to file
-  //
-
-  std::cout << "Write " << argv[2] << std::endl;
-
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput(newMesh);
   writer->SetFileName(argv[2]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/Review/test/itkDirectFourierReconstructionImageToImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDirectFourierReconstructionImageToImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkImageFileWriter.h"
 
 #include "itkDirectFourierReconstructionImageToImageFilter.h"
+#include "itkTestingMacros.h"
 
 using InternalPixelType = double;
 using TestOutputPixelType = short int;
@@ -82,11 +83,10 @@ itkDirectFourierReconstructionImageToImageFilterTest(int argc, char * argv[])
 
   if (argc != 18)
   {
-    std::cerr << "Wrong number of input arguments" << std::endl;
-    std::cerr << "Usage : " << std::endl << "\t";
-    std::cerr << argv[0] << " input output r_dir z_dir alpha_dir nz ng fc nb alpha_range x y z sx sy sz sigma"
-              << std::endl;
-    return 1;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " input output r_dir z_dir alpha_dir nz ng fc nb alpha_range x y z sx sy sz sigma" << std::endl;
+    return EXIT_FAILURE;
   }
 
   ReaderType::Pointer reader = ReaderType::New();
@@ -100,6 +100,10 @@ itkDirectFourierReconstructionImageToImageFilterTest(int argc, char * argv[])
 
 
   ReconstructionFilterType::Pointer reconstruct = ReconstructionFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(reconstruct, DirectFourierReconstructionImageToImageFilter, ImageToImageFilter);
+
+
   if (std::stod(argv[17]) == 0)
   {
     reconstruct->SetInput(reader->GetOutput());
@@ -152,22 +156,9 @@ itkDirectFourierReconstructionImageToImageFilterTest(int argc, char * argv[])
   writer->UseCompressionOn();
   writer->SetInput(ROIFilter->GetOutput());
 
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cerr << "An error occurred somewhere:" << std::endl;
-    std::cerr << err << std::endl;
-    return 2;
-  }
 
-  std::cout << "Done" << std::endl;
-
-  std::cout << reconstruct << std::endl;
-
-  return 0;
-
-} // main
+  std::cout << "Test finished." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/Modules/Nonunit/Review/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
@@ -185,8 +185,8 @@ itkDiscreteGaussianDerivativeImageFunctionTest(int argc, char * argv[])
   if (argc < 5)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0]
-              << "inputFileName"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "inputFileName"
                  " outputFileName"
                  " order"
                  " sigma"

--- a/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -196,8 +196,8 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0]
-              << "inputFileName"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "inputFileName"
                  " outputFileName"
                  " sigma"
                  " [maximumError]"

--- a/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -258,8 +258,8 @@ itkDiscreteHessianGaussianImageFunctionTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0]
-              << "inputFileName"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "inputFileName"
                  " outputFileName"
                  " sigma"
                  " [maximumError]"

--- a/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
@@ -29,7 +29,8 @@ itkGridForwardWarpImageFilterTest(int argc, char * argv[])
   if (argc != 2)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0] << " outputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " outputImage" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
@@ -23,6 +23,7 @@
 
 #include "itkCSVArray2DFileReader.h"
 #include "itkCSVNumericObjectFileWriter.h"
+#include "itkTestingMacros.h"
 
 // Helper function declaration.
 template <const unsigned int NDimension>
@@ -43,8 +44,9 @@ itkLabelGeometryImageFilterTest(int argc, char * argv[])
 {
   if (argc < 5)
   {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "labelImage intensityImage outputImage outputFileName [compareFileName]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "labelImage intensityImage outputImage outputFileName [compareFileName]" << std::endl;
     return EXIT_FAILURE;
   }
   // Legacy compat with older MetaImages
@@ -120,14 +122,8 @@ LabelGeometryImageFilterTest(std::string labelImageName,
   labelGeometryFilter->CalculateOrientedLabelRegionsOn();
   labelGeometryFilter->CalculateOrientedIntensityRegionsOn();
 
-  try
-  {
-    labelGeometryFilter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << e << std::endl;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(labelGeometryFilter->Update());
+
 
   // Write out the oriented image of the first object.
   typename LabelGeometryType::LabelPixelType labelValue = 1;
@@ -135,14 +131,9 @@ LabelGeometryImageFilterTest(std::string labelImageName,
   typename IntensityWriterType::Pointer intensityWriter = IntensityWriterType::New();
   intensityWriter->SetFileName(outputImageName);
   intensityWriter->SetInput(labelGeometryFilter->GetOrientedIntensityImage(labelValue));
-  try
-  {
-    intensityWriter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << e << std::endl;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(intensityWriter->Update());
+
 
   // Write all of the object features out to a csv file.
   int numberOfLabels = labelGeometryFilter->GetNumberOfLabels();
@@ -220,16 +211,10 @@ LabelGeometryImageFilterTest(std::string labelImageName,
   MatrixType * matrixPointer;
   matrixPointer = new MatrixType(matrix.data_block(), numberOfLabels, numberOfColumns);
   writer->SetInput(matrixPointer);
-  try
-  {
-    writer->Write();
-  }
-  catch (const itk::ExceptionObject & exp)
-  {
-    std::cerr << "Exception caught!" << std::endl;
-    std::cerr << exp << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Write());
+
+
   delete matrixPointer;
 
   // If an optional csv file was passed in, compare the results of this analysis with the values in the file.
@@ -251,17 +236,10 @@ LabelGeometryImageFilterTest(std::string labelImageName,
     compareReader->SetFieldDelimiterCharacter(',');
     compareReader->HasColumnHeadersOn();
     compareReader->HasRowHeadersOff();
-    try
-    {
-      newReader->Parse();
-      compareReader->Parse();
-    }
-    catch (const itk::ExceptionObject & exp)
-    {
-      std::cerr << "Exception caught!" << std::endl;
-      std::cerr << exp << std::endl;
-      return EXIT_FAILURE;
-    }
+
+    ITK_TRY_EXPECT_NO_EXCEPTION(newReader->Parse());
+    ITK_TRY_EXPECT_NO_EXCEPTION(compareReader->Parse());
+
 
     using DataFrameObjectType = itk::CSVArray2DDataObject<double>;
     DataFrameObjectType::Pointer newDFO = DataFrameObjectType::New();

--- a/Modules/Nonunit/Review/test/itkOptMattesMutualInformationImageToImageMetricThreadsTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkOptMattesMutualInformationImageToImageMetricThreadsTest1.cxx
@@ -19,6 +19,7 @@
 #include "itkTranslationTransform.h"
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itkMattesMutualInformationImageToImageMetric.h"
+#include "itkTestingMacros.h"
 
 int
 itkOptMattesMutualInformationImageToImageMetricThreadsTest1(int argc, char * argv[])
@@ -26,9 +27,9 @@ itkOptMattesMutualInformationImageToImageMetricThreadsTest1(int argc, char * arg
 
   if (argc < 3)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage " << std::endl;
-    std::cerr << argv[0] << " fixedImage movingImage [verbose(1/0)] [numberOfSamples]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " fixedImage movingImage [verbose(1/0)] [numberOfSamples]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -64,16 +65,9 @@ itkOptMattesMutualInformationImageToImageMetricThreadsTest1(int argc, char * arg
     verbose = std::stoi(argv[3]);
   }
 
-  try
-  {
-    fixedImageReader->Update();
-    movingImageReader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(fixedImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(movingImageReader->Update());
+
 
   using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType>;
 

--- a/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdCalculatorTest.cxx
@@ -30,7 +30,8 @@ itkRobustAutomaticThresholdCalculatorTest(int argc, char * argv[])
   if (argc != 4)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0] << " inputImage pow expectedOutput" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImage pow expectedOutput" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdImageFilterTest.cxx
@@ -32,8 +32,8 @@ itkRobustAutomaticThresholdImageFilterTest(int argc, char * argv[])
   if (argc != 7)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0] << " inputImage outputImage pow insideValue outsideValue expectedThreshold"
-              << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputImage outputImage pow insideValue outsideValue expectedThreshold" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -53,7 +53,9 @@ itkRobustAutomaticThresholdImageFilterTest(int argc, char * argv[])
   GradientType::Pointer gradient = GradientType::New();
   gradient->SetInput(reader->GetOutput());
   gradient->SetSigma(10);
-  gradient->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(gradient->Update());
+
 
   using FilterType = itk::RobustAutomaticThresholdImageFilter<ImageType, RealImageType>;
   FilterType::Pointer filter = FilterType::New();

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest2.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
+#include "itkTestingMacros.h"
 
 int
 itkScalarChanAndVeseDenseLevelSetImageFilterTest2(int argc, char * argv[])
@@ -27,9 +28,9 @@ itkScalarChanAndVeseDenseLevelSetImageFilterTest2(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "inputLevelSetImage inputFeatureImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "inputLevelSetImage inputFeatureImage ";
     std::cerr << " outputLevelSetImage CurvatureWeight AreaWeight";
     std::cerr << " ReinitializationWeight VolumeWeight Volume" << std::endl;
     return EXIT_FAILURE;
@@ -67,15 +68,19 @@ itkScalarChanAndVeseDenseLevelSetImageFilterTest2(int argc, char * argv[])
 
   LevelSetReaderType::Pointer levelSetReader1 = LevelSetReaderType::New();
   levelSetReader1->SetFileName(argv[1]);
-  levelSetReader1->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(levelSetReader1->Update());
+
 
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
   featureReader->SetFileName(argv[2]);
-  featureReader->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
+
 
   MultiLevelSetType::Pointer levelSetFilter = MultiLevelSetType::New();
 
-  levelSetReader1->Update();
+
   levelSetFilter->SetFunctionCount(1); // Protected ?
   levelSetFilter->SetFeatureImage(featureReader->GetOutput());
   levelSetFilter->SetLevelSet(0, levelSetReader1->GetOutput());
@@ -94,8 +99,8 @@ itkScalarChanAndVeseDenseLevelSetImageFilterTest2(int argc, char * argv[])
   function->SetLambda1(l1);
   function->SetLambda2(l2);
 
+  ITK_TRY_EXPECT_NO_EXCEPTION(levelSetFilter->Update());
 
-  levelSetFilter->Update();
 
   WriterType::Pointer writer1 = WriterType::New();
 
@@ -104,16 +109,8 @@ itkScalarChanAndVeseDenseLevelSetImageFilterTest2(int argc, char * argv[])
 
   writer1->SetFileName(argv[3]);
 
-  try
-  {
-    writer1->Update();
-  }
-  catch (const itk::ExceptionObject & excep)
-  {
-    std::cerr << "Exception caught !" << std::endl;
-    std::cerr << excep << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer1->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest4.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest4.cxx
@@ -21,6 +21,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
+#include "itkTestingMacros.h"
 
 int
 itkScalarChanAndVeseDenseLevelSetImageFilterTest4(int argc, char * argv[])
@@ -28,9 +29,9 @@ itkScalarChanAndVeseDenseLevelSetImageFilterTest4(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "inputLevelSetImage inputFeatureImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "inputLevelSetImage inputFeatureImage ";
     std::cerr << " outputLevelSetImage CurvatureWeight AreaWeight";
     std::cerr << " ReinitializationWeight VolumeWeight Volume" << std::endl;
     return EXIT_FAILURE;
@@ -79,15 +80,19 @@ itkScalarChanAndVeseDenseLevelSetImageFilterTest4(int argc, char * argv[])
 
   LevelSetReaderType::Pointer levelSetReader1 = LevelSetReaderType::New();
   levelSetReader1->SetFileName(argv[1]);
-  levelSetReader1->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(levelSetReader1->Update());
+
 
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
   featureReader->SetFileName(argv[2]);
-  featureReader->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
+
 
   MultiLevelSetType::Pointer levelSetFilter = MultiLevelSetType::New();
 
-  levelSetReader1->Update();
+
   levelSetFilter->SetFunctionCount(1); // Protected ?
   levelSetFilter->SetFeatureImage(featureReader->GetOutput());
   levelSetFilter->SetLevelSet(0, levelSetReader1->GetOutput());
@@ -105,8 +110,8 @@ itkScalarChanAndVeseDenseLevelSetImageFilterTest4(int argc, char * argv[])
   levelSetFilter->GetDifferenceFunction(0)->SetLambda1(l1);
   levelSetFilter->GetDifferenceFunction(0)->SetLambda2(l2);
 
+  ITK_TRY_EXPECT_NO_EXCEPTION(levelSetFilter->Update());
 
-  levelSetFilter->Update();
 
   WriterType::Pointer writer1 = WriterType::New();
 
@@ -115,16 +120,8 @@ itkScalarChanAndVeseDenseLevelSetImageFilterTest4(int argc, char * argv[])
 
   writer1->SetFileName(argv[3]);
 
-  try
-  {
-    writer1->Update();
-  }
-  catch (const itk::ExceptionObject & excep)
-  {
-    std::cerr << "Exception caught !" << std::endl;
-    std::cerr << excep << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer1->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseSparseLevelSetImageFilterTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseSparseLevelSetImageFilterTest2.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
+#include "itkTestingMacros.h"
 
 int
 itkScalarChanAndVeseSparseLevelSetImageFilterTest2(int argc, char * argv[])
@@ -27,9 +28,9 @@ itkScalarChanAndVeseSparseLevelSetImageFilterTest2(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "inputLevelSetImage inputFeatureImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "inputLevelSetImage inputFeatureImage ";
     std::cerr << " outputLevelSetImage" << std::endl;
     return EXIT_FAILURE;
   }
@@ -74,11 +75,15 @@ itkScalarChanAndVeseSparseLevelSetImageFilterTest2(int argc, char * argv[])
 
   LevelSetReaderType::Pointer levelSetReader1 = LevelSetReaderType::New();
   levelSetReader1->SetFileName(argv[1]);
-  levelSetReader1->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(levelSetReader1->Update());
+
 
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
   featureReader->SetFileName(argv[2]);
-  featureReader->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
+
 
   MultiLevelSetType::Pointer levelSetFilter = MultiLevelSetType::New();
 
@@ -96,7 +101,8 @@ itkScalarChanAndVeseSparseLevelSetImageFilterTest2(int argc, char * argv[])
   levelSetFilter->GetDifferenceFunction(0)->SetLambda1(l1);
   levelSetFilter->GetDifferenceFunction(0)->SetLambda2(l2);
 
-  levelSetFilter->Update();
+  ITK_TRY_EXPECT_NO_EXCEPTION(levelSetFilter->Update());
+
 
   WriterType::Pointer writer1 = WriterType::New();
 
@@ -105,16 +111,8 @@ itkScalarChanAndVeseSparseLevelSetImageFilterTest2(int argc, char * argv[])
 
   writer1->SetFileName(argv[3]);
 
-  try
-  {
-    writer1->Update();
-  }
-  catch (const itk::ExceptionObject & excep)
-  {
-    std::cerr << "Exception caught !" << std::endl;
-    std::cerr << excep << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer1->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
@@ -22,92 +22,84 @@
 #include "itkBinaryThresholdImageFunction.h"
 
 #include "itkShapedFloodFilledImageFunctionConditionalConstIterator.h"
+#include "itkTestingMacros.h"
 
 int
 itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Error: missing arguments" << std::endl;
-    std::cerr << argv[0] << " filename " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " filename " << std::endl;
     return EXIT_FAILURE;
   }
 
-  try
+  constexpr unsigned int ImageDimension = 2;
+  using PixelType = unsigned char;
+
+  using ImageType = itk::Image<PixelType, ImageDimension>;
+  using RegionType = ImageType::RegionType;
+  using IndexType = ImageType::IndexType;
+
+  using FunctionType = itk::BinaryThresholdImageFunction<ImageType>;
+  using ShapedFloodFilledIteratorType =
+    itk::ShapedFloodFilledImageFunctionConditionalConstIterator<ImageType, FunctionType>;
+
+  using ReaderType = itk::ImageFileReader<ImageType>;
+
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+
+  IndexType index;
+  index[0] = 29;
+  index[1] = 47;
+
+  std::vector<IndexType> seedList;
+  seedList.push_back(index);
+
+  RegionType region = reader->GetOutput()->GetBufferedRegion();
+
+  FunctionType::Pointer function = FunctionType::New();
+
+  function->SetInputImage(reader->GetOutput());
+  function->ThresholdAbove(1); // >= 1
+
+  ShapedFloodFilledIteratorType shapedFloodIt(reader->GetOutput(), function, seedList);
+  shapedFloodIt.SetFullyConnected(true); // 8-connected, default
+  //
+  // get the seeds and display them.
+  std::cout << "Iterator seeds";
+  for (auto seed : shapedFloodIt.GetSeeds())
   {
-    constexpr unsigned int ImageDimension = 2;
-    using PixelType = unsigned char;
-
-    using ImageType = itk::Image<PixelType, ImageDimension>;
-    using RegionType = ImageType::RegionType;
-    using IndexType = ImageType::IndexType;
-
-    using FunctionType = itk::BinaryThresholdImageFunction<ImageType>;
-    using ShapedFloodFilledIteratorType =
-      itk::ShapedFloodFilledImageFunctionConditionalConstIterator<ImageType, FunctionType>;
-
-    using ReaderType = itk::ImageFileReader<ImageType>;
-
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
-
-    IndexType index;
-    index[0] = 29;
-    index[1] = 47;
-
-    std::vector<IndexType> seedList;
-    seedList.push_back(index);
-
-    RegionType region = reader->GetOutput()->GetBufferedRegion();
-
-    FunctionType::Pointer function = FunctionType::New();
-
-    function->SetInputImage(reader->GetOutput());
-    function->ThresholdAbove(1); // >= 1
-
-    ShapedFloodFilledIteratorType shapedFloodIt(reader->GetOutput(), function, seedList);
-    shapedFloodIt.SetFullyConnected(true); // 8-connected, default
-    //
-    // get the seeds and display them.
-    std::cout << "Iterator seeds";
-    for (auto seed : shapedFloodIt.GetSeeds())
-    {
-      std::cout << " " << seed;
-    }
-    std::cout << std::endl;
-
-    ImageType::Pointer visitedImage = ImageType::New();
-    visitedImage->SetRegions(region);
-    visitedImage->Allocate(true); // initialize
-                                  // buffer to zero
-
-    for (; !shapedFloodIt.IsAtEnd(); ++shapedFloodIt)
-    {
-      visitedImage->SetPixel(shapedFloodIt.GetIndex(), 255);
-    }
-
-    using ConstIteratorType = itk::ImageRegionConstIterator<ImageType>;
-
-    ConstIteratorType inIt(reader->GetOutput(), region);
-    ConstIteratorType outIt(visitedImage, region);
-
-    for (; !inIt.IsAtEnd(); ++inIt, ++outIt)
-    {
-      if (inIt.Get() != outIt.Get())
-      {
-        return EXIT_FAILURE;
-      }
-    }
+    std::cout << " " << seed;
   }
-  catch (const itk::ExceptionObject & e)
+  std::cout << std::endl;
+
+  ImageType::Pointer visitedImage = ImageType::New();
+  visitedImage->SetRegions(region);
+  visitedImage->Allocate(true); // initialize
+                                // buffer to zero
+
+  for (; !shapedFloodIt.IsAtEnd(); ++shapedFloodIt)
   {
-    e.Print(std::cerr);
-    return EXIT_FAILURE;
+    visitedImage->SetPixel(shapedFloodIt.GetIndex(), 255);
   }
-  catch (...)
+
+  using ConstIteratorType = itk::ImageRegionConstIterator<ImageType>;
+
+  ConstIteratorType inIt(reader->GetOutput(), region);
+  ConstIteratorType outIt(visitedImage, region);
+
+  for (; !inIt.IsAtEnd(); ++inIt, ++outIt)
   {
-    return EXIT_FAILURE;
+    if (inIt.Get() != outIt.Get())
+    {
+      return EXIT_FAILURE;
+    }
   }
 
   return EXIT_SUCCESS;

--- a/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileWriter.h"
 #include "itkStochasticFractalDimensionImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 namespace StochasticFractalDimensionImageFilterTest
 {
@@ -99,30 +100,26 @@ public:
       fractalFilter->SetMaskImage(thresholder->GetOutput());
     }
 
-    try
-    {
-      itk::TimeProbe timer;
+    itk::TimeProbe timer;
 
-      timer.Start();
-      std::cout << "/" << std::flush;
-      fractalFilter->Update();
-      std::cout << "/" << std::flush;
-      timer.Stop();
+    timer.Start();
+    std::cout << "/" << std::flush;
 
-      std::cout << "   (elapsed time: " << timer.GetMean() << ")" << std::endl;
-    }
-    catch (...)
-    {
-      std::cerr << "Exception caught." << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(fractalFilter->Update());
+
+    std::cout << "/" << std::flush;
+    timer.Stop();
+
+    std::cout << "   (elapsed time: " << timer.GetMean() << ")" << std::endl;
 
     using WriterType = itk::ImageFileWriter<ImageType>;
     typename WriterType::Pointer writer = WriterType::New();
     writer->SetInput(fractalFilter->GetOutput());
     writer->SetFileName(argv[3]);
     writer->UseCompressionOn();
-    writer->Update();
+
+    ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
     return EXIT_SUCCESS;
   }
@@ -135,8 +132,9 @@ itkStochasticFractalDimensionImageFilterTest(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cout << "Usage: " << argv[0] << " imageDimension "
-              << "inputImage outputImage [radius] [labelImage] [label]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cout << " imageDimension inputImage outputImage [radius] [labelImage] [label]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
@@ -28,7 +28,8 @@ itkWarpHarmonicEnergyCalculatorTest(int argc, char * argv[])
   if (argc != 4)
   {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0] << " useImageSpacing"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " useImageSpacing"
               << " derivativeWeights"
               << " expectedEnergy" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest2.cxx
@@ -19,6 +19,7 @@
 #include "itkImageToHistogramFilter.h"
 #include "itkImageFileReader.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageToHistogramFilterTest2(int argc, char * argv[])
@@ -26,9 +27,9 @@ itkImageToHistogramFilterTest2(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputRGBImageFileName outputHistogramFile.txt [autoMinumumMaximum]"
-              << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputRGBImageFileName outputHistogramFile.txt [autoMinumumMaximum]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -97,15 +98,7 @@ itkImageToHistogramFilterTest2(int argc, char * argv[])
 
   histogramFilter->SetInput(reader->GetOutput());
 
-  try
-  {
-    histogramFilter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(histogramFilter->Update());
 
 
   using HistogramType = HistogramFilterType::HistogramType;
@@ -135,15 +128,7 @@ itkImageToHistogramFilterTest2(int argc, char * argv[])
 
   histogramFilter->SetHistogramSize(size);
 
-  try
-  {
-    histogramFilter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(histogramFilter->Update());
 
 
   channel = 1; // green channel
@@ -163,15 +148,7 @@ itkImageToHistogramFilterTest2(int argc, char * argv[])
 
   histogramFilter->SetHistogramSize(size);
 
-  try
-  {
-    histogramFilter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(histogramFilter->Update());
 
 
   channel = 2; // blue channel

--- a/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest3.cxx
@@ -19,6 +19,7 @@
 #include "itkScalarImageToHistogramGenerator.h"
 #include "itkMinimumMaximumImageFilter.h"
 #include "itkImageFileReader.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageToHistogramFilterTest3(int argc, char * argv[])
@@ -26,8 +27,9 @@ itkImageToHistogramFilterTest3(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Missing command line arguments" << std::endl;
-    std::cerr << "Usage :  " << argv[0] << " inputScalarImageFileName outputHistogramFile.txt" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputScalarImageFileName outputHistogramFile.txt" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -39,16 +41,9 @@ itkImageToHistogramFilterTest3(int argc, char * argv[])
 
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encountered while reading image file : " << argv[1] << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   itk::MinimumMaximumImageFilter<ScalarImageType>::Pointer minmaxFilter =
     itk::MinimumMaximumImageFilter<ScalarImageType>::New();

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest1.cxx
@@ -20,6 +20,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkListSample.h"
 #include "itkKdTreeGenerator.h"
+#include "itkTestingMacros.h"
 #include <fstream>
 
 int
@@ -27,9 +28,9 @@ itkKdTreeTest1(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " numberOfDataPoints numberOfTestPoints bucketSize [graphvizDotOutputFile]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " numberOfDataPoints numberOfTestPoints bucketSize [graphvizDotOutputFile]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest2.cxx
@@ -18,6 +18,7 @@
 
 #include "itkListSample.h"
 #include "itkKdTreeGenerator.h"
+#include "itkTestingMacros.h"
 
 #include <iostream>
 #include <fstream>
@@ -29,9 +30,9 @@ itkKdTreeTest2(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cerr << "Missing argument" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " pointsInputFile  bucketSize graphvizDotOutputFile" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " pointsInputFile  bucketSize graphvizDotOutputFile" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest3.cxx
@@ -19,6 +19,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkListSample.h"
 #include "itkKdTreeGenerator.h"
+#include "itkTestingMacros.h"
 #include <fstream>
 #include <algorithm>
 
@@ -27,9 +28,9 @@ itkKdTreeTest3(int argc, char * argv[])
 {
   if (argc < 5)
   {
-    std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " numberOfDataPoints numberOfTestPoints "
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " numberOfDataPoints numberOfTestPoints "
               << "numberOfNeighbors bucketSize [graphvizDotOutputFile]" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest5.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest5.cxx
@@ -20,6 +20,7 @@
 #include "itkSampleToHistogramFilter.h"
 #include "itkImageToListSampleFilter.h"
 #include "itkImageFileReader.h"
+#include "itkTestingMacros.h"
 
 int
 itkSampleToHistogramFilterTest5(int argc, char * argv[])
@@ -29,9 +30,9 @@ itkSampleToHistogramFilterTest5(int argc, char * argv[])
 
   if (argc < 2)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFilename " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << "  inputImageFilename " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -80,17 +81,7 @@ itkSampleToHistogramFilterTest5(int argc, char * argv[])
 
   // Test exception when calling Update() without having
   // defined the size of the histogram in the filter.
-  try
-  {
-    filter->Update();
-    std::cerr << "Failure to throw expected exception due to lack";
-    std::cerr << " of calling SetHistogramSize() in the filter ";
-    return EXIT_FAILURE;
-  }
-  catch (itk::ExceptionObject &)
-  {
-    std::cout << "Expected exception received" << std::endl;
-  }
+  ITK_TRY_EXPECT_EXCEPTION(filter->Update());
 
 
   const HistogramType * histogram = filter->GetOutput();
@@ -109,15 +100,8 @@ itkSampleToHistogramFilterTest5(int argc, char * argv[])
 
   filter->SetHistogramSize(histogramSize);
 
-  try
-  {
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   const unsigned int expectedHistogramSize = histogramSize[0] * histogramSize[1] * histogramSize[2];
 

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest1.cxx
@@ -19,6 +19,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkListSample.h"
 #include "itkWeightedCentroidKdTreeGenerator.h"
+#include "itkTestingMacros.h"
 #include <fstream>
 
 int
@@ -26,9 +27,9 @@ itkWeightedCentroidKdTreeGeneratorTest1(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " numberOfDataPoints numberOfTestPoints bucketSize [graphvizDotOutputFile]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " numberOfDataPoints numberOfTestPoints bucketSize [graphvizDotOutputFile]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
@@ -19,6 +19,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkListSample.h"
 #include "itkWeightedCentroidKdTreeGenerator.h"
+#include "itkTestingMacros.h"
 #include <fstream>
 
 // Generate Weighed centroid Kd tree generator using FixedArray
@@ -27,9 +28,9 @@ itkWeightedCentroidKdTreeGeneratorTest8(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " numberOfDataPoints numberOfTestPoints bucketSize [graphvizDotOutputFile]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " numberOfDataPoints numberOfTestPoints bucketSize [graphvizDotOutputFile]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
@@ -19,6 +19,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkListSample.h"
 #include "itkWeightedCentroidKdTreeGenerator.h"
+#include "itkTestingMacros.h"
 #include <fstream>
 
 // Testing the weighed centroid Kd tree generator using varaiable length vector
@@ -28,9 +29,9 @@ itkWeightedCentroidKdTreeGeneratorTest9(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing parameters" << std::endl;
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " numberOfDataPoints numberOfTestPoints bucketSize [graphvizDotOutputFile]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " numberOfDataPoints numberOfTestPoints bucketSize [graphvizDotOutputFile]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Registration/Common/test/itkMatchCardinalityImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMatchCardinalityImageToImageMetricTest.cxx
@@ -30,8 +30,10 @@ itkMatchCardinalityImageToImageMetricTest(int argc, char * argv[])
 
   if (argc < 2)
   {
-    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputFile" << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cout << " InputFile" << std::endl;
+    return EXIT_FAILURE;
   }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest2.cxx
@@ -35,6 +35,7 @@
 #include "itkCommand.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 #include <iomanip>
 
@@ -44,8 +45,8 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest2(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " fixedImageFile movingImageFile ";
     std::cerr << " outputImageFile ";
     std::cerr << " [gradientTolerance=1e-4] [max function iterations=100] [lineSearchTol=0.9] [stepLength=1.0] "
@@ -187,21 +188,8 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest2(int argc, char * argv[])
   optimizer->SetDefaultStepLength(stepLength);
   std::cout << "Initial stop description   = " << optimizer->GetStopConditionDescription() << std::endl;
 
-  // optimize
-  try
-  {
-    optimizer->StartOptimization();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception thrown ! " << std::endl;
-    std::cerr << "An error occurred during deformation Optimization:" << std::endl;
-    std::cerr << e.GetLocation() << std::endl;
-    std::cerr << e.GetDescription() << std::endl;
-    std::cerr << e.what() << std::endl;
-    std::cerr << "Test FAILED." << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(optimizer->StartOptimization());
+
 
   std::cout << "Number of threads: metric: " << metric->GetNumberOfWorkUnitsUsed()
             << " optimizer: " << optimizer->GetNumberOfWorkUnits() << std::endl;
@@ -230,7 +218,9 @@ itkMeanSquaresImageToImageMetricv4RegistrationTest2(int argc, char * argv[])
   writer->SetFileName(argv[3]);
   caster->SetInput(resample->GetOutput());
   writer->SetInput(caster->GetOutput());
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   std::cout << "After optimization affine params are: " << affineTransform->GetParameters() << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
@@ -21,7 +21,7 @@
 #include "itkNearestNeighborInterpolateImageFunction.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-
+#include "itkTestingMacros.h"
 
 namespace
 {
@@ -56,9 +56,8 @@ itkDiffeomorphicDemonsRegistrationFilterTest2(int argc, char * argv[])
 
   if (argc < 8)
   {
-    std::cerr << "Missing arguments" << std::endl;
-    std::cerr << "Usage:" << std::endl;
-    std::cerr << argv[0] << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << "fixedImage movingImage resampledImage" << std::endl;
     std::cerr << "GradientEnum [0=Symmetric,1=Fixed,2=WarpedMoving,3=MappedMoving]" << std::endl;
     std::cerr << "UseFirstOrderExp [0=No,1=Yes]" << std::endl;
@@ -87,16 +86,9 @@ itkDiffeomorphicDemonsRegistrationFilterTest2(int argc, char * argv[])
 
   writer->SetFileName(argv[3]);
 
-  try
-  {
-    fixedReader->Update();
-    movingReader->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(fixedReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(movingReader->Update());
+
 
   //-------------------------------------------------------------
   std::cout << "Run registration and warp moving" << std::endl;
@@ -210,15 +202,8 @@ itkDiffeomorphicDemonsRegistrationFilterTest2(int argc, char * argv[])
   writer->SetInput(warper->GetOutput());
   writer->UseCompressionOn();
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   std::cout << "Test passed" << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
@@ -113,11 +113,12 @@ PerformBSplineExpImageRegistration(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cout
-      << itkNameOfTestExecutableMacro(argv)
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr
       << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations"
       << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   using PixelType = double;
@@ -190,16 +191,8 @@ PerformBSplineExpImageRegistration(int argc, char * argv[])
     imageMetric->SetFloatingPointCorrectionResolution(1e4);
   }
 
-  try
-  {
-    std::cout << "Affine txf:" << std::endl;
-    affineSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(affineSimple->Update());
+
 
   {
     using ImageMetricType = itk::ImageToImageMetricv4<FixedImageType, MovingImageType>;
@@ -342,16 +335,8 @@ PerformBSplineExpImageRegistration(int argc, char * argv[])
     DisplacementFieldRegistrationCommandType::New();
   displacementFieldSimple->AddObserver(itk::IterationEvent(), displacementFieldObserver);
 
-  try
-  {
-    std::cout << "Displ. txf - bspline update" << std::endl;
-    displacementFieldSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(displacementFieldSimple->Update());
+
 
   compositeTransform->AddTransform(displacementFieldSimple->GetModifiableTransform());
 
@@ -417,11 +402,12 @@ itkBSplineExponentialImageRegistrationTest(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cout
-      << itkNameOfTestExecutableMacro(argv)
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr
       << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations"
       << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -434,7 +420,7 @@ itkBSplineExponentialImageRegistrationTest(int argc, char * argv[])
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
@@ -102,11 +102,12 @@ PerformBSplineImageRegistration(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cout
-      << itkNameOfTestExecutableMacro(argv)
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr
       << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations"
       << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   using PixelType = double;
@@ -175,16 +176,8 @@ PerformBSplineImageRegistration(int argc, char * argv[])
     imageMetric->SetFloatingPointCorrectionResolution(1e4);
   }
 
-  try
-  {
-    std::cout << "Affine txf:" << std::endl;
-    affineSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(affineSimple->Update());
+
 
   {
     using ImageMetricType = itk::ImageToImageMetricv4<FixedImageType, MovingImageType>;
@@ -318,16 +311,8 @@ PerformBSplineImageRegistration(int argc, char * argv[])
   typename BSplineRegistrationCommandType::Pointer bsplineObserver = BSplineRegistrationCommandType::New();
   bsplineRegistration->AddObserver(itk::IterationEvent(), bsplineObserver);
 
-  try
-  {
-    std::cout << "BSpline. txf - bspline update" << std::endl;
-    bsplineRegistration->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(bsplineRegistration->Update());
+
 
   compositeTransform->AddTransform(bsplineRegistration->GetModifiableTransform());
 
@@ -364,11 +349,12 @@ itkBSplineImageRegistrationTest(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cout
-      << itkNameOfTestExecutableMacro(argv)
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr
       << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations"
       << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -381,7 +367,7 @@ itkBSplineImageRegistrationTest(int argc, char * argv[])
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
 
   // Test streaming enumeration for ImageRegistrationMethodv4Enums::MetricSamplingStrategy elements

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
@@ -128,16 +128,8 @@ PerformBSplineSyNImageRegistration(int itkNotUsed(argc), char * argv[])
   typename AffineCommandType::Pointer affineObserver = AffineCommandType::New();
   affineSimple->AddObserver(itk::IterationEvent(), affineObserver);
 
-  try
-  {
-    std::cout << "Affine transform" << std::endl;
-    affineSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(affineSimple->Update());
+
 
   //
   // Now do the b-spline syn displacement field transform
@@ -306,16 +298,8 @@ PerformBSplineSyNImageRegistration(int itkNotUsed(argc), char * argv[])
   displacementFieldRegistration->SetInitialTransform(outputTransform);
   displacementFieldRegistration->InPlaceOn();
 
-  try
-  {
-    std::cout << "BSpline SyN registration" << std::endl;
-    displacementFieldRegistration->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(displacementFieldRegistration->Update());
+
 
   compositeTransform->AddTransform(outputTransform);
 
@@ -373,10 +357,11 @@ itkBSplineSyNImageRegistrationTest(int argc, char * argv[])
 {
   if (argc < 5)
   {
-    std::cout << itkNameOfTestExecutableMacro(argv)
-              << " imageDimension fixedImage movingImage outputPrefix numberOfDeformableIterations learningRate"
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " imageDimension fixedImage movingImage outputPrefix numberOfDeformableIterations learningRate"
               << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -389,7 +374,7 @@ itkBSplineSyNImageRegistrationTest(int argc, char * argv[])
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
@@ -115,11 +115,12 @@ PerformExpImageRegistration(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cout
-      << itkNameOfTestExecutableMacro(argv)
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr
       << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations"
       << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   itk::TimeProbesCollectorBase timer;
@@ -201,18 +202,11 @@ PerformExpImageRegistration(int argc, char * argv[])
     imageMetric->SetFloatingPointCorrectionResolution(1e4);
   }
 
-  try
-  {
-    std::cout << "Affine txf:" << std::endl;
-    timer.Start("4 affineSimple");
-    affineSimple->Update();
-    timer.Stop("4 affineSimple");
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  timer.Start("4 affineSimple");
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(affineSimple->Update());
+
+  timer.Stop("4 affineSimple");
 
   {
     using ImageMetricType = itk::ImageToImageMetricv4<FixedImageType, MovingImageType>;
@@ -351,18 +345,12 @@ PerformExpImageRegistration(int argc, char * argv[])
     DisplacementFieldRegistrationCommandType::New();
   displacementFieldSimple->AddObserver(itk::IterationEvent(), displacementFieldObserver);
 
-  try
-  {
-    std::cout << "Displ. txf - gauss update" << std::endl;
-    timer.Start("6 displacementFieldSimple");
-    displacementFieldSimple->Update();
-    timer.Stop("6 displacementFieldSimple");
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  timer.Start("6 displacementFieldSimple");
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(displacementFieldSimple->Update());
+
+  timer.Stop("6 displacementFieldSimple");
+
 
   compositeTransform->AddTransform(displacementFieldSimple->GetModifiableTransform());
 
@@ -440,11 +428,12 @@ itkExponentialImageRegistrationTest(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cout
-      << itkNameOfTestExecutableMacro(argv)
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr
       << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations"
       << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -457,7 +446,7 @@ itkExponentialImageRegistrationTest(int argc, char * argv[])
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -118,11 +118,12 @@ PerformSimpleImageRegistration(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cout << itkNameOfTestExecutableMacro(argv)
-              << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations "
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations "
                  "numberOfDeformableIterations"
               << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   using PixelType = TPixel;
@@ -351,16 +352,8 @@ PerformSimpleImageRegistration(int argc, char * argv[])
     DisplacementFieldRegistrationCommandType::New();
   displacementFieldSimple->AddObserver(itk::IterationEvent(), displacementFieldObserver);
 
-  try
-  {
-    std::cout << "Displ. txf - gauss update" << std::endl;
-    displacementFieldSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(displacementFieldSimple->Update());
+
 
   using ImageMetricType = itk::ImageToImageMetricv4<FixedImageType, MovingImageType>;
   typename ImageMetricType::ConstPointer imageMetric = dynamic_cast<const ImageMetricType *>(affineSimple->GetMetric());
@@ -412,11 +405,12 @@ itkSimpleImageRegistrationTest(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cout << itkNameOfTestExecutableMacro(argv)
-              << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations "
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations "
                  "numberOfDeformableIterations"
               << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   itk::Statistics::MersenneTwisterRandomVariateGenerator::GetInstance()->SetSeed(121212);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
@@ -28,6 +28,7 @@
 #include "itkCorrelationImageToImageMetricv4.h"
 #include "itkJointHistogramMutualInformationImageToImageMetricv4.h"
 #include "itkObjectToObjectMultiMetricv4.h"
+#include "itkTestingMacros.h"
 
 template <unsigned int TImageDimension>
 class RigidTransformTraits
@@ -134,11 +135,12 @@ PerformSimpleImageRegistration2(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cout
-      << argv[0]
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr
       << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations numberOfDeformableIterations"
       << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   using PixelType = double;
@@ -308,16 +310,8 @@ PerformSimpleImageRegistration2(int argc, char * argv[])
   typename CommandType::Pointer affineObserver = CommandType::New();
   affineSimple->AddObserver(itk::IterationEvent(), affineObserver);
 
-  try
-  {
-    std::cout << "Affine txf:" << std::endl;
-    affineSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(affineSimple->Update());
+
 
   {
     std::cout << "Affine parameters after registration: " << std::endl
@@ -357,8 +351,10 @@ itkSimpleImageRegistrationTest2(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations" << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " imageDimension fixedImage movingImage outputImage numberOfAffineIterations" << std::endl;
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -371,6 +367,6 @@ itkSimpleImageRegistrationTest2(int argc, char * argv[])
 
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
@@ -335,8 +335,10 @@ itkSimpleImageRegistrationTest3(int argc, char * argv[])
 {
   if (argc < 5)
   {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage outputPrefix" << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " imageDimension fixedImage movingImage outputPrefix" << std::endl;
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -349,6 +351,6 @@ itkSimpleImageRegistrationTest3(int argc, char * argv[])
 
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest4.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest4.cxx
@@ -166,8 +166,10 @@ itkSimpleImageRegistrationTest4(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cout << argv[0] << " imageDimension fixedImage movingImage" << std::endl;
-    exit(1);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " imageDimension fixedImage movingImage" << std::endl;
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -177,6 +179,6 @@ itkSimpleImageRegistrationTest4(int argc, char * argv[])
 
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
@@ -27,6 +27,7 @@
 #include "itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.h"
 #include "itkImageMaskSpatialObject.h"
 #include "itkJointHistogramMutualInformationImageToImageMetricv4.h"
+#include "itkTestingMacros.h"
 
 template <typename TFilter>
 class CommandIterationUpdate : public itk::Command
@@ -117,11 +118,12 @@ PerformSimpleImageRegistrationWithMaskAndSampling(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cout << argv[0]
-              << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations "
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations "
                  "numberOfDeformableIterations"
               << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   using PixelType = TPixel;
@@ -367,16 +369,8 @@ PerformSimpleImageRegistrationWithMaskAndSampling(int argc, char * argv[])
     DisplacementFieldRegistrationCommandType::New();
   displacementFieldSimple->AddObserver(itk::IterationEvent(), displacementFieldObserver);
 
-  try
-  {
-    std::cout << "Displ. txf - gauss update" << std::endl;
-    displacementFieldSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(displacementFieldSimple->Update());
+
 
   using ImageMetricType = itk::ImageToImageMetricv4<FixedImageType, MovingImageType>;
   typename ImageMetricType::ConstPointer imageMetric = dynamic_cast<const ImageMetricType *>(affineSimple->GetMetric());
@@ -428,11 +422,12 @@ itkSimpleImageRegistrationTestWithMaskAndSampling(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cout << argv[0]
-              << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations "
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " pixelType imageDimension fixedImage movingImage outputImage numberOfAffineIterations "
                  "numberOfDeformableIterations"
               << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[2]))
@@ -459,6 +454,6 @@ itkSimpleImageRegistrationTestWithMaskAndSampling(int argc, char * argv[])
 
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
@@ -152,16 +152,8 @@ PerformTimeVaryingBSplineVelocityFieldImageRegistration(int argc, char * argv[])
   typename AffineCommandType::Pointer affineObserver = AffineCommandType::New();
   affineSimple->AddObserver(itk::IterationEvent(), affineObserver);
 
-  try
-  {
-    std::cout << "Affine transform" << std::endl;
-    affineSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(affineSimple->Update());
+
 
   //
   // Now do the displacement field transform with gaussian smoothing using
@@ -385,16 +377,8 @@ PerformTimeVaryingBSplineVelocityFieldImageRegistration(int argc, char * argv[])
     VelocityFieldRegistrationCommandType::New();
   velocityFieldRegistration->AddObserver(itk::IterationEvent(), displacementFieldObserver);
 
-  try
-  {
-    std::cout << "Time-varying B-spline velocity field transform" << std::endl;
-    velocityFieldRegistration->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(velocityFieldRegistration->Update());
+
 
   compositeTransform->AddTransform(outputTransform);
 
@@ -454,12 +438,13 @@ itkTimeVaryingBSplineVelocityFieldImageRegistrationTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cout << itkNameOfTestExecutableMacro(argv)
-              << " imageDimension fixedImage movingImage outputPrefix [numberOfAffineIterations = 100] "
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " imageDimension fixedImage movingImage outputPrefix [numberOfAffineIterations = 100] "
               << "[numberOfDeformableIterationsLevel0 = 10] [numberOfDeformableIterationsLevel1 = 20] "
                  "[numberOfDeformableIterationsLevel2 = 11 ] [learningRate = 0.5]"
               << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -472,7 +457,7 @@ itkTimeVaryingBSplineVelocityFieldImageRegistrationTest(int argc, char * argv[])
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
@@ -152,16 +152,8 @@ PerformTimeVaryingVelocityFieldImageRegistration(int argc, char * argv[])
   typename AffineCommandType::Pointer affineObserver = AffineCommandType::New();
   affineSimple->AddObserver(itk::IterationEvent(), affineObserver);
 
-  try
-  {
-    std::cout << "Affine transform" << std::endl;
-    affineSimple->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(affineSimple->Update());
+
 
   //
   // Now do the displacement field transform with gaussian smoothing using
@@ -353,16 +345,8 @@ PerformTimeVaryingVelocityFieldImageRegistration(int argc, char * argv[])
     VelocityFieldRegistrationCommandType::New();
   velocityFieldRegistration->AddObserver(itk::IterationEvent(), displacementFieldObserver);
 
-  try
-  {
-    std::cout << "Time-varying velocity field transform (gaussian update)" << std::endl;
-    velocityFieldRegistration->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught: " << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(velocityFieldRegistration->Update());
+
 
   compositeTransform->AddTransform(outputTransform);
 
@@ -421,12 +405,13 @@ itkTimeVaryingVelocityFieldImageRegistrationTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cout << itkNameOfTestExecutableMacro(argv)
-              << " imageDimension fixedImage movingImage outputPrefix [numberOfAffineIterations = 100] "
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " imageDimension fixedImage movingImage outputPrefix [numberOfAffineIterations = 100] "
               << "[numberOfDeformableIterationsLevel0 = 10] [numberOfDeformableIterationsLevel1 = 20] "
                  "[numberOfDeformableIterationsLevel2 = 11 ] [learningRate = 0.5]"
               << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   switch (std::stoi(argv[1]))
@@ -439,7 +424,7 @@ itkTimeVaryingVelocityFieldImageRegistrationTest(int argc, char * argv[])
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest7.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest7.cxx
@@ -24,6 +24,7 @@
 
 #include "itkGaussianMixtureModelComponent.h"
 #include "itkExpectationMaximizationMixtureModelEstimator.h"
+#include "itkTestingMacros.h"
 
 // Sample classifier test using Gaussian Mixture model and EM estimator
 int
@@ -36,9 +37,9 @@ itkSampleClassifierFilterTest7(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cout << "ERROR: Missing arguments.\t" << argv[0] << "Input_data_sample"
-              << "\t"
-              << "Target_data_sample" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cout << "Input_data_sample Target_data_sample" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -282,15 +283,7 @@ itkSampleClassifierFilterTest7(int argc, char * argv[])
   filter->SetMembershipFunctions(membershipFunctionsObject);
   filter->SetMembershipFunctionsWeightsArray(weightArrayObjects);
 
-  try
-  {
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
 
   // Check if the measurement vectors are correctly labelled.

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
@@ -72,7 +72,7 @@ itkScalarImageKmeansImageFilter3DTest(int argc, char * argv[])
   }
   if (violated)
   {
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   using PixelType = signed short;
@@ -204,16 +204,9 @@ itkScalarImageKmeansImageFilter3DTest(int argc, char * argv[])
   kmeansFilter->SetUseNonContiguousLabels(useNonContiguousLabels);
 
   std::cout << "kmeansFilter->Update [[Watch out for infinite loop here!]] " << std::endl;
-  try
-  {
-    kmeansFilter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encountered while running K-means segmentation ";
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(kmeansFilter->Update());
+
 
   KMeansFilterType::ParametersType estimatedMeans = kmeansFilter->GetFinalMeans();
 
@@ -245,17 +238,8 @@ itkScalarImageKmeansImageFilter3DTest(int argc, char * argv[])
   kmeansNonBrainFilter->AddClassWithInitialMean(fatInitialMean);
   kmeansNonBrainFilter->SetUseNonContiguousLabels(useNonContiguousLabels);
 
-  std::cout << "kmeansNonBrainFilter->Update " << std::endl;
-  try
-  {
-    kmeansNonBrainFilter->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Problem encountered while Background K-Means segmentation ";
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(kmeansNonBrainFilter->Update());
+
 
   estimatedMeans = kmeansNonBrainFilter->GetFinalMeans();
 
@@ -334,13 +318,13 @@ itkScalarImageKmeansImageFilter3DTest(int argc, char * argv[])
     }
   }
 
-  /* Write out the resulting Label Image */
+  // Write out the resulting Label Image
   using WriterType = itk::ImageFileWriter<LabelImageType>;
   WriterType::Pointer labelWriter = WriterType::New();
   labelWriter->SetInput(kmeansLabelImage);
   labelWriter->SetFileName(outputLabelMapVolume);
-  std::cout << "labelWriter->Update " << std::endl;
-  labelWriter->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(labelWriter->Update());
 
 
   return EXIT_SUCCESS;

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 #include "vnl/vnl_sample.h"
 
 int
@@ -29,8 +30,8 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
 {
   if (argc < 5)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputImage  outputImage threshold_low threshold_hi [fully_connected] [minimum_object_size]"
               << std::endl;
     return EXIT_FAILURE;
@@ -90,15 +91,8 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
     std::cerr << "minSize: " << minSize << std::endl;
   }
 
-  try
-  {
-    relabel->Update();
-  }
-  catch (const itk::ExceptionObject & excep)
-  {
-    std::cerr << "Relabel: exception caught !" << std::endl;
-    std::cerr << excep << std::endl;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(relabel->Update());
+
 
   // Remap the labels to viewable colors
   RGBImageType::Pointer colored = RGBImageType::New();
@@ -137,17 +131,10 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
     ++cit;
   }
 
-  try
-  {
-    writer->SetInput(colored);
-    writer->SetFileName(argv[2]);
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & excep)
-  {
-    std::cerr << "Exception caught !" << std::endl;
-    std::cerr << excep << std::endl;
-  }
+  writer->SetInput(colored);
+  writer->SetFileName(argv[2]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   return EXIT_SUCCESS;

--- a/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
+++ b/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
@@ -34,7 +34,8 @@ itkVectorImageToVideoTest(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " inputFile outputFile";
     std::cerr << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
Increase tests style consistency:
- Use the `itkNameOfTestExecutableMacro` to get the test name and prevent
  the the test from crashing when `argv[0]` is null.
- Use the ITK testing macros when calling filter update methods to reduce
  boilerplate code.
- Increase consistency in the missing argument check message.
- Use `EXIT_SUCCESS` and `EXIT_FAILURE` to return from tests on
  success/failure.
- Use the `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro instead of explicitly
  calling the `Print` method.

Take advantage of the commit to:
- Remove the argument check when no input parameters are required.
- Define the required types within the test body.
- Define the required types once the input argument check has passed.
- Remove duplicate calls to filter updates.
- Remove unused expected exception cases.
- Only enclose within the `ITK_TRY_EXPECT_NO_EXCEPTION` macro the filter
  update calls that may throw exceptions.
- Remove some unnecessary printed messages.
- Remove unnecessary comment lines devoid of relevant content.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)