### PR TITLE
COMP: Fix missing initialization braces warning

### DIFF
--- a/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
@@ -59,7 +59,7 @@ itkLaplacianImageFilterTest(int argc, char * argv[])
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   // Assign a spacing other than [1,1] for testing
-  itk::Vector<float, 2> spacing({ 0.5, 5.0 });
+  itk::Vector<float, 2> spacing{ { 0.5, 5.0 } };
   reader->GetOutput()->SetSpacing(spacing);
 
   // Set up filter


### PR DESCRIPTION
Fix missing initialization braces warning.

Fixes:
```
[CTest: warning matched]
/Users/builder/externalModules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx:62:35:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
  itk::Vector<float, 2> spacing({ 0.5, 5.0 });
                                  ^~~~~~~~
                                  {       }
[CTest: warning suppressed] 1 warning generated.
```

reported at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=7468732

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)