### PR TITLE
STYLE: Improve const-correctness of protected CompositeTransform members

### DIFF
--- a/Modules/Core/Transform/include/itkCompositeTransform.h
+++ b/Modules/Core/Transform/include/itkCompositeTransform.h
@@ -447,11 +447,11 @@ protected:
   }
 
   /** Get a list of transforms to optimize. Helper function. */
-  TransformQueueType &
+  const TransformQueueType &
   GetTransformsToOptimizeQueue() const;
 
-  mutable TransformQueueType            m_TransformsToOptimizeQueue;
-  mutable TransformsToOptimizeFlagsType m_TransformsToOptimizeFlags;
+  mutable TransformQueueType    m_TransformsToOptimizeQueue;
+  TransformsToOptimizeFlagsType m_TransformsToOptimizeFlags;
 
 private:
   mutable ModifiedTimeType m_PreviousTransformsToOptimizeUpdateTime;

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -885,7 +885,7 @@ CompositeTransform<TParametersValueType, NDimensions>::UpdateTransformParameters
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::TransformQueueType &
+const typename CompositeTransform<TParametersValueType, NDimensions>::TransformQueueType &
 CompositeTransform<TParametersValueType, NDimensions>::GetTransformsToOptimizeQueue() const
 {
   /* Update the list of transforms to use for optimization only if


### PR DESCRIPTION
- Added `const` to reference returned by `GetTransformsToOptimizeQueue()`
- Made `m_TransformsToOptimizeFlags` non-`mutable`