### PR TITLE
ENH: Improve KLCompareHistogramImageToImageMetric coverage

### DIFF
--- a/Modules/Registration/Common/test/itkCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkCompareHistogramImageToImageMetricTest.cxx
@@ -20,6 +20,7 @@
 #include "itkLinearInterpolateImageFunction.h"
 #include "itkKullbackLeiblerCompareHistogramImageToImageMetric.h"
 #include "itkTranslationTransform.h"
+#include "itkTestingMacros.h"
 
 /** This test uses two 2D-Gaussians (standard deviation RegionSize/2).
     This test computes the mutual information between the two images.
@@ -27,131 +28,131 @@
 int
 itkCompareHistogramImageToImageMetricTest(int, char *[])
 {
-  try
+
+  // Create two simple images.
+  constexpr unsigned int ImageDimension = 2;
+  using PixelType = double;
+  using CoordinateRepresentationType = double;
+
+  // Allocate Images
+  using MovingImageType = itk::Image<PixelType, ImageDimension>;
+  using FixedImageType = itk::Image<PixelType, ImageDimension>;
+
+  // Declare Gaussian Sources
+  using MovingImageSourceType = itk::GaussianImageSource<MovingImageType>;
+  using FixedImageSourceType = itk::GaussianImageSource<FixedImageType>;
+
+  // Note: the following declarations are classical arrays
+  FixedImageType::SizeValueType  fixedImageSize[] = { 100, 100 };
+  MovingImageType::SizeValueType movingImageSize[] = { 100, 100 };
+
+  FixedImageType::SpacingValueType  fixedImageSpacing[] = { 1.0f, 1.0f };
+  MovingImageType::SpacingValueType movingImageSpacing[] = { 1.0f, 1.0f };
+
+  FixedImageType::PointValueType  fixedImageOrigin[] = { 0.0f, 0.0f };
+  MovingImageType::PointValueType movingImageOrigin[] = { 0.0f, 0.0f };
+
+  MovingImageSourceType::Pointer movingImageSource = MovingImageSourceType::New();
+  FixedImageSourceType::Pointer  fixedImageSource = FixedImageSourceType::New();
+
+  movingImageSource->SetSize(movingImageSize);
+  movingImageSource->SetOrigin(movingImageOrigin);
+  movingImageSource->SetSpacing(movingImageSpacing);
+  movingImageSource->SetNormalized(false);
+  movingImageSource->SetScale(250.0f);
+
+  fixedImageSource->SetSize(fixedImageSize);
+  fixedImageSource->SetOrigin(fixedImageOrigin);
+  fixedImageSource->SetSpacing(fixedImageSpacing);
+  fixedImageSource->SetNormalized(false);
+  fixedImageSource->SetScale(250.0f);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(movingImageSource->Update()); // Force the filter to run
+  ITK_TRY_EXPECT_NO_EXCEPTION(fixedImageSource->Update());  // Force the filter to run
+
+  MovingImageType::Pointer movingImage = movingImageSource->GetOutput();
+  FixedImageType::Pointer  fixedImage = fixedImageSource->GetOutput();
+
+  // Set up the metric.
+  using MetricType = itk::KullbackLeiblerCompareHistogramImageToImageMetric<FixedImageType, MovingImageType>;
+  using TransformBaseType = MetricType::TransformType;
+  using ScalesType = MetricType::ScalesType;
+  using ParametersType = TransformBaseType::ParametersType;
+
+  MetricType::Pointer metric = MetricType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
+    metric, KullbackLeiblerCompareHistogramImageToImageMetric, CompareHistogramImageToImageMetric);
+
+
+  auto epsilon = 1e-12;
+  ITK_TEST_SET_GET_VALUE(epsilon, metric->GetEpsilon());
+
+  unsigned int                        nBins = 256;
+  MetricType::HistogramType::SizeType histSize;
+
+  histSize.SetSize(2);
+
+  histSize[0] = nBins;
+  histSize[1] = nBins;
+  metric->SetHistogramSize(histSize);
+
+  // Plug the images into the metric.
+  metric->SetFixedImage(fixedImage);
+  metric->SetMovingImage(movingImage);
+
+  // Set up a transform.
+  using TransformType = itk::TranslationTransform<CoordinateRepresentationType, ImageDimension>;
+
+  TransformType::Pointer transform = TransformType::New();
+  metric->SetTransform(transform);
+
+  // Set up an interpolator.
+  using InterpolatorType = itk::LinearInterpolateImageFunction<MovingImageType, double>;
+
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  interpolator->SetInputImage(movingImage);
+  metric->SetInterpolator(interpolator);
+
+  // Define the region over which the metric will be computed.
+  metric->SetFixedImageRegion(fixedImage->GetBufferedRegion());
+
+  // Set up transform parameters.
+  ParametersType parameters(transform->GetNumberOfParameters());
+
+  for (unsigned int k = 0; k < ImageDimension; ++k)
   {
-    // Create two simple images.
-    constexpr unsigned int ImageDimension = 2;
-    using PixelType = double;
-    using CoordinateRepresentationType = double;
-
-    // Allocate Images
-    using MovingImageType = itk::Image<PixelType, ImageDimension>;
-    using FixedImageType = itk::Image<PixelType, ImageDimension>;
-
-    // Declare Gaussian Sources
-    using MovingImageSourceType = itk::GaussianImageSource<MovingImageType>;
-    using FixedImageSourceType = itk::GaussianImageSource<FixedImageType>;
-
-    // Note: the following declarations are classical arrays
-    FixedImageType::SizeValueType  fixedImageSize[] = { 100, 100 };
-    MovingImageType::SizeValueType movingImageSize[] = { 100, 100 };
-
-    FixedImageType::SpacingValueType  fixedImageSpacing[] = { 1.0f, 1.0f };
-    MovingImageType::SpacingValueType movingImageSpacing[] = { 1.0f, 1.0f };
-
-    FixedImageType::PointValueType  fixedImageOrigin[] = { 0.0f, 0.0f };
-    MovingImageType::PointValueType movingImageOrigin[] = { 0.0f, 0.0f };
-
-    MovingImageSourceType::Pointer movingImageSource = MovingImageSourceType::New();
-    FixedImageSourceType::Pointer  fixedImageSource = FixedImageSourceType::New();
-
-    movingImageSource->SetSize(movingImageSize);
-    movingImageSource->SetOrigin(movingImageOrigin);
-    movingImageSource->SetSpacing(movingImageSpacing);
-    movingImageSource->SetNormalized(false);
-    movingImageSource->SetScale(250.0f);
-
-    fixedImageSource->SetSize(fixedImageSize);
-    fixedImageSource->SetOrigin(fixedImageOrigin);
-    fixedImageSource->SetSpacing(fixedImageSpacing);
-    fixedImageSource->SetNormalized(false);
-    fixedImageSource->SetScale(250.0f);
-
-    movingImageSource->Update(); // Force the filter to run
-    fixedImageSource->Update();  // Force the filter to run
-
-    MovingImageType::Pointer movingImage = movingImageSource->GetOutput();
-    FixedImageType::Pointer  fixedImage = fixedImageSource->GetOutput();
-
-    // Set up the metric.
-    using MetricType = itk::KullbackLeiblerCompareHistogramImageToImageMetric<FixedImageType, MovingImageType>;
-    using TransformBaseType = MetricType::TransformType;
-    using ScalesType = MetricType::ScalesType;
-    using ParametersType = TransformBaseType::ParametersType;
-
-    MetricType::Pointer metric = MetricType::New();
-
-    unsigned int                        nBins = 256;
-    MetricType::HistogramType::SizeType histSize;
-
-    histSize.SetSize(2);
-
-    histSize[0] = nBins;
-    histSize[1] = nBins;
-    metric->SetHistogramSize(histSize);
-
-    // Plug the images into the metric.
-    metric->SetFixedImage(fixedImage);
-    metric->SetMovingImage(movingImage);
-
-    // Set up a transform.
-    using TransformType = itk::TranslationTransform<CoordinateRepresentationType, ImageDimension>;
-
-    TransformType::Pointer transform = TransformType::New();
-    metric->SetTransform(transform);
-
-    // Set up an interpolator.
-    using InterpolatorType = itk::LinearInterpolateImageFunction<MovingImageType, double>;
-
-    InterpolatorType::Pointer interpolator = InterpolatorType::New();
-    interpolator->SetInputImage(movingImage);
-    metric->SetInterpolator(interpolator);
-
-    // Define the region over which the metric will be computed.
-    metric->SetFixedImageRegion(fixedImage->GetBufferedRegion());
-
-    // Set up transform parameters.
-    ParametersType parameters(transform->GetNumberOfParameters());
-
-    for (unsigned int k = 0; k < ImageDimension; ++k)
-      parameters[k] = 0.0f;
-
-    // Set scales for derivative calculation.
-    ScalesType scales(transform->GetNumberOfParameters());
-
-    for (unsigned int k = 0; k < transform->GetNumberOfParameters(); ++k)
-      scales[k] = 1;
-
-    metric->SetDerivativeStepLengthScales(scales);
-
-    // Now set up the Training Stuff
-    metric->SetTrainingTransform(transform);
-    metric->SetTrainingFixedImage(fixedImage);
-    metric->SetTrainingFixedImageRegion(fixedImage->GetBufferedRegion());
-    metric->SetTrainingMovingImage(movingImage);
-    metric->SetTrainingInterpolator(interpolator);
-
-    // Initialize the metric.
-    metric->Initialize();
-
-    // Print out metric value and derivative.
-    MetricType::MeasureType    measure = metric->GetValue(parameters);
-    MetricType::DerivativeType derivative;
-    metric->GetDerivative(parameters, derivative);
-
-    std::cout << "Metric value = " << measure << std::endl << "Derivative = " << derivative << std::endl;
-
-    // Exercise Print() method.
-    metric->Print(std::cout);
-
-    std::cout << "Test passed." << std::endl;
-  }
-  catch (const itk::ExceptionObject & ex)
-  {
-    std::cerr << "Exception caught!" << std::endl;
-    std::cerr << ex << std::endl;
-    return EXIT_FAILURE;
+    parameters[k] = 0.0f;
   }
 
+  // Set scales for derivative calculation.
+  ScalesType scales(transform->GetNumberOfParameters());
+
+  for (unsigned int k = 0; k < transform->GetNumberOfParameters(); ++k)
+  {
+    scales[k] = 1;
+  }
+
+  metric->SetDerivativeStepLengthScales(scales);
+
+  // Now set up the Training Stuff
+  metric->SetTrainingTransform(transform);
+  metric->SetTrainingFixedImage(fixedImage);
+  metric->SetTrainingFixedImageRegion(fixedImage->GetBufferedRegion());
+  metric->SetTrainingMovingImage(movingImage);
+  metric->SetTrainingInterpolator(interpolator);
+
+  // Initialize the metric.
+  metric->Initialize();
+
+  // Print out metric value and derivative.
+  MetricType::MeasureType    measure = metric->GetValue(parameters);
+  MetricType::DerivativeType derivative;
+  metric->GetDerivative(parameters, derivative);
+
+  std::cout << "Metric value = " << measure << std::endl << "Derivative = " << derivative << std::endl;
+
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Increase `itk::KullbackLeiblerCompareHistogramImageToImageMetric` coverage:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.

Take advantage of the commit to improve the style:
- Only enclose within the `ITK_TRY_EXPECT_NO_EXCEPTION` macro the filter
  update calls that may throw exceptions.
- Add braces to control flow blocks even if composed with a single
  statement to comply with the ITK style.
- Mark the test ending according to the ITK style.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)