### PR TITLE
BUG: Fix matrix check rejecting NIFTI sform for small voxels

### DIFF
--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -20,7 +20,6 @@
 #include "itkMetaDataObject.h"
 #include "itkSpatialOrientationAdapter.h"
 #include <nifti1_io.h>
-
 #include "itkNiftiImageIOConfigurePrivate.h"
 
 namespace itk
@@ -1759,14 +1758,15 @@ IsAffine(const mat44 & nifti_mat)
       return false;
     }
   }
-  // Get the inverse of this matrix:
-  // Make sure the matrix is invertible to begin with...
-  if (fabs(vnl_determinant(mat)) <= 1e-5)
+
+  const float condition = vnl_matrix_inverse<float>(mat.as_matrix()).well_condition();
+  // Check matrix is invertible by testing condition number of inverse
+  if (!(condition > std::numeric_limits<float>::epsilon()))
   {
     return false;
   }
 
-  // Calculate the inverse and seperate the inverse translation component
+  // Calculate the inverse and separate the inverse translation component
   // and the top 3x3 part of the inverse matrix
   const vnl_matrix_fixed<float, 4, 4> inv4x4Matrix = vnl_matrix_inverse<float>(mat.as_matrix()).as_matrix();
   const vnl_vector_fixed<float, 3>    inv4x4Translation(inv4x4Matrix[0][3], inv4x4Matrix[1][3], inv4x4Matrix[2][3]);


### PR DESCRIPTION
Fixes #2674

NIFTI sform matrices were being called non-invertible if their determinant was <
10-5. Because the determinant scales with the product of the voxel spacings, any
image with voxels smaller than about 20 microns would not have its direction
cosines read from the sform. This caused errors when the header sform was valid,
but the qform transform was not available as a fallback.

Invertibility is now tested by checking the condition number of the singular
value decomposition. If this is above the float epsilon, the matrix will be
considered invertible.

An alternative solution would be to consider a matrix invertible whenever the
determinant is > 0, which is what itkMatrix does. The condition number test as
implemented is a bit more conservative, but should allow spacings down to a
nanometer or less.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
