### PR TITLE
COMP: add ITK_ prefix in itkStochasticFractalDimensionImageFilterTest

### DIFF
--- a/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
@@ -43,7 +43,7 @@ public:
     using FractalFilterType = itk::StochasticFractalDimensionImageFilter<ImageType>;
     typename FractalFilterType::Pointer fractalFilter = FractalFilterType::New();
 
-    EXERCISE_BASIC_OBJECT_METHODS(fractalFilter, StochasticFractalDimensionImageFilter, ImageToImageFilter);
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(fractalFilter, StochasticFractalDimensionImageFilter, ImageToImageFilter);
 
 
     fractalFilter->SetInput(imageReader->GetOutput());


### PR DESCRIPTION
To address https://open.cdash.org/viewBuildError.php?type=0&buildid=7354490:
```text
/Users/builder/externalModules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx:46:50: error: use of undeclared identifier 'StochasticFractalDimensionImageFilter'
    EXERCISE_BASIC_OBJECT_METHODS(fractalFilter, StochasticFractalDimensionImageFilter, ImageToImageFilter);
                                                 ^
/Users/builder/externalModules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx:46:89: error: use of undeclared identifier 'ImageToImageFilter'
    EXERCISE_BASIC_OBJECT_METHODS(fractalFilter, StochasticFractalDimensionImageFilter, ImageToImageFilter);
                                                                                        ^
2 errors generated.
```
