### PR TITLE
PERF: Use FixedArray for BSplineInterpolationWeightFunction OutputType

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -46,14 +46,16 @@ namespace itk
  */
 template <typename TCoordRep = float, unsigned int VSpaceDimension = 2, unsigned int VSplineOrder = 3>
 class ITK_TEMPLATE_EXPORT BSplineInterpolationWeightFunction
-  : public FunctionBase<ContinuousIndex<TCoordRep, VSpaceDimension>, Array<double>>
+  : public FunctionBase<ContinuousIndex<TCoordRep, VSpaceDimension>,
+                        FixedArray<double, Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension)>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineInterpolationWeightFunction);
 
   /** Standard class type aliases. */
   using Self = BSplineInterpolationWeightFunction;
-  using Superclass = FunctionBase<ContinuousIndex<TCoordRep, VSpaceDimension>, Array<double>>;
+  using Superclass = FunctionBase<ContinuousIndex<TCoordRep, VSpaceDimension>,
+                                  FixedArray<double, Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension)>>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -70,11 +72,11 @@ public:
   /** Spline order. */
   static constexpr unsigned int SplineOrder = VSplineOrder;
 
-  /** Number of weights. */
-  static constexpr unsigned int NumberOfWeights{ Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension) };
-
   /** OutputType type alias support. */
-  using WeightsType = Array<double>;
+  using WeightsType = typename Superclass::OutputType;
+
+  /** Number of weights. */
+  static constexpr unsigned int NumberOfWeights{ WeightsType::Length };
 
   /** Index and size type alias support. */
   using IndexType = Index<VSpaceDimension>;

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -56,7 +56,7 @@ typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineO
 BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::Evaluate(
   const ContinuousIndexType & index) const
 {
-  WeightsType weights(Self::NumberOfWeights);
+  WeightsType weights;
   IndexType   startIndex;
 
   this->Evaluate(index, weights, startIndex);

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -61,9 +61,6 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     WeightsType weights1;
     WeightsType weights2;
 
-    weights1.SetSize(SplineOrder + 1);
-    weights2.SetSize(SplineOrder + 1);
-
     ContinuousIndexType position1;
     ContinuousIndexType position2;
 
@@ -150,9 +147,6 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
 
     WeightsType weights1;
     WeightsType weights2;
-
-    weights1.SetSize(SplineOrder + 1);
-    weights2.SetSize(SplineOrder + 1);
 
     ContinuousIndexType position1;
     ContinuousIndexType position2;

--- a/Modules/Core/Common/wrapping/itkFunctionBase.wrap
+++ b/Modules/Core/Common/wrapping/itkFunctionBase.wrap
@@ -26,6 +26,10 @@ itk_wrap_class("itk::FunctionBase" POINTER)
     itk_wrap_template("${ITKM_PD${d}}RGBD" "${ITKT_PD${d}},itk::RGBPixel< double >")
     itk_wrap_template("${ITKM_PD${d}}RGBAD" "${ITKT_PD${d}},itk::RGBAPixel< double >")
 
+    # Required by BSplineInterpolationWeightFunction
+    itk_wrap_template("${ITKM_CID2}${ITKM_FAD9}" "${ITKT_CID2}, ${ITKT_FAD9}")
+    itk_wrap_template("${ITKM_CID3}${ITKM_FAD64}" "${ITKT_CID3}, ${ITKT_FAD64}")
+
   endforeach()
 
   foreach(r ${WRAP_ITK_REAL})

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -234,11 +234,11 @@ public:
   using WeightsType = typename WeightsFunctionType::WeightsType;
   using ContinuousIndexType = typename WeightsFunctionType::ContinuousIndexType;
 
-  /** Parameter index array type. */
-  using ParameterIndexArrayType = Array<unsigned long>;
-
   /** Number of weights. */
   static constexpr unsigned int NumberOfWeights{ WeightsFunctionType::NumberOfWeights };
+
+  /** Parameter index array type. */
+  using ParameterIndexArrayType = FixedArray<unsigned long, NumberOfWeights>;
 
   /**
    * Transform points by a BSpline deformable transformation.

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -315,7 +315,7 @@ typename BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::
 BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoint(
   const InputPointType & point) const
 {
-  WeightsType             weights(WeightsFunctionType::NumberOfWeights);
+  WeightsType             weights;
   ParameterIndexArrayType indices(WeightsFunctionType::NumberOfWeights);
   OutputPointType         outputPoint;
   bool                    inside;

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -316,7 +316,7 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::Transform
   const InputPointType & point) const
 {
   WeightsType             weights;
-  ParameterIndexArrayType indices(WeightsFunctionType::NumberOfWeights);
+  ParameterIndexArrayType indices;
   OutputPointType         outputPoint;
   bool                    inside;
 

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -573,7 +573,7 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Com
   }
 
   // Compute interpolation weights
-  WeightsType weights(WeightsFunctionType::NumberOfWeights);
+  WeightsType weights;
 
   IndexType supportIndex;
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -623,7 +623,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::ComputeJacobi
   }
 
   // Compute interpolation weights
-  WeightsType weights(WeightsFunctionType::NumberOfWeights);
+  WeightsType weights;
 
   IndexType supportIndex;
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -203,7 +203,7 @@ itkBSplineDeformableTransformTest1()
   using WeightsType = TransformType::WeightsType;
   using IndexArrayType = TransformType::ParameterIndexArrayType;
 
-  WeightsType    weights(TransformType::NumberOfWeights);
+  WeightsType    weights;
   IndexArrayType indices(TransformType::NumberOfWeights);
   bool           inside;
 

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -204,7 +204,7 @@ itkBSplineDeformableTransformTest1()
   using IndexArrayType = TransformType::ParameterIndexArrayType;
 
   WeightsType    weights;
-  IndexArrayType indices(TransformType::NumberOfWeights);
+  IndexArrayType indices;
   bool           inside;
 
   inputPoint.Fill(8.3);

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -239,7 +239,7 @@ itkBSplineTransformTest1()
   using WeightsType = TransformType::WeightsType;
   using IndexArrayType = TransformType::ParameterIndexArrayType;
 
-  WeightsType    weights(TransformType::NumberOfWeights);
+  WeightsType    weights;
   IndexArrayType indices(TransformType::NumberOfWeights);
   bool           inside;
 

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -240,7 +240,7 @@ itkBSplineTransformTest1()
   using IndexArrayType = TransformType::ParameterIndexArrayType;
 
   WeightsType    weights;
-  IndexArrayType indices(TransformType::NumberOfWeights);
+  IndexArrayType indices;
   bool           inside;
 
   inputPoint.Fill(8.3);

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -437,7 +437,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
     this->m_BSplineTransformIndicesArray.SetSize(1, 1);
     this->m_BSplinePreTransformPointsArray.resize(1);
     this->m_WithinBSplineSupportRegionArray.resize(1);
-    this->m_BSplineTransformWeights.SetSize(1);
     this->m_BSplineTransformIndices.SetSize(1);
 
     delete[] this->m_ThreaderBSplineTransformWeights;
@@ -457,7 +456,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
     }
     else
     {
-      this->m_BSplineTransformWeights.SetSize(this->m_NumBSplineWeights);
       this->m_BSplineTransformIndices.SetSize(this->m_NumBSplineWeights);
 
       this->m_ThreaderBSplineTransformWeights = new BSplineTransformWeightsType[m_NumberOfWorkUnits - 1];
@@ -465,7 +463,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
 
       for (ThreadIdType ithread = 0; ithread < m_NumberOfWorkUnits - 1; ++ithread)
       {
-        this->m_ThreaderBSplineTransformWeights[ithread].SetSize(this->m_NumBSplineWeights);
         this->m_ThreaderBSplineTransformIndices[ithread].SetSize(this->m_NumBSplineWeights);
       }
     }
@@ -797,7 +794,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PreComputeTransformValues()
   m_Transform->SetParameters(dummyParameters);
 
   // Cycle through each sampled fixed image point
-  BSplineTransformWeightsType    weights(m_NumBSplineWeights);
+  BSplineTransformWeightsType    weights;
   BSplineTransformIndexArrayType indices(m_NumBSplineWeights);
   bool                           valid;
   MovingImagePointType           mappedPoint;

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -437,7 +437,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
     this->m_BSplineTransformIndicesArray.SetSize(1, 1);
     this->m_BSplinePreTransformPointsArray.resize(1);
     this->m_WithinBSplineSupportRegionArray.resize(1);
-    this->m_BSplineTransformIndices.SetSize(1);
 
     delete[] this->m_ThreaderBSplineTransformWeights;
     this->m_ThreaderBSplineTransformWeights = nullptr;
@@ -456,15 +455,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::MultiThreadingInitialize()
     }
     else
     {
-      this->m_BSplineTransformIndices.SetSize(this->m_NumBSplineWeights);
-
       this->m_ThreaderBSplineTransformWeights = new BSplineTransformWeightsType[m_NumberOfWorkUnits - 1];
       this->m_ThreaderBSplineTransformIndices = new BSplineTransformIndexArrayType[m_NumberOfWorkUnits - 1];
-
-      for (ThreadIdType ithread = 0; ithread < m_NumberOfWorkUnits - 1; ++ithread)
-      {
-        this->m_ThreaderBSplineTransformIndices[ithread].SetSize(this->m_NumBSplineWeights);
-      }
     }
 
     for (unsigned int j = 0; j < FixedImageDimension; ++j)
@@ -795,7 +787,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PreComputeTransformValues()
 
   // Cycle through each sampled fixed image point
   BSplineTransformWeightsType    weights;
-  BSplineTransformIndexArrayType indices(m_NumBSplineWeights);
+  BSplineTransformIndexArrayType indices;
   bool                           valid;
   MovingImagePointType           mappedPoint;
 

--- a/Wrapping/WrapITKTypes.cmake
+++ b/Wrapping/WrapITKTypes.cmake
@@ -148,6 +148,13 @@ WRAP_TYPE("itk::FixedArray" "FA" "itkFixedArray.h")
     ADD_TEMPLATE("${ITKM_SC}${d}" "${ITKT_SC},${d}")
     ADD_TEMPLATE("${ITKM_B}${d}"  "${ITKT_B},${d}")
   endforeach()
+
+  # Wrap FixedArray for BSplineInterpolationWeightFunction:
+  ADD_TEMPLATE("${ITKM_D}9" "${ITKT_D},9")
+  ADD_TEMPLATE("${ITKM_D}16" "${ITKT_D},16")
+  ADD_TEMPLATE("${ITKM_UL}16" "${ITKT_UL},16")
+  ADD_TEMPLATE("${ITKM_D}64" "${ITKT_D},64")
+  ADD_TEMPLATE("${ITKM_UL}64" "${ITKT_UL},64")
 END_WRAP_TYPE()
 set(itk_Wrap_FixedArray ${WRAPPER_TEMPLATES})
 


### PR DESCRIPTION
Replaced `itk::Array` by `itk::FixedArray` as output type (array of
weights) of `itk::BSplineInterpolationWeightFunction`.

Observed a significant improvement of the runtime performance of a call to `itk::BSplineBaseTransform::TransformPoint`: the runtime duration appeared ~30% lower than before, from 1.5 sec. down to 1.0 sec. when calling `TransformPoint` 10'000'000 times. (Tested using Visual C++ 2019 Release).
