### PR TITLE
PERF: Use FixedArray for table within BSplineInterpolationWeightFunction

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -22,6 +22,7 @@
 #include "itkContinuousIndex.h"
 #include "itkArray.h"
 #include "itkArray2D.h"
+#include "itkIndexRange.h"
 #include "itkMath.h"
 
 namespace itk
@@ -112,15 +113,21 @@ public:
 #endif
 
 protected:
-  BSplineInterpolationWeightFunction();
+  BSplineInterpolationWeightFunction() = default;
   ~BSplineInterpolationWeightFunction() override = default;
 
 private:
   /** Lookup table type. */
-  using TableType = Array2D<unsigned int>;
+  using TableType = FixedArray<IndexType, NumberOfWeights>;
 
   /** Table mapping linear offset to indices. */
-  TableType m_OffsetToIndexTable;
+  const TableType m_OffsetToIndexTable{ [] {
+    TableType     table;
+    // Note: Copied the constexpr value `SupportSize` to a temporary, `SizeType{ SupportSize }`, to prevent a GCC
+    // (Ubuntu 7.5.0-3ubuntu1~18.04) link error, "undefined reference to `SupportSize`".
+    std::copy_n(ZeroBasedIndexRange<SpaceDimension>(SizeType{ SupportSize }).cbegin(), NumberOfWeights, table.begin());
+    return table;
+  }() };
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -23,30 +23,9 @@
 #include "itkImage.h"
 #include "itkMatrix.h"
 #include "itkMath.h"
-#include "itkIndexRange.h"
 
 namespace itk
 {
-/** Constructor */
-template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
-BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::BSplineInterpolationWeightFunction()
-{
-  // Initialize offset to index lookup table
-  m_OffsetToIndexTable.set_size(Self::NumberOfWeights, SpaceDimension);
-
-  constexpr auto supportSize = Self::SupportSize;
-  unsigned int   counter = 0;
-
-  for (const IndexType index : ZeroBasedIndexRange<VSpaceDimension>(supportSize))
-  {
-    for (unsigned int j = 0; j < SpaceDimension; ++j)
-    {
-      m_OffsetToIndexTable[counter][j] = index[j];
-    }
-    ++counter;
-  }
-}
-
 /** Compute weights for interpolation at continuous index position */
 template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::WeightsType


### PR DESCRIPTION
Replaced `itk::Array2D` by `itk::FixedArray`, used as private `TableType`
of `BSplineInterpolationWeightFunction`. This is the type of a table,
used internally by its `Evaluate` member function.

Declared this table `const`, and initialized the table by an in-class
default-member-initializer. Defaulted the default-constructor.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2712
commit bc7c5dff2d6a29815bce50cbe7fd8bb5476a4a2b
"PERF: Use FixedArray for BSplineBaseTransform ParameterIndexArrayType"
commit 9bf745bda51044c90208c7b0776e87d7c86adb11
"PERF: Use FixedArray for BSplineInterpolationWeightFunction OutputType"