### PR TITLE
STYLE: Make `itkLabelImageToLabelMapFilterTest` style consistent

### DIFF
--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -38,22 +38,15 @@ zeroSizeCase()
 }
 
 int
-itkLabelImageToLabelMapFilterTest(int argc, char * argv[])
+itkLabelImageToLabelMapFilterTest(int, char *[])
 {
+  constexpr int Dimension = 2;
 
-  if (argc != 1)
-  {
-    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << "" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  constexpr int dim = 2;
-
-  using LabelObjectType = itk::LabelObject<unsigned long, dim>;
+  using LabelObjectType = itk::LabelObject<unsigned long, Dimension>;
   using IndexType = LabelObjectType::IndexType;
   using LabelMapType = itk::LabelMap<LabelObjectType>;
   using SizeType = LabelMapType::SizeType;
-  using ImageType = itk::Image<unsigned char, dim>;
+  using ImageType = itk::Image<unsigned char, Dimension>;
 
   using LabelImageToLabelMapFilterType = itk::LabelImageToLabelMapFilter<ImageType, LabelMapType>;
 
@@ -94,6 +87,10 @@ itkLabelImageToLabelMapFilterTest(int argc, char * argv[])
   image->SetPixel(idxHorizontal, 3);
 
   LabelImageToLabelMapFilterType::Pointer conversion = LabelImageToLabelMapFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(conversion, LabelImageToLabelMapFilter, ImageToImageFilter);
+
+
   conversion->SetInput(image);
   conversion->SetBackgroundValue(255);
   conversion->Update();
@@ -144,12 +141,10 @@ itkLabelImageToLabelMapFilterTest(int argc, char * argv[])
       }
     }
   }
-  std::cout << "End - Printing out map." << std::endl << std::endl;
-
-  conversion->Print(std::cout);
 
   zeroSizeCase();
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Make `itkLabelImageToLabelMapFilterTest` style consistent with the
ITK style:
- Exercise the basic object methods using the
`ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Remove the test input argument check due to the absence of required
  arguments other than the test name.
- Comply with the ITK style in the test ending message.
- Capitalize the first letter for constant-valued names.
- Remove the explicit call to the Print method and rely on the basic
  method exercising macro call.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)