### PR TITLE
BUG: Fix ImageRegionSplitters with zero sized image

### DIFF
--- a/Modules/Core/Common/src/itkImageRegionSplitterDirection.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterDirection.cxx
@@ -41,9 +41,10 @@ ImageRegionSplitterDirection::GetNumberOfSplitsInternal(unsigned int         dim
                                                         const SizeValueType  regionSize[],
                                                         unsigned int         requestedNumber) const
 {
+  requestedNumber = std::max(1u, requestedNumber);
   // split on the outermost dimension available
   int splitAxis = dim - 1;
-  while (regionSize[splitAxis] == 1 || splitAxis == (int)m_Direction)
+  while (regionSize[splitAxis] <= 1 || splitAxis == (int)m_Direction)
   {
     --splitAxis;
     if (splitAxis < 0)
@@ -71,7 +72,7 @@ ImageRegionSplitterDirection::GetSplitInternal(unsigned int   dim,
   // split on the outermost dimension available
   // and avoid the current dimension
   int splitAxis = dim - 1;
-  while (regionSize[splitAxis] == 1 || splitAxis == (int)m_Direction)
+  while (regionSize[splitAxis] <= 1 || splitAxis == (int)m_Direction)
   {
     --splitAxis;
     if (splitAxis < 0)

--- a/Modules/Core/Common/src/itkImageRegionSplitterSlowDimension.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterSlowDimension.cxx
@@ -30,9 +30,10 @@ ImageRegionSplitterSlowDimension::GetNumberOfSplitsInternal(unsigned int        
                                                             const SizeValueType  regionSize[],
                                                             unsigned int         requestedNumber) const
 {
+  requestedNumber = std::max(1u, requestedNumber);
   // split on the outermost dimension available
   int splitAxis = dim - 1;
-  while (regionSize[splitAxis] == 1)
+  while (regionSize[splitAxis] <= 1)
   {
     --splitAxis;
     if (splitAxis < 0)
@@ -57,10 +58,9 @@ ImageRegionSplitterSlowDimension::GetSplitInternal(unsigned int   dim,
                                                    IndexValueType regionIndex[],
                                                    SizeValueType  regionSize[]) const
 {
-
   // split on the outermost dimension available
   unsigned int splitAxis = dim - 1;
-  while (regionSize[splitAxis] == 1)
+  while (regionSize[splitAxis] <= 1)
   {
     if (splitAxis == 0)
     { // cannot split

--- a/Modules/Core/Common/test/itkImageRegionSplitterDirectionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionSplitterDirectionTest.cxx
@@ -38,6 +38,7 @@ itkImageRegionSplitterDirectionTest(int, char *[])
 
   const itk::ImageRegion<2> lpRegion = region;
 
+  ITK_TEST_EXPECT_EQUAL(splitter->GetNumberOfSplits(lpRegion, 0), 1);
   ITK_TEST_EXPECT_EQUAL(splitter->GetNumberOfSplits(lpRegion, 1), 1);
   ITK_TEST_EXPECT_EQUAL(splitter->GetNumberOfSplits(lpRegion, 2), 2);
   ITK_TEST_EXPECT_EQUAL(splitter->GetNumberOfSplits(lpRegion, 3), 3);
@@ -65,6 +66,13 @@ itkImageRegionSplitterDirectionTest(int, char *[])
   splitter->GetSplit(1, 2, region);
   ITK_TEST_EXPECT_EQUAL(region.GetSize(0), 5);
   ITK_TEST_EXPECT_EQUAL(region.GetSize(1), 11);
+
+  const itk::ImageRegion<2> lpRegion2{}; // default zero sized
+  region = lpRegion2;
+  ITK_TEST_EXPECT_EQUAL(1, splitter->GetNumberOfSplits(lpRegion2, 1));
+  ITK_TEST_EXPECT_EQUAL(1, splitter->GetSplit(1, 1, region));
+  ITK_TEST_EXPECT_EQUAL(region.GetSize(0), 0);
+  ITK_TEST_EXPECT_EQUAL(region.GetSize(1), 0);
 
 
   return EXIT_SUCCESS;

--- a/Modules/Core/Common/test/itkImageRegionSplitterSlowDimensionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionSplitterSlowDimensionTest.cxx
@@ -37,7 +37,7 @@ itkImageRegionSplitterSlowDimensionTest(int, char *[])
   region.SetIndex(1, 10);
 
   const itk::ImageRegion<2> lpRegion = region;
-
+  ITK_TEST_EXPECT_EQUAL(splitter->GetNumberOfSplits(lpRegion, 0), 1);
   ITK_TEST_EXPECT_EQUAL(splitter->GetNumberOfSplits(lpRegion, 1), 1);
   ITK_TEST_EXPECT_EQUAL(splitter->GetNumberOfSplits(lpRegion, 2), 2);
   ITK_TEST_EXPECT_EQUAL(splitter->GetNumberOfSplits(lpRegion, 3), 3);
@@ -58,6 +58,12 @@ itkImageRegionSplitterSlowDimensionTest(int, char *[])
   ITK_TEST_EXPECT_EQUAL(region.GetSize(0), 10);
   ITK_TEST_EXPECT_EQUAL(region.GetSize(1), 5);
 
+  const itk::ImageRegion<2> lpRegion2{}; // default zero sized
+  region = lpRegion2;
+  ITK_TEST_EXPECT_EQUAL(1, splitter->GetNumberOfSplits(lpRegion2, 1));
+  ITK_TEST_EXPECT_EQUAL(1, splitter->GetSplit(1, 1, region));
+  ITK_TEST_EXPECT_EQUAL(region.GetSize(0), 0);
+  ITK_TEST_EXPECT_EQUAL(region.GetSize(1), 0);
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -20,6 +20,19 @@
 #include "itkLabelImageToLabelMapFilter.h"
 #include "itkTestingMacros.h"
 
+void
+zeroSizeCase()
+{
+  // test filter with zero sized image
+  auto p_filter = itk::LabelImageToLabelMapFilter<itk::Image<unsigned char, 3>>::New();
+  auto p_image = itk::Image<unsigned char, 3>::New();
+  p_image->SetRegions(itk::Size<3>{ 0, 0, 0 });
+  p_image->Allocate(true);
+
+  p_filter->SetInput(p_image);
+  p_filter->Update();
+}
+
 int
 itkLabelImageToLabelMapFilterTest(int argc, char * argv[])
 {
@@ -130,6 +143,9 @@ itkLabelImageToLabelMapFilterTest(int argc, char * argv[])
   std::cout << "End - Printing out map." << std::endl << std::endl;
 
   conversion->Print(std::cout);
+
+  zeroSizeCase();
+
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
When the image had a zero size, undefined results of division by zero
occoured. For both the ImageRegionSplitterSlowDimension and the
ImageRegionSplitterDirection classes when a region's size is zero, the
region has one "split" region of a zero sized region.

closes #2741
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
