### PR TITLE
ENH: Rename ResampleInPlaceImage to TransformGeometryImageFilter

### DIFF
--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
@@ -16,18 +16,18 @@
  *
  *=========================================================================*/
 
-#ifndef itkResampleInPlaceImageFilter_h
-#define itkResampleInPlaceImageFilter_h
+#ifndef itkTransformGeometryImageFilter_h
+#define itkTransformGeometryImageFilter_h
 
 #include "itkImageToImageFilter.h"
 #include "itkVersorRigid3DTransform.h"
 
 namespace itk
 {
-/** \class ResampleInPlaceImageFilter
- * \brief Resample an image in place.
+/** \class TransformGeometryImageFilter
+ * \brief Pseudo-Resample an image by modifying the geometric meta-data and not the pixels.
  *
- * The ResampleImageFilter will generate a physical memory-modified version of
+ * The TransformGeometryImageFilter will generate a physical memory-modified version of
  * the input image if the input transform is not identity. Its neglectful use
  * can be a source of problems: e.g. it can exhaust the memory if the image is
  * very large, and it WILL reduce the image quality when there are lots of
@@ -99,13 +99,13 @@ namespace itk
  * \ingroup ITKTransform
  */
 template <typename TInputImage, typename TOutputImage>
-class ITK_TEMPLATE_EXPORT ResampleInPlaceImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT TransformGeometryImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_MOVE(ResampleInPlaceImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(TransformGeometryImageFilter);
 
   /** Standard class type alias */
-  using Self = ResampleInPlaceImageFilter;
+  using Self = TransformGeometryImageFilter;
   using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -114,7 +114,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(ResampleInPlaceImageFilter, ImageToImageFilter);
+  itkTypeMacro(TransformGeometryImageFilter, ImageToImageFilter);
 
   /** input/output image type alias */
   using InputImageType = TInputImage;
@@ -153,8 +153,8 @@ public:
   GetInputImage() const;
 
 protected:
-  ResampleInPlaceImageFilter() = default;
-  ~ResampleInPlaceImageFilter() override = default;
+  TransformGeometryImageFilter() = default;
+  ~TransformGeometryImageFilter() override = default;
 
   void
   GenerateData() override;
@@ -169,7 +169,7 @@ private:
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkResampleInPlaceImageFilter.hxx"
+#  include "itkTransformGeometryImageFilter.hxx"
 #endif
 
 #endif

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.hxx
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.hxx
@@ -16,24 +16,24 @@
  *
  *=========================================================================*/
 
-#ifndef itkResampleInPlaceImageFilter_hxx
-#define itkResampleInPlaceImageFilter_hxx
+#ifndef itkTransformGeometryImageFilter_hxx
+#define itkTransformGeometryImageFilter_hxx
 
-#include "itkResampleInPlaceImageFilter.h"
+#include "itkTransformGeometryImageFilter.h"
 #include "itkCastImageFilter.h"
 
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 void
-ResampleInPlaceImageFilter<TInputImage, TOutputImage>::SetInputImage(const InputImageType * image)
+TransformGeometryImageFilter<TInputImage, TOutputImage>::SetInputImage(const InputImageType * image)
 {
   this->SetInput(0, image);
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename ResampleInPlaceImageFilter<TInputImage, TOutputImage>::InputImageType *
-ResampleInPlaceImageFilter<TInputImage, TOutputImage>::GetInputImage() const
+const typename TransformGeometryImageFilter<TInputImage, TOutputImage>::InputImageType *
+TransformGeometryImageFilter<TInputImage, TOutputImage>::GetInputImage() const
 {
   return this->GetInput(0);
 }
@@ -41,7 +41,7 @@ ResampleInPlaceImageFilter<TInputImage, TOutputImage>::GetInputImage() const
 
 template <typename TInputImage, typename TOutputImage>
 void
-ResampleInPlaceImageFilter<TInputImage, TOutputImage>::GenerateData()
+TransformGeometryImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
   if (!this->GetInput())
   {
@@ -81,7 +81,7 @@ ResampleInPlaceImageFilter<TInputImage, TOutputImage>::GenerateData()
 
 template <typename TInputImage, typename TOutputImage>
 void
-ResampleInPlaceImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
+TransformGeometryImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -38,7 +38,7 @@ itkCompositeTransformTest.cxx
 itkTransformCloneTest.cxx
 itkMultiTransformTest.cxx
 itkTestTransformGetInverse.cxx
-itkResampleInPlaceImageFilterTest.cxx
+        itkTransformGeometryImageFilterTest.cxx
 )
 
 CreateTestDriver(ITKTransform  "${ITKTransform-Test_LIBRARIES}" "${ITKTransformTests}")
@@ -179,8 +179,8 @@ itk_add_test(NAME itkTestTransformGetInverse
   COMMAND ITKTransformTestDriver itkTestTransformGetInverse)
 set_property(TEST itkTestTransformGetInverse APPEND PROPERTY LABELS RUNS_LONG)
 set_tests_properties( itkTestTransformGetInverse PROPERTIES COST 50 )
-itk_add_test(NAME itkResampleInPlaceImageFilterTest
-      COMMAND ITKTransformTestDriver itkResampleInPlaceImageFilterTest
+itk_add_test(NAME itkTransformGeometryImageFilterTest
+      COMMAND ITKTransformTestDriver itkTransformGeometryImageFilterTest
               ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensity3Slices.mha
               DATA{Baseline/BrainProtonDensity3SlicesHardened.mha}
               ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensity3SlicesHardened.mha)

--- a/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
@@ -16,7 +16,7 @@
  *
  *=========================================================================*/
 
-#include "itkResampleInPlaceImageFilter.h"
+#include "itkTransformGeometryImageFilter.h"
 
 #include "itkImage.h"
 #include "itkImageFileReader.h"
@@ -78,7 +78,7 @@ imagesDifferent(ImageType * baselineImage, ImageType * outputImage)
 }
 
 int
-itkResampleInPlaceImageFilterTest(int argc, char * argv[])
+itkTransformGeometryImageFilterTest(int argc, char * argv[])
 {
   if (argc < 3)
   {
@@ -94,7 +94,7 @@ itkResampleInPlaceImageFilterTest(int argc, char * argv[])
   using ImageType = itk::Image<PixelType, Dimension>;
   using ImagePointer = ImageType::Pointer;
   using TransformType = itk::VersorRigid3DTransform<double>;
-  using FilterType = itk::ResampleInPlaceImageFilter<ImageType, ImageType>;
+  using FilterType = itk::TransformGeometryImageFilter<ImageType, ImageType>;
 
   // Read in input test image
   ImagePointer inputImage;
@@ -125,9 +125,9 @@ itkResampleInPlaceImageFilterTest(int argc, char * argv[])
   transform->Translate(translation);
   transform->SetRotation(rotationAxis, rotationAngle);
 
-  // Set up the resample filter
+  // Set up the transform filter
   FilterType::Pointer filter = FilterType::New();
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, ResampleInPlaceImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, TransformGeometryImageFilter, ImageToImageFilter);
 
   // Test the exceptions
   ITK_TRY_EXPECT_EXCEPTION(filter->Update());

--- a/Modules/Core/Transform/wrapping/CMakeLists.txt
+++ b/Modules/Core/Transform/wrapping/CMakeLists.txt
@@ -15,7 +15,7 @@ set(WRAPPER_SUBMODULE_ORDER
   itkScalableAffineTransform
   itkScaleTransform
   itkKernelTransform
-  itkResampleInPlaceImageFilter
+  itkTransformGeometryImageFilter
 )
 itk_auto_load_submodules()
 itk_end_wrap_module()

--- a/Modules/Core/Transform/wrapping/itkTransformGeometryImageFilter.wrap
+++ b/Modules/Core/Transform/wrapping/itkTransformGeometryImageFilter.wrap
@@ -1,6 +1,6 @@
 itk_wrap_filter_dims(d3 3)
 if(d3)
-  itk_wrap_class("itk::ResampleInPlaceImageFilter" POINTER)
+  itk_wrap_class("itk::TransformGeometryImageFilter" POINTER)
     foreach(t ${WRAP_ITK_SCALAR})
       itk_wrap_template("${ITKM_I${t}${d3}}${ITKM_I${t}${d3}}" "${ITKT_I${t}${d3}},${ITKT_I${t}${d3}}")
     endforeach()


### PR DESCRIPTION
Community discussion and voting converged TransformGeometryImageFilter
is a more accurate name for the operation.

Renamed per the discussion: https://discourse.itk.org/t/simpleitk-euler3d-transform-adjust-image-origin-and-direction/3966/25

