### PR TITLE
STYLE: Improve the ivar printing in `PrintSelf` methods

### DIFF
--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -153,28 +153,17 @@ template <typename TPixel, unsigned int VDimension, typename TContainer>
 void
 Neighborhood<TPixel, VDimension, TContainer>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  os << indent << "m_Size: [ ";
-  for (DimensionValueType i = 0; i < VDimension; ++i)
-  {
-    os << m_Size[i] << " ";
-  }
-  os << "]" << std::endl;
+  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
+  os << indent << "Radius: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Radius) << std::endl;
 
-  os << indent << "m_Radius: [ ";
-  for (DimensionValueType i = 0; i < VDimension; ++i)
-  {
-    os << m_Radius[i] << " ";
-  }
-  os << "]" << std::endl;
-
-  os << indent << "m_StrideTable: [ ";
+  os << indent << "StrideTable: [ ";
   for (DimensionValueType i = 0; i < VDimension; ++i)
   {
     os << m_StrideTable[i] << " ";
   }
   os << "]" << std::endl;
 
-  os << indent << "m_OffsetTable: [ ";
+  os << indent << "OffsetTable: [ ";
   for (DimensionValueType i = 0; i < m_OffsetTable.size(); ++i)
   {
     os << m_OffsetTable[i] << " ";

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
@@ -112,23 +112,18 @@ ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::PrintSelf(s
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Normalize: " << m_Normalize << std::endl;
-  os << indent << "BoundaryCondition: " << m_BoundaryCondition->GetNameOfClass() << std::endl;
-  os << indent << "OutputRegionMode: ";
-  switch (m_OutputRegionMode)
+  os << indent << "DefaultBoundaryCondition: ";
+  m_DefaultBoundaryCondition.Print(os, indent);
+  os << indent << "BoundaryCondition: ";
+  if (m_BoundaryCondition)
   {
-    case OutputRegionModeEnum::SAME:
-      os << "SAME";
-      break;
-
-    case OutputRegionModeEnum::VALID:
-      os << "VALID";
-      break;
-
-    default:
-      os << "unknown";
-      break;
+    m_BoundaryCondition->Print(os, indent);
   }
-  os << std::endl;
+  else
+  {
+    os << indent << "nullptr" << std::endl;
+  }
+  os << indent << "OutputRegionMode: " << m_OutputRegionMode << std::endl;
 }
 } // namespace itk
 #endif

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
@@ -43,9 +43,9 @@ LandmarkDisplacementFieldSource<TOutputImage>::PrintSelf(std::ostream & os, Inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "OutputRegion:    " << m_OutputRegion << std::endl;
-  os << indent << "OutputSpacing:   " << m_OutputSpacing << std::endl;
-  os << indent << "OutputOrigin:    " << m_OutputOrigin << std::endl;
+  os << indent << "OutputRegion: " << m_OutputRegion << std::endl;
+  os << indent << "OutputSpacing: " << m_OutputSpacing << std::endl;
+  os << indent << "OutputOrigin: " << m_OutputOrigin << std::endl;
   os << indent << "OutputDirection: " << m_OutputDirection << std::endl;
   os << indent << "KernelTransform: " << m_KernelTransform.GetPointer() << std::endl;
   os << indent << "Source Landmarks: " << m_SourceLandmarks.GetPointer() << std::endl;

--- a/Modules/Filtering/FFT/include/itkFFTPadImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTPadImageFilter.hxx
@@ -83,6 +83,8 @@ FFTPadImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
   Superclass::PrintSelf(os, indent);
 
   os << indent << "SizeGreatestPrimeFactor: " << m_SizeGreatestPrimeFactor << std::endl;
+  os << indent << "DefaultBoundaryCondition: ";
+  m_DefaultBoundaryCondition.Print(os, indent);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx
@@ -42,13 +42,15 @@ void
 PadImageFilterBase<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+
+  os << indent << "BoundaryCondition: ";
   if (m_BoundaryCondition)
   {
     m_BoundaryCondition->Print(os, indent);
   }
   else
   {
-    os << "nullptr" << std::endl;
+    os << indent << "nullptr" << std::endl;
   }
 }
 

--- a/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.hxx
@@ -37,11 +37,8 @@ ImageShapeModelEstimatorBase<TInputImage, TOutputImage>::PrintSelf(std::ostream 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "                   " << std::endl;
-
-  os << indent << "InputImage: ";
-  os << m_InputImage.GetPointer() << std::endl;
-} // end PrintSelf
+  itkPrintSelfObjectMacro(InputImage);
+}
 } // namespace itk
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.hxx
@@ -51,8 +51,8 @@ void
 FEMObjectSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "FEMObject: " << std::endl;
-  os << indent << m_FEMObject << std::endl;
+
+  itkPrintSelfObjectMacro(FEMObject);
 }
 
 template <unsigned int TDimension>

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
@@ -36,15 +36,7 @@ VectorContainerToListSampleAdaptor<TVectorContainer>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "VectorContainer: ";
-  if (this->m_VectorContainer.IsNotNull())
-  {
-    os << this->m_VectorContainer << std::endl;
-  }
-  else
-  {
-    os << "not set." << std::endl;
-  }
+  itkPrintSelfObjectMacro(VectorContainer);
 }
 
 template <typename TVectorContainer>

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
@@ -156,53 +156,14 @@ CompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "TrainingFixedImage: ";
-  if (m_TrainingFixedImage.IsNull())
-  {
-    os << 0 << std::endl;
-  }
-  else
-  {
-    os << m_TrainingFixedImage << std::endl;
-  }
+  itkPrintSelfObjectMacro(TrainingFixedImage);
+  itkPrintSelfObjectMacro(TrainingMovingImage);
+  itkPrintSelfObjectMacro(TrainingTransform);
+  itkPrintSelfObjectMacro(TrainingInterpolator);
 
-  os << indent << "TrainingMovingImage: ";
-  if (m_TrainingMovingImage.IsNull())
-  {
-    os << 0 << std::endl;
-  }
-  else
-  {
-    os << m_TrainingMovingImage << std::endl;
-  }
-  os << indent << "TrainingTransform: ";
-  if (m_TrainingTransform.IsNull())
-  {
-    os << 0 << std::endl;
-  }
-  else
-  {
-    os << m_TrainingTransform << std::endl;
-  }
-  os << indent << "TrainingInterpolator: ";
-  if (m_TrainingInterpolator.IsNull())
-  {
-    os << 0 << std::endl;
-  }
-  else
-  {
-    os << m_TrainingInterpolator << std::endl;
-  }
-  os << indent << "TrainingHistogram: ";
-  if (m_TrainingHistogram.IsNull())
-  {
-    os << 0 << std::endl;
-  }
-  else
-  {
-    os << m_TrainingHistogram << std::endl;
-  }
   os << indent << "TrainingFixedImageRegion: " << m_TrainingFixedImageRegion << std::endl;
+
+  itkPrintSelfObjectMacro(TrainingHistogram);
 }
 
 } // end namespace itk

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
@@ -42,9 +42,10 @@ LevelSetMotionRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>:
                                                                                            Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Intensity difference threshold: " << this->GetIntensityDifferenceThreshold() << std::endl;
-  os << indent << "Gradient magnitude threshold: " << this->GetGradientMagnitudeThreshold() << std::endl;
-  os << indent << "Gradient smoothing standard deviations: " << this->GetGradientSmoothingStandardDeviations()
+
+  os << indent << "IntensityDifferenceThreshold: " << this->GetIntensityDifferenceThreshold() << std::endl;
+  os << indent << "GradientMagnitudeThreshold: " << this->GetGradientMagnitudeThreshold() << std::endl;
+  os << indent << "GradientSmoothingStandardDeviations: " << this->GetGradientSmoothingStandardDeviations()
      << std::endl;
 }
 

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
@@ -37,16 +37,9 @@ ClassifierBase<TDataContainer>::PrintSelf(std::ostream & os, Indent indent) cons
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Number of classes: " << m_NumberOfClasses << std::endl;
-  os << indent << "DecisionRule: ";
-  if (m_DecisionRule.IsNotNull())
-  {
-    os << m_DecisionRule << std::endl;
-  }
-  else
-  {
-    os << "not set." << std::endl;
-  }
+  os << indent << "NumberOfClasses: " << m_NumberOfClasses << std::endl;
+
+  itkPrintSelfObjectMacro(DecisionRule);
 
   os << indent << "MembershipFunctions: " << std::endl;
   for (unsigned int i = 0; i < m_MembershipFunctions.size(); ++i)

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.hxx
@@ -42,7 +42,8 @@ NarrowBandCurvesLevelSetImageFilter<TInputImage, TFeatureImage, TOutputType>::Pr
                                                                                         Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << "CurvesFunction: " << m_CurvesFunction.GetPointer();
+
+  itkPrintSelfObjectMacro(CurvesFunction);
 }
 
 template <typename TInputImage, typename TFeatureImage, typename TOutputType>


### PR DESCRIPTION
Improve the ivar printing in `PrintSelf` methods in miscellaneous classes:
- Use the `itkPrintSelfObjectMacro` macro to avoid boilerplate code when
  printing smart pointers/objects that can be null pointers.
- Take advantage of the overload of the ostream operator to print
  strongly typed enum class members.
- Print the member variable names verbatim to conform to the ITK SW Guide.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)