### PR TITLE
COMP: Add missing template export macro to SLICImageFilter

### DIFF
--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
@@ -58,7 +58,7 @@ namespace itk
  * \ingroup Segmentation ITKSuperPixel MultiThreading
  */
 template <typename TInputImage, typename TOutputImage, typename TDistancePixel = float>
-class SLICImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT SLICImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SLICImageFilter);


### PR DESCRIPTION
Addresses visibility issues when building on macOS / static, e.g. with
the Python wrappings.
