### PR TITLE
BUG: Initialize member in `itk::AttributeLabelObject`

### DIFF
--- a/Modules/Filtering/LabelMap/include/itkAttributeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeLabelObject.h
@@ -141,10 +141,7 @@ public:
   }
 
 protected:
-  AttributeLabelObject()
-  {
-    // how to initialize the attribute ?
-  }
+  AttributeLabelObject() = default;
 
 
   void
@@ -156,7 +153,7 @@ protected:
   }
 
 private:
-  AttributeValueType m_Attribute;
+  AttributeValueType m_Attribute{};
 };
 
 } // end namespace itk


### PR DESCRIPTION
Initialize member in `itk::AttributeLabelObject`.

Fixes:
```
==6189== Command: /tmp/bld/ITK-build/bin/ITKLabelMapTestDriver
itkAttributeLabelObjectAccessorsTest1
/tmp/bld/ITK-build/ExternalData/Testing/Data/Input/cthead1Label.png
/tmp/bld/ITK-build/ExternalData/Testing/Data/Input/cthead1.png
==6189== Parent PID: 55
==6189==
UMC ==6189== Conditional jump or move depends on uninitialised value(s)
==6189==    at 0x91423DC: __printf_fp_l (in /usr/lib64/libc-2.17.so)
==6189==    by 0x91414D6: vfprintf (in /usr/lib64/libc-2.17.so)
==6189==    by 0x916C178: vsnprintf (in /usr/lib64/libc-2.17.so)
==6189==    by 0x8C5B63C: ??? (in /usr/lib64/libstdc++.so.6.0.19)
==6189==    by 0x8C61CA3: std::ostreambuf_iterator > std::num_put >
>::_M_insert_float(std::ostreambuf_iterator >, std::ios_base&, char, char,
>double) const (in /usr/lib64/libstdc++.so.6.0.19)
==6189==    by 0x8C61F8F: std::num_put >
>::do_put(std::ostreambuf_iterator >, std::ios_base&, char, double) const
>(in /usr/lib64/libstdc++.so.6.0.19)
==6189==    by 0x8C6DB94: std::ostream& std::ostream::_M_insert(double)
(in /usr/lib64/libstdc++.so.6.0.19)
==6189==    by 0x2F0A06:
itk::AttributeLabelObject::PrintSelf(std::ostream&, itk::Indent) const
(itkAttributeLabelObject.h:155)
==6189==    by 0x67D4A99: itk::LightObject::Print(std::ostream&,
itk::Indent) const (itkLightObject.cxx:125)
==6189==    by 0x2E74F9: itkAttributeLabelObjectAccessorsTest1(int,
char**) (itkAttributeLabelObjectAccessorsTest1.cxx:80)
==6189==    by 0x278CF5: main (ITKLabelMapTestDriver.cxx:467)
```

Raised in:
https://open.cdash.org/viewDynamicAnalysisFile.php?id=8560922

Provide a default initialization to the default constructor.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)