### PR TITLE
COMP: Remove comparison to FixedArray in MatrixOffsetTransformBase GTest

### DIFF
--- a/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
+++ b/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
@@ -29,15 +29,19 @@ template <typename TParametersValueType, unsigned NDimensions>
 void
 Check_New_MatrixOffsetTransformBase()
 {
-  const auto transformBase = itk::MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>::New();
+  using MatrixOffsetTransformBaseType = itk::MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>;
+
+  const auto transformBase = MatrixOffsetTransformBaseType::New();
 
   EXPECT_TRUE(transformBase->GetMatrix().GetVnlMatrix().is_identity());
 
-  const auto zeroFilledFixedArray = itk::FixedArray<double, NDimensions>::Filled(0.0);
+  using OutputVectorType = typename MatrixOffsetTransformBaseType::OutputVectorType;
+  using InputPointType = typename MatrixOffsetTransformBaseType::InputPointType;
 
-  EXPECT_EQ(zeroFilledFixedArray, transformBase->GetOffset());
-  EXPECT_EQ(zeroFilledFixedArray, transformBase->GetCenter());
-  EXPECT_EQ(zeroFilledFixedArray, transformBase->GetTranslation());
+  // Expect that the offset, center, and translation are all entirely zero.
+  EXPECT_EQ(transformBase->GetOffset(), OutputVectorType());
+  EXPECT_EQ(transformBase->GetCenter(), InputPointType());
+  EXPECT_EQ(transformBase->GetTranslation(), OutputVectorType());
 }
 
 


### PR DESCRIPTION
Comparing an `itk::FixedArray` to an `itk::Point` appears to cause C++20
compilation errors, as observed with Visual Studio 2019 ("/std:c++latest"),
reported by @QuellaZhang, issue https://github.com/InsightSoftwareConsortium/ITK/issues/2640

> itkMatrixOffsetTransformBaseGTest.i(390249): error C2666: 'itk::FixedArray<double,2>::operator ==': 2 overloads have similar conversions
> itkMatrixOffsetTransformBaseGTest.i(87990): note: could be 'bool itk::FixedArray<double,2>::operator ==(const itk::FixedArray<double,2> &) const'
> itkMatrixOffsetTransformBaseGTest.i(390240): note: or       'bool testing::internal::operator ==(testing::internal::faketype,testing::internal::faketype)'
> itkMatrixOffsetTransformBaseGTest.i(269102): note: or 'bool itk::Point<TParametersValueType,2>::operator ==(const itk::Point<TParametersValueType,2> &) const' [synthesized expression 'y == x']
