### PR TITLE
STYLE: TransformInitializers constructors = default; default-member-init

### DIFF
--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
@@ -99,7 +99,7 @@ public:
   InitializeTransform() const;
 
 protected:
-  BSplineTransformInitializer();
+  BSplineTransformInitializer() = default;
   ~BSplineTransformInitializer() override = default;
 
   void
@@ -109,7 +109,7 @@ private:
   ImagePointer     m_Image;
   TransformPointer m_Transform;
 
-  MeshSizeType m_TransformDomainMeshSize;
+  MeshSizeType m_TransformDomainMeshSize{ MeshSizeType::Filled(1) };
   bool         m_SetTransformDomainMeshSizeViaInitializer{ false };
 
 }; // class BSplineTransformInitializer

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -28,14 +28,6 @@ namespace itk
 {
 
 template <typename TTransform, typename TImage>
-BSplineTransformInitializer<TTransform, TImage>::BSplineTransformInitializer()
-  : m_Transform(nullptr)
-
-{
-  this->m_TransformDomainMeshSize.Fill(1);
-}
-
-template <typename TTransform, typename TImage>
 void
 BSplineTransformInitializer<TTransform, TImage>::SetTransformDomainMeshSize(const MeshSizeType meshSize)
 {

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.h
@@ -137,7 +137,7 @@ public:
   itkGetModifiableObjectMacro(MovingCalculator, MovingImageCalculatorType);
 
 protected:
-  CenteredTransformInitializer();
+  CenteredTransformInitializer() = default;
   ~CenteredTransformInitializer() override = default;
 
   void
@@ -152,10 +152,10 @@ private:
 
   MovingImagePointer m_MovingImage;
 
-  bool m_UseMoments;
+  bool m_UseMoments{ false };
 
-  FixedImageCalculatorPointer  m_FixedCalculator;
-  MovingImageCalculatorPointer m_MovingCalculator;
+  const FixedImageCalculatorPointer  m_FixedCalculator{ FixedImageCalculatorType::New() };
+  const MovingImageCalculatorPointer m_MovingCalculator{ MovingImageCalculatorType::New() };
 }; // class CenteredTransformInitializer
 } // namespace itk
 

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
@@ -23,14 +23,6 @@
 namespace itk
 {
 template <typename TTransform, typename TFixedImage, typename TMovingImage>
-CenteredTransformInitializer<TTransform, TFixedImage, TMovingImage>::CenteredTransformInitializer()
-{
-  m_FixedCalculator = FixedImageCalculatorType::New();
-  m_MovingCalculator = MovingImageCalculatorType::New();
-  m_UseMoments = false;
-}
-
-template <typename TTransform, typename TFixedImage, typename TMovingImage>
 void
 CenteredTransformInitializer<TTransform, TFixedImage, TMovingImage>::InitializeTransform()
 {

--- a/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.h
@@ -98,7 +98,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool m_ComputeRotation;
+  bool m_ComputeRotation{ false };
 }; // class CenteredVersorTransformInitializer
 } // namespace itk
 

--- a/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.hxx
@@ -28,8 +28,6 @@ CenteredVersorTransformInitializer<TFixedImage, TMovingImage>::CenteredVersorTra
   // Force to use Moments computation since we need here the second
   // order moments in order to estimate a rotation
   this->Superclass::MomentsOn();
-
-  this->m_ComputeRotation = false;
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
@@ -178,7 +178,7 @@ public:
   InitializeTransform();
 
 protected:
-  LandmarkBasedTransformInitializer();
+  LandmarkBasedTransformInitializer() = default;
   ~LandmarkBasedTransformInitializer() override = default;
 
   void

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -27,16 +27,6 @@
 
 namespace itk
 {
-template <typename TTransform, typename TFixedImage, typename TMovingImage>
-LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::LandmarkBasedTransformInitializer()
-  : m_ReferenceImage(nullptr)
-  , m_Transform(nullptr)
-  , m_FixedLandmarks(0)
-  , m_MovingLandmarks(0)
-  , m_LandmarkWeight(0)
-
-{}
-
 /** default transform initializer, if transform type isn't
  * specifically handled.
  */

--- a/Modules/Registration/Common/test/CMakeLists.txt
+++ b/Modules/Registration/Common/test/CMakeLists.txt
@@ -226,6 +226,11 @@ itk_add_test(NAME itkEuclideanDistancePointMetricTestSquaredDistanceOff
 itk_add_test(NAME itkEuclideanDistancePointMetricTestSquaredDistanceOn
       COMMAND ITKRegistrationCommonTestDriver itkEuclideanDistancePointMetricTest 1)
 
+set(ITKRegistrationGTests
+  itkTransformInitializersGTest.cxx
+)
+CreateGoogleTestDriver(ITKRegistration "${ITKRegistrationCommon-Test_LIBRARIES}" "${ITKRegistrationGTests}")
+
 if(BUILD_EXAMPLES)
 #The historical examples from RegistrationITKv3 should no longer be used
 #as exemplars for best practices, but do provide reasonable historically

--- a/Modules/Registration/Common/test/itkTransformInitializersGTest.cxx
+++ b/Modules/Registration/Common/test/itkTransformInitializersGTest.cxx
@@ -1,0 +1,74 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header files to be tested:
+#include "itkBSplineTransformInitializer.h"
+#include "itkCenteredTransformInitializer.h"
+#include "itkCenteredVersorTransformInitializer.h"
+
+#include "itkBSplineTransform.h"
+#include "itkEuler2DTransform.h"
+
+#include <gtest/gtest.h>
+
+
+// Checks an object created by BSplineTransformInitializer::New().
+TEST(TransformInitializers, CheckNewBSplineTransformInitializer)
+{
+  using TransformType = itk::BSplineTransform<>;
+  using ImageType = itk::Image<int, TransformType::SpaceDimension>;
+  const auto transformInitializer = itk::BSplineTransformInitializer<TransformType, ImageType>::New();
+
+  ASSERT_NE(transformInitializer, nullptr);
+
+  EXPECT_EQ(transformInitializer->GetImage(), nullptr);
+  EXPECT_EQ(transformInitializer->GetTransform(), nullptr);
+
+  for (const auto sizeValue : transformInitializer->GetTransformDomainMeshSize())
+  {
+    EXPECT_EQ(sizeValue, 1);
+  }
+}
+
+
+// Checks an object created by CenteredTransformInitializer::New().
+TEST(TransformInitializers, CheckNewCenteredTransformInitializer)
+{
+  using TransformType = itk::Euler2DTransform<>;
+  using ImageType = itk::Image<int, TransformType::SpaceDimension>;
+  const auto transformInitializer = itk::CenteredTransformInitializer<TransformType, ImageType, ImageType>::New();
+
+  ASSERT_NE(transformInitializer, nullptr);
+
+  EXPECT_NE(transformInitializer->GetFixedCalculator(), nullptr);
+  EXPECT_NE(transformInitializer->GetMovingCalculator(), nullptr);
+}
+
+
+// Checks an object created by CenteredVersorTransformInitializer::New().
+TEST(TransformInitializers, CheckNewCenteredVersorTransformInitializer)
+{
+  using ImageType = itk::Image<int, 3>;
+  const auto transformInitializer = itk::CenteredVersorTransformInitializer<ImageType, ImageType>::New();
+
+  ASSERT_NE(transformInitializer, nullptr);
+
+  EXPECT_NE(transformInitializer->GetFixedCalculator(), nullptr);
+  EXPECT_NE(transformInitializer->GetMovingCalculator(), nullptr);
+  EXPECT_FALSE(transformInitializer->GetComputeRotation());
+}


### PR DESCRIPTION
Declared the default-constructors of `BSplineTransformInitializer`,
`CenteredTransformInitializer`, and `LandmarkBasedTransformInitializer`
by `= default`.

Initialized data members of `TransformInitializer` classes by in-class
default-member-initializers.

Added itkTransformInitializersGTest.cxx to check that `New()` still
properly initializes a `TransformInitializer`, as it did before.
