### PR TITLE
ENH: Spatial object const correctness rebase

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -62,6 +62,7 @@ public:
   /** SpatialObject Scene types */
   using SpatialObjectType = itk::SpatialObject<NDimensions>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
+  using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
 
   /** Typedef for auxiliary conversion classes */
   using MetaConverterBaseType = MetaConverterBase<NDimensions>;
@@ -74,10 +75,10 @@ public:
 
   /** write out a SpatialObject */
   bool
-  WriteMeta(SpatialObjectType * soScene,
-            const std::string & fileName,
-            unsigned int        depth = SpatialObjectType::MaximumDepth,
-            const std::string & soName = "");
+  WriteMeta(const SpatialObjectType * soScene,
+            const std::string &       fileName,
+            unsigned int              depth = SpatialObjectType::MaximumDepth,
+            const std::string &       soName = "");
 
   itkGetMacro(Event, MetaEvent *);
   itkSetObjectMacro(Event, MetaEvent);
@@ -108,9 +109,9 @@ public:
                         MetaConverterBaseType * converter);
 
   MetaScene *
-  CreateMetaScene(SpatialObjectType * soScene,
-                  unsigned int        depth = SpatialObjectType::MaximumDepth,
-                  const std::string & name = "");
+  CreateMetaScene(const SpatialObjectType * soScene,
+                  unsigned int              depth = SpatialObjectType::MaximumDepth,
+                  const std::string &       name = "");
 
   SpatialObjectPointer
   CreateSpatialObjectScene(MetaScene * mScene);
@@ -126,7 +127,7 @@ private:
 
   template <typename TConverter>
   MetaObject *
-  SpatialObjectToMetaObject(SpatialObjectPointer & so)
+  SpatialObjectToMetaObject(SpatialObjectConstPointer & so)
   {
     typename TConverter::Pointer converter = TConverter::New();
     // needed just for Image & ImageMask

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -250,9 +250,9 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::ReadMeta(const std::str
 /** Write a meta file give the type */
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
 MetaScene *
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(SpatialObjectType * soScene,
-                                                                         unsigned int        depth,
-                                                                         const std::string & name)
+MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(const SpatialObjectType * soScene,
+                                                                         unsigned int              depth,
+                                                                         const std::string &       name)
 {
   auto * metaScene = new MetaScene(NDimensions);
 
@@ -266,9 +266,9 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(Spatial
   metaScene->ElementSpacing(spacing);
   delete[] spacing;
 
-  using ListType = typename SpatialObjectType::ChildrenListType;
+  using ListType = typename SpatialObjectType::ChildrenConstListType;
 
-  ListType * childrenList = soScene->GetChildren(depth, name);
+  ListType * childrenList = soScene->GetConstChildren(depth, name);
   childrenList->push_front(soScene); // add the top level object to the list
                                      //   to be processed.
 
@@ -368,10 +368,10 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(Spatial
 /** Write a meta file give the type */
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
 bool
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::WriteMeta(SpatialObjectType * soScene,
-                                                                   const std::string & fileName,
-                                                                   unsigned int        depth,
-                                                                   const std::string & soName)
+MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::WriteMeta(const SpatialObjectType * soScene,
+                                                                   const std::string &       fileName,
+                                                                   unsigned int              depth,
+                                                                   const std::string &       soName)
 {
   MetaScene * metaScene = this->CreateMetaScene(soScene, depth, soName);
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -107,9 +107,12 @@ public:
 
   /** Return type for the list of children */
   using ChildrenListType = std::list<Pointer>;
+  using ChildrenConstListType = std::list<ConstPointer>;
   using ChildrenListPointer = ChildrenListType *;
+  using ChildrenConstListPointer = ChildrenConstListType *;
 
   using ObjectListType = std::list<Pointer>;
+  using ObjectConstListType = std::list<ConstPointer>;
 
   using RegionType = ImageRegion<VDimension>;
 
@@ -385,8 +388,16 @@ public:
   virtual ChildrenListType *
   GetChildren(unsigned int depth = 0, const std::string & name = "") const;
 
+  virtual ChildrenConstListType *
+  GetConstChildren(unsigned int depth = 0, const std::string & name = "") const;
+
   virtual void
   AddChildrenToList(ChildrenListType * childrenList, unsigned int depth = 0, const std::string & name = "") const;
+
+  virtual void
+  AddChildrenToConstList(ChildrenConstListType * childrenList,
+                         unsigned int            depth = 0,
+                         const std::string &     name = "") const;
 
   /** Returns the number of children currently assigned to the object. */
   unsigned int

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -783,6 +783,38 @@ SpatialObject<TDimension>::GetChildren(unsigned int depth, const std::string & n
   return childrenSO;
 }
 
+/** Get the children list as const pointers.
+ * User is responsible for freeing the list, but not the elements of
+ * the list. */
+template <unsigned int TDimension>
+typename SpatialObject<TDimension>::ChildrenConstListType *
+SpatialObject<TDimension>::GetConstChildren(unsigned int depth, const std::string & name) const
+{
+  auto * childrenSO = new ChildrenConstListType;
+
+  auto it = m_ChildrenList.begin();
+  while (it != m_ChildrenList.end())
+  {
+    if ((*it)->GetTypeName().find(name) != std::string::npos)
+    {
+      childrenSO->push_back((*it));
+    }
+    it++;
+  }
+
+  if (depth > 0)
+  {
+    it = m_ChildrenList.begin();
+    while (it != m_ChildrenList.end())
+    {
+      (*it)->AddChildrenToConstList(childrenSO, depth - 1, name);
+      it++;
+    }
+  }
+
+  return childrenSO;
+}
+
 template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::AddChildrenToList(ChildrenListType *  childrenList,
@@ -805,6 +837,33 @@ SpatialObject<TDimension>::AddChildrenToList(ChildrenListType *  childrenList,
     while (it != m_ChildrenList.end())
     {
       (*it)->AddChildrenToList(childrenList, depth - 1, name);
+      ++it;
+    }
+  }
+}
+
+template <unsigned int TDimension>
+void
+SpatialObject<TDimension>::AddChildrenToConstList(ChildrenConstListType * childrenList,
+                                                  unsigned int            depth,
+                                                  const std::string &     name) const
+{
+  auto it = m_ChildrenList.begin();
+  while (it != m_ChildrenList.end())
+  {
+    if ((*it)->GetTypeName().find(name) != std::string::npos)
+    {
+      childrenList->push_back((*it));
+    }
+    it++;
+  }
+
+  if (depth > 0)
+  {
+    it = m_ChildrenList.begin();
+    while (it != m_ChildrenList.end())
+    {
+      (*it)->AddChildrenToConstList(childrenList, depth - 1, name);
       ++it;
     }
   }

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -357,8 +357,6 @@ template <unsigned int TDimension>
 typename LightObject::Pointer
 SpatialObject<TDimension>::InternalClone() const
 {
-  // Default implementation just copies the parameters from
-  // this to new transform.
   typename LightObject::Pointer loPtr = CreateAnother();
 
   typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
@@ -366,6 +364,8 @@ SpatialObject<TDimension>::InternalClone() const
   {
     itkExceptionMacro(<< "downcast to type " << this->GetNameOfClass() << " failed.");
   }
+
+  rval->SetTypeName(this->GetTypeName());
   rval->SetId(this->GetId());
   rval->SetParentId(this->GetParentId());
   rval->SetObjectToParentTransform(this->GetObjectToParentTransform());
@@ -844,7 +844,7 @@ SpatialObject<TDimension>::AddChildrenToList(ChildrenListType *  childrenList,
 
 template <unsigned int TDimension>
 void
-SpatialObject<TDimension>::AddChildrenToConstList(ChildrenConstListType * childrenList,
+SpatialObject<TDimension>::AddChildrenToConstList(ChildrenConstListType * childrenCList,
                                                   unsigned int            depth,
                                                   const std::string &     name) const
 {
@@ -853,7 +853,7 @@ SpatialObject<TDimension>::AddChildrenToConstList(ChildrenConstListType * childr
   {
     if ((*it)->GetTypeName().find(name) != std::string::npos)
     {
-      childrenList->push_back((*it));
+      childrenCList->push_back(*it);
     }
     it++;
   }
@@ -863,7 +863,7 @@ SpatialObject<TDimension>::AddChildrenToConstList(ChildrenConstListType * childr
     it = m_ChildrenList.begin();
     while (it != m_ChildrenList.end())
     {
-      (*it)->AddChildrenToConstList(childrenList, depth - 1, name);
+      (*it)->AddChildrenToConstList(childrenCList, depth - 1, name);
       ++it;
     }
   }

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
@@ -58,9 +58,17 @@ public:
   const CovariantVectorType &
   GetNormalInObjectSpace() const;
 
+  /** Get Normal */
+  const CovariantVectorType
+  GetNormalInWorldSpace() const;
+
   /** Set Normal */
   void
   SetNormalInObjectSpace(const CovariantVectorType & normal);
+
+  /** Set Normal */
+  void
+  SetNormalInWorldSpace(const CovariantVectorType & normal);
 
   /** Copy one SurfaceSpatialObjectPoint to another */
   Self &

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -45,12 +45,39 @@ SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInObjectSpace(const Covaria
   m_NormalInObjectSpace = normal;
 }
 
+/** Set the normal : N-D case */
+template <unsigned int TPointDimension>
+void
+SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInWorldSpace(const CovariantVectorType & normal)
+{
+  if (this->m_SpatialObject == nullptr)
+  {
+    itkExceptionMacro(<< "The SpatialObject must be set prior to calling.");
+  }
+
+  m_NormalInObjectSpace =
+    Superclass::m_SpatialObject->GetObjectToWorldTransform()->GetInverseTransform()->TransformCovariantVector(normal);
+}
+
 /** Get the normal at one point */
 template <unsigned int TPointDimension>
 const typename SurfaceSpatialObjectPoint<TPointDimension>::CovariantVectorType &
 SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const
 {
   return m_NormalInObjectSpace;
+}
+
+/** Get the normal at one point */
+template <unsigned int TPointDimension>
+const typename SurfaceSpatialObjectPoint<TPointDimension>::CovariantVectorType
+SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInWorldSpace() const
+{
+  if (this->m_SpatialObject == nullptr)
+  {
+    itkExceptionMacro(<< "The SpatialObject must be set prior to calling.");
+  }
+
+  return Superclass::m_SpatialObject->GetObjectToWorldTransform()->TransformCovariantVector(m_NormalInObjectSpace);
 }
 
 /** Print the object */
@@ -72,7 +99,7 @@ SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObject
   if (this != &rhs)
   {
     Superclass::operator=(rhs);
-    this->m_NormalInObjectSpace = rhs.m_NormalInObjectSpace;
+    this->SetNormalInObjectSpace(rhs.GetNormalInObjectSpace());
   }
   return *this;
 }

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -95,6 +95,12 @@ itkSurfaceSpatialObjectTest(int, char *[])
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
+
+      if (itk::Math::NotExactlyEquals((*it).GetNormalInWorldSpace()[d], d))
+      {
+        std::cout << "[FAILED]" << std::endl;
+        return EXIT_FAILURE;
+      }
     }
     it++;
     i++;
@@ -167,6 +173,15 @@ itkSurfaceSpatialObjectTest(int, char *[])
     VectorType normal;
     normal.Fill(276);
     pOriginal.SetNormalInObjectSpace(normal);
+    for (size_t j = 0; j < 3; ++j)
+    {
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetNormalInWorldSpace()[j], normal[j]));
+    }
+    pOriginal.SetNormalInWorldSpace(normal);
+    for (size_t j = 0; j < 3; ++j)
+    {
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetNormalInObjectSpace()[j], normal[j]));
+    }
 
     // Copy
     SurfacePointType pCopy(pOriginal);
@@ -195,6 +210,8 @@ itkSurfaceSpatialObjectTest(int, char *[])
       {
         ITK_TEST_EXPECT_TRUE(
           itk::Math::AlmostEquals(pOriginal.GetNormalInObjectSpace()[j], pv.GetNormalInObjectSpace()[j]));
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(pOriginal.GetNormalInWorldSpace()[j], pv.GetNormalInObjectSpace()[j]));
       }
     }
   }

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -169,10 +169,20 @@ itkSurfaceSpatialObjectTest(int, char *[])
     pOriginal.SetColor(0.5, 0.4, 0.3, 0.2);
     pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
+
     // itk::SurfaceSpatialObjectPoint
     VectorType normal;
     normal.Fill(276);
     pOriginal.SetNormalInObjectSpace(normal);
+
+    Surface->AddPoint(pOriginal);
+
+    // Must get a copy of the added point. Each point contains a pointer
+    //   to the spatial object that it is a part of.  That assignment is
+    //   needed to determine the WorldSpace of the point - which is defined
+    //   by the tree of spatial objects it is a part of.
+    pOriginal = Surface->GetPoints().back();
+
     for (size_t j = 0; j < 3; ++j)
     {
       ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetNormalInWorldSpace()[j], normal[j]));

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
@@ -46,6 +46,7 @@ public:
 
   using SpatialObjectType = SpatialObject<NDimensions>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
+  using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
 
   /** base type for MetaConverters -- bidirections conversion btw
    *  SpatialObject & MetaObject
@@ -71,7 +72,7 @@ public:
 
   /** Set the Input  */
   void
-  SetInput(SpatialObjectType * input)
+  SetInput(const SpatialObjectType * input)
   {
     m_SpatialObject = input;
   }
@@ -104,7 +105,7 @@ protected:
   ~SpatialObjectWriter() override = default;
 
 private:
-  SpatialObjectPointer m_SpatialObject;
+  SpatialObjectConstPointer m_SpatialObject;
 
   typename MetaSceneConverterType::Pointer m_MetaToSpatialConverter;
 };


### PR DESCRIPTION
1. Extends itkSpatialObject and derived classes to include a method GetConstChildren() that is similar to GetChildren(), but is a const function and returns a list of const objects.

2. Corrects SpatialObject's MetaSceneConverter to accept const pointer to the spatialobject to be written. The MetaSceneConverter then uses the new GetConstChildren() member function of spatial objects to preserve const-ness as it writes the objects.

3. Updates SurfaceSpatialObject to have get/set member functions for setting a SurfacePoint's Normal in world space.

4. Updates SpatialObjectWriter to accept a const pointer - used by MetaSceneConverter that was also updated.

5. Updated tests for SpatialObjects to verify use of Surface normals in world space.