### PR TITLE
COMP: ambiguous equality operator in itkMatrixOffsetTransformBaseGTest

### DIFF
--- a/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
+++ b/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
@@ -33,10 +33,11 @@ Check_New_MatrixOffsetTransformBase()
 
   EXPECT_TRUE(transformBase->GetMatrix().GetVnlMatrix().is_identity());
 
-  const auto zeroFilledFixedArray = itk::FixedArray<double, NDimensions>::Filled(0.0);
+  using DoubleFixedArray = itk::FixedArray<double, NDimensions>;
+  const auto zeroFilledFixedArray = DoubleFixedArray::Filled(0.0);
 
   EXPECT_EQ(zeroFilledFixedArray, transformBase->GetOffset());
-  EXPECT_EQ(zeroFilledFixedArray, transformBase->GetCenter());
+  EXPECT_EQ(zeroFilledFixedArray, static_cast<DoubleFixedArray>(transformBase->GetCenter()));
   EXPECT_EQ(zeroFilledFixedArray, transformBase->GetTranslation());
 }
 


### PR DESCRIPTION
The problem was comparing a FixedArray to a Point returned by GetCenter() via EXPECT_EQ

Ref #2640.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

