### PR TITLE
COMP: Use mallinfo2 when available

### DIFF
--- a/Modules/Core/Common/CMake/itkCheckHasMallinfo2.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasMallinfo2.cxx
@@ -1,0 +1,16 @@
+#include <malloc.h>
+
+int
+main()
+{
+  /** Test whether mallinfo is available. This depends on the C library
+   * implementation. */
+
+  struct mallinfo2 minfo = mallinfo2();
+
+  if (minfo.uordblks > 0)
+  {
+    return 0;
+  }
+  return 1;
+}

--- a/Modules/Core/Common/CMakeLists.txt
+++ b/Modules/Core/Common/CMakeLists.txt
@@ -72,6 +72,11 @@ try_compile(ITK_HAS_MALLINFO
   ${CMAKE_CURRENT_SOURCE_DIR}/CMake/itkCheckHasMallinfo.cxx
   )
 
+try_compile(ITK_HAS_MALLINFO2
+  ${ITK_BINARY_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/CMake/itkCheckHasMallinfo2.cxx
+  )
+
 try_compile(ITK_HAS_FEENABLEEXCEPT
   ${ITK_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/CMake/itkCheckHasFeenableexcept.cxx

--- a/Modules/Core/Common/include/itkMemoryUsageObserver.h
+++ b/Modules/Core/Common/include/itkMemoryUsageObserver.h
@@ -124,7 +124,7 @@ public:
   GetMemoryUsage() override;
 };
 
-#  if defined(ITK_HAS_MALLINFO)
+#  if defined(ITK_HAS_MALLINFO) || defined(ITK_HAS_MALLINFO2)
 /** \class MallinfoMemoryUsageObserver
  * \brief The MallinfoMemoryUsageObserver
  * \ingroup ITKCommon

--- a/Modules/Core/Common/src/itkConfigure.h.in
+++ b/Modules/Core/Common/src/itkConfigure.h.in
@@ -104,6 +104,8 @@
 
 // defined if the C library as the mallinfo struct
 #cmakedefine ITK_HAS_MALLINFO
+// defined if the C library as the mallinfo2 struct
+#cmakedefine ITK_HAS_MALLINFO2
 // defined if feenableexcept is available
 #cmakedefine ITK_HAS_FEENABLEEXCEPT
 

--- a/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
+++ b/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
@@ -33,7 +33,7 @@
 
 #if !defined(WIN32) && !defined(_WIN32)
 #  include <sys/resource.h> // getrusage()
-#  if defined(ITK_HAS_MALLINFO)
+#  if defined(ITK_HAS_MALLINFO) || defined(ITK_HAS_MALLINFO2)
 #    include <malloc.h> // mallinfo()
 #  endif                // ITK_HAS_MALLINFO
 #endif                  // !defined(WIN32) && !defined(_WIN32)
@@ -438,7 +438,24 @@ SysResourceMemoryUsageObserver::GetMemoryUsage()
   return 0;
 }
 
-#  if defined(ITK_HAS_MALLINFO)
+#  if defined(ITK_HAS_MALLINFO2)
+
+/**         ----         Mallinfo Memory Usage Observer       ----       */
+
+MallinfoMemoryUsageObserver::~MallinfoMemoryUsageObserver() = default;
+
+MemoryUsageObserverBase::MemoryLoadType
+MallinfoMemoryUsageObserver::GetMemoryUsage()
+{
+  struct mallinfo2 minfo = mallinfo2();
+
+  auto mem = static_cast<MemoryLoadType>(static_cast<double>(minfo.uordblks) / 1024.0);
+
+  return mem;
+}
+
+// No mallinfo2, fallback to mallinfo
+#  elif defined(ITK_HAS_MALLINFO)
 
 /**         ----         Mallinfo Memory Usage Observer       ----       */
 


### PR DESCRIPTION
To address:

  [2026/8057] Building CXX object Modules/Core/Common/src/CMakeFiles/ITKCommon.dir/itkMemoryUsageObserver.cxx.o
  /home/matt/src/ITK/Modules/Core/Common/src/itkMemoryUsageObserver.cxx: In member function ‘virtual itk::MemoryUsageObserverBase::MemoryLoadType itk::MallinfoMemoryUsageObserver::GetMemoryUsage()’:
  /home/matt/src/ITK/Modules/Core/Common/src/itkMemoryUsageObserver.cxx:450:36: warning: ‘mallinfo mallinfo()’ is deprecated [-Wdeprecated-declarations]
    450 |   struct mallinfo minfo = mallinfo();
	|                                    ^
  In file included from /home/matt/src/ITK/Modules/Core/Common/src/itkMemoryUsageObserver.cxx:37:
  /usr/include/malloc.h:118:24: note: declared here
    118 | extern struct mallinfo mallinfo (void) __THROW __MALLOC_DEPRECATED;
	|                        ^~~~~~~~
