### PR TITLE
ENH: Improve KLCompareHistogramImageToImageMetric coverage

### DIFF
--- a/Modules/Registration/Common/test/itkCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkCompareHistogramImageToImageMetricTest.cxx
@@ -86,6 +86,7 @@ itkCompareHistogramImageToImageMetricTest(int, char *[])
 
 
   auto epsilon = 1e-12;
+  metric->SetEpsilon(epsilon);
   ITK_TEST_SET_GET_VALUE(epsilon, metric->GetEpsilon());
 
   unsigned int                        nBins = 256;


### PR DESCRIPTION
Increase `itk::KullbackLeiblerCompareHistogramImageToImageMetric` coverage:
- Exercise the Set method for the `m_Epsilon` ivar.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)