### PR TITLE
PERF: Remove protected `itk::Transform` data member `m_DirectionChange`

### DIFF
--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -590,8 +590,6 @@ protected:
   PreservationOfPrincipalDirectionDiffusionTensor3DReorientation(const InputDiffusionTensor3DType &,
                                                                  const InverseJacobianPositionType &) const;
 
-  mutable DirectionChangeMatrix m_DirectionChange;
-
 private:
   template <typename TType>
   static std::string


### PR DESCRIPTION
Observed ~29% reduction of `sizeof(itk::Transform<double>)`, from 248
bytes (before this commit) down to 176 bytes, using Visual C++ 2019
64-bit Release.

Follow-up to commit c42fb3f468c1acfd9b8ebd2fb99fe1d07e5b7e6b
"BUG: Remove extra m_DirectionChange from Transform." by Matt McCormick (@thewtex),
13 April 2012