### PR TITLE
COMP: test fails to compile when legacy support is removed

### DIFF
--- a/Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx
@@ -16,9 +16,6 @@
  *
  *=========================================================================*/
 
-// we need to test the deprecated itkStaticAssert
-#define ITK_LEGACY_TEST
-
 #include "itkMetaProgrammingLibrary.h"
 #include "itkIsSame.h"
 #include "itkStaticAssert.h"
@@ -28,6 +25,8 @@ int
 itkMetaProgrammingLibraryTest(int, char *[])
 {
   using namespace itk::mpl;
+
+#if !defined(ITK_LEGACY_REMOVE)
 
   // Or between constants
   itkStaticAssert((OrC<true, true, true>::Value == true), "Unit test failed");
@@ -88,6 +87,8 @@ itkMetaProgrammingLibraryTest(int, char *[])
   // Not between types
   itkStaticAssert((IsSame<Not<TrueType>::Type, FalseType>::Value), "Unit test failed");
   itkStaticAssert((IsSame<Not<FalseType>::Type, TrueType>::Value), "Unit test failed");
+
+#endif
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
itkMetaProgrammingLibraryTest is testing itkStaticAssert,
which has been recently deprecated.
When ITK_LEGACY_REMOVE is turned on, it caused compiler errors
of the following style:

```text
Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx line 33 (https://open.cdash.org/viewBuildError.php?type=0&amp;buildid=7345514
M:\Dashboard\ITK\Modules\Core\Common\test\itkMetaProgrammingLibraryTest.cxx(33): error C2065: 'Use': undeclared identifier [M:\Dashboard\ITK-build\Modules\Core\Common\test\ITKCommon2TestDriver.vcxproj]
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

