### PR TITLE
STYLE: Improve `itk::SimilarityIndexImageFilter` class test file style

### DIFF
--- a/Modules/Filtering/ImageCompare/test/itkSimilarityIndexImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSimilarityIndexImageFilterTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkSimilarityIndexImageFilter.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkSimilarityIndexImageFilterTest(int, char *[])
@@ -90,22 +91,14 @@ itkSimilarityIndexImageFilterTest(int, char *[])
   using FilterType = itk::SimilarityIndexImageFilter<Image1Type, Image2Type>;
   FilterType::Pointer filter = FilterType::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, SimilarityIndexImageFilter, ImageToImageFilter);
+
+
   filter->SetInput1(image1);
   filter->SetInput2(image2);
 
-  try
-  {
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "Caught an unexpected exception" << std::endl;
-    std::cout << err;
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-  filter->Print(std::cout);
 
   // check results
   FilterType::RealType trueOverlap = 0.5 / 0.75;


### PR DESCRIPTION
Improve `itk::SimilarityIndexImageFilter` class test file style:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Use the `ITK_TRY_EXPECT_NO_EXCEPTION` macro to avoid boilerplate code
  when updating a filter that can trigger exceptions.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)