### PR TITLE
COMP: a method should not return an integer instead of an std::string

### DIFF
--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5PropList.cpp
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5PropList.cpp
@@ -555,7 +555,7 @@ H5std_string PropList::getClassName() const
         return(class_name);
     }
     else
-        return 0;
+        return "";
 }
 //--------------------------------------------------------------------------
 // Function:    PropList::getNumProps


### PR DESCRIPTION
Ref #2640.

Error message from MSVC with C++23 enabled:

F:\gitP\InsightSoftwareConsortium\ITK\Modules\ThirdParty\HDF5\src\itkhdf5\c++\src\H5PropList.cpp(558,1): error C2440: 'return': cannot convert from 'int' to 'std::basic_string<char,std::char_traits,std::allocator>' [F:\gitP\InsightSoftwareConsortium\ITK\build_x86\Modules\ThirdParty\HDF5\src\itkhdf5\c++\src\hdf5_cpp-static.vcxproj]

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

