### PR TITLE
BUG: Disable all floating point exceptions 

### DIFF
--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -176,8 +176,7 @@ FloatingPointExceptions::Disable()
 {
   itkInitGlobalsMacro(PimplGlobals);
 #if defined(ITK_HAS_FPE_CAPABILITY)
-  itk_fedisableexcept(FE_DIVBYZERO);
-  itk_fedisableexcept(FE_INVALID);
+  itk_fedisableexcept(FE_ALL_EXCEPT);
   FloatingPointExceptions::m_PimplGlobals->m_Enabled = false;
 #else
   itkFloatingPointExceptionsNotSupported();


### PR DESCRIPTION
itk::FloatingPointExceptions::Disable()

In this commit, a flag is added to disable all floating-point exceptions, rather than just two exceptions. This bug was identified in the following discussion thread: https://discourse.itk.org/t/itk-not-loading-nrrd-files-any-more/4224/10. This fix will resolve an exception that occurs when loading NRRD images.

