### PR TITLE
BUG: Write spatial object color

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -355,6 +355,11 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(Spatial
       currentMeta->ParentID((*it)->GetParent()->GetId());
     }
     currentMeta->Name((*it)->GetProperty().GetName().c_str());
+    currentMeta->Color((*it)->GetProperty().GetRed(),
+                       (*it)->GetProperty().GetGreen(),
+                       (*it)->GetProperty().GetBlue(),
+                       (*it)->GetProperty().GetAlpha());
+
     this->SetTransform(currentMeta, (*it)->GetObjectToParentTransform());
     metaScene->AddObject(currentMeta);
     it++;


### PR DESCRIPTION
The color of a SpatialObject was not being passed to the MetaObject used to write it to disk.  As a result, color info was lost on write.

This is tested in itkTubeTK, but the baselines were incorrect.  Updated baselines in itkTubeTK will verify these changes.