### PR TITLE
BUG: BSplineInterpolationWeightFunction should not print NumberOfWeights

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -113,8 +113,6 @@ public:
 protected:
   BSplineInterpolationWeightFunction();
   ~BSplineInterpolationWeightFunction() override = default;
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
   /** Lookup table type. */

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -50,19 +50,6 @@ BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::BS
   m_Kernel = KernelType::New();
 }
 
-/**
- * Standard "PrintSelf" method
- */
-template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-void
-BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::PrintSelf(std::ostream & os,
-                                                                                        Indent         indent) const
-{
-  Superclass::PrintSelf(os, indent);
-
-  os << indent << "NumberOfWeights: " << Self::NumberOfWeights << std::endl;
-}
-
 /** Compute weights for interpolation at continuous index position */
 template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::WeightsType


### PR DESCRIPTION
Because `NumberOfWeights` is a static constexpr data member of
`BSplineInterpolationWeightFunction`, it should not be printed by its
`PrintSelf` override. As was remarked by Jon Haitz Legarreta Gorroño (@jhlegarreta),
and confirmed by Hans Johnson (@hjmjohnson) and Dženan Zukić (@dzenanz).

Because `BSplineInterpolationWeightFunction::PrintSelf` did not do
anything else anymore than just calling the corresponding `Superclass`
member function, the override is no longer necessary either, and is
removed by this commit.

For the record, `NumberOfWeights` was introduced by:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2709
commit 34f3db8d8ad0ba848cbbfee071edf327e09f6a96
"ENH: Replace GetNumberOfWeights() by static constexpr NumberOfWeights"