### PR TITLE
FastEvaluate(u) for both BSplineKernelFunction _and_ BSplineDerivativeKernelFunction 

### DIFF
--- a/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
@@ -60,11 +60,19 @@ public:
   /** Enum of for spline order. */
   static constexpr unsigned int SplineOrder = VSplineOrder;
 
+  /** Evaluate the function. Faster than the `Evaluate` member function, because it is static (while `Evaluate` is
+   * virtual). */
+  static TRealValueType
+  FastEvaluate(const TRealValueType u)
+  {
+    return Self::Evaluate(Dispatch<VSplineOrder>(), u);
+  }
+
   /** Evaluate the function. */
   TRealValueType
   Evaluate(const TRealValueType & u) const override
   {
-    return this->Evaluate(Dispatch<VSplineOrder>(), u);
+    return Self::FastEvaluate(u);
   }
 
 protected:
@@ -87,15 +95,15 @@ private:
   {};
 
   /** Evaluate the function:  zeroth order spline. */
-  inline TRealValueType
-  Evaluate(const Dispatch<0> &, const TRealValueType & itkNotUsed(u)) const
+  inline static TRealValueType
+  Evaluate(const Dispatch<0> &, const TRealValueType & itkNotUsed(u))
   {
     return TRealValueType{ 0.0 };
   }
 
   /** Evaluate the function:  first order spline */
-  inline TRealValueType
-  Evaluate(const Dispatch<1> &, const TRealValueType & u) const
+  inline static TRealValueType
+  Evaluate(const Dispatch<1> &, const TRealValueType & u)
   {
     if (Math::ExactlyEquals(u, TRealValueType{ -1.0 }))
     {
@@ -124,8 +132,8 @@ private:
   }
 
   /** Evaluate the function:  second order spline. */
-  inline TRealValueType
-  Evaluate(const Dispatch<2> &, const TRealValueType & u) const
+  inline static TRealValueType
+  Evaluate(const Dispatch<2> &, const TRealValueType & u)
   {
     if ((u > TRealValueType{ -0.5 }) && (u < TRealValueType{ 0.5 }))
     {
@@ -146,8 +154,8 @@ private:
   }
 
   /** Evaluate the function:  third order spline. */
-  inline TRealValueType
-  Evaluate(const Dispatch<3> &, const TRealValueType & u) const
+  inline static TRealValueType
+  Evaluate(const Dispatch<3> &, const TRealValueType & u)
   {
     if ((u >= TRealValueType{ 0.0 }) && (u < TRealValueType{ 1.0 }))
     {
@@ -172,10 +180,10 @@ private:
   }
 
   /** Evaluate the function:  unimplemented spline order */
-  inline TRealValueType
-  Evaluate(const DispatchBase &, const TRealValueType &) const
+  inline static TRealValueType
+  Evaluate(const DispatchBase &, const TRealValueType &)
   {
-    itkExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
+    itkGenericExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
   }
 };
 } // end namespace itk

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -323,10 +323,6 @@ private:
   PDFValueType  m_FixedImageBinSize{ 0.0 };
   PDFValueType  m_MovingImageBinSize{ 0.0 };
 
-  /** Cubic BSpline kernel for computing Parzen histograms. */
-  typename CubicBSplineFunctionType::Pointer           m_CubicBSplineKernel;
-  typename CubicBSplineDerivativeFunctionType::Pointer m_CubicBSplineDerivativeKernel;
-
   /** Helper array for storing the values of the JointPDF ratios. */
   using PRatioType = PDFValueType;
   using PRatioArrayType = Array2D<PRatioType>;

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -34,9 +34,7 @@ namespace itk
  */
 template <typename TFixedImage, typename TMovingImage>
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MattesMutualInformationImageToImageMetric()
-  : m_CubicBSplineKernel(nullptr)
-  , m_CubicBSplineDerivativeKernel(nullptr)
-  , m_PRatioArray(0, 0)
+  : m_PRatioArray(0, 0)
   ,
   // Initialize memory
   m_MovingImageMarginalPDF(0)
@@ -338,11 +336,6 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
       this->m_MMIMetricPerThreadVariables[workUnitID].MetricDerivative.Fill(NumericTraits<MeasureType>::ZeroValue());
     }
   }
-  /**
-   * Setup the kernels used for the Parzen windows.
-   */
-  this->m_CubicBSplineKernel = CubicBSplineFunctionType::New();
-  this->m_CubicBSplineDerivativeKernel = CubicBSplineDerivativeFunctionType::New();
 
   /**
    * Pre-compute the fixed image parzen window index for
@@ -460,7 +453,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueTh
 
   while (pdfMovingIndex <= pdfMovingIndexMax)
   {
-    *(pdfPtr++) += static_cast<PDFValueType>(this->m_CubicBSplineKernel->Evaluate(movingImageParzenWindowArg));
+    *(pdfPtr++) += CubicBSplineFunctionType::FastEvaluate(movingImageParzenWindowArg);
     movingImageParzenWindowArg += 1;
     ++pdfMovingIndex;
   }
@@ -705,13 +698,13 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAn
 
   while (pdfMovingIndex <= pdfMovingIndexMax)
   {
-    *(pdfPtr++) += static_cast<PDFValueType>(this->m_CubicBSplineKernel->Evaluate(movingImageParzenWindowArg));
+    *(pdfPtr++) += CubicBSplineFunctionType::FastEvaluate(movingImageParzenWindowArg);
 
     if (this->m_UseExplicitPDFDerivatives || this->m_ImplicitDerivativesSecondPass)
     {
       // Compute the cubicBSplineDerivative for later repeated use.
       const PDFValueType cubicBSplineDerivativeValue =
-        this->m_CubicBSplineDerivativeKernel->Evaluate(movingImageParzenWindowArg);
+        CubicBSplineDerivativeFunctionType::FastEvaluate(movingImageParzenWindowArg);
 
       // Compute PDF derivative contribution.
       this->ComputePDFDerivatives(

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
@@ -255,10 +255,6 @@ protected:
   PDFValueType  m_FixedImageBinSize;
   PDFValueType  m_MovingImageBinSize;
 
-  /** Cubic BSpline kernel for computing Parzen histograms. */
-  typename CubicBSplineFunctionType::Pointer           m_CubicBSplineKernel;
-  typename CubicBSplineDerivativeFunctionType::Pointer m_CubicBSplineDerivativeKernel;
-
   /** Helper array for storing the values of the JointPDF ratios. */
   using PRatioType = PDFValueType;
   using PRatioArrayType = std::vector<PRatioType>;

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -43,8 +43,6 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
   , m_MovingImageTrueMax(0.0)
   , m_FixedImageBinSize(0.0)
   , m_MovingImageBinSize(0.0)
-  , m_CubicBSplineKernel(nullptr)
-  , m_CubicBSplineDerivativeKernel(nullptr)
   , m_PRatioArray(0)
   ,
   // Initialize memory
@@ -60,8 +58,6 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
   // ImageToImageMetricv4 to use.
   this->m_DenseGetValueAndDerivativeThreader = MattesMutualInformationDenseGetValueAndDerivativeThreaderType::New();
   this->m_SparseGetValueAndDerivativeThreader = MattesMutualInformationSparseGetValueAndDerivativeThreaderType::New();
-  this->m_CubicBSplineKernel = CubicBSplineFunctionType::New();
-  this->m_CubicBSplineDerivativeKernel = CubicBSplineDerivativeFunctionType::New();
 }
 
 /**

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -345,16 +345,14 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
                                        MovingTransformType::TransformCategoryEnum::DisplacementField;
   while (pdfMovingIndex <= pdfMovingIndexMax)
   {
-    const auto val =
-      static_cast<PDFValueType>(this->m_MattesAssociate->m_CubicBSplineKernel->Evaluate(movingImageParzenWindowArg));
+    const auto val = CubicBSplineFunctionType::FastEvaluate(movingImageParzenWindowArg);
     *(pdfPtr++) += val;
 
     if (doComputeDerivative)
     {
       // Compute the cubicBSplineDerivative for later repeated use.
       const PDFValueType cubicBSplineDerivativeValue =
-        this->m_MattesAssociate->m_CubicBSplineDerivativeKernel->Evaluate(movingImageParzenWindowArg);
-
+        CubicBSplineDerivativeFunctionType::FastEvaluate(movingImageParzenWindowArg);
 
       if (transformIsDisplacement)
       {


### PR DESCRIPTION
Added static member function `FastEvaluate(u)` to `BSplineDerivativeKernelFunction`, just like the one added to `BSplineKernelFunction`.

Used the `FastEvaluate(u)`  member functions of both `BSplineKernelFunction` _and_ `BSplineDerivativeKernelFunction` inside the implementation of `MattesMutualInformationImageToImageMetric` and `MattesMutualInformationImageToImageMetricv4`.

Follow-up to pull request #2716 "PERF: `BSplineKernelFunction::FastEvaluate(u)`: a faster way to evaluate BSplineKernelFunction"