### PR TITLE
BUG: Missed wrapping of itkResampleInPlaceImageFilter

### DIFF
--- a/Modules/Core/Transform/wrapping/CMakeLists.txt
+++ b/Modules/Core/Transform/wrapping/CMakeLists.txt
@@ -15,6 +15,7 @@ set(WRAPPER_SUBMODULE_ORDER
   itkScalableAffineTransform
   itkScaleTransform
   itkKernelTransform
+  itkResampleInPlaceImageFilter
 )
 itk_auto_load_submodules()
 itk_end_wrap_module()


### PR DESCRIPTION
The wrapping of the new itkResampleInPlaceImageFilter was not
included in the CMakeLists.txt files.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
