### PR TITLE
ENH: Declare Filled and operator[] of Index, Size, FixedArray constexpr

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -262,8 +262,8 @@ public:
 #    pragma GCC diagnostic ignored "-Warray-bounds"
 #  endif
 #endif
-  reference       operator[](unsigned int index) { return m_InternalArray[index]; }
-  const_reference operator[](unsigned int index) const { return m_InternalArray[index]; }
+  constexpr reference       operator[](unsigned int index) { return m_InternalArray[index]; }
+  constexpr const_reference operator[](unsigned int index) const { return m_InternalArray[index]; }
 #if defined(__GNUC__)
 #  if (__GNUC__ == 4) && (__GNUC_MINOR__ == 9) || (__GNUC__ >= 7)
 #    pragma GCC diagnostic pop
@@ -425,8 +425,17 @@ private:
   CArray m_InternalArray;
 
 public:
-  static FixedArray
-  Filled(const ValueType &);
+  /** Return an FixedArray with the given value assigned to all elements. */
+  static constexpr FixedArray
+  Filled(const ValueType & value)
+  {
+    FixedArray result{};
+    for (ValueType & element : result.m_InternalArray)
+    {
+      element = value;
+    }
+    return result;
+  }
 };
 
 template <typename TValue, unsigned int VLength>

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -172,18 +172,6 @@ FixedArray<TValue, VLength>::Fill(const ValueType & value)
   std::fill_n(m_InternalArray, VLength, value);
 }
 
-/**
- * Return an FixedArray with all elements assigned to the given value.
- */
-template <typename TValue, unsigned int VLength>
-FixedArray<TValue, VLength>
-FixedArray<TValue, VLength>::Filled(const ValueType & value)
-{
-  FixedArray<ValueType, VLength> array;
-  array.Fill(value);
-  return array;
-}
-
 template <typename TValue, unsigned int VLength>
 std::ostream &
 operator<<(std::ostream & os, const FixedArray<TValue, VLength> & arr)

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -412,9 +412,9 @@ public:
     return false;
   }
 
-  reference operator[](size_type pos) { return m_InternalArray[pos]; }
+  constexpr reference operator[](size_type pos) { return m_InternalArray[pos]; }
 
-  const_reference operator[](size_type pos) const { return m_InternalArray[pos]; }
+  constexpr const_reference operator[](size_type pos) const { return m_InternalArray[pos]; }
 
   reference
   at(size_type pos)
@@ -469,11 +469,14 @@ public:
 
   /** Returns an Index object, filled with the specified value for each element.
    */
-  static Self
+  static constexpr Self
   Filled(const IndexValueType value)
   {
-    Self result;
-    result.Fill(value);
+    Self result{};
+    for (IndexValueType & indexValue : result.m_InternalArray)
+    {
+      indexValue = value;
+    }
     return result;
   }
 

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -324,9 +324,9 @@ public:
     return false;
   }
 
-  reference operator[](size_type pos) { return m_InternalArray[pos]; }
+  constexpr reference operator[](size_type pos) { return m_InternalArray[pos]; }
 
-  const_reference operator[](size_type pos) const { return m_InternalArray[pos]; }
+  constexpr const_reference operator[](size_type pos) const { return m_InternalArray[pos]; }
 
   reference
   at(size_type pos)
@@ -391,11 +391,14 @@ private:
 public:
   /** Returns a Size object, filled with the specified value for each element.
    */
-  static Self
+  static constexpr Self
   Filled(const SizeValueType value)
   {
-    Self result;
-    result.Fill(value);
+    Self result{};
+    for (SizeValueType & sizeValue : result.m_InternalArray)
+    {
+      sizeValue = value;
+    }
     return result;
   }
 

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -222,7 +222,31 @@ Check_iterators_increment_return_value()
   }
 }
 
+template <int VFillValue>
+constexpr bool
+Is_Filled_FixedArray_correctly_filled()
+{
+  using FixedArrayType = itk::FixedArray<int>;
+
+  constexpr auto filledFixedArray = FixedArrayType::Filled(VFillValue);
+
+  for (unsigned i{}; i < FixedArrayType::Length; ++i)
+  {
+    if (filledFixedArray[i] != VFillValue)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+
 } // End of namespace
+
+static_assert(Is_Filled_FixedArray_correctly_filled<0>() && Is_Filled_FixedArray_correctly_filled<1>() &&
+                Is_Filled_FixedArray_correctly_filled<std::numeric_limits<int>::min()>() &&
+                Is_Filled_FixedArray_correctly_filled<std::numeric_limits<int>::max()>(),
+              "itk::FixedArray::Filled(value) should be correctly filled at compile-time");
 
 
 // Tests that the values of a FixedArray (either const or non-const) can be retrieved by a

--- a/Modules/Core/Common/test/itkIndexGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexGTest.cxx
@@ -46,7 +46,29 @@ Expect_Filled_returns_Index_with_specified_value_for_each_element()
   }
   Expect_Filled_with_value(std::numeric_limits<IndexValueType>::max());
 }
+
+
+template <itk::IndexValueType VFillValue>
+constexpr bool
+Is_Filled_Index_correctly_filled()
+{
+  for (const auto actualValue : itk::Index<>::Filled(VFillValue).m_InternalArray)
+  {
+    if (actualValue != VFillValue)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace
+
+
+static_assert(Is_Filled_Index_correctly_filled<0>() && Is_Filled_Index_correctly_filled<1>() &&
+                Is_Filled_Index_correctly_filled<std::numeric_limits<itk::IndexValueType>::min()>() &&
+                Is_Filled_Index_correctly_filled<std::numeric_limits<itk::IndexValueType>::max()>(),
+              "itk::Index::Filled(value) should be correctly filled at compile-time");
 
 
 // Tests that itk::Index::Filled(value) returns an itk::Index with the

--- a/Modules/Core/Common/test/itkSizeGTest.cxx
+++ b/Modules/Core/Common/test/itkSizeGTest.cxx
@@ -46,7 +46,29 @@ Expect_Filled_returns_Size_with_specified_value_for_each_element()
   }
   Expect_Filled_with_value(std::numeric_limits<SizeValueType>::max());
 }
+
+
+template <itk::SizeValueType VFillValue>
+constexpr bool
+Is_Filled_Size_correctly_filled()
+{
+  for (const auto actualValue : itk::Size<>::Filled(VFillValue).m_InternalArray)
+  {
+    if (actualValue != VFillValue)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+
 } // namespace
+
+
+static_assert(Is_Filled_Size_correctly_filled<0>() && Is_Filled_Size_correctly_filled<1>() &&
+                Is_Filled_Size_correctly_filled<std::numeric_limits<itk::IndexValueType>::max()>(),
+              "itk::Size::Filled(value) should be correctly filled at compile-time");
 
 
 // Tests that itk::Size::Filled(value) returns an itk::Size with the


### PR DESCRIPTION
Declared the `Filled(value)` and `operator[](pos)` member functions of
`itk::FixedArray`, `itk::Index`, and `itk::Size` constexpr.