### PR TITLE
STYLE: Use modern C++ `TRealValueType{ x }` syntax

### DIFF
--- a/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
@@ -90,36 +90,36 @@ private:
   inline TRealValueType
   Evaluate(const Dispatch<0> &, const TRealValueType & itkNotUsed(u)) const
   {
-    return NumericTraits<TRealValueType>::ZeroValue();
+    return TRealValueType{ 0.0 };
   }
 
   /** Evaluate the function:  first order spline */
   inline TRealValueType
   Evaluate(const Dispatch<1> &, const TRealValueType & u) const
   {
-    if (Math::ExactlyEquals(u, -NumericTraits<TRealValueType>::OneValue()))
+    if (Math::ExactlyEquals(u, TRealValueType{ -1.0 }))
     {
-      return static_cast<TRealValueType>(0.5);
+      return TRealValueType{ 0.5 };
     }
-    else if ((u > -NumericTraits<TRealValueType>::OneValue()) && (u < NumericTraits<TRealValueType>::ZeroValue()))
+    else if ((u > TRealValueType{ -1.0 }) && (u < TRealValueType{ 0.0 }))
     {
-      return NumericTraits<TRealValueType>::OneValue();
+      return TRealValueType{ 1.0 };
     }
-    else if (Math::ExactlyEquals(u, NumericTraits<TRealValueType>::ZeroValue()))
+    else if (Math::ExactlyEquals(u, TRealValueType{ 0.0 }))
     {
-      return NumericTraits<TRealValueType>::ZeroValue();
+      return TRealValueType{ 0.0 };
     }
-    else if ((u > NumericTraits<TRealValueType>::ZeroValue()) && (u < NumericTraits<TRealValueType>::OneValue()))
+    else if ((u > TRealValueType{ 0.0 }) && (u < TRealValueType{ 1.0 }))
     {
-      return -NumericTraits<TRealValueType>::OneValue();
+      return TRealValueType{ -1.0 };
     }
-    else if (Math::ExactlyEquals(u, NumericTraits<TRealValueType>::OneValue()))
+    else if (Math::ExactlyEquals(u, TRealValueType{ 1.0 }))
     {
-      return static_cast<TRealValueType>(-0.5);
+      return TRealValueType{ -0.5 };
     }
     else
     {
-      return NumericTraits<TRealValueType>::ZeroValue();
+      return TRealValueType{ 0.0 };
     }
   }
 
@@ -127,21 +127,21 @@ private:
   inline TRealValueType
   Evaluate(const Dispatch<2> &, const TRealValueType & u) const
   {
-    if ((u > static_cast<TRealValueType>(-0.5)) && (u < static_cast<TRealValueType>(0.5)))
+    if ((u > TRealValueType{ -0.5 }) && (u < TRealValueType{ 0.5 }))
     {
-      return (static_cast<TRealValueType>(-2.0) * u);
+      return (TRealValueType{ -2.0 } * u);
     }
-    else if ((u >= static_cast<TRealValueType>(0.5)) && (u < static_cast<TRealValueType>(1.5)))
+    else if ((u >= TRealValueType{ 0.5 }) && (u < TRealValueType{ 1.5 }))
     {
-      return (static_cast<TRealValueType>(-1.5) + u);
+      return (TRealValueType{ -1.5 } + u);
     }
-    else if ((u > static_cast<TRealValueType>(-1.5)) && (u <= static_cast<TRealValueType>(-0.5)))
+    else if ((u > TRealValueType{ -1.5 }) && (u <= TRealValueType{ -0.5 }))
     {
-      return (static_cast<TRealValueType>(1.5) + u);
+      return (TRealValueType{ 1.5 } + u);
     }
     else
     {
-      return NumericTraits<TRealValueType>::ZeroValue();
+      return TRealValueType{ 0.0 };
     }
   }
 
@@ -149,27 +149,25 @@ private:
   inline TRealValueType
   Evaluate(const Dispatch<3> &, const TRealValueType & u) const
   {
-    if ((u >= NumericTraits<TRealValueType>::ZeroValue()) && (u < NumericTraits<TRealValueType>::OneValue()))
+    if ((u >= TRealValueType{ 0.0 }) && (u < TRealValueType{ 1.0 }))
     {
-      return (static_cast<TRealValueType>(-2.0) * u + static_cast<TRealValueType>(1.5) * u * u);
+      return (TRealValueType{ -2.0 } * u + TRealValueType{ 1.5 } * u * u);
     }
-    else if ((u > -NumericTraits<TRealValueType>::OneValue()) && (u < NumericTraits<TRealValueType>::ZeroValue()))
+    else if ((u > TRealValueType{ -1.0 }) && (u < TRealValueType{ 0.0 }))
     {
-      return (static_cast<TRealValueType>(-2.0) * u - static_cast<TRealValueType>(1.5) * u * u);
+      return (TRealValueType{ -2.0 } * u - TRealValueType{ 1.5 } * u * u);
     }
-    else if ((u >= NumericTraits<TRealValueType>::OneValue()) && (u < static_cast<TRealValueType>(2.0)))
+    else if ((u >= TRealValueType{ 1.0 }) && (u < TRealValueType{ 2.0 }))
     {
-      return (static_cast<TRealValueType>(-2.0) + static_cast<TRealValueType>(2.0) * u -
-              static_cast<TRealValueType>(0.5) * u * u);
+      return (TRealValueType{ -2.0 } + TRealValueType{ 2.0 } * u - TRealValueType{ 0.5 } * u * u);
     }
-    else if ((u > static_cast<TRealValueType>(-2.0)) && (u <= -NumericTraits<TRealValueType>::OneValue()))
+    else if ((u > TRealValueType{ -2.0 }) && (u <= TRealValueType{ -1.0 }))
     {
-      return (static_cast<TRealValueType>(2.0) + static_cast<TRealValueType>(2.0) * u +
-              static_cast<TRealValueType>(0.5) * u * u);
+      return (TRealValueType{ 2.0 } + TRealValueType{ 2.0 } * u + TRealValueType{ 0.5 } * u * u);
     }
     else
     {
-      return NumericTraits<TRealValueType>::ZeroValue();
+      return TRealValueType{ 0.0 };
     }
   }
 

--- a/Modules/Core/Common/include/itkBSplineKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineKernelFunction.h
@@ -98,17 +98,17 @@ private:
   Evaluate(const Dispatch<0> &, const TRealValueType & u)
   {
     const TRealValueType absValue = itk::Math::abs(u);
-    if (absValue < static_cast<TRealValueType>(0.5))
+    if (absValue < TRealValueType{ 0.5 })
     {
-      return NumericTraits<TRealValueType>::OneValue();
+      return TRealValueType{ 1.0 };
     }
-    else if (Math::ExactlyEquals(absValue, static_cast<TRealValueType>(0.5)))
+    else if (Math::ExactlyEquals(absValue, TRealValueType{ 0.5 }))
     {
-      return static_cast<TRealValueType>(0.5);
+      return TRealValueType{ 0.5 };
     }
     else
     {
-      return NumericTraits<TRealValueType>::ZeroValue();
+      return TRealValueType{ 0.0 };
     }
   }
 
@@ -117,13 +117,13 @@ private:
   Evaluate(const Dispatch<1> &, const TRealValueType & u)
   {
     const TRealValueType absValue = itk::Math::abs(u);
-    if (absValue < NumericTraits<TRealValueType>::OneValue())
+    if (absValue < TRealValueType{ 1.0 })
     {
-      return NumericTraits<TRealValueType>::OneValue() - absValue;
+      return TRealValueType{ 1.0 } - absValue;
     }
     else
     {
-      return NumericTraits<TRealValueType>::ZeroValue();
+      return TRealValueType{ 0.0 };
     }
   }
 
@@ -132,22 +132,21 @@ private:
   Evaluate(const Dispatch<2> &, const TRealValueType & u)
   {
     const TRealValueType absValue = itk::Math::abs(u);
-    if (absValue < static_cast<TRealValueType>(0.5))
+    if (absValue < TRealValueType{ 0.5 })
     {
       const TRealValueType sqrValue = itk::Math::sqr(absValue);
-      return static_cast<TRealValueType>(0.75) - sqrValue;
+      return TRealValueType{ 0.75 } - sqrValue;
     }
-    else if (absValue < static_cast<TRealValueType>(1.5))
+    else if (absValue < TRealValueType{ 1.5 })
     {
       const TRealValueType sqrValue = itk::Math::sqr(absValue);
-      // NOTE: 1.0/8.0 == static_cast< TRealValueType >( 0.125 )
-      return (static_cast<TRealValueType>(9.0) - static_cast<TRealValueType>(12.0) * absValue +
-              static_cast<TRealValueType>(4.0) * sqrValue) *
-             static_cast<TRealValueType>(0.125);
+      // NOTE: 1.0/8.0 == 0.125
+      return (TRealValueType{ 9.0 } - TRealValueType{ 12.0 } * absValue + TRealValueType{ 4.0 } * sqrValue) *
+             TRealValueType{ 0.125 };
     }
     else
     {
-      return NumericTraits<TRealValueType>::ZeroValue();
+      return TRealValueType{ 0.0 };
     }
   }
 
@@ -156,23 +155,22 @@ private:
   Evaluate(const Dispatch<3> &, const TRealValueType & u)
   {
     const TRealValueType absValue = itk::Math::abs(u);
-    if (absValue < NumericTraits<TRealValueType>::OneValue())
+    if (absValue < TRealValueType{ 1.0 })
     {
       const TRealValueType sqrValue = itk::Math::sqr(absValue);
-      return (static_cast<TRealValueType>(4.0) - static_cast<TRealValueType>(6.0) * sqrValue +
-              static_cast<TRealValueType>(3.0) * sqrValue * absValue) /
-             static_cast<TRealValueType>(6.0);
+      return (TRealValueType{ 4.0 } - TRealValueType{ 6.0 } * sqrValue + TRealValueType{ 3.0 } * sqrValue * absValue) /
+             TRealValueType{ 6.0 };
     }
-    else if (absValue < static_cast<TRealValueType>(2.0))
+    else if (absValue < TRealValueType{ 2.0 })
     {
       const TRealValueType sqrValue = itk::Math::sqr(absValue);
-      return (static_cast<TRealValueType>(8.0) - static_cast<TRealValueType>(12.0) * absValue +
-              static_cast<TRealValueType>(6.0) * sqrValue - sqrValue * absValue) /
-             static_cast<TRealValueType>(6.0);
+      return (TRealValueType{ 8.0 } - TRealValueType{ 12.0 } * absValue + TRealValueType{ 6.0 } * sqrValue -
+              sqrValue * absValue) /
+             TRealValueType{ 6.0 };
     }
     else
     {
-      return NumericTraits<TRealValueType>::ZeroValue();
+      return TRealValueType{ 0.0 };
     }
   }
 

--- a/Modules/Core/Common/include/itkGaussianKernelFunction.h
+++ b/Modules/Core/Common/include/itkGaussianKernelFunction.h
@@ -59,13 +59,12 @@ public:
   TRealValueType
   Evaluate(const TRealValueType & u) const override
   {
-    return (std::exp(static_cast<TRealValueType>(-0.5) * itk::Math::sqr(u)) * m_Factor);
+    return (std::exp(TRealValueType{ -0.5 } * itk::Math::sqr(u)) * m_Factor);
   }
 
 protected:
   GaussianKernelFunction()
-    : m_Factor(NumericTraits<TRealValueType>::OneValue() /
-               std::sqrt(static_cast<TRealValueType>(2.0 * itk::Math::pi))){};
+    : m_Factor(TRealValueType{ 1.0 } / std::sqrt(TRealValueType{ 2.0 * itk::Math::pi })){};
   ~GaussianKernelFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
@@ -46,20 +46,20 @@ template <unsigned int VSplineOrder, typename TRealValueType>
 void
 CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::GenerateBSplineShapeFunctions(const unsigned int order)
 {
-  const auto numberOfPieces = static_cast<unsigned int>(static_cast<TRealValueType>(0.5) * (order + 1));
+  const auto numberOfPieces = static_cast<unsigned int>(TRealValueType{ 0.5 } * (order + 1));
 
   this->m_BSplineShapeFunctions.set_size(numberOfPieces, order);
 
   VectorType knots(order + 1);
   for (unsigned int i = 0; i < knots.size(); ++i)
   {
-    knots[i] = static_cast<TRealValueType>(-0.5) * static_cast<TRealValueType>(order) + static_cast<TRealValueType>(i);
+    knots[i] = TRealValueType{ -0.5 } * static_cast<TRealValueType>(order) + static_cast<TRealValueType>(i);
   }
 
   for (unsigned int i = 0; i < numberOfPieces; ++i)
   {
     const PolynomialType poly =
-      this->CoxDeBoor(order, knots, 0, static_cast<unsigned int>(static_cast<TRealValueType>(0.5) * (order)) + i);
+      this->CoxDeBoor(order, knots, 0, static_cast<unsigned int>(TRealValueType{ 0.5 } * (order)) + i);
     this->m_BSplineShapeFunctions.set_row(i, poly.coefficients());
   }
 }
@@ -72,28 +72,28 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::CoxDeBoor(const un
                                                                         const unsigned int   whichPiece)
 {
   VectorType           tmp(2);
-  PolynomialType       poly1(NumericTraits<TRealValueType>::ZeroValue());
-  PolynomialType       poly2(NumericTraits<TRealValueType>::ZeroValue());
+  PolynomialType       poly1(TRealValueType{ 0.0 });
+  PolynomialType       poly2(TRealValueType{ 0.0 });
   const unsigned short p = order - 1;
   const unsigned short i = whichBasisFunction;
 
   if (p == 0 && whichBasisFunction == whichPiece)
   {
-    PolynomialType poly(NumericTraits<TRealValueType>::OneValue());
+    PolynomialType poly(TRealValueType{ 1.0 });
     return poly;
   }
 
   // Term 1
   TRealValueType den = knots(i + p) - knots(i);
 
-  if (itk::Math::AlmostEquals(den, NumericTraits<TRealValueType>::ZeroValue()))
+  if (itk::Math::AlmostEquals(den, TRealValueType{ 0.0 }))
   {
-    PolynomialType poly(NumericTraits<TRealValueType>::ZeroValue());
+    PolynomialType poly(TRealValueType{ 0.0 });
     poly1 = poly;
   }
   else
   {
-    tmp(0) = NumericTraits<TRealValueType>::OneValue();
+    tmp(0) = TRealValueType{ 1.0 };
     tmp(1) = -knots(i);
     tmp /= den;
     poly1 = PolynomialType(tmp) * this->CoxDeBoor(order - 1, knots, i, whichPiece);
@@ -101,14 +101,14 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::CoxDeBoor(const un
 
   // Term 2
   den = knots(i + p + 1) - knots(i + 1);
-  if (itk::Math::AlmostEquals(den, NumericTraits<TRealValueType>::ZeroValue()))
+  if (itk::Math::AlmostEquals(den, TRealValueType{ 0.0 }))
   {
-    PolynomialType poly(NumericTraits<TRealValueType>::ZeroValue());
+    PolynomialType poly(TRealValueType{ 0.0 });
     poly2 = poly;
   }
   else
   {
-    tmp(0) = -NumericTraits<TRealValueType>::OneValue();
+    tmp(0) = TRealValueType{ -1.0 };
     tmp(1) = knots(i + p + 1);
     tmp /= den;
     poly2 = PolynomialType(tmp) * this->CoxDeBoor(order - 1, knots, i + 1, whichPiece);
@@ -156,7 +156,7 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::Evaluate(const TRe
   unsigned int which;
   if (this->m_SplineOrder % 2 == 0)
   {
-    which = static_cast<unsigned int>(absValue + static_cast<TRealValueType>(0.5));
+    which = static_cast<unsigned int>(absValue + TRealValueType{ 0.5 });
   }
   else
   {
@@ -169,7 +169,7 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::Evaluate(const TRe
   }
   else
   {
-    return NumericTraits<TRealValueType>::ZeroValue();
+    return TRealValueType{ 0.0 };
   }
 }
 
@@ -190,7 +190,7 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::EvaluateNthDerivat
   unsigned int which;
   if (this->m_SplineOrder % 2 == 0)
   {
-    which = static_cast<unsigned int>(absValue + static_cast<TRealValueType>(0.5));
+    which = static_cast<unsigned int>(absValue + TRealValueType{ 0.5 });
   }
   else
   {
@@ -205,7 +205,7 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::EvaluateNthDerivat
       polynomial = polynomial.derivative();
     }
     const TRealValueType der = polynomial.evaluate(absValue);
-    if (u < NumericTraits<TRealValueType>::ZeroValue() && n % 2 != 0)
+    if (u < TRealValueType{ 0.0 } && n % 2 != 0)
     {
       return -der;
     }
@@ -216,7 +216,7 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::EvaluateNthDerivat
   }
   else
   {
-    return NumericTraits<TRealValueType>::ZeroValue();
+    return TRealValueType{ 0.0 };
   }
 }
 
@@ -228,8 +228,8 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::PrintSelf(std::ost
   os << indent << "Spline Order: " << this->m_SplineOrder << std::endl;
   os << indent << "Piecewise Polynomial Pieces: " << std::endl;
 
-  TRealValueType a = NumericTraits<TRealValueType>::ZeroValue();
-  TRealValueType b = NumericTraits<TRealValueType>::ZeroValue();
+  TRealValueType a{ 0.0 };
+  TRealValueType b{ 0.0 };
 
   for (unsigned int i = 0; i < this->m_BSplineShapeFunctions.rows(); ++i)
   {
@@ -241,17 +241,17 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::PrintSelf(std::ost
     {
       if (this->m_SplineOrder % 2 == 0)
       {
-        b = static_cast<TRealValueType>(0.5);
+        b = TRealValueType{ 0.5 };
       }
       else
       {
-        b = NumericTraits<TRealValueType>::OneValue();
+        b = TRealValueType{ 1.0 };
       }
     }
     else
     {
       a = b;
-      b += NumericTraits<TRealValueType>::OneValue();
+      b += TRealValueType{ 1.0 };
     }
 
     os << ",  X \\in [" << a << ", " << b << "]" << std::endl;

--- a/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
@@ -69,9 +69,8 @@ public:
   Evaluate(const TRealValueType & u) const override
   {
     TRealValueType parameter = itk::Math::sqr(u / this->m_Sigma);
-    TRealValueType envelope = std::exp(static_cast<TRealValueType>(-0.5) * parameter);
-    TRealValueType phase =
-      static_cast<TRealValueType>(2.0 * itk::Math::pi) * this->m_Frequency * u + this->m_PhaseOffset;
+    TRealValueType envelope = std::exp(TRealValueType{ -0.5 } * parameter);
+    TRealValueType phase = TRealValueType{ 2.0 * itk::Math::pi } * this->m_Frequency * u + this->m_PhaseOffset;
 
     if (this->m_CalculateImaginaryPart)
     {
@@ -105,9 +104,9 @@ protected:
   GaborKernelFunction()
   {
     this->m_CalculateImaginaryPart = false;
-    this->m_Sigma = NumericTraits<TRealValueType>::OneValue();
-    this->m_Frequency = static_cast<TRealValueType>(0.4);
-    this->m_PhaseOffset = NumericTraits<TRealValueType>::ZeroValue();
+    this->m_Sigma = TRealValueType{ 1.0 };
+    this->m_Frequency = TRealValueType{ 0.4 };
+    this->m_PhaseOffset = TRealValueType{ 0.0 };
   }
   ~GaborKernelFunction() override = default;
   void


### PR DESCRIPTION
Replaced `static_cast<TRealValueType>(x)` by `TRealValueType{ x }`,
following C++ Core Guidelines, August 19, 2021, "Don’t use static_cast
for arithmetic types", from
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-arithmeticcast

The syntax `TRealValueType{ x }` is more type-safe than
`static_cast<TRealValueType>(x)`, as it prevents against accidental
narrowing (lossy) conversions.

Also replaced `ZeroValue()` and `OneValue()` calls by the corresponding
`TRealValueType{ x }` syntax.