### PR TITLE
COMP: Add ITK_TEMPLATE_EXPORT to some class declarations.

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkInOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkInOrderTreeIterator.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 template <typename TTreeType>
-class InOrderTreeIterator : public TreeIteratorBase<TTreeType>
+class ITK_TEMPLATE_EXPORT InOrderTreeIterator : public TreeIteratorBase<TTreeType>
 {
 public:
   /** Typedefs */

--- a/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPostOrderTreeIterator.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 template <typename TTreeType>
-class PostOrderTreeIterator : public TreeIteratorBase<TTreeType>
+class ITK_TEMPLATE_EXPORT PostOrderTreeIterator : public TreeIteratorBase<TTreeType>
 {
 public:
   /** Typedefs */

--- a/Modules/Compatibility/Deprecated/include/itkPreOrderTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkPreOrderTreeIterator.h
@@ -27,7 +27,7 @@ template <typename TTreeType>
 class ITK_TEMPLATE_EXPORT LeafTreeIterator;
 
 template <typename TTreeType>
-class PreOrderTreeIterator : public TreeIteratorBase<TTreeType>
+class ITK_TEMPLATE_EXPORT PreOrderTreeIterator : public TreeIteratorBase<TTreeType>
 {
 public:
   /** Typedefs */

--- a/Modules/Compatibility/Deprecated/include/itkRootTreeIterator.h
+++ b/Modules/Compatibility/Deprecated/include/itkRootTreeIterator.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 template <typename TTreeType>
-class RootTreeIterator : public TreeIteratorBase<TTreeType>
+class ITK_TEMPLATE_EXPORT RootTreeIterator : public TreeIteratorBase<TTreeType>
 {
 public:
   /** Typedefs */

--- a/Modules/Compatibility/Deprecated/include/itkTreeChangeEvent.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeChangeEvent.h
@@ -94,7 +94,7 @@ protected:
  * \ingroup ITKDeprecated
  */
 template <typename TTreeType>
-class TreeNodeChangeEvent : public TreeChangeEvent<TTreeType>
+class ITK_TEMPLATE_EXPORT TreeNodeChangeEvent : public TreeChangeEvent<TTreeType>
 {
 public:
   using Self = TreeNodeChangeEvent;

--- a/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <unsigned int VSplineOrder = 3, typename TRealValueType = double>
-class BSplineDerivativeKernelFunction : public KernelFunctionBase<TRealValueType>
+class ITK_TEMPLATE_EXPORT BSplineDerivativeKernelFunction : public KernelFunctionBase<TRealValueType>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineDerivativeKernelFunction);

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -43,7 +43,7 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TCoordRep = double, unsigned int VIndexDimension = 2>
-class ContinuousIndex : public Point<TCoordRep, VIndexDimension>
+class ITK_TEMPLATE_EXPORT ContinuousIndex : public Point<TCoordRep, VIndexDimension>
 {
   static_assert(std::is_floating_point<TCoordRep>::value,
                 "The coordinates of a continuous index must be represented by floating point numbers.");

--- a/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
+++ b/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
@@ -138,7 +138,7 @@ ExtractImageFilterCopyRegion(const typename BinaryUnsignedIntDispatch<T1, T2>::F
  * \ingroup ITKCommon
  */
 template <unsigned int T1, unsigned int T2>
-class ExtractImageFilterRegionCopier : public ImageRegionCopier<T1, T2>
+class ITK_TEMPLATE_EXPORT ExtractImageFilterRegionCopier : public ImageRegionCopier<T1, T2>
 {
 public:
   virtual void

--- a/Modules/Core/Common/include/itkGaussianKernelFunction.h
+++ b/Modules/Core/Common/include/itkGaussianKernelFunction.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TRealValueType = double>
-class GaussianKernelFunction : public KernelFunctionBase<TRealValueType>
+class ITK_TEMPLATE_EXPORT GaussianKernelFunction : public KernelFunctionBase<TRealValueType>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GaussianKernelFunction);

--- a/Modules/Core/Common/include/itkHeavisideStepFunctionBase.h
+++ b/Modules/Core/Common/include/itkHeavisideStepFunctionBase.h
@@ -48,7 +48,7 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TInput = float, typename TOutput = double>
-class HeavisideStepFunctionBase : public FunctionBase<TInput, TOutput>
+class ITK_TEMPLATE_EXPORT HeavisideStepFunctionBase : public FunctionBase<TInput, TOutput>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(HeavisideStepFunctionBase);

--- a/Modules/Core/Common/include/itkKernelFunctionBase.h
+++ b/Modules/Core/Common/include/itkKernelFunctionBase.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TRealValueType = double>
-class KernelFunctionBase : public FunctionBase<TRealValueType, TRealValueType>
+class ITK_TEMPLATE_EXPORT KernelFunctionBase : public FunctionBase<TRealValueType, TRealValueType>
 {
 public:
   /** Standard class type aliases. */

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
@@ -44,7 +44,7 @@ namespace itk
  * \ingroup ITKGPUFiniteDifference
  **/
 template <typename TImageType>
-class GPUFiniteDifferenceFunction : public FiniteDifferenceFunction<TImageType>
+class ITK_TEMPLATE_EXPORT GPUFiniteDifferenceFunction : public FiniteDifferenceFunction<TImageType>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GPUFiniteDifferenceFunction);

--- a/Modules/Core/ImageAdaptors/include/itkAddImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAddImageAdaptor.h
@@ -34,7 +34,8 @@ namespace itk
  * \ingroup ITKImageAdaptors
  */
 template <typename TImage>
-class AddImageAdaptor : public ImageAdaptor<TImage, Accessor::AddPixelAccessor<typename TImage::PixelType>>
+class ITK_TEMPLATE_EXPORT AddImageAdaptor
+  : public ImageAdaptor<TImage, Accessor::AddPixelAccessor<typename TImage::PixelType>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AddImageAdaptor);

--- a/Modules/Core/ImageAdaptors/include/itkNthElementImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementImageAdaptor.h
@@ -55,7 +55,7 @@ public:
 };
 
 template <typename TImage, typename TOutputPixelType>
-class NthElementImageAdaptor : public NthElementImageAdaptorHelper<TImage, TOutputPixelType>::Super
+class ITK_TEMPLATE_EXPORT NthElementImageAdaptor : public NthElementImageAdaptorHelper<TImage, TOutputPixelType>::Super
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NthElementImageAdaptor);

--- a/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
@@ -38,7 +38,8 @@ namespace itk
  * \ingroup ITKImageFunction
  */
 template <typename TInputImage, typename TCoordRep = float>
-class NearestNeighborExtrapolateImageFunction : public ExtrapolateImageFunction<TInputImage, TCoordRep>
+class ITK_TEMPLATE_EXPORT NearestNeighborExtrapolateImageFunction
+  : public ExtrapolateImageFunction<TInputImage, TCoordRep>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NearestNeighborExtrapolateImageFunction);

--- a/Modules/Core/ImageFunction/include/itkVectorNearestNeighborInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorNearestNeighborInterpolateImageFunction.h
@@ -40,7 +40,8 @@ namespace itk
  * \ingroup ITKImageFunction
  */
 template <typename TInputImage, typename TCoordRep = double>
-class VectorNearestNeighborInterpolateImageFunction : public VectorInterpolateImageFunction<TInputImage, TCoordRep>
+class ITK_TEMPLATE_EXPORT VectorNearestNeighborInterpolateImageFunction
+  : public VectorInterpolateImageFunction<TInputImage, TCoordRep>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorNearestNeighborInterpolateImageFunction);

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -262,7 +262,7 @@ template <typename TInputImage,
           typename TWindowFunction = Function::HammingWindowFunction<VRadius>,
           class TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TInputImage, TInputImage>,
           class TCoordRep = double>
-class WindowedSincInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordRep>
+class ITK_TEMPLATE_EXPORT WindowedSincInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordRep>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(WindowedSincInterpolateImageFunction);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -227,7 +227,7 @@ protected:
  * \ingroup ITKQuadEdgeMesh
  */
 template <typename TQuadEdge>
-class QuadEdgeMeshIterator : public QuadEdgeMeshBaseIterator<TQuadEdge>
+class ITK_TEMPLATE_EXPORT QuadEdgeMeshIterator : public QuadEdgeMeshBaseIterator<TQuadEdge>
 {
 public:
   /** Hierarchy type alias and values. */
@@ -264,7 +264,7 @@ public:
  * \ingroup ITKQuadEdgeMesh
  */
 template <typename TGeometricalQuadEdge>
-class QuadEdgeMeshIteratorGeom : public QuadEdgeMeshIterator<TGeometricalQuadEdge>
+class ITK_TEMPLATE_EXPORT QuadEdgeMeshIteratorGeom : public QuadEdgeMeshIterator<TGeometricalQuadEdge>
 {
 public:
   /** Hierarchy type alias and values. */
@@ -293,7 +293,7 @@ public:
  * \ingroup ITKQuadEdgeMesh
  */
 template <typename TQuadEdge>
-class QuadEdgeMeshConstIterator : public QuadEdgeMeshBaseIterator<TQuadEdge>
+class ITK_TEMPLATE_EXPORT QuadEdgeMeshConstIterator : public QuadEdgeMeshBaseIterator<TQuadEdge>
 {
 public:
   /** Hierarchy type alias & values. */
@@ -338,7 +338,7 @@ public:
  * \ingroup ITKQuadEdgeMesh
  */
 template <typename TGeometricalQuadEdge>
-class QuadEdgeMeshConstIteratorGeom : public QuadEdgeMeshConstIterator<TGeometricalQuadEdge>
+class ITK_TEMPLATE_EXPORT QuadEdgeMeshConstIteratorGeom : public QuadEdgeMeshConstIterator<TGeometricalQuadEdge>
 {
 public:
   /** Hierarchy type alias and values. */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup ITKQuadEdgeMesh
  */
 template <typename TMesh, typename TQEType>
-class QuadEdgeMeshEulerOperatorSplitEdgeFunction : public QuadEdgeMeshFunctionBase<TMesh, TQEType *>
+class ITK_TEMPLATE_EXPORT QuadEdgeMeshEulerOperatorSplitEdgeFunction : public QuadEdgeMeshFunctionBase<TMesh, TQEType *>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(QuadEdgeMeshEulerOperatorSplitEdgeFunction);

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureAnisotropicDiffusionImageFilter.h
@@ -55,7 +55,8 @@ namespace itk
  * \ingroup ITKAnisotropicSmoothing
  */
 template <typename TInputImage, typename TOutputImage>
-class CurvatureAnisotropicDiffusionImageFilter : public AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT CurvatureAnisotropicDiffusionImageFilter
+  : public AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(CurvatureAnisotropicDiffusionImageFilter);

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
@@ -65,7 +65,8 @@ namespace itk
  * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage>
-class VectorCurvatureAnisotropicDiffusionImageFilter : public AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT VectorCurvatureAnisotropicDiffusionImageFilter
+  : public AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorCurvatureAnisotropicDiffusionImageFilter);

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
@@ -58,7 +58,8 @@ namespace itk
  * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage>
-class VectorGradientAnisotropicDiffusionImageFilter : public AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT VectorGradientAnisotropicDiffusionImageFilter
+  : public AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorGradientAnisotropicDiffusionImageFilter);

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkFastIncrementalBinaryDilateImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkFastIncrementalBinaryDilateImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  * \ingroup ITKBinaryMathematicalMorphology
  */
 template <typename TInputImage, typename TOutputImage, typename TKernel>
-class FastIncrementalBinaryDilateImageFilter : public BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>
+class ITK_TEMPLATE_EXPORT FastIncrementalBinaryDilateImageFilter
+  : public BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FastIncrementalBinaryDilateImageFilter);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingNumberOfElementsStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingNumberOfElementsStoppingCriterion.h
@@ -38,7 +38,8 @@ namespace itk
  * \ingroup ITKFastMarching
  */
 template <typename TInput, typename TOutput>
-class FastMarchingNumberOfElementsStoppingCriterion : public FastMarchingStoppingCriterionBase<TInput, TOutput>
+class ITK_TEMPLATE_EXPORT FastMarchingNumberOfElementsStoppingCriterion
+  : public FastMarchingStoppingCriterionBase<TInput, TOutput>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FastMarchingNumberOfElementsStoppingCriterion);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
@@ -56,7 +56,8 @@ extern ITKFastMarching_EXPORT std::ostream &
  * \ingroup ITKFastMarching
  */
 template <typename TInput, typename TOutput>
-class FastMarchingReachedTargetNodesStoppingCriterion : public FastMarchingStoppingCriterionBase<TInput, TOutput>
+class ITK_TEMPLATE_EXPORT FastMarchingReachedTargetNodesStoppingCriterion
+  : public FastMarchingStoppingCriterionBase<TInput, TOutput>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FastMarchingReachedTargetNodesStoppingCriterion);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingThresholdStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingThresholdStoppingCriterion.h
@@ -32,7 +32,8 @@ namespace itk
  * \ingroup ITKFastMarching
  */
 template <typename TInput, typename TOutput>
-class FastMarchingThresholdStoppingCriterion : public FastMarchingStoppingCriterionBase<TInput, TOutput>
+class ITK_TEMPLATE_EXPORT FastMarchingThresholdStoppingCriterion
+  : public FastMarchingStoppingCriterionBase<TInput, TOutput>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FastMarchingThresholdStoppingCriterion);

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionFunction.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup ITKGPUAnisotropicSmoothing
  */
 template <typename TImage>
-class GPUAnisotropicDiffusionFunction : public GPUFiniteDifferenceFunction<TImage>
+class ITK_TEMPLATE_EXPORT GPUAnisotropicDiffusionFunction : public GPUFiniteDifferenceFunction<TImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GPUAnisotropicDiffusionFunction);

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUBoxImageFilter.h
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUBoxImageFilter.h
@@ -39,7 +39,8 @@ namespace itk
 template <typename TInputImage,
           typename TOutputImage,
           typename TParentImageFilter = BoxImageFilter<TInputImage, TOutputImage>>
-class GPUBoxImageFilter : public GPUImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>
+class ITK_TEMPLATE_EXPORT GPUBoxImageFilter
+  : public GPUImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GPUBoxImageFilter);

--- a/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
@@ -82,7 +82,8 @@ public:
 } // namespace Functor
 
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
-class AbsoluteValueDifferenceImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT AbsoluteValueDifferenceImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AbsoluteValueDifferenceImageFilter);

--- a/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
@@ -80,7 +80,8 @@ public:
 } // namespace Functor
 
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
-class SquaredDifferenceImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT SquaredDifferenceImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SquaredDifferenceImageFilter);

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.h
@@ -52,7 +52,7 @@ namespace itk
  *
  */
 template <typename TInputImage, typename TOutputImage>
-class UnaryGeneratorImageFilter : public InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT UnaryGeneratorImageFilter : public InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(UnaryGeneratorImageFilter);

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
@@ -50,7 +50,7 @@ namespace itk
  * \ingroup ITKImageFrequency
  */
 template <typename TImageType, typename TFrequencyIterator = FrequencyFFTLayoutImageRegionIteratorWithIndex<TImageType>>
-class FrequencyBandImageFilter : public UnaryFrequencyDomainFilter<TImageType, TFrequencyIterator>
+class ITK_TEMPLATE_EXPORT FrequencyBandImageFilter : public UnaryFrequencyDomainFilter<TImageType, TFrequencyIterator>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FrequencyBandImageFilter);

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -112,7 +112,8 @@ namespace itk
  *
  */
 template <typename TImage>
-class FrequencyFFTLayoutImageRegionConstIteratorWithIndex : public ImageRegionConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT FrequencyFFTLayoutImageRegionConstIteratorWithIndex
+  : public ImageRegionConstIteratorWithIndex<TImage>
 {
 public:
   /** Standard class type alias. */

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionConstIteratorWithIndex.h
@@ -75,7 +75,7 @@ namespace itk
  *
  */
 template <typename TImage>
-class FrequencyImageRegionConstIteratorWithIndex : public ImageRegionConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT FrequencyImageRegionConstIteratorWithIndex : public ImageRegionConstIteratorWithIndex<TImage>
 {
 public:
   /** Standard class type alias. */

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionIteratorWithIndex.h
@@ -61,7 +61,8 @@ namespace itk
  *
  */
 template <typename TImage>
-class FrequencyImageRegionIteratorWithIndex : public FrequencyImageRegionConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT FrequencyImageRegionIteratorWithIndex
+  : public FrequencyImageRegionConstIteratorWithIndex<TImage>
 {
 public:
   /** Standard class type alias. */

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -112,7 +112,8 @@ namespace itk
  *
  */
 template <typename TImage>
-class FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex : public ImageRegionConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex
+  : public ImageRegionConstIteratorWithIndex<TImage>
 {
 public:
   /** Standard class type alias. */

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
@@ -58,7 +58,7 @@ namespace itk
  * \ingroup ITKImageFrequency
  */
 template <typename TImageType, typename TFrequencyIterator = FrequencyFFTLayoutImageRegionIteratorWithIndex<TImageType>>
-class UnaryFrequencyDomainFilter : public InPlaceImageFilter<TImageType, TImageType>
+class ITK_TEMPLATE_EXPORT UnaryFrequencyDomainFilter : public InPlaceImageFilter<TImageType, TImageType>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(UnaryFrequencyDomainFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
@@ -65,7 +65,7 @@ public:
  * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage>
-class AbsImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT AbsImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AbsImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
@@ -76,7 +76,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class AcosImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT AcosImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AcosImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkAndImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAndImageFilter.h
@@ -52,7 +52,7 @@ namespace itk
  * \endsphinx
  */
 template <typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1>
-class AndImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT AndImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AndImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
@@ -76,7 +76,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class AsinImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT AsinImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AsinImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
@@ -77,7 +77,7 @@ public:
  * \endsphinx
  */
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
-class Atan2ImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT Atan2ImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(Atan2ImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
@@ -72,7 +72,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class AtanImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT AtanImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AtanImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
@@ -81,7 +81,8 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
-class BinaryMagnitudeImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT BinaryMagnitudeImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BinaryMagnitudeImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
@@ -66,7 +66,7 @@ public:
 } // namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-class BoundedReciprocalImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT BoundedReciprocalImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BoundedReciprocalImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
@@ -55,7 +55,7 @@ public:
 } // namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-class ComplexToImaginaryImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ComplexToImaginaryImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ComplexToImaginaryImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
@@ -54,7 +54,7 @@ public:
 } // namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-class ComplexToModulusImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ComplexToModulusImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ComplexToModulusImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
@@ -55,7 +55,7 @@ public:
 } // namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-class ComplexToPhaseImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ComplexToPhaseImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ComplexToPhaseImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
@@ -54,7 +54,7 @@ public:
 } // namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-class ComplexToRealImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ComplexToRealImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ComplexToRealImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
@@ -90,7 +90,8 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
-class ConstrainedValueAdditionImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT ConstrainedValueAdditionImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ConstrainedValueAdditionImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
@@ -74,7 +74,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class CosImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT CosImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(CosImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkDivideOrZeroOutImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideOrZeroOutImageFilter.h
@@ -38,7 +38,8 @@ namespace itk
  *
  */
 template <typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1>
-class DivideOrZeroOutImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT DivideOrZeroOutImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DivideOrZeroOutImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
@@ -62,7 +62,7 @@ public:
 } // namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-class EdgePotentialImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT EdgePotentialImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(EdgePotentialImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
@@ -64,7 +64,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class ExpImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ExpImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ExpImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
@@ -63,7 +63,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class Log10ImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT Log10ImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(Log10ImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
@@ -61,7 +61,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class LogImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT LogImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(LogImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -148,7 +148,7 @@ private:
  * \endsphinx
  */
 template <typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage>
-class MaskImageFilter : public BinaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT MaskImageFilter : public BinaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage>
 
 {
 public:

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -132,7 +132,8 @@ private:
  * \endsphinx
  */
 template <typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage>
-class MaskNegatedImageFilter : public BinaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT MaskNegatedImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MaskNegatedImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
@@ -78,7 +78,8 @@ public:
  * \endsphinx
  */
 template <typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1>
-class MaximumImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT MaximumImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MaximumImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
@@ -70,7 +70,8 @@ public:
  * \endsphinx
  */
 template <typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1>
-class MinimumImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT MinimumImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MinimumImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkOrImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkOrImageFilter.h
@@ -53,7 +53,7 @@ namespace itk
  * \endsphinx
  */
 template <typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1>
-class OrImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT OrImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(OrImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkPowImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPowImageFilter.h
@@ -89,7 +89,7 @@ public:
  *
  */
 template <typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1>
-class PowImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT PowImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 
 {
 public:

--- a/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
@@ -62,7 +62,7 @@ public:
 } // namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-class RGBToLuminanceImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT RGBToLuminanceImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(RGBToLuminanceImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkRoundImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRoundImageFilter.h
@@ -62,7 +62,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class RoundImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT RoundImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(RoundImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
@@ -66,7 +66,7 @@ public:
  * \endsphinx
  */
 template <typename TInputImage, typename TOutputImage>
-class SinImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT SinImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SinImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
@@ -63,7 +63,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class SqrtImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT SqrtImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SqrtImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
@@ -61,7 +61,7 @@ public:
 };
 } // namespace Functor
 template <typename TInputImage, typename TOutputImage>
-class SquareImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT SquareImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SquareImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkSubtractImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSubtractImageFilter.h
@@ -65,7 +65,8 @@ namespace itk
  * \endsphinx
  */
 template <typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1>
-class SubtractImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT SubtractImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SubtractImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
@@ -63,7 +63,7 @@ public:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TOutputImage>
-class TanImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT TanImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TanImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryAddImageFilter.h
@@ -36,7 +36,8 @@ namespace itk
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage1, typename TInputImage2, typename TInputImage3, typename TOutputImage>
-class TernaryAddImageFilter : public TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>
+class ITK_TEMPLATE_EXPORT TernaryAddImageFilter
+  : public TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TernaryAddImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryOperatorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryOperatorImageFilter.h
@@ -64,7 +64,7 @@ namespace itk
  * \ingroup ITKImageIntensity
  */
 template <typename TMask, typename TImage>
-class TernaryOperatorImageFilter : public TernaryGeneratorImageFilter<TMask, TImage, TImage, TImage>
+class ITK_TEMPLATE_EXPORT TernaryOperatorImageFilter : public TernaryGeneratorImageFilter<TMask, TImage, TImage, TImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TernaryOperatorImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
@@ -68,7 +68,7 @@ public:
 } // namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-class VectorMagnitudeImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT VectorMagnitudeImageFilter : public UnaryGeneratorImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VectorMagnitudeImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
@@ -113,7 +113,8 @@ private:
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
-class WeightedAddImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT WeightedAddImageFilter
+  : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 
 {
 public:

--- a/Modules/Filtering/ImageIntensity/include/itkXorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkXorImageFilter.h
@@ -53,7 +53,7 @@ namespace itk
  * \endsphinx
  */
 template <typename TInputImage1, typename TInputImage2 = TInputImage1, typename TOutputImage = TInputImage1>
-class XorImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
+class ITK_TEMPLATE_EXPORT XorImageFilter : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(XorImageFilter);

--- a/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
@@ -48,7 +48,7 @@ namespace itk
  * \ingroup ITKImageSources
  */
 template <typename TRealValueType>
-class GaborKernelFunction : public KernelFunctionBase<TRealValueType>
+class ITK_TEMPLATE_EXPORT GaborKernelFunction : public KernelFunctionBase<TRealValueType>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GaborKernelFunction);

--- a/Modules/Filtering/LabelMap/include/itkAttributeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeLabelObject.h
@@ -70,7 +70,7 @@ public:
  * \ingroup ITKLabelMap
  */
 template <typename TLabel, unsigned int VImageDimension, typename TAttributeValue>
-class AttributeLabelObject : public LabelObject<TLabel, VImageDimension>
+class ITK_TEMPLATE_EXPORT AttributeLabelObject : public LabelObject<TLabel, VImageDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AttributeLabelObject);

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 template <typename TLabel, unsigned int VImageDimension>
-class ShapeLabelObject : public LabelObject<TLabel, VImageDimension>
+class ITK_TEMPLATE_EXPORT ShapeLabelObject : public LabelObject<TLabel, VImageDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ShapeLabelObject);

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 template <typename TLabel, unsigned int VImageDimension>
-class StatisticsLabelObject : public ShapeLabelObject<TLabel, VImageDimension>
+class ITK_TEMPLATE_EXPORT StatisticsLabelObject : public ShapeLabelObject<TLabel, VImageDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(StatisticsLabelObject);

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
@@ -209,7 +209,7 @@ class MorphologicalGradientHistogram<signed char> : public VectorMorphologicalGr
 {};
 
 template <>
-class MorphologicalGradientHistogram<bool> : public VectorMorphologicalGradientHistogram<bool>
+class ITK_TEMPLATE_EXPORT MorphologicalGradientHistogram<bool> : public VectorMorphologicalGradientHistogram<bool>
 {};
 
 /// \endcond

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankHistogram.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankHistogram.h
@@ -405,7 +405,7 @@ class RankHistogram<signed char> : public VectorRankHistogram<signed char>
 {};
 
 template <>
-class RankHistogram<bool> : public VectorRankHistogram<bool>
+class ITK_TEMPLATE_EXPORT RankHistogram<bool> : public VectorRankHistogram<bool>
 {};
 
 /// \endcond

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
@@ -29,7 +29,7 @@ namespace itk
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInput, typename TOutput, typename TCriterion>
-class DecimationQuadEdgeMeshFilter : public QuadEdgeMeshToQuadEdgeMeshFilter<TInput, TOutput>
+class ITK_TEMPLATE_EXPORT DecimationQuadEdgeMeshFilter : public QuadEdgeMeshToQuadEdgeMeshFilter<TInput, TOutput>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DecimationQuadEdgeMeshFilter);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
@@ -32,7 +32,8 @@ namespace itk
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh, typename TOutputMesh = TInputMesh>
-class DiscreteCurvatureQuadEdgeMeshFilter : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
+class ITK_TEMPLATE_EXPORT DiscreteCurvatureQuadEdgeMeshFilter
+  : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DiscreteCurvatureQuadEdgeMeshFilter);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureTensorQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureTensorQuadEdgeMeshFilter.h
@@ -30,7 +30,8 @@ namespace itk
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh, typename TOutputMesh = TInputMesh>
-class DiscreteCurvatureTensorQuadEdgeMeshFilter : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
+class ITK_TEMPLATE_EXPORT DiscreteCurvatureTensorQuadEdgeMeshFilter
+  : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DiscreteCurvatureTensorQuadEdgeMeshFilter);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
@@ -35,7 +35,8 @@ namespace itk
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh, typename TOutputMesh = TInputMesh>
-class DiscreteGaussianCurvatureQuadEdgeMeshFilter : public DiscreteCurvatureQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
+class ITK_TEMPLATE_EXPORT DiscreteGaussianCurvatureQuadEdgeMeshFilter
+  : public DiscreteCurvatureQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DiscreteGaussianCurvatureQuadEdgeMeshFilter);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
@@ -33,7 +33,8 @@ namespace itk
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh, typename TOutputMesh = TInputMesh>
-class DiscreteMeanCurvatureQuadEdgeMeshFilter : public DiscreteCurvatureQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
+class ITK_TEMPLATE_EXPORT DiscreteMeanCurvatureQuadEdgeMeshFilter
+  : public DiscreteCurvatureQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DiscreteMeanCurvatureQuadEdgeMeshFilter);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
@@ -111,7 +111,8 @@ template <typename TMesh,
           typename TMeasure = double,
           typename TPriorityQueueWrapper =
             MinPriorityQueueElementWrapper<typename TMesh::QEType *, std::pair<bool, TMeasure>>>
-class NumberOfPointsCriterion : public QuadEdgeMeshDecimationCriterion<TMesh, TElement, TMeasure, TPriorityQueueWrapper>
+class ITK_TEMPLATE_EXPORT NumberOfPointsCriterion
+  : public QuadEdgeMeshDecimationCriterion<TMesh, TElement, TMeasure, TPriorityQueueWrapper>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NumberOfPointsCriterion);
@@ -154,7 +155,8 @@ template <typename TMesh,
           typename TMeasure = double,
           typename TPriorityQueueWrapper =
             MinPriorityQueueElementWrapper<typename TMesh::QEType *, std::pair<bool, TMeasure>>>
-class NumberOfFacesCriterion : public QuadEdgeMeshDecimationCriterion<TMesh, TElement, TMeasure, TPriorityQueueWrapper>
+class ITK_TEMPLATE_EXPORT NumberOfFacesCriterion
+  : public QuadEdgeMeshDecimationCriterion<TMesh, TElement, TMeasure, TPriorityQueueWrapper>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NumberOfFacesCriterion);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -52,7 +52,7 @@ public:
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh>
-class OnesMatrixCoefficients : public MatrixCoefficients<TInputMesh>
+class ITK_TEMPLATE_EXPORT OnesMatrixCoefficients : public MatrixCoefficients<TInputMesh>
 {
 public:
   using Superclass = MatrixCoefficients<TInputMesh>;
@@ -81,7 +81,7 @@ public:
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh>
-class InverseEuclideanDistanceMatrixCoefficients : public MatrixCoefficients<TInputMesh>
+class ITK_TEMPLATE_EXPORT InverseEuclideanDistanceMatrixCoefficients : public MatrixCoefficients<TInputMesh>
 {
 public:
   using Superclass = MatrixCoefficients<TInputMesh>;
@@ -123,7 +123,7 @@ public:
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh>
-class ConformalMatrixCoefficients : public MatrixCoefficients<TInputMesh>
+class ITK_TEMPLATE_EXPORT ConformalMatrixCoefficients : public MatrixCoefficients<TInputMesh>
 {
 public:
   using Superclass = MatrixCoefficients<TInputMesh>;
@@ -177,7 +177,7 @@ public:
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh>
-class AuthalicMatrixCoefficients : public MatrixCoefficients<TInputMesh>
+class ITK_TEMPLATE_EXPORT AuthalicMatrixCoefficients : public MatrixCoefficients<TInputMesh>
 {
 public:
   using Superclass = MatrixCoefficients<TInputMesh>;
@@ -233,7 +233,7 @@ public:
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh>
-class IntrinsicMatrixCoefficients : public MatrixCoefficients<TInputMesh>
+class ITK_TEMPLATE_EXPORT IntrinsicMatrixCoefficients : public MatrixCoefficients<TInputMesh>
 {
 public:
   using Superclass = MatrixCoefficients<TInputMesh>;
@@ -268,7 +268,7 @@ public:
  * \ingroup ITKQuadEdgeMeshFiltering
  */
 template <typename TInputMesh>
-class HarmonicMatrixCoefficients : public MatrixCoefficients<TInputMesh>
+class ITK_TEMPLATE_EXPORT HarmonicMatrixCoefficients : public MatrixCoefficients<TInputMesh>
 {
 public:
   using Superclass = MatrixCoefficients<TInputMesh>;

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class HuangThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT HuangThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(HuangThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class IntermodesThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT IntermodesThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(IntermodesThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkIsoDataThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIsoDataThresholdImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class IsoDataThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT IsoDataThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(IsoDataThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkLiThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkLiThresholdImageFilter.h
@@ -53,7 +53,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class LiThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT LiThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(LiThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class MaximumEntropyThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT MaximumEntropyThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MaximumEntropyThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkMomentsThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkMomentsThresholdImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class MomentsThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT MomentsThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MomentsThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -52,7 +52,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class OtsuThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT OtsuThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(OtsuThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class RenyiEntropyThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT RenyiEntropyThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(RenyiEntropyThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkShanbhagThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkShanbhagThresholdImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class ShanbhagThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT ShanbhagThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ShanbhagThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkTriangleThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkTriangleThresholdImageFilter.h
@@ -49,7 +49,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class TriangleThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT TriangleThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TriangleThresholdImageFilter);

--- a/Modules/Filtering/Thresholding/include/itkYenThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkYenThresholdImageFilter.h
@@ -48,7 +48,8 @@ namespace itk
  */
 
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TOutputImage>
-class YenThresholdImageFilter : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
+class ITK_TEMPLATE_EXPORT YenThresholdImageFilter
+  : public HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(YenThresholdImageFilter);

--- a/Modules/IO/SpatialObjects/include/itkPolygonGroupSpatialObjectXMLFile.h
+++ b/Modules/IO/SpatialObjects/include/itkPolygonGroupSpatialObjectXMLFile.h
@@ -31,7 +31,7 @@ namespace itk
  * creates a corresponding PolygonGroupSpatialObject
  * \ingroup ITKIOSpatialObjects
  */
-class PolygonGroupSpatialObjectXMLFileReader : public XMLReader<GroupSpatialObject<3>>
+class ITK_TEMPLATE_EXPORT PolygonGroupSpatialObjectXMLFileReader : public XMLReader<GroupSpatialObject<3>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(PolygonGroupSpatialObjectXMLFileReader);
@@ -85,7 +85,7 @@ private:
  * based on a GroupSpatialObject.
  * \ingroup ITKIOSpatialObjects
  */
-class PolygonGroupSpatialObjectXMLFileWriter : public XMLWriterBase<GroupSpatialObject<3>>
+class ITK_TEMPLATE_EXPORT PolygonGroupSpatialObjectXMLFileWriter : public XMLWriterBase<GroupSpatialObject<3>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(PolygonGroupSpatialObjectXMLFileWriter);

--- a/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
@@ -45,7 +45,8 @@ namespace itk
  * \ingroup ITKIOTransformMINC
  */
 template <typename TParametersValueType = double, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
-class MINCTransformAdapter : public Transform<TParametersValueType, NInputDimensions, NOutputDimensions>
+class ITK_TEMPLATE_EXPORT MINCTransformAdapter
+  : public Transform<TParametersValueType, NInputDimensions, NOutputDimensions>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MINCTransformAdapter);

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunctionData.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunctionData.h
@@ -58,7 +58,8 @@ namespace itk
  * \ingroup ITKReview
  */
 template <typename TInputImage, typename TFeatureImage>
-class ScalarChanAndVeseLevelSetFunctionData : public RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>
+class ITK_TEMPLATE_EXPORT ScalarChanAndVeseLevelSetFunctionData
+  : public RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ScalarChanAndVeseLevelSetFunctionData);

--- a/Modules/Numerics/FEM/include/itkFEMSpatialObjectReader.h
+++ b/Modules/Numerics/FEM/include/itkFEMSpatialObjectReader.h
@@ -32,7 +32,7 @@ namespace itk
 template <unsigned int NDimensions = 3,
           typename PixelType = unsigned char,
           typename TMeshTraits = DefaultStaticMeshTraits<PixelType, NDimensions, NDimensions>>
-class FEMSpatialObjectReader : public SpatialObjectReader<NDimensions, PixelType, TMeshTraits>
+class ITK_TEMPLATE_EXPORT FEMSpatialObjectReader : public SpatialObjectReader<NDimensions, PixelType, TMeshTraits>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FEMSpatialObjectReader);

--- a/Modules/Numerics/FEM/include/itkFEMSpatialObjectWriter.h
+++ b/Modules/Numerics/FEM/include/itkFEMSpatialObjectWriter.h
@@ -32,7 +32,7 @@ namespace itk
 template <unsigned int NDimensions = 3,
           typename PixelType = unsigned char,
           typename TMeshTraits = DefaultStaticMeshTraits<PixelType, NDimensions, NDimensions>>
-class FEMSpatialObjectWriter : public SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>
+class ITK_TEMPLATE_EXPORT FEMSpatialObjectWriter : public SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FEMSpatialObjectWriter);

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedCostFunctionv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedCostFunctionv4.h
@@ -47,7 +47,8 @@ namespace itk
  * \ingroup ITKOptimizersv4
  */
 template <typename TInternalComputationValueType>
-class SingleValuedCostFunctionv4Template : public CostFunctionTemplate<TInternalComputationValueType>
+class ITK_TEMPLATE_EXPORT SingleValuedCostFunctionv4Template
+  : public CostFunctionTemplate<TInternalComputationValueType>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(SingleValuedCostFunctionv4Template);

--- a/Modules/Registration/Common/include/itkPDEDeformableRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkPDEDeformableRegistrationFunction.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup ITKRegistrationCommon
  */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-class PDEDeformableRegistrationFunction : public FiniteDifferenceFunction<TDisplacementField>
+class ITK_TEMPLATE_EXPORT PDEDeformableRegistrationFunction : public FiniteDifferenceFunction<TDisplacementField>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(PDEDeformableRegistrationFunction);

--- a/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
+++ b/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
@@ -70,7 +70,8 @@ protected:
 // This UI allows the number of iterations and learning rate
 // to be changes at each resolution level.
 template <typename TRegistration>
-class SimpleMultiResolutionImageRegistrationUI2 : public SimpleMultiResolutionImageRegistrationUI<TRegistration>
+class ITK_TEMPLATE_EXPORT SimpleMultiResolutionImageRegistrationUI2
+  : public SimpleMultiResolutionImageRegistrationUI<TRegistration>
 {
 public:
   using Superclass = SimpleMultiResolutionImageRegistrationUI<

--- a/Modules/Registration/GPUCommon/include/itkGPUPDEDeformableRegistrationFunction.h
+++ b/Modules/Registration/GPUCommon/include/itkGPUPDEDeformableRegistrationFunction.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup ITKGPURegistrationCommon
  */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-class GPUPDEDeformableRegistrationFunction : public GPUFiniteDifferenceFunction<TDisplacementField>
+class ITK_TEMPLATE_EXPORT GPUPDEDeformableRegistrationFunction : public GPUFiniteDifferenceFunction<TDisplacementField>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GPUPDEDeformableRegistrationFunction);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
@@ -36,7 +36,7 @@ namespace itk
  *  \ingroup ITKLevelSetsv4
  */
 template <typename TIdentifier, typename TLevelSet>
-class LevelSetContainer : public LevelSetContainerBase<TIdentifier, TLevelSet>
+class ITK_TEMPLATE_EXPORT LevelSetContainer : public LevelSetContainerBase<TIdentifier, TLevelSet>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(LevelSetContainer);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationRegionTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationRegionTerm.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 template <typename TInput, typename TLevelSetContainer>
-class LevelSetEquationRegionTerm : public LevelSetEquationTermBase<TInput, TLevelSetContainer>
+class ITK_TEMPLATE_EXPORT LevelSetEquationRegionTerm : public LevelSetEquationTermBase<TInput, TLevelSetContainer>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(LevelSetEquationRegionTerm);

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -50,7 +50,8 @@ namespace itk
  * \ingroup ITKSignedDistanceFunction
  */
 template <typename TCoordRep, unsigned int VSpaceDimension>
-class ShapeSignedDistanceFunction : public SpatialFunction<double, VSpaceDimension, Point<TCoordRep, VSpaceDimension>>
+class ITK_TEMPLATE_EXPORT ShapeSignedDistanceFunction
+  : public SpatialFunction<double, VSpaceDimension, Point<TCoordRep, VSpaceDimension>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ShapeSignedDistanceFunction);


### PR DESCRIPTION
Adding ITK_TEMPLATE_EXPORT to class declarations of classes that have a public, templated superclass; except not to classes that are for tests, examples, or are ThirdParty.  Submitting this as a pull request to check that this works on multiple platforms.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
