### PR TITLE
BUG: Improve dimension-dependent BSplineInterpolationWeightFunction wrapping

### DIFF
--- a/Modules/Core/Common/wrapping/itkBSplineInterpolationWeightFunction.wrap
+++ b/Modules/Core/Common/wrapping/itkBSplineInterpolationWeightFunction.wrap
@@ -1,5 +1,5 @@
 itk_wrap_class("itk::BSplineInterpolationWeightFunction" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    itk_wrap_template("${ITKM_D}${d}${d}" "${ITKT_D},${d},${d}")
+    itk_wrap_template("${ITKM_D}${d}3" "${ITKT_D},${d},3")
   endforeach()
 itk_end_wrap_class()

--- a/Modules/Core/Common/wrapping/itkFunctionBase.wrap
+++ b/Modules/Core/Common/wrapping/itkFunctionBase.wrap
@@ -27,8 +27,12 @@ itk_wrap_class("itk::FunctionBase" POINTER)
     itk_wrap_template("${ITKM_PD${d}}RGBAD" "${ITKT_PD${d}},itk::RGBAPixel< double >")
 
     # Required by BSplineInterpolationWeightFunction
-    itk_wrap_template("${ITKM_CID2}${ITKM_FAD9}" "${ITKT_CID2}, ${ITKT_FAD9}")
-    itk_wrap_template("${ITKM_CID3}${ITKM_FAD64}" "${ITKT_CID3}, ${ITKT_FAD64}")
+    # Wrapping for spline order 3, components = (SplineOrder + 1)^SpaceDimension
+    set(comp 1)
+    foreach(i RANGE 1 ${d})
+      math(EXPR comp "${comp}*4")
+    endforeach()
+    itk_wrap_template("${ITKM_CID${d}}${ITKM_FAD${comp}}" "${ITKT_CID${d}}, ${ITKT_FAD${comp}}")
 
   endforeach()
 

--- a/Wrapping/WrapITKTypes.cmake
+++ b/Wrapping/WrapITKTypes.cmake
@@ -150,11 +150,15 @@ WRAP_TYPE("itk::FixedArray" "FA" "itkFixedArray.h")
   endforeach()
 
   # Wrap FixedArray for BSplineInterpolationWeightFunction:
-  ADD_TEMPLATE("${ITKM_D}9" "${ITKT_D},9")
-  ADD_TEMPLATE("${ITKM_D}16" "${ITKT_D},16")
-  ADD_TEMPLATE("${ITKM_UL}16" "${ITKT_UL},16")
-  ADD_TEMPLATE("${ITKM_D}64" "${ITKT_D},64")
-  ADD_TEMPLATE("${ITKM_UL}64" "${ITKT_UL},64")
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    # Wrapping for spline order 3, components = (SplineOrder + 1)^SpaceDimension
+    set(comp 1)
+    foreach(i RANGE 1 ${d})
+      math(EXPR comp "${comp}*4")
+    endforeach()
+    ADD_TEMPLATE("${ITKM_D}${comp}" "${ITKT_D},${comp}")
+    ADD_TEMPLATE("${ITKM_UL}${comp}" "${ITKT_UL},${comp}")
+  endforeach()
 END_WRAP_TYPE()
 set(itk_Wrap_FixedArray ${WRAPPER_TEMPLATES})
 


### PR DESCRIPTION
Avoid build errors when we wrap for 4-D images.
