### PR TITLE
COMP: set the required CXX standard to 14 in the bundled example

### DIFF
--- a/Examples/Installation/CMakeLists.txt
+++ b/Examples/Installation/CMakeLists.txt
@@ -11,6 +11,8 @@ foreach(p
   endif()
 endforeach()
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # This project is designed to be built outside the Insight source tree.
 project(HelloWorld)


### PR DESCRIPTION
As suggested by @krm15 on the [forum](https://discourse.itk.org/t/hello-world-from-itk-examples-installation-not-compiling-for-itk-5-3/4441).

