### PR TITLE
BUG: Initialize C++ standard for remote modules

### DIFF
--- a/CMake/ITKInitializeCXXStandard.cmake
+++ b/CMake/ITKInitializeCXXStandard.cmake
@@ -1,0 +1,10 @@
+##  Set the default target properties for ITK
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14) # Supported values are 14, 17, 20, and 23.
+endif()
+if(NOT CMAKE_CXX_STANDARD_REQUIRED)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+if(NOT CMAKE_CXX_EXTENSIONS)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()

--- a/CMake/ITKModuleExternal.cmake
+++ b/CMake/ITKModuleExternal.cmake
@@ -120,6 +120,7 @@ if(NOT ITK_INSTALL_PACKAGE_DIR)
   set(ITK_INSTALL_PACKAGE_DIR "lib/cmake/ITK-${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}")
 endif()
 
+include(${ITK_CMAKE_DIR}/ITKInitializeCXXStandard.cmake)
 include(${ITK_CMAKE_DIR}/ITKInitializeBuildType.cmake)
 
 # Use ITK's flags.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,14 @@ foreach(pold "CMP0091")
   endif()
 endforeach()
 
+# ====
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKInitializeCXXStandard.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKInitializeBuildType.cmake)
+
 # ==== Define language standard configurations requiring at least c++14 standard
 if(CMAKE_CXX_STANDARD EQUAL "98" OR CMAKE_CXX_STANDARD LESS "14")
    message(FATAL_ERROR "C++98 to C++11 are no longer supported in ITK version 5.3 and greater.")
 endif()
-
-# ====
-include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKInitializeCXXStandard.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKInitializeBuildType.cmake)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake ${CMAKE_MODULE_PATH})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,19 +40,8 @@ if(CMAKE_CXX_STANDARD EQUAL "98" OR CMAKE_CXX_STANDARD LESS "14")
    message(FATAL_ERROR "C++98 to C++11 are no longer supported in ITK version 5.3 and greater.")
 endif()
 
-#####
-##  Set the default target properties for ITK
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14) # Supported values are 14, 17, 20, and 23.
-endif()
-if(NOT CMAKE_CXX_STANDARD_REQUIRED)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-if(NOT CMAKE_CXX_EXTENSIONS)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
 # ====
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKInitializeCXXStandard.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/ITKInitializeBuildType.cmake)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
We now default to C++14, which is not the default standard on most compilers. Addresses:

  Modules/Core/Common/include/itkMacro.h:192:6: error: "Apple LLVM < 5.1 (clang < 3.4) is not supported under ITKv5.3"

When building remote modules externally, which is triggered by too low of a C++ standard.
