### PR TITLE
COMP: Do not enable remote module examples when building Doxygen docs

### DIFF
--- a/CMake/ITKModuleMacros.cmake
+++ b/CMake/ITKModuleMacros.cmake
@@ -337,7 +337,7 @@ macro(itk_module_examples)
   cmake_dependent_option(Module_${itk-module}_BUILD_EXAMPLES
     "Build the examples for Module_${itk-module}"
     ON
-    "BUILD_EXAMPLES OR ITK_BUILD_EXAMPLES;Module_${itk-module}"
+    "BUILD_EXAMPLES OR ITK_BUILD_EXAMPLES;Module_${itk-module};NOT ITK_BUILD_DOCUMENTATION"
     OFF
   )
   if(Module_${itk-module}_BUILD_EXAMPLES)


### PR DESCRIPTION
With CMake 3.20.4, this causes some sort of cache / module enablement
recursion issue resulting in the backtrace:

  CMake Error at CMake/ITKModuleAPI.cmake:78 (message):
    No such module: "ITKIOPNG"
  Call Stack (most recent call first):
    CMake/ITKModuleAPI.cmake:31 (itk_module_load)
    CMake/ITKModuleAPI.cmake:129 (_itk_module_config_recurse)
    /home/kitware/Dashboards/Tests/ITK-build/CMakeTmp/ITKConfig.cmake:47 (itk_module_config)
    Modules/Remote/AnisotropicDiffusionLBR/examples/CMakeLists.txt:5 (find_packag

We do not need the remote module examples for the Doxygen build, so do
not enable them by default in this case.
