### PR TITLE
Remove (ITK_FUTURE_LEGACY_REMOVE) itkStaticConstMacro and itkGetStaticConstMacro

### DIFF
--- a/Modules/Core/Common/include/itkImageSink.h
+++ b/Modules/Core/Common/include/itkImageSink.h
@@ -82,7 +82,7 @@ public:
   using typename Superclass::DataObjectIdentifierType;
 
   /** Dimension of input images. */
-  itkStaticConstMacro(InputImageDimension, unsigned int, InputImageType::ImageDimension);
+  static constexpr unsigned int InputImageDimension = InputImageType::ImageDimension;
 
 
   using Superclass::SetInput;

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -784,6 +784,12 @@ compilers.
 //  !!  The ITK Get/Set Macros for various types !!
 //  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+#  define itkStaticConstMacro(name, type, value)                                                                       \
+    "Replace itkStaticConstMacro(name, type, value) with `static constexpr type name = value`"
+#  define itkGetStaticConstMacro(name) "Replace itkGetStaticConstMacro(name) with `Self::name`"
+#else
 /** Portable definition of static constants.
  *
  * \pre \c type shall be an integral type (\c bool and enums are accepted as
@@ -798,9 +804,10 @@ compilers.
  * and is beneficial in other cases where a value can be constant.
  *
  * \ingroup ITKCommon */
-#define itkStaticConstMacro(name, type, value) static constexpr type name = value
+#  define itkStaticConstMacro(name, type, value) static constexpr type name = value
 
-#define itkGetStaticConstMacro(name) (Self::name)
+#  define itkGetStaticConstMacro(name) (Self::name)
+#endif
 
 /** Set an input. This defines the Set"name"() method */
 #define itkSetInputMacro(name, type)                                                                                   \

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.h
@@ -211,9 +211,9 @@ public:
 
 
   /** ImageDimension constants */
-  itkStaticConstMacro(InputImage1Dimension, unsigned int, TInputImage1::ImageDimension);
-  itkStaticConstMacro(InputImage2Dimension, unsigned int, TInputImage2::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImage1Dimension = TInputImage1::ImageDimension;
+  static constexpr unsigned int InputImage2Dimension = TInputImage2::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.h
@@ -218,11 +218,9 @@ public:
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(SameDimensionCheck1,
-                  (Concept::SameDimension<itkGetStaticConstMacro(InputImage1Dimension),
-                                          itkGetStaticConstMacro(InputImage2Dimension)>));
+                  (Concept::SameDimension<Self::InputImage1Dimension, Self::InputImage2Dimension>));
   itkConceptMacro(SameDimensionCheck2,
-                  (Concept::SameDimension<itkGetStaticConstMacro(InputImage1Dimension),
-                                          itkGetStaticConstMacro(OutputImageDimension)>));
+                  (Concept::SameDimension<Self::InputImage1Dimension, Self::OutputImageDimension>));
   // End concept checking
 #endif
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -43,20 +43,20 @@ public:
   using typename Superclass::FixedParametersType;
 
   /** Standard vector type for this class. */
-  using InputVectorType = itk::Vector<double, itkGetStaticConstMacro(InputSpaceDimension)>;
-  using OutputVectorType = itk::Vector<double, itkGetStaticConstMacro(OutputSpaceDimension)>;
+  using InputVectorType = itk::Vector<double, Self::InputSpaceDimension>;
+  using OutputVectorType = itk::Vector<double, Self::OutputSpaceDimension>;
 
   /** Standard covariant vector type for this class. */
-  using InputCovariantVectorType = itk::CovariantVector<double, itkGetStaticConstMacro(InputSpaceDimension)>;
-  using OutputCovariantVectorType = itk::CovariantVector<double, itkGetStaticConstMacro(OutputSpaceDimension)>;
+  using InputCovariantVectorType = itk::CovariantVector<double, Self::InputSpaceDimension>;
+  using OutputCovariantVectorType = itk::CovariantVector<double, Self::OutputSpaceDimension>;
 
   /** Standard vnl_vector type for this class. */
-  using InputVnlVectorType = vnl_vector_fixed<double, itkGetStaticConstMacro(InputSpaceDimension)>;
-  using OutputVnlVectorType = vnl_vector_fixed<double, itkGetStaticConstMacro(OutputSpaceDimension)>;
+  using InputVnlVectorType = vnl_vector_fixed<double, Self::InputSpaceDimension>;
+  using OutputVnlVectorType = vnl_vector_fixed<double, Self::OutputSpaceDimension>;
 
   /** Standard coordinate point type for this class. */
-  using InputPointType = itk::Point<double, itkGetStaticConstMacro(InputSpaceDimension)>;
-  using OutputPointType = itk::Point<double, itkGetStaticConstMacro(OutputSpaceDimension)>;
+  using InputPointType = itk::Point<double, Self::InputSpaceDimension>;
+  using OutputPointType = itk::Point<double, Self::OutputSpaceDimension>;
 
   using Superclass::TransformCovariantVector;
   using Superclass::TransformVector;


### PR DESCRIPTION
Removed the remaining calls to itkStaticConstMacro and itkGetStaticConstMacro. Most of them were removed already by Hans Johnson (@hjmjohnson): 

Commit 5c14741e1e063a132ea7e7ee69c5bd0a4e49af74 2 February 2018: "STYLE: Replace itkStaticConstMacro with static constexpr", 
Commit d72d28f5a1f405f740fe7f296d0f308793263ab2 4 March 2018: "STYLE: Do not use itkGetStaticConstMacro in ITK"

Declared both macro's `ITK_FUTURE_LEGACY_REMOVE`.