### PR TITLE
ENH: Replace BSpline GetSupportSize() by static constexpr `SupportSize`

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -441,7 +441,8 @@ now has signature
 See commit [commit 212cae5](https://github.com/InsightSoftwareConsortium/ITK/commit/212cae522d8451ea089c41f8a151279e1dd17042) for details.
 
 With ITK 5.3, the `GetNumberOfWeights()` member functions of `itk::BSplineBaseTransform` and `itk::BSplineInterpolationWeightFunction`
-are replaced by static constexpr data members named `NumberOfWeights`.
+are replaced by static constexpr data members named `NumberOfWeights`, and the `GetSupportSize()` member function of
+`itk::BSplineInterpolationWeightFunction` is replaced by a static constexpr data member named `SupportSize`.
 
 Consolidated Vector Filter
 --------------------------

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -83,6 +83,9 @@ public:
   /** ContinuousIndex type alias support. */
   using ContinuousIndexType = ContinuousIndex<TCoordRep, VSpaceDimension>;
 
+  /** The support region size: a hypercube of length SplineOrder + 1 */
+  static constexpr SizeType SupportSize{ SizeType::Filled(VSplineOrder + 1) };
+
   /** Evaluate the weights at specified ContinuousIndex position.
    * Subclasses must provide this method. */
   WeightsType
@@ -99,10 +102,10 @@ public:
   virtual void
   Evaluate(const ContinuousIndexType & index, WeightsType & weights, IndexType & startIndex) const;
 
-  /** Get support region size. */
-  itkGetConstMacro(SupportSize, SizeType);
-
 #if !defined(ITK_LEGACY_REMOVE)
+  /** Get support region size. */
+  itkLegacyMacro(SizeType GetSupportSize() const) { return Self::SupportSize; };
+
   /** Get number of weights. */
   itkLegacyMacro(unsigned int GetNumberOfWeights() const) { return Self::NumberOfWeights; }
 #endif
@@ -114,9 +117,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  /** Size of support region. */
-  SizeType m_SupportSize;
-
   /** Lookup table type. */
   using TableType = Array2D<unsigned int>;
 

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -30,15 +30,13 @@ namespace itk
 template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::BSplineInterpolationWeightFunction()
 {
-  // Initialize support region is a hypercube of length SplineOrder + 1
-  m_SupportSize.Fill(SplineOrder + 1);
-
   // Initialize offset to index lookup table
   m_OffsetToIndexTable.set_size(Self::NumberOfWeights, SpaceDimension);
 
-  unsigned int counter = 0;
+  constexpr auto supportSize = Self::SupportSize;
+  unsigned int   counter = 0;
 
-  for (const IndexType index : ZeroBasedIndexRange<VSpaceDimension>(m_SupportSize))
+  for (const IndexType index : ZeroBasedIndexRange<VSpaceDimension>(supportSize))
   {
     for (unsigned int j = 0; j < SpaceDimension; ++j)
     {
@@ -63,7 +61,6 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Pr
   Superclass::PrintSelf(os, indent);
 
   os << indent << "NumberOfWeights: " << Self::NumberOfWeights << std::endl;
-  os << indent << "SupportSize: " << m_SupportSize << std::endl;
 }
 
 /** Compute weights for interpolation at continuous index position */

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -240,7 +240,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     FunctionType::Pointer function = FunctionType::New();
     function->Print(std::cout);
 
-    SizeType      size = function->GetSupportSize();
+    SizeType      size = FunctionType::SupportSize;
     unsigned long numberOfWeights = FunctionType::NumberOfWeights;
 
     std::cout << "Number Of Weights: " << numberOfWeights << std::endl;

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -497,8 +497,8 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Tra
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);
 
   // For each dimension, correlate coefficient with weights
-  RegionType supportRegion;
-  SizeType   supportSize = this->m_WeightsFunction->GetSupportSize();
+  RegionType         supportRegion;
+  constexpr SizeType supportSize = WeightsFunctionType::SupportSize;
   supportRegion.SetSize(supportSize);
   supportRegion.SetIndex(supportIndex);
 


### PR DESCRIPTION
Replaced the `GetSupportSize()` member function of
`BSplineInterpolationWeightFunction` by a static constexpr data member,
`SupportSize`.

Allows using this size at compile-time.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2709
commit 34f3db8d8ad0ba848cbbfee071edf327e09f6a96
"ENH: Replace GetNumberOfWeights() by static constexpr `NumberOfWeights`"
