### PR TITLE
Refactor TransformGeometryImageFilter

### DIFF
--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
@@ -19,7 +19,7 @@
 #ifndef itkTransformGeometryImageFilter_h
 #define itkTransformGeometryImageFilter_h
 
-#include "itkImageToImageFilter.h"
+#include "itkInPlaceImageFilter.h"
 #include "itkVersorRigid3DTransform.h"
 #include "itkDataObjectDecorator.h"
 
@@ -100,14 +100,14 @@ namespace itk
  * \ingroup ITKTransform
  */
 template <typename TInputImage, typename TOutputImage>
-class ITK_TEMPLATE_EXPORT TransformGeometryImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT TransformGeometryImageFilter : public InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TransformGeometryImageFilter);
 
   /** Standard class type alias */
   using Self = TransformGeometryImageFilter;
-  using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
+  using Superclass = InPlaceImageFilter<TInputImage, TOutputImage>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -115,7 +115,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(TransformGeometryImageFilter, ImageToImageFilter);
+  itkTypeMacro(TransformGeometryImageFilter, InPlaceImageFilter);
 
   /** input/output image type alias */
   using InputImageType = TInputImage;

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
@@ -142,17 +142,19 @@ public:
   using RigidTransformType = VersorRigid3DTransform<double>;
   using RigidTransformConstPointer = typename RigidTransformType::ConstPointer;
 
-  /** Set/Get rigid transform. The default is an identity transform */
+  /** Set/Get required rigid transform. */
   itkSetGetDecoratedObjectInputMacro(RigidTransform, RigidTransformType);
 
   /** Set/Get required input image. (A wrapper to this->Set/GetInput()) */
   itkSetInputMacro(InputImage, InputImageType);
-
   itkGetInputMacro(InputImage, InputImageType);
 
 protected:
   TransformGeometryImageFilter();
   ~TransformGeometryImageFilter() override = default;
+
+  void
+  GenerateOutputInformation() override;
 
   void
   GenerateData() override;

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
@@ -21,6 +21,7 @@
 
 #include "itkImageToImageFilter.h"
 #include "itkVersorRigid3DTransform.h"
+#include "itkDataObjectDecorator.h"
 
 namespace itk
 {
@@ -142,29 +143,19 @@ public:
   using RigidTransformConstPointer = typename RigidTransformType::ConstPointer;
 
   /** Set/Get rigid transform. The default is an identity transform */
-  itkSetConstObjectMacro(RigidTransform, RigidTransformType);
-  itkGetConstObjectMacro(RigidTransform, RigidTransformType);
+  itkSetGetDecoratedObjectInputMacro(RigidTransform, RigidTransformType);
 
   /** Set/Get required input image. (A wrapper to this->Set/GetInput()) */
-  void
-  SetInputImage(const InputImageType * image);
+  itkSetInputMacro(InputImage, InputImageType);
 
-  const InputImageType *
-  GetInputImage() const;
+  itkGetInputMacro(InputImage, InputImageType);
 
 protected:
-  TransformGeometryImageFilter() = default;
+  TransformGeometryImageFilter();
   ~TransformGeometryImageFilter() override = default;
 
   void
   GenerateData() override;
-
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
-
-private:
-  OutputImagePointer         m_OutputImage;
-  RigidTransformConstPointer m_RigidTransform;
 };
 } // end namespace itk
 

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
@@ -139,11 +139,11 @@ public:
 #endif
 
   /** Transform type alias */
-  using RigidTransformType = VersorRigid3DTransform<double>;
-  using RigidTransformConstPointer = typename RigidTransformType::ConstPointer;
+  using TransformType = Transform<double, InputImageDimension, OutputImageDimension>;
+  using TransformConstPointer = typename TransformType::ConstPointer;
 
   /** Set/Get required rigid transform. */
-  itkSetGetDecoratedObjectInputMacro(RigidTransform, RigidTransformType);
+  itkSetGetDecoratedObjectInputMacro(Transform, TransformType);
 
   /** Set/Get required input image. (A wrapper to this->Set/GetInput()) */
   itkSetInputMacro(InputImage, InputImageType);
@@ -155,6 +155,9 @@ protected:
 
   void
   GenerateOutputInformation() override;
+
+  void
+  VerifyPreconditions() ITKv5_CONST override;
 
   void
   GenerateData() override;

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.hxx
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.hxx
@@ -69,6 +69,11 @@ template <typename TInputImage, typename TOutputImage>
 void
 TransformGeometryImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
+  if (this->GetRunningInPlace())
+  {
+    // No need to copy the bulk data
+    return;
+  }
   OutputImageType * output = this->GetOutput();
 
   auto input = InputImageType::New();
@@ -87,6 +92,7 @@ TransformGeometryImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Can't use graft as it will overwrite the new meta-data
   output->SetPixelContainer(castFilter->GetOutput()->GetPixelContainer());
+  output->SetBufferedRegion(castFilter->GetOutput()->GetBufferedRegion());
 }
 
 } // end namespace itk

--- a/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
@@ -135,8 +135,8 @@ itkTransformGeometryImageFilterTest(int argc, char * argv[])
 
   filter->SetInputImage(inputImage);
   ITK_TEST_SET_GET_VALUE(inputImage, filter->GetInputImage());
-  filter->SetRigidTransform(transform);
-  ITK_TEST_SET_GET_VALUE(transform, filter->GetRigidTransform());
+  filter->SetTransform(transform);
+  ITK_TEST_SET_GET_VALUE(transform, filter->GetTransform());
   ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
   ImagePointer outputImage = filter->GetOutput();
   ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(outputImage, argv[3]));

--- a/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
@@ -127,7 +127,7 @@ itkTransformGeometryImageFilterTest(int argc, char * argv[])
 
   // Set up the transform filter
   FilterType::Pointer filter = FilterType::New();
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, TransformGeometryImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, TransformGeometryImageFilter, InPlaceImageFilter);
 
   // Test the exceptions
   ITK_TRY_EXPECT_EXCEPTION(filter->Update());


### PR DESCRIPTION
Im proves the conformance to expected ITK pipeline behaviors. 

Addresses bug related to:
 -  output information being update at the incorrect phase
 - composition pipeline execution escaping the GenerateData method
 - Not correctly updating region filter indicates it will

Derive class from InPlaceImageFilter, and set the default "RunInPlace" to true.

Made RigidTransform a pipeline object.