### PR TITLE
BUG #2762

### DIFF
--- a/Modules/IO/DCMTK/wrapping/itkDCMTKImageIO.wrap
+++ b/Modules/IO/DCMTK/wrapping/itkDCMTKImageIO.wrap
@@ -1,5 +1,7 @@
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkDCMTKImageIO.h")
+itk_wrap_include("itkDCMTKImageIOFactory.h")
+itk_wrap_include("itkDCMTKSeriesFileNames.h")
 itk_wrap_simple_class("itk::DCMTKImageIOEnums")
 itk_wrap_simple_class("itk::DCMTKImageIO" POINTER)
 itk_wrap_simple_class("itk::DCMTKImageIOFactory" POINTER)


### PR DESCRIPTION
BUG Fix for Building v5.2.1 fails on itkDCMTKImageIO.cxx #2762 

Add missing includes to Modules/IO/DCMTK/wrapping/itkDCMTKImageIO.wrap:
```
itk_wrap_include("itkDCMTKImageIOFactory.h")
itk_wrap_include("itkDCMTKSeriesFileNames.h")
```
