### PR TITLE
ENH: Replace GetNumberOfWeights() by static constexpr `NumberOfWeights`

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -440,6 +440,9 @@ now has signature
 `JacobianPositionType` is publicly exposed in `itk::Transform`.
 See commit [commit 212cae5](https://github.com/InsightSoftwareConsortium/ITK/commit/212cae522d8451ea089c41f8a151279e1dd17042) for details.
 
+With ITK 5.3, the `GetNumberOfWeights()` member functions of `itk::BSplineBaseTransform` and `itk::BSplineInterpolationWeightFunction`
+are replaced by static constexpr data members named `NumberOfWeights`.
+
 Consolidated Vector Filter
 --------------------------
 

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -23,6 +23,7 @@
 #include "itkBSplineKernelFunction.h"
 #include "itkArray.h"
 #include "itkArray2D.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -69,6 +70,9 @@ public:
   /** Spline order. */
   static constexpr unsigned int SplineOrder = VSplineOrder;
 
+  /** Number of weights. */
+  static constexpr unsigned int NumberOfWeights{ Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension) };
+
   /** OutputType type alias support. */
   using WeightsType = Array<double>;
 
@@ -98,8 +102,10 @@ public:
   /** Get support region size. */
   itkGetConstMacro(SupportSize, SizeType);
 
+#if !defined(ITK_LEGACY_REMOVE)
   /** Get number of weights. */
-  itkGetConstMacro(NumberOfWeights, unsigned int);
+  itkLegacyMacro(unsigned int GetNumberOfWeights() const) { return Self::NumberOfWeights; }
+#endif
 
 protected:
   BSplineInterpolationWeightFunction();
@@ -108,9 +114,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  /** Number of weights. */
-  unsigned int m_NumberOfWeights;
-
   /** Size of support region. */
   SizeType m_SupportSize;
 

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -30,15 +30,11 @@ namespace itk
 template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::BSplineInterpolationWeightFunction()
 {
-  // Initialize the number of weights;
-  m_NumberOfWeights =
-    static_cast<unsigned int>(std::pow(static_cast<double>(SplineOrder + 1), static_cast<double>(SpaceDimension)));
-
   // Initialize support region is a hypercube of length SplineOrder + 1
   m_SupportSize.Fill(SplineOrder + 1);
 
   // Initialize offset to index lookup table
-  m_OffsetToIndexTable.set_size(m_NumberOfWeights, SpaceDimension);
+  m_OffsetToIndexTable.set_size(Self::NumberOfWeights, SpaceDimension);
 
   unsigned int counter = 0;
 
@@ -66,7 +62,7 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "NumberOfWeights: " << m_NumberOfWeights << std::endl;
+  os << indent << "NumberOfWeights: " << Self::NumberOfWeights << std::endl;
   os << indent << "SupportSize: " << m_SupportSize << std::endl;
 }
 
@@ -76,7 +72,7 @@ typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineO
 BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
   const ContinuousIndexType & index) const
 {
-  WeightsType weights(m_NumberOfWeights);
+  WeightsType weights(Self::NumberOfWeights);
   IndexType   startIndex;
 
   this->Evaluate(index, weights, startIndex);
@@ -116,7 +112,7 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Ev
     }
   }
 
-  for (k = 0; k < m_NumberOfWeights; ++k)
+  for (k = 0; k < Self::NumberOfWeights; ++k)
   {
     weights[k] = 1.0;
 

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -26,6 +26,15 @@
 // compiler bug.
 template class itk::BSplineInterpolationWeightFunction<float, 2U, 1U>;
 
+
+// Test NumberOfWeights:
+static_assert((itk::BSplineInterpolationWeightFunction<float, 2, 1>::NumberOfWeights == 4) &&
+                (itk::BSplineInterpolationWeightFunction<float, 2, 2>::NumberOfWeights == 9) &&
+                (itk::BSplineInterpolationWeightFunction<float, 2, 3>::NumberOfWeights == 16) &&
+                (itk::BSplineInterpolationWeightFunction<float, 3, 3>::NumberOfWeights == 64),
+              "NumberOfWeights must be (SplineOrder+1) ^ SpaceDimension");
+
+
 /*
  * This test exercises methods in the
  * BSplineInterpolationWeightFunction class.
@@ -232,7 +241,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     function->Print(std::cout);
 
     SizeType      size = function->GetSupportSize();
-    unsigned long numberOfWeights = function->GetNumberOfWeights();
+    unsigned long numberOfWeights = FunctionType::NumberOfWeights;
 
     std::cout << "Number Of Weights: " << numberOfWeights << std::endl;
 

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -237,6 +237,9 @@ public:
   /** Parameter index array type. */
   using ParameterIndexArrayType = Array<unsigned long>;
 
+  /** Number of weights. */
+  static constexpr unsigned int NumberOfWeights{ WeightsFunctionType::NumberOfWeights };
+
   /**
    * Transform points by a BSpline deformable transformation.
    * On return, weights contains the interpolation weights used to compute the
@@ -252,12 +255,10 @@ public:
                  ParameterIndexArrayType & indices,
                  bool &                    inside) const = 0;
 
+#if !defined(ITK_LEGACY_REMOVE)
   /** Get number of weights. */
-  unsigned long
-  GetNumberOfWeights() const
-  {
-    return m_WeightsFunction->GetNumberOfWeights();
-  }
+  itkLegacyMacro(unsigned long GetNumberOfWeights() const) { return m_WeightsFunction->GetNumberOfWeights(); }
+#endif
 
   /** Method to transform a vector -
    *  not applicable for this type of transform. */

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -291,7 +291,7 @@ template <typename TParametersValueType, unsigned int NDimensions, unsigned int 
 unsigned int
 BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfAffectedWeights() const
 {
-  return this->m_WeightsFunction->GetNumberOfWeights();
+  return WeightsFunctionType::NumberOfWeights;
 }
 
 // This helper class is used to work around a race condition where the dynamically
@@ -315,8 +315,8 @@ typename BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::
 BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoint(
   const InputPointType & point) const
 {
-  WeightsType             weights(this->m_WeightsFunction->GetNumberOfWeights());
-  ParameterIndexArrayType indices(this->m_WeightsFunction->GetNumberOfWeights());
+  WeightsType             weights(WeightsFunctionType::NumberOfWeights);
+  ParameterIndexArrayType indices(WeightsFunctionType::NumberOfWeights);
   OutputPointType         outputPoint;
   bool                    inside;
 

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -573,7 +573,7 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Com
   }
 
   // Compute interpolation weights
-  WeightsType weights(this->m_WeightsFunction->GetNumberOfWeights());
+  WeightsType weights(WeightsFunctionType::NumberOfWeights);
 
   IndexType supportIndex;
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -623,7 +623,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::ComputeJacobi
   }
 
   // Compute interpolation weights
-  WeightsType weights(this->m_WeightsFunction->GetNumberOfWeights());
+  WeightsType weights(WeightsFunctionType::NumberOfWeights);
 
   IndexType supportIndex;
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -203,8 +203,8 @@ itkBSplineDeformableTransformTest1()
   using WeightsType = TransformType::WeightsType;
   using IndexArrayType = TransformType::ParameterIndexArrayType;
 
-  WeightsType    weights(transform->GetNumberOfWeights());
-  IndexArrayType indices(transform->GetNumberOfWeights());
+  WeightsType    weights(TransformType::NumberOfWeights);
+  IndexArrayType indices(TransformType::NumberOfWeights);
   bool           inside;
 
   inputPoint.Fill(8.3);
@@ -221,7 +221,7 @@ itkBSplineDeformableTransformTest1()
 
   // cycling through all the parameters and weights used in the previous
   // transformation
-  unsigned int numberOfCoefficientInSupportRegion = transform->GetNumberOfWeights();
+  unsigned int numberOfCoefficientInSupportRegion = TransformType::NumberOfWeights;
   unsigned int numberOfParametersPerDimension = transform->GetNumberOfParametersPerDimension();
   unsigned int linearIndex;
   unsigned int baseIndex;

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -239,8 +239,8 @@ itkBSplineTransformTest1()
   using WeightsType = TransformType::WeightsType;
   using IndexArrayType = TransformType::ParameterIndexArrayType;
 
-  WeightsType    weights(transform->GetNumberOfWeights());
-  IndexArrayType indices(transform->GetNumberOfWeights());
+  WeightsType    weights(TransformType::NumberOfWeights);
+  IndexArrayType indices(TransformType::NumberOfWeights);
   bool           inside;
 
   inputPoint.Fill(8.3);
@@ -257,7 +257,7 @@ itkBSplineTransformTest1()
 
   // cycling through all the parameters and weights used in the previous
   // transformation
-  unsigned int numberOfCoefficientInSupportRegion = transform->GetNumberOfWeights();
+  unsigned int numberOfCoefficientInSupportRegion = TransformType::NumberOfWeights;
   unsigned int numberOfParametersPerDimension = transform->GetNumberOfParametersPerDimension();
   unsigned int linearIndex;
   unsigned int baseIndex;

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -426,7 +426,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
   else
   {
     m_BSplineTransform = testPtr2;
-    m_NumBSplineWeights = m_BSplineTransform->GetNumberOfWeights();
+    m_NumBSplineWeights = BSplineTransformType::NumberOfWeights;
     itkDebugMacro("Transform is BSplineDeformable");
   }
 


### PR DESCRIPTION
Replaced the `GetNumberOfWeights()` member functions of both `BSplineBaseTransform` and `BSplineInterpolationWeightFunction` by static constexpr `NumberOfWeights` data members.

Allows using the number of weights at compile-time, for example to declare an `std::array` of those weights.