### PR TITLE
ENH: SurfaceSpatialObject templated over point type

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup ITKSpatialObjects
  */
 
-template <unsigned int TDimension = 3>
+template <unsigned int TDimension = 3, class TSpatialObjectPointType = SurfaceSpatialObjectPoint<TDimension>>
 class ITK_TEMPLATE_EXPORT SurfaceSpatialObject
   : public PointBasedSpatialObject<TDimension, SurfaceSpatialObjectPoint<TDimension>>
 {
@@ -43,18 +43,18 @@ public:
   ITK_DISALLOW_COPY_AND_MOVE(SurfaceSpatialObject);
 
   using Self = SurfaceSpatialObject;
-  using Superclass = PointBasedSpatialObject<TDimension, SurfaceSpatialObjectPoint<TDimension>>;
+  using Superclass = PointBasedSpatialObject<TDimension, TSpatialObjectPointType>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
   using ScalarType = double;
 
-  using SurfacePointType = SurfaceSpatialObjectPoint<TDimension>;
+  using SurfacePointType = TSpatialObjectPointType;
   using SurfacePointListType = std::vector<SurfacePointType>;
 
-  using SpatialObjectPointType = typename Superclass::SpatialObjectPointType;
   using PointType = typename Superclass::PointType;
   using TransformType = typename Superclass::TransformType;
+  using SpatialObjectPointType = typename Superclass::SpatialObjectPointType;
   using PointContainerType = VectorContainer<IdentifierType, PointType>;
   using PointContainerPointer = SmartPointer<PointContainerType>;
   using BoundingBoxType = typename Superclass::BoundingBoxType;
@@ -71,9 +71,13 @@ public:
   void
   Clear() override;
 
-  /** Compute the normals to the surface from neighboring points */
+/** Compute the normals to the surface from neighboring points */
+#if !defined(ITK_LEGACY_REMOVE)
+  /** Calculate the normalized tangent - Old spelling of function name */
+  itkLegacyMacro(bool Approximate3DNormals());
+#endif
   bool
-  Approximate3DNormals();
+  ComputeNormals();
 
 protected:
   SurfaceSpatialObject();

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -25,8 +25,8 @@
 namespace itk
 {
 /** Constructor */
-template <unsigned int TDimension>
-SurfaceSpatialObject<TDimension>::SurfaceSpatialObject()
+template <unsigned int TDimension, typename TSurfacePointType>
+SurfaceSpatialObject<TDimension, TSurfacePointType>::SurfaceSpatialObject()
 {
   this->SetTypeName("SurfaceSpatialObject");
 
@@ -35,9 +35,9 @@ SurfaceSpatialObject<TDimension>::SurfaceSpatialObject()
   this->Update();
 }
 
-template <unsigned int TDimension>
+template <unsigned int TDimension, typename TSurfacePointType>
 void
-SurfaceSpatialObject<TDimension>::Clear()
+SurfaceSpatialObject<TDimension, TSurfacePointType>::Clear()
 {
   Superclass::Clear();
 
@@ -50,9 +50,9 @@ SurfaceSpatialObject<TDimension>::Clear()
 }
 
 /** InternalClone */
-template <unsigned int TDimension>
+template <unsigned int TDimension, typename TSurfacePointType>
 typename LightObject::Pointer
-SurfaceSpatialObject<TDimension>::InternalClone() const
+SurfaceSpatialObject<TDimension, TSurfacePointType>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
@@ -68,18 +68,19 @@ SurfaceSpatialObject<TDimension>::InternalClone() const
 }
 
 /** Print the surface object */
-template <unsigned int TDimension>
+template <unsigned int TDimension, typename TSurfacePointType>
 void
-SurfaceSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
+SurfaceSpatialObject<TDimension, TSurfacePointType>::PrintSelf(std::ostream & os, Indent indent) const
 {
   os << indent << "SurfaceSpatialObject(" << this << ")" << std::endl;
   Superclass::PrintSelf(os, indent);
 }
 
+#if !defined(ITK_LEGACY_REMOVE)
 /** Approximate the normals of the surface */
-template <unsigned int TDimension>
+template <unsigned int TDimension, typename TSurfacePointType>
 bool
-SurfaceSpatialObject<TDimension>::Approximate3DNormals()
+SurfaceSpatialObject<TDimension, TSurfacePointType>::Approximate3DNormals()
 {
   if (TDimension != 3)
   {
@@ -219,6 +220,184 @@ SurfaceSpatialObject<TDimension>::Approximate3DNormals()
         normal[1] = cob / absvec;
         normal[2] = coc / absvec;
         (*it).SetNormalInObjectSpace(normal);
+      }
+    } while ((Math::AlmostEquals(absvec, 0.0)) && (badId.size() < this->m_Points.size() - 1));
+
+    if (Math::AlmostEquals(absvec, 0.0))
+    {
+      std::cout << "Approximate3DNormals Failed!" << std::endl;
+      std::cout << identifier[0] << " : " << identifier[1] << " : " << identifier[2] << std::endl;
+      std::cout << badId.size() << " : " << this->m_Points.size() - 1 << std::endl;
+      return false;
+    }
+
+    it++;
+  }
+
+  return true;
+}
+#endif // LEGACY
+
+/** Approximate the normals of the surface */
+template <unsigned int TDimension, typename TSurfacePointType>
+bool
+SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
+{
+  if (this->m_Points.size() < 3)
+  {
+    itkExceptionMacro("Approximate3DNormals requires at least 3 points");
+  }
+
+  typename SurfacePointListType::iterator it = this->m_Points.begin();
+  typename SurfacePointListType::iterator itEnd = this->m_Points.end();
+
+  while (it != itEnd)
+  {
+    // Try to find 3 points close to the corresponding point
+    SurfacePointType pt = *it;
+    PointType        pos = (*it).GetPositionInObjectSpace();
+
+    std::list<int> badId;
+    unsigned int   identifier[3];
+    double         absvec = 0;
+    do
+    {
+      identifier[0] = 0;
+      identifier[1] = 0;
+      identifier[2] = 0;
+
+      float max[3];
+      max[0] = 99999999;
+      max[1] = 99999999;
+      max[2] = 99999999;
+
+      typename SurfacePointListType::const_iterator it2 = this->m_Points.begin();
+
+      int i = 0;
+      while (it2 != this->m_Points.end())
+      {
+        if (it2 == it)
+        {
+          i++;
+          it2++;
+          continue;
+        }
+
+        bool                           badPoint = false;
+        std::list<int>::const_iterator itBadId = badId.begin();
+        while (itBadId != badId.end())
+        {
+          if (*itBadId == i)
+          {
+            badPoint = true;
+            break;
+          }
+          itBadId++;
+        }
+
+        if (badPoint)
+        {
+          i++;
+          it2++;
+          continue;
+        }
+
+        PointType pos2 = (*it2).GetPositionInObjectSpace();
+        float     distance = pos2.EuclideanDistanceTo(pos);
+
+        // Check that the point is not the same as some previously defined
+        bool valid = true;
+        for (auto & j : identifier)
+        {
+          PointType p = this->m_Points[j].GetPositionInObjectSpace();
+          float     d = pos2.EuclideanDistanceTo(p);
+          if (Math::AlmostEquals(d, 0.0f))
+          {
+            valid = false;
+            break;
+          }
+        }
+
+        if (Math::AlmostEquals(distance, 0.0f) || !valid)
+        {
+          i++;
+          it2++;
+          continue;
+        }
+
+        if (distance < max[0])
+        {
+          max[2] = max[1];
+          max[1] = max[0];
+          max[0] = distance;
+          identifier[0] = i;
+        }
+        else if (distance < max[1])
+        {
+          max[2] = max[1];
+          max[1] = distance;
+          identifier[1] = i;
+        }
+        else if (distance < max[2])
+        {
+          max[2] = distance;
+          identifier[2] = i;
+        }
+        i++;
+        it2++;
+      }
+
+      if ((identifier[0] == identifier[1]) || (identifier[1] == identifier[2]) || (identifier[0] == identifier[2]))
+      {
+        std::cout << "Cannot find 3 distinct points!" << std::endl;
+        std::cout << identifier[0] << " : " << identifier[1] << " : " << identifier[2] << std::endl;
+        std::cout << max[0] << " : " << max[1] << " : " << max[2] << std::endl;
+        return false;
+      }
+
+      PointType v1 = this->m_Points[identifier[0]].GetPositionInObjectSpace();
+      PointType v2 = this->m_Points[identifier[1]].GetPositionInObjectSpace();
+      PointType v3 = this->m_Points[identifier[2]].GetPositionInObjectSpace();
+
+      if (TDimension == 3)
+      {
+        double coa = -(v1[1] * (v2[2] - v3[2]) + v2[1] * (v3[2] - v1[2]) + v3[1] * (v1[2] - v2[2]));
+        double cob = -(v1[2] * (v2[0] - v3[0]) + v2[2] * (v3[0] - v1[0]) + v3[2] * (v1[0] - v2[0]));
+        double coc = -(v1[0] * (v2[1] - v3[1]) + v2[0] * (v3[1] - v1[1]) + v3[0] * (v1[1] - v2[1]));
+
+        absvec = -std::sqrt((double)((coa * coa) + (cob * cob) + (coc * coc)));
+
+        if (Math::AlmostEquals(absvec, 0.0))
+        {
+          badId.push_back(identifier[2]);
+        }
+        else
+        {
+          CovariantVectorType normal;
+          normal[0] = coa / absvec;
+          normal[1] = cob / absvec;
+          normal[2] = coc / absvec;
+          (*it).SetNormalInObjectSpace(normal);
+        }
+      }
+      else
+      {
+        double coa = -(v1[1] * (v2[0] - v3[0]) + v2[1] * (v3[0] - v1[0]) + v3[1] * (v1[0] - v2[0]));
+        double cob = -(v1[0] * (v2[1] - v3[1]) + v2[0] * (v3[1] - v1[1]) + v3[0] * (v1[1] - v2[1]));
+
+        absvec = -std::sqrt((double)((coa * coa) + (cob * cob)));
+
+        if (Math::AlmostEquals(absvec, 0.0))
+        {
+          badId.push_back(identifier[2]);
+        }
+        else
+        {
+          CovariantVectorType normal;
+          normal[0] = coa / absvec;
+          normal[1] = cob / absvec;
+          (*it).SetNormalInObjectSpace(normal);
+        }
       }
     } while ((Math::AlmostEquals(absvec, 0.0)) && (badId.size() < this->m_Points.size() - 1));
 


### PR DESCRIPTION
By templating over point type, derived surface classes can specify new point types with additional meta data.  This is the same design patter used for TubeSpatialObjects.

Also, updated the normal computation to work for 2D data, instead of just 3D data, and marked old code as Legacy.