### PR TITLE
COMP: Copy BSplineInterpolationWeightFunction::SupportSize within lambda

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -123,9 +123,11 @@ private:
   /** Table mapping linear offset to indices. */
   const TableType m_OffsetToIndexTable{ [] {
     TableType     table;
-    // Note: Copied the constexpr value `SupportSize` to a temporary, `SizeType{ SupportSize }`, to prevent a GCC
-    // (Ubuntu 7.5.0-3ubuntu1~18.04) link error, "undefined reference to `SupportSize`".
-    std::copy_n(ZeroBasedIndexRange<SpaceDimension>(SizeType{ SupportSize }).cbegin(), NumberOfWeights, table.begin());
+    // Note: Copied the constexpr value `SupportSize` to a local variable, to prevent a GCC
+    // (Ubuntu 7.5.0-3ubuntu1~18.04) link error, "undefined reference to `SupportSize`", and Clang
+    // (Mac10.13-AppleClang-dbg-x86_64-static) "Undefined symbols for architecture x86_64".
+    const auto    supportSize = SupportSize;
+    std::copy_n(ZeroBasedIndexRange<SpaceDimension>(supportSize).cbegin(), NumberOfWeights, table.begin());
     return table;
   }() };
 };


### PR DESCRIPTION
Copied the constexpr static data member `SupportSize` to a local
variable, to prevent Clang linker errors, like:

> Undefined symbols for architecture x86_64:
> "itk::BSplineInterpolationWeightFunction::SupportSize", referenced from:
> itk::BSplineInterpolationWeightFunction::'lambda'()::operator()() const in itkBSplineInterpolationWeightFunctionTest.cxx.o

From Mac10.13-AppleClang-dbg-x86_64-static https://open.cdash.org/viewBuildError.php?type=0&buildid=7457677, reported by Sean McBride (@seanm).