### PR TITLE
COMP: Fix missing initialization braces warning

### DIFF
--- a/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
@@ -59,7 +59,7 @@ itkLaplacianImageFilterTest(int argc, char * argv[])
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   // Assign a spacing other than [1,1] for testing
-  itk::Vector<float, 2> spacing{ { 0.5, 5.0 } };
+  itk::Vector<float, 2> spacing{ { { 0.5, 5.0 } } };
   reader->GetOutput()->SetSpacing(spacing);
 
   // Set up filter

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -24,9 +24,13 @@ void
 zeroSizeCase()
 {
   // test filter with zero sized image
-  auto p_filter = itk::LabelImageToLabelMapFilter<itk::Image<unsigned char, 3>>::New();
-  auto p_image = itk::Image<unsigned char, 3>::New();
-  p_image->SetRegions(itk::Size<3>{ 0, 0, 0 });
+  constexpr unsigned int ImageDimension = 3;
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType, ImageDimension>;
+  auto p_filter = itk::LabelImageToLabelMapFilter<ImageType>::New();
+  auto p_image = ImageType::New();
+
+  // The image region is empty by default: do not set any region to it and allocate memory
   p_image->Allocate(true);
 
   p_filter->SetInput(p_image);


### PR DESCRIPTION
Fix missing initialization braces warning.

Fixes:
````
[CTest: warning matched]
/Users/builder/externalModules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx:29:37:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
  p_image->SetRegions(itk::Size<3>{ 0, 0, 0 });
                                    ^~~~~~~
                                    {      }
[CTest: warning suppressed] 1 warning generated.
```

and
```
[CTest: warning matched]
/Users/builder/externalModules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx:62:36:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
  itk::Vector<float, 2> spacin{ { 0.5, 5.0 } };
                                  ^~~~~~~~
                                  {       }
[CTest: warning suppressed] 1 warning generated.
```

reported at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=7475017

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)