### PR TITLE
ENH: Update FFTW to 3.3.10

### DIFF
--- a/CMake/itkExternal_FFTW.cmake
+++ b/CMake/itkExternal_FFTW.cmake
@@ -49,8 +49,8 @@ if(NOT ITK_USE_SYSTEM_FFTW)
 
     include(GNUInstallDirs)
 
-    set(_fftw_target_version 3.3.8)
-    set(_fftw_url_hash "ab918b742a7c7dcb56390a0a0014f517a6dff9a2e4b4591060deeb2c652bf3c6868aa74559a422a276b853289b4b701bdcbd3d4d8c08943acf29167a7be81a38")
+    set(_fftw_target_version 3.3.10)
+    set(_fftw_url_hash "2d34b5ccac7b08740dbdacc6ebe451d8a34cf9d9bfec85a5e776e87adf94abfd803c222412d8e10fbaa4ed46f504aa87180396af1b108666cde4314a55610b40")
     set(_fftw_url "https://data.kitware.com/api/v1/file/hashsum/sha512/${_fftw_url_hash}/download")
 
     set(FFTW_STAGED_INSTALL_PREFIX "${ITK_BINARY_DIR}/fftw")


### PR DESCRIPTION
FFTW 3.3.10
  Sep 15th, 2021
  Fix bug that would cause 2-way SIMD (notably SSE2 in double precision)
  to attempt unaligned accesses in certain obscure cases, causing
  segfaults.  The following test triggers the bug (SSE2, double
    precision): ./tests/bench -oexhaustive r4*2:5:3

  This test computes a pair of length-4 real->complex transforms where
  the second input is 5 real numbers away from the first input. That is,
  there is a gap of one real number between the first and second input
  array.  The -oexhaustive level allow FFTW to attempt to compute this
  transform by reducing it to a pair of complex transforms of length 2,
  but now the second input is not aligned to a complex-number boundary.
  The fact that 5 is odd is the problem.

  The bug cannot occur in complex->complex transforms because the
  complex interface accepts strides in units of complex numbers, so
  strides are aligned by construction.

  This bug has been around at least since fftw-3.1.2 (July 2006), and probably since fftw-3.0 (2003).

FFTW 3.3.9
  Dec 13th, 2020

  New API fftw_planner_nthreads() returns the number of threads currently being used by the planner.
  Fix incorrect math in 128-bit generic SIMD
  Fix wisdom for avx512.
  The avx512 alignment requirement was set to 64 bytes, but this is
  wrong. Alignment requirements are a property of the platform (e.g.,
    x86) and not of the instruction set (e.g., AVX). Among other things,
  this broke wisdom with avx512.

  Note that avx512 support is still experimental because the FFTW authors
  have no avx512 hardware available for testing.

  fftw_threads_set_callback function to change the threading backend at runtime.
