### PR TITLE
numpy 1.21.1 testing

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -31,7 +31,7 @@ jobs:
 
     - bash: |
         set -x
-        python3 -m pip install ninja numpy==1.20.3 typing-extensions
+        python3 -m pip install ninja numpy>=1.20 typing-extensions
         python3 -m pip install --upgrade setuptools
         python3 -m pip install lxml scikit-ci-addons dask distributed
       displayName: 'Install dependencies'

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -26,7 +26,8 @@ jobs:
 
     - bash: |
         set -x
-        sudo pip3 install ninja numpy==1.20.3 typing-extensions
+        sudo pip3 install ninja numpy
+        sudo pip3 install ninja numpy>=1.20 typing-extensions
         sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install scikit-ci-addons
         sudo python3 -m pip install lxml dask distributed

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -28,7 +28,7 @@ jobs:
         architecture: 'x64'
 
     - script: |
-        python -m pip install ninja numpy==1.20.3 typing-extensions
+        python -m pip install ninja numpy>=1.20 typing-extensions
         python -m pip install --upgrade setuptools
         python -m pip install scikit-ci-addons dask distributed lxml
       displayName: 'Install dependencies'


### PR DESCRIPTION
- COMP: Revert "COMP: Use numpy==1.20.3 for CI testing". Closes #2613.
