### PR TITLE
COMP: Update SpatialObjects to correct const-ness

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -62,6 +62,7 @@ public:
   /** SpatialObject Scene types */
   using SpatialObjectType = itk::SpatialObject<NDimensions>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
+  using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
 
   /** Typedef for auxiliary conversion classes */
   using MetaConverterBaseType = MetaConverterBase<NDimensions>;
@@ -74,10 +75,10 @@ public:
 
   /** write out a SpatialObject */
   bool
-  WriteMeta(SpatialObjectType * soScene,
-            const std::string & fileName,
-            unsigned int        depth = SpatialObjectType::MaximumDepth,
-            const std::string & soName = "");
+  WriteMeta(const SpatialObjectType * soScene,
+            const std::string &       fileName,
+            unsigned int              depth = SpatialObjectType::MaximumDepth,
+            const std::string &       soName = "");
 
   itkGetMacro(Event, MetaEvent *);
   itkSetObjectMacro(Event, MetaEvent);
@@ -108,9 +109,9 @@ public:
                         MetaConverterBaseType * converter);
 
   MetaScene *
-  CreateMetaScene(SpatialObjectType * soScene,
-                  unsigned int        depth = SpatialObjectType::MaximumDepth,
-                  const std::string & name = "");
+  CreateMetaScene(const SpatialObjectType * soScene,
+                  unsigned int              depth = SpatialObjectType::MaximumDepth,
+                  const std::string &       name = "");
 
   SpatialObjectPointer
   CreateSpatialObjectScene(MetaScene * mScene);
@@ -126,7 +127,7 @@ private:
 
   template <typename TConverter>
   MetaObject *
-  SpatialObjectToMetaObject(SpatialObjectPointer & so)
+  SpatialObjectToMetaObject(SpatialObjectConstPointer & so)
   {
     typename TConverter::Pointer converter = TConverter::New();
     // needed just for Image & ImageMask

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -250,9 +250,9 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::ReadMeta(const std::str
 /** Write a meta file give the type */
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
 MetaScene *
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(SpatialObjectType * soScene,
-                                                                         unsigned int        depth,
-                                                                         const std::string & name)
+MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(const SpatialObjectType * soScene,
+                                                                         unsigned int              depth,
+                                                                         const std::string &       name)
 {
   auto * metaScene = new MetaScene(NDimensions);
 
@@ -266,9 +266,9 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(Spatial
   metaScene->ElementSpacing(spacing);
   delete[] spacing;
 
-  using ListType = typename SpatialObjectType::ChildrenListType;
+  using ListType = typename SpatialObjectType::ChildrenConstListType;
 
-  ListType * childrenList = soScene->GetChildren(depth, name);
+  ListType * childrenList = soScene->GetConstChildren(depth, name);
   childrenList->push_front(soScene); // add the top level object to the list
                                      //   to be processed.
 
@@ -373,10 +373,10 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(Spatial
 /** Write a meta file give the type */
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
 bool
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::WriteMeta(SpatialObjectType * soScene,
-                                                                   const std::string & fileName,
-                                                                   unsigned int        depth,
-                                                                   const std::string & soName)
+MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::WriteMeta(const SpatialObjectType * soScene,
+                                                                   const std::string &       fileName,
+                                                                   unsigned int              depth,
+                                                                   const std::string &       soName)
 {
   MetaScene * metaScene = this->CreateMetaScene(soScene, depth, soName);
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -107,9 +107,12 @@ public:
 
   /** Return type for the list of children */
   using ChildrenListType = std::list<Pointer>;
+  using ChildrenConstListType = std::list<ConstPointer>;
   using ChildrenListPointer = ChildrenListType *;
+  using ChildrenConstListPointer = ChildrenConstListType *;
 
   using ObjectListType = std::list<Pointer>;
+  using ObjectConstListType = std::list<ConstPointer>;
 
   using RegionType = ImageRegion<VDimension>;
 
@@ -385,8 +388,16 @@ public:
   virtual ChildrenListType *
   GetChildren(unsigned int depth = 0, const std::string & name = "") const;
 
+  virtual ChildrenConstListType *
+  GetConstChildren(unsigned int depth = 0, const std::string & name = "") const;
+
   virtual void
   AddChildrenToList(ChildrenListType * childrenList, unsigned int depth = 0, const std::string & name = "") const;
+
+  virtual void
+  AddChildrenToConstList(ChildrenConstListType * childrenList,
+                         unsigned int            depth = 0,
+                         const std::string &     name = "") const;
 
   /** Returns the number of children currently assigned to the object. */
   unsigned int

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
@@ -58,9 +58,17 @@ public:
   const CovariantVectorType &
   GetNormalInObjectSpace() const;
 
+  /** Get Normal */
+  const CovariantVectorType
+  GetNormalInWorldSpace() const;
+
   /** Set Normal */
   void
   SetNormalInObjectSpace(const CovariantVectorType & normal);
+
+  /** Set Normal */
+  void
+  SetNormalInWorldSpace(const CovariantVectorType & normal);
 
   /** Copy one SurfaceSpatialObjectPoint to another */
   Self &

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -45,12 +45,39 @@ SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInObjectSpace(const Covaria
   m_NormalInObjectSpace = normal;
 }
 
+/** Set the normal : N-D case */
+template <unsigned int TPointDimension>
+void
+SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInWorldSpace(const CovariantVectorType & normal)
+{
+  if (this->m_SpatialObject == nullptr)
+  {
+    itkExceptionMacro(<< "The SpatialObject must be set prior to calling.");
+  }
+
+  m_NormalInObjectSpace =
+    Superclass::m_SpatialObject->GetObjectToWorldTransform()->GetInverseTransform()->TransformCovariantVector(normal);
+}
+
 /** Get the normal at one point */
 template <unsigned int TPointDimension>
 const typename SurfaceSpatialObjectPoint<TPointDimension>::CovariantVectorType &
 SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const
 {
   return m_NormalInObjectSpace;
+}
+
+/** Get the normal at one point */
+template <unsigned int TPointDimension>
+const typename SurfaceSpatialObjectPoint<TPointDimension>::CovariantVectorType
+SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInWorldSpace() const
+{
+  if (this->m_SpatialObject == nullptr)
+  {
+    itkExceptionMacro(<< "The SpatialObject must be set prior to calling.");
+  }
+
+  return Superclass::m_SpatialObject->GetObjectToWorldTransform()->TransformCovariantVector(m_NormalInObjectSpace);
 }
 
 /** Print the object */
@@ -72,7 +99,7 @@ SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObject
   if (this != &rhs)
   {
     Superclass::operator=(rhs);
-    this->m_NormalInObjectSpace = rhs.m_NormalInObjectSpace;
+    this->SetNormalInObjectSpace(rhs.GetNormalInObjectSpace());
   }
   return *this;
 }

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -95,6 +95,12 @@ itkSurfaceSpatialObjectTest(int, char *[])
         std::cout << "[FAILED]" << std::endl;
         return EXIT_FAILURE;
       }
+
+      if (itk::Math::NotExactlyEquals((*it).GetNormalInWorldSpace()[d], d))
+      {
+        std::cout << "[FAILED]" << std::endl;
+        return EXIT_FAILURE;
+      }
     }
     it++;
     i++;
@@ -163,10 +169,29 @@ itkSurfaceSpatialObjectTest(int, char *[])
     pOriginal.SetColor(0.5, 0.4, 0.3, 0.2);
     pOriginal.SetPositionInObjectSpace(42, 41, 43);
 
+
     // itk::SurfaceSpatialObjectPoint
     VectorType normal;
     normal.Fill(276);
     pOriginal.SetNormalInObjectSpace(normal);
+
+    Surface->AddPoint(pOriginal);
+
+    // Must get a copy of the added point. Each point contains a pointer
+    //   to the spatial object that it is a part of.  That assignment is
+    //   needed to determine the WorldSpace of the point - which is defined
+    //   by the tree of spatial objects it is a part of.
+    pOriginal = Surface->GetPoints().back();
+
+    for (size_t j = 0; j < 3; ++j)
+    {
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetNormalInWorldSpace()[j], normal[j]));
+    }
+    pOriginal.SetNormalInWorldSpace(normal);
+    for (size_t j = 0; j < 3; ++j)
+    {
+      ITK_TEST_EXPECT_TRUE(itk::Math::AlmostEquals(pOriginal.GetNormalInObjectSpace()[j], normal[j]));
+    }
 
     // Copy
     SurfacePointType pCopy(pOriginal);
@@ -195,6 +220,8 @@ itkSurfaceSpatialObjectTest(int, char *[])
       {
         ITK_TEST_EXPECT_TRUE(
           itk::Math::AlmostEquals(pOriginal.GetNormalInObjectSpace()[j], pv.GetNormalInObjectSpace()[j]));
+        ITK_TEST_EXPECT_TRUE(
+          itk::Math::AlmostEquals(pOriginal.GetNormalInWorldSpace()[j], pv.GetNormalInObjectSpace()[j]));
       }
     }
   }

--- a/Modules/Core/SpatialObjects/wrapping/itkSpatialObjectBase.wrap
+++ b/Modules/Core/SpatialObjects/wrapping/itkSpatialObjectBase.wrap
@@ -1,7 +1,7 @@
 itk_wrap_include("itkSpatialObject.h")
 itk_wrap_simple_class("itk::MetaEvent")
 
-itk_wrap_class("itk::SpatialObject" POINTER_WITH_EXPLICIT_SPECIALIZATION)
+itk_wrap_class("itk::SpatialObject" POINTER_WITH_CONST_POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     itk_wrap_template("${d}" "${d}")
   endforeach()

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
@@ -46,6 +46,7 @@ public:
 
   using SpatialObjectType = SpatialObject<NDimensions>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
+  using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
 
   /** base type for MetaConverters -- bidirections conversion btw
    *  SpatialObject & MetaObject
@@ -71,7 +72,7 @@ public:
 
   /** Set the Input  */
   void
-  SetInput(SpatialObjectType * input)
+  SetInput(const SpatialObjectType * input)
   {
     m_SpatialObject = input;
   }
@@ -104,7 +105,7 @@ protected:
   ~SpatialObjectWriter() override = default;
 
 private:
-  SpatialObjectPointer m_SpatialObject;
+  SpatialObjectConstPointer m_SpatialObject;
 
   typename MetaSceneConverterType::Pointer m_MetaToSpatialConverter;
 };


### PR DESCRIPTION

SpatialObjects can now return a const list of their children, and SpatialObjectWriter accepts a const object.

Furthermore, updated test...A spatial object point has a position in object space, but until it is added to a spatial object (which potentially exists in a hierarchy of objects with parent/child transforms) the point does not have a position in world space.  So, the test has been updated to add a point to an object before asking for that point's world space position.