### PR TITLE
Workaround VS2017 compile errors using-declarations

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -70,8 +70,9 @@ PyBuffer<TImage>::_GetArrayViewFromImage(ImageType * image)
 }
 
 template <class TImage>
-const typename PyBuffer<TImage>::OutputImagePointer
+auto
 PyBuffer<TImage>::_GetImageViewFromArray(PyObject * arr, PyObject * shape, PyObject * numOfComponent)
+  -> const OutputImagePointer
 {
   PyObject * shapeseq = NULL;
   PyObject * item = NULL;

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -57,8 +57,9 @@ PyVectorContainer<TElementIdentifier, TElement>::_array_view_from_vector_contain
 }
 
 template <typename TElementIdentifier, typename TElement>
-const typename PyVectorContainer<TElementIdentifier, TElement>::VectorContainerType::Pointer
-PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(PyObject * arr, PyObject * shape)
+auto
+PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(PyObject * arr, PyObject * shape) -> const
+  typename VectorContainerType::Pointer
 {
   PyObject * obj = NULL;
   PyObject * shapeseq = NULL;

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -57,8 +57,8 @@ PyVnl<TElement>::_GetArrayViewFromVnlVector(VectorType * vector)
 }
 
 template <class TElement>
-const typename PyVnl<TElement>::VectorType
-PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape)
+auto
+PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * shape) -> const VectorType
 {
   PyObject * obj = NULL;
   PyObject * shapeseq = NULL;
@@ -144,8 +144,8 @@ PyVnl<TElement>::_GetArrayViewFromVnlMatrix(MatrixType * matrix)
 }
 
 template <class TElement>
-const typename PyVnl<TElement>::MatrixType
-PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape)
+auto
+PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * shape) -> const MatrixType
 {
   PyObject * obj = NULL;
   PyObject * shapeseq = NULL;

--- a/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
@@ -123,8 +123,8 @@ VTKImageExport<TInputImage>::SetInput(const InputImageType * input)
  * Get the current input image.
  */
 template <typename TInputImage>
-typename VTKImageExport<TInputImage>::InputImageType *
-VTKImageExport<TInputImage>::GetInput()
+auto
+VTKImageExport<TInputImage>::GetInput() -> InputImageType *
 {
   return itkDynamicCastInDebugMode<TInputImage *>(this->ProcessObject::GetInput(0));
 }

--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -73,8 +73,8 @@ ImageToVTKImageFilter<TInputImage>::SetInput(const InputImageType * inputImage)
 }
 
 template <typename TInputImage>
-typename ImageToVTKImageFilter<TInputImage>::InputImageType *
-ImageToVTKImageFilter<TInputImage>::GetInput()
+auto
+ImageToVTKImageFilter<TInputImage>::GetInput() -> InputImageType *
 {
   return m_Exporter->GetInput();
 }
@@ -103,8 +103,8 @@ ImageToVTKImageFilter<TInputImage>::GetImporter() const
  * Get the exporter filter
  */
 template <typename TInputImage>
-typename ImageToVTKImageFilter<TInputImage>::ExporterFilterType *
-ImageToVTKImageFilter<TInputImage>::GetExporter() const
+auto
+ImageToVTKImageFilter<TInputImage>::GetExporter() const -> ExporterFilterType *
 {
   return m_Exporter.GetPointer();
 }

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
@@ -93,8 +93,8 @@ VTKImageToImageFilter<TOutputImage>::GetExporter() const
  * Get the importer filter
  */
 template <typename TOutputImage>
-const typename VTKImageToImageFilter<TOutputImage>::Superclass *
-VTKImageToImageFilter<TOutputImage>::GetImporter() const
+auto
+VTKImageToImageFilter<TOutputImage>::GetImporter() const -> const Superclass *
 {
   return this;
 }

--- a/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkChildTreeIterator.hxx
@@ -81,8 +81,8 @@ ChildTreeIterator<TTreeType>::GoToParent()
 
 /** Return the type of the iterator */
 template <typename TTreeType>
-typename ChildTreeIterator<TTreeType>::NodeType
-ChildTreeIterator<TTreeType>::GetType() const
+auto
+ChildTreeIterator<TTreeType>::GetType() const -> NodeType
 {
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::CHILD;
 }
@@ -104,8 +104,8 @@ ChildTreeIterator<TTreeType>::HasNext() const
 
 /** Return the next node */
 template <typename TTreeType>
-const typename ChildTreeIterator<TTreeType>::ValueType &
-ChildTreeIterator<TTreeType>::Next()
+auto
+ChildTreeIterator<TTreeType>::Next() -> const ValueType &
 {
   m_ListPosition++;
   this->m_Position = m_ParentNode->GetChild(m_ListPosition);

--- a/Modules/Compatibility/Deprecated/include/itkImageTransformer.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkImageTransformer.hxx
@@ -71,8 +71,8 @@ ImageTransformer<TInputImage>::SetInput(unsigned int index, const TInputImage * 
  *
  */
 template <typename TInputImage>
-const typename ImageTransformer<TInputImage>::InputImageType *
-ImageTransformer<TInputImage>::GetInput() const
+auto
+ImageTransformer<TInputImage>::GetInput() const -> const InputImageType *
 {
   if (this->GetNumberOfInputs() < 1)
   {
@@ -86,8 +86,8 @@ ImageTransformer<TInputImage>::GetInput() const
  *
  */
 template <typename TInputImage>
-typename ImageTransformer<TInputImage>::InputImageType *
-ImageTransformer<TInputImage>::GetInput()
+auto
+ImageTransformer<TInputImage>::GetInput() -> InputImageType *
 {
   if (this->GetNumberOfInputs() < 1)
   {
@@ -101,8 +101,8 @@ ImageTransformer<TInputImage>::GetInput()
  *
  */
 template <typename TInputImage>
-const typename ImageTransformer<TInputImage>::InputImageType *
-ImageTransformer<TInputImage>::GetInput(unsigned int idx) const
+auto
+ImageTransformer<TInputImage>::GetInput(unsigned int idx) const -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<const TInputImage *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkLevelOrderTreeIterator.hxx
@@ -73,8 +73,8 @@ LevelOrderTreeIterator<TTreeType>::LevelOrderTreeIterator(TTreeType *          t
 
 /** Return the type of iterator */
 template <typename TTreeType>
-typename LevelOrderTreeIterator<TTreeType>::NodeType
-LevelOrderTreeIterator<TTreeType>::GetType() const
+auto
+LevelOrderTreeIterator<TTreeType>::GetType() const -> NodeType
 {
   return TreeIteratorBaseEnums::TreeIteratorBaseNode::LEVELORDER;
 }
@@ -93,8 +93,8 @@ LevelOrderTreeIterator<TTreeType>::HasNext() const
 
 /** Return the next node */
 template <typename TTreeType>
-const typename LevelOrderTreeIterator<TTreeType>::ValueType &
-LevelOrderTreeIterator<TTreeType>::Next()
+auto
+LevelOrderTreeIterator<TTreeType>::Next() -> const ValueType &
 {
   this->m_Position = const_cast<TreeNodeType *>(FindNextNode());
   if (this->m_Position == nullptr)
@@ -122,8 +122,8 @@ LevelOrderTreeIterator<TTreeType>::GetEndLevel() const
 
 /** Find the next available node */
 template <typename TTreeType>
-const typename LevelOrderTreeIterator<TTreeType>::TreeNodeType *
-LevelOrderTreeIterator<TTreeType>::FindNextNode() const
+auto
+LevelOrderTreeIterator<TTreeType>::FindNextNode() const -> const TreeNodeType *
 {
   int                  level;
   const TreeNodeType * node;
@@ -186,8 +186,8 @@ LevelOrderTreeIterator<TTreeType>::GetLevel(const TreeNodeType * node) const
 
 /** Helper function to find the next node */
 template <typename TTreeType>
-const typename LevelOrderTreeIterator<TTreeType>::TreeNodeType *
-LevelOrderTreeIterator<TTreeType>::FindNextNodeHelp() const
+auto
+LevelOrderTreeIterator<TTreeType>::FindNextNodeHelp() const -> const TreeNodeType *
 {
   if (m_Queue.empty())
   {

--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.hxx
@@ -74,8 +74,8 @@ TreeIteratorBase<TTreeType>::TreeIteratorBase(const TTreeType * tree, const Tree
 
 /** Return the current value of the node */
 template <typename TTreeType>
-const typename TreeIteratorBase<TTreeType>::ValueType &
-TreeIteratorBase<TTreeType>::Get() const
+auto
+TreeIteratorBase<TTreeType>::Get() const -> const ValueType &
 {
   return m_Position->Get();
 }
@@ -342,8 +342,8 @@ TreeIteratorBase<TTreeType>::Children()
 
 /** Return the first parent found */
 template <typename TTreeType>
-const typename TreeIteratorBase<TTreeType>::TreeNodeType *
-TreeIteratorBase<TTreeType>::GetParent() const
+auto
+TreeIteratorBase<TTreeType>::GetParent() const -> const TreeNodeType *
 {
   if (m_Position == nullptr)
   {
@@ -445,32 +445,32 @@ TreeIteratorBase<TTreeType>::Count()
 
 /** Get the node pointed by the iterator */
 template <typename TTreeType>
-typename TreeIteratorBase<TTreeType>::TreeNodeType *
-TreeIteratorBase<TTreeType>::GetNode()
+auto
+TreeIteratorBase<TTreeType>::GetNode() -> TreeNodeType *
 {
   return const_cast<TreeNodeType *>(m_Position);
 }
 
 /** Get the node pointed by the iterator */
 template <typename TTreeType>
-const typename TreeIteratorBase<TTreeType>::TreeNodeType *
-TreeIteratorBase<TTreeType>::GetNode() const
+auto
+TreeIteratorBase<TTreeType>::GetNode() const -> const TreeNodeType *
 {
   return m_Position;
 }
 
 /** Get the root */
 template <typename TTreeType>
-typename TreeIteratorBase<TTreeType>::TreeNodeType *
-TreeIteratorBase<TTreeType>::GetRoot()
+auto
+TreeIteratorBase<TTreeType>::GetRoot() -> TreeNodeType *
 {
   return const_cast<TreeNodeType *>(m_Root);
 }
 
 /** Get the root (const) */
 template <typename TTreeType>
-const typename TreeIteratorBase<TTreeType>::TreeNodeType *
-TreeIteratorBase<TTreeType>::GetRoot() const
+auto
+TreeIteratorBase<TTreeType>::GetRoot() const -> const TreeNodeType *
 {
   return m_Root;
 }

--- a/Modules/Compatibility/Deprecated/include/itkTreeNode.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkTreeNode.hxx
@@ -122,8 +122,8 @@ TreeNode<TValue>::HasChildren() const
 
 /** Return the number of children */
 template <typename TValue>
-typename TreeNode<TValue>::ChildIdentifier
-TreeNode<TValue>::CountChildren() const
+auto
+TreeNode<TValue>::CountChildren() const -> ChildIdentifier
 {
   return static_cast<ChildIdentifier>(m_Children.size());
 }
@@ -183,8 +183,8 @@ TreeNode<TValue>::ChildPosition(const Self * node) const
 
 /** Return the child position given an element, the first child found. */
 template <typename TValue>
-typename TreeNode<TValue>::ChildIdentifier
-TreeNode<TValue>::ChildPosition(TValue element) const
+auto
+TreeNode<TValue>::ChildPosition(TValue element) const -> ChildIdentifier
 {
   const auto numberOfChildren = static_cast<ChildIdentifier>(m_Children.size());
 
@@ -233,8 +233,8 @@ TreeNode<TValue>::AddChild(ChildIdentifier number, Self * node)
 
 /** Get the number of children given a name and a depth */
 template <typename TValue>
-typename TreeNode<TValue>::ChildIdentifier
-TreeNode<TValue>::GetNumberOfChildren(unsigned int depth, char * name) const
+auto
+TreeNode<TValue>::GetNumberOfChildren(unsigned int depth, char * name) const -> ChildIdentifier
 {
   auto it = m_Children.begin();
   auto itEnd = m_Children.end();
@@ -266,8 +266,8 @@ TreeNode<TValue>::GetNumberOfChildren(unsigned int depth, char * name) const
 /** Get children given a name and a depth */
 #if !defined(ITK_WRAPPING_PARSER)
 template <typename TValue>
-typename TreeNode<TValue>::ChildrenListType *
-TreeNode<TValue>::GetChildren(unsigned int depth, char * name) const
+auto
+TreeNode<TValue>::GetChildren(unsigned int depth, char * name) const -> ChildrenListType *
 {
   auto * children = new ChildrenListType;
 

--- a/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkVectorCentralDifferenceImageFunction.hxx
@@ -46,8 +46,9 @@ VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ost
  *
  */
 template <typename TInputImage, typename TCoordRep>
-typename VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 VectorCentralDifferenceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+  -> OutputType
 {
   OutputType derivative;
 

--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -57,8 +57,8 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::Fill(const CoefficientVector & 
 }
 
 template <typename TPixel, unsigned int TDimension, typename TAllocator>
-typename AnnulusOperator<TPixel, TDimension, TAllocator>::CoefficientVector
-AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients()
+auto
+AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   // Determine the initial kernel values...
   double interiorV, annulusV, exteriorV;

--- a/Modules/Core/Common/include/itkArray.hxx
+++ b/Modules/Core/Common/include/itkArray.hxx
@@ -148,8 +148,8 @@ Array<TValue>::SetSize(SizeValueType sz)
 }
 
 template <typename TValue>
-const typename Array<TValue>::Self &
-Array<TValue>::operator=(const Self & rhs)
+auto
+Array<TValue>::operator=(const Self & rhs) -> const Self &
 {
   if (this != &rhs)
   {
@@ -167,8 +167,8 @@ Array<TValue>::operator=(const Self & rhs)
 }
 
 template <typename TValue>
-const typename Array<TValue>::Self &
-Array<TValue>::operator=(const VnlVectorType & rhs)
+auto
+Array<TValue>::operator=(const VnlVectorType & rhs) -> const Self &
 {
   if (this != &rhs)
   {

--- a/Modules/Core/Common/include/itkAtanRegularizedHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkAtanRegularizedHeavisideStepFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 {
 
 template <typename TInput, typename TOutput>
-typename AtanRegularizedHeavisideStepFunction<TInput, TOutput>::OutputType
-AtanRegularizedHeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType & input) const
+auto
+AtanRegularizedHeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType & input) const -> OutputType
 {
   const RealType t = static_cast<RealType>(input) * this->GetOneOverEpsilon();
   return 0.5 + static_cast<OutputType>(itk::Math::one_over_pi * std::atan(t));
@@ -34,8 +34,8 @@ AtanRegularizedHeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType 
 
 /** Evaluate the derivative at the specified input position */
 template <typename TInput, typename TOutput>
-typename AtanRegularizedHeavisideStepFunction<TInput, TOutput>::OutputType
-AtanRegularizedHeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const InputType & input) const
+auto
+AtanRegularizedHeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const InputType & input) const -> OutputType
 {
   const RealType oneOverEpsilon = this->GetOneOverEpsilon();
   const RealType t = static_cast<RealType>(input) * oneOverEpsilon;

--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.hxx
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 template <typename TPixel, unsigned int TDimension, typename TAllocator>
-typename BackwardDifferenceOperator<TPixel, TDimension, TAllocator>::CoefficientVector
-BackwardDifferenceOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients()
+auto
+BackwardDifferenceOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   CoefficientVector coeff(3);
 

--- a/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.hxx
@@ -41,8 +41,8 @@ BinaryThresholdSpatialFunction<TFunction>::PrintSelf(std::ostream & os, Indent i
 }
 
 template <typename TFunction>
-typename BinaryThresholdSpatialFunction<TFunction>::OutputType
-BinaryThresholdSpatialFunction<TFunction>::Evaluate(const InputType & point) const
+auto
+BinaryThresholdSpatialFunction<TFunction>::Evaluate(const InputType & point) const -> OutputType
 {
   FunctionOutputType value = m_Function->Evaluate(point);
 

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -66,8 +66,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Set
 
 /** Access routine to get the points container. */
 template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
-const typename BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::PointsContainer *
+auto
 BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetPoints() const
+  -> const PointsContainer *
 {
   itkDebugMacro("returning Points container of " << m_PointsContainer);
 
@@ -107,8 +108,8 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
 #if !defined(ITK_LEGACY_REMOVE)
 /** Compute and get the corners of the bounding box */
 template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
-const typename BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::PointsContainer *
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetCorners()
+auto
+BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetCorners() -> const PointsContainer *
 {
   m_CornersContainer->clear();
   m_CornersContainer->Reserve(NumberOfCorners);
@@ -191,8 +192,8 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Com
 }
 
 template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
-typename BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::PointType
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetCenter() const
+auto
+BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetCenter() const -> PointType
 {
   this->ComputeBoundingBox();
 
@@ -206,8 +207,8 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
 }
 
 template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
-typename BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::PointType
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetMinimum() const
+auto
+BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetMinimum() const -> PointType
 {
   this->ComputeBoundingBox();
 
@@ -233,8 +234,8 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Set
 }
 
 template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
-typename BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::PointType
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetMaximum() const
+auto
+BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetMaximum() const -> PointType
 {
   this->ComputeBoundingBox();
 
@@ -286,8 +287,9 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Con
 }
 
 template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
-typename BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::AccumulateType
+auto
 BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::GetDiagonalLength2() const
+  -> AccumulateType
 {
   typename NumericTraits<CoordRepType>::AccumulateType dist2 = NumericTraits<CoordRepType>::ZeroValue();
 
@@ -341,8 +343,8 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Get
 }
 
 template <typename TPointIdentifier, unsigned int VPointDimension, typename TCoordRep, typename TPointsContainer>
-typename BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::Pointer
-BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::DeepCopy() const
+auto
+BoundingBox<TPointIdentifier, VPointDimension, TCoordRep, TPointsContainer>::DeepCopy() const -> Pointer
 {
   Pointer clone = Self::New();
 

--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -26,8 +26,8 @@
 namespace itk
 {
 template <unsigned int VDimension>
-typename BresenhamLine<VDimension>::OffsetArray
-BresenhamLine<VDimension>::BuildLine(LType Direction, unsigned int length)
+auto
+BresenhamLine<VDimension>::BuildLine(LType Direction, unsigned int length) -> OffsetArray
 {
   // copied from the line iterator
   /** Variables that drive the Bresenham-Algorithm */
@@ -113,8 +113,8 @@ BresenhamLine<VDimension>::BuildLine(LType Direction, unsigned int length)
 }
 
 template <unsigned int VDimension>
-typename BresenhamLine<VDimension>::IndexArray
-BresenhamLine<VDimension>::BuildLine(IndexType p0, IndexType p1)
+auto
+BresenhamLine<VDimension>::BuildLine(IndexType p0, IndexType p1) -> IndexArray
 {
   itk::Point<float, VDimension> point0;
   itk::Point<float, VDimension> point1;

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -55,7 +55,7 @@
 #define itkCellInheritedTypedefs(superclassArg)                                                                        \
   using Superclass = superclassArg;                                                                                    \
   using typename Superclass::PixelType;                                                                                \
-  using typename Superclass::CellType;                                                                                 \
+  using CellType = typename Superclass::CellType;                                                                      \
   using typename Superclass::CellAutoPointer;                                                                          \
   using typename Superclass::CellConstAutoPointer;                                                                     \
   using typename Superclass::CellRawPointer;                                                                           \

--- a/Modules/Core/Common/include/itkCellInterface.hxx
+++ b/Modules/Core/Common/include/itkCellInterface.hxx
@@ -38,15 +38,15 @@ CellInterface<TPixelType, TCellTraits>::GetInterpolationOrder() const
  * PointIdsBegin() const.
  */
 template <typename TPixelType, typename TCellTraits>
-typename CellInterface<TPixelType, TCellTraits>::PointIdConstIterator
-CellInterface<TPixelType, TCellTraits>::GetPointIds() const
+auto
+CellInterface<TPixelType, TCellTraits>::GetPointIds() const -> PointIdConstIterator
 {
   return this->PointIdsBegin();
 }
 
 template <typename TPixelType, typename TCellTraits>
-typename CellInterface<TPixelType, TCellTraits>::PointIdentifierContainerType
-CellInterface<TPixelType, TCellTraits>::GetPointIdsContainer() const
+auto
+CellInterface<TPixelType, TCellTraits>::GetPointIdsContainer() const -> PointIdentifierContainerType
 {
   PointIdentifierContainerType res;
   res.SetSize(this->GetNumberOfPoints());
@@ -136,8 +136,8 @@ CellInterface<TPixelType, TCellTraits>::GetNumberOfUsingCells()
  * Get a begin iterator for the UsingCellsContainer.
  */
 template <typename TPixelType, typename TCellTraits>
-typename CellInterface<TPixelType, TCellTraits>::UsingCellsContainerIterator
-CellInterface<TPixelType, TCellTraits>::UsingCellsBegin()
+auto
+CellInterface<TPixelType, TCellTraits>::UsingCellsBegin() -> UsingCellsContainerIterator
 {
   return m_UsingCells.begin();
 }
@@ -146,8 +146,8 @@ CellInterface<TPixelType, TCellTraits>::UsingCellsBegin()
  * Get an end iterator for the UsingCellsContainer.
  */
 template <typename TPixelType, typename TCellTraits>
-typename CellInterface<TPixelType, TCellTraits>::UsingCellsContainerIterator
-CellInterface<TPixelType, TCellTraits>::UsingCellsEnd()
+auto
+CellInterface<TPixelType, TCellTraits>::UsingCellsEnd() -> UsingCellsContainerIterator
 {
   return m_UsingCells.end();
 }

--- a/Modules/Core/Common/include/itkCompensatedSummation.hxx
+++ b/Modules/Core/Common/include/itkCompensatedSummation.hxx
@@ -80,8 +80,8 @@ CompensatedSummation<TFloat>::CompensatedSummation(const Self & rhs)
 }
 
 template <typename TFloat>
-typename CompensatedSummation<TFloat>::Self &
-CompensatedSummation<TFloat>::operator=(const Self & rhs)
+auto
+CompensatedSummation<TFloat>::operator=(const Self & rhs) -> Self &
 {
   if (this != &rhs)
   {
@@ -161,8 +161,8 @@ CompensatedSummation<TFloat>::operator=(const FloatType & rhs)
 }
 
 template <typename TFloat>
-const typename CompensatedSummation<TFloat>::AccumulateType &
-CompensatedSummation<TFloat>::GetSum() const
+auto
+CompensatedSummation<TFloat>::GetSum() const -> const AccumulateType &
 {
   return this->m_Sum;
 }

--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
@@ -41,8 +41,8 @@ ConicShellInteriorExteriorSpatialFunction<VDimension, TInput>::SetOriginGradient
 }
 
 template <unsigned int VDimension, typename TInput>
-typename ConicShellInteriorExteriorSpatialFunction<VDimension, TInput>::OutputType
-ConicShellInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const
+auto
+ConicShellInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const -> OutputType
 {
   using VectorType = Vector<double, VDimension>;
 

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -144,8 +144,9 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::IndexInBounds(const Neigh
 }
 
 template <typename TImage, typename TBoundaryCondition>
-typename ConstNeighborhoodIterator<TImage, TBoundaryCondition>::PixelType
+auto
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetPixel(NeighborIndexType n, bool & IsInBounds) const
+  -> PixelType
 {
   // If the region the iterator is walking (padded by the neighborhood size)
   // never bumps up against the bounds of the buffered region, then don't
@@ -182,8 +183,9 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetPixel(NeighborIndexTyp
 }
 
 template <typename TImage, typename TBoundaryCondition>
-typename ConstNeighborhoodIterator<TImage, TBoundaryCondition>::OffsetType
+auto
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::ComputeInternalIndex(const NeighborIndexType n) const
+  -> OffsetType
 {
   OffsetType ans;
   auto       r = (unsigned long)n;
@@ -196,8 +198,8 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::ComputeInternalIndex(cons
 }
 
 template <typename TImage, typename TBoundaryCondition>
-typename ConstNeighborhoodIterator<TImage, TBoundaryCondition>::RegionType
-ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetBoundingBoxAsImageRegion() const
+auto
+ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetBoundingBoxAsImageRegion() const -> RegionType
 {
   const IndexValueType zero = NumericTraits<IndexValueType>::ZeroValue();
   RegionType           ans;
@@ -297,8 +299,8 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::SetEndIndex()
 }
 
 template <typename TImage, typename TBoundaryCondition>
-typename ConstNeighborhoodIterator<TImage, TBoundaryCondition>::NeighborhoodType
-ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetNeighborhood() const
+auto
+ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetNeighborhood() const -> NeighborhoodType
 {
   OffsetType OverlapLow, OverlapHigh, temp, offset;
 

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -104,8 +104,8 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::IndexInBounds(const NeighborInde
 }
 
 template <typename TImage>
-typename ConstNeighborhoodIteratorWithOnlyIndex<TImage>::OffsetType
-ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ComputeInternalIndex(NeighborIndexType n) const
+auto
+ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ComputeInternalIndex(NeighborIndexType n) const -> OffsetType
 {
   OffsetType ans;
   auto       r = (unsigned long)n;
@@ -118,8 +118,8 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ComputeInternalIndex(NeighborInd
 }
 
 template <typename TImage>
-typename ConstNeighborhoodIteratorWithOnlyIndex<TImage>::RegionType
-ConstNeighborhoodIteratorWithOnlyIndex<TImage>::GetBoundingBoxAsImageRegion() const
+auto
+ConstNeighborhoodIteratorWithOnlyIndex<TImage>::GetBoundingBoxAsImageRegion() const -> RegionType
 {
   const IndexValueType zero = NumericTraits<IndexValueType>::ZeroValue();
   RegionType           ans;

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
@@ -57,8 +57,8 @@ ConstantBoundaryCondition<TInputImage, TOutputImage>::SetConstant(const OutputPi
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename ConstantBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType &
-ConstantBoundaryCondition<TInputImage, TOutputImage>::GetConstant() const
+auto
+ConstantBoundaryCondition<TInputImage, TOutputImage>::GetConstant() const -> const OutputPixelType &
 {
   return m_Constant;
 }
@@ -86,8 +86,9 @@ ConstantBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ConstantBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 ConstantBoundaryCondition<TInputImage, TOutputImage>::GetPixel(const IndexType & index, const TInputImage * image) const
+  -> OutputPixelType
 {
   RegionType imageRegion = image->GetLargestPossibleRegion();
   if (imageRegion.IsInside(index))

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -65,7 +65,7 @@ public:
   using IndexType = Index<VIndexDimension>;
 
   /** The Array type from which this Vector is derived. */
-  using typename Superclass::BaseArray;
+  using BaseArray = typename Superclass::BaseArray;
   using Iterator = typename BaseArray::Iterator;
   using ConstIterator = typename BaseArray::ConstIterator;
 

--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -38,8 +38,8 @@ CovariantVector<T, NVectorDimension>::operator=(const ValueType r[NVectorDimensi
 }
 
 template <typename T, unsigned int NVectorDimension>
-const typename CovariantVector<T, NVectorDimension>::Self &
-CovariantVector<T, NVectorDimension>::operator+=(const Self & vec)
+auto
+CovariantVector<T, NVectorDimension>::operator+=(const Self & vec) -> const Self &
 {
   for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
@@ -49,8 +49,8 @@ CovariantVector<T, NVectorDimension>::operator+=(const Self & vec)
 }
 
 template <typename T, unsigned int NVectorDimension>
-const typename CovariantVector<T, NVectorDimension>::Self &
-CovariantVector<T, NVectorDimension>::operator-=(const Self & vec)
+auto
+CovariantVector<T, NVectorDimension>::operator-=(const Self & vec) -> const Self &
 {
   for (unsigned int i = 0; i < NVectorDimension; ++i)
   {
@@ -73,8 +73,8 @@ CovariantVector<T, NVectorDimension>::operator-() const
 }
 
 template <typename T, unsigned int NVectorDimension>
-typename CovariantVector<T, NVectorDimension>::Self
-CovariantVector<T, NVectorDimension>::operator+(const Self & vec) const
+auto
+CovariantVector<T, NVectorDimension>::operator+(const Self & vec) const -> Self
 {
   Self result;
 
@@ -86,8 +86,8 @@ CovariantVector<T, NVectorDimension>::operator+(const Self & vec) const
 }
 
 template <typename T, unsigned int NVectorDimension>
-typename CovariantVector<T, NVectorDimension>::Self
-CovariantVector<T, NVectorDimension>::operator-(const Self & vec) const
+auto
+CovariantVector<T, NVectorDimension>::operator-(const Self & vec) const -> Self
 {
   Self result;
 
@@ -123,8 +123,8 @@ typename CovariantVector<T, NVectorDimension>::ValueType CovariantVector<T, NVec
 }
 
 template <typename T, unsigned int NVectorDimension>
-typename CovariantVector<T, NVectorDimension>::RealValueType
-CovariantVector<T, NVectorDimension>::GetSquaredNorm() const
+auto
+CovariantVector<T, NVectorDimension>::GetSquaredNorm() const -> RealValueType
 {
   RealValueType sum = NumericTraits<RealValueType>::ZeroValue();
 
@@ -137,15 +137,15 @@ CovariantVector<T, NVectorDimension>::GetSquaredNorm() const
 }
 
 template <typename T, unsigned int NVectorDimension>
-typename CovariantVector<T, NVectorDimension>::RealValueType
-CovariantVector<T, NVectorDimension>::GetNorm() const
+auto
+CovariantVector<T, NVectorDimension>::GetNorm() const -> RealValueType
 {
   return std::sqrt(this->GetSquaredNorm());
 }
 
 template <typename T, unsigned int NVectorDimension>
-typename CovariantVector<T, NVectorDimension>::RealValueType
-CovariantVector<T, NVectorDimension>::Normalize()
+auto
+CovariantVector<T, NVectorDimension>::Normalize() -> RealValueType
 {
   const RealValueType norm = this->GetNorm();
 

--- a/Modules/Core/Common/include/itkDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkDerivativeOperator.hxx
@@ -24,8 +24,8 @@
 namespace itk
 {
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-typename DerivativeOperator<TPixel, VDimension, TAllocator>::CoefficientVector
-DerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
+auto
+DerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   unsigned int       i;
   unsigned int       j;

--- a/Modules/Core/Common/include/itkDiffusionTensor3D.hxx
+++ b/Modules/Core/Common/include/itkDiffusionTensor3D.hxx
@@ -96,8 +96,8 @@ DiffusionTensor3D<T>::operator=(const Superclass & r)
  *
  */
 template <typename T>
-typename DiffusionTensor3D<T>::AccumulateValueType
-DiffusionTensor3D<T>::GetTrace() const
+auto
+DiffusionTensor3D<T>::GetTrace() const -> AccumulateValueType
 {
   AccumulateValueType trace = (*this)[0];
 
@@ -110,8 +110,8 @@ DiffusionTensor3D<T>::GetTrace() const
  *  Compute the value of fractional anisotropy
  */
 template <typename T>
-typename DiffusionTensor3D<T>::RealValueType
-DiffusionTensor3D<T>::GetFractionalAnisotropy() const
+auto
+DiffusionTensor3D<T>::GetFractionalAnisotropy() const -> RealValueType
 {
   // Computed as
   // FA = std::sqrt(1.5*sum(sum(N.*N))/sum((sum(D.*D))))
@@ -144,8 +144,8 @@ DiffusionTensor3D<T>::GetFractionalAnisotropy() const
  *  Compute the value of relative anisotropy
  */
 template <typename T>
-typename DiffusionTensor3D<T>::RealValueType
-DiffusionTensor3D<T>::GetRelativeAnisotropy() const
+auto
+DiffusionTensor3D<T>::GetRelativeAnisotropy() const -> RealValueType
 {
   const RealValueType trace = this->GetTrace();
   const RealValueType isp = this->GetInnerScalarProduct();
@@ -175,8 +175,8 @@ DiffusionTensor3D<T>::GetRelativeAnisotropy() const
  *  Compute the inner scalar product
  */
 template <typename T>
-typename DiffusionTensor3D<T>::RealValueType
-DiffusionTensor3D<T>::GetInnerScalarProduct() const
+auto
+DiffusionTensor3D<T>::GetInnerScalarProduct() const -> RealValueType
 {
   const RealValueType xx = (*this)[0];
   const RealValueType xy = (*this)[1];

--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -47,8 +47,8 @@ EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::~EllipsoidInterior
 }
 
 template <unsigned int VDimension, typename TInput>
-typename EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::OutputType
-EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const
+auto
+EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const -> OutputType
 {
   double distanceSquared = 0;
 

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -67,8 +67,8 @@ FiniteCylinderSpatialFunction<VDimension, TInput>::SetOrientation(const InputTyp
 }
 
 template <unsigned int VDimension, typename TInput>
-typename FiniteCylinderSpatialFunction<VDimension, TInput>::OutputType
-FiniteCylinderSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const
+auto
+FiniteCylinderSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const -> OutputType
 {
   const double halfAxisLength = 0.5 * m_AxisLength;
 

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -72,8 +72,8 @@ FixedArray<TValue, VLength>::operator==(const FixedArray & r) const
  * Get an Iterator for the beginning of the FixedArray.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::Iterator
-FixedArray<TValue, VLength>::Begin()
+auto
+FixedArray<TValue, VLength>::Begin() -> Iterator
 {
   return Iterator(m_InternalArray);
 }
@@ -82,8 +82,8 @@ FixedArray<TValue, VLength>::Begin()
  * Get a ConstIterator for the beginning of the FixedArray.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::ConstIterator
-FixedArray<TValue, VLength>::Begin() const
+auto
+FixedArray<TValue, VLength>::Begin() const -> ConstIterator
 {
   return ConstIterator(m_InternalArray);
 }
@@ -92,8 +92,8 @@ FixedArray<TValue, VLength>::Begin() const
  * Get an Iterator for the end of the FixedArray.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::Iterator
-FixedArray<TValue, VLength>::End()
+auto
+FixedArray<TValue, VLength>::End() -> Iterator
 {
   return Iterator(m_InternalArray + VLength);
 }
@@ -102,8 +102,8 @@ FixedArray<TValue, VLength>::End()
  * Get a ConstIterator for the end of the FixedArray.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::ConstIterator
-FixedArray<TValue, VLength>::End() const
+auto
+FixedArray<TValue, VLength>::End() const -> ConstIterator
 {
   return ConstIterator(m_InternalArray + VLength);
 }
@@ -114,8 +114,8 @@ FixedArray<TValue, VLength>::End() const
  * Get a begin ReverseIterator.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::ReverseIterator
-FixedArray<TValue, VLength>::rBegin()
+auto
+FixedArray<TValue, VLength>::rBegin() -> ReverseIterator
 {
   return ReverseIterator(m_InternalArray + VLength);
 }
@@ -124,8 +124,8 @@ FixedArray<TValue, VLength>::rBegin()
  * Get a begin ConstReverseIterator.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::ConstReverseIterator
-FixedArray<TValue, VLength>::rBegin() const
+auto
+FixedArray<TValue, VLength>::rBegin() const -> ConstReverseIterator
 {
   return ConstReverseIterator(m_InternalArray + VLength);
 }
@@ -134,8 +134,8 @@ FixedArray<TValue, VLength>::rBegin() const
  * Get an end ReverseIterator.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::ReverseIterator
-FixedArray<TValue, VLength>::rEnd()
+auto
+FixedArray<TValue, VLength>::rEnd() -> ReverseIterator
 {
   return ReverseIterator(m_InternalArray);
 }
@@ -144,8 +144,8 @@ FixedArray<TValue, VLength>::rEnd()
  * Get an end ConstReverseIterator.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::ConstReverseIterator
-FixedArray<TValue, VLength>::rEnd() const
+auto
+FixedArray<TValue, VLength>::rEnd() const -> ConstReverseIterator
 {
   return ConstReverseIterator(m_InternalArray);
 }
@@ -156,8 +156,8 @@ FixedArray<TValue, VLength>::rEnd() const
  * Get the size of the FixedArray.
  */
 template <typename TValue, unsigned int VLength>
-typename FixedArray<TValue, VLength>::SizeType
-FixedArray<TValue, VLength>::Size() const
+auto
+FixedArray<TValue, VLength>::Size() const -> SizeType
 {
   return VLength;
 }

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.hxx
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.hxx
@@ -24,8 +24,8 @@
 namespace itk
 {
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-typename ForwardDifferenceOperator<TPixel, VDimension, TAllocator>::CoefficientVector
-ForwardDifferenceOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
+auto
+ForwardDifferenceOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   CoefficientVector coeff(3);
 

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
@@ -29,8 +29,8 @@ FrustumSpatialFunction<VDimension, TInput>::FrustumSpatialFunction()
 }
 
 template <unsigned int VDimension, typename TInput>
-typename FrustumSpatialFunction<VDimension, TInput>::OutputType
-FrustumSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const
+auto
+FrustumSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const -> OutputType
 {
   using PointType = InputType;
   using VectorType = typename PointType::VectorType;

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -28,8 +28,8 @@ namespace itk
 {
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-typename GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::CoefficientVector
-GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
+auto
+GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
 
   // compute gaussian kernel of 0-order
@@ -101,8 +101,8 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-typename GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::CoefficientVector
-GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateGaussianCoefficients() const
+auto
+GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateGaussianCoefficients() const -> CoefficientVector
 {
 
   CoefficientVector coeff;

--- a/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
@@ -35,8 +35,9 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::GaussianDer
 }
 
 template <typename TOutput, unsigned int VImageDimension, typename TInput>
-typename GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::OutputType
+auto
 GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(const TInput & position) const
+  -> OutputType
 {
   // Normalizing the Gaussian is important for statistical applications
   // but is generally not desirable for creating images because of the
@@ -75,8 +76,9 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(co
 
 /** Evaluate the function at a given position and return a vector */
 template <typename TOutput, unsigned int VImageDimension, typename TInput>
-typename GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::VectorType
+auto
 GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::EvaluateVector(const TInput & position) const
+  -> VectorType
 {
   VectorType gradient;
 

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-typename GaussianOperator<TPixel, VDimension, TAllocator>::CoefficientVector
-GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
+auto
+GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   CoefficientVector coeff;
   double            sum;

--- a/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
@@ -33,8 +33,8 @@ GaussianSpatialFunction<TOutput, VImageDimension, TInput>::GaussianSpatialFuncti
 }
 
 template <typename TOutput, unsigned int VImageDimension, typename TInput>
-typename GaussianSpatialFunction<TOutput, VImageDimension, TInput>::OutputType
-GaussianSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(const TInput & position) const
+auto
+GaussianSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(const TInput & position) const -> OutputType
 {
   // We have to compute the Gaussian in several stages, because of the
   // n-dimensional generalization

--- a/Modules/Core/Common/include/itkHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkHeavisideStepFunction.hxx
@@ -29,16 +29,16 @@ HeavisideStepFunction<TInput, TOutput>::HeavisideStepFunction()
 {}
 
 template <typename TInput, typename TOutput>
-typename HeavisideStepFunction<TInput, TOutput>::OutputType
-HeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType & input) const
+auto
+HeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType & input) const -> OutputType
 {
   return (input >= NumericTraits<InputType>::ZeroValue()) ? NumericTraits<OutputType>::OneValue()
                                                           : NumericTraits<OutputType>::ZeroValue();
 }
 
 template <typename TInput, typename TOutput>
-typename HeavisideStepFunction<TInput, TOutput>::OutputType
-HeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const InputType & input) const
+auto
+HeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const InputType & input) const -> OutputType
 {
   return (Math::ExactlyEquals(input, NumericTraits<InputType>::ZeroValue())) ? NumericTraits<OutputType>::OneValue()
                                                                              : NumericTraits<OutputType>::ZeroValue();

--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -71,8 +71,8 @@ HexahedronCell<TCellInterface>::GetNumberOfPoints() const
  * Get the number of boundary features of the given dimension.
  */
 template <typename TCellInterface>
-typename HexahedronCell<TCellInterface>::CellFeatureCount
-HexahedronCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+HexahedronCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -192,8 +192,8 @@ HexahedronCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
  * Get a begin iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename HexahedronCell<TCellInterface>::PointIdIterator
-HexahedronCell<TCellInterface>::PointIdsBegin()
+auto
+HexahedronCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   return &m_PointIds[0];
 }
@@ -204,8 +204,8 @@ HexahedronCell<TCellInterface>::PointIdsBegin()
  * by the cell.
  */
 template <typename TCellInterface>
-typename HexahedronCell<TCellInterface>::PointIdConstIterator
-HexahedronCell<TCellInterface>::PointIdsBegin() const
+auto
+HexahedronCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   return &m_PointIds[0];
 }
@@ -215,8 +215,8 @@ HexahedronCell<TCellInterface>::PointIdsBegin() const
  * Get an end iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename HexahedronCell<TCellInterface>::PointIdIterator
-HexahedronCell<TCellInterface>::PointIdsEnd()
+auto
+HexahedronCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -227,8 +227,8 @@ HexahedronCell<TCellInterface>::PointIdsEnd()
  * by the cell.
  */
 template <typename TCellInterface>
-typename HexahedronCell<TCellInterface>::PointIdConstIterator
-HexahedronCell<TCellInterface>::PointIdsEnd() const
+auto
+HexahedronCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -238,8 +238,8 @@ HexahedronCell<TCellInterface>::PointIdsEnd() const
  * Get the number of vertices defining the hexahedron.
  */
 template <typename TCellInterface>
-typename HexahedronCell<TCellInterface>::CellFeatureCount
-HexahedronCell<TCellInterface>::GetNumberOfVertices() const
+auto
+HexahedronCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
 {
   return Self::NumberOfVertices;
 }
@@ -249,8 +249,8 @@ HexahedronCell<TCellInterface>::GetNumberOfVertices() const
  * Get the number of edges defined for the hexahedron.
  */
 template <typename TCellInterface>
-typename HexahedronCell<TCellInterface>::CellFeatureCount
-HexahedronCell<TCellInterface>::GetNumberOfEdges() const
+auto
+HexahedronCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
 {
   return Self::NumberOfEdges;
 }
@@ -260,8 +260,8 @@ HexahedronCell<TCellInterface>::GetNumberOfEdges() const
  * Get the number of faces defined for the hexahedron.
  */
 template <typename TCellInterface>
-typename HexahedronCell<TCellInterface>::CellFeatureCount
-HexahedronCell<TCellInterface>::GetNumberOfFaces() const
+auto
+HexahedronCell<TCellInterface>::GetNumberOfFaces() const -> CellFeatureCount
 {
   return Self::NumberOfFaces;
 }

--- a/Modules/Core/Common/include/itkImageKernelOperator.hxx
+++ b/Modules/Core/Common/include/itkImageKernelOperator.hxx
@@ -44,15 +44,15 @@ ImageKernelOperator<TPixel, VDimension, TAllocator>::SetImageKernel(const ImageT
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-const typename ImageKernelOperator<TPixel, VDimension, TAllocator>::ImageType *
-ImageKernelOperator<TPixel, VDimension, TAllocator>::GetImageKernel() const
+auto
+ImageKernelOperator<TPixel, VDimension, TAllocator>::GetImageKernel() const -> const ImageType *
 {
   return m_ImageKernel;
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-typename ImageKernelOperator<TPixel, VDimension, TAllocator>::CoefficientVector
-ImageKernelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
+auto
+ImageKernelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   // Check that the input image is fully buffered.
   if (m_ImageKernel->GetBufferedRegion() != m_ImageKernel->GetLargestPossibleRegion())

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
@@ -56,8 +56,8 @@ ImageRandomConstIteratorWithIndex<TImage>::SetNumberOfSamples(SizeValueType numb
 
 /**  Set the number of samples to extract from the region */
 template <typename TImage>
-typename ImageRandomConstIteratorWithIndex<TImage>::SizeValueType
-ImageRandomConstIteratorWithIndex<TImage>::GetNumberOfSamples() const
+auto
+ImageRandomConstIteratorWithIndex<TImage>::GetNumberOfSamples() const -> SizeValueType
 {
   return m_NumberOfSamplesRequested;
 }

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
@@ -56,8 +56,8 @@ ImageRandomConstIteratorWithOnlyIndex<TImage>::SetNumberOfSamples(SizeValueType 
 
 /**  Set the number of samples to extract from the region */
 template <typename TImage>
-typename ImageRandomConstIteratorWithOnlyIndex<TImage>::SizeValueType
-ImageRandomConstIteratorWithOnlyIndex<TImage>::GetNumberOfSamples() const
+auto
+ImageRandomConstIteratorWithOnlyIndex<TImage>::GetNumberOfSamples() const -> SizeValueType
 {
   return m_NumberOfSamplesRequested;
 }

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
@@ -87,8 +87,8 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SetNumberOfSamples(SizeVa
 
 /**  Set the number of samples to extract from the region */
 template <typename TImage>
-typename ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SizeValueType
-ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::GetNumberOfSamples() const
+auto
+ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::GetNumberOfSamples() const -> SizeValueType
 {
   return m_NumberOfSamplesRequested;
 }

--- a/Modules/Core/Common/include/itkImageRegion.hxx
+++ b/Modules/Core/Common/include/itkImageRegion.hxx
@@ -33,8 +33,8 @@
 namespace itk
 {
 template <unsigned int VImageDimension>
-typename ImageRegion<VImageDimension>::IndexType
-ImageRegion<VImageDimension>::GetUpperIndex() const
+auto
+ImageRegion<VImageDimension>::GetUpperIndex() const -> IndexType
 {
   IndexType idx;
   for (unsigned int i = 0; i < VImageDimension; ++i)
@@ -70,8 +70,8 @@ ImageRegion<VImageDimension>::ComputeOffsetTable(OffsetTableType offsetTable) co
 }
 
 template <unsigned int VImageDimension>
-typename ImageRegion<VImageDimension>::SizeValueType
-ImageRegion<VImageDimension>::GetNumberOfPixels() const
+auto
+ImageRegion<VImageDimension>::GetNumberOfPixels() const -> SizeValueType
 {
   SizeValueType numPixels = 1;
 
@@ -245,8 +245,8 @@ ImageRegion<VImageDimension>::Crop(const Self & region)
 }
 
 template <unsigned int VImageDimension>
-typename ImageRegion<VImageDimension>::SliceRegion
-ImageRegion<VImageDimension>::Slice(const unsigned int dim) const
+auto
+ImageRegion<VImageDimension>::Slice(const unsigned int dim) const -> SliceRegion
 {
   if (dim >= VImageDimension)
   {

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -47,16 +47,16 @@ ImageSink<TInputImage>::SetInput(const InputImageType * input)
 
 
 template <typename TInputImage>
-const typename ImageSink<TInputImage>::InputImageType *
-ImageSink<TInputImage>::GetInput() const
+auto
+ImageSink<TInputImage>::GetInput() const -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<const TInputImage *>(this->ProcessObject::GetPrimaryInput());
 }
 
 
 template <typename TInputImage>
-const typename ImageSink<TInputImage>::InputImageType *
-ImageSink<TInputImage>::GetInput(unsigned int idx) const
+auto
+ImageSink<TInputImage>::GetInput(unsigned int idx) const -> const InputImageType *
 {
   const auto * in = dynamic_cast<const TInputImage *>(this->ProcessObject::GetInput(idx));
 
@@ -69,8 +69,8 @@ ImageSink<TInputImage>::GetInput(unsigned int idx) const
 
 
 template <typename TInputImage>
-const typename ImageSink<TInputImage>::InputImageType *
-ImageSink<TInputImage>::GetInput(const DataObjectIdentifierType & key) const
+auto
+ImageSink<TInputImage>::GetInput(const DataObjectIdentifierType & key) const -> const InputImageType *
 {
   const auto * in = dynamic_cast<const TInputImage *>(this->ProcessObject::GetInput(key));
 

--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -72,24 +72,24 @@ ImageSource<TOutputImage>::MakeOutput(const ProcessObject::DataObjectIdentifierT
 }
 
 template <typename TOutputImage>
-typename ImageSource<TOutputImage>::OutputImageType *
-ImageSource<TOutputImage>::GetOutput()
+auto
+ImageSource<TOutputImage>::GetOutput() -> OutputImageType *
 {
   // we assume that the first output is of the templated type
   return itkDynamicCastInDebugMode<TOutputImage *>(this->GetPrimaryOutput());
 }
 
 template <typename TOutputImage>
-const typename ImageSource<TOutputImage>::OutputImageType *
-ImageSource<TOutputImage>::GetOutput() const
+auto
+ImageSource<TOutputImage>::GetOutput() const -> const OutputImageType *
 {
   // we assume that the first output is of the templated type
   return itkDynamicCastInDebugMode<const TOutputImage *>(this->GetPrimaryOutput());
 }
 
 template <typename TOutputImage>
-typename ImageSource<TOutputImage>::OutputImageType *
-ImageSource<TOutputImage>::GetOutput(unsigned int idx)
+auto
+ImageSource<TOutputImage>::GetOutput(unsigned int idx) -> OutputImageType *
 {
   auto * out = dynamic_cast<TOutputImage *>(this->ProcessObject::GetOutput(idx));
 

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -64,16 +64,16 @@ ImageToImageFilter<TInputImage, TOutputImage>::SetInput(unsigned int index, cons
 
 
 template <typename TInputImage, typename TOutputImage>
-const typename ImageToImageFilter<TInputImage, TOutputImage>::InputImageType *
-ImageToImageFilter<TInputImage, TOutputImage>::GetInput() const
+auto
+ImageToImageFilter<TInputImage, TOutputImage>::GetInput() const -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<const TInputImage *>(this->GetPrimaryInput());
 }
 
 
 template <typename TInputImage, typename TOutputImage>
-const typename ImageToImageFilter<TInputImage, TOutputImage>::InputImageType *
-ImageToImageFilter<TInputImage, TOutputImage>::GetInput(unsigned int idx) const
+auto
+ImageToImageFilter<TInputImage, TOutputImage>::GetInput(unsigned int idx) const -> const InputImageType *
 {
   const auto * in = dynamic_cast<const TInputImage *>(this->ProcessObject::GetInput(idx));
 

--- a/Modules/Core/Common/include/itkLaplacianOperator.hxx
+++ b/Modules/Core/Common/include/itkLaplacianOperator.hxx
@@ -66,8 +66,8 @@ LaplacianOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector 
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-typename LaplacianOperator<TPixel, VDimension, TAllocator>::CoefficientVector
-LaplacianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
+auto
+LaplacianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   unsigned int i, w;
 

--- a/Modules/Core/Common/include/itkLineCell.hxx
+++ b/Modules/Core/Common/include/itkLineCell.hxx
@@ -59,8 +59,8 @@ LineCell<TCellInterface>::GetNumberOfPoints() const
  * Get the number of boundary entities of the given dimension.
  */
 template <typename TCellInterface>
-typename LineCell<TCellInterface>::CellFeatureCount
-LineCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+LineCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -148,8 +148,8 @@ LineCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
  * Get a begin iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename LineCell<TCellInterface>::PointIdIterator
-LineCell<TCellInterface>::PointIdsBegin()
+auto
+LineCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   return &m_PointIds[0];
 }
@@ -160,8 +160,8 @@ LineCell<TCellInterface>::PointIdsBegin()
  * by the cell.
  */
 template <typename TCellInterface>
-typename LineCell<TCellInterface>::PointIdConstIterator
-LineCell<TCellInterface>::PointIdsBegin() const
+auto
+LineCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   return &m_PointIds[0];
 }
@@ -171,8 +171,8 @@ LineCell<TCellInterface>::PointIdsBegin() const
  * Get an end iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename LineCell<TCellInterface>::PointIdIterator
-LineCell<TCellInterface>::PointIdsEnd()
+auto
+LineCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -183,8 +183,8 @@ LineCell<TCellInterface>::PointIdsEnd()
  * by the cell.
  */
 template <typename TCellInterface>
-typename LineCell<TCellInterface>::PointIdConstIterator
-LineCell<TCellInterface>::PointIdsEnd() const
+auto
+LineCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -194,8 +194,8 @@ LineCell<TCellInterface>::PointIdsEnd() const
  * Get the number of vertices for this line.
  */
 template <typename TCellInterface>
-typename LineCell<TCellInterface>::CellFeatureCount
-LineCell<TCellInterface>::GetNumberOfVertices() const
+auto
+LineCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
 {
   return Self::NumberOfPoints;
 }

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
@@ -81,8 +81,8 @@ LoggerThreadWrapper<SimpleLoggerType>::SetDelay(DelayType delay)
 }
 
 template <typename SimpleLoggerType>
-typename LoggerThreadWrapper<SimpleLoggerType>::DelayType
-LoggerThreadWrapper<SimpleLoggerType>::GetDelay() const
+auto
+LoggerThreadWrapper<SimpleLoggerType>::GetDelay() const -> DelayType
 {
   this->m_Mutex.lock();
   DelayType delay = this->m_Delay;

--- a/Modules/Core/Common/include/itkMapContainer.hxx
+++ b/Modules/Core/Common/include/itkMapContainer.hxx
@@ -29,8 +29,8 @@ namespace itk
  * reference.
  */
 template <typename TElementIdentifier, typename TElement>
-typename MapContainer<TElementIdentifier, TElement>::Element &
-MapContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id)
+auto
+MapContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) -> Element &
 {
   this->Modified();
   return this->MapType::operator[](id);
@@ -41,8 +41,8 @@ MapContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id)
  *
  */
 template <typename TElementIdentifier, typename TElement>
-const typename MapContainer<TElementIdentifier, TElement>::Element &
-MapContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) const
+auto
+MapContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) const -> const Element &
 {
   return this->MapType::find(id)->second;
 }
@@ -55,8 +55,8 @@ MapContainer<TElementIdentifier, TElement>::ElementAt(ElementIdentifier id) cons
  * reference.
  */
 template <typename TElementIdentifier, typename TElement>
-typename MapContainer<TElementIdentifier, TElement>::Element &
-MapContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdentifier id)
+auto
+MapContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdentifier id) -> Element &
 {
   this->Modified();
   return this->MapType::operator[](id);
@@ -67,8 +67,8 @@ MapContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdentifier id
  * existence performed.
  */
 template <typename TElementIdentifier, typename TElement>
-typename MapContainer<TElementIdentifier, TElement>::Element
-MapContainer<TElementIdentifier, TElement>::GetElement(ElementIdentifier id) const
+auto
+MapContainer<TElementIdentifier, TElement>::GetElement(ElementIdentifier id) const -> Element
 {
   return this->MapType::find(id)->second;
 }
@@ -158,8 +158,8 @@ MapContainer<TElementIdentifier, TElement>::DeleteIndex(ElementIdentifier id)
  * Get a begin const iterator for the map.
  */
 template <typename TElementIdentifier, typename TElement>
-typename MapContainer<TElementIdentifier, TElement>::ConstIterator
-MapContainer<TElementIdentifier, TElement>::Begin() const
+auto
+MapContainer<TElementIdentifier, TElement>::Begin() const -> ConstIterator
 {
   return ConstIterator(this->MapType::begin());
 }
@@ -168,8 +168,8 @@ MapContainer<TElementIdentifier, TElement>::Begin() const
  * Get an end const iterator for the map.
  */
 template <typename TElementIdentifier, typename TElement>
-typename MapContainer<TElementIdentifier, TElement>::ConstIterator
-MapContainer<TElementIdentifier, TElement>::End() const
+auto
+MapContainer<TElementIdentifier, TElement>::End() const -> ConstIterator
 {
   return ConstIterator(this->MapType::end());
 }
@@ -178,8 +178,8 @@ MapContainer<TElementIdentifier, TElement>::End() const
  * Get a begin const iterator for the map.
  */
 template <typename TElementIdentifier, typename TElement>
-typename MapContainer<TElementIdentifier, TElement>::Iterator
-MapContainer<TElementIdentifier, TElement>::Begin()
+auto
+MapContainer<TElementIdentifier, TElement>::Begin() -> Iterator
 {
   return Iterator(this->MapType::begin());
 }
@@ -188,8 +188,8 @@ MapContainer<TElementIdentifier, TElement>::Begin()
  * Get an end const iterator for the map.
  */
 template <typename TElementIdentifier, typename TElement>
-typename MapContainer<TElementIdentifier, TElement>::Iterator
-MapContainer<TElementIdentifier, TElement>::End()
+auto
+MapContainer<TElementIdentifier, TElement>::End() -> Iterator
 {
   return Iterator(this->MapType::end());
 }
@@ -198,8 +198,8 @@ MapContainer<TElementIdentifier, TElement>::End()
  * Get the number of elements currently stored in the map.
  */
 template <typename TElementIdentifier, typename TElement>
-typename MapContainer<TElementIdentifier, TElement>::ElementIdentifier
-MapContainer<TElementIdentifier, TElement>::Size() const
+auto
+MapContainer<TElementIdentifier, TElement>::Size() const -> ElementIdentifier
 {
   return static_cast<ElementIdentifier>(this->MapType::size());
 }

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -137,8 +137,8 @@ Neighborhood<TPixel, VDimension, TContainer>::GetSlice(unsigned int d) const
 }
 
 template <typename TPixel, unsigned int VDimension, typename TContainer>
-typename Neighborhood<TPixel, VDimension, TContainer>::NeighborIndexType
-Neighborhood<TPixel, VDimension, TContainer>::GetNeighborhoodIndex(const OffsetType & o) const
+auto
+Neighborhood<TPixel, VDimension, TContainer>::GetNeighborhoodIndex(const OffsetType & o) const -> NeighborIndexType
 {
   unsigned int idx = (this->Size() / 2);
 

--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
@@ -166,8 +166,9 @@ ImageBoundaryFacesCalculator<TImage>::Compute(const TImage & img, RegionType reg
 
 
 template <typename TImage>
-typename ImageBoundaryFacesCalculator<TImage>::FaceListType
+auto
 ImageBoundaryFacesCalculator<TImage>::operator()(const TImage * img, RegionType regionToProcess, RadiusType radius)
+  -> FaceListType
 {
   const auto result = Compute(*img, regionToProcess, radius);
 
@@ -185,8 +186,8 @@ ImageBoundaryFacesCalculator<TImage>::operator()(const TImage * img, RegionType 
 
 
 template <typename TImage>
-typename CalculateOutputWrapOffsetModifiers<TImage>::OffsetType
-CalculateOutputWrapOffsetModifiers<TImage>::operator()(TImage * input, TImage * output) const
+auto
+CalculateOutputWrapOffsetModifiers<TImage>::operator()(TImage * input, TImage * output) const -> OffsetType
 {
   OffsetType ans;
 

--- a/Modules/Core/Common/include/itkObjectStore.hxx
+++ b/Modules/Core/Common/include/itkObjectStore.hxx
@@ -60,8 +60,8 @@ ObjectStore<TObjectType>::Reserve(SizeValueType n)
 }
 
 template <typename TObjectType>
-typename ObjectStore<TObjectType>::ObjectType *
-ObjectStore<TObjectType>::Borrow()
+auto
+ObjectStore<TObjectType>::Borrow() -> ObjectType *
 {
   ObjectType * p;
 

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -257,8 +257,8 @@ Octree<TPixel, ColorTableSize, MappingFunctionType>::BuildFromImage(ImageType * 
 }
 
 template <typename TPixel, unsigned int ColorTableSize, typename MappingFunctionType>
-typename Octree<TPixel, ColorTableSize, MappingFunctionType>::ImageTypePointer
-Octree<TPixel, ColorTableSize, MappingFunctionType>::GetImage()
+auto
+Octree<TPixel, ColorTableSize, MappingFunctionType>::GetImage() -> ImageTypePointer
 {
   typename ImageType::SizeType imageSize = { { 0, 0, 0 } };
   SizeValueType                sizes[3];

--- a/Modules/Core/Common/include/itkOptimizerParameters.h
+++ b/Modules/Core/Common/include/itkOptimizerParameters.h
@@ -41,7 +41,7 @@ public:
   using Self = OptimizerParameters;
   using Superclass = Array<TParametersValueType>;
   using ArrayType = Superclass;
-  using typename Superclass::VnlVectorType;
+  using VnlVectorType = typename Superclass::VnlVectorType;
   using typename Superclass::SizeValueType;
 
   /** Helper class for managing different types of parameter

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
@@ -180,8 +180,9 @@ PeriodicBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
 
 
 template <typename TInputImage, typename TOutputImage>
-typename PeriodicBoundaryCondition<TInputImage, TOutputImage>::OutputPixelType
+auto
 PeriodicBoundaryCondition<TInputImage, TOutputImage>::GetPixel(const IndexType & index, const TInputImage * image) const
+  -> OutputPixelType
 {
   RegionType imageRegion = image->GetLargestPossibleRegion();
   IndexType  imageIndex = imageRegion.GetIndex();

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -136,8 +136,8 @@ Point<T, TPointDimension>::GetVnlVector() const
 }
 
 template <typename T, unsigned int TPointDimension>
-typename Point<T, TPointDimension>::VectorType
-Point<T, TPointDimension>::GetVectorFromOrigin() const
+auto
+Point<T, TPointDimension>::GetVectorFromOrigin() const -> VectorType
 {
   // VectorType knows how to construct from ValueType*.
   return &(*this)[0];

--- a/Modules/Core/Common/include/itkPointSet.hxx
+++ b/Modules/Core/Common/include/itkPointSet.hxx
@@ -71,8 +71,8 @@ PointSet<TPixelType, VDimension, TMeshTraits>::SetPoints(PointsContainer * point
  * Access routine to get the points container.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename PointSet<TPixelType, VDimension, TMeshTraits>::PointsContainer *
-PointSet<TPixelType, VDimension, TMeshTraits>::GetPoints()
+auto
+PointSet<TPixelType, VDimension, TMeshTraits>::GetPoints() -> PointsContainer *
 {
   itkDebugMacro("Starting GetPoints()");
   if (!m_PointsContainer)
@@ -87,8 +87,8 @@ PointSet<TPixelType, VDimension, TMeshTraits>::GetPoints()
  * Access routine to get the points container.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-const typename PointSet<TPixelType, VDimension, TMeshTraits>::PointsContainer *
-PointSet<TPixelType, VDimension, TMeshTraits>::GetPoints() const
+auto
+PointSet<TPixelType, VDimension, TMeshTraits>::GetPoints() const -> const PointsContainer *
 {
   itkDebugMacro("returning Points container of " << m_PointsContainer);
   return m_PointsContainer.GetPointer();
@@ -113,8 +113,8 @@ PointSet<TPixelType, VDimension, TMeshTraits>::SetPointData(PointDataContainer *
  * Access routine to get the point data container.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename PointSet<TPixelType, VDimension, TMeshTraits>::PointDataContainer *
-PointSet<TPixelType, VDimension, TMeshTraits>::GetPointData()
+auto
+PointSet<TPixelType, VDimension, TMeshTraits>::GetPointData() -> PointDataContainer *
 {
   if (!m_PointDataContainer)
   {
@@ -128,8 +128,8 @@ PointSet<TPixelType, VDimension, TMeshTraits>::GetPointData()
  * Access routine to get the point data container.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-const typename PointSet<TPixelType, VDimension, TMeshTraits>::PointDataContainer *
-PointSet<TPixelType, VDimension, TMeshTraits>::GetPointData() const
+auto
+PointSet<TPixelType, VDimension, TMeshTraits>::GetPointData() const -> const PointDataContainer *
 {
   itkDebugMacro("returning PointData container of " << m_PointDataContainer);
   return m_PointDataContainer.GetPointer();
@@ -183,8 +183,8 @@ PointSet<TPixelType, VDimension, TMeshTraits>::GetPoint(PointIdentifier ptId, Po
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename PointSet<TPixelType, VDimension, TMeshTraits>::PointType
-PointSet<TPixelType, VDimension, TMeshTraits>::GetPoint(PointIdentifier ptId) const
+auto
+PointSet<TPixelType, VDimension, TMeshTraits>::GetPoint(PointIdentifier ptId) const -> PointType
 {
   /**
    * If the points container doesn't exist, then the point doesn't either.
@@ -270,8 +270,8 @@ PointSet<TPixelType, VDimension, TMeshTraits>::PassStructure(Self *)
  * Get the number of points in the PointsContainer.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename PointSet<TPixelType, VDimension, TMeshTraits>::PointIdentifier
-PointSet<TPixelType, VDimension, TMeshTraits>::GetNumberOfPoints() const
+auto
+PointSet<TPixelType, VDimension, TMeshTraits>::GetNumberOfPoints() const -> PointIdentifier
 {
   if (m_PointsContainer)
   {

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
@@ -59,16 +59,16 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::SetInput(unsigned int index
 
 /** Get the input point-set */
 template <typename TInputPointSet, typename TOutputImage>
-const typename PointSetToImageFilter<TInputPointSet, TOutputImage>::InputPointSetType *
-PointSetToImageFilter<TInputPointSet, TOutputImage>::GetInput()
+auto
+PointSetToImageFilter<TInputPointSet, TOutputImage>::GetInput() -> const InputPointSetType *
 {
   return itkDynamicCastInDebugMode<const TInputPointSet *>(this->GetPrimaryInput());
 }
 
 /** Get the input point-set */
 template <typename TInputPointSet, typename TOutputImage>
-const typename PointSetToImageFilter<TInputPointSet, TOutputImage>::InputPointSetType *
-PointSetToImageFilter<TInputPointSet, TOutputImage>::GetInput(unsigned int idx)
+auto
+PointSetToImageFilter<TInputPointSet, TOutputImage>::GetInput(unsigned int idx) -> const InputPointSetType *
 {
   return itkDynamicCastInDebugMode<const TInputPointSet *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/Core/Common/include/itkPolygonCell.hxx
+++ b/Modules/Core/Common/include/itkPolygonCell.hxx
@@ -80,8 +80,8 @@ PolygonCell<TCellInterface>::GetNumberOfPoints() const
  * Get the number of boundary features of the given dimension.
  */
 template <typename TCellInterface>
-typename PolygonCell<TCellInterface>::CellFeatureCount
-PolygonCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+PolygonCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -275,8 +275,8 @@ PolygonCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
  * Get a begin iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename PolygonCell<TCellInterface>::PointIdIterator
-PolygonCell<TCellInterface>::PointIdsBegin()
+auto
+PolygonCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   if (!m_PointIds.empty())
   {
@@ -294,8 +294,8 @@ PolygonCell<TCellInterface>::PointIdsBegin()
  * by the cell.
  */
 template <typename TCellInterface>
-typename PolygonCell<TCellInterface>::PointIdConstIterator
-PolygonCell<TCellInterface>::PointIdsBegin() const
+auto
+PolygonCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   if (!m_PointIds.empty())
   {
@@ -312,8 +312,8 @@ PolygonCell<TCellInterface>::PointIdsBegin() const
  * Get an end iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename PolygonCell<TCellInterface>::PointIdIterator
-PolygonCell<TCellInterface>::PointIdsEnd()
+auto
+PolygonCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   if (!m_PointIds.empty())
   {
@@ -331,8 +331,8 @@ PolygonCell<TCellInterface>::PointIdsEnd()
  * by the cell.
  */
 template <typename TCellInterface>
-typename PolygonCell<TCellInterface>::PointIdConstIterator
-PolygonCell<TCellInterface>::PointIdsEnd() const
+auto
+PolygonCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   if (!m_PointIds.empty())
   {
@@ -349,8 +349,8 @@ PolygonCell<TCellInterface>::PointIdsEnd() const
  * Get the number of vertices defining the Polygon.
  */
 template <typename TCellInterface>
-typename PolygonCell<TCellInterface>::CellFeatureCount
-PolygonCell<TCellInterface>::GetNumberOfVertices() const
+auto
+PolygonCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
 {
   return static_cast<CellFeatureCount>(m_PointIds.size());
 }
@@ -360,8 +360,8 @@ PolygonCell<TCellInterface>::GetNumberOfVertices() const
  * Get the number of edges defined for the Polygon.
  */
 template <typename TCellInterface>
-typename PolygonCell<TCellInterface>::CellFeatureCount
-PolygonCell<TCellInterface>::GetNumberOfEdges() const
+auto
+PolygonCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
 {
   return static_cast<CellFeatureCount>(m_Edges.size());
 }

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.hxx
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.hxx
@@ -59,8 +59,8 @@ QuadraticEdgeCell<TCellInterface>::GetNumberOfPoints() const
  * Get the number of boundary entities of the given dimension.
  */
 template <typename TCellInterface>
-typename QuadraticEdgeCell<TCellInterface>::CellFeatureCount
-QuadraticEdgeCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+QuadraticEdgeCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -156,8 +156,8 @@ QuadraticEdgeCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
  * Get a begin iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename QuadraticEdgeCell<TCellInterface>::PointIdIterator
-QuadraticEdgeCell<TCellInterface>::PointIdsBegin()
+auto
+QuadraticEdgeCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   return &m_PointIds[0];
 }
@@ -168,8 +168,8 @@ QuadraticEdgeCell<TCellInterface>::PointIdsBegin()
  * by the cell.
  */
 template <typename TCellInterface>
-typename QuadraticEdgeCell<TCellInterface>::PointIdConstIterator
-QuadraticEdgeCell<TCellInterface>::PointIdsBegin() const
+auto
+QuadraticEdgeCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   return &m_PointIds[0];
 }
@@ -179,8 +179,8 @@ QuadraticEdgeCell<TCellInterface>::PointIdsBegin() const
  * Get an end iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename QuadraticEdgeCell<TCellInterface>::PointIdIterator
-QuadraticEdgeCell<TCellInterface>::PointIdsEnd()
+auto
+QuadraticEdgeCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -191,8 +191,8 @@ QuadraticEdgeCell<TCellInterface>::PointIdsEnd()
  * by the cell.
  */
 template <typename TCellInterface>
-typename QuadraticEdgeCell<TCellInterface>::PointIdConstIterator
-QuadraticEdgeCell<TCellInterface>::PointIdsEnd() const
+auto
+QuadraticEdgeCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -202,8 +202,8 @@ QuadraticEdgeCell<TCellInterface>::PointIdsEnd() const
  * Get the number of vertices for this line.
  */
 template <typename TCellInterface>
-typename QuadraticEdgeCell<TCellInterface>::CellFeatureCount
-QuadraticEdgeCell<TCellInterface>::GetNumberOfVertices() const
+auto
+QuadraticEdgeCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
 {
   return Self::NumberOfVertices;
 }

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.hxx
@@ -59,8 +59,8 @@ QuadraticTriangleCell<TCellInterface>::GetNumberOfPoints() const
  * Get the number of boundary features of the given dimension.
  */
 template <typename TCellInterface>
-typename QuadraticTriangleCell<TCellInterface>::CellFeatureCount
-QuadraticTriangleCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+QuadraticTriangleCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -168,8 +168,8 @@ QuadraticTriangleCell<TCellInterface>::SetPointId(int localId, PointIdentifier p
  * Get a begin iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename QuadraticTriangleCell<TCellInterface>::PointIdIterator
-QuadraticTriangleCell<TCellInterface>::PointIdsBegin()
+auto
+QuadraticTriangleCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   return &m_PointIds[0];
 }
@@ -180,8 +180,8 @@ QuadraticTriangleCell<TCellInterface>::PointIdsBegin()
  * by the cell.
  */
 template <typename TCellInterface>
-typename QuadraticTriangleCell<TCellInterface>::PointIdConstIterator
-QuadraticTriangleCell<TCellInterface>::PointIdsBegin() const
+auto
+QuadraticTriangleCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   return &m_PointIds[0];
 }
@@ -191,8 +191,8 @@ QuadraticTriangleCell<TCellInterface>::PointIdsBegin() const
  * Get an end iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename QuadraticTriangleCell<TCellInterface>::PointIdIterator
-QuadraticTriangleCell<TCellInterface>::PointIdsEnd()
+auto
+QuadraticTriangleCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -203,8 +203,8 @@ QuadraticTriangleCell<TCellInterface>::PointIdsEnd()
  * by the cell.
  */
 template <typename TCellInterface>
-typename QuadraticTriangleCell<TCellInterface>::PointIdConstIterator
-QuadraticTriangleCell<TCellInterface>::PointIdsEnd() const
+auto
+QuadraticTriangleCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -214,8 +214,8 @@ QuadraticTriangleCell<TCellInterface>::PointIdsEnd() const
  * Get the number of vertices defining the triangle.
  */
 template <typename TCellInterface>
-typename QuadraticTriangleCell<TCellInterface>::CellFeatureCount
-QuadraticTriangleCell<TCellInterface>::GetNumberOfVertices() const
+auto
+QuadraticTriangleCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
 {
   return Self::NumberOfVertices;
 }
@@ -225,8 +225,8 @@ QuadraticTriangleCell<TCellInterface>::GetNumberOfVertices() const
  * Get the number of edges defined for the triangle.
  */
 template <typename TCellInterface>
-typename QuadraticTriangleCell<TCellInterface>::CellFeatureCount
-QuadraticTriangleCell<TCellInterface>::GetNumberOfEdges() const
+auto
+QuadraticTriangleCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
 {
   return Self::NumberOfEdges;
 }

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -61,8 +61,8 @@ QuadrilateralCell<TCellInterface>::GetNumberOfPoints() const
  * Get the number of boundary features of the given dimension.
  */
 template <typename TCellInterface>
-typename QuadrilateralCell<TCellInterface>::CellFeatureCount
-QuadrilateralCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+QuadrilateralCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -170,8 +170,8 @@ QuadrilateralCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
  * Get a begin iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename QuadrilateralCell<TCellInterface>::PointIdIterator
-QuadrilateralCell<TCellInterface>::PointIdsBegin()
+auto
+QuadrilateralCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   return &m_PointIds[0];
 }
@@ -182,8 +182,8 @@ QuadrilateralCell<TCellInterface>::PointIdsBegin()
  * by the cell.
  */
 template <typename TCellInterface>
-typename QuadrilateralCell<TCellInterface>::PointIdConstIterator
-QuadrilateralCell<TCellInterface>::PointIdsBegin() const
+auto
+QuadrilateralCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   return &m_PointIds[0];
 }
@@ -193,8 +193,8 @@ QuadrilateralCell<TCellInterface>::PointIdsBegin() const
  * Get an end iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename QuadrilateralCell<TCellInterface>::PointIdIterator
-QuadrilateralCell<TCellInterface>::PointIdsEnd()
+auto
+QuadrilateralCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -205,8 +205,8 @@ QuadrilateralCell<TCellInterface>::PointIdsEnd()
  * by the cell.
  */
 template <typename TCellInterface>
-typename QuadrilateralCell<TCellInterface>::PointIdConstIterator
-QuadrilateralCell<TCellInterface>::PointIdsEnd() const
+auto
+QuadrilateralCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -216,8 +216,8 @@ QuadrilateralCell<TCellInterface>::PointIdsEnd() const
  * Get the number of vertices defining the quadrilateral.
  */
 template <typename TCellInterface>
-typename QuadrilateralCell<TCellInterface>::CellFeatureCount
-QuadrilateralCell<TCellInterface>::GetNumberOfVertices() const
+auto
+QuadrilateralCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
 {
   return NumberOfVertices;
 }
@@ -227,8 +227,8 @@ QuadrilateralCell<TCellInterface>::GetNumberOfVertices() const
  * Get the number of edges defined for the quadrilateral.
  */
 template <typename TCellInterface>
-typename QuadrilateralCell<TCellInterface>::CellFeatureCount
-QuadrilateralCell<TCellInterface>::GetNumberOfEdges() const
+auto
+QuadrilateralCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
 {
   return Self::NumberOfEdges;
 }

--- a/Modules/Core/Common/include/itkRGBAPixel.hxx
+++ b/Modules/Core/Common/include/itkRGBAPixel.hxx
@@ -150,8 +150,8 @@ RGBAPixel<T>::operator<(const Self & r) const
 }
 
 template <typename T>
-typename RGBAPixel<T>::LuminanceType
-RGBAPixel<T>::GetLuminance() const
+auto
+RGBAPixel<T>::GetLuminance() const -> LuminanceType
 {
   const LuminanceType luminance = 0.30 * static_cast<LuminanceType>(this->GetRed()) +
                                   0.59 * static_cast<LuminanceType>(this->GetGreen()) +

--- a/Modules/Core/Common/include/itkRGBPixel.hxx
+++ b/Modules/Core/Common/include/itkRGBPixel.hxx
@@ -150,8 +150,8 @@ RGBPixel<T>::operator<(const Self & r) const
 }
 
 template <typename T>
-typename RGBPixel<T>::LuminanceType
-RGBPixel<T>::GetLuminance() const
+auto
+RGBPixel<T>::GetLuminance() const -> LuminanceType
 {
   const LuminanceType luminance = 0.30 * static_cast<LuminanceType>(this->GetRed()) +
                                   0.59 * static_cast<LuminanceType>(this->GetGreen()) +

--- a/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.hxx
@@ -24,8 +24,8 @@
 namespace itk
 {
 template <typename TInput, typename TOutput>
-typename SinRegularizedHeavisideStepFunction<TInput, TOutput>::OutputType
-SinRegularizedHeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType & input) const
+auto
+SinRegularizedHeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType & input) const -> OutputType
 {
   if (static_cast<RealType>(input) >= this->GetEpsilon())
   {
@@ -48,8 +48,8 @@ SinRegularizedHeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType &
 }
 
 template <typename TInput, typename TOutput>
-typename SinRegularizedHeavisideStepFunction<TInput, TOutput>::OutputType
-SinRegularizedHeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const InputType & input) const
+auto
+SinRegularizedHeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const InputType & input) const -> OutputType
 {
   if (itk::Math::abs(static_cast<RealType>(input)) >= this->GetEpsilon())
   {

--- a/Modules/Core/Common/include/itkSmapsFileParser.hxx
+++ b/Modules/Core/Common/include/itkSmapsFileParser.hxx
@@ -43,8 +43,8 @@ MapFileParser<TMapDataType>::Update()
 }
 
 template <typename TMapDataType>
-typename MapFileParser<TMapDataType>::MemoryLoadType
-MapFileParser<TMapDataType>::GetHeapUsage()
+auto
+MapFileParser<TMapDataType>::GetHeapUsage() -> MemoryLoadType
 {
   if (m_MapData.Empty())
   {
@@ -54,8 +54,8 @@ MapFileParser<TMapDataType>::GetHeapUsage()
 }
 
 template <typename TMapDataType>
-typename MapFileParser<TMapDataType>::MemoryLoadType
-MapFileParser<TMapDataType>::GetStackUsage()
+auto
+MapFileParser<TMapDataType>::GetStackUsage() -> MemoryLoadType
 {
   if (m_MapData.Empty())
   {
@@ -65,8 +65,8 @@ MapFileParser<TMapDataType>::GetStackUsage()
 }
 
 template <typename TMapDataType>
-typename MapFileParser<TMapDataType>::MemoryLoadType
-MapFileParser<TMapDataType>::GetTotalMemoryUsage()
+auto
+MapFileParser<TMapDataType>::GetTotalMemoryUsage() -> MemoryLoadType
 {
   if (m_MapData.Empty())
   {
@@ -76,8 +76,8 @@ MapFileParser<TMapDataType>::GetTotalMemoryUsage()
 }
 
 template <typename TMapDataType>
-typename MapFileParser<TMapDataType>::MemoryLoadType
-MapFileParser<TMapDataType>::GetMemoryUsage(const char * filter, const char * token)
+auto
+MapFileParser<TMapDataType>::GetMemoryUsage(const char * filter, const char * token) -> MemoryLoadType
 {
   if (m_MapData.Empty())
   {

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -74,8 +74,8 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
-typename SobelOperator<TPixel, VDimension, TAllocator>::CoefficientVector
-SobelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients()
+auto
+SobelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   std::vector<double> coeff;
   if (VDimension == 2 && this->GetDirection() == 0)

--- a/Modules/Core/Common/include/itkSparseFieldLayer.hxx
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.hxx
@@ -55,8 +55,8 @@ SparseFieldLayer<TNodeType>::Size() const
 }
 
 template <typename TNodeType>
-typename SparseFieldLayer<TNodeType>::RegionListType
-SparseFieldLayer<TNodeType>::SplitRegions(int num) const
+auto
+SparseFieldLayer<TNodeType>::SplitRegions(int num) const -> RegionListType
 {
   std::vector<RegionType> regionlist;
   unsigned int            size, regionsize;

--- a/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
@@ -31,8 +31,8 @@ SphereSpatialFunction<VImageDimension, TInput>::SphereSpatialFunction()
 }
 
 template <unsigned int VImageDimension, typename TInput>
-typename SphereSpatialFunction<VImageDimension, TInput>::OutputType
-SphereSpatialFunction<VImageDimension, TInput>::Evaluate(const InputType & position) const
+auto
+SphereSpatialFunction<VImageDimension, TInput>::Evaluate(const InputType & position) const -> OutputType
 {
   double acc = 0;
 

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -32,8 +32,9 @@ SymmetricEllipsoidInteriorExteriorSpatialFunction<VDimension,
 }
 
 template <unsigned int VDimension, typename TInput>
-typename SymmetricEllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::OutputType
+auto
 SymmetricEllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const
+  -> OutputType
 {
   double uniqueTerm;    // Term in ellipsoid equation for unique axis
   double symmetricTerm; // Term in ellipsoid equation for symmetric axes

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
@@ -168,8 +168,8 @@ SymmetricSecondRankTensor<T, NDimension>::operator/(const RealValueType & r) con
  * Matrix notation access to elements
  */
 template <typename T, unsigned int NDimension>
-const typename SymmetricSecondRankTensor<T, NDimension>::ValueType &
-SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned int col) const
+auto
+SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned int col) const -> const ValueType &
 {
   unsigned int k;
 
@@ -194,8 +194,8 @@ SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned 
  * Matrix notation access to elements
  */
 template <typename T, unsigned int NDimension>
-typename SymmetricSecondRankTensor<T, NDimension>::ValueType &
-SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned int col)
+auto
+SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned int col) -> ValueType &
 {
   unsigned int k;
 
@@ -235,8 +235,8 @@ SymmetricSecondRankTensor<T, NDimension>::SetIdentity()
  * Get the Trace
  */
 template <typename T, unsigned int NDimension>
-typename SymmetricSecondRankTensor<T, NDimension>::AccumulateValueType
-SymmetricSecondRankTensor<T, NDimension>::GetTrace() const
+auto
+SymmetricSecondRankTensor<T, NDimension>::GetTrace() const -> AccumulateValueType
 {
   AccumulateValueType trace = NumericTraits<AccumulateValueType>::ZeroValue();
   unsigned int        k = 0;
@@ -340,8 +340,8 @@ SymmetricSecondRankTensor<T, NDimension>::Rotate(const Matrix<TMatrixValueType, 
  * Pre-multiply the Tensor by a Matrix
  */
 template <typename T, unsigned int NDimension>
-typename SymmetricSecondRankTensor<T, NDimension>::MatrixType
-SymmetricSecondRankTensor<T, NDimension>::PreMultiply(const MatrixType & m) const
+auto
+SymmetricSecondRankTensor<T, NDimension>::PreMultiply(const MatrixType & m) const -> MatrixType
 {
   MatrixType result;
 
@@ -365,8 +365,8 @@ SymmetricSecondRankTensor<T, NDimension>::PreMultiply(const MatrixType & m) cons
  * Post-multiply the Tensor by a Matrix
  */
 template <typename T, unsigned int NDimension>
-typename SymmetricSecondRankTensor<T, NDimension>::MatrixType
-SymmetricSecondRankTensor<T, NDimension>::PostMultiply(const MatrixType & m) const
+auto
+SymmetricSecondRankTensor<T, NDimension>::PostMultiply(const MatrixType & m) const -> MatrixType
 {
   MatrixType result;
 

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -60,8 +60,8 @@ TetrahedronCell<TCellInterface>::GetNumberOfPoints() const
  * Get the number of boundary features of the given dimension.
  */
 template <typename TCellInterface>
-typename TetrahedronCell<TCellInterface>::CellFeatureCount
-TetrahedronCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+TetrahedronCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -324,8 +324,8 @@ TetrahedronCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
  * Get a begin iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename TetrahedronCell<TCellInterface>::PointIdIterator
-TetrahedronCell<TCellInterface>::PointIdsBegin()
+auto
+TetrahedronCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   return &m_PointIds[0];
 }
@@ -336,8 +336,8 @@ TetrahedronCell<TCellInterface>::PointIdsBegin()
  * by the cell.
  */
 template <typename TCellInterface>
-typename TetrahedronCell<TCellInterface>::PointIdConstIterator
-TetrahedronCell<TCellInterface>::PointIdsBegin() const
+auto
+TetrahedronCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   return &m_PointIds[0];
 }
@@ -347,8 +347,8 @@ TetrahedronCell<TCellInterface>::PointIdsBegin() const
  * Get an end iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename TetrahedronCell<TCellInterface>::PointIdIterator
-TetrahedronCell<TCellInterface>::PointIdsEnd()
+auto
+TetrahedronCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -359,8 +359,8 @@ TetrahedronCell<TCellInterface>::PointIdsEnd()
  * by the cell.
  */
 template <typename TCellInterface>
-typename TetrahedronCell<TCellInterface>::PointIdConstIterator
-TetrahedronCell<TCellInterface>::PointIdsEnd() const
+auto
+TetrahedronCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -370,8 +370,8 @@ TetrahedronCell<TCellInterface>::PointIdsEnd() const
  * Get the number of vertices defining the tetrahedron.
  */
 template <typename TCellInterface>
-typename TetrahedronCell<TCellInterface>::CellFeatureCount
-TetrahedronCell<TCellInterface>::GetNumberOfVertices() const
+auto
+TetrahedronCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
 {
   return Self::NumberOfVertices;
 }
@@ -381,8 +381,8 @@ TetrahedronCell<TCellInterface>::GetNumberOfVertices() const
  * Get the number of edges defined for the tetrahedron.
  */
 template <typename TCellInterface>
-typename TetrahedronCell<TCellInterface>::CellFeatureCount
-TetrahedronCell<TCellInterface>::GetNumberOfEdges() const
+auto
+TetrahedronCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
 {
   return Self::NumberOfEdges;
 }
@@ -392,8 +392,8 @@ TetrahedronCell<TCellInterface>::GetNumberOfEdges() const
  * Get the number of faces defined for the tetrahedron.
  */
 template <typename TCellInterface>
-typename TetrahedronCell<TCellInterface>::CellFeatureCount
-TetrahedronCell<TCellInterface>::GetNumberOfFaces() const
+auto
+TetrahedronCell<TCellInterface>::GetNumberOfFaces() const -> CellFeatureCount
 {
   return Self::NumberOfFaces;
 }

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
@@ -30,8 +30,8 @@ TorusInteriorExteriorSpatialFunction<VDimension, TInput>::TorusInteriorExteriorS
 }
 
 template <unsigned int VDimension, typename TInput>
-typename TorusInteriorExteriorSpatialFunction<VDimension, TInput>::OutputType
-TorusInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const
+auto
+TorusInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const -> OutputType
 {
   double x = position[0] - m_Origin[0];
   double y = position[1] - m_Origin[1];

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -60,8 +60,8 @@ TriangleCell<TCellInterface>::GetNumberOfPoints() const
  * Get the number of boundary features of the given dimension.
  */
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::CellFeatureCount
-TriangleCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+TriangleCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -169,8 +169,8 @@ TriangleCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
  * Get a begin iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::PointIdIterator
-TriangleCell<TCellInterface>::PointIdsBegin()
+auto
+TriangleCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   return &m_PointIds[0];
 }
@@ -181,8 +181,8 @@ TriangleCell<TCellInterface>::PointIdsBegin()
  * by the cell.
  */
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::PointIdConstIterator
-TriangleCell<TCellInterface>::PointIdsBegin() const
+auto
+TriangleCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   return &m_PointIds[0];
 }
@@ -192,8 +192,8 @@ TriangleCell<TCellInterface>::PointIdsBegin() const
  * Get an end iterator to the list of point identifiers used by the cell.
  */
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::PointIdIterator
-TriangleCell<TCellInterface>::PointIdsEnd()
+auto
+TriangleCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -204,8 +204,8 @@ TriangleCell<TCellInterface>::PointIdsEnd()
  * by the cell.
  */
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::PointIdConstIterator
-TriangleCell<TCellInterface>::PointIdsEnd() const
+auto
+TriangleCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -215,8 +215,8 @@ TriangleCell<TCellInterface>::PointIdsEnd() const
  * Get the number of vertices defining the triangle.
  */
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::CellFeatureCount
-TriangleCell<TCellInterface>::GetNumberOfVertices() const
+auto
+TriangleCell<TCellInterface>::GetNumberOfVertices() const -> CellFeatureCount
 {
   return Self::NumberOfVertices;
 }
@@ -226,8 +226,8 @@ TriangleCell<TCellInterface>::GetNumberOfVertices() const
  * Get the number of edges defined for the triangle.
  */
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::CellFeatureCount
-TriangleCell<TCellInterface>::GetNumberOfEdges() const
+auto
+TriangleCell<TCellInterface>::GetNumberOfEdges() const -> CellFeatureCount
 {
   return Self::NumberOfEdges;
 }
@@ -348,8 +348,8 @@ TriangleCell<TCellInterface>::DistanceToLine(PointType   x,
 }
 
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::CoordRepType
-TriangleCell<TCellInterface>::ComputeArea(PointsContainer * iPoints)
+auto
+TriangleCell<TCellInterface>::ComputeArea(PointsContainer * iPoints) -> CoordRepType
 {
   PointType p[3];
 
@@ -367,8 +367,8 @@ TriangleCell<TCellInterface>::ComputeArea(PointsContainer * iPoints)
 }
 
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::PointType
-TriangleCell<TCellInterface>::ComputeBarycenter(CoordRepType * iWeights, PointsContainer * iPoints)
+auto
+TriangleCell<TCellInterface>::ComputeBarycenter(CoordRepType * iWeights, PointsContainer * iPoints) -> PointType
 {
   PointType    p[3];
   CoordRepType sum_weights(0.);
@@ -398,16 +398,16 @@ TriangleCell<TCellInterface>::ComputeBarycenter(CoordRepType * iWeights, PointsC
 }
 
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::PointType
-TriangleCell<TCellInterface>::ComputeCenterOfGravity(PointsContainer * iPoints)
+auto
+TriangleCell<TCellInterface>::ComputeCenterOfGravity(PointsContainer * iPoints) -> PointType
 {
   std::vector<CoordRepType> weights(3, 1. / 3.);
   return ComputeBarycenter(&weights[0], iPoints);
 }
 
 template <typename TCellInterface>
-typename TriangleCell<TCellInterface>::PointType
-TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints)
+auto
+TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints) -> PointType
 {
   std::vector<CoordRepType> weights(3, 0.);
 

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -56,8 +56,8 @@ TriangleHelper<TPoint>::IsObtuse(const PointType & iA, const PointType & iB, con
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::VectorType
-TriangleHelper<TPoint>::ComputeNormal(const PointType & iA, const PointType & iB, const PointType & iC)
+auto
+TriangleHelper<TPoint>::ComputeNormal(const PointType & iA, const PointType & iB, const PointType & iC) -> VectorType
 {
   CrossVectorType cross;
   VectorType      w = cross(iB - iA, iC - iA);
@@ -72,8 +72,8 @@ TriangleHelper<TPoint>::ComputeNormal(const PointType & iA, const PointType & iB
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::CoordRepType
-TriangleHelper<TPoint>::Cotangent(const PointType & iA, const PointType & iB, const PointType & iC)
+auto
+TriangleHelper<TPoint>::Cotangent(const PointType & iA, const PointType & iB, const PointType & iC) -> CoordRepType
 {
   VectorType v21 = iA - iB;
 
@@ -132,8 +132,9 @@ TriangleHelper<TPoint>::ComputeBarycenter(const CoordRepType & iA1,
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::CoordRepType
+auto
 TriangleHelper<TPoint>::ComputeAngle(const PointType & iP1, const PointType & iP2, const PointType & iP3)
+  -> CoordRepType
 {
   VectorType v21 = iP1 - iP2;
   VectorType v23 = iP3 - iP2;
@@ -158,15 +159,17 @@ TriangleHelper<TPoint>::ComputeAngle(const PointType & iP1, const PointType & iP
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::PointType
+auto
 TriangleHelper<TPoint>::ComputeGravityCenter(const PointType & iP1, const PointType & iP2, const PointType & iP3)
+  -> PointType
 {
   return ComputeBarycenter(1., iP1, 1., iP2, 1., iP3);
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::PointType
+auto
 TriangleHelper<TPoint>::ComputeCircumCenter(const PointType & iP1, const PointType & iP2, const PointType & iP3)
+  -> PointType
 {
   PointType oPt;
 
@@ -208,8 +211,8 @@ TriangleHelper<TPoint>::ComputeConstrainedCircumCenter(const PointType & iP1,
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::CoordRepType
-TriangleHelper<TPoint>::ComputeArea(const PointType & iP1, const PointType & iP2, const PointType & iP3)
+auto
+TriangleHelper<TPoint>::ComputeArea(const PointType & iP1, const PointType & iP2, const PointType & iP3) -> CoordRepType
 {
   CoordRepType a = iP2.EuclideanDistanceTo(iP3);
   CoordRepType b = iP1.EuclideanDistanceTo(iP3);
@@ -221,8 +224,9 @@ TriangleHelper<TPoint>::ComputeArea(const PointType & iP1, const PointType & iP2
 }
 
 template <typename TPoint>
-typename TriangleHelper<TPoint>::CoordRepType
+auto
 TriangleHelper<TPoint>::ComputeMixedArea(const PointType & iP1, const PointType & iP2, const PointType & iP3)
+  -> CoordRepType
 {
   using TriangleType = TriangleHelper<TPoint>;
 

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -411,8 +411,8 @@ VariableLengthVector<TValue>::operator==(const Self & v) const
  * Returns vector's Euclidean Norm
  */
 template <typename TValue>
-typename VariableLengthVector<TValue>::RealValueType
-VariableLengthVector<TValue>::GetNorm() const
+auto
+VariableLengthVector<TValue>::GetNorm() const -> RealValueType
 {
   using std::sqrt;
   return static_cast<RealValueType>(sqrt(this->GetSquaredNorm()));
@@ -422,8 +422,8 @@ VariableLengthVector<TValue>::GetNorm() const
  * Returns vector's Squared Euclidean Norm
  */
 template <typename TValue>
-typename VariableLengthVector<TValue>::RealValueType
-VariableLengthVector<TValue>::GetSquaredNorm() const
+auto
+VariableLengthVector<TValue>::GetSquaredNorm() const -> RealValueType
 {
   RealValueType sum = 0.0;
 
@@ -436,15 +436,15 @@ VariableLengthVector<TValue>::GetSquaredNorm() const
 }
 
 template <typename TExpr1, typename TExpr2, typename TBinaryOp>
-typename VariableLengthVectorExpression<TExpr1, TExpr2, TBinaryOp>::RealValueType
-VariableLengthVectorExpression<TExpr1, TExpr2, TBinaryOp>::GetNorm() const
+auto
+VariableLengthVectorExpression<TExpr1, TExpr2, TBinaryOp>::GetNorm() const -> RealValueType
 {
   return itk::GetNorm(*this);
 }
 
 template <typename TExpr1, typename TExpr2, typename TBinaryOp>
-typename VariableLengthVectorExpression<TExpr1, TExpr2, TBinaryOp>::RealValueType
-VariableLengthVectorExpression<TExpr1, TExpr2, TBinaryOp>::GetSquaredNorm() const
+auto
+VariableLengthVectorExpression<TExpr1, TExpr2, TBinaryOp>::GetSquaredNorm() const -> RealValueType
 {
   return itk::GetSquaredNorm(*this);
 }

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -39,8 +39,8 @@ Vector<T, TVectorDimension>::operator=(const ValueType r[TVectorDimension])
 }
 
 template <typename T, unsigned int TVectorDimension>
-const typename Vector<T, TVectorDimension>::Self &
-Vector<T, TVectorDimension>::operator+=(const Self & vec)
+auto
+Vector<T, TVectorDimension>::operator+=(const Self & vec) -> const Self &
 {
   for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
@@ -50,8 +50,8 @@ Vector<T, TVectorDimension>::operator+=(const Self & vec)
 }
 
 template <typename T, unsigned int TVectorDimension>
-const typename Vector<T, TVectorDimension>::Self &
-Vector<T, TVectorDimension>::operator-=(const Self & vec)
+auto
+Vector<T, TVectorDimension>::operator-=(const Self & vec) -> const Self &
 {
   for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
@@ -100,8 +100,8 @@ Vector<T, TVectorDimension>::operator-(const Self & vec) const
 }
 
 template <typename T, unsigned int TVectorDimension>
-typename Vector<T, TVectorDimension>::RealValueType
-Vector<T, TVectorDimension>::GetSquaredNorm() const
+auto
+Vector<T, TVectorDimension>::GetSquaredNorm() const -> RealValueType
 {
   typename NumericTraits<RealValueType>::AccumulateType sum = NumericTraits<T>::ZeroValue();
   for (unsigned int i = 0; i < TVectorDimension; ++i)
@@ -113,15 +113,15 @@ Vector<T, TVectorDimension>::GetSquaredNorm() const
 }
 
 template <typename T, unsigned int TVectorDimension>
-typename Vector<T, TVectorDimension>::RealValueType
-Vector<T, TVectorDimension>::GetNorm() const
+auto
+Vector<T, TVectorDimension>::GetNorm() const -> RealValueType
 {
   return RealValueType(std::sqrt(double(this->GetSquaredNorm())));
 }
 
 template <typename T, unsigned int TVectorDimension>
-typename Vector<T, TVectorDimension>::RealValueType
-Vector<T, TVectorDimension>::Normalize()
+auto
+Vector<T, TVectorDimension>::Normalize() -> RealValueType
 {
   const RealValueType norm = this->GetNorm();
   if (norm < NumericTraits<RealValueType>::epsilon())

--- a/Modules/Core/Common/include/itkVectorContainer.hxx
+++ b/Modules/Core/Common/include/itkVectorContainer.hxx
@@ -77,8 +77,8 @@ VectorContainer<TElementIdentifier, TElement>::CreateElementAt(ElementIdentifier
  * It is assumed that the index exists.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorContainer<TElementIdentifier, TElement>::Element
-VectorContainer<TElementIdentifier, TElement>::GetElement(ElementIdentifier id) const
+auto
+VectorContainer<TElementIdentifier, TElement>::GetElement(ElementIdentifier id) const -> Element
 {
   return this->VectorType::operator[](id);
 }
@@ -193,8 +193,8 @@ VectorContainer<TElementIdentifier, TElement>::DeleteIndex(ElementIdentifier id)
  * Get a begin const iterator for the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorContainer<TElementIdentifier, TElement>::ConstIterator
-VectorContainer<TElementIdentifier, TElement>::Begin() const
+auto
+VectorContainer<TElementIdentifier, TElement>::Begin() const -> ConstIterator
 {
   return ConstIterator(0, this->VectorType::begin());
 }
@@ -203,8 +203,8 @@ VectorContainer<TElementIdentifier, TElement>::Begin() const
  * Get an end const iterator for the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorContainer<TElementIdentifier, TElement>::ConstIterator
-VectorContainer<TElementIdentifier, TElement>::End() const
+auto
+VectorContainer<TElementIdentifier, TElement>::End() const -> ConstIterator
 {
   return ConstIterator(this->VectorType::size() - 1, this->VectorType::end());
 }
@@ -213,8 +213,8 @@ VectorContainer<TElementIdentifier, TElement>::End() const
  * Get a begin iterator for the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorContainer<TElementIdentifier, TElement>::Iterator
-VectorContainer<TElementIdentifier, TElement>::Begin()
+auto
+VectorContainer<TElementIdentifier, TElement>::Begin() -> Iterator
 {
   return Iterator(0, this->VectorType::begin());
 }
@@ -223,8 +223,8 @@ VectorContainer<TElementIdentifier, TElement>::Begin()
  * Get an end iterator for the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorContainer<TElementIdentifier, TElement>::Iterator
-VectorContainer<TElementIdentifier, TElement>::End()
+auto
+VectorContainer<TElementIdentifier, TElement>::End() -> Iterator
 {
   return Iterator(this->VectorType::size() - 1, this->VectorType::end());
 }
@@ -233,8 +233,8 @@ VectorContainer<TElementIdentifier, TElement>::End()
  * Get the number of elements currently stored in the vector.
  */
 template <typename TElementIdentifier, typename TElement>
-typename VectorContainer<TElementIdentifier, TElement>::ElementIdentifier
-VectorContainer<TElementIdentifier, TElement>::Size() const
+auto
+VectorContainer<TElementIdentifier, TElement>::Size() const -> ElementIdentifier
 {
   return static_cast<ElementIdentifier>(this->VectorType::size());
 }

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -192,8 +192,8 @@ Versor<T>::GetReciprocal() const
 
 /** Get Tensor part */
 template <typename T>
-typename Versor<T>::ValueType
-Versor<T>::GetTensor() const
+auto
+Versor<T>::GetTensor() const -> ValueType
 {
   const auto tensor = static_cast<ValueType>(std::sqrt(m_X * m_X + m_Y * m_Y + m_Z * m_Z + m_W * m_W));
 
@@ -223,8 +223,8 @@ Versor<T>::Normalize()
 
 /** Get Axis */
 template <typename T>
-typename Versor<T>::VectorType
-Versor<T>::GetAxis() const
+auto
+Versor<T>::GetAxis() const -> VectorType
 {
   VectorType axis;
 
@@ -252,8 +252,8 @@ Versor<T>::GetAxis() const
 
 /** Get Right part */
 template <typename T>
-typename Versor<T>::VectorType
-Versor<T>::GetRight() const
+auto
+Versor<T>::GetRight() const -> VectorType
 {
   VectorType axis;
 
@@ -266,16 +266,16 @@ Versor<T>::GetRight() const
 
 /** Get Scalar part */
 template <typename T>
-typename Versor<T>::ValueType
-Versor<T>::GetScalar() const
+auto
+Versor<T>::GetScalar() const -> ValueType
 {
   return m_W;
 }
 
 /** Get Angle (in radians) */
 template <typename T>
-typename Versor<T>::ValueType
-Versor<T>::GetAngle() const
+auto
+Versor<T>::GetAngle() const -> ValueType
 {
   const auto ax = static_cast<RealType>(m_X);
   const auto ay = static_cast<RealType>(m_Y);
@@ -581,8 +581,8 @@ localTransformVectorMath(const InputVectorType & VectorObject,
 
 /** Transform a Vector */
 template <typename T>
-typename Versor<T>::VectorType
-Versor<T>::Transform(const VectorType & v) const
+auto
+Versor<T>::Transform(const VectorType & v) const -> VectorType
 {
   return localTransformVectorMath<VectorType, T, typename Versor<T>::VectorType>(
     v, this->m_X, this->m_Y, this->m_Z, this->m_W);
@@ -592,8 +592,8 @@ Versor<T>::Transform(const VectorType & v) const
  *  given that this is an orthogonal transformation
  *  CovariantVectors are transformed as vectors. */
 template <typename T>
-typename Versor<T>::CovariantVectorType
-Versor<T>::Transform(const CovariantVectorType & v) const
+auto
+Versor<T>::Transform(const CovariantVectorType & v) const -> CovariantVectorType
 {
   return localTransformVectorMath<CovariantVectorType, T, typename Versor<T>::CovariantVectorType>(
     v, this->m_X, this->m_Y, this->m_Z, this->m_W);
@@ -601,8 +601,8 @@ Versor<T>::Transform(const CovariantVectorType & v) const
 
 /** Transform a Point */
 template <typename T>
-typename Versor<T>::PointType
-Versor<T>::Transform(const PointType & v) const
+auto
+Versor<T>::Transform(const PointType & v) const -> PointType
 {
   return localTransformVectorMath<PointType, T, typename Versor<T>::PointType>(
     v, this->m_X, this->m_Y, this->m_Z, this->m_W);
@@ -610,8 +610,8 @@ Versor<T>::Transform(const PointType & v) const
 
 /** Transform a VnlVector */
 template <typename T>
-typename Versor<T>::VnlVectorType
-Versor<T>::Transform(const VnlVectorType & v) const
+auto
+Versor<T>::Transform(const VnlVectorType & v) const -> VnlVectorType
 {
   return localTransformVectorMath<VnlVectorType, T, typename Versor<T>::VnlVectorType>(
     v, this->m_X, this->m_Y, this->m_Z, this->m_W);

--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -51,8 +51,8 @@ VertexCell<TCellInterface>::GetNumberOfPoints() const
 /** Standard CellInterface:
  *  A vertex has no boundary entities of any dimension. */
 template <typename TCellInterface>
-typename VertexCell<TCellInterface>::CellFeatureCount
-VertexCell<TCellInterface>::GetNumberOfBoundaryFeatures(int) const
+auto
+VertexCell<TCellInterface>::GetNumberOfBoundaryFeatures(int) const -> CellFeatureCount
 {
   return 0;
 }
@@ -114,8 +114,8 @@ VertexCell<TCellInterface>::SetPointId(int localId, PointIdentifier ptId)
  *  Get a begin iterator to the list of point identifiers used by the
  *  cell. */
 template <typename TCellInterface>
-typename VertexCell<TCellInterface>::PointIdIterator
-VertexCell<TCellInterface>::PointIdsBegin()
+auto
+VertexCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
 {
   return &m_PointIds[0];
 }
@@ -124,8 +124,8 @@ VertexCell<TCellInterface>::PointIdsBegin()
  *  Get a const begin iterator to the list of point identifiers used
  *  by the cell. */
 template <typename TCellInterface>
-typename VertexCell<TCellInterface>::PointIdConstIterator
-VertexCell<TCellInterface>::PointIdsBegin() const
+auto
+VertexCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
 {
   return &m_PointIds[0];
 }
@@ -133,8 +133,8 @@ VertexCell<TCellInterface>::PointIdsBegin() const
 /** Standard CellInterface:
  *  Get an end iterator to the list of point identifiers used by the cell. */
 template <typename TCellInterface>
-typename VertexCell<TCellInterface>::PointIdIterator
-VertexCell<TCellInterface>::PointIdsEnd()
+auto
+VertexCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -143,8 +143,8 @@ VertexCell<TCellInterface>::PointIdsEnd()
  *  Get a const end iterator to the list of point identifiers used
  *  by the cell. */
 template <typename TCellInterface>
-typename VertexCell<TCellInterface>::PointIdConstIterator
-VertexCell<TCellInterface>::PointIdsEnd() const
+auto
+VertexCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
 {
   return &m_PointIds[Self::NumberOfPoints - 1] + 1;
 }
@@ -161,8 +161,8 @@ VertexCell<TCellInterface>::SetPointId(PointIdentifier ptId)
 /** Vertex-specific:
  *  Get the identifier of the point defining the vertex. */
 template <typename TCellInterface>
-typename VertexCell<TCellInterface>::PointIdentifier
-VertexCell<TCellInterface>::GetPointId()
+auto
+VertexCell<TCellInterface>::GetPointId() -> PointIdentifier
 {
   return m_PointIds[0];
 }

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -121,8 +121,8 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ApplyUpdateThreader
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::TimeStepType
-DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CalculateChange()
+auto
+DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CalculateChange() -> TimeStepType
 {
   // Set up for multithreaded processing.
   DenseFDThreadStruct str;

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.hxx
@@ -41,8 +41,8 @@ FiniteDifferenceFunction<TImageType>::SetRadius(const RadiusType & r)
 }
 
 template <typename TImageType>
-const typename FiniteDifferenceFunction<TImageType>::RadiusType &
-FiniteDifferenceFunction<TImageType>::GetRadius() const
+auto
+FiniteDifferenceFunction<TImageType>::GetRadius() const -> const RadiusType &
 {
   return m_Radius;
 }
@@ -77,8 +77,8 @@ FiniteDifferenceFunction<TImageType>::PrintSelf(std::ostream & os, Indent indent
 }
 
 template <typename TImageType>
-const typename FiniteDifferenceFunction<TImageType>::NeighborhoodScalesType
-FiniteDifferenceFunction<TImageType>::ComputeNeighborhoodScales() const
+auto
+FiniteDifferenceFunction<TImageType>::ComputeNeighborhoodScales() const -> const NeighborhoodScalesType
 {
   NeighborhoodScalesType neighborhoodScales;
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -148,8 +148,8 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Prec
 }
 
 template <typename TInputImageType, typename TSparseOutputImageType>
-typename FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::TimeStepType
-FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::CalculateChange()
+auto
+FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::CalculateChange() -> TimeStepType
 {
   if (m_PrecomputeFlag == true)
   {

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.hxx
@@ -152,8 +152,8 @@ GPUDenseFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilte
 }
 
 template <typename TInputImage, typename TOutputImage, typename TParentImageFilter>
-typename GPUDenseFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::TimeStepType
-GPUDenseFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::GPUCalculateChange()
+auto
+GPUDenseFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::GPUCalculateChange() -> TimeStepType
 {
   typename OutputImageType::Pointer output = this->GetOutput();
 

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
@@ -125,16 +125,16 @@ ImageAdaptor<TImage, TAccessor>::PrintSelf(std::ostream & os, Indent indent) con
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-const typename ImageAdaptor<TImage, TAccessor>::OffsetValueType *
-ImageAdaptor<TImage, TAccessor>::GetOffsetTable() const
+auto
+ImageAdaptor<TImage, TAccessor>::GetOffsetTable() const -> const OffsetValueType *
 {
   return m_Image->GetOffsetTable();
 }
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-typename ImageAdaptor<TImage, TAccessor>::IndexType
-ImageAdaptor<TImage, TAccessor>::ComputeIndex(OffsetValueType offset) const
+auto
+ImageAdaptor<TImage, TAccessor>::ComputeIndex(OffsetValueType offset) const -> IndexType
 {
   return m_Image->ComputeIndex(offset);
 }
@@ -220,8 +220,8 @@ ImageAdaptor<TImage, TAccessor>::CopyInformation(const DataObject * data)
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-const typename ImageAdaptor<TImage, TAccessor>::SpacingType &
-ImageAdaptor<TImage, TAccessor>::GetSpacing() const
+auto
+ImageAdaptor<TImage, TAccessor>::GetSpacing() const -> const SpacingType &
 {
   return m_Image->GetSpacing();
 }
@@ -282,8 +282,8 @@ ImageAdaptor<TImage, TAccessor>::SetOrigin(const float * origin /*[Self::ImageDi
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-const typename ImageAdaptor<TImage, TAccessor>::PointType &
-ImageAdaptor<TImage, TAccessor>::GetOrigin() const
+auto
+ImageAdaptor<TImage, TAccessor>::GetOrigin() const -> const PointType &
 {
   return m_Image->GetOrigin();
 }
@@ -299,8 +299,8 @@ ImageAdaptor<TImage, TAccessor>::SetDirection(const DirectionType & direction)
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-const typename ImageAdaptor<TImage, TAccessor>::DirectionType &
-ImageAdaptor<TImage, TAccessor>::GetDirection() const
+auto
+ImageAdaptor<TImage, TAccessor>::GetDirection() const -> const DirectionType &
 {
   return m_Image->GetDirection();
 }
@@ -320,16 +320,16 @@ ImageAdaptor<TImage, TAccessor>::SetImage(TImage * image)
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-const typename ImageAdaptor<TImage, TAccessor>::InternalPixelType *
-ImageAdaptor<TImage, TAccessor>::GetBufferPointer() const
+auto
+ImageAdaptor<TImage, TAccessor>::GetBufferPointer() const -> const InternalPixelType *
 {
   return m_Image->GetBufferPointer();
 }
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-typename ImageAdaptor<TImage, TAccessor>::InternalPixelType *
-ImageAdaptor<TImage, TAccessor>::GetBufferPointer()
+auto
+ImageAdaptor<TImage, TAccessor>::GetBufferPointer() -> InternalPixelType *
 {
   return m_Image->GetBufferPointer();
 }
@@ -371,8 +371,8 @@ ImageAdaptor<TImage, TAccessor>::SetBufferedRegion(const RegionType & region)
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-const typename ImageAdaptor<TImage, TAccessor>::RegionType &
-ImageAdaptor<TImage, TAccessor>::GetBufferedRegion() const
+auto
+ImageAdaptor<TImage, TAccessor>::GetBufferedRegion() const -> const RegionType &
 {
   // delegation to internal image
   return m_Image->GetBufferedRegion();
@@ -392,8 +392,8 @@ ImageAdaptor<TImage, TAccessor>::SetLargestPossibleRegion(const RegionType & reg
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-const typename ImageAdaptor<TImage, TAccessor>::RegionType &
-ImageAdaptor<TImage, TAccessor>::GetLargestPossibleRegion() const
+auto
+ImageAdaptor<TImage, TAccessor>::GetLargestPossibleRegion() const -> const RegionType &
 {
   // delegation to internal image
   return m_Image->GetLargestPossibleRegion();
@@ -437,8 +437,8 @@ ImageAdaptor<TImage, TAccessor>::VerifyRequestedRegion()
 
 //----------------------------------------------------------------------------
 template <typename TImage, typename TAccessor>
-const typename ImageAdaptor<TImage, TAccessor>::RegionType &
-ImageAdaptor<TImage, TAccessor>::GetRequestedRegion() const
+auto
+ImageAdaptor<TImage, TAccessor>::GetRequestedRegion() const -> const RegionType &
 {
   // delegation to internal image
   return m_Image->GetRequestedRegion();

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -102,8 +102,9 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::PrintSelf(s
  * EvaluateAtIndex
  */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
-typename CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::OutputType
+auto
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtIndex(const IndexType & index) const
+  -> OutputType
 {
   OutputType derivative;
 
@@ -260,8 +261,9 @@ CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::EvaluateAtI
  *
  */
 template <typename TInputImage, typename TCoordRep, typename TOutputType>
-typename CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::OutputType
+auto
 CentralDifferenceImageFunction<TInputImage, TCoordRep, TOutputType>::Evaluate(const PointType & point) const
+  -> OutputType
 {
   OutputType derivative;
 

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
@@ -31,8 +31,8 @@ CovarianceImageFunction<TInputImage, TCoordRep>::CovarianceImageFunction()
   = default;
 
 template <typename TInputImage, typename TCoordRep>
-typename CovarianceImageFunction<TInputImage, TCoordRep>::RealType
-CovarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+auto
+CovarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   using PixelType = typename TInputImage::PixelType;
   using PixelComponentType = typename PixelType::ValueType;

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -194,8 +194,8 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussianKernel()
 }
 
 template <typename TInputImage, typename TOutput>
-typename GaussianDerivativeImageFunction<TInputImage, TOutput>::OutputType
-GaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType & index) const
+auto
+GaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType & index) const -> OutputType
 {
   OutputType gradient;
 
@@ -227,8 +227,8 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const Ind
 }
 
 template <typename TInputImage, typename TOutput>
-typename GaussianDerivativeImageFunction<TInputImage, TOutput>::OutputType
-GaussianDerivativeImageFunction<TInputImage, TOutput>::Evaluate(const PointType & point) const
+auto
+GaussianDerivativeImageFunction<TInputImage, TOutput>::Evaluate(const PointType & point) const -> OutputType
 {
   IndexType index;
 

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -215,8 +215,8 @@ GaussianInterpolateImageFunction<TImageType, TCoordRep>::ComputeErrorFunctionArr
 
 
 template <typename TImageType, typename TCoordRep>
-typename GaussianInterpolateImageFunction<TImageType, TCoordRep>::SizeType
-GaussianInterpolateImageFunction<TImageType, TCoordRep>::GetRadius() const
+auto
+GaussianInterpolateImageFunction<TImageType, TCoordRep>::GetRadius() const -> SizeType
 {
   SizeType radius;
 

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
@@ -26,8 +26,9 @@
 namespace itk
 {
 template <typename TInputImage, typename TCoordRep>
-typename LinearInterpolateImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 LinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateUnoptimized(const ContinuousIndexType & index) const
+  -> OutputType
 {
   // Avoid the smartpointer de-reference in the loop for
   // "return m_InputImage.GetPointer()"

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -32,8 +32,8 @@ MeanImageFunction<TInputImage, TCoordRep>::MeanImageFunction()
   = default;
 
 template <typename TInputImage, typename TCoordRep>
-typename MeanImageFunction<TInputImage, TCoordRep>::RealType
-MeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+auto
+MeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   RealType sum;
 

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
@@ -61,8 +61,8 @@ MedianImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Indent
  *
  */
 template <typename TInputImage, typename TCoordRep>
-typename MedianImageFunction<TInputImage, TCoordRep>::OutputType
-MedianImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+auto
+MedianImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> OutputType
 {
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1433,8 +1433,8 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream 
    ----------------------------------------------------------------------- */
 
 template <typename TInputImage, typename TCoordRep>
-typename RayCastInterpolateImageFunction<TInputImage, TCoordRep>::OutputType
-RayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & point) const
+auto
+RayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & point) const -> OutputType
 {
   double integral = 0;
 

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
@@ -47,8 +47,8 @@ ScatterMatrixImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os,
  *
  */
 template <typename TInputImage, typename TCoordRep>
-typename ScatterMatrixImageFunction<TInputImage, TCoordRep>::RealType
-ScatterMatrixImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+auto
+ScatterMatrixImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   RealType covariance;
 

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
@@ -33,8 +33,8 @@ SumOfSquaresImageFunction<TInputImage, TCoordRep>::SumOfSquaresImageFunction()
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename SumOfSquaresImageFunction<TInputImage, TCoordRep>::RealType
-SumOfSquaresImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+auto
+SumOfSquaresImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   RealType sumOfSquares;
 

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
@@ -48,8 +48,8 @@ VarianceImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, Inde
  *
  */
 template <typename TInputImage, typename TCoordRep>
-typename VarianceImageFunction<TInputImage, TCoordRep>::RealType
-VarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+auto
+VarianceImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
   RealType sum;
   RealType sumOfSquares;

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
@@ -47,8 +47,8 @@ VectorMeanImageFunction<TInputImage, TCoordRep>::PrintSelf(std::ostream & os, In
  *
  */
 template <typename TInputImage, typename TCoordRep>
-typename VectorMeanImageFunction<TInputImage, TCoordRep>::RealType
-VectorMeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const
+auto
+VectorMeanImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
 
   using PixelType = typename TInputImage::PixelType;

--- a/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.hxx
@@ -40,8 +40,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AutomaticTopologyMeshSource()
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(const PointType & p0)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(const PointType & p0) -> IdentifierType
 {
   IdentifierType   nextNewPointID = m_OutputMesh->GetNumberOfPoints();
   IdentifierType & pointIDPlusOne = m_PointsHashTable[p0];
@@ -61,8 +61,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(const PointType & p0)
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(const CoordinateType * p0)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(const CoordinateType * p0) -> IdentifierType
 {
   PointType    newPoint;
   unsigned int i;
@@ -100,8 +100,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(CoordinateType x0,
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const IdentifierArrayType & pointIDs)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const IdentifierArrayType & pointIDs) -> IdentifierType
 {
   // pointIDs is an array with one element; this is for consistency.
 
@@ -133,8 +133,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const IdentifierArrayType & 
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const IdentifierArrayType & pointIDs)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const IdentifierArrayType & pointIDs) -> IdentifierType
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
@@ -181,8 +181,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const IdentifierArrayType & po
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(const IdentifierArrayType & pointIDs)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(const IdentifierArrayType & pointIDs) -> IdentifierType
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
@@ -243,8 +243,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(const IdentifierArrayType 
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(const IdentifierArrayType & pointIDs)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(const IdentifierArrayType & pointIDs) -> IdentifierType
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
@@ -304,8 +304,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(const IdentifierArray
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(const IdentifierArrayType & pointIDs)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(const IdentifierArrayType & pointIDs) -> IdentifierType
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
@@ -381,8 +381,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(const IdentifierArrayTy
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const IdentifierArrayType & pointIDs)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const IdentifierArrayType & pointIDs) -> IdentifierType
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
@@ -466,8 +466,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const IdentifierArrayTyp
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(IdentifierType pointId0)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(IdentifierType pointId0) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(1);
   pointIDs[0] = pointId0;
@@ -475,8 +475,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(IdentifierType pointId0)
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddLine(IdentifierType pointId0, IdentifierType pointId1)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddLine(IdentifierType pointId0, IdentifierType pointId1) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(2);
   pointIDs[0] = pointId0;
@@ -551,8 +551,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(IdentifierType pointId0,
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const PointType & p0)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const PointType & p0) -> IdentifierType
 {
   IdentifierType pointId = AddPoint(p0);
 
@@ -560,8 +560,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const PointType & p0)
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const PointType & p0, const PointType & p1)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const PointType & p0, const PointType & p1) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(2);
   pointIDs[0] = AddPoint(p0);
@@ -570,8 +570,9 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const PointType & p0, const Po
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(const PointType & p0, const PointType & p1, const PointType & p2)
+  -> IdentifierType
 {
   Array<IdentifierType> pointIDs(3);
   pointIDs[0] = AddPoint(p0);
@@ -634,8 +635,8 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const PointType & p0,
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
-AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const CoordinateType * p0)
+auto
+AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const CoordinateType * p0) -> IdentifierType
 {
   Array<IdentifierType> pointIDs(1);
   pointIDs[0] = AddPoint(p0);
@@ -643,8 +644,9 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const CoordinateType * p0)
 }
 
 template <typename TOutputMesh>
-typename AutomaticTopologyMeshSource<TOutputMesh>::IdentifierType
+auto
 AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const CoordinateType * p0, const CoordinateType * p1)
+  -> IdentifierType
 {
   Array<IdentifierType> pointIDs(2);
   pointIDs[0] = AddPoint(p0);

--- a/Modules/Core/Mesh/include/itkImageToMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkImageToMeshFilter.hxx
@@ -62,8 +62,8 @@ ImageToMeshFilter<TInputImage, TOutputMesh>::SetInput(unsigned int idx, const In
  *
  */
 template <typename TInputImage, typename TOutputMesh>
-const typename ImageToMeshFilter<TInputImage, TOutputMesh>::InputImageType *
-ImageToMeshFilter<TInputImage, TOutputMesh>::GetInput(unsigned int idx)
+auto
+ImageToMeshFilter<TInputImage, TOutputMesh>::GetInput(unsigned int idx) -> const InputImageType *
 {
   return dynamic_cast<const InputImageType *>(this->ProcessObject::GetInput(idx));
 }
@@ -72,8 +72,8 @@ ImageToMeshFilter<TInputImage, TOutputMesh>::GetInput(unsigned int idx)
  *
  */
 template <typename TInputImage, typename TOutputMesh>
-typename ImageToMeshFilter<TInputImage, TOutputMesh>::OutputMeshType *
-ImageToMeshFilter<TInputImage, TOutputMesh>::GetOutput()
+auto
+ImageToMeshFilter<TInputImage, TOutputMesh>::GetOutput() -> OutputMeshType *
 {
   return dynamic_cast<OutputMeshType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -73,16 +73,16 @@ Mesh<TPixelType, VDimension, TMeshTraits>::SetCellLinks(CellLinksContainer * cel
  * Access routines to get the cell links container.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename Mesh<TPixelType, VDimension, TMeshTraits>::CellLinksContainer *
-Mesh<TPixelType, VDimension, TMeshTraits>::GetCellLinks()
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetCellLinks() -> CellLinksContainer *
 {
   itkDebugMacro("returning CellLinks container of " << m_CellLinksContainer);
   return m_CellLinksContainer;
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-const typename Mesh<TPixelType, VDimension, TMeshTraits>::CellLinksContainer *
-Mesh<TPixelType, VDimension, TMeshTraits>::GetCellLinks() const
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetCellLinks() const -> const CellLinksContainer *
 {
   itkDebugMacro("returning CellLinks container of " << m_CellLinksContainer);
   return m_CellLinksContainer;
@@ -108,16 +108,16 @@ Mesh<TPixelType, VDimension, TMeshTraits>::SetCells(CellsContainer * cells)
  * Access routines to get the cells container.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename Mesh<TPixelType, VDimension, TMeshTraits>::CellsContainer *
-Mesh<TPixelType, VDimension, TMeshTraits>::GetCells()
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetCells() -> CellsContainer *
 {
   itkDebugMacro("returning Cells container of " << m_CellsContainer);
   return m_CellsContainer;
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-const typename Mesh<TPixelType, VDimension, TMeshTraits>::CellsContainer *
-Mesh<TPixelType, VDimension, TMeshTraits>::GetCells() const
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetCells() const -> const CellsContainer *
 {
   itkDebugMacro("returning Cells container of " << m_CellsContainer);
   return m_CellsContainer;
@@ -142,24 +142,24 @@ Mesh<TPixelType, VDimension, TMeshTraits>::SetCellData(CellDataContainer * cellD
  * Access routines to get the cell data container.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename Mesh<TPixelType, VDimension, TMeshTraits>::CellDataContainer *
-Mesh<TPixelType, VDimension, TMeshTraits>::GetCellData()
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetCellData() -> CellDataContainer *
 {
   itkDebugMacro("returning CellData container of " << m_CellDataContainer);
   return m_CellDataContainer;
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-const typename Mesh<TPixelType, VDimension, TMeshTraits>::CellDataContainer *
-Mesh<TPixelType, VDimension, TMeshTraits>::GetCellData() const
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetCellData() const -> const CellDataContainer *
 {
   itkDebugMacro("returning CellData container of " << m_CellDataContainer);
   return m_CellDataContainer;
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-const typename Mesh<TPixelType, VDimension, TMeshTraits>::BoundingBoxType *
-Mesh<TPixelType, VDimension, TMeshTraits>::GetBoundingBox() const
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetBoundingBox() const -> const BoundingBoxType *
 {
   m_BoundingBox->SetPoints(this->m_PointsContainer.GetPointer());
   if (m_BoundingBox->GetMTime() > this->GetMTime())
@@ -191,8 +191,8 @@ Mesh<TPixelType, VDimension, TMeshTraits>::SetBoundaryAssignments(int           
  * dimension.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename Mesh<TPixelType, VDimension, TMeshTraits>::BoundaryAssignmentsContainerPointer
-Mesh<TPixelType, VDimension, TMeshTraits>::GetBoundaryAssignments(int dimension)
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetBoundaryAssignments(int dimension) -> BoundaryAssignmentsContainerPointer
 {
   itkDebugMacro("returning BoundaryAssignments[" << dimension << "] container of "
                                                  << m_BoundaryAssignmentsContainers[dimension]);
@@ -200,8 +200,9 @@ Mesh<TPixelType, VDimension, TMeshTraits>::GetBoundaryAssignments(int dimension)
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-const typename Mesh<TPixelType, VDimension, TMeshTraits>::BoundaryAssignmentsContainerPointer
+auto
 Mesh<TPixelType, VDimension, TMeshTraits>::GetBoundaryAssignments(int dimension) const
+  -> const BoundaryAssignmentsContainerPointer
 {
   itkDebugMacro("returning BoundaryAssignments[" << dimension << "] container of "
                                                  << m_BoundaryAssignmentsContainers[dimension]);
@@ -425,8 +426,9 @@ Mesh<TPixelType, VDimension, TMeshTraits>::RemoveBoundaryAssignment(int         
  * on the cell with the given identifier.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename Mesh<TPixelType, VDimension, TMeshTraits>::CellFeatureCount
+auto
 Mesh<TPixelType, VDimension, TMeshTraits>::GetNumberOfCellBoundaryFeatures(int dimension, CellIdentifier cellId) const
+  -> CellFeatureCount
 {
   /**
    * Make sure the cell container exists and contains the given cell Id.
@@ -461,8 +463,8 @@ Mesh<TPixelType, VDimension, TMeshTraits>::PassStructure(Self *)
  * Get the number of cells in the CellsContainer.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename Mesh<TPixelType, VDimension, TMeshTraits>::CellIdentifier
-Mesh<TPixelType, VDimension, TMeshTraits>::GetNumberOfCells() const
+auto
+Mesh<TPixelType, VDimension, TMeshTraits>::GetNumberOfCells() const -> CellIdentifier
 {
   if (!m_CellsContainer)
   {
@@ -716,8 +718,9 @@ Mesh<TPixelType, VDimension, TMeshTraits>::GetCellBoundaryFeatureNeighbors(int  
  * though, and we are not sure how wide-spread this support is.
  */
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename Mesh<TPixelType, VDimension, TMeshTraits>::CellIdentifier
+auto
 Mesh<TPixelType, VDimension, TMeshTraits>::GetCellNeighbors(CellIdentifier cellId, std::set<CellIdentifier> * cellSet)
+  -> CellIdentifier
 {
   /**
    * Sanity check on mesh status.

--- a/Modules/Core/Mesh/include/itkMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkMeshSource.hxx
@@ -52,8 +52,8 @@ typename MeshSource<TOutputMesh>::DataObjectPointer MeshSource<TOutputMesh>::Mak
  *
  */
 template <typename TOutputMesh>
-typename MeshSource<TOutputMesh>::OutputMeshType *
-MeshSource<TOutputMesh>::GetOutput()
+auto
+MeshSource<TOutputMesh>::GetOutput() -> OutputMeshType *
 {
   return itkDynamicCastInDebugMode<TOutputMesh *>(this->GetPrimaryOutput());
 }
@@ -62,8 +62,8 @@ MeshSource<TOutputMesh>::GetOutput()
  *
  */
 template <typename TOutputMesh>
-typename MeshSource<TOutputMesh>::OutputMeshType *
-MeshSource<TOutputMesh>::GetOutput(unsigned int idx)
+auto
+MeshSource<TOutputMesh>::GetOutput(unsigned int idx) -> OutputMeshType *
 {
   return itkDynamicCastInDebugMode<TOutputMesh *>(this->ProcessObject::GetOutput(idx));
 }

--- a/Modules/Core/Mesh/include/itkMeshToMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkMeshToMeshFilter.hxx
@@ -58,8 +58,8 @@ MeshToMeshFilter<TInputMesh, TOutputMesh>::SetInput(const TInputMesh * input)
  *
  */
 template <typename TInputMesh, typename TOutputMesh>
-const typename MeshToMeshFilter<TInputMesh, TOutputMesh>::InputMeshType *
-MeshToMeshFilter<TInputMesh, TOutputMesh>::GetInput() const
+auto
+MeshToMeshFilter<TInputMesh, TOutputMesh>::GetInput() const -> const InputMeshType *
 {
   return itkDynamicCastInDebugMode<const TInputMesh *>(this->GetPrimaryInput());
 }
@@ -68,8 +68,8 @@ MeshToMeshFilter<TInputMesh, TOutputMesh>::GetInput() const
  *
  */
 template <typename TInputMesh, typename TOutputMesh>
-const typename MeshToMeshFilter<TInputMesh, TOutputMesh>::InputMeshType *
-MeshToMeshFilter<TInputMesh, TOutputMesh>::GetInput(unsigned int idx) const
+auto
+MeshToMeshFilter<TInputMesh, TOutputMesh>::GetInput(unsigned int idx) const -> const InputMeshType *
 {
   return dynamic_cast<const TInputMesh *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
@@ -318,8 +318,8 @@ RegularSphereMeshSource<TOutputMesh>::GenerateData()
 }
 
 template <typename TOutputMesh>
-typename RegularSphereMeshSource<TOutputMesh>::PointType
-RegularSphereMeshSource<TOutputMesh>::Divide(const PointType & p1, const PointType & p2) const
+auto
+RegularSphereMeshSource<TOutputMesh>::Divide(const PointType & p1, const PointType & p2) const -> PointType
 {
   PointType p;
   PointType f;

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -93,8 +93,8 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::SetBarycentricCoordinates(Poin
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename SimplexMesh<TPixelType, VDimension, TMeshTraits>::PointType
-SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetBarycentricCoordinates(PointIdentifier idx) const
+auto
+SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetBarycentricCoordinates(PointIdentifier idx) const -> PointType
 {
   return m_GeometryData->GetElement(idx)->eps;
 }
@@ -109,8 +109,8 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::SetReferenceMetrics(PointIdent
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename SimplexMesh<TPixelType, VDimension, TMeshTraits>::PointType
-SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetReferenceMetrics(PointIdentifier idx) const
+auto
+SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetReferenceMetrics(PointIdentifier idx) const -> PointType
 {
   return m_GeometryData->GetElement(idx)->referenceMetrics;
 }
@@ -184,8 +184,9 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetDistance(PointIdentifier id
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename SimplexMesh<TPixelType, VDimension, TMeshTraits>::CellIdentifier
+auto
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::AddEdge(PointIdentifier startPointId, PointIdentifier endPointId)
+  -> CellIdentifier
 {
   CellAutoPointer NewCellPointer(new LineType, true);
   CellIdentifier  edgeId = m_LastCellId;
@@ -199,8 +200,8 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::AddEdge(PointIdentifier startP
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename SimplexMesh<TPixelType, VDimension, TMeshTraits>::CellIdentifier
-SimplexMesh<TPixelType, VDimension, TMeshTraits>::AddFace(CellAutoPointer & cellPointer)
+auto
+SimplexMesh<TPixelType, VDimension, TMeshTraits>::AddFace(CellAutoPointer & cellPointer) -> CellIdentifier
 {
   this->SetCell(m_LastCellId, cellPointer);
   m_LastCellId++;
@@ -251,8 +252,8 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::SetGeometryData(PointIdentifie
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename SimplexMesh<TPixelType, VDimension, TMeshTraits>::IndexArray
-SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetNeighbors(PointIdentifier idx) const
+auto
+SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetNeighbors(PointIdentifier idx) const -> IndexArray
 {
   return m_GeometryData->GetElement(idx)->neighborIndices;
 }
@@ -399,8 +400,8 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::SwapNeighbors(PointIdentifier 
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
-typename SimplexMesh<TPixelType, VDimension, TMeshTraits>::CovariantVectorType
-SimplexMesh<TPixelType, VDimension, TMeshTraits>::ComputeNormal(PointIdentifier idx) const
+auto
+SimplexMesh<TPixelType, VDimension, TMeshTraits>::ComputeNormal(PointIdentifier idx) const -> CovariantVectorType
 {
   PointType p, n1, n2, n3;
 

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -388,8 +388,9 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream 
 }
 
 template <typename TInputMesh, typename TOutputMesh>
-typename SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::InputPointType
+auto
 SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::ComputeCellCenter(InputCellAutoPointer & simplexCell)
+  -> InputPointType
 {
   OutputMeshPointer           outputMesh = this->GetOutput();
   InputPolygonPointIdIterator pointIt = simplexCell->PointIdsBegin();

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -58,16 +58,16 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::SetInput(TInputMesh *
 
 /** Get the input Mesh */
 template <typename TInputMesh, typename TOutputImage>
-typename TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::InputMeshType *
-TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GetInput()
+auto
+TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GetInput() -> InputMeshType *
 {
   return static_cast<TInputMesh *>(this->ProcessObject::GetInput(0));
 }
 
 /** Get the input Mesh */
 template <typename TInputMesh, typename TOutputImage>
-typename TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::InputMeshType *
-TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GetInput(unsigned int idx)
+auto
+TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GetInput(unsigned int idx) -> InputMeshType *
 {
   return itkDynamicCastInDebugMode<TInputMesh *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.hxx
@@ -35,8 +35,9 @@ WarpMeshFilter<TInputMesh, TOutputMesh, TDisplacementField>::WarpMeshFilter()
 }
 
 template <typename TInputMesh, typename TOutputMesh, typename TDisplacementField>
-const typename WarpMeshFilter<TInputMesh, TOutputMesh, TDisplacementField>::DisplacementFieldType *
+auto
 WarpMeshFilter<TInputMesh, TOutputMesh, TDisplacementField>::GetDisplacementField() const
+  -> const DisplacementFieldType *
 {
   return itkDynamicCastInDebugMode<const DisplacementFieldType *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
@@ -214,8 +214,9 @@ GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::IsLnextSh
 /**
  */
 template <typename TVRef, typename TFRef, typename TPrimalData, typename TDualData, bool PrimalDual>
-typename GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::Self *
+auto
 GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::GetNextBorderEdgeWithUnsetLeft(Self * edgeTest)
+  -> Self *
 {
   // Definition: an edge is said to be a boundary edge when it is adjacent to
   // noface i.e. when at least one of the faces edge->GetLeft() or

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -97,8 +97,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::Graft(const DataObject * data)
  * \brief The one and only method to modify the edge connectivity.
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::PointIdentifier
-QuadEdgeMesh<TPixel, VDimension, TTraits>::Splice(QEPrimal * a, QEPrimal * b)
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::Splice(QEPrimal * a, QEPrimal * b) -> PointIdentifier
 {
   bool            SplitingOrigin = a->IsInOnextRing(b);
   PointIdentifier resultingOriginId;
@@ -404,8 +404,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::SetCell(CellIdentifier cId, CellAutoP
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::PointIdentifier
-QuadEdgeMesh<TPixel, VDimension, TTraits>::FindFirstUnusedPointIndex()
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::FindFirstUnusedPointIndex() -> PointIdentifier
 {
   PointIdentifier pid = 0;
   PointIdentifier maxpid = this->GetNumberOfPoints();
@@ -525,8 +525,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::SqueezePointsIds()
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::PointIdentifier
-QuadEdgeMesh<TPixel, VDimension, TTraits>::AddPoint(const PointType & p)
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::AddPoint(const PointType & p) -> PointIdentifier
 {
   PointIdentifier pid = this->FindFirstUnusedPointIndex();
 
@@ -571,8 +571,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::DeletePoint(const PointIdentifier & p
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::PointType
-QuadEdgeMesh<TPixel, VDimension, TTraits>::GetPoint(const PointIdentifier & pid) const
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::GetPoint(const PointIdentifier & pid) const -> PointType
 {
   return (this->GetPoints()->GetElement(pid));
 }
@@ -580,8 +580,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::GetPoint(const PointIdentifier & pid)
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::VectorType
-QuadEdgeMesh<TPixel, VDimension, TTraits>::GetVector(const PointIdentifier & pid) const
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::GetVector(const PointIdentifier & pid) const -> VectorType
 {
   return (this->GetPoint(pid).GetVectorFromOrigin());
 }
@@ -589,8 +589,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::GetVector(const PointIdentifier & pid
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::CellIdentifier
-QuadEdgeMesh<TPixel, VDimension, TTraits>::FindFirstUnusedCellIndex()
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::FindFirstUnusedCellIndex() -> CellIdentifier
 {
   CellIdentifier cid;
 
@@ -622,8 +622,9 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::FindFirstUnusedCellIndex()
  * @sa \ref GeometricalQuadEdge::InsertAfterNextBorderEdgeWithUnsetLeft
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
+auto
 QuadEdgeMesh<TPixel, VDimension, TTraits>::AddEdge(const PointIdentifier & orgPid, const PointIdentifier & destPid)
+  -> QEPrimal *
 {
   // Make sure the points are different
   if (orgPid == destPid)
@@ -1068,8 +1069,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::DeleteFace(FaceRefType faceToDelete)
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
-QuadEdgeMesh<TPixel, VDimension, TTraits>::GetEdge() const
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::GetEdge() const -> QEPrimal *
 {
   if (this->GetEdgeCells()->empty())
   {
@@ -1086,8 +1087,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::GetEdge() const
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
-QuadEdgeMesh<TPixel, VDimension, TTraits>::GetEdge(const CellIdentifier & eid) const
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::GetEdge(const CellIdentifier & eid) const -> QEPrimal *
 {
   CellType * c;
 
@@ -1104,8 +1105,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::GetEdge(const CellIdentifier & eid) c
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
-QuadEdgeMesh<TPixel, VDimension, TTraits>::FindEdge(const PointIdentifier & pid0) const
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::FindEdge(const PointIdentifier & pid0) const -> QEPrimal *
 {
   PointType p = this->GetPoint(pid0);
 
@@ -1115,8 +1116,9 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::FindEdge(const PointIdentifier & pid0
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
+auto
 QuadEdgeMesh<TPixel, VDimension, TTraits>::FindEdge(const PointIdentifier & pid0, const PointIdentifier & pid1) const
+  -> QEPrimal *
 {
   QEPrimal * initialEdge = this->GetPoint(pid0).GetEdge();
 
@@ -1160,8 +1162,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::FindEdgeCell(const PointIdentifier & 
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
-QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFace(const PointIdList & points)
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFace(const PointIdList & points) -> QEPrimal *
 {
   size_t N = points.size();
 
@@ -1226,8 +1228,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFace(const PointIdList & points)
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
-QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFaceWithSecurePointList(const PointIdList & points)
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFaceWithSecurePointList(const PointIdList & points) -> QEPrimal *
 {
   return AddFaceWithSecurePointList(points, true);
 }
@@ -1235,8 +1237,9 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFaceWithSecurePointList(const Poin
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::QEPrimal *
+auto
 QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFaceWithSecurePointList(const PointIdList & points, bool CheckEdges)
+  -> QEPrimal *
 {
   const auto numberOfPoints = static_cast<PointIdentifier>(points.size());
 
@@ -1388,8 +1391,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::ClearCellsContainer()
 /**
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::CoordRepType
-QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeEdgeLength(QEPrimal * e)
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeEdgeLength(QEPrimal * e) -> CoordRepType
 {
   const PointsContainer * points = this->GetPoints();
 
@@ -1408,8 +1411,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeEdgeLength(QEPrimal * e)
  * understanding is not useful at first contact with the class.
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::PointIdentifier
-QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfPoints() const
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfPoints() const -> PointIdentifier
 {
   const PointsContainer * points = this->GetPoints();
 
@@ -1442,8 +1445,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfPoints() const
  * understanding is not useful at first contact with the class.
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::CellIdentifier
-QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfFaces() const
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfFaces() const -> CellIdentifier
 {
   CellIdentifier              numberOfFaces = NumericTraits<CellIdentifier>::ZeroValue();
   CellsContainerConstIterator cellIterator = this->GetCells()->Begin();
@@ -1471,8 +1474,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfFaces() const
  *       understanding is not useful at first contact with the class.
  */
 template <typename TPixel, unsigned int VDimension, typename TTraits>
-typename QuadEdgeMesh<TPixel, VDimension, TTraits>::CellIdentifier
-QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfEdges() const
+auto
+QuadEdgeMesh<TPixel, VDimension, TTraits>::ComputeNumberOfEdges() const -> CellIdentifier
 {
   return static_cast<CellIdentifier>(this->GetEdgeCells()->size());
 }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBoundaryEdgesMeshFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBoundaryEdgesMeshFunction.hxx
@@ -24,8 +24,8 @@
 namespace itk
 {
 template <typename TMesh>
-typename QuadEdgeMeshBoundaryEdgesMeshFunction<TMesh>::OutputType
-QuadEdgeMeshBoundaryEdgesMeshFunction<TMesh>::Evaluate(const InputType & mesh) const
+auto
+QuadEdgeMeshBoundaryEdgesMeshFunction<TMesh>::Evaluate(const InputType & mesh) const -> OutputType
 {
   // Push on a list all the non internal edges:
   using CellsContainerConstIterator = typename MeshType::CellsContainerConstIterator;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorCreateCenterVertexFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshEulerOperatorCreateCenterVertexFunction<TMesh, TQEType>::Evaluate(QEType * e)
+auto
+QuadEdgeMeshEulerOperatorCreateCenterVertexFunction<TMesh, TQEType>::Evaluate(QEType * e) -> OutputType
 {
   // Is there any input ?
 #ifndef NDEBUG

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction<TMesh, TQEType>::Evaluate(QEType * g)
+auto
+QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction<TMesh, TQEType>::Evaluate(QEType * g) -> OutputType
 {
   if (!g)
   {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.hxx
@@ -107,8 +107,8 @@ QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::CheckStatus(QEType * 
 }
 
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::Evaluate(QEType * h)
+auto
+QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::Evaluate(QEType * h) -> OutputType
 {
   //
   //    X ---<-G---- X              X ---<-G---- X
@@ -153,8 +153,8 @@ QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::Evaluate(QEType * h)
 }
 
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::Process(QEType * h)
+auto
+QuadEdgeMeshEulerOperatorFlipEdgeFunction<TMesh, TQEType>::Process(QEType * h) -> OutputType
 {
   // The following is not optimum, since we create a new face (with JoinFacet)
   // that is immediately deleted (with SplitFacet). Still we chose to write it

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinFacetFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinFacetFunction.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorJoinFacetFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshEulerOperatorJoinFacetFunction<TMesh, TQEType>::Evaluate(QEType * e)
+auto
+QuadEdgeMeshEulerOperatorJoinFacetFunction<TMesh, TQEType>::Evaluate(QEType * e) -> OutputType
 {
 #ifndef NDEBUG
   if (!e)

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -84,8 +84,8 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::PrintSelf(std::ostr
 
 //--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::Evaluate(QEType * e)
+auto
+QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::Evaluate(QEType * e) -> OutputType
 {
   std::stack<QEType *> edges_to_be_deleted;
 
@@ -527,8 +527,8 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsEye(QEType * e)
 
 //--------------------------------------------------------------------------
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::PointIdentifier
-QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::CommonVertexNeighboor(QEType * e)
+auto
+QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::CommonVertexNeighboor(QEType * e) -> PointIdentifier
 {
   QEType * qe = e;
   QEType * e_it = qe->GetOnext();

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorSplitFacetFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshEulerOperatorSplitFacetFunction<TMesh, TQEType>::Evaluate(QEType * h, QEType * g)
+auto
+QuadEdgeMeshEulerOperatorSplitFacetFunction<TMesh, TQEType>::Evaluate(QEType * h, QEType * g) -> OutputType
 {
   //
   //  g->Dest() ---<----- X                    destPid  --------- X        //

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshEulerOperatorSplitVertexFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshEulerOperatorSplitVertexFunction<TMesh, TQEType>::Evaluate(QEType * h, QEType * g)
+auto
+QuadEdgeMeshEulerOperatorSplitVertexFunction<TMesh, TQEType>::Evaluate(QEType * h, QEType * g) -> OutputType
 {
   if (!this->m_Mesh)
   {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
@@ -129,8 +129,8 @@ QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::operator++()
  * QEType.
  */
 template <typename TMesh, typename TQE>
-typename QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::QEType *
-QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::FindDefaultSeed()
+auto
+QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::FindDefaultSeed() -> QEType *
 {
   if (auto * edge = dynamic_cast<QEType *>(m_Mesh->GetEdge()))
   {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.h
@@ -54,12 +54,12 @@ public:
   // itkCellInheritedTypedefs
   using Superclass = TCellInterface;
   using typename Superclass::PixelType;
-  using typename Superclass::CellType;
+  using CellType = typename Superclass::CellType;
   using typename Superclass::CellAutoPointer;
   using typename Superclass::CellConstAutoPointer;
   using typename Superclass::CellRawPointer;
   using typename Superclass::CellConstRawPointer;
-  using typename Superclass::CellTraits;
+  using CellTraits = typename Superclass::CellTraits;
   using typename Superclass::CoordRepType;
   using typename Superclass::InterpolationWeightType;
   using typename Superclass::PointIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
@@ -117,8 +117,8 @@ QuadEdgeMeshLineCell<TCellInterface>::Accept(CellIdentifier cellId, MultiVisitor
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshLineCell<TCellInterface>::CellFeatureCount
-QuadEdgeMeshLineCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+QuadEdgeMeshLineCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   if (dimension == 0)
   {
@@ -211,40 +211,40 @@ QuadEdgeMeshLineCell<TCellInterface>::SetPointId(int localId, PointIdentifier pI
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshLineCell<TCellInterface>::PointIdInternalIterator
-QuadEdgeMeshLineCell<TCellInterface>::InternalPointIdsBegin()
+auto
+QuadEdgeMeshLineCell<TCellInterface>::InternalPointIdsBegin() -> PointIdInternalIterator
 {
   return (PointIdInternalIterator(this->m_QuadEdgeGeom, PointIdInternalIterator::OperatorSym, true));
 }
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshLineCell<TCellInterface>::PointIdInternalIterator
-QuadEdgeMeshLineCell<TCellInterface>::InternalPointIdsEnd()
+auto
+QuadEdgeMeshLineCell<TCellInterface>::InternalPointIdsEnd() -> PointIdInternalIterator
 {
   return (PointIdInternalIterator(this->m_QuadEdgeGeom, PointIdInternalIterator::OperatorSym, false));
 }
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshLineCell<TCellInterface>::PointIdInternalConstIterator
-QuadEdgeMeshLineCell<TCellInterface>::InternalGetPointIds() const
+auto
+QuadEdgeMeshLineCell<TCellInterface>::InternalGetPointIds() const -> PointIdInternalConstIterator
 {
   return (PointIdInternalConstIterator(this->m_QuadEdgeGeom, PointIdInternalConstIterator::OperatorSym, true));
 }
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshLineCell<TCellInterface>::PointIdInternalConstIterator
-QuadEdgeMeshLineCell<TCellInterface>::InternalPointIdsBegin() const
+auto
+QuadEdgeMeshLineCell<TCellInterface>::InternalPointIdsBegin() const -> PointIdInternalConstIterator
 {
   return (PointIdInternalConstIterator(this->m_QuadEdgeGeom, PointIdInternalConstIterator::OperatorSym, true));
 }
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshLineCell<TCellInterface>::PointIdInternalConstIterator
-QuadEdgeMeshLineCell<TCellInterface>::InternalPointIdsEnd() const
+auto
+QuadEdgeMeshLineCell<TCellInterface>::InternalPointIdsEnd() const -> PointIdInternalConstIterator
 {
   return (PointIdInternalConstIterator(this->m_QuadEdgeGeom, PointIdInternalConstIterator::OperatorSym, false));
 }
@@ -261,8 +261,8 @@ QuadEdgeMeshLineCell<TCellInterface>::SetIdent(CellIdentifier cid)
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshLineCell<TCellInterface>::CellIdentifier
-QuadEdgeMeshLineCell<TCellInterface>::GetIdent()
+auto
+QuadEdgeMeshLineCell<TCellInterface>::GetIdent() -> CellIdentifier
 {
   return this->m_Identifier;
 }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -47,7 +47,6 @@ public:
   using typename Superclass::ValueType;
   using typename Superclass::CoordRepType;
   using typename Superclass::RealType;
-  using typename Superclass::BaseArray;
   using typename Superclass::Iterator;
   using typename Superclass::ConstIterator;
   using typename Superclass::VectorType;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
@@ -52,12 +52,12 @@ public:
   // itkCellInheritedTypedefs
   using Superclass = TCellInterface;
   using typename Superclass::PixelType;
-  using typename Superclass::CellType;
+  using CellType = typename Superclass::CellType;
   using typename Superclass::CellAutoPointer;
   using typename Superclass::CellConstAutoPointer;
   using typename Superclass::CellRawPointer;
   using typename Superclass::CellConstRawPointer;
-  using typename Superclass::CellTraits;
+  using CellTraits = typename Superclass::CellTraits;
   using typename Superclass::CoordRepType;
   using typename Superclass::InterpolationWeightType;
   using typename Superclass::PointIdentifier;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
@@ -94,8 +94,8 @@ QuadEdgeMeshPolygonCell<TCellInterface>::~QuadEdgeMeshPolygonCell()
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshPolygonCell<TCellInterface>::SelfAutoPointer
-QuadEdgeMeshPolygonCell<TCellInterface>::New()
+auto
+QuadEdgeMeshPolygonCell<TCellInterface>::New() -> SelfAutoPointer
 {
   SelfAutoPointer ptr(new Self);
 
@@ -144,8 +144,8 @@ QuadEdgeMeshPolygonCell<TCellInterface>::GetNumberOfPoints() const
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshPolygonCell<TCellInterface>::CellFeatureCount
-QuadEdgeMeshPolygonCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const
+auto
+QuadEdgeMeshPolygonCell<TCellInterface>::GetNumberOfBoundaryFeatures(int dimension) const -> CellFeatureCount
 {
   switch (dimension)
   {
@@ -270,8 +270,8 @@ QuadEdgeMeshPolygonCell<TCellInterface>::SetPointId(int localId, PointIdentifier
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshPolygonCell<TCellInterface>::PointIdentifier
-QuadEdgeMeshPolygonCell<TCellInterface>::GetPointId(int localId) const
+auto
+QuadEdgeMeshPolygonCell<TCellInterface>::GetPointId(int localId) const -> PointIdentifier
 {
   int                          n = 0;
   PointIdInternalConstIterator it = this->InternalPointIdsBegin();
@@ -290,24 +290,24 @@ QuadEdgeMeshPolygonCell<TCellInterface>::GetPointId(int localId) const
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshPolygonCell<TCellInterface>::PointIdInternalIterator
-QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsBegin()
+auto
+QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsBegin() -> PointIdInternalIterator
 {
   return m_EdgeRingEntry->BeginGeomLnext();
 }
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshPolygonCell<TCellInterface>::PointIdInternalIterator
-QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsEnd()
+auto
+QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsEnd() -> PointIdInternalIterator
 {
   return m_EdgeRingEntry->EndGeomLnext();
 }
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshPolygonCell<TCellInterface>::PointIdInternalConstIterator
-QuadEdgeMeshPolygonCell<TCellInterface>::InternalGetPointIds() const
+auto
+QuadEdgeMeshPolygonCell<TCellInterface>::InternalGetPointIds() const -> PointIdInternalConstIterator
 {
   const QuadEdgeType *         edge = const_cast<QuadEdgeType *>(m_EdgeRingEntry);
   PointIdInternalConstIterator iterator(edge->BeginGeomLnext());
@@ -317,8 +317,8 @@ QuadEdgeMeshPolygonCell<TCellInterface>::InternalGetPointIds() const
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshPolygonCell<TCellInterface>::PointIdInternalConstIterator
-QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsBegin() const
+auto
+QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsBegin() const -> PointIdInternalConstIterator
 {
   const QuadEdgeType *         edge = const_cast<QuadEdgeType *>(m_EdgeRingEntry);
   PointIdInternalConstIterator iterator(edge->BeginGeomLnext());
@@ -328,8 +328,8 @@ QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsBegin() const
 
 // ---------------------------------------------------------------------
 template <typename TCellInterface>
-typename QuadEdgeMeshPolygonCell<TCellInterface>::PointIdInternalConstIterator
-QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsEnd() const
+auto
+QuadEdgeMeshPolygonCell<TCellInterface>::InternalPointIdsEnd() const -> PointIdInternalConstIterator
 {
   const auto *                 edge = const_cast<const QuadEdgeType *>(m_EdgeRingEntry);
   PointIdInternalConstIterator iterator = edge->EndGeomLnext();

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.hxx
@@ -23,8 +23,8 @@
 namespace itk
 {
 template <typename TMesh, typename TQEType>
-typename QuadEdgeMeshZipMeshFunction<TMesh, TQEType>::OutputType
-QuadEdgeMeshZipMeshFunction<TMesh, TQEType>::Evaluate(QEType * e)
+auto
+QuadEdgeMeshZipMeshFunction<TMesh, TQEType>::Evaluate(QEType * e) -> OutputType
 {
   if (!this->m_Mesh)
   {

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -92,8 +92,8 @@ ArrowSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) c
 }
 
 template <unsigned int TDimension>
-typename ArrowSpatialObject<TDimension>::PointType
-ArrowSpatialObject<TDimension>::GetPositionInWorldSpace() const
+auto
+ArrowSpatialObject<TDimension>::GetPositionInWorldSpace() const -> PointType
 {
   PointType pnt = this->GetPositionInObjectSpace();
 
@@ -103,8 +103,8 @@ ArrowSpatialObject<TDimension>::GetPositionInWorldSpace() const
 }
 
 template <unsigned int TDimension>
-typename ArrowSpatialObject<TDimension>::VectorType
-ArrowSpatialObject<TDimension>::GetDirectionInWorldSpace() const
+auto
+ArrowSpatialObject<TDimension>::GetDirectionInWorldSpace() const -> VectorType
 {
   PointType pnt = this->GetPositionInObjectSpace();
   PointType pnt2;

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -47,8 +47,8 @@ ContourSpatialObjectPoint<TPointDimension>::SetPickedPointInObjectSpace(const Po
 }
 
 template <unsigned int TPointDimension>
-const typename ContourSpatialObjectPoint<TPointDimension>::PointType &
-ContourSpatialObjectPoint<TPointDimension>::GetPickedPointInObjectSpace() const
+auto
+ContourSpatialObjectPoint<TPointDimension>::GetPickedPointInObjectSpace() const -> const PointType &
 {
   return m_PickedPointInObjectSpace;
 }
@@ -61,15 +61,15 @@ ContourSpatialObjectPoint<TPointDimension>::SetNormalInObjectSpace(const Covaria
 }
 
 template <unsigned int TPointDimension>
-const typename ContourSpatialObjectPoint<TPointDimension>::CovariantVectorType &
-ContourSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const
+auto
+ContourSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const -> const CovariantVectorType &
 {
   return m_NormalInObjectSpace;
 }
 
 template <unsigned int TPointDimension>
-typename ContourSpatialObjectPoint<TPointDimension>::Self &
-ContourSpatialObjectPoint<TPointDimension>::operator=(const ContourSpatialObjectPoint & rhs)
+auto
+ContourSpatialObjectPoint<TPointDimension>::operator=(const ContourSpatialObjectPoint & rhs) -> Self &
 {
   if (this != &rhs)
   {

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -179,8 +179,8 @@ DTITubeSpatialObjectPoint<TPointDimension>::GetField(DTITubeSpatialObjectPointFi
 }
 
 template <unsigned int TPointDimension>
-typename DTITubeSpatialObjectPoint<TPointDimension>::Self &
-DTITubeSpatialObjectPoint<TPointDimension>::operator=(const DTITubeSpatialObjectPoint & rhs)
+auto
+DTITubeSpatialObjectPoint<TPointDimension>::operator=(const DTITubeSpatialObjectPoint & rhs) -> Self &
 {
   if (this != &rhs)
   {

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -51,8 +51,8 @@ GaussianSpatialObject<TDimension>::Clear()
 /** The z-score is the root mean square of the z-scores along
  *  each principal axis. */
 template <unsigned int TDimension>
-typename GaussianSpatialObject<TDimension>::ScalarType
-GaussianSpatialObject<TDimension>::SquaredZScoreInObjectSpace(const PointType & point) const
+auto
+GaussianSpatialObject<TDimension>::SquaredZScoreInObjectSpace(const PointType & point) const -> ScalarType
 {
   ScalarType r = 0;
   for (unsigned int i = 0; i < TDimension; ++i)
@@ -65,8 +65,8 @@ GaussianSpatialObject<TDimension>::SquaredZScoreInObjectSpace(const PointType & 
 /** The z-score is the root mean square of the z-scores along
  *  each principal axis. */
 template <unsigned int TDimension>
-typename GaussianSpatialObject<TDimension>::ScalarType
-GaussianSpatialObject<TDimension>::SquaredZScoreInWorldSpace(const PointType & point) const
+auto
+GaussianSpatialObject<TDimension>::SquaredZScoreInWorldSpace(const PointType & point) const -> ScalarType
 {
   PointType transformedPoint = this->GetObjectToWorldTransformInverse()->TransformPoint(point);
 

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -144,8 +144,8 @@ ImageMaskSpatialObject<TDimension, TPixel>::PrintSelf(std::ostream & os, Indent 
 
 
 template <unsigned int TDimension, typename TPixel>
-typename ImageMaskSpatialObject<TDimension, TPixel>::RegionType
-ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBoxInIndexSpace() const
+auto
+ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBoxInIndexSpace() const -> RegionType
 {
   const ImagePointer imagePointer = this->GetImage();
 
@@ -231,8 +231,8 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBoxInIndexSpace() c
 
 #if !defined(ITK_LEGACY_REMOVE)
 template <unsigned int TDimension, typename TPixel>
-typename ImageMaskSpatialObject<TDimension, TPixel>::RegionType
-ImageMaskSpatialObject<TDimension, TPixel>::GetAxisAlignedBoundingBoxRegion() const
+auto
+ImageMaskSpatialObject<TDimension, TPixel>::GetAxisAlignedBoundingBoxRegion() const -> RegionType
 {
   return ComputeMyBoundingBoxInIndexSpace();
 }

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -172,8 +172,8 @@ ImageSpatialObject<TDimension, PixelType>::SetImage(const ImageType * image)
 
 /** Get the image inside the spatial object */
 template <unsigned int TDimension, typename PixelType>
-const typename ImageSpatialObject<TDimension, PixelType>::ImageType *
-ImageSpatialObject<TDimension, PixelType>::GetImage() const
+auto
+ImageSpatialObject<TDimension, PixelType>::GetImage() const -> const ImageType *
 {
   return m_Image.GetPointer();
 }

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -46,8 +46,8 @@ LineSpatialObjectPoint<TPointDimension>::LineSpatialObjectPoint(const LineSpatia
 
 /** Get the specified normal */
 template <unsigned int TPointDimension>
-const typename LineSpatialObjectPoint<TPointDimension>::CovariantVectorType &
-LineSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace(unsigned int index) const
+auto
+LineSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace(unsigned int index) const -> const CovariantVectorType &
 {
   return m_NormalArrayInObjectSpace[index];
 }
@@ -77,8 +77,8 @@ LineSpatialObjectPoint<TPointDimension>::SetNormalInObjectSpace(CovariantVectorT
 
 /** Copy a point to another */
 template <unsigned int TPointDimension>
-typename LineSpatialObjectPoint<TPointDimension>::Self &
-LineSpatialObjectPoint<TPointDimension>::operator=(const LineSpatialObjectPoint & rhs)
+auto
+LineSpatialObjectPoint<TPointDimension>::operator=(const LineSpatialObjectPoint & rhs) -> Self &
 {
   if (this != &rhs)
   {

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -127,15 +127,15 @@ MeshSpatialObject<TMesh>::SetMesh(MeshType * mesh)
 
 /** Get the Mesh inside the spatial object */
 template <typename TMesh>
-typename MeshSpatialObject<TMesh>::MeshType *
-MeshSpatialObject<TMesh>::GetMesh()
+auto
+MeshSpatialObject<TMesh>::GetMesh() -> MeshType *
 {
   return m_Mesh.GetPointer();
 }
 
 template <typename TMesh>
-const typename MeshSpatialObject<TMesh>::MeshType *
-MeshSpatialObject<TMesh>::GetMesh() const
+auto
+MeshSpatialObject<TMesh>::GetMesh() const -> const MeshType *
 {
   return m_Mesh.GetPointer();
 }

--- a/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
@@ -24,16 +24,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaArrowConverter<NDimensions>::MetaObjectType *
-MetaArrowConverter<NDimensions>::CreateMetaObject()
+auto
+MetaArrowConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new ArrowMetaObjectType);
 }
 
 /** Convert a metaArrow into an arrow SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaArrowConverter<NDimensions>::SpatialObjectPointer
-MetaArrowConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaArrowConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * metaArrow = dynamic_cast<const MetaArrow *>(mo);
   if (metaArrow == nullptr)
@@ -72,8 +72,8 @@ MetaArrowConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType 
 
 /** Convert an arrow SpatialObject into a metaArrow */
 template <unsigned int NDimensions>
-typename MetaArrowConverter<NDimensions>::MetaObjectType *
-MetaArrowConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject)
+auto
+MetaArrowConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   ArrowSpatialObjectConstPointer arrowSO = dynamic_cast<const ArrowSpatialObjectType *>(spatialObject);
   if (arrowSO.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
@@ -24,16 +24,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaBlobConverter<NDimensions>::MetaObjectType *
-MetaBlobConverter<NDimensions>::CreateMetaObject()
+auto
+MetaBlobConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new BlobMetaObjectType);
 }
 
 /** Convert a metaBlob into an Blob SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaBlobConverter<NDimensions>::SpatialObjectPointer
-MetaBlobConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaBlobConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * Blob = dynamic_cast<const BlobMetaObjectType *>(mo);
   if (Blob == nullptr)
@@ -85,8 +85,8 @@ MetaBlobConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
 
 /** Convert a Blob SpatialObject into a metaBlob */
 template <unsigned int NDimensions>
-typename MetaBlobConverter<NDimensions>::MetaObjectType *
-MetaBlobConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject)
+auto
+MetaBlobConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   BlobSpatialObjectConstPointer blobSO = dynamic_cast<const BlobSpatialObjectType *>(spatialObject);
   if (blobSO.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
@@ -24,16 +24,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaContourConverter<NDimensions>::MetaObjectType *
-MetaContourConverter<NDimensions>::CreateMetaObject()
+auto
+MetaContourConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new ContourMetaObjectType);
 }
 
 /** Convert a metaContour into an Contour SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaContourConverter<NDimensions>::SpatialObjectPointer
-MetaContourConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaContourConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * contourMO = dynamic_cast<const MetaContour *>(mo);
   if (contourMO == nullptr)
@@ -130,8 +130,8 @@ MetaContourConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 
 /** Convert a Contour SpatialObject into a metaContour */
 template <unsigned int NDimensions>
-typename MetaContourConverter<NDimensions>::MetaObjectType *
-MetaContourConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+auto
+MetaContourConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   ContourSpatialObjectConstPointer contourSO = dynamic_cast<const ContourSpatialObjectType *>(so);
   if (contourSO.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
@@ -25,8 +25,8 @@ namespace itk
 {
 
 template <unsigned VDimension>
-typename MetaConverterBase<VDimension>::SpatialObjectPointer
-MetaConverterBase<VDimension>::ReadMeta(const char * name)
+auto
+MetaConverterBase<VDimension>::ReadMeta(const char * name) -> SpatialObjectPointer
 {
   SpatialObjectPointer rval;
   MetaObjectType *     mo = this->CreateMetaObject();

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -25,16 +25,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaDTITubeConverter<NDimensions>::MetaObjectType *
-MetaDTITubeConverter<NDimensions>::CreateMetaObject()
+auto
+MetaDTITubeConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new DTITubeMetaObjectType);
 }
 
 /** Convert a MetaDTITube into an Tube SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaDTITubeConverter<NDimensions>::SpatialObjectPointer
-MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * tube = dynamic_cast<const MetaDTITube *>(mo);
   if (tube == nullptr)
@@ -180,8 +180,9 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 
 /** Convert a Tube SpatialObject into a MetaDTITube */
 template <unsigned int NDimensions>
-typename MetaDTITubeConverter<NDimensions>::MetaObjectType *
+auto
 MetaDTITubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject)
+  -> MetaObjectType *
 {
   DTITubeSpatialObjectConstPointer DTITubeSO = dynamic_cast<const DTITubeSpatialObjectType *>(spatialObject);
   if (DTITubeSO.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
@@ -24,16 +24,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaEllipseConverter<NDimensions>::MetaObjectType *
-MetaEllipseConverter<NDimensions>::CreateMetaObject()
+auto
+MetaEllipseConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new EllipseMetaObjectType);
 }
 
 /** Convert a metaEllipse into an ellipse SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaEllipseConverter<NDimensions>::SpatialObjectPointer
-MetaEllipseConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaEllipseConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * ellipseMO = dynamic_cast<const EllipseMetaObjectType *>(mo);
   if (ellipseMO == nullptr)
@@ -63,8 +63,8 @@ MetaEllipseConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 
 /** Convert an ellipse SpatialObject into a metaEllipse */
 template <unsigned int NDimensions>
-typename MetaEllipseConverter<NDimensions>::MetaObjectType *
-MetaEllipseConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+auto
+MetaEllipseConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   EllipseSpatialObjectConstPointer ellipseSO = dynamic_cast<const EllipseSpatialObjectType *>(so);
   if (ellipseSO.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.hxx
@@ -24,16 +24,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaGaussianConverter<NDimensions>::MetaObjectType *
-MetaGaussianConverter<NDimensions>::CreateMetaObject()
+auto
+MetaGaussianConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new GaussianMetaObjectType);
 }
 
 /** Convert a metaGaussian into a gaussian SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaGaussianConverter<NDimensions>::SpatialObjectPointer
-MetaGaussianConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaGaussianConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * metaGaussian = dynamic_cast<const GaussianMetaObjectType *>(mo);
   if (metaGaussian == nullptr)
@@ -59,8 +59,8 @@ MetaGaussianConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTy
 
 /** Convert a gaussian SpatialObject into a metaGaussian */
 template <unsigned int NDimensions>
-typename MetaGaussianConverter<NDimensions>::MetaObjectType *
-MetaGaussianConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+auto
+MetaGaussianConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   GaussianSpatialObjectConstPointer gaussianSO = dynamic_cast<const GaussianSpatialObjectType *>(so);
   auto *                            metaGaussian = new GaussianMetaObjectType;

--- a/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.hxx
@@ -23,16 +23,16 @@
 namespace itk
 {
 template <unsigned int NDimensions>
-typename MetaGroupConverter<NDimensions>::MetaObjectType *
-MetaGroupConverter<NDimensions>::CreateMetaObject()
+auto
+MetaGroupConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new GroupMetaObjectType);
 }
 
 /** Convert a metaGroup into an group SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaGroupConverter<NDimensions>::SpatialObjectPointer
-MetaGroupConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaGroupConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * group = dynamic_cast<const GroupMetaObjectType *>(mo);
   if (group == nullptr)
@@ -54,8 +54,8 @@ MetaGroupConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType 
 
 /** Convert a group SpatialObject into a metaGroup */
 template <unsigned int NDimensions>
-typename MetaGroupConverter<NDimensions>::MetaObjectType *
-MetaGroupConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+auto
+MetaGroupConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   GroupSpatialObjectConstPointer groupSO = dynamic_cast<const GroupSpatialObjectType *>(so);
   if (groupSO.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -26,8 +26,8 @@
 namespace itk
 {
 template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
-typename MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::MetaObjectType *
-MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::CreateMetaObject()
+auto
+MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new ImageMetaObjectType);
 }
@@ -40,8 +40,9 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::GetMetaObjectSub
 }
 
 template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
-typename MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::ImageType::Pointer
-MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(const ImageMetaObjectType * image)
+auto
+MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(const ImageMetaObjectType * image) ->
+  typename ImageType::Pointer
 {
   typename ImageType::Pointer rval = ImageType::New();
 
@@ -80,8 +81,9 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(co
 
 /** Convert a metaImage into an ImageMaskSpatialObject  */
 template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
-typename MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::SpatialObjectPointer
+auto
 MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+  -> SpatialObjectPointer
 {
   const auto * imageMO = dynamic_cast<const ImageMetaObjectType *>(mo);
 
@@ -112,8 +114,9 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::MetaObjectToSpat
 
 /** Convert an Image SpatialObject into a metaImage */
 template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
-typename MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::MetaObjectType *
+auto
 MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+  -> MetaObjectType *
 {
   const ImageSpatialObjectConstPointer imageSO = dynamic_cast<const ImageSpatialObjectType *>(so);
 

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
@@ -24,16 +24,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaLandmarkConverter<NDimensions>::MetaObjectType *
-MetaLandmarkConverter<NDimensions>::CreateMetaObject()
+auto
+MetaLandmarkConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new LandmarkMetaObjectType);
 }
 
 /** Convert a metaLandmark into an Landmark SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaLandmarkConverter<NDimensions>::SpatialObjectPointer
-MetaLandmarkConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaLandmarkConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * landmarkMO = dynamic_cast<const LandmarkMetaObjectType *>(mo);
   if (landmarkMO == nullptr)
@@ -83,8 +83,8 @@ MetaLandmarkConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTy
 
 /** Convert a Landmark SpatialObject into a metaLandmark */
 template <unsigned int NDimensions>
-typename MetaLandmarkConverter<NDimensions>::MetaObjectType *
-MetaLandmarkConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+auto
+MetaLandmarkConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   const LandmarkSpatialObjectConstPointer landmarkSO = dynamic_cast<const LandmarkSpatialObjectType *>(so);
 

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
@@ -24,16 +24,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaLineConverter<NDimensions>::MetaObjectType *
-MetaLineConverter<NDimensions>::CreateMetaObject()
+auto
+MetaLineConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new LineMetaObjectType);
 }
 
 /** Convert a metaLine into an Line SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaLineConverter<NDimensions>::SpatialObjectPointer
-MetaLineConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaLineConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * lineMO = dynamic_cast<const LineMetaObjectType *>(mo);
   if (lineMO == nullptr)
@@ -93,8 +93,8 @@ MetaLineConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
 
 /** Convert a Line SpatialObject into a metaLine */
 template <unsigned int NDimensions>
-typename MetaLineConverter<NDimensions>::MetaObjectType *
-MetaLineConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject)
+auto
+MetaLineConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   LineSpatialObjectConstPointer lineSO = dynamic_cast<const LineSpatialObjectType *>(spatialObject);
   if (lineSO.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -29,16 +29,17 @@ namespace itk
 {
 
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-typename MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectType *
-MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaObject()
+auto
+MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new MeshMetaObjectType);
 }
 
 /** Convert a metaMesh into an Mesh SpatialObject  */
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-typename MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::SpatialObjectPointer
+auto
 MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+  -> SpatialObjectPointer
 {
   const auto * _mesh = dynamic_cast<const MeshMetaObjectType *>(mo);
   if (_mesh == nullptr)
@@ -202,8 +203,9 @@ MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectToSpatialObjec
 
 /** Convert a Mesh SpatialObject into a metaMesh */
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-typename MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectType *
+auto
 MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+  -> MetaObjectType *
 {
   const MeshSpatialObjectConstPointer meshSO = dynamic_cast<const MeshSpatialObjectType *>(so);
 

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -112,8 +112,9 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::SetTransform(SpatialObj
 /** Convert a metaScene into a Composite Spatial Object
  *  Also Managed Composite Spatial Object to keep a hierarchy */
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-typename MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::SpatialObjectPointer
+auto
 MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateSpatialObjectScene(MetaScene * mScene)
+  -> SpatialObjectPointer
 {
   SpatialObjectPointer soScene = nullptr;
 
@@ -232,8 +233,8 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateSpatialObjectScen
 
 /** Read a meta file give the type */
 template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-typename MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::SpatialObjectPointer
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::ReadMeta(const std::string & name)
+auto
+MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::ReadMeta(const std::string & name) -> SpatialObjectPointer
 {
   auto * mScene = new MetaScene;
 

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
@@ -23,16 +23,16 @@
 namespace itk
 {
 template <unsigned int NDimensions>
-typename MetaSurfaceConverter<NDimensions>::MetaObjectType *
-MetaSurfaceConverter<NDimensions>::CreateMetaObject()
+auto
+MetaSurfaceConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new SurfaceMetaObjectType);
 }
 
 /** Convert a metaSurface into an Surface SpatialObject */
 template <unsigned int NDimensions>
-typename MetaSurfaceConverter<NDimensions>::SpatialObjectPointer
-MetaSurfaceConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaSurfaceConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * surfaceMO = dynamic_cast<const SurfaceMetaObjectType *>(mo);
   if (surfaceMO == nullptr)
@@ -89,8 +89,8 @@ MetaSurfaceConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 
 /** Convert a Surface SpatialObject into a metaSurface */
 template <unsigned int NDimensions>
-typename MetaSurfaceConverter<NDimensions>::MetaObjectType *
-MetaSurfaceConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+auto
+MetaSurfaceConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   SurfaceSpatialObjectConstPointer surfaceSO = dynamic_cast<const SurfaceSpatialObjectType *>(so);
 

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
@@ -23,16 +23,16 @@
 namespace itk
 {
 template <unsigned int NDimensions>
-typename MetaTubeConverter<NDimensions>::MetaObjectType *
-MetaTubeConverter<NDimensions>::CreateMetaObject()
+auto
+MetaTubeConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new TubeMetaObjectType);
 }
 
 /** Convert a metaTube into an Tube SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaTubeConverter<NDimensions>::SpatialObjectPointer
-MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * tubeMO = dynamic_cast<const TubeMetaObjectType *>(mo);
   if (tubeMO == nullptr)
@@ -123,8 +123,8 @@ MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
 
 /** Convert a Tube SpatialObject into a metaTube */
 template <unsigned int NDimensions>
-typename MetaTubeConverter<NDimensions>::MetaObjectType *
-MetaTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject)
+auto
+MetaTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   TubeSpatialObjectConstPointer tubeSO = dynamic_cast<const TubeSpatialObjectType *>(spatialObject);
   if (tubeSO.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
@@ -24,16 +24,16 @@ namespace itk
 {
 
 template <unsigned int NDimensions>
-typename MetaVesselTubeConverter<NDimensions>::MetaObjectType *
-MetaVesselTubeConverter<NDimensions>::CreateMetaObject()
+auto
+MetaVesselTubeConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new VesselTubeMetaObjectType);
 }
 
 /** Convert a MetaVesselTube into an Tube SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaVesselTubeConverter<NDimensions>::SpatialObjectPointer
-MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * vesselTubeMO = dynamic_cast<const VesselTubeMetaObjectType *>(mo);
   if (vesselTubeMO == nullptr)
@@ -134,8 +134,8 @@ MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObject
 
 /** Convert a Tube SpatialObject into a MetaVesselTube */
 template <unsigned int NDimensions>
-typename MetaVesselTubeConverter<NDimensions>::MetaObjectType *
-MetaVesselTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+auto
+MetaVesselTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   const typename VesselTubeSpatialObjectType::ConstPointer vesselTubeSO =
     dynamic_cast<const VesselTubeSpatialObjectType *>(so);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -411,8 +411,8 @@ SpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 
 /** Get the bounds of the object */
 template <unsigned int TDimension>
-const typename SpatialObject<TDimension>::BoundingBoxType *
-SpatialObject<TDimension>::GetFamilyBoundingBoxInWorldSpace() const
+auto
+SpatialObject<TDimension>::GetFamilyBoundingBoxInWorldSpace() const -> const BoundingBoxType *
 {
   // Next Transform the corners of the bounding box
   using PointsContainer = typename BoundingBoxType::PointsContainer;
@@ -522,8 +522,8 @@ SpatialObject<TDimension>::SetObjectToParentTransform(const TransformType * tran
 
 /** Set the local to global transformation */
 template <unsigned int TDimension>
-const typename SpatialObject<TDimension>::TransformType *
-SpatialObject<TDimension>::GetObjectToParentTransformInverse() const
+auto
+SpatialObject<TDimension>::GetObjectToParentTransformInverse() const -> const TransformType *
 {
   if (m_ObjectToParentTransform->GetMTime() > m_ObjectToParentTransformInverse->GetMTime())
   {
@@ -579,8 +579,8 @@ SpatialObject<TDimension>::SetObjectToWorldTransform(const TransformType * trans
 
 /** Set the local to global transformation */
 template <unsigned int TDimension>
-const typename SpatialObject<TDimension>::TransformType *
-SpatialObject<TDimension>::GetObjectToWorldTransformInverse() const
+auto
+SpatialObject<TDimension>::GetObjectToWorldTransformInverse() const -> const TransformType *
 {
   if (m_ObjectToWorldTransform->GetMTime() > m_ObjectToWorldTransformInverse->GetMTime())
   {
@@ -659,8 +659,8 @@ SpatialObject<TDimension>::ComputeMyBoundingBox()
 
 /** Get the bounds of the object */
 template <unsigned int TDimension>
-const typename SpatialObject<TDimension>::BoundingBoxType *
-SpatialObject<TDimension>::GetMyBoundingBoxInWorldSpace() const
+auto
+SpatialObject<TDimension>::GetMyBoundingBoxInWorldSpace() const -> const BoundingBoxType *
 {
   // Next Transform the corners of the bounding box
   using PointsContainer = typename BoundingBoxType::PointsContainer;
@@ -755,8 +755,8 @@ SpatialObject<TDimension>::ComputeFamilyBoundingBox(unsigned int depth, const st
  * User is responsible for freeing the list, but not the elements of
  * the list. */
 template <unsigned int TDimension>
-typename SpatialObject<TDimension>::ChildrenListType *
-SpatialObject<TDimension>::GetChildren(unsigned int depth, const std::string & name) const
+auto
+SpatialObject<TDimension>::GetChildren(unsigned int depth, const std::string & name) const -> ChildrenListType *
 {
   auto * childrenSO = new ChildrenListType;
 
@@ -787,8 +787,9 @@ SpatialObject<TDimension>::GetChildren(unsigned int depth, const std::string & n
  * User is responsible for freeing the list, but not the elements of
  * the list. */
 template <unsigned int TDimension>
-typename SpatialObject<TDimension>::ChildrenConstListType *
+auto
 SpatialObject<TDimension>::GetConstChildren(unsigned int depth, const std::string & name) const
+  -> ChildrenConstListType *
 {
   auto * childrenSO = new ChildrenConstListType;
 

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -64,8 +64,8 @@ SpatialObjectPoint<TPointDimension>::SetPositionInWorldSpace(const PointType & p
 }
 
 template <unsigned int TPointDimension>
-typename SpatialObjectPoint<TPointDimension>::PointType
-SpatialObjectPoint<TPointDimension>::GetPositionInWorldSpace() const
+auto
+SpatialObjectPoint<TPointDimension>::GetPositionInWorldSpace() const -> PointType
 {
   if (m_SpatialObject == nullptr)
   {
@@ -87,8 +87,8 @@ SpatialObjectPoint<TPointDimension>::SetColor(double r, double g, double b, doub
 }
 
 template <unsigned int TPointDimension>
-typename SpatialObjectPoint<TPointDimension>::Self &
-SpatialObjectPoint<TPointDimension>::operator=(const SpatialObjectPoint & rhs)
+auto
+SpatialObjectPoint<TPointDimension>::operator=(const SpatialObjectPoint & rhs) -> Self &
 {
   if (this != &rhs)
   {

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -66,16 +66,17 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SetInput(unsigned
 
 /** Get the input Spatial Object */
 template <typename TInputSpatialObject, typename TOutputImage>
-const typename SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::InputSpatialObjectType *
-SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GetInput()
+auto
+SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GetInput() -> const InputSpatialObjectType *
 {
   return static_cast<const TInputSpatialObject *>(this->GetPrimaryInput());
 }
 
 /** Get the input Spatial Object */
 template <typename TInputSpatialObject, typename TOutputImage>
-const typename SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::InputSpatialObjectType *
+auto
 SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GetInput(unsigned int idx)
+  -> const InputSpatialObjectType *
 {
   return static_cast<const TInputSpatialObject *>(this->ProcessObject::GetInput(idx));
 }
@@ -255,8 +256,8 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SetDirection(cons
 }
 
 template <typename TInputSpatialObject, typename TOutputImage>
-const typename SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::DirectionType &
-SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GetDirection() const
+auto
+SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GetDirection() const -> const DirectionType &
 {
   return m_Direction;
 }

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
@@ -48,15 +48,16 @@ SpatialObjectToPointSetFilter<TPointBasedSpatialObject, TOutputPointSet>::SetInp
 }
 
 template <typename TPointBasedSpatialObject, typename TOutputPointSet>
-const typename SpatialObjectToPointSetFilter<TPointBasedSpatialObject, TOutputPointSet>::SpatialObjectType *
-SpatialObjectToPointSetFilter<TPointBasedSpatialObject, TOutputPointSet>::GetInput()
+auto
+SpatialObjectToPointSetFilter<TPointBasedSpatialObject, TOutputPointSet>::GetInput() -> const SpatialObjectType *
 {
   return static_cast<const SpatialObjectType *>(this->GetPrimaryInput());
 }
 
 template <typename TPointBasedSpatialObject, typename TOutputPointSet>
-const typename SpatialObjectToPointSetFilter<TPointBasedSpatialObject, TOutputPointSet>::SpatialObjectType *
+auto
 SpatialObjectToPointSetFilter<TPointBasedSpatialObject, TOutputPointSet>::GetInput(unsigned int idx)
+  -> const SpatialObjectType *
 {
   return static_cast<const SpatialObjectType *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -61,16 +61,16 @@ SurfaceSpatialObjectPoint<TPointDimension>::SetNormalInWorldSpace(const Covarian
 
 /** Get the normal at one point */
 template <unsigned int TPointDimension>
-const typename SurfaceSpatialObjectPoint<TPointDimension>::CovariantVectorType &
-SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const
+auto
+SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInObjectSpace() const -> const CovariantVectorType &
 {
   return m_NormalInObjectSpace;
 }
 
 /** Get the normal at one point */
 template <unsigned int TPointDimension>
-const typename SurfaceSpatialObjectPoint<TPointDimension>::CovariantVectorType
-SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInWorldSpace() const
+auto
+SurfaceSpatialObjectPoint<TPointDimension>::GetNormalInWorldSpace() const -> const CovariantVectorType
 {
   if (this->m_SpatialObject == nullptr)
   {
@@ -93,8 +93,8 @@ SurfaceSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent 
 
 /** Copy a surface point to another */
 template <unsigned int TPointDimension>
-typename SurfaceSpatialObjectPoint<TPointDimension>::Self &
-SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObjectPoint & rhs)
+auto
+SurfaceSpatialObjectPoint<TPointDimension>::operator=(const SurfaceSpatialObjectPoint & rhs) -> Self &
 {
   if (this != &rhs)
   {

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -110,8 +110,8 @@ TubeSpatialObjectPoint<TPointDimension>::SetRadiusInWorldSpace(double newR)
 }
 
 template <unsigned int TPointDimension>
-const typename TubeSpatialObjectPoint<TPointDimension>::VectorType
-TubeSpatialObjectPoint<TPointDimension>::GetTangentInWorldSpace() const
+auto
+TubeSpatialObjectPoint<TPointDimension>::GetTangentInWorldSpace() const -> const VectorType
 {
   if (this->m_SpatialObject == nullptr)
   {
@@ -135,8 +135,8 @@ TubeSpatialObjectPoint<TPointDimension>::SetTangentInWorldSpace(const VectorType
 }
 
 template <unsigned int TPointDimension>
-const typename TubeSpatialObjectPoint<TPointDimension>::CovariantVectorType
-TubeSpatialObjectPoint<TPointDimension>::GetNormal1InWorldSpace() const
+auto
+TubeSpatialObjectPoint<TPointDimension>::GetNormal1InWorldSpace() const -> const CovariantVectorType
 {
   if (this->m_SpatialObject == nullptr)
   {
@@ -160,8 +160,8 @@ TubeSpatialObjectPoint<TPointDimension>::SetNormal1InWorldSpace(const CovariantV
 }
 
 template <unsigned int TPointDimension>
-const typename TubeSpatialObjectPoint<TPointDimension>::CovariantVectorType
-TubeSpatialObjectPoint<TPointDimension>::GetNormal2InWorldSpace() const
+auto
+TubeSpatialObjectPoint<TPointDimension>::GetNormal2InWorldSpace() const -> const CovariantVectorType
 {
   if (this->m_SpatialObject == nullptr)
   {
@@ -206,8 +206,8 @@ TubeSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent ind
 }
 
 template <unsigned int TPointDimension>
-typename TubeSpatialObjectPoint<TPointDimension>::Self &
-TubeSpatialObjectPoint<TPointDimension>::operator=(const TubeSpatialObjectPoint & rhs)
+auto
+TubeSpatialObjectPoint<TPointDimension>::operator=(const TubeSpatialObjectPoint & rhs) -> Self &
 {
   if (this != &rhs)
   {

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -80,8 +80,8 @@ RandomImageSource<TOutputImage>::SetSize(SizeValueArrayType sizeArray)
 }
 
 template <typename TOutputImage>
-const typename RandomImageSource<TOutputImage>::SizeValueType *
-RandomImageSource<TOutputImage>::GetSize() const
+auto
+RandomImageSource<TOutputImage>::GetSize() const -> const SizeValueType *
 {
   return this->m_Size.GetSize();
 }
@@ -135,8 +135,8 @@ RandomImageSource<TOutputImage>::SetOrigin(PointValueArrayType originArray)
 }
 
 template <typename TOutputImage>
-const typename RandomImageSource<TOutputImage>::PointValueType *
-RandomImageSource<TOutputImage>::GetOrigin() const
+auto
+RandomImageSource<TOutputImage>::GetOrigin() const -> const PointValueType *
 {
   for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {
@@ -146,8 +146,8 @@ RandomImageSource<TOutputImage>::GetOrigin() const
 }
 
 template <typename TOutputImage>
-const typename RandomImageSource<TOutputImage>::SpacingValueType *
-RandomImageSource<TOutputImage>::GetSpacing() const
+auto
+RandomImageSource<TOutputImage>::GetSpacing() const -> const SpacingValueType *
 {
   for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {

--- a/Modules/Core/TestKernel/include/itkTestingHashImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingHashImageFilter.hxx
@@ -39,8 +39,8 @@ HashImageFilter<TImageType>::HashImageFilter()
 
 
 template <typename TImageType>
-typename HashImageFilter<TImageType>::DataObjectPointer
-HashImageFilter<TImageType>::MakeOutput(DataObjectPointerArraySizeType idx)
+auto
+HashImageFilter<TImageType>::MakeOutput(DataObjectPointerArraySizeType idx) -> DataObjectPointer
 {
   if (idx == 1)
   {

--- a/Modules/Core/Transform/include/itkAffineTransform.h
+++ b/Modules/Core/Transform/include/itkAffineTransform.h
@@ -145,7 +145,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost.*/
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Compose affine transformation with a translation

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -207,16 +207,17 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::WrapAsIma
 
 // Get the parameters
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-const typename BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::ParametersType &
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetParameters() const
+auto
+BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetParameters() const -> const ParametersType &
 {
   return this->m_InternalParametersBuffer;
 }
 
 // Get the parameters
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-const typename BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::FixedParametersType &
+auto
 BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetFixedParameters() const
+  -> const FixedParametersType &
 {
   // HACK:  This should not be necessary if the
   //       class is kept in a consistent state
@@ -297,8 +298,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumber
 // This helper class is used to work around a race condition where the dynamically
 // generated images must exist before the references to the sub-sections are created.
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::CoefficientImageArray
+auto
 BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::ArrayOfImagePointerGeneratorHelper()
+  -> CoefficientImageArray
 {
   CoefficientImageArray tempArrayOfPointers;
 

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -75,8 +75,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::BSp
 
 // Get the number of parameters
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::NumberOfParametersType
+auto
 BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfParameters() const
+  -> NumberOfParametersType
 {
   // The number of parameters equal SpaceDimension * number of
   // of pixels in the grid region.
@@ -85,8 +86,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Get
 
 // Get the number of parameters per dimension
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::NumberOfParametersType
+auto
 BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfParametersPerDimension() const
+  -> NumberOfParametersType
 {
   // The number of parameters per dimension equal number of
   // of pixels in the grid region.

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -81,8 +81,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformT
 
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::NumberOfParametersType
+auto
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfParameters() const
+  -> NumberOfParametersType
 {
   // The number of parameters equals SpaceDimension * number of
   // of pixels in the grid region.
@@ -91,8 +92,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfPa
 
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::NumberOfParametersType
+auto
 BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfParametersPerDimension() const
+  -> NumberOfParametersType
 {
   // The number of parameters per dimension equals the number of
   // of pixels in the grid region.

--- a/Modules/Core/Transform/include/itkCenteredAffineTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredAffineTransform.h
@@ -78,7 +78,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set/Get the transformation from a container of parameters.

--- a/Modules/Core/Transform/include/itkCenteredAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredAffineTransform.hxx
@@ -32,8 +32,8 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::CenteredAffineTransf
 
 // Get parameters
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename CenteredAffineTransform<TParametersValueType, NDimensions>::ParametersType &
-CenteredAffineTransform<TParametersValueType, NDimensions>::GetParameters() const
+auto
+CenteredAffineTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
 {
   // Transfer the linear part
   unsigned int par = 0;
@@ -168,8 +168,8 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::GetInverse(Self * in
 
 // Return an inverse of this transform
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CenteredAffineTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
-CenteredAffineTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+auto
+CenteredAffineTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkCenteredEuler3DTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredEuler3DTransform.h
@@ -83,7 +83,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set the transformation from a container of parameters

--- a/Modules/Core/Transform/include/itkCenteredEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredEuler3DTransform.hxx
@@ -99,8 +99,8 @@ CenteredEuler3DTransform<TParametersValueType>::SetParameters(const ParametersTy
 //
 
 template <typename TParametersValueType>
-const typename CenteredEuler3DTransform<TParametersValueType>::ParametersType &
-CenteredEuler3DTransform<TParametersValueType>::GetParameters() const
+auto
+CenteredEuler3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   ParametersType parameters;
 
@@ -192,8 +192,8 @@ CenteredEuler3DTransform<TParametersValueType>::GetInverse(Self * inverse) const
 
 // Return an inverse of this transform
 template <typename TParametersValueType>
-typename CenteredEuler3DTransform<TParametersValueType>::InverseTransformBasePointer
-CenteredEuler3DTransform<TParametersValueType>::GetInverseTransform() const
+auto
+CenteredEuler3DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkCenteredRigid2DTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredRigid2DTransform.h
@@ -106,7 +106,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set the transformation from a container of parameters

--- a/Modules/Core/Transform/include/itkCenteredRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredRigid2DTransform.hxx
@@ -87,8 +87,8 @@ CenteredRigid2DTransform<TParametersValueType>::SetParameters(const ParametersTy
 
 
 template <typename TParametersValueType>
-const typename CenteredRigid2DTransform<TParametersValueType>::ParametersType &
-CenteredRigid2DTransform<TParametersValueType>::GetParameters() const
+auto
+CenteredRigid2DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
   // Parameters are ordered as:
@@ -162,8 +162,8 @@ CenteredRigid2DTransform<TParametersValueType>::SetFixedParameters(const FixedPa
 
 
 template <typename TParametersValueType>
-const typename CenteredRigid2DTransform<TParametersValueType>::FixedParametersType &
-CenteredRigid2DTransform<TParametersValueType>::GetFixedParameters() const
+auto
+CenteredRigid2DTransform<TParametersValueType>::GetFixedParameters() const -> const FixedParametersType &
 {
   // return dummy parameters
   return this->m_FixedParameters;
@@ -197,8 +197,8 @@ CenteredRigid2DTransform<TParametersValueType>::GetInverse(Self * inverse) const
 
 
 template <typename TParametersValueType>
-typename CenteredRigid2DTransform<TParametersValueType>::InverseTransformBasePointer
-CenteredRigid2DTransform<TParametersValueType>::GetInverseTransform() const
+auto
+CenteredRigid2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.h
@@ -112,7 +112,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set the transformation from a container of parameters

--- a/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
@@ -84,8 +84,8 @@ CenteredSimilarity2DTransform<TParametersValueType>::SetParameters(const Paramet
 
 
 template <typename TParametersValueType>
-const typename CenteredSimilarity2DTransform<TParametersValueType>::ParametersType &
-CenteredSimilarity2DTransform<TParametersValueType>::GetParameters() const
+auto
+CenteredSimilarity2DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 
@@ -163,8 +163,8 @@ CenteredSimilarity2DTransform<TParametersValueType>::SetFixedParameters(
 
 
 template <typename TParametersValueType>
-const typename CenteredSimilarity2DTransform<TParametersValueType>::FixedParametersType &
-CenteredSimilarity2DTransform<TParametersValueType>::GetFixedParameters() const
+auto
+CenteredSimilarity2DTransform<TParametersValueType>::GetFixedParameters() const -> const FixedParametersType &
 {
   // return dummy parameters
   return this->m_FixedParameters;
@@ -212,8 +212,8 @@ CenteredSimilarity2DTransform<TParametersValueType>::GetInverse(Self * inverse) 
 
 
 template <typename TParametersValueType>
-typename CenteredSimilarity2DTransform<TParametersValueType>::InverseTransformBasePointer
-CenteredSimilarity2DTransform<TParametersValueType>::GetInverseTransform() const
+auto
+CenteredSimilarity2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
@@ -152,8 +152,8 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const Par
 //
 
 template <typename TParametersValueType>
-const typename ComposeScaleSkewVersor3DTransform<TParametersValueType>::ParametersType &
-ComposeScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const
+auto
+ComposeScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Modules/Core/Transform/include/itkCompositeTransform.h
+++ b/Modules/Core/Transform/include/itkCompositeTransform.h
@@ -102,7 +102,7 @@ public:
   itkNewMacro(Self);
 
   /** Sub transform type **/
-  using typename Superclass::TransformType;
+  using TransformType = typename Superclass::TransformType;
   using typename Superclass::TransformTypePointer;
   /** InverseTransform type. */
   using typename Superclass::InverseTransformBasePointer;

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -33,8 +33,8 @@ CompositeTransform<TParametersValueType, NDimensions>::CompositeTransform()
 }
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::TransformCategoryEnum
-CompositeTransform<TParametersValueType, NDimensions>::GetTransformCategory() const
+auto
+CompositeTransform<TParametersValueType, NDimensions>::GetTransformCategory() const -> TransformCategoryEnum
 {
   // Check if linear
   bool isLinearTransform = this->IsLinear();
@@ -67,8 +67,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetTransformCategory() co
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputPointType
+auto
 CompositeTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & inputPoint) const
+  -> OutputPointType
 {
 
   /* Apply in reverse queue order.  */
@@ -82,8 +83,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformPoint(const Inpu
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorType
+auto
 CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorType & inputVector) const
+  -> OutputVectorType
 {
   OutputVectorType outputVector(inputVector);
 
@@ -137,8 +139,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVnlVectorType
+auto
 CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVnlVectorType & inputVector) const
+  -> OutputVnlVectorType
 {
   OutputVnlVectorType outputVector(inputVector);
 
@@ -153,8 +156,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorPixelType
+auto
 CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorPixelType & inputVector) const
+  -> OutputVectorPixelType
 {
   OutputVectorPixelType outputVector(inputVector);
 
@@ -446,8 +450,8 @@ CompositeTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
-CompositeTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+auto
+CompositeTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   /* This method can't be defined in Superclass because of the call to New() */
   Pointer inverseTransform = New();
@@ -610,8 +614,8 @@ CompositeTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespec
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename CompositeTransform<TParametersValueType, NDimensions>::ParametersType &
-CompositeTransform<TParametersValueType, NDimensions>::GetParameters() const
+auto
+CompositeTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
 {
   const TransformQueueType & transforms = this->GetTransformsToOptimizeQueue();
   if (transforms.size() == 1)
@@ -703,8 +707,8 @@ CompositeTransform<TParametersValueType, NDimensions>::SetParameters(const Param
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename CompositeTransform<TParametersValueType, NDimensions>::FixedParametersType &
-CompositeTransform<TParametersValueType, NDimensions>::GetFixedParameters() const
+auto
+CompositeTransform<TParametersValueType, NDimensions>::GetFixedParameters() const -> const FixedParametersType &
 {
   TransformQueueType transforms = this->GetTransformsToOptimizeQueue();
   /* Resize destructively. But if it's already this size, nothing is done so
@@ -755,8 +759,8 @@ CompositeTransform<TParametersValueType, NDimensions>::SetFixedParameters(const 
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::NumberOfParametersType
-CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfParameters() const
+auto
+CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfParameters() const -> NumberOfParametersType
 {
   /* Returns to total number of params in all transforms currently
    * set to be used for optimized.
@@ -781,8 +785,8 @@ CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfParameters() c
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::NumberOfParametersType
-CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfLocalParameters() const
+auto
+CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfLocalParameters() const -> NumberOfParametersType
 {
   if (this->GetMTime() == this->m_LocalParametersUpdateTime)
   {
@@ -811,8 +815,8 @@ CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfLocalParameter
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::NumberOfParametersType
-CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfFixedParameters() const
+auto
+CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfFixedParameters() const -> NumberOfParametersType
 {
   /* Returns to total number of params in all transforms currently
    * set to be used for optimized.
@@ -885,8 +889,9 @@ CompositeTransform<TParametersValueType, NDimensions>::UpdateTransformParameters
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename CompositeTransform<TParametersValueType, NDimensions>::TransformQueueType &
+auto
 CompositeTransform<TParametersValueType, NDimensions>::GetTransformsToOptimizeQueue() const
+  -> const TransformQueueType &
 {
   /* Update the list of transforms to use for optimization only if
    the selection of transforms to optimize may have changed */

--- a/Modules/Core/Transform/include/itkEuler2DTransform.h
+++ b/Modules/Core/Transform/include/itkEuler2DTransform.h
@@ -89,7 +89,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost.*/
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /**

--- a/Modules/Core/Transform/include/itkEuler2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler2DTransform.hxx
@@ -63,8 +63,8 @@ Euler2DTransform<TParametersValueType>::GetInverse(Self * inverse) const
 
 // Return an inverse of this transform
 template <typename TParametersValueType>
-typename Euler2DTransform<TParametersValueType>::InverseTransformBasePointer
-Euler2DTransform<TParametersValueType>::GetInverseTransform() const
+auto
+Euler2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -106,8 +106,8 @@ Euler3DTransform<TParametersValueType>::SetParameters(const ParametersType & par
 
 // Get Parameters
 template <typename TParametersValueType>
-const typename Euler3DTransform<TParametersValueType>::ParametersType &
-Euler3DTransform<TParametersValueType>::GetParameters() const
+auto
+Euler3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   this->m_Parameters[0] = m_AngleX;
   this->m_Parameters[1] = m_AngleY;
@@ -120,8 +120,8 @@ Euler3DTransform<TParametersValueType>::GetParameters() const
 }
 
 template <typename TParametersValueType>
-const typename Euler3DTransform<TParametersValueType>::FixedParametersType &
-Euler3DTransform<TParametersValueType>::GetFixedParameters() const
+auto
+Euler3DTransform<TParametersValueType>::GetFixedParameters() const -> const FixedParametersType &
 {
   // Call the superclass GetFixedParameters so that it fills the
   // array, we ignore the returned data and add the additional

--- a/Modules/Core/Transform/include/itkIdentityTransform.h
+++ b/Modules/Core/Transform/include/itkIdentityTransform.h
@@ -102,7 +102,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost.*/
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /**  Method to transform a point. */

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -319,8 +319,9 @@ KernelTransform<TParametersValueType, NDimensions>::ReorganizeW()
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename KernelTransform<TParametersValueType, NDimensions>::OutputPointType
+auto
 KernelTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & thisPoint) const
+  -> OutputPointType
 {
   OutputPointType result;
 
@@ -473,8 +474,8 @@ KernelTransform<TParametersValueType, NDimensions>::UpdateParameters() const
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename KernelTransform<TParametersValueType, NDimensions>::ParametersType &
-KernelTransform<TParametersValueType, NDimensions>::GetParameters() const
+auto
+KernelTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
 {
   this->UpdateParameters();
   return this->m_Parameters;
@@ -482,8 +483,8 @@ KernelTransform<TParametersValueType, NDimensions>::GetParameters() const
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename KernelTransform<TParametersValueType, NDimensions>::FixedParametersType &
-KernelTransform<TParametersValueType, NDimensions>::GetFixedParameters() const
+auto
+KernelTransform<TParametersValueType, NDimensions>::GetFixedParameters() const -> const FixedParametersType &
 {
   // Get the fixed parameters
   // This returns the target landmark locations

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -194,7 +194,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set the transformation to an Identity

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -392,8 +392,9 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 
 
 template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-const typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::InverseMatrixType &
+auto
 MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverseMatrix() const
+  -> const InverseMatrixType &
 {
   // If the transform has been modified we recompute the inverse
   if (m_InverseMatrixMTime != m_MatrixMTime)
@@ -485,8 +486,9 @@ const typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions,
 
 
 template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-const typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::ParametersType &
+auto
 MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetParameters() const
+  -> const ParametersType &
 {
   // Transfer the linear part
   unsigned int par = 0;

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -34,8 +34,8 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::MultiTransfor
 }
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
-typename MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::TransformCategoryEnum
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetTransformCategory() const
+auto
+MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetTransformCategory() const -> TransformCategoryEnum
 {
   // If all sub-transforms are the same, return that type. Otherwise
   // return Unknown.
@@ -79,8 +79,8 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::IsLinear() co
 
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
-const typename MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::ParametersType &
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetParameters() const
+auto
+MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetParameters() const -> const ParametersType &
 {
   /* Resize destructively. But if it's already this size, nothing is done so
    * it's efficient. */
@@ -148,8 +148,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::SetParameters
 
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
-const typename MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::FixedParametersType &
+auto
 MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetFixedParameters() const
+  -> const FixedParametersType &
 {
   /* Resize destructively. But if it's already this size, nothing is done so
    * it's efficient. */
@@ -207,8 +208,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::SetFixedParam
 
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
-typename MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::NumberOfParametersType
+auto
 MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfParameters() const
+  -> NumberOfParametersType
 {
   /* Returns to total number of params in all transforms currently
    * set to be used for optimized.
@@ -231,8 +233,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfPa
 
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
-typename MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::NumberOfParametersType
+auto
 MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfLocalParameters() const
+  -> NumberOfParametersType
 {
   if (this->GetMTime() == this->m_LocalParametersUpdateTime)
   {
@@ -257,8 +260,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfLo
 
 
 template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
-typename MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::NumberOfParametersType
+auto
 MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfFixedParameters() const
+  -> NumberOfParametersType
 {
   NumberOfParametersType result = NumericTraits<NumberOfParametersType>::ZeroValue();
 

--- a/Modules/Core/Transform/include/itkQuaternionRigidTransform.hxx
+++ b/Modules/Core/Transform/include/itkQuaternionRigidTransform.hxx
@@ -114,8 +114,8 @@ QuaternionRigidTransform<TParametersValueType>::SetParameters(const ParametersTy
 
 // Set Parameters
 template <typename TParametersValueType>
-const typename QuaternionRigidTransform<TParametersValueType>::ParametersType &
-QuaternionRigidTransform<TParametersValueType>::GetParameters() const
+auto
+QuaternionRigidTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   VnlQuaternionType quaternion = this->GetRotation();
   OutputVectorType  translation = this->GetTranslation();
@@ -175,8 +175,8 @@ QuaternionRigidTransform<TParametersValueType>::ComputeJacobianWithRespectToPara
 }
 
 template <typename TParametersValueType>
-const typename QuaternionRigidTransform<TParametersValueType>::InverseMatrixType &
-QuaternionRigidTransform<TParametersValueType>::GetInverseMatrix() const
+auto
+QuaternionRigidTransform<TParametersValueType>::GetInverseMatrix() const -> const InverseMatrixType &
 {
   // If the transform has been modified we recompute the inverse
   if (this->InverseMatrixIsOld())

--- a/Modules/Core/Transform/include/itkRigid2DTransform.h
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.h
@@ -116,7 +116,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /**

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -150,8 +150,8 @@ Rigid2DTransform<TParametersValueType>::GetInverse(Self * inverse) const
 
 
 template <typename TParametersValueType>
-typename Rigid2DTransform<TParametersValueType>::InverseTransformBasePointer
-Rigid2DTransform<TParametersValueType>::GetInverseTransform() const
+auto
+Rigid2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 
@@ -255,8 +255,8 @@ Rigid2DTransform<TParametersValueType>::SetParameters(const ParametersType & par
 
 
 template <typename TParametersValueType>
-const typename Rigid2DTransform<TParametersValueType>::ParametersType &
-Rigid2DTransform<TParametersValueType>::GetParameters() const
+auto
+Rigid2DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.hxx
@@ -109,8 +109,8 @@ Rigid3DPerspectiveTransform<TParametersValueType>::SetParameters(const Parameter
 
 // Set Parameters
 template <typename TParametersValueType>
-const typename Rigid3DPerspectiveTransform<TParametersValueType>::ParametersType &
-Rigid3DPerspectiveTransform<TParametersValueType>::GetParameters() const
+auto
+Rigid3DPerspectiveTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 
@@ -164,8 +164,8 @@ Rigid3DPerspectiveTransform<TParametersValueType>::SetRotation(const Vector<TPar
 
 // Transform a point
 template <typename TParametersValueType>
-typename Rigid3DPerspectiveTransform<TParametersValueType>::OutputPointType
-Rigid3DPerspectiveTransform<TParametersValueType>::TransformPoint(const InputPointType & point) const
+auto
+Rigid3DPerspectiveTransform<TParametersValueType>::TransformPoint(const InputPointType & point) const -> OutputPointType
 {
   unsigned int   i;
   InputPointType centered;

--- a/Modules/Core/Transform/include/itkRigid3DTransform.h
+++ b/Modules/Core/Transform/include/itkRigid3DTransform.h
@@ -103,7 +103,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set the transformation from a container of parameters

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.h
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.h
@@ -80,7 +80,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost.  */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set the transformation to an Identity

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
@@ -150,8 +150,8 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::GetInverse(Self * in
 
 // Return an inverse of this transform
 template <typename TParametersValueType, unsigned int NDimensions>
-typename ScalableAffineTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
-ScalableAffineTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+auto
+ScalableAffineTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
@@ -47,8 +47,8 @@ ScaleLogarithmicTransform<TParametersValueType, NDimensions>::SetParameters(cons
 
 // Get Parameters
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename ScaleLogarithmicTransform<TParametersValueType, NDimensions>::ParametersType &
-ScaleLogarithmicTransform<TParametersValueType, NDimensions>::GetParameters() const
+auto
+ScaleLogarithmicTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.hxx
@@ -151,8 +151,8 @@ ScaleSkewVersor3DTransform<TParametersValueType>::SetParameters(const Parameters
 //
 
 template <typename TParametersValueType>
-const typename ScaleSkewVersor3DTransform<TParametersValueType>::ParametersType &
-ScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const
+auto
+ScaleSkewVersor3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Modules/Core/Transform/include/itkScaleTransform.h
+++ b/Modules/Core/Transform/include/itkScaleTransform.h
@@ -93,7 +93,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost.*/
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   using typename Superclass::MatrixType;

--- a/Modules/Core/Transform/include/itkScaleTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleTransform.hxx
@@ -55,8 +55,8 @@ ScaleTransform<TParametersValueType, NDimensions>::SetParameters(const Parameter
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename ScaleTransform<TParametersValueType, NDimensions>::ParametersType &
-ScaleTransform<TParametersValueType, NDimensions>::GetParameters() const
+auto
+ScaleTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
   // Transfer the translation part
@@ -104,8 +104,8 @@ ScaleTransform<TParametersValueType, NDimensions>::Scale(const ScaleType & scale
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename ScaleTransform<TParametersValueType, NDimensions>::OutputPointType
-ScaleTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & point) const
+auto
+ScaleTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & point) const -> OutputPointType
 {
   OutputPointType        result;
   const InputPointType & center = this->GetCenter();
@@ -119,8 +119,9 @@ ScaleTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPoi
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename ScaleTransform<TParametersValueType, NDimensions>::OutputVectorType
+auto
 ScaleTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorType & vect) const
+  -> OutputVectorType
 {
   OutputVectorType result;
 
@@ -133,8 +134,9 @@ ScaleTransform<TParametersValueType, NDimensions>::TransformVector(const InputVe
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename ScaleTransform<TParametersValueType, NDimensions>::OutputVnlVectorType
+auto
 ScaleTransform<TParametersValueType, NDimensions>::TransformVector(const InputVnlVectorType & vect) const
+  -> OutputVnlVectorType
 {
   OutputVnlVectorType result;
 
@@ -147,8 +149,9 @@ ScaleTransform<TParametersValueType, NDimensions>::TransformVector(const InputVn
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename ScaleTransform<TParametersValueType, NDimensions>::OutputCovariantVectorType
+auto
 ScaleTransform<TParametersValueType, NDimensions>::TransformCovariantVector(const InputCovariantVectorType & vect) const
+  -> OutputCovariantVectorType
 {
   // Covariant Vectors are scaled by the inverse
   OutputCovariantVectorType result;
@@ -180,8 +183,8 @@ ScaleTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) co
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename ScaleTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
-ScaleTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+auto
+ScaleTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkScaleVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleVersor3DTransform.hxx
@@ -139,8 +139,8 @@ ScaleVersor3DTransform<TParametersValueType>::SetParameters(const ParametersType
 //
 
 template <typename TParametersValueType>
-const typename ScaleVersor3DTransform<TParametersValueType>::ParametersType &
-ScaleVersor3DTransform<TParametersValueType>::GetParameters() const
+auto
+ScaleVersor3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.h
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.h
@@ -122,7 +122,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set the Scale part of the transform. */

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
@@ -88,8 +88,8 @@ Similarity2DTransform<TParametersValueType>::SetParameters(const ParametersType 
 
 
 template <typename TParametersValueType>
-const typename Similarity2DTransform<TParametersValueType>::ParametersType &
-Similarity2DTransform<TParametersValueType>::GetParameters() const
+auto
+Similarity2DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 
@@ -257,8 +257,8 @@ Similarity2DTransform<TParametersValueType>::GetInverse(Self * inverse) const
 
 
 template <typename TParametersValueType>
-typename Similarity2DTransform<TParametersValueType>::InverseTransformBasePointer
-Similarity2DTransform<TParametersValueType>::GetInverseTransform() const
+auto
+Similarity2DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
@@ -185,8 +185,8 @@ Similarity3DTransform<TParametersValueType>::SetParameters(const ParametersType 
 //
 
 template <typename TParametersValueType>
-const typename Similarity3DTransform<TParametersValueType>::ParametersType &
-Similarity3DTransform<TParametersValueType>::GetParameters() const
+auto
+Similarity3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -94,7 +94,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost.*/
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Transform category type. */

--- a/Modules/Core/Transform/include/itkTranslationTransform.hxx
+++ b/Modules/Core/Transform/include/itkTranslationTransform.hxx
@@ -75,8 +75,8 @@ TranslationTransform<TParametersValueType, NDimensions>::SetParameters(const Par
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-const typename TranslationTransform<TParametersValueType, NDimensions>::ParametersType &
-TranslationTransform<TParametersValueType, NDimensions>::GetParameters() const
+auto
+TranslationTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
 {
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
@@ -119,24 +119,27 @@ TranslationTransform<TParametersValueType, NDimensions>::Translate(const OutputV
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename TranslationTransform<TParametersValueType, NDimensions>::OutputPointType
+auto
 TranslationTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & point) const
+  -> OutputPointType
 {
   return point + m_Offset;
 }
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename TranslationTransform<TParametersValueType, NDimensions>::OutputVectorType
+auto
 TranslationTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorType & vect) const
+  -> OutputVectorType
 {
   return vect;
 }
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename TranslationTransform<TParametersValueType, NDimensions>::OutputVnlVectorType
+auto
 TranslationTransform<TParametersValueType, NDimensions>::TransformVector(const InputVnlVectorType & vect) const
+  -> OutputVnlVectorType
 {
   return vect;
 }
@@ -167,8 +170,8 @@ TranslationTransform<TParametersValueType, NDimensions>::GetInverse(Self * inver
 
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename TranslationTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
-TranslationTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+auto
+TranslationTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
@@ -106,8 +106,8 @@ VersorRigid3DTransform<TParametersValueType>::SetParameters(const ParametersType
 //
 
 template <typename TParametersValueType>
-const typename VersorRigid3DTransform<TParametersValueType>::ParametersType &
-VersorRigid3DTransform<TParametersValueType>::GetParameters() const
+auto
+VersorRigid3DTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 

--- a/Modules/Core/Transform/include/itkVersorTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorTransform.hxx
@@ -83,8 +83,8 @@ VersorTransform<TParametersValueType>::SetParameters(const ParametersType & para
 
 /** Set Parameters */
 template <typename TParametersValueType>
-const typename VersorTransform<TParametersValueType>::ParametersType &
-VersorTransform<TParametersValueType>::GetParameters() const
+auto
+VersorTransform<TParametersValueType>::GetParameters() const -> const ParametersType &
 {
   this->m_Parameters[0] = this->m_Versor.GetRight()[0];
   this->m_Parameters[1] = this->m_Versor.GetRight()[1];

--- a/Modules/Core/Transform/include/itkv3Rigid3DTransform.h
+++ b/Modules/Core/Transform/include/itkv3Rigid3DTransform.h
@@ -110,7 +110,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Get an inverse of this transform. */

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -90,7 +90,7 @@ public:
   itkNewMacro(Self);
 
   /** Sub transform type **/
-  using typename Superclass::TransformType;
+  using TransformType = typename Superclass::TransformType;
   using typename Superclass::TransformTypePointer;
   /** InverseTransform type. */
   using typename Superclass::InverseTransformBasePointer;

--- a/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
@@ -36,7 +36,7 @@ public:
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using typename Superclass::InverseTransformBaseType;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   InverseTransformBasePointer

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
@@ -169,8 +169,8 @@ MRASlabIdentifier<TInputImage>::GenerateSlabRegions()
 }
 
 template <typename TInputImage>
-typename MRASlabIdentifier<TInputImage>::SlabRegionVectorType
-MRASlabIdentifier<TInputImage>::GetSlabRegionVector()
+auto
+MRASlabIdentifier<TInputImage>::GetSlabRegionVector() -> SlabRegionVectorType
 {
   return m_Slabs;
 }

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -62,8 +62,8 @@ MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::GetNumberOfParameters() c
 }
 
 template <typename TImage, typename TImageMask, typename TBiasField>
-typename MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::MeasureType
-MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::GetValue(const ParametersType & parameters) const
+auto
+MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::GetValue(const ParametersType & parameters) const -> MeasureType
 {
   if (m_Image.IsNull())
   {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
@@ -43,8 +43,8 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::BinaryPruningImageFilter()
  *  Return the pruning Image pointer
  */
 template <typename TInputImage, typename TOutputImage>
-typename BinaryPruningImageFilter<TInputImage, TOutputImage>::OutputImageType *
-BinaryPruningImageFilter<TInputImage, TOutputImage>::GetPruning()
+auto
+BinaryPruningImageFilter<TInputImage, TOutputImage>::GetPruning() -> OutputImageType *
 {
   return dynamic_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -42,8 +42,8 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::BinaryThinningImageFilter(
  *  Return the thinning Image pointer
  */
 template <typename TInputImage, typename TOutputImage>
-typename BinaryThinningImageFilter<TInputImage, TOutputImage>::OutputImageType *
-BinaryThinningImageFilter<TInputImage, TOutputImage>::GetThinning()
+auto
+BinaryThinningImageFilter<TInputImage, TOutputImage>::GetThinning() -> OutputImageType *
 {
   return dynamic_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename AutumnColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-AutumnColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+AutumnColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkBlueColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkBlueColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename BlueColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-BlueColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+BlueColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkCoolColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCoolColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename CoolColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-CoolColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+CoolColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkCopperColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCopperColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename CopperColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-CopperColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+CopperColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkCustomColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCustomColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename CustomColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-CustomColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+CustomColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkGreenColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkGreenColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename GreenColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-GreenColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+GreenColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkGreyColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkGreyColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename GreyColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-GreyColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+GreyColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkHSVColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkHSVColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename HSVColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-HSVColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+HSVColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkHotColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkHotColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename HotColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-HotColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+HotColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkJetColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkJetColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename JetColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-JetColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+JetColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename OverUnderColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-OverUnderColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+OverUnderColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkRedColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkRedColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename RedColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-RedColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+RedColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkSpringColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkSpringColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename SpringColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-SpringColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+SpringColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkSummerColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkSummerColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename SummerColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-SummerColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+SummerColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Colormap/include/itkWinterColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkWinterColormapFunction.hxx
@@ -25,8 +25,8 @@ namespace itk
 namespace Function
 {
 template <typename TScalar, typename TRGBPixel>
-typename WinterColormapFunction<TScalar, TRGBPixel>::RGBPixelType
-WinterColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const
+auto
+WinterColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> RGBPixelType
 {
   // Map the input scalar between [0, 1].
   RealType value = this->RescaleInputValue(v);

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
@@ -204,8 +204,8 @@ ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::GetKernelNeedsP
 }
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage>
-typename ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::KernelSizeType
-ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::GetKernelPadSize() const
+auto
+ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::GetKernelPadSize() const -> KernelSizeType
 {
   const KernelImageType * kernel = this->GetKernelImage();
   KernelRegionType        kernelRegion = kernel->GetLargestPossibleRegion();
@@ -223,8 +223,9 @@ ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::GetKernelPadSiz
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage>
 template <typename TImage>
-typename ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::KernelSizeType
+auto
 ConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage>::GetKernelRadius(const TImage * kernelImage) const
+  -> KernelSizeType
 {
   // Compute the kernel radius.
   KernelSizeType radius;

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
@@ -48,8 +48,8 @@ ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::GenerateOut
 }
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage>
-typename ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::OutputRegionType
-ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::GetValidRegion() const
+auto
+ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>::GetValidRegion() const -> OutputRegionType
 {
   typename InputImageType::ConstPointer inputPtr = this->GetInput();
 

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -358,8 +358,9 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
 }
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage, typename TInternalPrecision>
-typename FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::InputSizeType
+auto
 FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::GetPadLowerBound() const
+  -> InputSizeType
 {
   typename InputImageType::ConstPointer inputImage = this->GetInput();
   InputSizeType                         inputSize = inputImage->GetLargestPossibleRegion().GetSize();
@@ -375,8 +376,9 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
 }
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage, typename TInternalPrecision>
-typename FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::InputSizeType
+auto
 FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::GetPadSize() const
+  -> InputSizeType
 {
   typename InputImageType::ConstPointer  inputImage = this->GetInput();
   InputSizeType                          inputSize = inputImage->GetLargestPossibleRegion().GetSize();

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -46,8 +46,8 @@ CurvatureFlowFunction<TImage>::CurvatureFlowFunction()
  * Compute the global time step
  */
 template <typename TImage>
-typename CurvatureFlowFunction<TImage>::TimeStepType
-CurvatureFlowFunction<TImage>::ComputeGlobalTimeStep(void * itkNotUsed(gd)) const
+auto
+CurvatureFlowFunction<TImage>::ComputeGlobalTimeStep(void * itkNotUsed(gd)) const -> TimeStepType
 {
   return this->GetTimeStep();
 }

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -129,8 +129,9 @@ MinMaxCurvatureFlowFunction<TImage>::InitializeStencilOperator()
  * the direction perpendicular to the image gradient.
  */
 template <typename TImage>
-typename MinMaxCurvatureFlowFunction<TImage>::PixelType
+auto
 MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, const NeighborhoodType & it) const
+  -> PixelType
 {
   PixelType threshold = NumericTraits<PixelType>::ZeroValue();
 
@@ -229,8 +230,9 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
  * the direction perpendicular to the image gradient.
  */
 template <typename TImage>
-typename MinMaxCurvatureFlowFunction<TImage>::PixelType
+auto
 MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<2> &, const NeighborhoodType & it) const
+  -> PixelType
 {
   constexpr unsigned int imageDimension = 2;
 
@@ -294,8 +296,9 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<2> &, const
  * the direction perpendicular to the image gradient.
  */
 template <typename TImage>
-typename MinMaxCurvatureFlowFunction<TImage>::PixelType
+auto
 MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const NeighborhoodType & it) const
+  -> PixelType
 {
   constexpr unsigned int imageDimension = 3;
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -163,15 +163,16 @@ PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::SetPatchWeights(c
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::PatchWeightsType
-PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchWeights() const
+auto
+PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchWeights() const -> PatchWeightsType
 {
   return m_PatchWeights;
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::PatchRadiusType::SizeValueType
-PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchLengthInVoxels() const
+auto
+PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchLengthInVoxels() const ->
+  typename PatchRadiusType::SizeValueType
 {
   const PatchRadiusType diameter = this->GetPatchDiameterInVoxels();
 
@@ -184,8 +185,8 @@ PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchLengthInV
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::PatchRadiusType
-PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchDiameterInVoxels() const
+auto
+PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchDiameterInVoxels() const -> PatchRadiusType
 {
   PatchRadiusType one;
   PatchRadiusType two;
@@ -198,8 +199,8 @@ PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchDiameterI
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::PatchRadiusType
-PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchRadiusInVoxels() const
+auto
+PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchRadiusInVoxels() const -> PatchRadiusType
 {
   const typename Self::Pointer thisPtr = const_cast<Self *>(this);
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -86,8 +86,8 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::SetThreadData(int thr
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadDataStruct
-PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::GetThreadData(int threadId)
+auto
+PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::GetThreadData(int threadId) -> ThreadDataStruct
 {
   if (threadId < static_cast<int>(m_ThreadData.size()))
   {
@@ -1143,8 +1143,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeLogMapAndWeigh
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::RealType
+auto
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::AddEuclideanUpdate(const RealType & a, const RealType & b)
+  -> RealType
 {
   RealType result = m_ZeroPixel;
 
@@ -1816,8 +1817,8 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadedComputeSigmaU
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::RealArrayType
-PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ResolveSigmaUpdate()
+auto
+PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ResolveSigmaUpdate() -> RealArrayType
 {
   RealArrayType sigmaUpdate(m_NumIndependentComponents);
 

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -97,8 +97,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::GetInverse(Se
 
 // Return an inverse of this transform
 template <typename TParametersValueType, unsigned int NDimensions>
-typename ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
+auto
 ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+  -> InverseTransformBasePointer
 {
   Pointer inverseTransform = New();
   if (this->GetInverse(inverseTransform))

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -63,8 +63,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::DisplacementField
 }
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename DisplacementFieldTransform<TParametersValueType, NDimensions>::OutputPointType
+auto
 DisplacementFieldTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & inputPoint) const
+  -> OutputPointType
 {
   if (!this->m_DisplacementField)
   {
@@ -118,8 +119,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverse(Self *
 }
 
 template <typename TParametersValueType, unsigned int NDimensions>
-typename DisplacementFieldTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
+auto
 DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+  -> InverseTransformBasePointer
 {
   Pointer inverseTransform = New();
 

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -102,8 +102,8 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::SetInput
 }
 
 template <typename TOutputImage, typename TParametersValueType>
-const typename TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::TransformInputType *
-TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::GetInput() const
+auto
+TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::GetInput() const -> const TransformInputType *
 {
   return itkDynamicCastInDebugMode<const TransformInputType *>(this->GetPrimaryInput());
 }

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -95,8 +95,8 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::GetInverse(Self * inv
 
 // Return an inverse of this transform
 template <typename TParametersValueType, unsigned int NDimensions>
-typename VelocityFieldTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
-VelocityFieldTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+auto
+VelocityFieldTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inverseTransform = New();
   if (this->GetInverse(inverseTransform))

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -61,15 +61,15 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::SetInput2(co
 }
 
 template <typename TInputImage1, typename TInputImage2>
-const typename ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::InputImage1Type *
-ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::GetInput1()
+auto
+ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::GetInput1() -> const InputImage1Type *
 {
   return this->GetInput();
 }
 
 template <typename TInputImage1, typename TInputImage2>
-const typename ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::InputImage2Type *
-ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::GetInput2()
+auto
+ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::GetInput2() -> const InputImage2Type *
 {
   return itkDynamicCastInDebugMode<const TInputImage2 *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
@@ -51,16 +51,16 @@ ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::SetInput2(const TInp
 }
 
 template <typename TInputImage1, typename TInputImage2>
-const typename ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::InputImage1Type *
-ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::GetInput1()
+auto
+ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::GetInput1() -> const InputImage1Type *
 {
   return this->GetInput();
 }
 
 
 template <typename TInputImage1, typename TInputImage2>
-const typename ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::InputImage2Type *
-ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::GetInput2()
+auto
+ContourMeanDistanceImageFilter<TInputImage1, TInputImage2>::GetInput2() -> const InputImage2Type *
 {
   return itkDynamicCastInDebugMode<const TInputImage2 *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -66,22 +66,22 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Make
 }
 
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
-typename DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::OutputImageType *
-DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetDistanceMap()
+auto
+DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetDistanceMap() -> OutputImageType *
 {
   return dynamic_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 }
 
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
-typename DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::VoronoiImageType *
-DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVoronoiMap()
+auto
+DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVoronoiMap() -> VoronoiImageType *
 {
   return dynamic_cast<VoronoiImageType *>(this->ProcessObject::GetOutput(1));
 }
 
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
-typename DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::VectorImageType *
-DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVectorDistanceMap()
+auto
+DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVectorDistanceMap() -> VectorImageType *
 {
   return dynamic_cast<VectorImageType *>(this->ProcessObject::GetOutput(2));
 }

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -53,15 +53,15 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::SetInput2(cons
 }
 
 template <typename TInputImage1, typename TInputImage2>
-const typename DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::InputImage1Type *
-DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::GetInput1()
+auto
+DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::GetInput1() -> const InputImage1Type *
 {
   return this->GetInput();
 }
 
 template <typename TInputImage1, typename TInputImage2>
-const typename DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::InputImage2Type *
-DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::GetInput2()
+auto
+DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::GetInput2() -> const InputImage2Type *
 {
   return itkDynamicCastInDebugMode<const TInputImage2 *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -67,8 +67,8 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::SetRegionToProcess(co
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename FastChamferDistanceImageFilter<TInputImage, TOutputImage>::RegionType
-FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GetRegionToProcess() const
+auto
+FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GetRegionToProcess() const -> RegionType
 {
   return m_RegionToProcess;
 }
@@ -85,8 +85,8 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::SetNarrowBand(NarrowB
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename FastChamferDistanceImageFilter<TInputImage, TOutputImage>::NarrowBandPointer
-FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GetNarrowBand() const
+auto
+FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GetNarrowBand() const -> NarrowBandPointer
 {
   return m_NarrowBand;
 }

--- a/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.hxx
@@ -51,15 +51,15 @@ HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::SetInput2(const TInput
 }
 
 template <typename TInputImage1, typename TInputImage2>
-const typename HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::InputImage1Type *
-HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::GetInput1()
+auto
+HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::GetInput1() -> const InputImage1Type *
 {
   return this->GetInput();
 }
 
 template <typename TInputImage1, typename TInputImage2>
-const typename HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::InputImage2Type *
-HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::GetInput2()
+auto
+HausdorffDistanceImageFilter<TInputImage1, TInputImage2>::GetInput2() -> const InputImage2Type *
 {
   return itkDynamicCastInDebugMode<const TInputImage2 *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
@@ -72,8 +72,8 @@ SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>
  *  Return the distance map Image pointer
  */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
-typename SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::OutputImageType *
-SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetDistanceMap()
+auto
+SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetDistanceMap() -> OutputImageType *
 {
   return dynamic_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 }
@@ -82,8 +82,8 @@ SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>
  *  Return Closest Points Map
  */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
-typename SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::VoronoiImageType *
-SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVoronoiMap()
+auto
+SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVoronoiMap() -> VoronoiImageType *
 {
   return dynamic_cast<VoronoiImageType *>(this->ProcessObject::GetOutput(1));
 }
@@ -92,8 +92,9 @@ SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>
  *  Return the distance vectors
  */
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
-typename SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::VectorImageType *
+auto
 SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::GetVectorDistanceMap()
+  -> VectorImageType *
 {
   return dynamic_cast<VectorImageType *>(this->ProcessObject::GetOutput(2));
 }

--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.hxx
@@ -76,8 +76,8 @@ struct DispatchFFTW_Complex_New<TSelfPointer, TImage, float>
 #endif
 
 template <typename TImage>
-typename ComplexToComplexFFTImageFilter<TImage>::Pointer
-ComplexToComplexFFTImageFilter<TImage>::New()
+auto
+ComplexToComplexFFTImageFilter<TImage>::New() -> Pointer
 {
   Pointer smartPtr = ObjectFactory<Self>::Create();
 

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
@@ -63,8 +63,8 @@ struct DispatchFFTW_Forward_New<TSelfPointer, TInputImage, TOutputImage, float>
 #endif
 
 template <typename TInputImage, typename TOutputImage>
-typename ForwardFFTImageFilter<TInputImage, TOutputImage>::Pointer
-ForwardFFTImageFilter<TInputImage, TOutputImage>::New()
+auto
+ForwardFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
 {
   Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
 

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -63,8 +63,8 @@ struct Dispatch_C2R_New<TSelfPointer, TInputImage, TOutputImage, float>
 #endif
 
 template <typename TInputImage, typename TOutputImage>
-typename HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::Pointer
-HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::New()
+auto
+HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
 {
   Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
 

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
@@ -64,8 +64,8 @@ struct Dispatch_Inverse_New<TSelfPointer, TInputImage, TOutputImage, float>
 #endif
 
 template <typename TInputImage, typename TOutputImage>
-typename InverseFFTImageFilter<TInputImage, TOutputImage>::Pointer
-InverseFFTImageFilter<TInputImage, TOutputImage>::New()
+auto
+InverseFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
 {
   Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
 

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -62,8 +62,8 @@ struct DispatchFFTW_R2C_New<TSelfPointer, TInputImage, TOutputImage, float>
 #endif
 
 template <typename TInputImage, typename TOutputImage>
-typename RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::Pointer
-RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::New()
+auto
+RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
 {
   Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.hxx
@@ -55,8 +55,9 @@ FastMarchingExtensionImageFilter<TLevelSet, TAuxValue, VAuxDimension, TSpeedImag
  *
  */
 template <typename TLevelSet, typename TAuxValue, unsigned int VAuxDimension, typename TSpeedImage>
-typename FastMarchingExtensionImageFilter<TLevelSet, TAuxValue, VAuxDimension, TSpeedImage>::AuxImageType *
+auto
 FastMarchingExtensionImageFilter<TLevelSet, TAuxValue, VAuxDimension, TSpeedImage>::GetAuxiliaryImage(unsigned int idx)
+  -> AuxImageType *
 {
   if (idx >= AuxDimension || this->GetNumberOfIndexedOutputs() < idx + 2)
   {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -124,8 +124,9 @@ FastMarchingImageFilterBase<TInput, TOutput>::SetOutputValue(OutputImageType *  
 }
 
 template <typename TInput, typename TOutput>
-const typename FastMarchingImageFilterBase<TInput, TOutput>::OutputPixelType
+auto
 FastMarchingImageFilterBase<TInput, TOutput>::GetOutputValue(OutputImageType * oImage, const NodeType & iNode) const
+  -> const OutputPixelType
 {
   return oImage->GetPixel(iNode);
 }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
@@ -61,22 +61,22 @@ FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::SetForbidd
 }
 
 template <typename TInput, typename TOutput, typename TImage>
-typename FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::NodePairContainerType *
-FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::GetAlivePoints()
+auto
+FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::GetAlivePoints() -> NodePairContainerType *
 {
   return m_AlivePoints.GetPointer();
 }
 
 template <typename TInput, typename TOutput, typename TImage>
-typename FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::NodePairContainerType *
-FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::GetTrialPoints()
+auto
+FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::GetTrialPoints() -> NodePairContainerType *
 {
   return m_TrialPoints.GetPointer();
 }
 
 template <typename TInput, typename TOutput, typename TImage>
-typename FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::NodePairContainerType *
-FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::GetForbiddenPoints()
+auto
+FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::GetForbiddenPoints() -> NodePairContainerType *
 {
   return m_ForbiddenPoints.GetPointer();
 }

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
@@ -37,8 +37,8 @@ FastMarchingUpwindGradientImageFilterBase<TInput, TOutput>::FastMarchingUpwindGr
 }
 
 template <typename TInput, typename TOutput>
-typename FastMarchingUpwindGradientImageFilterBase<TInput, TOutput>::GradientImageType *
-FastMarchingUpwindGradientImageFilterBase<TInput, TOutput>::GetGradientImage()
+auto
+FastMarchingUpwindGradientImageFilterBase<TInput, TOutput>::GetGradientImage() -> GradientImageType *
 {
   return dynamic_cast<GradientImageType *>(this->ProcessObject::GetOutput(1));
 }

--- a/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
@@ -46,8 +46,8 @@ SimilarityIndexImageFilter<TInputImage1, TInputImage2>::SetInput2(const TInputIm
 }
 
 template <typename TInputImage1, typename TInputImage2>
-const typename SimilarityIndexImageFilter<TInputImage1, TInputImage2>::InputImage2Type *
-SimilarityIndexImageFilter<TInputImage1, TInputImage2>::GetInput2()
+auto
+SimilarityIndexImageFilter<TInputImage1, TInputImage2>::GetInput2() -> const InputImage2Type *
 {
   return itkDynamicCastInDebugMode<const TInputImage2 *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -103,8 +103,8 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(RealTyp
  * Get value of Sigma
  */
 template <typename TInputImage, typename TOutputImage>
-typename HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::RealType
-HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const
+auto
+HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const -> RealType
 {
   return m_DerivativeFilterA->GetSigma();
 }

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -179,8 +179,9 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
 }
 
 template <typename TInputPixelType, typename TOutputPixelType, typename TRadiusPixelType>
-typename HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPixelType>::CirclesListType &
+auto
 HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPixelType>::GetCircles()
+  -> CirclesListType &
 {
   // Make sure that all the required inputs exist and have a non-null value
   this->VerifyPreconditions();

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -218,8 +218,8 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::Simplify()
 
 
 template <typename TInputPixelType, typename TOutputPixelType>
-typename HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::LinesListType &
-HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GetLines()
+auto
+HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GetLines() -> LinesListType &
 {
   // If the filter has not been updated.
   if (this->GetMTime() == m_OldModifiedTime)

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -84,8 +84,8 @@ LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigma(RealT
  * Get value of Sigma
  */
 template <typename TInputImage, typename TOutputImage>
-typename LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::RealType
-LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const
+auto
+LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const -> RealType
 {
   return m_DerivativeFilter->GetSigma();
 }

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -334,8 +334,9 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
 /** Get the image containing the Hessian at which each pixel gave the
  * best response */
 template <typename TInputImage, typename THessianImage, typename TOutputImage>
-const typename MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImage>::HessianImageType *
+auto
 MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImage>::GetHessianOutput() const
+  -> const HessianImageType *
 {
   return static_cast<const HessianImageType *>(this->ProcessObject::GetOutput(2));
 }
@@ -344,8 +345,9 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
 /** Get the image containing the scales at which each pixel gave the
  * best response */
 template <typename TInputImage, typename THessianImage, typename TOutputImage>
-const typename MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImage>::ScalesImageType *
+auto
 MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImage>::GetScalesOutput() const
+  -> const ScalesImageType *
 {
   return static_cast<const ScalesImageType *>(this->ProcessObject::GetOutput(1));
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.hxx
@@ -71,8 +71,9 @@ BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage, TFunction>::S
 }
 
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage, typename TFunction>
-const typename BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage, TFunction>::Input1ImagePixelType &
+auto
 BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage, TFunction>::GetConstant1() const
+  -> const Input1ImagePixelType &
 {
   const auto * input = dynamic_cast<const DecoratedInput1ImagePixelType *>(this->ProcessObject::GetInput(0));
   if (input == nullptr)
@@ -118,8 +119,9 @@ BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage, TFunction>::S
 }
 
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage, typename TFunction>
-const typename BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage, TFunction>::Input2ImagePixelType &
+auto
 BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage, TFunction>::GetConstant2() const
+  -> const Input2ImagePixelType &
 {
   const auto * input = dynamic_cast<const DecoratedInput2ImagePixelType *>(this->ProcessObject::GetInput(1));
   if (input == nullptr)

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.hxx
@@ -69,8 +69,9 @@ BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>::SetConstan
 }
 
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
-const typename BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>::Input1ImagePixelType &
+auto
 BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>::GetConstant1() const
+  -> const Input1ImagePixelType &
 {
   const auto * input = dynamic_cast<const DecoratedInput1ImagePixelType *>(this->ProcessObject::GetInput(0));
   if (input == nullptr)
@@ -114,8 +115,9 @@ BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>::SetConstan
 }
 
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
-const typename BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>::Input2ImagePixelType &
+auto
 BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>::GetConstant2() const
+  -> const Input2ImagePixelType &
 {
   const auto * input = dynamic_cast<const DecoratedInput2ImagePixelType *>(this->ProcessObject::GetInput(1));
   if (input == nullptr)

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
@@ -79,8 +79,8 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::SetLabelImage(c
  * Get Label Image
  */
 template <typename TInputImage, typename TLabelImage, typename TOutputImage>
-const typename LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::LabelImageType *
-LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::GetLabelImage() const
+auto
+LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::GetLabelImage() const -> const LabelImageType *
 {
   return itkDynamicCastInDebugMode<LabelImageType *>(const_cast<DataObject *>(this->ProcessObject::GetInput(1)));
 }

--- a/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.hxx
@@ -45,8 +45,8 @@ ScalarToRGBPixelFunctor<TScalar>::ScalarToRGBPixelFunctor()
 }
 
 template <typename TScalar>
-typename ScalarToRGBPixelFunctor<TScalar>::RGBPixelType
-ScalarToRGBPixelFunctor<TScalar>::operator()(const TScalar & v) const
+auto
+ScalarToRGBPixelFunctor<TScalar>::operator()(const TScalar & v) const -> RGBPixelType
 {
   TScalar      buf = v;
   const auto * bytes = reinterpret_cast<const unsigned char *>(&buf);

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -97,8 +97,8 @@ GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSig
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::RealType
-GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma()
+auto
+GradientMagnitudeRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() -> RealType
 {
   // just return the sigma value of one filter
   return m_DerivativeFilter->GetSigma();

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -113,8 +113,8 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigmaArray(c
  * Get the Sigma array.
  */
 template <typename TInputImage, typename TOutputImage>
-typename GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SigmaArrayType
-GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigmaArray() const
+auto
+GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigmaArray() const -> SigmaArrayType
 {
   return m_Sigma;
 }
@@ -123,8 +123,8 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigmaArray()
  * Get value of Sigma. Returns the sigma along the first dimension.
  */
 template <typename TInputImage, typename TOutputImage>
-typename GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::ScalarRealType
-GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const
+auto
+GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const -> ScalarRealType
 {
   return m_Sigma[0];
 }

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -381,8 +381,9 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::SplitRequestedRegion(
 }
 
 template <typename TInputPointImage, typename TOutputImage>
-typename BSplineControlPointImageFilter<TInputPointImage, TOutputImage>::ControlPointLatticeType::Pointer
-BSplineControlPointImageFilter<TInputPointImage, TOutputImage>::RefineControlPointLattice(ArrayType numberOfLevels)
+auto
+BSplineControlPointImageFilter<TInputPointImage, TOutputImage>::RefineControlPointLattice(ArrayType numberOfLevels) ->
+  typename ControlPointLatticeType::Pointer
 {
   this->SetNumberOfLevels(numberOfLevels);
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -120,8 +120,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::SetInputImage(const In
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::OutputType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtParametricPoint(const PointType & point) const
+  -> OutputType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -133,8 +134,8 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtParametricPo
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::OutputType
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & idx) const
+auto
+BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtIndex(const IndexType & idx) const -> OutputType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -160,8 +161,8 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuousIn
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::OutputType
-BSplineControlPointImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & params) const
+auto
+BSplineControlPointImageFunction<TInputImage, TCoordRep>::Evaluate(const PointType & params) const -> OutputType
 {
   vnl_vector<CoordRepType> p(ImageDimension);
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -279,8 +280,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtPara
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::GradientType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtIndex(const IndexType & idx) const
+  -> GradientType
 {
   PointType params;
   for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -306,8 +308,9 @@ BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradientAtCont
 }
 
 template <typename TInputImage, typename TCoordRep>
-typename BSplineControlPointImageFunction<TInputImage, TCoordRep>::GradientType
+auto
 BSplineControlPointImageFunction<TInputImage, TCoordRep>::EvaluateGradient(const PointType & params) const
+  -> GradientType
 {
   vnl_vector<CoordRepType> p(ImageDimension);
   for (unsigned int i = 0; i < ImageDimension; ++i)

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
@@ -117,8 +117,8 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::CoxDeBoor(const un
 }
 
 template <unsigned int VSplineOrder, typename TRealValueType>
-typename CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::MatrixType
-CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::GetShapeFunctionsInZeroToOneInterval()
+auto
+CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::GetShapeFunctionsInZeroToOneInterval() -> MatrixType
 {
   const int  order = this->m_SplineOrder + 1;
   const auto numberOfPieces = static_cast<unsigned int>(order);
@@ -140,8 +140,8 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::GetShapeFunctionsI
 }
 
 template <unsigned int VSplineOrder, typename TRealValueType>
-typename CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::MatrixType
-CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::GetShapeFunctions()
+auto
+CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::GetShapeFunctions() -> MatrixType
 {
   return this->m_BSplineShapeFunctions;
 }

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
@@ -56,8 +56,8 @@ InterpolateImageFilter<TInputImage, TOutputImage>::SetInput2(const InputImageTyp
 
 
 template <typename TInputImage, typename TOutputImage>
-const typename InterpolateImageFilter<TInputImage, TOutputImage>::InputImageType *
-InterpolateImageFilter<TInputImage, TOutputImage>::GetInput2()
+auto
+InterpolateImageFilter<TInputImage, TOutputImage>::GetInput2() -> const InputImageType *
 {
   return static_cast<const TInputImage *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
@@ -111,8 +111,8 @@ WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::SetDisplac
 
 
 template <typename TInputImage, typename TOutputImage, typename TDisplacementField>
-typename WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::DisplacementFieldType *
-WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::GetDisplacementField()
+auto
+WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::GetDisplacementField() -> DisplacementFieldType *
 {
   return itkDynamicCastInDebugMode<DisplacementFieldType *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
@@ -35,15 +35,15 @@ Clamp<TInput, TOutput>::Clamp()
 {}
 
 template <typename TInput, typename TOutput>
-typename Clamp<TInput, TOutput>::OutputType
-Clamp<TInput, TOutput>::GetLowerBound() const
+auto
+Clamp<TInput, TOutput>::GetLowerBound() const -> OutputType
 {
   return m_LowerBound;
 }
 
 template <typename TInput, typename TOutput>
-typename Clamp<TInput, TOutput>::OutputType
-Clamp<TInput, TOutput>::GetUpperBound() const
+auto
+Clamp<TInput, TOutput>::GetUpperBound() const -> OutputType
 {
   return m_UpperBound;
 }
@@ -71,15 +71,15 @@ Clamp<TInput, TOutput>::operator==(const Self & other) const
 } // end namespace Functor
 
 template <typename TInputImage, typename TOutputImage>
-typename ClampImageFilter<TInputImage, TOutputImage>::OutputPixelType
-ClampImageFilter<TInputImage, TOutputImage>::GetLowerBound() const
+auto
+ClampImageFilter<TInputImage, TOutputImage>::GetLowerBound() const -> OutputPixelType
 {
   return this->GetFunctor().GetLowerBound();
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ClampImageFilter<TInputImage, TOutputImage>::OutputPixelType
-ClampImageFilter<TInputImage, TOutputImage>::GetUpperBound() const
+auto
+ClampImageFilter<TInputImage, TOutputImage>::GetUpperBound() const -> OutputPixelType
 {
   return this->GetFunctor().GetUpperBound();
 }

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
@@ -69,15 +69,15 @@ IntensityWindowingImageFilter<TInputImage, TOutputImage>::SetWindowLevel(const I
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename IntensityWindowingImageFilter<TInputImage, TOutputImage>::InputPixelType
-IntensityWindowingImageFilter<TInputImage, TOutputImage>::GetWindow() const
+auto
+IntensityWindowingImageFilter<TInputImage, TOutputImage>::GetWindow() const -> InputPixelType
 {
   return this->m_WindowMaximum - this->m_WindowMinimum;
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename IntensityWindowingImageFilter<TInputImage, TOutputImage>::InputPixelType
-IntensityWindowingImageFilter<TInputImage, TOutputImage>::GetLevel() const
+auto
+IntensityWindowingImageFilter<TInputImage, TOutputImage>::GetLevel() const -> InputPixelType
 {
   return (this->m_WindowMaximum + this->m_WindowMinimum) / 2;
 }

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -124,8 +124,9 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
 }
 
 template <typename TInputImage, typename TPolyline, typename TVector, typename TOutputImage>
-typename PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::ProjPlanePointType
+auto
 PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::TransformProjectPoint(PointType inputPoint)
+  -> ProjPlanePointType
 {
   PointType centered;
 

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -44,8 +44,8 @@ NoiseBaseImageFilter<TInputImage, TOutputImage>::SetSeed()
 }
 
 template <class TInputImage, class TOutputImage>
-typename NoiseBaseImageFilter<TInputImage, TOutputImage>::OutputImagePixelType
-NoiseBaseImageFilter<TInputImage, TOutputImage>::ClampCast(const double & value)
+auto
+NoiseBaseImageFilter<TInputImage, TOutputImage>::ClampCast(const double & value) -> OutputImagePixelType
 {
   if (value >= (double)NumericTraits<OutputImagePixelType>::max())
   {

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -56,8 +56,8 @@ GaussianImageSource<TOutputImage>::SetParameters(const ParametersType & paramete
 }
 
 template <typename TOutputImage>
-typename GaussianImageSource<TOutputImage>::ParametersType
-GaussianImageSource<TOutputImage>::GetParameters() const
+auto
+GaussianImageSource<TOutputImage>::GetParameters() const -> ParametersType
 {
   ParametersType parameters(2 * ArrayType::Length + 1);
   for (unsigned int i = 0; i < ArrayType::Length; ++i)

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -179,8 +179,8 @@ ImageMomentsCalculator<TImage>::Compute()
 //---------------------------------------------------------------------
 // Get sum of intensities
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::ScalarType
-ImageMomentsCalculator<TImage>::GetTotalMass() const
+auto
+ImageMomentsCalculator<TImage>::GetTotalMass() const -> ScalarType
 {
   if (!m_Valid)
   {
@@ -192,8 +192,8 @@ ImageMomentsCalculator<TImage>::GetTotalMass() const
 //--------------------------------------------------------------------
 // Get first moments about origin, in index coordinates
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::VectorType
-ImageMomentsCalculator<TImage>::GetFirstMoments() const
+auto
+ImageMomentsCalculator<TImage>::GetFirstMoments() const -> VectorType
 {
   if (!m_Valid)
   {
@@ -205,8 +205,8 @@ ImageMomentsCalculator<TImage>::GetFirstMoments() const
 //--------------------------------------------------------------------
 // Get second moments about origin, in index coordinates
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::MatrixType
-ImageMomentsCalculator<TImage>::GetSecondMoments() const
+auto
+ImageMomentsCalculator<TImage>::GetSecondMoments() const -> MatrixType
 {
   if (!m_Valid)
   {
@@ -218,8 +218,8 @@ ImageMomentsCalculator<TImage>::GetSecondMoments() const
 //--------------------------------------------------------------------
 // Get center of gravity, in physical coordinates
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::VectorType
-ImageMomentsCalculator<TImage>::GetCenterOfGravity() const
+auto
+ImageMomentsCalculator<TImage>::GetCenterOfGravity() const -> VectorType
 {
   if (!m_Valid)
   {
@@ -231,8 +231,8 @@ ImageMomentsCalculator<TImage>::GetCenterOfGravity() const
 //--------------------------------------------------------------------
 // Get second central moments, in physical coordinates
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::MatrixType
-ImageMomentsCalculator<TImage>::GetCentralMoments() const
+auto
+ImageMomentsCalculator<TImage>::GetCentralMoments() const -> MatrixType
 {
   if (!m_Valid)
   {
@@ -244,8 +244,8 @@ ImageMomentsCalculator<TImage>::GetCentralMoments() const
 //--------------------------------------------------------------------
 // Get principal moments, in physical coordinates
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::VectorType
-ImageMomentsCalculator<TImage>::GetPrincipalMoments() const
+auto
+ImageMomentsCalculator<TImage>::GetPrincipalMoments() const -> VectorType
 {
   if (!m_Valid)
   {
@@ -258,8 +258,8 @@ ImageMomentsCalculator<TImage>::GetPrincipalMoments() const
 //--------------------------------------------------------------------
 // Get principal axes, in physical coordinates
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::MatrixType
-ImageMomentsCalculator<TImage>::GetPrincipalAxes() const
+auto
+ImageMomentsCalculator<TImage>::GetPrincipalAxes() const -> MatrixType
 {
   if (!m_Valid)
   {
@@ -271,8 +271,8 @@ ImageMomentsCalculator<TImage>::GetPrincipalAxes() const
 //--------------------------------------------------------------------
 // Get principal axes to physical axes transform
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::AffineTransformPointer
-ImageMomentsCalculator<TImage>::GetPrincipalAxesToPhysicalAxesTransform() const
+auto
+ImageMomentsCalculator<TImage>::GetPrincipalAxesToPhysicalAxesTransform() const -> AffineTransformPointer
 {
   typename AffineTransformType::MatrixType matrix;
   typename AffineTransformType::OffsetType offset;
@@ -297,8 +297,8 @@ ImageMomentsCalculator<TImage>::GetPrincipalAxesToPhysicalAxesTransform() const
 // Get physical axes to principal axes transform
 
 template <typename TImage>
-typename ImageMomentsCalculator<TImage>::AffineTransformPointer
-ImageMomentsCalculator<TImage>::GetPhysicalAxesToPrincipalAxesTransform() const
+auto
+ImageMomentsCalculator<TImage>::GetPhysicalAxesToPrincipalAxesTransform() const -> AffineTransformPointer
 {
   typename AffineTransformType::MatrixType matrix;
   typename AffineTransformType::OffsetType offset;

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -158,8 +158,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::ThreadedGenerateData(const RegionT
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetTotalOverlap() const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetTotalOverlap() const -> RealType
 {
   RealType numerator = 0.0;
   RealType denominator = 0.0;
@@ -185,8 +185,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetTotalOverlap() const
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetTargetOverlap(LabelType label) const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetTargetOverlap(LabelType label) const -> RealType
 {
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
@@ -209,8 +209,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetTargetOverlap(LabelType label) 
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap() const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap() const -> RealType
 {
   RealType numerator = 0.0;
   RealType denominator = 0.0;
@@ -236,8 +236,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap() const
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap(LabelType label) const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap(LabelType label) const -> RealType
 {
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
@@ -260,24 +260,24 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap(LabelType label) c
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetMeanOverlap() const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetMeanOverlap() const -> RealType
 {
   RealType uo = this->GetUnionOverlap();
   return (2.0 * uo / (1.0 + uo));
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetMeanOverlap(LabelType label) const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetMeanOverlap(LabelType label) const -> RealType
 {
   RealType uo = this->GetUnionOverlap(label);
   return (2.0 * uo / (1.0 + uo));
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity() const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity() const -> RealType
 {
   RealType numerator = 0.0;
   RealType denominator = 0.0;
@@ -304,8 +304,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity() const
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity(LabelType label) const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity(LabelType label) const -> RealType
 {
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
@@ -320,8 +320,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity(LabelType labe
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError() const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError() const -> RealType
 {
   RealType numerator = 0.0;
   RealType denominator = 0.0;
@@ -347,8 +347,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError() const
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError(LabelType label) const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError(LabelType label) const -> RealType
 {
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())
@@ -371,8 +371,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError(LabelType la
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError() const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError() const -> RealType
 {
   RealType numerator = 0.0;
   RealType denominator = 0.0;
@@ -398,8 +398,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError() const
 }
 
 template <typename TLabelImage>
-typename LabelOverlapMeasuresImageFilter<TLabelImage>::RealType
-LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError(LabelType label) const
+auto
+LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError(LabelType label) const -> RealType
 {
   auto mapIt = this->m_LabelSetMeasures.find(label);
   if (mapIt == this->m_LabelSetMeasures.end())

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -284,8 +284,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::ThreadedStreamedGenerateDa
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::RealType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMinimum(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMinimum(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -302,8 +302,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMinimum(LabelPixelType 
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::RealType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMaximum(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMaximum(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -320,8 +320,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMaximum(LabelPixelType 
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::RealType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMean(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMean(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -338,8 +338,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMean(LabelPixelType lab
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::RealType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSum(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSum(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -356,8 +356,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSum(LabelPixelType labe
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::RealType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSigma(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSigma(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -374,8 +374,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSigma(LabelPixelType la
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::RealType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetVariance(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetVariance(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -392,8 +392,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetVariance(LabelPixelType
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::BoundingBoxType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetBoundingBox(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetBoundingBox(LabelPixelType label) const -> BoundingBoxType
 {
   MapConstIterator mapIt;
 
@@ -411,8 +411,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetBoundingBox(LabelPixelT
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::RegionType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetRegion(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetRegion(LabelPixelType label) const -> RegionType
 {
   MapConstIterator mapIt;
 
@@ -444,8 +444,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetRegion(LabelPixelType l
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::MapSizeType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetCount(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetCount(LabelPixelType label) const -> MapSizeType
 {
   MapConstIterator mapIt;
 
@@ -462,8 +462,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetCount(LabelPixelType la
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::RealType
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMedian(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMedian(LabelPixelType label) const -> RealType
 {
   RealType         median = 0.0;
   MapConstIterator mapIt;
@@ -501,8 +501,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMedian(LabelPixelType l
 }
 
 template <typename TInputImage, typename TLabelImage>
-typename LabelStatisticsImageFilter<TInputImage, TLabelImage>::HistogramPointer
-LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetHistogram(LabelPixelType label) const
+auto
+LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetHistogram(LabelPixelType label) const -> HistogramPointer
 {
   MapConstIterator mapIt;
 

--- a/Modules/Filtering/LabelMap/include/itkAttributeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeLabelObject.h
@@ -79,7 +79,7 @@ public:
   using Self = AttributeLabelObject;
   using Superclass = LabelObject<TLabel, VImageDimension>;
   using Pointer = SmartPointer<Self>;
-  using typename Superclass::LabelObjectType;
+  using LabelObjectType = typename Superclass::LabelObjectType;
   using ConstPointer = SmartPointer<const Self>;
   using ConstWeakPointer = WeakPointer<const Self>;
 

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
@@ -61,7 +61,7 @@ public:
   using PixelType = typename ImageType::PixelType;
   using IndexType = typename ImageType::IndexType;
 
-  using typename Superclass::LabelObjectType;
+  using LabelObjectType = typename Superclass::LabelObjectType;
 
   using AttributeAccessorType = TAttributeAccessor;
   using AttributeValueType = typename AttributeAccessorType::AttributeValueType;

--- a/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.hxx
@@ -37,8 +37,8 @@ ChangeLabelLabelMapFilter<TImage>::SetChangeMap(const ChangeMapType & changeMap)
 }
 
 template <typename TImage>
-const typename ChangeLabelLabelMapFilter<TImage>::ChangeMapType &
-ChangeLabelLabelMapFilter<TImage>::GetChangeMap() const
+auto
+ChangeLabelLabelMapFilter<TImage>::GetChangeMap() const -> const ChangeMapType &
 {
   return m_MapOfLabelToBeReplaced;
 }

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
@@ -116,8 +116,8 @@ LabelMap<TLabelObject>::Graft(const DataObject * data)
 
 
 template <typename TLabelObject>
-typename LabelMap<TLabelObject>::LabelObjectType *
-LabelMap<TLabelObject>::GetLabelObject(const LabelType & label)
+auto
+LabelMap<TLabelObject>::GetLabelObject(const LabelType & label) -> LabelObjectType *
 {
   if (m_BackgroundValue == label)
   {
@@ -136,8 +136,8 @@ LabelMap<TLabelObject>::GetLabelObject(const LabelType & label)
 
 
 template <typename TLabelObject>
-const typename LabelMap<TLabelObject>::LabelObjectType *
-LabelMap<TLabelObject>::GetLabelObject(const LabelType & label) const
+auto
+LabelMap<TLabelObject>::GetLabelObject(const LabelType & label) const -> const LabelObjectType *
 {
   if (m_BackgroundValue == label)
   {
@@ -164,8 +164,8 @@ LabelMap<TLabelObject>::HasLabel(const LabelType label) const
 
 
 template <typename TLabelObject>
-const typename LabelMap<TLabelObject>::LabelType &
-LabelMap<TLabelObject>::GetPixel(const IndexType & idx) const
+auto
+LabelMap<TLabelObject>::GetPixel(const IndexType & idx) const -> const LabelType &
 {
   auto end = m_LabelObjectContainer.end();
 
@@ -181,8 +181,8 @@ LabelMap<TLabelObject>::GetPixel(const IndexType & idx) const
 
 
 template <typename TLabelObject>
-typename LabelMap<TLabelObject>::LabelObjectType *
-LabelMap<TLabelObject>::GetNthLabelObject(const SizeValueType & pos)
+auto
+LabelMap<TLabelObject>::GetNthLabelObject(const SizeValueType & pos) -> LabelObjectType *
 {
   SizeValueType i = 0;
 
@@ -200,8 +200,8 @@ LabelMap<TLabelObject>::GetNthLabelObject(const SizeValueType & pos)
 
 
 template <typename TLabelObject>
-const typename LabelMap<TLabelObject>::LabelObjectType *
-LabelMap<TLabelObject>::GetNthLabelObject(const SizeValueType & pos) const
+auto
+LabelMap<TLabelObject>::GetNthLabelObject(const SizeValueType & pos) const -> const LabelObjectType *
 {
   SizeValueType i = 0;
 
@@ -370,8 +370,8 @@ LabelMap<TLabelObject>::SetLine(const IndexType & idx, const LengthType & length
 
 
 template <typename TLabelObject>
-typename LabelMap<TLabelObject>::LabelObjectType *
-LabelMap<TLabelObject>::GetLabelObject(const IndexType & idx) const
+auto
+LabelMap<TLabelObject>::GetLabelObject(const IndexType & idx) const -> LabelObjectType *
 {
   for (auto it = m_LabelObjectContainer.begin(); it != m_LabelObjectContainer.end(); ++it)
   {
@@ -496,16 +496,16 @@ LabelMap<TLabelObject>::ClearLabels()
 
 
 template <typename TLabelObject>
-typename LabelMap<TLabelObject>::SizeValueType
-LabelMap<TLabelObject>::GetNumberOfLabelObjects() const
+auto
+LabelMap<TLabelObject>::GetNumberOfLabelObjects() const -> SizeValueType
 {
   return static_cast<typename LabelMap<TLabelObject>::SizeValueType>(m_LabelObjectContainer.size());
 }
 
 
 template <typename TLabelObject>
-typename LabelMap<TLabelObject>::LabelVectorType
-LabelMap<TLabelObject>::GetLabels() const
+auto
+LabelMap<TLabelObject>::GetLabels() const -> LabelVectorType
 {
   LabelVectorType res;
 
@@ -519,8 +519,8 @@ LabelMap<TLabelObject>::GetLabels() const
 
 
 template <typename TLabelObject>
-typename LabelMap<TLabelObject>::LabelObjectVectorType
-LabelMap<TLabelObject>::GetLabelObjects() const
+auto
+LabelMap<TLabelObject>::GetLabelObjects() const -> LabelObjectVectorType
 {
   LabelObjectVectorType res;
 

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
@@ -60,7 +60,7 @@ public:
   using typename Superclass::InputImageConstPointer;
   using typename Superclass::InputImageRegionType;
   using typename Superclass::InputImagePixelType;
-  using typename Superclass::LabelObjectType;
+  using LabelObjectType = typename Superclass::LabelObjectType;
 
   using typename Superclass::OutputImageType;
   using typename Superclass::OutputImagePointer;

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -33,8 +33,8 @@ LabelObject<TLabel, VImageDimension>::LabelObject()
 }
 
 template <typename TLabel, unsigned int VImageDimension>
-typename LabelObject<TLabel, VImageDimension>::AttributeType
-LabelObject<TLabel, VImageDimension>::GetAttributeFromName(const std::string & s)
+auto
+LabelObject<TLabel, VImageDimension>::GetAttributeFromName(const std::string & s) -> AttributeType
 {
   if (s == "Label")
   {
@@ -61,8 +61,8 @@ LabelObject<TLabel, VImageDimension>::GetNameFromAttribute(const AttributeType &
  * Set/Get the label associated with that object.
  */
 template <typename TLabel, unsigned int VImageDimension>
-const typename LabelObject<TLabel, VImageDimension>::LabelType &
-LabelObject<TLabel, VImageDimension>::GetLabel() const
+auto
+LabelObject<TLabel, VImageDimension>::GetLabel() const -> const LabelType &
 {
   return m_Label;
 }
@@ -190,29 +190,29 @@ LabelObject<TLabel, VImageDimension>::AddLine(const LineType & line)
 }
 
 template <typename TLabel, unsigned int VImageDimension>
-typename LabelObject<TLabel, VImageDimension>::SizeValueType
-LabelObject<TLabel, VImageDimension>::GetNumberOfLines() const
+auto
+LabelObject<TLabel, VImageDimension>::GetNumberOfLines() const -> SizeValueType
 {
   return static_cast<typename LabelObject<TLabel, VImageDimension>::SizeValueType>(m_LineContainer.size());
 }
 
 template <typename TLabel, unsigned int VImageDimension>
-const typename LabelObject<TLabel, VImageDimension>::LineType &
-LabelObject<TLabel, VImageDimension>::GetLine(SizeValueType i) const
+auto
+LabelObject<TLabel, VImageDimension>::GetLine(SizeValueType i) const -> const LineType &
 {
   return m_LineContainer[i];
 }
 
 template <typename TLabel, unsigned int VImageDimension>
-typename LabelObject<TLabel, VImageDimension>::LineType &
-LabelObject<TLabel, VImageDimension>::GetLine(SizeValueType i)
+auto
+LabelObject<TLabel, VImageDimension>::GetLine(SizeValueType i) -> LineType &
 {
   return m_LineContainer[i];
 }
 
 template <typename TLabel, unsigned int VImageDimension>
-typename LabelObject<TLabel, VImageDimension>::SizeValueType
-LabelObject<TLabel, VImageDimension>::Size() const
+auto
+LabelObject<TLabel, VImageDimension>::Size() const -> SizeValueType
 {
   int size = 0;
 
@@ -231,8 +231,8 @@ LabelObject<TLabel, VImageDimension>::Empty() const
 }
 
 template <typename TLabel, unsigned int VImageDimension>
-typename LabelObject<TLabel, VImageDimension>::IndexType
-LabelObject<TLabel, VImageDimension>::GetIndex(SizeValueType offset) const
+auto
+LabelObject<TLabel, VImageDimension>::GetIndex(SizeValueType offset) const -> IndexType
 {
   SizeValueType o = offset;
 

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
@@ -43,8 +43,8 @@ LabelObjectLine<VImageDimension>::SetIndex(const IndexType & idx)
 }
 
 template <unsigned int VImageDimension>
-const typename LabelObjectLine<VImageDimension>::IndexType &
-LabelObjectLine<VImageDimension>::GetIndex() const
+auto
+LabelObjectLine<VImageDimension>::GetIndex() const -> const IndexType &
 {
   return m_Index;
 }
@@ -57,8 +57,8 @@ LabelObjectLine<VImageDimension>::SetLength(const LengthType length)
 }
 
 template <unsigned int VImageDimension>
-const typename LabelObjectLine<VImageDimension>::LengthType &
-LabelObjectLine<VImageDimension>::GetLength() const
+auto
+LabelObjectLine<VImageDimension>::GetLength() const -> const LengthType &
 {
   return m_Length;
 }

--- a/Modules/Filtering/LabelMap/include/itkRegionFromReferenceLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkRegionFromReferenceLabelMapFilter.hxx
@@ -54,8 +54,8 @@ RegionFromReferenceLabelMapFilter<TInputImage>::SetReferenceImage(const Referenc
 }
 
 template <typename TInputImage>
-const typename RegionFromReferenceLabelMapFilter<TInputImage>::ReferenceImageType *
-RegionFromReferenceLabelMapFilter<TInputImage>::GetReferenceImage() const
+auto
+RegionFromReferenceLabelMapFilter<TInputImage>::GetReferenceImage() const -> const ReferenceImageType *
 {
   auto * surrogate = const_cast<Self *>(this);
 

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -48,7 +48,7 @@ public:
   /** Standard class type aliases */
   using Self = ShapeLabelObject;
   using Superclass = LabelObject<TLabel, VImageDimension>;
-  using typename Superclass::LabelObjectType;
+  using LabelObjectType = typename Superclass::LabelObjectType;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   using ConstWeakPointer = WeakPointer<const Self>;

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
@@ -46,7 +46,7 @@ public:
   /** Standard class type aliases */
   using Self = StatisticsLabelObject;
   using Superclass = ShapeLabelObject<TLabel, VImageDimension>;
-  using typename Superclass::LabelObjectType;
+  using LabelObjectType = typename Superclass::LabelObjectType;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   using ConstWeakPointer = WeakPointer<const Self>;

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1247,8 +1247,9 @@ FlatStructuringElement<VDimension>::ComputeBufferFromLines()
 
 /** Check if size of input Image is odd in all dimensions, throwing exception if even */
 template <unsigned int VDimension>
-typename FlatStructuringElement<VDimension>::RadiusType
+auto
 FlatStructuringElement<VDimension>::CheckImageSize(const typename FlatStructuringElement<VDimension>::ImageType * image)
+  -> RadiusType
 {
   const RadiusType & size = image->GetLargestPossibleRegion().GetSize();
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -52,8 +52,8 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::SetMarkerImage(co
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::MarkerImageType *
-GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GetMarkerImage()
+auto
+GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GetMarkerImage() -> const MarkerImageType *
 {
   return this->GetInput(0);
 }
@@ -67,8 +67,8 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::SetMaskImage(cons
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::MaskImageType *
-GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GetMaskImage()
+auto
+GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GetMaskImage() -> const MaskImageType *
 {
   return this->GetInput(1);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -52,8 +52,8 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::SetMarkerImage(con
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::MarkerImageType *
-GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GetMarkerImage()
+auto
+GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GetMarkerImage() -> const MarkerImageType *
 {
   return this->GetInput(0);
 }
@@ -67,8 +67,8 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::SetMaskImage(const
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::MaskImageType *
-GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GetMaskImage()
+auto
+GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GetMaskImage() -> const MaskImageType *
 {
   return this->GetInput(1);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -116,8 +116,9 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
 }
 
 template <typename TInputImage, typename TMaskImage, typename TOutputImage, typename TKernel, typename THistogram>
-typename MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel, THistogram>::MaskImageType *
+auto
 MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel, THistogram>::GetOutputMask()
+  -> MaskImageType *
 {
   typename MaskImageType::Pointer res = dynamic_cast<MaskImageType *>(this->ProcessObject::GetOutput(1));
   return res;

--- a/Modules/Filtering/Path/include/itkChainCodePath.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodePath.hxx
@@ -24,8 +24,8 @@
 namespace itk
 {
 template <unsigned int VDimension>
-typename ChainCodePath<VDimension>::IndexType
-ChainCodePath<VDimension>::EvaluateToIndex(const InputType & input) const
+auto
+ChainCodePath<VDimension>::EvaluateToIndex(const InputType & input) const -> IndexType
 {
   /* We could do something fancy here, such as "secretly" store the input and
    * total offset from the last time this function was called, and use such
@@ -72,8 +72,8 @@ ChainCodePath<VDimension>::EvaluateToIndex(const InputType & input) const
 }
 
 template <unsigned int VDimension>
-typename ChainCodePath<VDimension>::OffsetType
-ChainCodePath<VDimension>::IncrementInput(InputType & input) const
+auto
+ChainCodePath<VDimension>::IncrementInput(InputType & input) const -> OffsetType
 {
   if (input < NumberOfSteps())
   {

--- a/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
+++ b/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
@@ -24,8 +24,8 @@
 namespace itk
 {
 template <unsigned int VDimension>
-typename FourierSeriesPath<VDimension>::OutputType
-FourierSeriesPath<VDimension>::Evaluate(const InputType & input) const
+auto
+FourierSeriesPath<VDimension>::Evaluate(const InputType & input) const -> OutputType
 {
   InputType  theta;
   OutputType output;
@@ -53,8 +53,8 @@ FourierSeriesPath<VDimension>::Evaluate(const InputType & input) const
 }
 
 template <unsigned int VDimension>
-typename FourierSeriesPath<VDimension>::VectorType
-FourierSeriesPath<VDimension>::EvaluateDerivative(const InputType & input) const
+auto
+FourierSeriesPath<VDimension>::EvaluateDerivative(const InputType & input) const -> VectorType
 {
   InputType  theta;
   VectorType output;

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -47,8 +47,8 @@ HilbertPath<TIndexValue, VDimension>::ConstructHilbertPath()
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::IndexType
-HilbertPath<TIndexValue, VDimension>::TransformPathIndexToMultiDimensionalIndex(const PathIndexType id)
+auto
+HilbertPath<TIndexValue, VDimension>::TransformPathIndexToMultiDimensionalIndex(const PathIndexType id) -> IndexType
 {
   PathIndexType d = 0;
   PathIndexType e = 0;
@@ -73,8 +73,9 @@ HilbertPath<TIndexValue, VDimension>::TransformPathIndexToMultiDimensionalIndex(
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
+auto
 HilbertPath<TIndexValue, VDimension>::TransformMultiDimensionalIndexToPathIndex(const IndexType & index)
+  -> PathIndexType
 {
   PathIndexType id = 0;
 
@@ -129,15 +130,17 @@ HilbertPath<TIndexValue, VDimension>::GetBitRange(const PathIndexType x,
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
+auto
 HilbertPath<TIndexValue, VDimension>::GetLeftBitRotation(PathIndexType x, PathIndexType i, const PathIndexType width)
+  -> PathIndexType
 {
   return (((x << (i % width)) | (x >> (width - (i % width)))) & ((1 << width) - 1));
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
+auto
 HilbertPath<TIndexValue, VDimension>::GetRightBitRotation(PathIndexType x, PathIndexType i, const PathIndexType width)
+  -> PathIndexType
 {
   return (((x >> (i % width)) | (x << (width - (i % width)))) & ((1 << width) - 1));
 }
@@ -160,15 +163,15 @@ HilbertPath<TIndexValue, VDimension>::SetBit(const PathIndexType x,
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
-HilbertPath<TIndexValue, VDimension>::GetGrayCode(const PathIndexType x)
+auto
+HilbertPath<TIndexValue, VDimension>::GetGrayCode(const PathIndexType x) -> PathIndexType
 {
   return (x ^ (x >> 1));
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
-HilbertPath<TIndexValue, VDimension>::GetInverseGrayCode(const PathIndexType x)
+auto
+HilbertPath<TIndexValue, VDimension>::GetInverseGrayCode(const PathIndexType x) -> PathIndexType
 {
   if (x == 0)
   {
@@ -190,8 +193,9 @@ HilbertPath<TIndexValue, VDimension>::GetInverseGrayCode(const PathIndexType x)
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
+auto
 HilbertPath<TIndexValue, VDimension>::GetTrailingSetBits(const PathIndexType x, const PathIndexType width)
+  -> PathIndexType
 {
   PathIndexType i = 0;
   PathIndexType y = x;
@@ -205,8 +209,8 @@ HilbertPath<TIndexValue, VDimension>::GetTrailingSetBits(const PathIndexType x, 
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
-HilbertPath<TIndexValue, VDimension>::GetDirection(const PathIndexType x, const PathIndexType n)
+auto
+HilbertPath<TIndexValue, VDimension>::GetDirection(const PathIndexType x, const PathIndexType n) -> PathIndexType
 {
   if (x == 0)
   {
@@ -223,8 +227,8 @@ HilbertPath<TIndexValue, VDimension>::GetDirection(const PathIndexType x, const 
 }
 
 template <typename TIndexValue, unsigned int VDimension>
-typename HilbertPath<TIndexValue, VDimension>::PathIndexType
-HilbertPath<TIndexValue, VDimension>::GetEntry(const PathIndexType x)
+auto
+HilbertPath<TIndexValue, VDimension>::GetEntry(const PathIndexType x) -> PathIndexType
 {
   if (x == 0)
   {

--- a/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.hxx
@@ -46,15 +46,15 @@ ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::SetImageInput(
 }
 
 template <typename TInputImage, typename TInputPath, typename TOutputImage>
-const typename ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::InputImageType *
-ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetImageInput()
+auto
+ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetImageInput() -> const InputImageType *
 {
   return this->GetNonConstImageInput();
 }
 
 template <typename TInputImage, typename TInputPath, typename TOutputImage>
-typename ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::InputImageType *
-ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetNonConstImageInput()
+auto
+ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetNonConstImageInput() -> InputImageType *
 {
   auto * temp_return = dynamic_cast<TInputImage *>(this->ProcessObject::GetInput(0));
   if (temp_return == nullptr)
@@ -75,15 +75,15 @@ ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::SetPathInput(c
 }
 
 template <typename TInputImage, typename TInputPath, typename TOutputImage>
-const typename ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::InputPathType *
-ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetPathInput()
+auto
+ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetPathInput() -> const InputPathType *
 {
   return this->GetNonConstPathInput();
 }
 
 template <typename TInputImage, typename TInputPath, typename TOutputImage>
-typename ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::InputPathType *
-ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetNonConstPathInput()
+auto
+ImageAndPathToImageFilter<TInputImage, TInputPath, TOutputImage>::GetNonConstPathInput() -> InputPathType *
 {
   auto * temp_return = dynamic_cast<TInputPath *>(this->ProcessObject::GetInput(1));
   if (temp_return == nullptr)

--- a/Modules/Filtering/Path/include/itkImageToPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkImageToPathFilter.hxx
@@ -60,16 +60,16 @@ ImageToPathFilter<TInputImage, TOutputPath>::SetInput(unsigned int index, const 
 
 
 template <typename TInputImage, typename TOutputPath>
-const typename ImageToPathFilter<TInputImage, TOutputPath>::InputImageType *
-ImageToPathFilter<TInputImage, TOutputPath>::GetInput()
+auto
+ImageToPathFilter<TInputImage, TOutputPath>::GetInput() -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<const TInputImage *>(this->GetPrimaryInput());
 }
 
 
 template <typename TInputImage, typename TOutputPath>
-const typename ImageToPathFilter<TInputImage, TOutputPath>::InputImageType *
-ImageToPathFilter<TInputImage, TOutputPath>::GetInput(unsigned int idx)
+auto
+ImageToPathFilter<TInputImage, TOutputPath>::GetInput(unsigned int idx) -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<const TInputImage *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/Filtering/Path/include/itkParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkParametricPath.hxx
@@ -33,8 +33,8 @@ ParametricPath<VDimension>::ParametricPath()
 }
 
 template <unsigned int VDimension>
-typename ParametricPath<VDimension>::IndexType
-ParametricPath<VDimension>::EvaluateToIndex(const InputType & input) const
+auto
+ParametricPath<VDimension>::EvaluateToIndex(const InputType & input) const -> IndexType
 {
   ContinuousIndexType continuousIndex;
   IndexType           index;
@@ -51,8 +51,8 @@ ParametricPath<VDimension>::EvaluateToIndex(const InputType & input) const
 }
 
 template <unsigned int VDimension>
-typename ParametricPath<VDimension>::OffsetType
-ParametricPath<VDimension>::IncrementInput(InputType & input) const
+auto
+ParametricPath<VDimension>::IncrementInput(InputType & input) const -> OffsetType
 {
   int        iterationCount;
   bool       tooSmall;
@@ -119,8 +119,8 @@ ParametricPath<VDimension>::IncrementInput(InputType & input) const
 }
 
 template <unsigned int VDimension>
-typename ParametricPath<VDimension>::VectorType
-ParametricPath<VDimension>::EvaluateDerivative(const InputType & input) const
+auto
+ParametricPath<VDimension>::EvaluateDerivative(const InputType & input) const -> VectorType
 {
   InputType inputStepSize;
 

--- a/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.hxx
@@ -46,8 +46,8 @@ PathAndImageToPathFilter<TInputPath, TInputImage, TOutputPath>::SetPathInput(con
 }
 
 template <typename TInputPath, typename TInputImage, typename TOutputPath>
-const typename PathAndImageToPathFilter<TInputPath, TInputImage, TOutputPath>::InputPathType *
-PathAndImageToPathFilter<TInputPath, TInputImage, TOutputPath>::GetPathInput()
+auto
+PathAndImageToPathFilter<TInputPath, TInputImage, TOutputPath>::GetPathInput() -> const InputPathType *
 {
   return itkDynamicCastInDebugMode<const TInputPath *>(this->GetPrimaryInput());
 }
@@ -63,8 +63,8 @@ PathAndImageToPathFilter<TInputPath, TInputImage, TOutputPath>::SetImageInput(co
 }
 
 template <typename TInputPath, typename TInputImage, typename TOutputPath>
-const typename PathAndImageToPathFilter<TInputPath, TInputImage, TOutputPath>::InputImageType *
-PathAndImageToPathFilter<TInputPath, TInputImage, TOutputPath>::GetImageInput()
+auto
+PathAndImageToPathFilter<TInputPath, TInputImage, TOutputPath>::GetImageInput() -> const InputImageType *
 {
   return static_cast<const TInputImage *>(this->ProcessObject::GetInput(1));
 }

--- a/Modules/Filtering/Path/include/itkPathSource.hxx
+++ b/Modules/Filtering/Path/include/itkPathSource.hxx
@@ -42,8 +42,8 @@ PathSource<TOutputPath>::PathSource()
  *
  */
 template <typename TOutputPath>
-typename PathSource<TOutputPath>::OutputPathType *
-PathSource<TOutputPath>::GetOutput()
+auto
+PathSource<TOutputPath>::GetOutput() -> OutputPathType *
 {
   return itkDynamicCastInDebugMode<TOutputPath *>(this->GetPrimaryOutput());
 }
@@ -52,8 +52,8 @@ PathSource<TOutputPath>::GetOutput()
  *
  */
 template <typename TOutputPath>
-typename PathSource<TOutputPath>::OutputPathType *
-PathSource<TOutputPath>::GetOutput(unsigned int idx)
+auto
+PathSource<TOutputPath>::GetOutput(unsigned int idx) -> OutputPathType *
 {
   return itkDynamicCastInDebugMode<TOutputPath *>(this->ProcessObject::GetOutput(idx));
 }

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -64,16 +64,16 @@ PathToImageFilter<TInputPath, TOutputImage>::SetInput(unsigned int index, const 
 
 /** Get the input Path */
 template <typename TInputPath, typename TOutputImage>
-const typename PathToImageFilter<TInputPath, TOutputImage>::InputPathType *
-PathToImageFilter<TInputPath, TOutputImage>::GetInput()
+auto
+PathToImageFilter<TInputPath, TOutputImage>::GetInput() -> const InputPathType *
 {
   return itkDynamicCastInDebugMode<const TInputPath *>(this->GetPrimaryInput());
 }
 
 /** Get the input Path */
 template <typename TInputPath, typename TOutputImage>
-const typename PathToImageFilter<TInputPath, TOutputImage>::InputPathType *
-PathToImageFilter<TInputPath, TOutputImage>::GetInput(unsigned int idx)
+auto
+PathToImageFilter<TInputPath, TOutputImage>::GetInput(unsigned int idx) -> const InputPathType *
 {
   return itkDynamicCastInDebugMode<const TInputPath *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/Filtering/Path/include/itkPathToPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToPathFilter.hxx
@@ -57,8 +57,8 @@ PathToPathFilter<TInputPath, TOutputPath>::SetInput(unsigned int index, const TI
  *
  */
 template <typename TInputPath, typename TOutputPath>
-const typename PathToPathFilter<TInputPath, TOutputPath>::InputPathType *
-PathToPathFilter<TInputPath, TOutputPath>::GetInput()
+auto
+PathToPathFilter<TInputPath, TOutputPath>::GetInput() -> const InputPathType *
 {
   return itkDynamicCastInDebugMode<const TInputPath *>(this->GetPrimaryInput());
 }
@@ -67,8 +67,8 @@ PathToPathFilter<TInputPath, TOutputPath>::GetInput()
  *
  */
 template <typename TInputPath, typename TOutputPath>
-const typename PathToPathFilter<TInputPath, TOutputPath>::InputPathType *
-PathToPathFilter<TInputPath, TOutputPath>::GetInput(unsigned int idx)
+auto
+PathToPathFilter<TInputPath, TOutputPath>::GetInput(unsigned int idx) -> const InputPathType *
 {
   return itkDynamicCastInDebugMode<const TInputPath *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/Filtering/Path/include/itkPolyLineParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkPolyLineParametricPath.hxx
@@ -26,8 +26,8 @@
 namespace itk
 {
 template <unsigned int VDimension>
-typename PolyLineParametricPath<VDimension>::OutputType
-PolyLineParametricPath<VDimension>::Evaluate(const InputType & input) const
+auto
+PolyLineParametricPath<VDimension>::Evaluate(const InputType & input) const -> OutputType
 {
   // Handle the endpoint carefully, since there is no following vertex
   const auto endPoint = static_cast<InputType>(m_VertexList->Size() - 1);
@@ -56,8 +56,8 @@ PolyLineParametricPath<VDimension>::Evaluate(const InputType & input) const
 }
 
 template <unsigned int VDimension>
-typename PolyLineParametricPath<VDimension>::VectorType
-PolyLineParametricPath<VDimension>::EvaluateDerivative(const InputType & input) const
+auto
+PolyLineParametricPath<VDimension>::EvaluateDerivative(const InputType & input) const -> VectorType
 {
   // Get next integral time-point
   const InputType nextTimepoint = std::min(std::floor(input + 1.0), this->EndOfInput());
@@ -80,8 +80,8 @@ PolyLineParametricPath<VDimension>::EvaluateDerivative(const InputType & input) 
 }
 
 template <unsigned int VDimension>
-typename PolyLineParametricPath<VDimension>::OffsetType
-PolyLineParametricPath<VDimension>::IncrementInput(InputType & input) const
+auto
+PolyLineParametricPath<VDimension>::IncrementInput(InputType & input) const -> OffsetType
 {
   // Save this input index since we will use it to calculate the offset
   const IndexType originalIndex = this->EvaluateToIndex(input);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -33,16 +33,16 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::BorderQuadEdgeMeshFilter()
 
 // ----------------------------------------------------------------------------
 template <typename TInputMesh, typename TOutputMesh>
-typename BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::MapPointIdentifier
-BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetBoundaryPtMap()
+auto
+BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetBoundaryPtMap() -> MapPointIdentifier
 {
   return this->m_BoundaryPtMap;
 }
 
 // ----------------------------------------------------------------------------
 template <typename TInputMesh, typename TOutputMesh>
-typename BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::InputVectorPointType
-BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetBorder()
+auto
+BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetBorder() -> InputVectorPointType
 {
   return this->m_Border;
 }
@@ -93,8 +93,8 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
 // *** under testing ***
 #if !defined(ITK_WRAPPING_PARSER)
 template <typename TInputMesh, typename TOutputMesh>
-typename BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::InputQEType *
-BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLongestBorder()
+auto
+BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLongestBorder() -> InputQEType *
 {
   BoundaryRepresentativeEdgesPointer boundaryRepresentativeEdges = BoundaryRepresentativeEdgesType::New();
 
@@ -143,8 +143,8 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLongestBorder()
 // ----------------------------------------------------------------------------
 #if !defined(ITK_WRAPPING_PARSER)
 template <typename TInputMesh, typename TOutputMesh>
-typename BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::InputQEType *
-BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLargestBorder()
+auto
+BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeLargestBorder() -> InputQEType *
 {
   BoundaryRepresentativeEdgesPointer boundaryRepresentativeEdges = BoundaryRepresentativeEdgesType::New();
 
@@ -254,8 +254,8 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::DiskTransform()
 
 // ----------------------------------------------------------------------------
 template <typename TInputMesh, typename TOutputMesh>
-typename BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::InputCoordRepType
-BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::RadiusMaxSquare()
+auto
+BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::RadiusMaxSquare() -> InputCoordRepType
 {
   InputMeshConstPointer input = this->GetInput();
 
@@ -281,8 +281,8 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::RadiusMaxSquare()
 
 // ----------------------------------------------------------------------------
 template <typename TInputMesh, typename TOutputMesh>
-typename BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::InputPointType
-BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetMeshBarycentre()
+auto
+BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetMeshBarycentre() -> InputPointType
 {
   InputMeshConstPointer input = this->GetInput();
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
@@ -30,8 +30,8 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::NormalQuadEdgeMeshFilter()
 }
 
 template <typename TInputMesh, typename TOutputMesh>
-typename NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::OutputFaceNormalType
-NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeFaceNormal(OutputPolygonType * iPoly)
+auto
+NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeFaceNormal(OutputPolygonType * iPoly) -> OutputFaceNormalType
 {
   OutputMeshPointer output = this->GetOutput();
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.hxx
@@ -67,8 +67,8 @@ QuadricDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::DeletePoint(
 }
 
 template <typename TInput, typename TOutput, typename TCriterion>
-typename QuadricDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::OutputPointType
-QuadricDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::Relocate(OutputQEType * iEdge)
+auto
+QuadricDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::Relocate(OutputQEType * iEdge) -> OutputPointType
 {
   OutputPointIdentifier id_org = iEdge->GetOrigin();
   OutputPointIdentifier id_dest = iEdge->GetDestination();

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilter.hxx
@@ -29,8 +29,9 @@ SquaredEdgeLengthDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::
 {}
 
 template <typename TInput, typename TOutput, typename TCriterion>
-typename SquaredEdgeLengthDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::OutputPointType
+auto
 SquaredEdgeLengthDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::Relocate(OutputQEType * iEdge)
+  -> OutputPointType
 {
   OutputMeshPointer     output = this->GetOutput();
   OutputPointIdentifier id_org = iEdge->GetOrigin();

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
@@ -137,16 +137,16 @@ SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetSigmaArray(
 
 
 template <typename TInputImage, typename TOutputImage>
-typename SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SigmaArrayType
-SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigmaArray() const
+auto
+SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigmaArray() const -> SigmaArrayType
 {
   return m_Sigma;
 }
 
 
 template <typename TInputImage, typename TOutputImage>
-typename SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::ScalarRealType
-SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const
+auto
+SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GetSigma() const -> ScalarRealType
 {
   return m_Sigma[0];
 }

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.hxx
@@ -86,8 +86,8 @@ BinaryThresholdImageFilter<TInputImage, TOutputImage>::SetLowerThresholdInput(co
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename BinaryThresholdImageFilter<TInputImage, TOutputImage>::InputPixelType
-BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetLowerThreshold() const
+auto
+BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetLowerThreshold() const -> InputPixelType
 {
   typename InputPixelObjectType::Pointer lower = const_cast<Self *>(this)->GetLowerThresholdInput();
 
@@ -95,8 +95,8 @@ BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetLowerThreshold() const
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename BinaryThresholdImageFilter<TInputImage, TOutputImage>::InputPixelObjectType *
-BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetLowerThresholdInput()
+auto
+BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetLowerThresholdInput() -> InputPixelObjectType *
 {
   typename InputPixelObjectType::Pointer lower = static_cast<InputPixelObjectType *>(this->ProcessObject::GetInput(1));
   if (!lower)
@@ -112,8 +112,8 @@ BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetLowerThresholdInput()
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename BinaryThresholdImageFilter<TInputImage, TOutputImage>::InputPixelObjectType *
-BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetLowerThresholdInput() const
+auto
+BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetLowerThresholdInput() const -> const InputPixelObjectType *
 {
   typename InputPixelObjectType::Pointer lower =
     const_cast<InputPixelObjectType *>(static_cast<const InputPixelObjectType *>(this->ProcessObject::GetInput(1)));
@@ -165,8 +165,8 @@ BinaryThresholdImageFilter<TInputImage, TOutputImage>::SetUpperThresholdInput(co
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename BinaryThresholdImageFilter<TInputImage, TOutputImage>::InputPixelType
-BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetUpperThreshold() const
+auto
+BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetUpperThreshold() const -> InputPixelType
 {
   typename InputPixelObjectType::Pointer upper = const_cast<Self *>(this)->GetUpperThresholdInput();
 
@@ -174,8 +174,8 @@ BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetUpperThreshold() const
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename BinaryThresholdImageFilter<TInputImage, TOutputImage>::InputPixelObjectType *
-BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetUpperThresholdInput()
+auto
+BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetUpperThresholdInput() -> InputPixelObjectType *
 {
   typename InputPixelObjectType::Pointer upper = static_cast<InputPixelObjectType *>(this->ProcessObject::GetInput(2));
   if (!upper)
@@ -191,8 +191,8 @@ BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetUpperThresholdInput()
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename BinaryThresholdImageFilter<TInputImage, TOutputImage>::InputPixelObjectType *
-BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetUpperThresholdInput() const
+auto
+BinaryThresholdImageFilter<TInputImage, TOutputImage>::GetUpperThresholdInput() const -> const InputPixelObjectType *
 {
   typename InputPixelObjectType::Pointer upper =
     const_cast<InputPixelObjectType *>(static_cast<const InputPixelObjectType *>(this->ProcessObject::GetInput(2)));

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
@@ -101,8 +101,8 @@ KappaSigmaThresholdImageCalculator<TInputImage, TMaskImage>::Compute()
 }
 
 template <typename TInputImage, typename TMaskImage>
-const typename KappaSigmaThresholdImageCalculator<TInputImage, TMaskImage>::InputPixelType &
-KappaSigmaThresholdImageCalculator<TInputImage, TMaskImage>::GetOutput() const
+auto
+KappaSigmaThresholdImageCalculator<TInputImage, TMaskImage>::GetOutput() const -> const InputPixelType &
 {
   if (!this->m_Valid)
   {

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -32,8 +32,8 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::OtsuMultipleThresholdsCalcula
 }
 
 template <typename TInputHistogram>
-const typename OtsuMultipleThresholdsCalculator<TInputHistogram>::OutputType &
-OtsuMultipleThresholdsCalculator<TInputHistogram>::GetOutput()
+auto
+OtsuMultipleThresholdsCalculator<TInputHistogram>::GetOutput() -> const OutputType &
 {
   return m_Output;
 }

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
@@ -27,15 +27,15 @@ namespace itk
 {
 
 template <typename TData>
-typename CSVArray2DDataObject<TData>::StringVectorType
-CSVArray2DDataObject<TData>::GetColumnHeaders() const
+auto
+CSVArray2DDataObject<TData>::GetColumnHeaders() const -> StringVectorType
 {
   return this->m_ColumnHeaders;
 }
 
 template <typename TData>
-typename CSVArray2DDataObject<TData>::StringVectorType
-CSVArray2DDataObject<TData>::GetRowHeaders() const
+auto
+CSVArray2DDataObject<TData>::GetRowHeaders() const -> StringVectorType
 {
   return this->m_RowHeaders;
 }
@@ -79,8 +79,8 @@ CSVArray2DDataObject<TData>::GetColumnIndexByName(const std::string & column_nam
 }
 
 template <typename TData>
-typename CSVArray2DDataObject<TData>::NumericVectorType
-CSVArray2DDataObject<TData>::GetRow(const unsigned int & row_index) const
+auto
+CSVArray2DDataObject<TData>::GetRow(const unsigned int & row_index) const -> NumericVectorType
 {
   NumericVectorType row;
   unsigned int      max_rows = this->m_Matrix.rows() - 1;
@@ -97,8 +97,8 @@ CSVArray2DDataObject<TData>::GetRow(const unsigned int & row_index) const
 }
 
 template <typename TData>
-typename CSVArray2DDataObject<TData>::NumericVectorType
-CSVArray2DDataObject<TData>::GetRow(const std::string & row_name) const
+auto
+CSVArray2DDataObject<TData>::GetRow(const std::string & row_name) const -> NumericVectorType
 {
   NumericVectorType row;
   unsigned int      index = this->GetRowIndexByName(row_name);
@@ -107,8 +107,8 @@ CSVArray2DDataObject<TData>::GetRow(const std::string & row_name) const
 }
 
 template <typename TData>
-typename CSVArray2DDataObject<TData>::NumericVectorType
-CSVArray2DDataObject<TData>::GetColumn(const unsigned int & column_index) const
+auto
+CSVArray2DDataObject<TData>::GetColumn(const unsigned int & column_index) const -> NumericVectorType
 {
   NumericVectorType column;
   unsigned int      max_columns = this->m_Matrix.columns() - 1;
@@ -125,8 +125,8 @@ CSVArray2DDataObject<TData>::GetColumn(const unsigned int & column_index) const
 }
 
 template <typename TData>
-typename CSVArray2DDataObject<TData>::NumericVectorType
-CSVArray2DDataObject<TData>::GetColumn(const std::string & column_name) const
+auto
+CSVArray2DDataObject<TData>::GetColumn(const std::string & column_name) const -> NumericVectorType
 {
   NumericVectorType column;
   unsigned int      index = this->GetColumnIndexByName(column_name);

--- a/Modules/IO/CSV/include/itkCSVArray2DFileReader.hxx
+++ b/Modules/IO/CSV/include/itkCSVArray2DFileReader.hxx
@@ -132,8 +132,8 @@ CSVArray2DFileReader<TData>::Update()
 
 /** Get the output */
 template <typename TData>
-typename CSVArray2DFileReader<TData>::Array2DDataObjectPointer
-CSVArray2DFileReader<TData>::GetOutput()
+auto
+CSVArray2DFileReader<TData>::GetOutput() -> Array2DDataObjectPointer
 {
   return this->GetModifiableArray2DDataObject();
 }

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -47,16 +47,16 @@ ImageFileWriter<TInputImage>::SetInput(const InputImageType * input)
 
 //---------------------------------------------------------
 template <typename TInputImage>
-const typename ImageFileWriter<TInputImage>::InputImageType *
-ImageFileWriter<TInputImage>::GetInput()
+auto
+ImageFileWriter<TInputImage>::GetInput() -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<TInputImage *>(this->GetPrimaryInput());
 }
 
 //---------------------------------------------------------
 template <typename TInputImage>
-const typename ImageFileWriter<TInputImage>::InputImageType *
-ImageFileWriter<TInputImage>::GetInput(unsigned int idx)
+auto
+ImageFileWriter<TInputImage>::GetInput(unsigned int idx) -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<TInputImage *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -495,8 +495,8 @@ ImageSeriesReader<TOutputImage>::GenerateData()
 }
 
 template <typename TOutputImage>
-typename ImageSeriesReader<TOutputImage>::DictionaryArrayRawPointer
-ImageSeriesReader<TOutputImage>::GetMetaDataDictionaryArray() const
+auto
+ImageSeriesReader<TOutputImage>::GetMetaDataDictionaryArray() const -> DictionaryArrayRawPointer
 {
   // this warning has been introduced in 3.17 due to a change in
   // behavior. It may be removed in the future.

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -51,16 +51,16 @@ ImageSeriesWriter<TInputImage, TOutputImage>::SetInput(const InputImageType * in
 
 //---------------------------------------------------------
 template <typename TInputImage, typename TOutputImage>
-const typename ImageSeriesWriter<TInputImage, TOutputImage>::InputImageType *
-ImageSeriesWriter<TInputImage, TOutputImage>::GetInput()
+auto
+ImageSeriesWriter<TInputImage, TOutputImage>::GetInput() -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<TInputImage *>(this->GetPrimaryInput());
 }
 
 //---------------------------------------------------------
 template <typename TInputImage, typename TOutputImage>
-const typename ImageSeriesWriter<TInputImage, TOutputImage>::InputImageType *
-ImageSeriesWriter<TInputImage, TOutputImage>::GetInput(unsigned int idx)
+auto
+ImageSeriesWriter<TInputImage, TOutputImage>::GetInput(unsigned int idx) -> const InputImageType *
 {
   return itkDynamicCastInDebugMode<TInputImage *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -47,8 +47,8 @@ MeshFileWriter<TInputMesh>::SetInput(const InputMeshType * input)
 }
 
 template <typename TInputMesh>
-const typename MeshFileWriter<TInputMesh>::InputMeshType *
-MeshFileWriter<TInputMesh>::GetInput()
+auto
+MeshFileWriter<TInputMesh>::GetInput() -> const InputMeshType *
 {
   if (this->GetNumberOfInputs() < 1)
   {
@@ -59,8 +59,8 @@ MeshFileWriter<TInputMesh>::GetInput()
 }
 
 template <typename TInputMesh>
-const typename MeshFileWriter<TInputMesh>::InputMeshType *
-MeshFileWriter<TInputMesh>::GetInput(unsigned int idx)
+auto
+MeshFileWriter<TInputMesh>::GetInput(unsigned int idx) -> const InputMeshType *
 {
   return static_cast<TInputMesh *>(this->ProcessObject::GetInput(idx));
 }

--- a/Modules/IO/XML/include/itkDOMReader.hxx
+++ b/Modules/IO/XML/include/itkDOMReader.hxx
@@ -61,16 +61,16 @@ DOMReader<TOutput>::SetOutput(OutputType * output)
 
 /** Get the output object for full access. */
 template <typename TOutput>
-typename DOMReader<TOutput>::OutputType *
-DOMReader<TOutput>::GetOutput()
+auto
+DOMReader<TOutput>::GetOutput() -> OutputType *
 {
   return this->m_Output;
 }
 
 /** Get the output object for read-only access. */
 template <typename TOutput>
-const typename DOMReader<TOutput>::OutputType *
-DOMReader<TOutput>::GetOutput() const
+auto
+DOMReader<TOutput>::GetOutput() const -> const OutputType *
 {
   return this->m_Output;
 }

--- a/Modules/IO/XML/include/itkDOMWriter.hxx
+++ b/Modules/IO/XML/include/itkDOMWriter.hxx
@@ -59,8 +59,8 @@ DOMWriter<TInput>::SetInput(const InputType * input)
 
 /** Get the input object to be written. */
 template <typename TInput>
-const typename DOMWriter<TInput>::InputType *
-DOMWriter<TInput>::GetInput() const
+auto
+DOMWriter<TInput>::GetInput() const -> const InputType *
 {
   return this->m_Input;
 }

--- a/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -158,8 +158,9 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
 
 /** Evaluate the function at the specified index */
 template <typename TInputImage, typename TOutput>
-typename DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::OutputType
+auto
 DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType & index) const
+  -> OutputType
 {
   OutputType derivative;
 
@@ -172,8 +173,8 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtIndex(c
 
 /** Evaluate the function at the specified point */
 template <typename TInputImage, typename TOutput>
-typename DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::OutputType
-DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::Evaluate(const PointType & point) const
+auto
+DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::Evaluate(const PointType & point) const -> OutputType
 {
   if (m_InterpolationMode == InterpolationModeEnum::NearestNeighbourInterpolation)
   {

--- a/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -179,8 +179,9 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
 
 /** Evaluate the function at the specified index */
 template <typename TInputImage, typename TOutput>
-typename DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::OutputType
+auto
 DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType & index) const
+  -> OutputType
 {
   OutputType gradientMagnitude = itk::NumericTraits<OutputType>::ZeroValue();
   OutputType temp;
@@ -205,8 +206,9 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::EvaluateAt
 
 /** Evaluate the function at the specified point */
 template <typename TInputImage, typename TOutput>
-typename DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::OutputType
+auto
 DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::Evaluate(const PointType & point) const
+  -> OutputType
 {
   if (m_InterpolationMode == InterpolationModeEnum::NearestNeighbourInterpolation)
   {

--- a/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -189,8 +189,8 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
 
 /** Evaluate the function at the specified index */
 template <typename TInputImage, typename TOutput>
-typename DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::OutputType
-DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType & index) const
+auto
+DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType & index) const -> OutputType
 {
   OutputType hessian;
 
@@ -204,8 +204,8 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::EvaluateAtIndex(cons
 
 /** Evaluate the function at the specified point */
 template <typename TInputImage, typename TOutput>
-typename DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::OutputType
-DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::Evaluate(const PointType & point) const
+auto
+DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::Evaluate(const PointType & point) const -> OutputType
 {
   if (m_InterpolationMode == InterpolationModeEnum::NearestNeighbourInterpolation)
   {

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -575,8 +575,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::CalculateOrientedBoundin
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelIndicesType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetPixelIndices(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetPixelIndices(LabelPixelType label) const -> LabelIndicesType
 {
   MapConstIterator mapIt;
 
@@ -613,8 +613,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetVolume(LabelPixelType
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RealType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetIntegratedIntensity(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetIntegratedIntensity(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -631,8 +631,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetIntegratedIntensity(L
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelPointType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetCentroid(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetCentroid(LabelPixelType label) const -> LabelPointType
 {
   MapConstIterator mapIt;
 
@@ -651,8 +651,9 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetCentroid(LabelPixelTy
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelPointType
+auto
 LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetWeightedCentroid(LabelPixelType label) const
+  -> LabelPointType
 {
   MapConstIterator mapIt;
 
@@ -671,8 +672,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetWeightedCentroid(Labe
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::VectorType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEigenvalues(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEigenvalues(LabelPixelType label) const -> VectorType
 {
   MapConstIterator mapIt;
 
@@ -690,8 +691,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEigenvalues(LabelPixe
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::MatrixType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEigenvectors(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEigenvectors(LabelPixelType label) const -> MatrixType
 {
   MapConstIterator mapIt;
 
@@ -709,8 +710,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEigenvectors(LabelPix
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::AxesLengthType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetAxesLength(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetAxesLength(LabelPixelType label) const -> AxesLengthType
 {
   MapConstIterator mapIt;
 
@@ -729,8 +730,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetAxesLength(LabelPixel
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RealType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetMinorAxisLength(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetMinorAxisLength(LabelPixelType label) const -> RealType
 {
   AxesLengthType axisLength = GetAxesLength(label);
 
@@ -738,8 +739,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetMinorAxisLength(Label
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RealType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetMajorAxisLength(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetMajorAxisLength(LabelPixelType label) const -> RealType
 {
   AxesLengthType axisLength = GetAxesLength(label);
 
@@ -747,8 +748,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetMajorAxisLength(Label
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RealType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEccentricity(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEccentricity(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -765,8 +766,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetEccentricity(LabelPix
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RealType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetElongation(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetElongation(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -783,8 +784,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetElongation(LabelPixel
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RealType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientation(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientation(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -801,8 +802,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientation(LabelPixe
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::BoundingBoxType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBox(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBox(LabelPixelType label) const -> BoundingBoxType
 {
   MapConstIterator mapIt;
 
@@ -821,8 +822,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBox(LabelPixe
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RealType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxVolume(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxVolume(LabelPixelType label) const -> RealType
 {
   MapConstIterator mapIt;
 
@@ -839,8 +840,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxVolume(Lab
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelSizeType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxSize(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxSize(LabelPixelType label) const -> LabelSizeType
 {
   MapConstIterator mapIt;
 
@@ -859,8 +860,9 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetBoundingBoxSize(Label
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::BoundingBoxVerticesType
+auto
 LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxVertices(LabelPixelType label) const
+  -> BoundingBoxVerticesType
 {
   unsigned int     numberOfVertices = 1 << ImageDimension;
   MapConstIterator mapIt = m_LabelGeometryMapper.find(label);
@@ -880,8 +882,9 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxVe
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RealType
+auto
 LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxVolume(LabelPixelType label) const
+  -> RealType
 {
   MapConstIterator mapIt;
 
@@ -898,8 +901,9 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxVo
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelPointType
+auto
 LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxSize(LabelPixelType label) const
+  -> LabelPointType
 {
   MapConstIterator mapIt;
 
@@ -921,8 +925,9 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxSi
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelPointType
+auto
 LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxOrigin(LabelPixelType label) const
+  -> LabelPointType
 {
   MapConstIterator mapIt;
 
@@ -941,8 +946,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetOrientedBoundingBoxOr
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::MatrixType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetRotationMatrix(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetRotationMatrix(LabelPixelType label) const -> MatrixType
 {
   MapConstIterator mapIt;
 
@@ -960,8 +965,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetRotationMatrix(LabelP
 }
 
 template <typename TLabelImage, typename TIntensityImage>
-typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::RegionType
-LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetRegion(LabelPixelType label) const
+auto
+LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GetRegion(LabelPixelType label) const -> RegionType
 {
   MapConstIterator mapIt;
 

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -56,8 +56,8 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::RegionBasedLevelSetF
 }
 
 template <typename TInput, typename TFeature, typename TSharedData>
-typename RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::VectorType
-RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::InitializeZeroVectorConstant()
+auto
+RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::InitializeZeroVectorConstant() -> VectorType
 {
   VectorType ans;
 
@@ -126,8 +126,9 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::UpdateSharedData(boo
 }
 
 template <typename TInput, typename TFeature, typename TSharedData>
-typename RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::TimeStepType
+auto
 RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeGlobalTimeStep(void * GlobalData) const
+  -> TimeStepType
 {
   /* Computing the time-step for stable curve evolution */
 
@@ -325,8 +326,8 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const 
 }
 
 template <typename TInput, typename TFeature, typename TSharedData>
-typename RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ScalarValueType
-RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeLaplacian(GlobalDataStruct * gd)
+auto
+RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeLaplacian(GlobalDataStruct * gd) -> ScalarValueType
 {
   ScalarValueType laplacian = 0.;
 
@@ -340,8 +341,8 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeLaplacian(Glo
 }
 
 template <typename TInput, typename TFeature, typename TSharedData>
-typename RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ScalarValueType
-RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeVolumeRegularizationTerm()
+auto
+RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeVolumeRegularizationTerm() -> ScalarValueType
 {
   return 2 *
          (this->m_SharedData->m_LevelSetDataPointerVector[this->m_FunctionId]->m_WeightedNumberOfPixelsInsideLevelSet -

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
@@ -56,8 +56,9 @@ RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::CreateHeavisideFunc
 }
 
 template <typename TInputImage, typename TFeatureImage>
-typename RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::InputIndexType
+auto
 RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::GetIndex(const FeatureIndexType & featureIndex)
+  -> InputIndexType
 {
   InputIndexType index;
 
@@ -70,8 +71,9 @@ RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::GetIndex(const Feat
 }
 
 template <typename TInputImage, typename TFeatureImage>
-typename RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::FeatureIndexType
+auto
 RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::GetFeatureIndex(const InputIndexType & inputIndex)
+  -> FeatureIndexType
 {
   FeatureIndexType index;
 

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
@@ -62,8 +62,8 @@ RobustAutomaticThresholdCalculator<TInputImage, TGradientImage>::Compute()
 }
 
 template <typename TInputImage, typename TGradientImage>
-const typename RobustAutomaticThresholdCalculator<TInputImage, TGradientImage>::InputPixelType &
-RobustAutomaticThresholdCalculator<TInputImage, TGradientImage>::GetOutput() const
+auto
+RobustAutomaticThresholdCalculator<TInputImage, TGradientImage>::GetOutput() const -> const InputPixelType &
 {
   if (!m_Valid)
   {

--- a/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
@@ -47,8 +47,9 @@ StochasticFractalDimensionImageFilter<TInputImage, TMaskImage, TOutputImage>::Se
 }
 
 template <typename TInputImage, typename TMaskImage, typename TOutputImage>
-const typename StochasticFractalDimensionImageFilter<TInputImage, TMaskImage, TOutputImage>::MaskImageType *
+auto
 StochasticFractalDimensionImageFilter<TInputImage, TMaskImage, TOutputImage>::GetMaskImage() const
+  -> const MaskImageType *
 {
   const auto * maskImage = dynamic_cast<const MaskImageType *>(this->ProcessObject::GetInput(1));
 

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -74,8 +74,9 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Se
  * Get the largest eigenvalue considering the sign
  */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
-typename EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::EigenValueImageType *
+auto
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::GetMaxEigenValue()
+  -> EigenValueImageType *
 {
   return dynamic_cast<EigenValueImageType *>(this->ProcessObject::GetOutput(0));
 }
@@ -84,8 +85,9 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
  * Get the smallest eigenvalue considering the sign
  */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
-typename EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::EigenValueImageType *
+auto
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::GetMinEigenValue()
+  -> EigenValueImageType *
 {
   return dynamic_cast<EigenValueImageType *>(this->ProcessObject::GetOutput(1));
 }
@@ -94,8 +96,9 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
  * Get the eigenvector corresponding to the largest eigenvalue (considering the sign)
  */
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>
-typename EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::EigenVectorImageType *
+auto
 EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::GetMaxEigenVector()
+  -> EigenVectorImageType *
 {
   auto * eigenVector = dynamic_cast<EigenVectorImageType *>(this->ProcessObject::GetOutput(2));
 

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
@@ -141,8 +141,8 @@ ImageMetricLoad<TMoving, TFixed>::ImageMetricLoad()
 }
 
 template <typename TMoving, typename TFixed>
-typename ImageMetricLoad<TMoving, TFixed>::Float
-ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution(Element::ArrayType * element, Float step)
+auto
+ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution(Element::ArrayType * element, Float step) -> Float
 {
   Float energy = 0.0, defe = 0.0;
 
@@ -209,8 +209,8 @@ ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution(Element::ArrayType
 }
 
 template <typename TMoving, typename TFixed>
-typename ImageMetricLoad<TMoving, TFixed>::Float
-ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution1(Element::ArrayType * element, Float step)
+auto
+ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution1(Element::ArrayType * element, Float step) -> Float
 {
   Float energy = 0.0, defe = 0.0;
 
@@ -276,8 +276,8 @@ ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution1(Element::ArrayTyp
 }
 
 template <typename TMoving, typename TFixed>
-typename ImageMetricLoad<TMoving, TFixed>::VectorType
-ImageMetricLoad<TMoving, TFixed>::Fe(VectorType Gpos, VectorType Gsol)
+auto
+ImageMetricLoad<TMoving, TFixed>::Fe(VectorType Gpos, VectorType Gsol) -> VectorType
 {
   // We assume the vector input is of size 2*ImageDimension.
   // The 0 to ImageDimension-1 elements contain the position, p,
@@ -392,8 +392,8 @@ ImageMetricLoad<TMoving, TFixed>::Fe(VectorType Gpos, VectorType Gsol)
 }
 
 template <typename TMoving, typename TFixed>
-typename ImageMetricLoad<TMoving, TFixed>::Float
-ImageMetricLoad<TMoving, TFixed>::GetMetric(VectorType InVec)
+auto
+ImageMetricLoad<TMoving, TFixed>::GetMetric(VectorType InVec) -> Float
 {
   // We assume the vector input is of size 2*ImageDimension.
   // The 0 to ImageDimension-1 elements contain the position, p,
@@ -491,8 +491,8 @@ ImageMetricLoad<TMoving, TFixed>::GetMetric(VectorType InVec)
 }
 
 template <typename TMoving, typename TFixed>
-typename ImageMetricLoad<TMoving, TFixed>::VectorType
-ImageMetricLoad<TMoving, TFixed>::MetricFiniteDiff(VectorType Gpos, VectorType Gsol)
+auto
+ImageMetricLoad<TMoving, TFixed>::MetricFiniteDiff(VectorType Gpos, VectorType Gsol) -> VectorType
 {
   typename MetricBaseType::MeasureType measure;
 
@@ -590,8 +590,8 @@ ImageMetricLoad<TMoving, TFixed>::MetricFiniteDiff(VectorType Gpos, VectorType G
 }
 
 template <typename TMoving, typename TFixed>
-typename ImageMetricLoad<TMoving, TFixed>::VectorType
-ImageMetricLoad<TMoving, TFixed>::GetPolynomialFitToMetric(VectorType Gpos, VectorType Gsol)
+auto
+ImageMetricLoad<TMoving, TFixed>::GetPolynomialFitToMetric(VectorType Gpos, VectorType Gsol) -> VectorType
 {
   // discrete orthogonal polynomial fitting
   // see p.394-403 haralick computer and robot vision

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -83,8 +83,8 @@ Solver<VDimension>::SetInput(unsigned int index, FEMObjectType * fem)
 }
 
 template <unsigned int VDimension>
-typename Solver<VDimension>::FEMObjectType *
-Solver<VDimension>::GetInput()
+auto
+Solver<VDimension>::GetInput() -> FEMObjectType *
 {
   if (this->GetNumberOfInputs() < 1)
   {
@@ -95,15 +95,15 @@ Solver<VDimension>::GetInput()
 }
 
 template <unsigned int VDimension>
-typename Solver<VDimension>::FEMObjectType *
-Solver<VDimension>::GetInput(unsigned int idx)
+auto
+Solver<VDimension>::GetInput(unsigned int idx) -> FEMObjectType *
 {
   return itkDynamicCastInDebugMode<FEMObjectType *>(this->ProcessObject::GetInput(idx));
 }
 
 template <unsigned int VDimension>
-typename Solver<VDimension>::Float
-Solver<VDimension>::GetTimeStep() const
+auto
+Solver<VDimension>::GetTimeStep() const -> Float
 {
   return NumericTraits<Float>::ZeroValue();
 }
@@ -114,22 +114,22 @@ Solver<VDimension>::SetTimeStep(Float itkNotUsed(dt))
 {}
 
 template <unsigned int VDimension>
-typename Solver<VDimension>::Float
-Solver<VDimension>::GetSolution(unsigned int i, unsigned int which)
+auto
+Solver<VDimension>::GetSolution(unsigned int i, unsigned int which) -> Float
 {
   return this->m_LinearSystem->GetSolutionValue(i, which);
 }
 
 template <unsigned int VDimension>
-typename Solver<VDimension>::DataObjectPointer
-Solver<VDimension>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
+auto
+Solver<VDimension>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx)) -> DataObjectPointer
 {
   return FEMObjectType::New().GetPointer();
 }
 
 template <unsigned int VDimension>
-typename Solver<VDimension>::FEMObjectType *
-Solver<VDimension>::GetOutput()
+auto
+Solver<VDimension>::GetOutput() -> FEMObjectType *
 {
   if (this->GetNumberOfOutputs() < 1)
   {
@@ -140,8 +140,8 @@ Solver<VDimension>::GetOutput()
 }
 
 template <unsigned int VDimension>
-typename Solver<VDimension>::FEMObjectType *
-Solver<VDimension>::GetOutput(unsigned int idx)
+auto
+Solver<VDimension>::GetOutput(unsigned int idx) -> FEMObjectType *
 {
   auto * out = dynamic_cast<FEMObjectType *>(this->ProcessObject::GetOutput(idx));
 
@@ -586,8 +586,8 @@ Solver<VDimension>::UpdateDisplacements()
 }
 
 template <unsigned int VDimension>
-typename Solver<VDimension>::Float
-Solver<VDimension>::GetDeformationEnergy(unsigned int SolutionIndex)
+auto
+Solver<VDimension>::GetDeformationEnergy(unsigned int SolutionIndex) -> Float
 {
   Float               U = 0.0f;
   Element::MatrixType LocalSolution;

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -65,8 +65,8 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::SetInput(unsigned int index, Inp
  *
  */
 template <typename TInputImage>
-typename ImageToRectilinearFEMObjectFilter<TInputImage>::InputImageType *
-ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput()
+auto
+ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput() -> InputImageType *
 {
   if (this->GetNumberOfInputs() < 1)
   {
@@ -80,8 +80,8 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput()
  *
  */
 template <typename TInputImage>
-typename ImageToRectilinearFEMObjectFilter<TInputImage>::InputImageType *
-ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput(unsigned int idx)
+auto
+ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput(unsigned int idx) -> InputImageType *
 {
   return itkDynamicCastInDebugMode<InputImageType *>(this->ProcessObject::GetInput(idx));
 }
@@ -90,8 +90,9 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GetInput(unsigned int idx)
  *
  */
 template <typename TInputImage>
-typename ImageToRectilinearFEMObjectFilter<TInputImage>::DataObjectPointer
+auto
 ImageToRectilinearFEMObjectFilter<TInputImage>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
+  -> DataObjectPointer
 {
   return FEMObjectType::New().GetPointer();
 }
@@ -100,8 +101,8 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::MakeOutput(DataObjectPointerArra
  *
  */
 template <typename TInputImage>
-typename ImageToRectilinearFEMObjectFilter<TInputImage>::FEMObjectType *
-ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput()
+auto
+ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput() -> FEMObjectType *
 {
   if (this->GetNumberOfOutputs() < 1)
   {
@@ -115,8 +116,8 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput()
  *
  */
 template <typename TInputImage>
-typename ImageToRectilinearFEMObjectFilter<TInputImage>::FEMObjectType *
-ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput(unsigned int idx)
+auto
+ImageToRectilinearFEMObjectFilter<TInputImage>::GetOutput(unsigned int idx) -> FEMObjectType *
 {
   auto * out = dynamic_cast<FEMObjectType *>(this->ProcessObject::GetOutput(idx));
 

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
@@ -35,16 +35,16 @@ template <unsigned int NDimensions>
 MetaFEMObjectConverter<NDimensions>::MetaFEMObjectConverter() = default;
 
 template <unsigned int NDimensions>
-typename MetaFEMObjectConverter<NDimensions>::MetaObjectType *
-MetaFEMObjectConverter<NDimensions>::CreateMetaObject()
+auto
+MetaFEMObjectConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new FEMObjectMetaObjectType);
 }
 
 /** Convert a metaFEMObject into an FEMObject SpatialObject  */
 template <unsigned int NDimensions>
-typename MetaFEMObjectConverter<NDimensions>::SpatialObjectPointer
-MetaFEMObjectConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+auto
+MetaFEMObjectConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * FEMmo = dynamic_cast<const MetaFEMObject *>(mo);
   if (FEMmo == nullptr)
@@ -315,8 +315,8 @@ MetaFEMObjectConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectT
 
 /** Convert an FEMObject SpatialObject into a metaFEMObject */
 template <unsigned int NDimensions>
-typename MetaFEMObjectConverter<NDimensions>::MetaObjectType *
-MetaFEMObjectConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+auto
+MetaFEMObjectConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   FEMObjectSpatialObjectConstPointer FEMSO = dynamic_cast<const FEMObjectSpatialObjectType *>(so);
   if (FEMSO.IsNull())

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
@@ -242,8 +242,9 @@ NarrowBandImageFilterBase<TInputImage, TOutputImage>::ThreadedApplyUpdate(const 
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename NarrowBandImageFilterBase<TInputImage, TOutputImage>::TimeStepType
+auto
 NarrowBandImageFilterBase<TInputImage, TOutputImage>::ThreadedCalculateChange(const ThreadRegionType & regionToProcess)
+  -> TimeStepType
 {
   using OutputSizeType = typename OutputImageType::SizeType;
 

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -89,8 +89,9 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
 
 //-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
-const typename GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::StopConditionReturnStringType
+auto
 GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::GetStopConditionDescription() const
+  -> const StopConditionReturnStringType
 {
   return this->m_StopConditionDescription.str();
 }

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
@@ -187,8 +187,8 @@ LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::StartOptimization(bool /* doOnl
 }
 
 template <typename TInternalVnlOptimizerType>
-typename LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::InternalOptimizerType *
-LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::GetOptimizer()
+auto
+LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::GetOptimizer() -> InternalOptimizerType *
 {
   return m_VnlOptimizer.get();
 }

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -48,8 +48,8 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::
 
 //-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
-typename MultiGradientOptimizerv4Template<TInternalComputationValueType>::OptimizersListType &
-MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetOptimizersList()
+auto
+MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetOptimizersList() -> OptimizersListType &
 {
   return this->m_OptimizersList;
 }
@@ -69,16 +69,18 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::SetOptimizersLi
 
 /** Get the list of metric values that we produced after the multi-gradient optimization.  */
 template <typename TInternalComputationValueType>
-const typename MultiGradientOptimizerv4Template<TInternalComputationValueType>::MetricValuesListType &
+auto
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetMetricValuesList() const
+  -> const MetricValuesListType &
 {
   return this->m_MetricValuesList;
 }
 
 //-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
-const typename MultiGradientOptimizerv4Template<TInternalComputationValueType>::StopConditionReturnStringType
+auto
 MultiGradientOptimizerv4Template<TInternalComputationValueType>::GetStopConditionDescription() const
+  -> const StopConditionReturnStringType
 {
   return this->m_StopConditionDescription.str();
 }

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -50,8 +50,8 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::ost
 
 //-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
-typename MultiStartOptimizerv4Template<TInternalComputationValueType>::ParametersListType &
-MultiStartOptimizerv4Template<TInternalComputationValueType>::GetParametersList()
+auto
+MultiStartOptimizerv4Template<TInternalComputationValueType>::GetParametersList() -> ParametersListType &
 {
   return this->m_ParametersList;
 }
@@ -71,16 +71,17 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::SetParametersList(
 
 /** Get the list of metric values that we produced after the multi-start search.  */
 template <typename TInternalComputationValueType>
-const typename MultiStartOptimizerv4Template<TInternalComputationValueType>::MetricValuesListType &
+auto
 MultiStartOptimizerv4Template<TInternalComputationValueType>::GetMetricValuesList() const
+  -> const MetricValuesListType &
 {
   return this->m_MetricValuesList;
 }
 
 //-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
-typename MultiStartOptimizerv4Template<TInternalComputationValueType>::ParametersType
-MultiStartOptimizerv4Template<TInternalComputationValueType>::GetBestParameters()
+auto
+MultiStartOptimizerv4Template<TInternalComputationValueType>::GetBestParameters() -> ParametersType
 {
   return this->m_ParametersList[m_BestParametersIndex];
 }
@@ -99,8 +100,9 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::InstantiateLocalOp
 
 //-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
-const typename MultiStartOptimizerv4Template<TInternalComputationValueType>::StopConditionReturnStringType
+auto
 MultiStartOptimizerv4Template<TInternalComputationValueType>::GetStopConditionDescription() const
+  -> const StopConditionReturnStringType
 {
   return this->m_StopConditionDescription.str();
 }

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -434,8 +434,9 @@ template <unsigned int TFixedDimension,
           unsigned int TMovingDimension,
           typename TVirtualImage,
           typename TParametersValueType>
-typename ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParametersValueType>::VirtualOriginType
+auto
 ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParametersValueType>::GetVirtualOrigin() const
+  -> VirtualOriginType
 {
   if (this->m_VirtualImage)
   {

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
@@ -52,8 +52,8 @@ ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::GetGradientSour
 
 //-------------------------------------------------------------------
 template <typename TInternalComputationValueType>
-typename ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::MeasureType
-ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::GetCurrentValue() const
+auto
+ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::GetCurrentValue() const -> MeasureType
 {
   return m_Value;
 }

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
@@ -282,8 +282,8 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::GetStopConditi
 }
 
 template <typename TInternalComputationValueType>
-const typename OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::MeasureType &
-OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::GetValue() const
+auto
+OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::GetValue() const -> const MeasureType &
 {
   return this->GetCurrentCost();
 }

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -47,8 +47,8 @@ RegistrationParameterScalesEstimator<TMetric>::RegistrationParameterScalesEstima
 
 /** Estimate the trusted scale for steps. It returns the voxel spacing. */
 template <typename TMetric>
-typename RegistrationParameterScalesEstimator<TMetric>::FloatType
-RegistrationParameterScalesEstimator<TMetric>::EstimateMaximumStepSize()
+auto
+RegistrationParameterScalesEstimator<TMetric>::EstimateMaximumStepSize() -> FloatType
 {
   this->CheckAndSetInputs();
 
@@ -479,8 +479,8 @@ RegistrationParameterScalesEstimator<TMetric>::CheckGeneralAffineTransformTempla
  *  Get the index of the virtual image center.
  */
 template <typename TMetric>
-typename RegistrationParameterScalesEstimator<TMetric>::VirtualIndexType
-RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralIndex()
+auto
+RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralIndex() -> VirtualIndexType
 {
   VirtualRegionType   region = this->m_Metric->GetVirtualRegion();
   const SizeValueType dim = this->GetDimension();
@@ -501,8 +501,8 @@ RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralIndex()
  *  Get the region around the virtual image center.
  */
 template <typename TMetric>
-typename RegistrationParameterScalesEstimator<TMetric>::VirtualRegionType
-RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralRegion()
+auto
+RegistrationParameterScalesEstimator<TMetric>::GetVirtualDomainCentralRegion() -> VirtualRegionType
 {
   VirtualIndexType centralIndex = this->GetVirtualDomainCentralIndex();
 

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.hxx
@@ -71,8 +71,8 @@ RegistrationParameterScalesFromJacobian<TMetric>::EstimateScales(ScalesType & pa
  *  Compute the scale for a STEP, the impact of a STEP on the transform.
  */
 template <typename TMetric>
-typename RegistrationParameterScalesFromJacobian<TMetric>::FloatType
-RegistrationParameterScalesFromJacobian<TMetric>::EstimateStepScale(const ParametersType & step)
+auto
+RegistrationParameterScalesFromJacobian<TMetric>::EstimateStepScale(const ParametersType & step) -> FloatType
 {
   this->CheckAndSetInputs();
   this->SetStepScaleSamplingStrategy();

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -123,8 +123,8 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateScales(ScalesType & p
  * w.r.t. the step is the shift produced by step.
  */
 template <typename TMetric>
-typename RegistrationParameterScalesFromShiftBase<TMetric>::FloatType
-RegistrationParameterScalesFromShiftBase<TMetric>::EstimateStepScale(const ParametersType & step)
+auto
+RegistrationParameterScalesFromShiftBase<TMetric>::EstimateStepScale(const ParametersType & step) -> FloatType
 {
   this->CheckAndSetInputs();
   this->SetStepScaleSamplingStrategy();
@@ -201,8 +201,9 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateLocalStepScales(const
  * Compute the maximum shift when a transform is changed with deltaParameters
  */
 template <typename TMetric>
-typename RegistrationParameterScalesFromShiftBase<TMetric>::FloatType
+auto
 RegistrationParameterScalesFromShiftBase<TMetric>::ComputeMaximumVoxelShift(const ParametersType & deltaParameters)
+  -> FloatType
 {
   ScalesType sampleShifts;
 

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
@@ -62,8 +62,8 @@ WindowConvergenceMonitoringFunction<TScalar>::ClearEnergyValues()
 }
 
 template <typename TScalar>
-typename WindowConvergenceMonitoringFunction<TScalar>::RealType
-WindowConvergenceMonitoringFunction<TScalar>::GetConvergenceValue() const
+auto
+WindowConvergenceMonitoringFunction<TScalar>::GetConvergenceValue() const -> RealType
 {
   if (this->GetNumberOfEnergyValues() < this->m_WindowSize)
   {

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
@@ -57,8 +57,8 @@ CovarianceSampleFilter<TSample>::GetInput() const
 }
 
 template <typename TSample>
-typename CovarianceSampleFilter<TSample>::DataObjectPointer
-CovarianceSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType index)
+auto
+CovarianceSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType index) -> DataObjectPointer
 {
   MeasurementVectorSizeType measurementVectorSize = this->GetMeasurementVectorSize();
 
@@ -85,8 +85,8 @@ CovarianceSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType index
 }
 
 template <typename TSample>
-typename CovarianceSampleFilter<TSample>::MeasurementVectorSizeType
-CovarianceSampleFilter<TSample>::GetMeasurementVectorSize() const
+auto
+CovarianceSampleFilter<TSample>::GetMeasurementVectorSize() const -> MeasurementVectorSizeType
 {
   const SampleType * input = this->GetInput();
 
@@ -198,29 +198,29 @@ CovarianceSampleFilter<TSample>::GenerateData()
 }
 
 template <typename TSample>
-const typename CovarianceSampleFilter<TSample>::MatrixDecoratedType *
-CovarianceSampleFilter<TSample>::GetCovarianceMatrixOutput() const
+auto
+CovarianceSampleFilter<TSample>::GetCovarianceMatrixOutput() const -> const MatrixDecoratedType *
 {
   return static_cast<const MatrixDecoratedType *>(this->ProcessObject::GetOutput(0));
 }
 
 template <typename TSample>
-const typename CovarianceSampleFilter<TSample>::MatrixType
-CovarianceSampleFilter<TSample>::GetCovarianceMatrix() const
+auto
+CovarianceSampleFilter<TSample>::GetCovarianceMatrix() const -> const MatrixType
 {
   return this->GetCovarianceMatrixOutput()->Get();
 }
 
 template <typename TSample>
-const typename CovarianceSampleFilter<TSample>::MeasurementVectorDecoratedType *
-CovarianceSampleFilter<TSample>::GetMeanOutput() const
+auto
+CovarianceSampleFilter<TSample>::GetMeanOutput() const -> const MeasurementVectorDecoratedType *
 {
   return static_cast<const MeasurementVectorDecoratedType *>(this->ProcessObject::GetOutput(1));
 }
 
 template <typename TSample>
-const typename CovarianceSampleFilter<TSample>::MeasurementVectorRealType
-CovarianceSampleFilter<TSample>::GetMean() const
+auto
+CovarianceSampleFilter<TSample>::GetMean() const -> const MeasurementVectorRealType
 {
   return this->GetMeanOutput()->Get();
 }

--- a/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.hxx
@@ -53,8 +53,8 @@ DistanceToCentroidMembershipFunction<TVector>::SetMeasurementVectorSize(Measurem
 }
 
 template <typename TVector>
-const typename DistanceToCentroidMembershipFunction<TVector>::CentroidType &
-DistanceToCentroidMembershipFunction<TVector>::GetCentroid() const
+auto
+DistanceToCentroidMembershipFunction<TVector>::GetCentroid() const -> const CentroidType &
 {
   return m_DistanceMetric->GetOrigin();
 }

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
@@ -74,15 +74,15 @@ ExpectationMaximizationMixtureModelEstimator<TSample>::SetInitialProportions(Pro
 }
 
 template <typename TSample>
-const typename ExpectationMaximizationMixtureModelEstimator<TSample>::ProportionVectorType &
-ExpectationMaximizationMixtureModelEstimator<TSample>::GetInitialProportions() const
+auto
+ExpectationMaximizationMixtureModelEstimator<TSample>::GetInitialProportions() const -> const ProportionVectorType &
 {
   return m_InitialProportions;
 }
 
 template <typename TSample>
-const typename ExpectationMaximizationMixtureModelEstimator<TSample>::ProportionVectorType &
-ExpectationMaximizationMixtureModelEstimator<TSample>::GetProportions() const
+auto
+ExpectationMaximizationMixtureModelEstimator<TSample>::GetProportions() const -> const ProportionVectorType &
 {
   return m_Proportions;
 }
@@ -117,15 +117,16 @@ ExpectationMaximizationMixtureModelEstimator<TSample>::GetNumberOfComponents() c
 }
 
 template <typename TSample>
-typename ExpectationMaximizationMixtureModelEstimator<TSample>::TERMINATION_CODE_ENUM
-ExpectationMaximizationMixtureModelEstimator<TSample>::GetTerminationCode() const
+auto
+ExpectationMaximizationMixtureModelEstimator<TSample>::GetTerminationCode() const -> TERMINATION_CODE_ENUM
 {
   return m_TerminationCode;
 }
 
 template <typename TSample>
-typename ExpectationMaximizationMixtureModelEstimator<TSample>::ComponentMembershipFunctionType *
+auto
 ExpectationMaximizationMixtureModelEstimator<TSample>::GetComponentMembershipFunction(int componentIndex) const
+  -> ComponentMembershipFunctionType *
 {
   return (m_ComponentVector[componentIndex])->GetMembershipFunction();
 }
@@ -342,8 +343,8 @@ ExpectationMaximizationMixtureModelEstimator<TSample>::GenerateData()
 }
 
 template <typename TSample>
-const typename ExpectationMaximizationMixtureModelEstimator<TSample>::MembershipFunctionVectorObjectType *
-ExpectationMaximizationMixtureModelEstimator<TSample>::GetOutput() const
+auto
+ExpectationMaximizationMixtureModelEstimator<TSample>::GetOutput() const -> const MembershipFunctionVectorObjectType *
 {
   size_t                         numberOfComponents = m_ComponentVector.size();
   MembershipFunctionVectorType & membershipFunctionsVector = m_MembershipFunctionsObject->Get();
@@ -388,8 +389,9 @@ ExpectationMaximizationMixtureModelEstimator<TSample>::GetOutput() const
 }
 
 template <typename TSample>
-const typename ExpectationMaximizationMixtureModelEstimator<TSample>::MembershipFunctionsWeightsArrayObjectType *
+auto
 ExpectationMaximizationMixtureModelEstimator<TSample>::GetMembershipFunctionsWeightsArray() const
+  -> const MembershipFunctionsWeightsArrayObjectType *
 {
   size_t                 numberOfComponents = m_ComponentVector.size();
   ProportionVectorType & membershipFunctionsWeightVector = m_MembershipFunctionsWeightArrayObject->Get();

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
@@ -54,7 +54,7 @@ public:
   /** Standard class type aliases */
   using Self = GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>;
   using Superclass = UniformRandomSpatialNeighborSubsampler<TSample, TRegion>;
-  using typename Superclass::Baseclass;
+  using Baseclass = typename Superclass::Baseclass;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -40,8 +40,8 @@ Histogram<TMeasurement, TFrequencyContainer>::Histogram()
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-typename Histogram<TMeasurement, TFrequencyContainer>::InstanceIdentifier
-Histogram<TMeasurement, TFrequencyContainer>::Size() const
+auto
+Histogram<TMeasurement, TFrequencyContainer>::Size() const -> InstanceIdentifier
 {
   if (this->GetMeasurementVectorSize() == 0)
   {
@@ -56,29 +56,31 @@ Histogram<TMeasurement, TFrequencyContainer>::Size() const
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::SizeType &
-Histogram<TMeasurement, TFrequencyContainer>::GetSize() const
+auto
+Histogram<TMeasurement, TFrequencyContainer>::GetSize() const -> const SizeType &
 {
   return m_Size;
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-typename Histogram<TMeasurement, TFrequencyContainer>::SizeValueType
-Histogram<TMeasurement, TFrequencyContainer>::GetSize(unsigned int dimension) const
+auto
+Histogram<TMeasurement, TFrequencyContainer>::GetSize(unsigned int dimension) const -> SizeValueType
 {
   return m_Size[dimension];
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::MeasurementType &
+auto
 Histogram<TMeasurement, TFrequencyContainer>::GetBinMin(unsigned int dimension, InstanceIdentifier nbin) const
+  -> const MeasurementType &
 {
   return m_Min[dimension][nbin];
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::MeasurementType &
+auto
 Histogram<TMeasurement, TFrequencyContainer>::GetBinMax(unsigned int dimension, InstanceIdentifier nbin) const
+  -> const MeasurementType &
 {
   return m_Max[dimension][nbin];
 }
@@ -102,36 +104,36 @@ Histogram<TMeasurement, TFrequencyContainer>::SetBinMax(unsigned int       dimen
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::BinMinVectorType &
-Histogram<TMeasurement, TFrequencyContainer>::GetDimensionMins(unsigned int dimension) const
+auto
+Histogram<TMeasurement, TFrequencyContainer>::GetDimensionMins(unsigned int dimension) const -> const BinMinVectorType &
 {
   return m_Min[dimension];
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::BinMaxVectorType &
-Histogram<TMeasurement, TFrequencyContainer>::GetDimensionMaxs(unsigned int dimension) const
+auto
+Histogram<TMeasurement, TFrequencyContainer>::GetDimensionMaxs(unsigned int dimension) const -> const BinMaxVectorType &
 {
   return m_Max[dimension];
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::BinMinContainerType &
-Histogram<TMeasurement, TFrequencyContainer>::GetMins() const
+auto
+Histogram<TMeasurement, TFrequencyContainer>::GetMins() const -> const BinMinContainerType &
 {
   return m_Min;
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::BinMaxContainerType &
-Histogram<TMeasurement, TFrequencyContainer>::GetMaxs() const
+auto
+Histogram<TMeasurement, TFrequencyContainer>::GetMaxs() const -> const BinMaxContainerType &
 {
   return m_Max;
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-typename Histogram<TMeasurement, TFrequencyContainer>::AbsoluteFrequencyType
-Histogram<TMeasurement, TFrequencyContainer>::GetFrequency(InstanceIdentifier id) const
+auto
+Histogram<TMeasurement, TFrequencyContainer>::GetFrequency(InstanceIdentifier id) const -> AbsoluteFrequencyType
 {
   return m_FrequencyContainer->GetFrequency(id);
 }
@@ -439,8 +441,9 @@ Histogram<TMeasurement, TFrequencyContainer>::GetBinMaxFromValue(const unsigned 
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::MeasurementVectorType &
+auto
 Histogram<TMeasurement, TFrequencyContainer>::GetHistogramMinFromIndex(const IndexType & index) const
+  -> const MeasurementVectorType &
 {
   const unsigned int measurementVectorSize = this->GetMeasurementVectorSize();
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
@@ -451,8 +454,9 @@ Histogram<TMeasurement, TFrequencyContainer>::GetHistogramMinFromIndex(const Ind
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-const typename Histogram<TMeasurement, TFrequencyContainer>::MeasurementVectorType &
+auto
 Histogram<TMeasurement, TFrequencyContainer>::GetHistogramMaxFromIndex(const IndexType & index) const
+  -> const MeasurementVectorType &
 {
   const unsigned int measurementVectorSize = this->GetMeasurementVectorSize();
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
@@ -543,15 +547,17 @@ Histogram<TMeasurement, TFrequencyContainer>::GetFrequency(const IndexType & ind
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-typename Histogram<TMeasurement, TFrequencyContainer>::MeasurementType
+auto
 Histogram<TMeasurement, TFrequencyContainer>::GetMeasurement(InstanceIdentifier n, unsigned int dimension) const
+  -> MeasurementType
 {
   return static_cast<MeasurementType>((m_Min[dimension][n] + m_Max[dimension][n]) / 2);
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>
-typename Histogram<TMeasurement, TFrequencyContainer>::AbsoluteFrequencyType
+auto
 Histogram<TMeasurement, TFrequencyContainer>::GetFrequency(InstanceIdentifier n, unsigned int dimension) const
+  -> AbsoluteFrequencyType
 {
   InstanceIdentifier nextOffset = this->m_OffsetTable[dimension + 1];
   InstanceIdentifier current = this->m_OffsetTable[dimension] * n;

--- a/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
@@ -42,8 +42,8 @@ HistogramToImageFilter<THistogram, TImage, TFunction>::SetInput(const HistogramT
 }
 
 template <typename THistogram, typename TImage, typename TFunction>
-const typename HistogramToImageFilter<THistogram, TImage, TFunction>::HistogramType *
-HistogramToImageFilter<THistogram, TImage, TFunction>::GetInput()
+auto
+HistogramToImageFilter<THistogram, TImage, TFunction>::GetInput() -> const HistogramType *
 {
   return itkDynamicCastInDebugMode<const HistogramType *>(this->GetPrimaryInput());
 }

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
@@ -51,8 +51,8 @@ HistogramToRunLengthFeaturesFilter<THistogram>::SetInput(const HistogramType * h
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::HistogramType *
-HistogramToRunLengthFeaturesFilter<THistogram>::GetInput() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetInput() const -> const HistogramType *
 {
   if (this->GetNumberOfInputs() < 1)
   {
@@ -62,8 +62,9 @@ HistogramToRunLengthFeaturesFilter<THistogram>::GetInput() const
 }
 
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::DataObjectPointer
+auto
 HistogramToRunLengthFeaturesFilter<THistogram>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
+  -> DataObjectPointer
 {
   return MeasurementObjectType::New().GetPointer();
 }
@@ -175,143 +176,149 @@ HistogramToRunLengthFeaturesFilter<THistogram>::GenerateData()
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunEmphasisOutput() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunEmphasisOutput() const -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(0));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunEmphasisOutput() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunEmphasisOutput() const -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(1));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToRunLengthFeaturesFilter<THistogram>::GetGreyLevelNonuniformityOutput() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetGreyLevelNonuniformityOutput() const -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(2));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToRunLengthFeaturesFilter<THistogram>::GetRunLengthNonuniformityOutput() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetRunLengthNonuniformityOutput() const -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(3));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
+auto
 HistogramToRunLengthFeaturesFilter<THistogram>::GetLowGreyLevelRunEmphasisOutput() const
+  -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(4));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
+auto
 HistogramToRunLengthFeaturesFilter<THistogram>::GetHighGreyLevelRunEmphasisOutput() const
+  -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(5));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
+auto
 HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunLowGreyLevelEmphasisOutput() const
+  -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(6));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
+auto
 HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunHighGreyLevelEmphasisOutput() const
+  -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(7));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
+auto
 HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunLowGreyLevelEmphasisOutput() const
+  -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(8));
 }
 
 template <typename THistogram>
-const typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementObjectType *
+auto
 HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunHighGreyLevelEmphasisOutput() const
+  -> const MeasurementObjectType *
 {
   return itkDynamicCastInDebugMode<const MeasurementObjectType *>(this->ProcessObject::GetOutput(9));
 }
 
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunEmphasis() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunEmphasis() const -> MeasurementType
 {
   return this->GetShortRunEmphasisOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunEmphasis() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunEmphasis() const -> MeasurementType
 {
   return this->GetLongRunEmphasisOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetGreyLevelNonuniformity() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetGreyLevelNonuniformity() const -> MeasurementType
 {
   return this->GetGreyLevelNonuniformityOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetRunLengthNonuniformity() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetRunLengthNonuniformity() const -> MeasurementType
 {
   return this->GetRunLengthNonuniformityOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetLowGreyLevelRunEmphasis() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetLowGreyLevelRunEmphasis() const -> MeasurementType
 {
   return this->GetLowGreyLevelRunEmphasisOutput()->Get();
 }
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetHighGreyLevelRunEmphasis() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetHighGreyLevelRunEmphasis() const -> MeasurementType
 {
   return this->GetHighGreyLevelRunEmphasisOutput()->Get();
 }
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunLowGreyLevelEmphasis() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunLowGreyLevelEmphasis() const -> MeasurementType
 {
   return this->GetShortRunLowGreyLevelEmphasisOutput()->Get();
 }
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunHighGreyLevelEmphasis() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetShortRunHighGreyLevelEmphasis() const -> MeasurementType
 {
   return this->GetShortRunHighGreyLevelEmphasisOutput()->Get();
 }
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunLowGreyLevelEmphasis() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunLowGreyLevelEmphasis() const -> MeasurementType
 {
   return this->GetLongRunLowGreyLevelEmphasisOutput()->Get();
 }
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunHighGreyLevelEmphasis() const
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetLongRunHighGreyLevelEmphasis() const -> MeasurementType
 {
   return this->GetLongRunHighGreyLevelEmphasisOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToRunLengthFeaturesFilter<THistogram>::MeasurementType
-HistogramToRunLengthFeaturesFilter<THistogram>::GetFeature(RunLengthFeatureEnum feature)
+auto
+HistogramToRunLengthFeaturesFilter<THistogram>::GetFeature(RunLengthFeatureEnum feature) -> MeasurementType
 {
   switch (feature)
   {

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -50,15 +50,16 @@ HistogramToTextureFeaturesFilter<THistogram>::SetInput(const HistogramType * his
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::HistogramType *
-HistogramToTextureFeaturesFilter<THistogram>::GetInput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetInput() const -> const HistogramType *
 {
   return itkDynamicCastInDebugMode<const HistogramType *>(this->GetPrimaryInput());
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::DataObjectPointer
+auto
 HistogramToTextureFeaturesFilter<THistogram>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
+  -> DataObjectPointer
 {
   return MeasurementObjectType::New().GetPointer();
 }
@@ -247,120 +248,120 @@ HistogramToTextureFeaturesFilter<THistogram>::ComputeMeansAndVariances(double & 
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToTextureFeaturesFilter<THistogram>::GetEnergyOutput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetEnergyOutput() const -> const MeasurementObjectType *
 {
   return static_cast<const MeasurementObjectType *>(this->ProcessObject::GetOutput(0));
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToTextureFeaturesFilter<THistogram>::GetEntropyOutput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetEntropyOutput() const -> const MeasurementObjectType *
 {
   return static_cast<const MeasurementObjectType *>(this->ProcessObject::GetOutput(1));
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToTextureFeaturesFilter<THistogram>::GetCorrelationOutput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetCorrelationOutput() const -> const MeasurementObjectType *
 {
   return static_cast<const MeasurementObjectType *>(this->ProcessObject::GetOutput(2));
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToTextureFeaturesFilter<THistogram>::GetInverseDifferenceMomentOutput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetInverseDifferenceMomentOutput() const -> const MeasurementObjectType *
 {
   return static_cast<const MeasurementObjectType *>(this->ProcessObject::GetOutput(3));
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToTextureFeaturesFilter<THistogram>::GetInertiaOutput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetInertiaOutput() const -> const MeasurementObjectType *
 {
   return static_cast<const MeasurementObjectType *>(this->ProcessObject::GetOutput(4));
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToTextureFeaturesFilter<THistogram>::GetClusterShadeOutput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetClusterShadeOutput() const -> const MeasurementObjectType *
 {
   return static_cast<const MeasurementObjectType *>(this->ProcessObject::GetOutput(5));
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToTextureFeaturesFilter<THistogram>::GetClusterProminenceOutput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetClusterProminenceOutput() const -> const MeasurementObjectType *
 {
   return static_cast<const MeasurementObjectType *>(this->ProcessObject::GetOutput(6));
 }
 
 template <typename THistogram>
-const typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementObjectType *
-HistogramToTextureFeaturesFilter<THistogram>::GetHaralickCorrelationOutput() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetHaralickCorrelationOutput() const -> const MeasurementObjectType *
 {
   return static_cast<const MeasurementObjectType *>(this->ProcessObject::GetOutput(7));
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetEnergy() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetEnergy() const -> MeasurementType
 {
   return this->GetEnergyOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetEntropy() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetEntropy() const -> MeasurementType
 {
   return this->GetEntropyOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetCorrelation() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetCorrelation() const -> MeasurementType
 {
   return this->GetCorrelationOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetInverseDifferenceMoment() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetInverseDifferenceMoment() const -> MeasurementType
 {
   return this->GetInverseDifferenceMomentOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetInertia() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetInertia() const -> MeasurementType
 {
   return this->GetInertiaOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetClusterShade() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetClusterShade() const -> MeasurementType
 {
   return this->GetClusterShadeOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetClusterProminence() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetClusterProminence() const -> MeasurementType
 {
   return this->GetClusterProminenceOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetHaralickCorrelation() const
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetHaralickCorrelation() const -> MeasurementType
 {
   return this->GetHaralickCorrelationOutput()->Get();
 }
 
 template <typename THistogram>
-typename HistogramToTextureFeaturesFilter<THistogram>::MeasurementType
-HistogramToTextureFeaturesFilter<THistogram>::GetFeature(TextureFeatureEnum feature)
+auto
+HistogramToTextureFeaturesFilter<THistogram>::GetFeature(TextureFeatureEnum feature) -> MeasurementType
 {
   switch (feature)
   {

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
@@ -55,8 +55,8 @@ ImageToHistogramFilter<TImage>::MakeOutput(DataObjectPointerArraySizeType itkNot
 }
 
 template <typename TImage>
-const typename ImageToHistogramFilter<TImage>::HistogramType *
-ImageToHistogramFilter<TImage>::GetOutput() const
+auto
+ImageToHistogramFilter<TImage>::GetOutput() const -> const HistogramType *
 {
   auto * output = itkDynamicCastInDebugMode<const HistogramType *>(this->ProcessObject::GetPrimaryOutput());
 
@@ -64,8 +64,8 @@ ImageToHistogramFilter<TImage>::GetOutput() const
 }
 
 template <typename TImage>
-typename ImageToHistogramFilter<TImage>::HistogramType *
-ImageToHistogramFilter<TImage>::GetOutput()
+auto
+ImageToHistogramFilter<TImage>::GetOutput() -> HistogramType *
 {
 
   auto * output = itkDynamicCastInDebugMode<HistogramType *>(this->ProcessObject::GetPrimaryOutput());

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
@@ -31,8 +31,8 @@ ImageToListSampleAdaptor<TImage>::ImageToListSampleAdaptor()
 }
 
 template <typename TImage>
-const typename ImageToListSampleAdaptor<TImage>::MeasurementVectorType &
-ImageToListSampleAdaptor<TImage>::GetMeasurementVector(InstanceIdentifier id) const
+auto
+ImageToListSampleAdaptor<TImage>::GetMeasurementVector(InstanceIdentifier id) const -> const MeasurementVectorType &
 {
   if (m_Image.IsNull())
   {
@@ -45,8 +45,8 @@ ImageToListSampleAdaptor<TImage>::GetMeasurementVector(InstanceIdentifier id) co
 
 /** returns the number of measurement vectors in this container*/
 template <typename TImage>
-typename ImageToListSampleAdaptor<TImage>::InstanceIdentifier
-ImageToListSampleAdaptor<TImage>::Size() const
+auto
+ImageToListSampleAdaptor<TImage>::Size() const -> InstanceIdentifier
 {
   if (m_Image.IsNull())
   {
@@ -115,8 +115,8 @@ ImageToListSampleAdaptor<TImage>::GetImage() const
 }
 
 template <typename TImage>
-typename ImageToListSampleAdaptor<TImage>::TotalAbsoluteFrequencyType
-ImageToListSampleAdaptor<TImage>::GetTotalFrequency() const
+auto
+ImageToListSampleAdaptor<TImage>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   if (m_Image.IsNull())
   {

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
@@ -75,8 +75,9 @@ ImageToListSampleFilter<TImage, TMaskImage>::GetMaskImage() const
 }
 
 template <typename TImage, typename TMaskImage>
-typename ImageToListSampleFilter<TImage, TMaskImage>::DataObjectPointer
+auto
 ImageToListSampleFilter<TImage, TMaskImage>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
+  -> DataObjectPointer
 {
   return ListSampleType::New().GetPointer();
 }
@@ -184,8 +185,8 @@ ImageToListSampleFilter<TImage, TMaskImage>::GenerateInputRequestedRegion()
 }
 
 template <typename TImage, typename TMaskImage>
-const typename ImageToListSampleFilter<TImage, TMaskImage>::ListSampleType *
-ImageToListSampleFilter<TImage, TMaskImage>::GetOutput() const
+auto
+ImageToListSampleFilter<TImage, TMaskImage>::GetOutput() const -> const ListSampleType *
 {
   const auto * output = static_cast<const ListSampleType *>(this->ProcessObject::GetOutput(0));
 

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -44,8 +44,9 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::ImageToNeighborhoo
 }
 
 template <typename TImage, typename TBoundaryCondition>
-const typename ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::MeasurementVectorType &
+auto
 ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetMeasurementVector(InstanceIdentifier id) const
+  -> const MeasurementVectorType &
 {
   if (m_Image.IsNull())
   {
@@ -74,8 +75,8 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetMeasurementVect
 
 /** returns the number of measurement vectors in this container*/
 template <typename TImage, typename TBoundaryCondition>
-typename ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::InstanceIdentifier
-ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::Size() const
+auto
+ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::Size() const -> InstanceIdentifier
 {
   if (m_Image.IsNull())
   {
@@ -173,8 +174,8 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::SetRadius(const Ne
 }
 
 template <typename TImage, typename TBoundaryCondition>
-typename ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::NeighborhoodRadiusType
-ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetRadius() const
+auto
+ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetRadius() const -> NeighborhoodRadiusType
 {
   return m_Radius;
 }
@@ -203,8 +204,8 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::SetRegion(const Re
 }
 
 template <typename TImage, typename TBoundaryCondition>
-typename ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::RegionType
-ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetRegion() const
+auto
+ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetRegion() const -> RegionType
 {
   return m_Region;
 }
@@ -224,8 +225,8 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::SetUseImageRegion(
 }
 
 template <typename TImage, typename TBoundaryCondition>
-typename ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::TotalAbsoluteFrequencyType
-ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetTotalFrequency() const
+auto
+ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   if (m_Image.IsNull())
   {

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.hxx
@@ -34,8 +34,8 @@ JointDomainImageToListSampleAdaptor<TImage>::JointDomainImageToListSampleAdaptor
 
 /** returns the number of measurement vectors in this container*/
 template <typename TImage>
-typename JointDomainImageToListSampleAdaptor<TImage>::InstanceIdentifier
-JointDomainImageToListSampleAdaptor<TImage>::Size() const
+auto
+JointDomainImageToListSampleAdaptor<TImage>::Size() const -> InstanceIdentifier
 {
   if (m_Image.IsNull())
   {
@@ -97,8 +97,8 @@ JointDomainImageToListSampleAdaptor<TImage>::GetImage() const
 }
 
 template <typename TImage>
-typename JointDomainImageToListSampleAdaptor<TImage>::TotalAbsoluteFrequencyType
-JointDomainImageToListSampleAdaptor<TImage>::GetTotalFrequency() const
+auto
+JointDomainImageToListSampleAdaptor<TImage>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   if (m_Image.IsNull())
   {
@@ -120,8 +120,9 @@ JointDomainImageToListSampleAdaptor<TImage>::SetNormalizationFactors(Normalizati
 }
 
 template <typename TImage>
-const typename JointDomainImageToListSampleAdaptor<TImage>::MeasurementVectorType &
+auto
 JointDomainImageToListSampleAdaptor<TImage>::GetMeasurementVector(InstanceIdentifier id) const
+  -> const MeasurementVectorType &
 {
   m_TempIndex = this->GetImage()->ComputeIndex(id);
 

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -401,8 +401,8 @@ KdTreeBasedKmeansEstimator<TKdTree>::GetKdTree() const
 }
 
 template <typename TKdTree>
-const typename KdTreeBasedKmeansEstimator<TKdTree>::MembershipFunctionVectorObjectType *
-KdTreeBasedKmeansEstimator<TKdTree>::GetOutput() const
+auto
+KdTreeBasedKmeansEstimator<TKdTree>::GetOutput() const -> const MembershipFunctionVectorObjectType *
 {
   // INSERT CHECKS if all the required inputs are set and optmization has been
   // run.

--- a/Modules/Numerics/Statistics/include/itkListSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkListSample.hxx
@@ -52,15 +52,15 @@ ListSample<TMeasurementVector>::PushBack(const MeasurementVectorType & mv)
 }
 
 template <typename TMeasurementVector>
-typename ListSample<TMeasurementVector>::InstanceIdentifier
-ListSample<TMeasurementVector>::Size() const
+auto
+ListSample<TMeasurementVector>::Size() const -> InstanceIdentifier
 {
   return static_cast<InstanceIdentifier>(this->m_InternalContainer.size());
 }
 
 template <typename TMeasurementVector>
-typename ListSample<TMeasurementVector>::TotalAbsoluteFrequencyType
-ListSample<TMeasurementVector>::GetTotalFrequency() const
+auto
+ListSample<TMeasurementVector>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   // Since the entries are unique, the total
   // frequency is equal to the numbe of entries.
@@ -68,8 +68,9 @@ ListSample<TMeasurementVector>::GetTotalFrequency() const
 }
 
 template <typename TMeasurementVector>
-const typename ListSample<TMeasurementVector>::MeasurementVectorType &
+auto
 ListSample<TMeasurementVector>::GetMeasurementVector(InstanceIdentifier instanceId) const
+  -> const MeasurementVectorType &
 {
   if (instanceId < m_InternalContainer.size())
   {
@@ -101,8 +102,8 @@ ListSample<TMeasurementVector>::SetMeasurementVector(InstanceIdentifier instance
 }
 
 template <typename TMeasurementVector>
-typename ListSample<TMeasurementVector>::AbsoluteFrequencyType
-ListSample<TMeasurementVector>::GetFrequency(InstanceIdentifier instanceId) const
+auto
+ListSample<TMeasurementVector>::GetFrequency(InstanceIdentifier instanceId) const -> AbsoluteFrequencyType
 {
   if (instanceId < m_InternalContainer.size())
   {

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
@@ -47,8 +47,8 @@ MahalanobisDistanceMetric<TVector>::SetMean(const MeanVectorType & mean)
 }
 
 template <typename TVector>
-const typename MahalanobisDistanceMetric<TVector>::MeanVectorType &
-MahalanobisDistanceMetric<TVector>::GetMean() const
+auto
+MahalanobisDistanceMetric<TVector>::GetMean() const -> const MeanVectorType &
 {
   return Superclass::GetOrigin();
 }

--- a/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
@@ -59,8 +59,8 @@ MeanSampleFilter<TSample>::GetInput() const
 }
 
 template <typename TSample>
-typename MeanSampleFilter<TSample>::DataObjectPointer
-MeanSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
+auto
+MeanSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx)) -> DataObjectPointer
 {
   MeasurementVectorRealType mean;
   (void)mean; // for complainty pants : valgrind
@@ -72,23 +72,23 @@ MeanSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(
 }
 
 template <typename TSample>
-const typename MeanSampleFilter<TSample>::MeasurementVectorDecoratedType *
-MeanSampleFilter<TSample>::GetOutput() const
+auto
+MeanSampleFilter<TSample>::GetOutput() const -> const MeasurementVectorDecoratedType *
 {
   return itkDynamicCastInDebugMode<const MeasurementVectorDecoratedType *>(this->ProcessObject::GetOutput(0));
 }
 
 template <typename TSample>
-const typename MeanSampleFilter<TSample>::MeasurementVectorRealType
-MeanSampleFilter<TSample>::GetMean() const
+auto
+MeanSampleFilter<TSample>::GetMean() const -> const MeasurementVectorRealType
 {
   const MeasurementVectorDecoratedType * decorator = this->GetOutput();
   return decorator->Get();
 }
 
 template <typename TSample>
-typename MeanSampleFilter<TSample>::MeasurementVectorSizeType
-MeanSampleFilter<TSample>::GetMeasurementVectorSize() const
+auto
+MeanSampleFilter<TSample>::GetMeasurementVectorSize() const -> MeasurementVectorSizeType
 {
   const SampleType * input = this->GetInput();
 

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
@@ -81,15 +81,15 @@ MembershipSample<TSample>::GetInternalClassLabel(const ClassLabelType classLabel
 }
 
 template <typename TSample>
-const typename MembershipSample<TSample>::ClassLabelHolderType
-MembershipSample<TSample>::GetClassLabelHolder() const
+auto
+MembershipSample<TSample>::GetClassLabelHolder() const -> const ClassLabelHolderType
 {
   return m_ClassLabelHolder;
 }
 
 template <typename TSample>
-const typename MembershipSample<TSample>::ClassSampleType *
-MembershipSample<TSample>::GetClassSample(const ClassLabelType & classLabel) const
+auto
+MembershipSample<TSample>::GetClassSample(const ClassLabelType & classLabel) const -> const ClassSampleType *
 {
   int classIndex = this->GetInternalClassLabel(classLabel);
   if (classIndex < 0)

--- a/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.hxx
+++ b/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.hxx
@@ -113,8 +113,8 @@ MixtureModelComponentBase<TSample>::SetMembershipFunction(MembershipFunctionType
 }
 
 template <typename TSample>
-typename MixtureModelComponentBase<TSample>::MembershipFunctionType *
-MixtureModelComponentBase<TSample>::GetMembershipFunction()
+auto
+MixtureModelComponentBase<TSample>::GetMembershipFunction() -> MembershipFunctionType *
 {
   return m_MembershipFunction;
 }

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.hxx
@@ -72,8 +72,8 @@ PointSetToListSampleAdaptor<TPointSet>::GetPointSet()
 
 /** returns the number of measurement vectors in this container*/
 template <typename TPointSet>
-typename PointSetToListSampleAdaptor<TPointSet>::InstanceIdentifier
-PointSetToListSampleAdaptor<TPointSet>::Size() const
+auto
+PointSetToListSampleAdaptor<TPointSet>::Size() const -> InstanceIdentifier
 {
   if (m_PointSet.IsNull())
   {
@@ -109,8 +109,8 @@ inline typename PointSetToListSampleAdaptor<TPointSet>::AbsoluteFrequencyType
 }
 
 template <typename TPointSet>
-typename PointSetToListSampleAdaptor<TPointSet>::TotalAbsoluteFrequencyType
-PointSetToListSampleAdaptor<TPointSet>::GetTotalFrequency() const
+auto
+PointSetToListSampleAdaptor<TPointSet>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   if (m_PointSet.IsNull())
   {

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
@@ -59,7 +59,7 @@ public:
   /** Standard class type aliases */
   using Self = RegionConstrainedSubsampler<TSample, TRegion>;
   using Superclass = SubsamplerBase<TSample>;
-  using typename Superclass::Baseclass;
+  using Baseclass = typename Superclass::Baseclass;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.hxx
@@ -177,8 +177,8 @@ SampleClassifierFilter<TSample>::GenerateData()
 }
 
 template <typename TSample>
-const typename SampleClassifierFilter<TSample>::MembershipSampleType *
-SampleClassifierFilter<TSample>::GetOutput() const
+auto
+SampleClassifierFilter<TSample>::GetOutput() const -> const MembershipSampleType *
 {
   return static_cast<const MembershipSampleType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.hxx
@@ -47,8 +47,8 @@ SampleToHistogramFilter<TSample, THistogram>::SetInput(const SampleType * sample
 }
 
 template <typename TSample, typename THistogram>
-const typename SampleToHistogramFilter<TSample, THistogram>::SampleType *
-SampleToHistogramFilter<TSample, THistogram>::GetInput() const
+auto
+SampleToHistogramFilter<TSample, THistogram>::GetInput() const -> const SampleType *
 {
   const auto * input = static_cast<const SampleType *>(this->ProcessObject::GetInput(0));
 
@@ -56,8 +56,8 @@ SampleToHistogramFilter<TSample, THistogram>::GetInput() const
 }
 
 template <typename TSample, typename THistogram>
-const typename SampleToHistogramFilter<TSample, THistogram>::HistogramType *
-SampleToHistogramFilter<TSample, THistogram>::GetOutput() const
+auto
+SampleToHistogramFilter<TSample, THistogram>::GetOutput() const -> const HistogramType *
 {
   const auto * output = static_cast<const HistogramType *>(this->ProcessObject::GetOutput(0));
 

--- a/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.hxx
@@ -42,8 +42,8 @@ SampleToSubsampleFilter<TSample>::SetInput(const SampleType * sample)
 }
 
 template <typename TSample>
-const typename SampleToSubsampleFilter<TSample>::SampleType *
-SampleToSubsampleFilter<TSample>::GetInput() const
+auto
+SampleToSubsampleFilter<TSample>::GetInput() const -> const SampleType *
 {
   const auto * input = static_cast<const SampleType *>(this->ProcessObject::GetInput(0));
 
@@ -58,8 +58,8 @@ typename SampleToSubsampleFilter<TSample>::DataObjectPointer SampleToSubsampleFi
 }
 
 template <typename TSample>
-const typename SampleToSubsampleFilter<TSample>::OutputType *
-SampleToSubsampleFilter<TSample>::GetOutput() const
+auto
+SampleToSubsampleFilter<TSample>::GetOutput() const -> const OutputType *
 {
   const auto * output = static_cast<const SubsampleType *>(this->ProcessObject::GetOutput(0));
 

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -56,8 +56,8 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GetInput() const
 }
 
 template <typename TImage>
-const typename ScalarImageToCooccurrenceListSampleFilter<TImage>::SampleType *
-ScalarImageToCooccurrenceListSampleFilter<TImage>::GetOutput() const
+auto
+ScalarImageToCooccurrenceListSampleFilter<TImage>::GetOutput() const -> const SampleType *
 {
   const auto * output = static_cast<const SampleType *>(this->ProcessObject::GetOutput(0));
 

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
@@ -100,8 +100,9 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
 }
 
 template <typename TImageType, typename THistogramFrequencyContainer>
-const typename ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::HistogramType *
+auto
 ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::GetOutput() const
+  -> const HistogramType *
 {
   const auto * output = static_cast<const HistogramType *>(this->ProcessObject::GetOutput(0));
 

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
@@ -40,8 +40,8 @@ ScalarImageToHistogramGenerator<TImage>::SetInput(const ImageType * image)
 }
 
 template <typename TImage>
-const typename ScalarImageToHistogramGenerator<TImage>::HistogramType *
-ScalarImageToHistogramGenerator<TImage>::GetOutput() const
+auto
+ScalarImageToHistogramGenerator<TImage>::GetOutput() const -> const HistogramType *
 {
   return m_HistogramGenerator->GetOutput();
 }

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -106,8 +106,8 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Ge
 }
 
 template <typename TImageType, typename THistogramFrequencyContainer>
-const typename ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::HistogramType *
-ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::GetOutput() const
+auto
+ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::GetOutput() const -> const HistogramType *
 {
   const auto * output = static_cast<const HistogramType *>(this->ProcessObject::GetOutput(0));
   return output;

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
@@ -56,7 +56,7 @@ public:
   /** Standard class type aliases */
   using Self = SpatialNeighborSubsampler<TSample, TRegion>;
   using Superclass = RegionConstrainedSubsampler<TSample, TRegion>;
-  using typename Superclass::Baseclass;
+  using Baseclass = typename Superclass::Baseclass;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
@@ -58,8 +58,9 @@ StandardDeviationPerComponentSampleFilter<TSample>::GetInput() const
 }
 
 template <typename TSample>
-typename StandardDeviationPerComponentSampleFilter<TSample>::DataObjectPointer
+auto
 StandardDeviationPerComponentSampleFilter<TSample>::MakeOutput(DataObjectPointerArraySizeType index)
+  -> DataObjectPointer
 {
   if (index == 0)
   {
@@ -89,8 +90,8 @@ StandardDeviationPerComponentSampleFilter<TSample>::MakeOutput(DataObjectPointer
 }
 
 template <typename TSample>
-typename StandardDeviationPerComponentSampleFilter<TSample>::MeasurementVectorSizeType
-StandardDeviationPerComponentSampleFilter<TSample>::GetMeasurementVectorSize() const
+auto
+StandardDeviationPerComponentSampleFilter<TSample>::GetMeasurementVectorSize() const -> MeasurementVectorSizeType
 {
   const SampleType * input = this->GetInput();
 
@@ -185,29 +186,32 @@ StandardDeviationPerComponentSampleFilter<TSample>::GenerateData()
 }
 
 template <typename TSample>
-const typename StandardDeviationPerComponentSampleFilter<TSample>::MeasurementVectorRealDecoratedType *
+auto
 StandardDeviationPerComponentSampleFilter<TSample>::GetStandardDeviationPerComponentOutput() const
+  -> const MeasurementVectorRealDecoratedType *
 {
   return static_cast<const MeasurementVectorRealDecoratedType *>(this->ProcessObject::GetOutput(0));
 }
 
 template <typename TSample>
-const typename StandardDeviationPerComponentSampleFilter<TSample>::MeasurementVectorRealType
+auto
 StandardDeviationPerComponentSampleFilter<TSample>::GetStandardDeviationPerComponent() const
+  -> const MeasurementVectorRealType
 {
   return this->GetStandardDeviationPerComponentOutput()->Get();
 }
 
 template <typename TSample>
-const typename StandardDeviationPerComponentSampleFilter<TSample>::MeasurementVectorRealDecoratedType *
+auto
 StandardDeviationPerComponentSampleFilter<TSample>::GetMeanPerComponentOutput() const
+  -> const MeasurementVectorRealDecoratedType *
 {
   return static_cast<const MeasurementVectorRealDecoratedType *>(this->ProcessObject::GetOutput(1));
 }
 
 template <typename TSample>
-const typename StandardDeviationPerComponentSampleFilter<TSample>::MeasurementVectorRealType
-StandardDeviationPerComponentSampleFilter<TSample>::GetMeanPerComponent() const
+auto
+StandardDeviationPerComponentSampleFilter<TSample>::GetMeanPerComponent() const -> const MeasurementVectorRealType
 {
   return this->GetMeanPerComponentOutput()->Get();
 }

--- a/Modules/Numerics/Statistics/include/itkSubsample.hxx
+++ b/Modules/Numerics/Statistics/include/itkSubsample.hxx
@@ -104,8 +104,8 @@ Subsample<TSample>::AddInstance(InstanceIdentifier id)
 }
 
 template <typename TSample>
-typename Subsample<TSample>::InstanceIdentifier
-Subsample<TSample>::Size() const
+auto
+Subsample<TSample>::Size() const -> InstanceIdentifier
 {
   return static_cast<unsigned int>(m_IdHolder.size());
 }
@@ -120,8 +120,8 @@ Subsample<TSample>::Clear()
 }
 
 template <typename TSample>
-const typename Subsample<TSample>::MeasurementVectorType &
-Subsample<TSample>::GetMeasurementVector(InstanceIdentifier id) const
+auto
+Subsample<TSample>::GetMeasurementVector(InstanceIdentifier id) const -> const MeasurementVectorType &
 {
   if (id >= m_IdHolder.size())
   {
@@ -193,8 +193,8 @@ Subsample<TSample>::GetFrequencyByIndex(unsigned int index) const
 }
 
 template <typename TSample>
-typename Subsample<TSample>::InstanceIdentifier
-Subsample<TSample>::GetInstanceIdentifier(unsigned int index)
+auto
+Subsample<TSample>::GetInstanceIdentifier(unsigned int index) -> InstanceIdentifier
 {
   if (index >= m_IdHolder.size())
   {

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
@@ -54,7 +54,7 @@ public:
   /** Standard class type aliases */
   using Self = UniformRandomSpatialNeighborSubsampler<TSample, TRegion>;
   using Superclass = SpatialNeighborSubsampler<TSample, TRegion>;
-  using typename Superclass::Baseclass;
+  using Baseclass = typename Superclass::Baseclass;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
@@ -40,8 +40,8 @@ VectorContainerToListSampleAdaptor<TVectorContainer>::PrintSelf(std::ostream & o
 }
 
 template <typename TVectorContainer>
-typename VectorContainerToListSampleAdaptor<TVectorContainer>::InstanceIdentifier
-VectorContainerToListSampleAdaptor<TVectorContainer>::Size() const
+auto
+VectorContainerToListSampleAdaptor<TVectorContainer>::Size() const -> InstanceIdentifier
 {
   if (this->m_VectorContainer.IsNull())
   {
@@ -76,8 +76,8 @@ inline typename VectorContainerToListSampleAdaptor<TVectorContainer>::AbsoluteFr
 }
 
 template <typename TVectorContainer>
-typename VectorContainerToListSampleAdaptor<TVectorContainer>::TotalAbsoluteFrequencyType
-VectorContainerToListSampleAdaptor<TVectorContainer>::GetTotalFrequency() const
+auto
+VectorContainerToListSampleAdaptor<TVectorContainer>::GetTotalFrequency() const -> TotalAbsoluteFrequencyType
 {
   if (this->m_VectorContainer.IsNull())
   {

--- a/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.hxx
@@ -57,8 +57,8 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredSize(con
 }
 
 template <typename TTransform>
-const typename ConstantVelocityFieldTransformParametersAdaptor<TTransform>::SizeType
-ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSize() const
+auto
+ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSize() const -> const SizeType
 {
   SizeType size;
   for (SizeValueType d = 0; d < ConstantVelocityFieldDimension; ++d)
@@ -90,8 +90,8 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredOrigin(c
 }
 
 template <typename TTransform>
-const typename ConstantVelocityFieldTransformParametersAdaptor<TTransform>::PointType
-ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredOrigin() const
+auto
+ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredOrigin() const -> const PointType
 {
   PointType origin;
   for (SizeValueType d = 0; d < ConstantVelocityFieldDimension; ++d)
@@ -123,8 +123,8 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredSpacing(
 }
 
 template <typename TTransform>
-const typename ConstantVelocityFieldTransformParametersAdaptor<TTransform>::SpacingType
-ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSpacing() const
+auto
+ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSpacing() const -> const SpacingType
 {
   SpacingType spacing;
   for (SizeValueType d = 0; d < ConstantVelocityFieldDimension; ++d)
@@ -162,8 +162,8 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredDirectio
 }
 
 template <typename TTransform>
-const typename ConstantVelocityFieldTransformParametersAdaptor<TTransform>::DirectionType
-ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredDirection() const
+auto
+ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredDirection() const -> const DirectionType
 {
   DirectionType direction;
   for (SizeValueType di = 0; di < ConstantVelocityFieldDimension; ++di)

--- a/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
@@ -35,8 +35,9 @@ CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Ev
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeanX(HistogramType & histogram) const
+  -> MeasureType
 {
   MeasureType meanX = NumericTraits<MeasureType>::ZeroValue();
 
@@ -53,8 +54,9 @@ CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Me
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeanY(HistogramType & histogram) const
+  -> MeasureType
 {
   MeasureType meanY = NumericTraits<MeasureType>::ZeroValue();
 
@@ -71,8 +73,9 @@ CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Me
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::VarianceX(HistogramType & histogram) const
+  -> MeasureType
 {
   MeasureType varX = NumericTraits<MeasureType>::ZeroValue();
 
@@ -86,8 +89,9 @@ CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Va
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::VarianceY(HistogramType & histogram) const
+  -> MeasureType
 {
   MeasureType varY = NumericTraits<MeasureType>::ZeroValue();
 

--- a/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.hxx
@@ -57,8 +57,8 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::SetRequiredSize(const S
 }
 
 template <typename TTransform>
-const typename DisplacementFieldTransformParametersAdaptor<TTransform>::SizeType
-DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredSize() const
+auto
+DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredSize() const -> const SizeType
 {
   SizeType size;
   for (SizeValueType d = 0; d < SpaceDimension; ++d)
@@ -90,8 +90,8 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::SetRequiredOrigin(const
 }
 
 template <typename TTransform>
-const typename DisplacementFieldTransformParametersAdaptor<TTransform>::PointType
-DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredOrigin() const
+auto
+DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredOrigin() const -> const PointType
 {
   PointType origin;
   for (SizeValueType d = 0; d < SpaceDimension; ++d)
@@ -123,8 +123,8 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::SetRequiredSpacing(cons
 }
 
 template <typename TTransform>
-const typename DisplacementFieldTransformParametersAdaptor<TTransform>::SpacingType
-DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredSpacing() const
+auto
+DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredSpacing() const -> const SpacingType
 {
   SpacingType spacing;
   for (SizeValueType d = 0; d < SpaceDimension; ++d)
@@ -160,8 +160,8 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::SetRequiredDirection(co
 }
 
 template <typename TTransform>
-const typename DisplacementFieldTransformParametersAdaptor<TTransform>::DirectionType
-DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredDirection() const
+auto
+DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredDirection() const -> const DirectionType
 {
   DirectionType direction;
   for (SizeValueType di = 0; di < SpaceDimension; ++di)

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -53,8 +53,8 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::SetUpperBound(const Meas
 }
 
 template <typename TFixedImage, typename TMovingImage>
-const typename HistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasurementVectorType &
-HistogramImageToImageMetric<TFixedImage, TMovingImage>::GetUpperBound() const
+auto
+HistogramImageToImageMetric<TFixedImage, TMovingImage>::GetUpperBound() const -> const MeasurementVectorType &
 {
   return m_UpperBound;
 }
@@ -69,8 +69,8 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::SetLowerBound(const Meas
 }
 
 template <typename TFixedImage, typename TMovingImage>
-const typename HistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasurementVectorType &
-HistogramImageToImageMetric<TFixedImage, TMovingImage>::GetLowerBound() const
+auto
+HistogramImageToImageMetric<TFixedImage, TMovingImage>::GetLowerBound() const -> const MeasurementVectorType &
 {
   return m_LowerBound;
 }
@@ -167,8 +167,9 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::SetTransform(TransformTy
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename HistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 HistogramImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const
+  -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -282,8 +282,8 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::GenerateData()
  *  Get Output
  */
 template <typename TFixedImage, typename TMovingImage>
-const typename ImageRegistrationMethod<TFixedImage, TMovingImage>::TransformOutputType *
-ImageRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const
+auto
+ImageRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const -> const TransformOutputType *
 {
   return static_cast<const TransformOutputType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
@@ -150,8 +150,9 @@ ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::Gener
 }
 
 template <typename TFixedImage, typename TMovingSpatialObject>
-const typename ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::TransformOutputType *
+auto
 ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::GetOutput() const
+  -> const TransformOutputType *
 {
   return static_cast<const TransformOutputType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -34,8 +34,9 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::KappaStatisticImage
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const TransformParametersType & parameters) const
+  -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -514,8 +514,9 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueTh
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters) const
+  -> MeasureType
 {
   // Set up the parameters in the transform
   this->m_Transform->SetParameters(parameters);

--- a/Modules/Registration/Common/include/itkMeanSquaresHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresHistogramImageToImageMetric.hxx
@@ -23,8 +23,9 @@
 namespace itk
 {
 template <typename TFixedImage, typename TMovingImage>
-typename MeanSquaresHistogramImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 MeanSquaresHistogramImageToImageMetric<TFixedImage, TMovingImage>::EvaluateMeasure(HistogramType & histogram) const
+  -> MeasureType
 {
   MeasureType            measure = NumericTraits<MeasureType>::ZeroValue();
   HistogramIteratorType  it = histogram.Begin();

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
@@ -97,8 +97,9 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueThreadProcessS
 }
 
 template <typename TFixedImage, typename TMovingImage>
-typename MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters) const
+  -> MeasureType
 {
   itkDebugMacro("GetValue( " << parameters << " ) ");
 

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -440,8 +440,8 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GetMTime() co
  *  Get Output
  */
 template <typename TFixedImage, typename TMovingImage>
-const typename MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::TransformOutputType *
-MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const
+auto
+MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const -> const TransformOutputType *
 {
   return static_cast<const TransformOutputType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -198,8 +198,9 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
  * Get the match Measure
  */
 template <typename TFixedImage, typename TMovingImage>
-typename MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MeasureType
+auto
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const ParametersType & parameters) const
+  -> MeasureType
 {
   // make sure the transform has the current parameters
   this->m_Transform->SetParameters(parameters);

--- a/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
@@ -148,8 +148,8 @@ PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::GenerateData()
 }
 
 template <typename TFixedPointSet, typename TMovingImage>
-const typename PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::TransformOutputType *
-PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::GetOutput() const
+auto
+PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::GetOutput() const -> const TransformOutputType *
 {
   return static_cast<const TransformOutputType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
@@ -142,8 +142,8 @@ PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::GenerateD
 }
 
 template <typename TFixedPointSet, typename TMovingPointSet>
-const typename PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::TransformOutputType *
-PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::GetOutput() const
+auto
+PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::GetOutput() const -> const TransformOutputType *
 {
   return static_cast<const TransformOutputType *>(this->ProcessObject::GetOutput(0));
 }

--- a/Modules/Registration/Common/include/itkPointsLocator.hxx
+++ b/Modules/Registration/Common/include/itkPointsLocator.hxx
@@ -59,8 +59,8 @@ PointsLocator<TPointsContainer>::Initialize()
 }
 
 template <typename TPointsContainer>
-typename PointsLocator<TPointsContainer>::PointIdentifier
-PointsLocator<TPointsContainer>::FindClosestPoint(const PointType & query) const
+auto
+PointsLocator<TPointsContainer>::FindClosestPoint(const PointType & query) const -> PointIdentifier
 {
   NeighborsIdentifierType identifiers;
   this->m_Tree->Search(query, 1u, identifiers);

--- a/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.hxx
@@ -57,8 +57,8 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredSize(
 }
 
 template <typename TTransform>
-const typename TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::SizeType
-TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSize() const
+auto
+TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSize() const -> const SizeType
 {
   SizeType size;
   for (SizeValueType d = 0; d < TotalDimension; ++d)
@@ -90,8 +90,8 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredOrigi
 }
 
 template <typename TTransform>
-const typename TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::PointType
-TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredOrigin() const
+auto
+TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredOrigin() const -> const PointType
 {
   PointType origin;
   for (SizeValueType d = 0; d < TotalDimension; ++d)
@@ -123,8 +123,8 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredSpaci
 }
 
 template <typename TTransform>
-const typename TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::SpacingType
-TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSpacing() const
+auto
+TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSpacing() const -> const SpacingType
 {
   SpacingType spacing;
   for (SizeValueType d = 0; d < TotalDimension; ++d)
@@ -160,8 +160,8 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredDirec
 }
 
 template <typename TTransform>
-const typename TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::DirectionType
-TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredDirection() const
+auto
+TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredDirection() const -> const DirectionType
 {
   DirectionType direction;
   for (SizeValueType di = 0; di < TotalDimension; ++di)

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -121,8 +121,9 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::SetCurrentEnergy(double e)
 }
 
 template <typename TMoving, typename TFixed>
-typename FiniteDifferenceFunctionLoad<TMoving, TFixed>::Float
+auto
 FiniteDifferenceFunctionLoad<TMoving, TFixed>::EvaluateMetricGivenSolution(ElementContainerType * el, Float step)
+  -> Float
 {
   Float energy = 0.0, defe = 0.0;
 
@@ -199,8 +200,8 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::EvaluateMetricGivenSolution(Eleme
 }
 
 template <typename TMoving, typename TFixed>
-typename FiniteDifferenceFunctionLoad<TMoving, TFixed>::FEMVectorType
-FiniteDifferenceFunctionLoad<TMoving, TFixed>::Fe(FEMVectorType Gpos)
+auto
+FiniteDifferenceFunctionLoad<TMoving, TFixed>::Fe(FEMVectorType Gpos) -> FEMVectorType
 {
 
   // We assume the vector input is of size 2*ImageDimension.

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -193,8 +193,8 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::SetInputFEMObject(
 }
 
 template <typename TMovingImage, typename TFixedImage, typename TFemObject>
-typename FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::FEMObjectType *
-FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::GetInputFEMObject(unsigned int level)
+auto
+FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::GetInputFEMObject(unsigned int level) -> FEMObjectType *
 {
   return static_cast<FEMObjectType *>(this->ProcessObject::GetInput(2 + level));
 }

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.h
@@ -138,7 +138,7 @@ public:
 
   using typename Superclass::FixedImageType;
   using typename Superclass::MovingImageType;
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::FixedOutputPointType;
   using typename Superclass::MovingOutputPointType;
 

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -74,7 +74,7 @@ public:
   using typename Superclass::DomainType;
   using typename Superclass::AssociateType;
 
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::FixedImagePointType;

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.h
@@ -108,7 +108,7 @@ public:
 
   using typename Superclass::MovingTransformType;
   using typename Superclass::JacobianType;
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::VirtualPointSetType;

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -50,7 +50,7 @@ public:
   using typename Superclass::DomainType;
   using typename Superclass::AssociateType;
 
-  using typename Superclass::ImageToImageMetricv4Type;
+  using ImageToImageMetricv4Type = typename Superclass::ImageToImageMetricv4Type;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::FixedImagePointType;

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
@@ -52,7 +52,7 @@ public:
   using typename Superclass::DomainType;
   using typename Superclass::AssociateType;
 
-  using typename Superclass::ImageToImageMetricv4Type;
+  using ImageToImageMetricv4Type = typename Superclass::ImageToImageMetricv4Type;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::FixedImagePointType;

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.h
@@ -90,7 +90,7 @@ public:
 
   using typename Superclass::MovingTransformType;
   using typename Superclass::JacobianType;
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using VirtualSPointSetType = typename Superclass::VirtualPointSetType;

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -50,7 +50,7 @@ public:
   using typename Superclass::DomainType;
   using typename Superclass::AssociateType;
 
-  using typename Superclass::ImageToImageMetricv4Type;
+  using ImageToImageMetricv4Type = typename Superclass::ImageToImageMetricv4Type;
   using typename Superclass::VirtualPointType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::FixedImagePointType;

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -227,7 +227,7 @@ public:
   using typename Superclass::FixedTransformJacobianType;
   using typename Superclass::MovingTransformJacobianType;
 
-  using typename Superclass::ObjectType;
+  using ObjectType = typename Superclass::ObjectType;
 
   /** Image-accessor type alias */
   using FixedImageType = TFixedImage;
@@ -247,7 +247,7 @@ public:
   using MovingImageIndexType = typename MovingImageType::IndexType;
 
   /** Types for the virtual domain */
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualImagePointer;
   using typename Superclass::VirtualPixelType;
   using typename Superclass::VirtualRegionType;

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -76,7 +76,7 @@ public:
 
   /** Types of the target class. */
   using ImageToImageMetricv4Type = TImageToImageMetricv4;
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::FixedImagePointType;
@@ -152,8 +152,8 @@ public:
   using typename Superclass::AssociateType;
 
   /** Types of the target class. */
-  using typename Superclass::ImageToImageMetricv4Type;
-  using typename Superclass::VirtualImageType;
+  using ImageToImageMetricv4Type = typename Superclass::ImageToImageMetricv4Type;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::FixedImagePointType;

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.h
@@ -76,7 +76,7 @@ public:
   using typename Superclass::DomainType;
   using typename Superclass::AssociateType;
 
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
 
@@ -117,7 +117,7 @@ public:
   using typename Superclass::DomainType;
   using typename Superclass::AssociateType;
 
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
 

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.h
@@ -88,7 +88,7 @@ public:
   using FixedTransformJacobianType = typename Superclass::FixedTransformType::JacobianType;
   using MovingTransformJacobianType = typename Superclass::MovingTransformType::JacobianType;
 
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::VirtualPointSetType;

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -178,8 +178,9 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::Evaluate(c
 }
 
 template <typename TPointSet, typename TOutput, typename TCoordRep>
-typename ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::GaussianConstPointer
+auto
 ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>::GetGaussian(PointIdentifier i) const
+  -> GaussianConstPointer
 {
   if (i < this->m_Gaussians.size())
   {

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
@@ -136,7 +136,7 @@ public:
 
   using typename Superclass::MovingTransformType;
   using typename Superclass::JacobianType;
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::VirtualPointSetType;

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -52,7 +52,7 @@ public:
   using typename Superclass::DomainType;
   using typename Superclass::AssociateType;
 
-  using typename Superclass::ImageToImageMetricv4Type;
+  using ImageToImageMetricv4Type = typename Superclass::ImageToImageMetricv4Type;
   using typename Superclass::VirtualPointType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::FixedImagePointType;

--- a/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4.h
@@ -74,7 +74,7 @@ public:
 
   using typename Superclass::MovingTransformType;
   using typename Superclass::JacobianType;
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::VirtualPointType;
   using typename Superclass::VirtualPointSetType;

--- a/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -50,7 +50,7 @@ public:
   using typename Superclass::DomainType;
   using typename Superclass::AssociateType;
 
-  using typename Superclass::ImageToImageMetricv4Type;
+  using ImageToImageMetricv4Type = typename Superclass::ImageToImageMetricv4Type;
   using typename Superclass::VirtualPointType;
   using typename Superclass::VirtualIndexType;
   using typename Superclass::FixedImagePointType;

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.h
@@ -129,7 +129,7 @@ public:
   using MetricBaseConstPointer = typename MetricType::ConstPointer;
   using MetricQueueType = std::deque<MetricBasePointer>;
 
-  using typename Superclass::ObjectType;
+  using ObjectType = typename Superclass::ObjectType;
 
   using WeightValueType = typename DerivativeType::ValueType;
   using WeightsArrayType = Array<WeightValueType>;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -120,7 +120,7 @@ public:
 
   using DisplacementFieldTransformType = typename Superclass::MovingDisplacementFieldTransformType;
 
-  using typename Superclass::ObjectType;
+  using ObjectType = typename Superclass::ObjectType;
 
   /** Dimension type */
   using typename Superclass::DimensionType;
@@ -167,7 +167,7 @@ public:
   using LocalDerivativeType = FixedArray<DerivativeValueType, Self::PointDimension>;
 
   /** Types for the virtual domain */
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualImagePointer;
   using typename Superclass::VirtualPixelType;
   using typename Superclass::VirtualRegionType;

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -156,7 +156,7 @@ public:
   using typename Superclass::LocalDerivativeType;
 
   /** Types for the virtual domain */
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualImagePointer;
   using typename Superclass::VirtualPixelType;
   using typename Superclass::VirtualRegionType;

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
@@ -183,8 +183,9 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
  *
  */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GradientType
+auto
 DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetUseGradientType() const
+  -> GradientType
 {
   const DemonsRegistrationFunctionType * drfp = this->DownCastDifferenceFunctionType();
 

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
@@ -137,8 +137,9 @@ FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplace
  *
  */
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
-typename FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GradientType
+auto
 FastSymmetricForcesDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetUseGradientType() const
+  -> GradientType
 {
   const DemonsRegistrationFunctionType * drfp = this->DownCastDifferenceFunctionType();
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.h
@@ -94,7 +94,7 @@ public:
   using MovingMaskImageType = typename ImageMaskSpatialObjectType::ImageType;
   using typename Superclass::MovingImageMasksContainerType;
 
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualImageBaseType;
   using typename Superclass::VirtualImageBaseConstPointer;
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
@@ -114,7 +114,7 @@ public:
   using MovingMaskImageType = typename ImageMaskSpatialObjectType::ImageType;
   using typename Superclass::MovingImageMasksContainerType;
 
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualImageBaseType;
   using typename Superclass::VirtualImageBaseConstPointer;
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
@@ -127,7 +127,7 @@ public:
   using MeasureType = typename ImageMetricType::MeasureType;
   using MetricDerivativeType = typename ImageMetricType::DerivativeType;
 
-  using typename Superclass::VirtualImageType;
+  using VirtualImageType = typename Superclass::VirtualImageType;
   using typename Superclass::VirtualImageBaseType;
   using typename Superclass::VirtualImageBaseConstPointer;
 

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -228,8 +228,8 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::SetGradient(const Gradie
 
 /* Get the gradient image as an input */
 template <typename TInputMesh, typename TOutputMesh>
-const typename DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::GradientImageType *
-DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::GetGradient() const
+auto
+DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::GetGradient() const -> const GradientImageType *
 {
   const auto * gradientImage = dynamic_cast<const GradientImageType *>(this->ProcessObject::GetInput(1));
 

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -168,8 +168,8 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateOutputImage()
 } // end GenerateOutputImage()
 
 template <typename TInputImage, typename TOutputImage>
-typename KLMRegionGrowImageFilter<TInputImage, TOutputImage>::LabelImagePointer
-KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GetLabelledImage()
+auto
+KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GetLabelledImage() -> LabelImagePointer
 {
   // Allocate the memory for the labelled image
 
@@ -195,8 +195,9 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GetLabelledImage()
 } // end GetLabelledImage()
 
 template <typename TInputImage, typename TOutputImage>
-typename KLMRegionGrowImageFilter<TInputImage, TOutputImage>::LabelImagePointer
+auto
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GenerateLabelledImage(LabelImageType * labelImagePtr)
+  -> LabelImagePointer
 {
   InputImageConstPointer inputImage = this->GetInput();
   InputImageSizeType     inputImageSize = inputImage->GetBufferedRegion().GetSize();

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -36,8 +36,8 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::LabelVotingImageFilter()
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename LabelVotingImageFilter<TInputImage, TOutputImage>::InputPixelType
-LabelVotingImageFilter<TInputImage, TOutputImage>::ComputeMaximumInputValue()
+auto
+LabelVotingImageFilter<TInputImage, TOutputImage>::ComputeMaximumInputValue() -> InputPixelType
 {
   InputPixelType maxLabel = 0;
 

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
@@ -64,8 +64,9 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::SetInputVel
  *
  */
 template <typename TLevelSet, typename TAuxValue, unsigned int VAuxDimension>
-const typename ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::AuxImageType *
+auto
 ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GetInputVelocityImage(unsigned int idx)
+  -> const AuxImageType *
 {
   if (idx >= VAuxDimension || this->GetNumberOfIndexedInputs() < idx + 2)
   {
@@ -79,8 +80,9 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GetInputVel
  *
  */
 template <typename TLevelSet, typename TAuxValue, unsigned int VAuxDimension>
-typename ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::AuxImageType *
+auto
 ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GetOutputVelocityImage(unsigned int idx)
+  -> AuxImageType *
 {
   if (idx >= VAuxDimension || this->GetNumberOfIndexedOutputs() < idx + 2)
   {

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -174,8 +174,8 @@ LevelSetFunction<TImageType>::ComputeMeanCurvature(const NeighborhoodType & itkN
 }
 
 template <typename TImageType>
-typename LevelSetFunction<TImageType>::VectorType
-LevelSetFunction<TImageType>::InitializeZeroVectorConstant()
+auto
+LevelSetFunction<TImageType>::InitializeZeroVectorConstant() -> VectorType
 {
   VectorType ans;
 
@@ -213,8 +213,8 @@ template <typename TImageType>
 double LevelSetFunction<TImageType>::m_DT = 1.0 / (2.0 * ImageDimension);
 
 template <typename TImageType>
-typename LevelSetFunction<TImageType>::TimeStepType
-LevelSetFunction<TImageType>::ComputeGlobalTimeStep(void * GlobalData) const
+auto
+LevelSetFunction<TImageType>::ComputeGlobalTimeStep(void * GlobalData) const -> TimeStepType
 {
   TimeStepType dt;
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
@@ -56,8 +56,9 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::PrintSelf(std::ostr
 }
 
 template <typename TImageType, typename TSparseImageType>
-typename LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::TimeStepType
+auto
 LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeGlobalTimeStep(void * GlobalData) const
+  -> TimeStepType
 {
   TimeStepType dt = Superclass::ComputeGlobalTimeStep(GlobalData);
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -1252,8 +1252,9 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Iterate()
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::TimeStepType
+auto
 ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedCalculateChange(ThreadIdType ThreadId)
+  -> TimeStepType
 {
   typename FiniteDifferenceFunctionType::Pointer         df = this->GetDifferenceFunction();
   typename FiniteDifferenceFunctionType::FloatOffsetType offset;

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
@@ -54,8 +54,9 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::PrintSelf(std::ostream &
  *
  */
 template <typename TFeatureImage, typename TOutputPixel>
-typename ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::MeasureType
+auto
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogInsideTerm(const ParametersType & parameters) const
+  -> MeasureType
 {
   this->m_ShapeFunction->SetParameters(parameters);
 
@@ -116,8 +117,9 @@ ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogShapePriorTerm
  *
  */
 template <typename TFeatureImage, typename TOutputPixel>
-typename ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::MeasureType
+auto
 ShapePriorMAPCostFunction<TFeatureImage, TOutputPixel>::ComputeLogGradientTerm(const ParametersType & parameters) const
+  -> MeasureType
 {
   this->m_ShapeFunction->SetParameters(parameters);
 

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.hxx
@@ -50,8 +50,9 @@ ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::PrintSelf(std::ostre
  *
  */
 template <typename TFeatureImage, typename TOutputPixel>
-typename ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::MeasureType
+auto
 ShapePriorMAPCostFunctionBase<TFeatureImage, TOutputPixel>::GetValue(const ParametersType & parameters) const
+  -> MeasureType
 {
   return (this->ComputeLogInsideTerm(parameters) + this->ComputeLogGradientTerm(parameters) +
           this->ComputeLogShapePriorTerm(parameters) + this->ComputeLogPosePriorTerm(parameters));

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
@@ -87,8 +87,9 @@ ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ComputeUp
  * Compute the global time step.
  */
 template <typename TImageType, typename TFeatureImageType>
-typename ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::TimeStepType
+auto
 ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::ComputeGlobalTimeStep(void * gd) const
+  -> TimeStepType
 {
   TimeStepType dt;
 

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -845,8 +845,8 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::AllocateUpdateBuffer(
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::TimeStepType
-SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::CalculateChange()
+auto
+SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::CalculateChange() -> TimeStepType
 {
   const typename Superclass::FiniteDifferenceFunctionType::Pointer   df = this->GetDifferenceFunction();
   typename Superclass::FiniteDifferenceFunctionType::FloatOffsetType offset;

--- a/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.hxx
@@ -26,8 +26,8 @@ namespace itk
 
 // ----------------------------------------------------------------------------
 template <typename TOutput, unsigned int VDimension>
-typename DiscreteLevelSetImage<TOutput, VDimension>::GradientType
-DiscreteLevelSetImage<TOutput, VDimension>::EvaluateGradient(const InputType & inputIndex) const
+auto
+DiscreteLevelSetImage<TOutput, VDimension>::EvaluateGradient(const InputType & inputIndex) const -> GradientType
 {
   InputType inputIndexA = inputIndex;
   InputType inputIndexB = inputIndex;
@@ -65,8 +65,8 @@ DiscreteLevelSetImage<TOutput, VDimension>::EvaluateGradient(const InputType & i
 
 // ----------------------------------------------------------------------------
 template <typename TOutput, unsigned int VDimension>
-typename DiscreteLevelSetImage<TOutput, VDimension>::GradientType
-DiscreteLevelSetImage<TOutput, VDimension>::EvaluateForwardGradient(const InputType & inputIndex) const
+auto
+DiscreteLevelSetImage<TOutput, VDimension>::EvaluateForwardGradient(const InputType & inputIndex) const -> GradientType
 {
   const auto centerValue = static_cast<OutputRealType>(this->Evaluate(inputIndex));
 
@@ -96,8 +96,8 @@ DiscreteLevelSetImage<TOutput, VDimension>::EvaluateForwardGradient(const InputT
 
 // ----------------------------------------------------------------------------
 template <typename TOutput, unsigned int VDimension>
-typename DiscreteLevelSetImage<TOutput, VDimension>::GradientType
-DiscreteLevelSetImage<TOutput, VDimension>::EvaluateBackwardGradient(const InputType & inputIndex) const
+auto
+DiscreteLevelSetImage<TOutput, VDimension>::EvaluateBackwardGradient(const InputType & inputIndex) const -> GradientType
 {
   const auto centerValue = static_cast<OutputRealType>(this->Evaluate(inputIndex));
 
@@ -126,8 +126,8 @@ DiscreteLevelSetImage<TOutput, VDimension>::EvaluateBackwardGradient(const Input
 
 // ----------------------------------------------------------------------------
 template <typename TOutput, unsigned int VDimension>
-typename DiscreteLevelSetImage<TOutput, VDimension>::HessianType
-DiscreteLevelSetImage<TOutput, VDimension>::EvaluateHessian(const InputType & inputIndex) const
+auto
+DiscreteLevelSetImage<TOutput, VDimension>::EvaluateHessian(const InputType & inputIndex) const -> HessianType
 {
   HessianType oHessian;
 
@@ -219,8 +219,8 @@ DiscreteLevelSetImage<TOutput, VDimension>::EvaluateHessian(const InputType & in
 
 // ----------------------------------------------------------------------------
 template <typename TOutput, unsigned int VDimension>
-typename DiscreteLevelSetImage<TOutput, VDimension>::OutputRealType
-DiscreteLevelSetImage<TOutput, VDimension>::EvaluateLaplacian(const InputType & inputIndex) const
+auto
+DiscreteLevelSetImage<TOutput, VDimension>::EvaluateLaplacian(const InputType & inputIndex) const -> OutputRealType
 {
   OutputRealType oLaplacian = NumericTraits<OutputRealType>::ZeroValue();
 
@@ -438,8 +438,8 @@ DiscreteLevelSetImage<TOutput, VDimension>::EvaluateHessian(const InputType & in
 
 // ----------------------------------------------------------------------------
 template <typename TOutput, unsigned int VDimension>
-typename DiscreteLevelSetImage<TOutput, VDimension>::OutputRealType
-DiscreteLevelSetImage<TOutput, VDimension>::EvaluateMeanCurvature(const InputType & inputIndex) const
+auto
+DiscreteLevelSetImage<TOutput, VDimension>::EvaluateMeanCurvature(const InputType & inputIndex) const -> OutputRealType
 {
   OutputRealType oValue = NumericTraits<OutputRealType>::ZeroValue();
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
@@ -68,8 +68,8 @@ LevelSetBase<TInput, VDimension, TOutput, TDomain>::EvaluateGradientNorm(const I
 
 // ----------------------------------------------------------------------------
 template <typename TInput, unsigned int VDimension, typename TOutput, typename TDomain>
-typename LevelSetBase<TInput, VDimension, TOutput, TDomain>::OutputRealType
-LevelSetBase<TInput, VDimension, TOutput, TDomain>::EvaluateGradientNorm(const InputType & iP) const
+auto
+LevelSetBase<TInput, VDimension, TOutput, TDomain>::EvaluateGradientNorm(const InputType & iP) const -> OutputRealType
 {
   GradientType grad = this->EvaluateGradient(iP);
   return grad.GetNorm();
@@ -77,8 +77,8 @@ LevelSetBase<TInput, VDimension, TOutput, TDomain>::EvaluateGradientNorm(const I
 
 // ----------------------------------------------------------------------------
 template <typename TInput, unsigned int VDimension, typename TOutput, typename TDomain>
-typename LevelSetBase<TInput, VDimension, TOutput, TDomain>::OutputRealType
-LevelSetBase<TInput, VDimension, TOutput, TDomain>::EvaluateMeanCurvature(const InputType & iP) const
+auto
+LevelSetBase<TInput, VDimension, TOutput, TDomain>::EvaluateMeanCurvature(const InputType & iP) const -> OutputRealType
 {
   OutputRealType oValue = NumericTraits<OutputRealType>::ZeroValue();
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.hxx
@@ -25,8 +25,8 @@ namespace itk
 {
 
 template <typename TIdentifier, typename TLevelSet>
-const typename LevelSetContainerBase<TIdentifier, TLevelSet>::LevelSetContainerType &
-LevelSetContainerBase<TIdentifier, TLevelSet>::GetContainer() const
+auto
+LevelSetContainerBase<TIdentifier, TLevelSet>::GetContainer() const -> const LevelSetContainerType &
 {
   return m_Container;
 }
@@ -39,43 +39,43 @@ LevelSetContainerBase<TIdentifier, TLevelSet>::SetContainer(const LevelSetContai
 }
 
 template <typename TIdentifier, typename TLevelSet>
-typename LevelSetContainerBase<TIdentifier, TLevelSet>::Iterator
-LevelSetContainerBase<TIdentifier, TLevelSet>::Begin()
+auto
+LevelSetContainerBase<TIdentifier, TLevelSet>::Begin() -> Iterator
 {
   return Iterator(m_Container.begin());
 }
 
 template <typename TIdentifier, typename TLevelSet>
-typename LevelSetContainerBase<TIdentifier, TLevelSet>::ConstIterator
-LevelSetContainerBase<TIdentifier, TLevelSet>::Begin() const
+auto
+LevelSetContainerBase<TIdentifier, TLevelSet>::Begin() const -> ConstIterator
 {
   return ConstIterator(m_Container.begin());
 }
 
 template <typename TIdentifier, typename TLevelSet>
-typename LevelSetContainerBase<TIdentifier, TLevelSet>::Iterator
-LevelSetContainerBase<TIdentifier, TLevelSet>::End()
+auto
+LevelSetContainerBase<TIdentifier, TLevelSet>::End() -> Iterator
 {
   return Iterator(m_Container.end());
 }
 
 template <typename TIdentifier, typename TLevelSet>
-typename LevelSetContainerBase<TIdentifier, TLevelSet>::ConstIterator
-LevelSetContainerBase<TIdentifier, TLevelSet>::End() const
+auto
+LevelSetContainerBase<TIdentifier, TLevelSet>::End() const -> ConstIterator
 {
   return ConstIterator(m_Container.end());
 }
 
 template <typename TIdentifier, typename TLevelSet>
-typename LevelSetContainerBase<TIdentifier, TLevelSet>::LevelSetIdentifierType
-LevelSetContainerBase<TIdentifier, TLevelSet>::Size() const
+auto
+LevelSetContainerBase<TIdentifier, TLevelSet>::Size() const -> LevelSetIdentifierType
 {
   return static_cast<LevelSetIdentifierType>(m_Container.size());
 }
 
 template <typename TIdentifier, typename TLevelSet>
-typename LevelSetContainerBase<TIdentifier, TLevelSet>::LevelSetPointer
-LevelSetContainerBase<TIdentifier, TLevelSet>::GetLevelSet(const LevelSetIdentifierType & iId) const
+auto
+LevelSetContainerBase<TIdentifier, TLevelSet>::GetLevelSet(const LevelSetIdentifierType & iId) const -> LevelSetPointer
 {
   auto it = m_Container.find(iId);
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDenseImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDenseImage.hxx
@@ -42,8 +42,8 @@ LevelSetDenseImage<TImage>::SetImage(ImageType * inputImage)
 
 // ----------------------------------------------------------------------------
 template <typename TImage>
-typename LevelSetDenseImage<TImage>::OutputType
-LevelSetDenseImage<TImage>::Evaluate(const InputType & inputIndex) const
+auto
+LevelSetDenseImage<TImage>::Evaluate(const InputType & inputIndex) const -> OutputType
 {
   InputType mapIndex = inputIndex - this->m_DomainOffset;
   return this->m_Image->GetPixel(mapIndex);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
@@ -33,8 +33,8 @@ LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::LevelSetDomainMapImageF
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::DomainMapType &
-LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::GetDomainMap() const
+auto
+LevelSetDomainMapImageFilter<TInputImage, TOutputImage>::GetDomainMap() const -> const DomainMapType &
 {
   return this->m_DomainMap;
 }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
@@ -30,8 +30,8 @@ LevelSetDomainPartitionImage<TImage>::SetLevelSetDomainRegionVector(const LevelS
 }
 
 template <typename TImage>
-const typename LevelSetDomainPartitionImage<TImage>::LevelSetDomainRegionVectorType &
-LevelSetDomainPartitionImage<TImage>::GetLevelSetDomainRegionVector() const
+auto
+LevelSetDomainPartitionImage<TImage>::GetLevelSetDomainRegionVector() const -> const LevelSetDomainRegionVectorType &
 {
   return m_LevelSetDomainRegionVector;
 }

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -138,15 +138,17 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::UpdatePixel(
 {}
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::VectorType
+auto
 LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::AdvectionSpeed(const LevelSetInputIndexType & iP) const
+  -> VectorType
 {
   return this->m_AdvectionImage->GetPixel(iP);
 }
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & iP)
+  -> LevelSetOutputRealType
 {
   VectorType             advectionField = this->AdvectionSpeed(iP);
   LevelSetOutputRealType oValue = NumericTraits<LevelSetOutputRealType>::ZeroValue();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
@@ -59,8 +59,9 @@ LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::UpdatePixel(
 {}
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & index)
+  -> LevelSetOutputRealType
 {
   const InputPixelType   pixel = this->m_Mask->GetPixel(index);
   LevelSetOutputRealType value;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
@@ -113,8 +113,9 @@ LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::UpdatePixel
 }
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationChanAndVeseInternalTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & inputIndex)
+  -> LevelSetOutputRealType
 {
   if (this->m_Heaviside.IsNotNull())
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.hxx
@@ -56,8 +56,8 @@ LevelSetEquationContainer<TTermContainer>::AddEquation(const LevelSetIdentifierT
 }
 
 template <typename TTermContainer>
-typename LevelSetEquationContainer<TTermContainer>::TermContainerType *
-LevelSetEquationContainer<TTermContainer>::GetEquation(const LevelSetIdentifierType & iId) const
+auto
+LevelSetEquationContainer<TTermContainer>::GetEquation(const LevelSetIdentifierType & iId) const -> TermContainerType *
 {
   if (this->m_Container.empty())
   {
@@ -73,29 +73,29 @@ LevelSetEquationContainer<TTermContainer>::GetEquation(const LevelSetIdentifierT
 }
 
 template <typename TTermContainer>
-typename LevelSetEquationContainer<TTermContainer>::Iterator
-LevelSetEquationContainer<TTermContainer>::Begin()
+auto
+LevelSetEquationContainer<TTermContainer>::Begin() -> Iterator
 {
   return Iterator(m_Container.begin());
 }
 
 template <typename TTermContainer>
-typename LevelSetEquationContainer<TTermContainer>::Iterator
-LevelSetEquationContainer<TTermContainer>::End()
+auto
+LevelSetEquationContainer<TTermContainer>::End() -> Iterator
 {
   return Iterator(m_Container.end());
 }
 
 template <typename TTermContainer>
-typename LevelSetEquationContainer<TTermContainer>::ConstIterator
-LevelSetEquationContainer<TTermContainer>::Begin() const
+auto
+LevelSetEquationContainer<TTermContainer>::Begin() const -> ConstIterator
 {
   return ConstIterator(m_Container.begin());
 }
 
 template <typename TTermContainer>
-typename LevelSetEquationContainer<TTermContainer>::ConstIterator
-LevelSetEquationContainer<TTermContainer>::End() const
+auto
+LevelSetEquationContainer<TTermContainer>::End() const -> ConstIterator
 {
   return ConstIterator(m_Container.end());
 }
@@ -133,8 +133,8 @@ LevelSetEquationContainer<TTermContainer>::InitializeParameters()
 }
 
 template <typename TTermContainer>
-typename LevelSetEquationContainer<TTermContainer>::LevelSetOutputRealType
-LevelSetEquationContainer<TTermContainer>::ComputeCFLContribution() const
+auto
+LevelSetEquationContainer<TTermContainer>::ComputeCFLContribution() const -> LevelSetOutputRealType
 {
   LevelSetOutputRealType oValue = NumericTraits<LevelSetOutputRealType>::max();
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
@@ -97,8 +97,9 @@ LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Upda
 {}
 
 template <typename TInput, typename TLevelSetContainer, typename TCurvatureImage>
-typename LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::LevelSetOutputRealType
+auto
 LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Value(const LevelSetInputIndexType & iP)
+  -> LevelSetOutputRealType
 {
   if (!m_UseCurvatureImage)
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
@@ -64,8 +64,9 @@ LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::LaplacianSpeed(
 }
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & iP)
+  -> LevelSetOutputRealType
 {
   LevelSetOutputRealType laplacian = this->m_CurrentLevelSetPointer->EvaluateLaplacian(iP);
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
@@ -61,8 +61,9 @@ LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::Initialize(
 {}
 
 template <typename TInput, typename TLevelSetContainer>
-typename LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & index)
+  -> LevelSetOutputRealType
 {
   LevelSetOutputRealType value = NumericTraits<LevelSetOutputRealType>::ZeroValue();
   this->ComputeSumTerm(index, value);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
@@ -77,8 +77,9 @@ LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::
 }
 
 template <typename TInput, typename TLevelSetContainer, typename TPropagationImage>
-typename LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::LevelSetOutputRealType
+auto
 LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::Value(const LevelSetInputIndexType & iP)
+  -> LevelSetOutputRealType
 {
   LevelSetGradientType backwardGradient = this->m_CurrentLevelSetPointer->EvaluateBackwardGradient(iP);
   LevelSetGradientType forwardGradient = this->m_CurrentLevelSetPointer->EvaluateForwardGradient(iP);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
@@ -38,8 +38,8 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::LevelSetEquationTermB
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-const typename LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::RequiredDataType &
-LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::GetRequiredData() const
+auto
+LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::GetRequiredData() const -> const RequiredDataType &
 {
   return this->m_RequiredData;
 }
@@ -63,8 +63,9 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::SetLevelSetContainer(
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::Evaluate(const LevelSetInputIndexType & iP)
+  -> LevelSetOutputRealType
 {
   if (itk::Math::abs(this->m_Coefficient) > NumericTraits<LevelSetOutputRealType>::epsilon())
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
@@ -34,32 +34,32 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::LevelSetEquation
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Iterator
-LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Begin()
+auto
+LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Begin() -> Iterator
 {
   return Iterator(this->m_Container.begin());
 }
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Iterator
-LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::End()
+auto
+LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::End() -> Iterator
 {
   return Iterator(this->m_Container.end());
 }
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::ConstIterator
-LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Begin() const
+auto
+LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Begin() const -> ConstIterator
 {
   return ConstIterator(this->m_Container.begin());
 }
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::ConstIterator
-LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::End() const
+auto
+LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::End() const -> ConstIterator
 {
   return ConstIterator(this->m_Container.end());
 }
@@ -180,8 +180,8 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::PushTerm(TermTyp
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::TermType *
-LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::GetTerm(const std::string & iName)
+auto
+LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::GetTerm(const std::string & iName) -> TermType *
 {
   MapTermContainerIteratorType it = m_Container.find(iName);
 
@@ -195,8 +195,8 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::GetTerm(const st
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::TermType *
-LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::GetTerm(const TermIdType & iId)
+auto
+LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::GetTerm(const TermIdType & iId) -> TermType *
 {
   auto it = m_Container.find(iId);
 
@@ -257,8 +257,9 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::InitializeParame
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::LevelSetOutputRealType
+auto
 LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Evaluate(const LevelSetInputIndexType & iP)
+  -> LevelSetOutputRealType
 {
   auto term_it = m_Container.begin();
   auto term_end = m_Container.end();
@@ -329,8 +330,8 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::Update()
 
 // ----------------------------------------------------------------------------
 template <typename TInputImage, typename TLevelSetContainer>
-typename LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::LevelSetOutputRealType
-LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::ComputeCFLContribution() const
+auto
+LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::ComputeCFLContribution() const -> LevelSetOutputRealType
 {
   auto term_it = m_Container.begin();
   auto term_end = m_Container.end();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetQuadEdgeMesh.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetQuadEdgeMesh.hxx
@@ -24,8 +24,8 @@
 namespace itk
 {
 template <typename TMesh>
-typename LevelSetQuadEdgeMesh<TMesh>::OutputType
-LevelSetQuadEdgeMesh<TMesh>::Evaluate(const InputType & iP) const
+auto
+LevelSetQuadEdgeMesh<TMesh>::Evaluate(const InputType & iP) const -> OutputType
 {
   OutputType oValue = 0.;
   this->m_Mesh->GetPointData(iP, &oValue);
@@ -33,16 +33,16 @@ LevelSetQuadEdgeMesh<TMesh>::Evaluate(const InputType & iP) const
 }
 
 template <typename TMesh>
-typename LevelSetQuadEdgeMesh<TMesh>::GradientType
-LevelSetQuadEdgeMesh<TMesh>::EvaluateGradient(const InputType & itkNotUsed(iP)) const
+auto
+LevelSetQuadEdgeMesh<TMesh>::EvaluateGradient(const InputType & itkNotUsed(iP)) const -> GradientType
 {
   itkWarningMacro(<< "to be implemented");
   return Self::GradientType(); // Create a new object with default initializer
 }
 
 template <typename TMesh>
-typename LevelSetQuadEdgeMesh<TMesh>::HessianType
-LevelSetQuadEdgeMesh<TMesh>::EvaluateHessian(const InputType & itkNotUsed(iP)) const
+auto
+LevelSetQuadEdgeMesh<TMesh>::EvaluateHessian(const InputType & itkNotUsed(iP)) const -> HessianType
 {
   itkWarningMacro(<< "to be implemented");
   return Self::HessianType(); // Create a new objet with default initializer

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.hxx
@@ -25,8 +25,8 @@ namespace itk
 {
 
 template <typename TOutput, unsigned int VDimension>
-typename LevelSetSparseImage<TOutput, VDimension>::LayerIdType
-LevelSetSparseImage<TOutput, VDimension>::Status(const InputType & inputIndex) const
+auto
+LevelSetSparseImage<TOutput, VDimension>::Status(const InputType & inputIndex) const -> LayerIdType
 {
   InputType mapIndex = inputIndex - this->m_DomainOffset;
   return this->m_LabelMap->GetPixel(mapIndex);
@@ -89,8 +89,8 @@ LevelSetSparseImage<TOutput, VDimension>::Graft(const DataObject * data)
 
 
 template <typename TOutput, unsigned int VDimension>
-const typename LevelSetSparseImage<TOutput, VDimension>::LayerType &
-LevelSetSparseImage<TOutput, VDimension>::GetLayer(LayerIdType value) const
+auto
+LevelSetSparseImage<TOutput, VDimension>::GetLayer(LayerIdType value) const -> const LayerType &
 {
   auto it = m_Layers.find(value);
   if (it == m_Layers.end())
@@ -102,8 +102,8 @@ LevelSetSparseImage<TOutput, VDimension>::GetLayer(LayerIdType value) const
 
 
 template <typename TOutput, unsigned int VDimension>
-typename LevelSetSparseImage<TOutput, VDimension>::LayerType &
-LevelSetSparseImage<TOutput, VDimension>::GetLayer(LayerIdType value)
+auto
+LevelSetSparseImage<TOutput, VDimension>::GetLayer(LayerIdType value) -> LayerType &
 {
   auto it = m_Layers.find(value);
   if (it == m_Layers.end())

--- a/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.hxx
@@ -33,8 +33,8 @@ MalcolmSparseLevelSetImage<VDimension>::MalcolmSparseLevelSetImage()
 
 // ----------------------------------------------------------------------------
 template <unsigned int VDimension>
-typename MalcolmSparseLevelSetImage<VDimension>::OutputType
-MalcolmSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputPixel) const
+auto
+MalcolmSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputPixel) const -> OutputType
 {
   InputType mapIndex = inputPixel - this->m_DomainOffset;
   auto      layerIt = this->m_Layers.begin();
@@ -70,8 +70,8 @@ MalcolmSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputPixel) c
 
 // ----------------------------------------------------------------------------
 template <unsigned int VDimension>
-typename MalcolmSparseLevelSetImage<VDimension>::HessianType
-MalcolmSparseLevelSetImage<VDimension>::EvaluateHessian(const InputType & inputPixel) const
+auto
+MalcolmSparseLevelSetImage<VDimension>::EvaluateHessian(const InputType & inputPixel) const -> HessianType
 {
   (void)inputPixel;
   itkGenericExceptionMacro(<< "The approximation of the hessian in the Malcolm's"
@@ -84,8 +84,8 @@ MalcolmSparseLevelSetImage<VDimension>::EvaluateHessian(const InputType & inputP
 
 // ----------------------------------------------------------------------------
 template <unsigned int VDimension>
-typename MalcolmSparseLevelSetImage<VDimension>::OutputRealType
-MalcolmSparseLevelSetImage<VDimension>::EvaluateLaplacian(const InputType & inputPixel) const
+auto
+MalcolmSparseLevelSetImage<VDimension>::EvaluateLaplacian(const InputType & inputPixel) const -> OutputRealType
 {
   (void)inputPixel;
   itkGenericExceptionMacro(<< "The approximation of the hessian in the Malcolm's"
@@ -98,8 +98,8 @@ MalcolmSparseLevelSetImage<VDimension>::EvaluateLaplacian(const InputType & inpu
 
 // ----------------------------------------------------------------------------
 template <unsigned int VDimension>
-typename MalcolmSparseLevelSetImage<VDimension>::OutputRealType
-MalcolmSparseLevelSetImage<VDimension>::EvaluateMeanCurvature(const InputType & inputPixel) const
+auto
+MalcolmSparseLevelSetImage<VDimension>::EvaluateMeanCurvature(const InputType & inputPixel) const -> OutputRealType
 {
   (void)inputPixel;
   itkGenericExceptionMacro(<< "The approximation of the hessian in the Malcolm's"

--- a/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.hxx
@@ -32,8 +32,8 @@ ShiSparseLevelSetImage<VDimension>::ShiSparseLevelSetImage()
 }
 
 template <unsigned int VDimension>
-typename ShiSparseLevelSetImage<VDimension>::OutputType
-ShiSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputIndex) const
+auto
+ShiSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputIndex) const -> OutputType
 {
   InputType mapIndex = inputIndex - this->m_DomainOffset;
   auto      layerIt = this->m_Layers.begin();
@@ -70,8 +70,8 @@ ShiSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputIndex) const
 
 
 template <unsigned int VDimension>
-typename ShiSparseLevelSetImage<VDimension>::HessianType
-ShiSparseLevelSetImage<VDimension>::EvaluateHessian(const InputType & itkNotUsed(inputIndex)) const
+auto
+ShiSparseLevelSetImage<VDimension>::EvaluateHessian(const InputType & itkNotUsed(inputIndex)) const -> HessianType
 {
   itkGenericExceptionMacro(<< "The approximation of the hessian in the Shi's"
                            << " representation is poor, and far to be representative."
@@ -82,8 +82,8 @@ ShiSparseLevelSetImage<VDimension>::EvaluateHessian(const InputType & itkNotUsed
 
 
 template <unsigned int VDimension>
-typename ShiSparseLevelSetImage<VDimension>::OutputRealType
-ShiSparseLevelSetImage<VDimension>::EvaluateLaplacian(const InputType & itkNotUsed(inputIndex)) const
+auto
+ShiSparseLevelSetImage<VDimension>::EvaluateLaplacian(const InputType & itkNotUsed(inputIndex)) const -> OutputRealType
 {
   itkGenericExceptionMacro(<< "The approximation of the hessian in the Shi's"
                            << " representation is poor, and far to be representative."
@@ -94,8 +94,9 @@ ShiSparseLevelSetImage<VDimension>::EvaluateLaplacian(const InputType & itkNotUs
 
 
 template <unsigned int VDimension>
-typename ShiSparseLevelSetImage<VDimension>::OutputRealType
+auto
 ShiSparseLevelSetImage<VDimension>::EvaluateMeanCurvature(const InputType & itkNotUsed(inputIndex)) const
+  -> OutputRealType
 {
   itkGenericExceptionMacro(<< "The approximation of the hessian in the Shi's"
                            << " representation is poor, and far to be representative."

--- a/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.hxx
@@ -32,8 +32,8 @@ WhitakerSparseLevelSetImage<TOutput, VDimension>::WhitakerSparseLevelSetImage()
 }
 
 template <typename TOutput, unsigned int VDimension>
-typename WhitakerSparseLevelSetImage<TOutput, VDimension>::OutputType
-WhitakerSparseLevelSetImage<TOutput, VDimension>::Evaluate(const InputType & inputIndex) const
+auto
+WhitakerSparseLevelSetImage<TOutput, VDimension>::Evaluate(const InputType & inputIndex) const -> OutputType
 {
   InputType mapIndex = inputIndex - this->m_DomainOffset;
   auto      layerIt = this->m_Layers.begin();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetTestFunction.hxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetTestFunction.hxx
@@ -25,16 +25,16 @@ namespace itk
 {
 
 template <typename TPixel>
-typename LevelSetTestFunction<TPixel>::OutputRealType
-LevelSetTestFunction<TPixel>::Evaluate(const PointType & point) const
+auto
+LevelSetTestFunction<TPixel>::Evaluate(const PointType & point) const -> OutputRealType
 {
   return static_cast<OutputRealType>(
     std::sqrt((point[0] - 7.0) * (point[0] - 7.0) + (point[1] - 4.0) * (point[1] - 4.0)) - 3.0);
 }
 
 template <typename TPixel>
-typename LevelSetTestFunction<TPixel>::GradientType
-LevelSetTestFunction<TPixel>::EvaluateGradient(const PointType & point) const
+auto
+LevelSetTestFunction<TPixel>::EvaluateGradient(const PointType & point) const -> GradientType
 {
   GradientType gradient;
   gradient[0] = (point[0] - 7.0) / std::sqrt((point[0] - 7.0) * (point[0] - 7.0) + (point[1] - 4.0) * (point[1] - 4.0));

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -74,8 +74,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::AddSeed(const IndexTy
 
 /** Method to access seed container */
 template <typename TInputImage, typename TOutputImage>
-const typename ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::SeedsContainerType &
-ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds() const
+auto
+ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds() const -> const SeedsContainerType &
 {
   itkDebugMacro("returning Seeds");
   return this->m_Seeds;

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
@@ -70,8 +70,8 @@ ConnectedThresholdImageFilter<TInputImage, TOutputImage>::ClearSeeds()
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename ConnectedThresholdImageFilter<TInputImage, TOutputImage>::SeedContainerType &
-ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetSeeds() const
+auto
+ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetSeeds() const -> const SeedContainerType &
 {
   return this->m_Seeds;
 }
@@ -165,8 +165,8 @@ ConnectedThresholdImageFilter<TInputImage, TOutputImage>::SetLower(const InputIm
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ConnectedThresholdImageFilter<TInputImage, TOutputImage>::InputPixelObjectType *
-ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetLowerInput()
+auto
+ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetLowerInput() -> InputPixelObjectType *
 {
   typename InputPixelObjectType::Pointer lower = static_cast<InputPixelObjectType *>(this->ProcessObject::GetInput(1));
   if (!lower)
@@ -182,8 +182,8 @@ ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetLowerInput()
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ConnectedThresholdImageFilter<TInputImage, TOutputImage>::InputPixelObjectType *
-ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetUpperInput()
+auto
+ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetUpperInput() -> InputPixelObjectType *
 {
   typename InputPixelObjectType::Pointer upper = static_cast<InputPixelObjectType *>(this->ProcessObject::GetInput(2));
   if (!upper)
@@ -199,8 +199,8 @@ ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetUpperInput()
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ConnectedThresholdImageFilter<TInputImage, TOutputImage>::InputImagePixelType
-ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetLower() const
+auto
+ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetLower() const -> InputImagePixelType
 {
   typename InputPixelObjectType::Pointer lower = const_cast<Self *>(this)->GetLowerInput();
 
@@ -208,8 +208,8 @@ ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetLower() const
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename ConnectedThresholdImageFilter<TInputImage, TOutputImage>::InputImagePixelType
-ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetUpper() const
+auto
+ConnectedThresholdImageFilter<TInputImage, TOutputImage>::GetUpper() const -> InputImagePixelType
 {
   typename InputPixelObjectType::Pointer upper = const_cast<Self *>(this)->GetUpperInput();
 

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -157,16 +157,16 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::ClearSeeds2()
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename IsolatedConnectedImageFilter<TInputImage, TOutputImage>::SeedsContainerType &
-IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds1() const
+auto
+IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds1() const -> const SeedsContainerType &
 {
   itkDebugMacro("returning Seeds1");
   return this->m_Seeds1;
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename IsolatedConnectedImageFilter<TInputImage, TOutputImage>::SeedsContainerType &
-IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds2() const
+auto
+IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds2() const -> const SeedsContainerType &
 {
   itkDebugMacro("returning Seeds2");
   return this->m_Seeds2;

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -346,22 +346,22 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::CovarianceMatrixType &
-VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetCovariance() const
+auto
+VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetCovariance() const -> const CovarianceMatrixType &
 {
   return m_ThresholdFunction->GetCovariance();
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::MeanVectorType &
-VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetMean() const
+auto
+VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetMean() const -> const MeanVectorType &
 {
   return m_ThresholdFunction->GetMean();
 }
 
 template <typename TInputImage, typename TOutputImage>
-const typename VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::SeedsContainerType &
-VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds() const
+auto
+VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GetSeeds() const -> const SeedsContainerType &
 {
   itkDebugMacro("returning Seeds");
   return this->m_Seeds;

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
@@ -162,8 +162,9 @@ PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::Initialize()
 
 // Evaluate the signed distance
 template <typename TCoordRep, unsigned int VSpaceDimension, typename TImage>
-typename PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::OutputType
+auto
 PCAShapeSignedDistanceFunction<TCoordRep, VSpaceDimension, TImage>::Evaluate(const PointType & point) const
+  -> OutputType
 {
   // transform the point into the shape model space
   PointType mappedPoint = m_Transform->TransformPoint(point);

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.hxx
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.hxx
@@ -67,8 +67,8 @@ SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::PrintSelf(std::ostream
 
 // Evaluate the signed distance
 template <typename TCoordRep, unsigned int VSpaceDimension>
-typename SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::OutputType
-SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::Evaluate(const PointType & point) const
+auto
+SphereSignedDistanceFunction<TCoordRep, VSpaceDimension>::Evaluate(const PointType & point) const -> OutputType
 {
   using RealType = typename NumericTraits<OutputType>::RealType;
   RealType output = 0.0;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.hxx
@@ -90,8 +90,8 @@ VoronoiDiagram2D<TCoordRepType>::GetCellId(CellIdentifier cellId, CellAutoPointe
 
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2D<TCoordRepType>::EdgeInfo
-VoronoiDiagram2D<TCoordRepType>::GetSeedsIDAroundEdge(VoronoiEdge * task)
+auto
+VoronoiDiagram2D<TCoordRepType>::GetSeedsIDAroundEdge(VoronoiEdge * task) -> EdgeInfo
 {
   EdgeInfo answer;
 
@@ -102,56 +102,56 @@ VoronoiDiagram2D<TCoordRepType>::GetSeedsIDAroundEdge(VoronoiEdge * task)
 
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2D<TCoordRepType>::VoronoiEdgeIterator
-VoronoiDiagram2D<TCoordRepType>::EdgeBegin()
+auto
+VoronoiDiagram2D<TCoordRepType>::EdgeBegin() -> VoronoiEdgeIterator
 {
   return m_EdgeList.begin();
 }
 
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2D<TCoordRepType>::VoronoiEdgeIterator
-VoronoiDiagram2D<TCoordRepType>::EdgeEnd()
+auto
+VoronoiDiagram2D<TCoordRepType>::EdgeEnd() -> VoronoiEdgeIterator
 {
   return m_EdgeList.end();
 }
 
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2D<TCoordRepType>::NeighborIdIterator
-VoronoiDiagram2D<TCoordRepType>::NeighborIdsBegin(int seeds)
+auto
+VoronoiDiagram2D<TCoordRepType>::NeighborIdsBegin(int seeds) -> NeighborIdIterator
 {
   return m_CellNeighborsID[seeds].begin();
 }
 
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2D<TCoordRepType>::NeighborIdIterator
-VoronoiDiagram2D<TCoordRepType>::NeighborIdsEnd(int seeds)
+auto
+VoronoiDiagram2D<TCoordRepType>::NeighborIdsEnd(int seeds) -> NeighborIdIterator
 {
   return m_CellNeighborsID[seeds].end();
 }
 
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2D<TCoordRepType>::VertexIterator
-VoronoiDiagram2D<TCoordRepType>::VertexBegin()
+auto
+VoronoiDiagram2D<TCoordRepType>::VertexBegin() -> VertexIterator
 {
   return this->m_PointsContainer->Begin();
 }
 
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2D<TCoordRepType>::VertexIterator
-VoronoiDiagram2D<TCoordRepType>::VertexEnd()
+auto
+VoronoiDiagram2D<TCoordRepType>::VertexEnd() -> VertexIterator
 {
   return this->m_PointsContainer->End();
 }
 
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2D<TCoordRepType>::PointType
-VoronoiDiagram2D<TCoordRepType>::GetSeed(int SeedID)
+auto
+VoronoiDiagram2D<TCoordRepType>::GetSeed(int SeedID) -> PointType
 {
   PointType answer;
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -144,8 +144,8 @@ VoronoiDiagram2DGenerator<TCoordRepType>::AddOneSeed(PointType inputSeed)
 }
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2DGenerator<TCoordRepType>::PointType
-VoronoiDiagram2DGenerator<TCoordRepType>::GetSeed(int SeedID)
+auto
+VoronoiDiagram2DGenerator<TCoordRepType>::GetSeed(int SeedID) -> PointType
 {
   PointType answer;
 
@@ -587,8 +587,8 @@ VoronoiDiagram2DGenerator<TCoordRepType>::dist(FortuneSite * s1, FortuneSite * s
 }
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2DGenerator<TCoordRepType>::FortuneHalfEdge *
-VoronoiDiagram2DGenerator<TCoordRepType>::ELgethash(int b)
+auto
+VoronoiDiagram2DGenerator<TCoordRepType>::ELgethash(int b) -> FortuneHalfEdge *
 {
   if ((b < 0) || (b >= static_cast<int>(m_ELhashsize)))
   {
@@ -613,8 +613,8 @@ VoronoiDiagram2DGenerator<TCoordRepType>::ELgethash(int b)
 }
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2DGenerator<TCoordRepType>::FortuneHalfEdge *
-VoronoiDiagram2DGenerator<TCoordRepType>::findLeftHE(PointType * p)
+auto
+VoronoiDiagram2DGenerator<TCoordRepType>::findLeftHE(PointType * p) -> FortuneHalfEdge *
 {
   int  i;
   auto bucket = (int)((((*p)[0]) - m_Pxmin) / m_Deltax * m_ELhashsize);
@@ -667,8 +667,8 @@ VoronoiDiagram2DGenerator<TCoordRepType>::findLeftHE(PointType * p)
 }
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2DGenerator<TCoordRepType>::FortuneSite *
-VoronoiDiagram2DGenerator<TCoordRepType>::getRightReg(FortuneHalfEdge * he)
+auto
+VoronoiDiagram2DGenerator<TCoordRepType>::getRightReg(FortuneHalfEdge * he) -> FortuneSite *
 {
   if ((he->m_Edge) == nullptr)
   {
@@ -685,8 +685,8 @@ VoronoiDiagram2DGenerator<TCoordRepType>::getRightReg(FortuneHalfEdge * he)
 }
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2DGenerator<TCoordRepType>::FortuneSite *
-VoronoiDiagram2DGenerator<TCoordRepType>::getLeftReg(FortuneHalfEdge * he)
+auto
+VoronoiDiagram2DGenerator<TCoordRepType>::getLeftReg(FortuneHalfEdge * he) -> FortuneSite *
 {
   if ((he->m_Edge) == nullptr)
   {
@@ -807,8 +807,8 @@ VoronoiDiagram2DGenerator<TCoordRepType>::intersect(FortuneSite * newV, FortuneH
 }
 
 template <typename TCoordRepType>
-typename VoronoiDiagram2DGenerator<TCoordRepType>::FortuneHalfEdge *
-VoronoiDiagram2DGenerator<TCoordRepType>::getPQmin()
+auto
+VoronoiDiagram2DGenerator<TCoordRepType>::getPQmin() -> FortuneHalfEdge *
 {
   FortuneHalfEdge * curr = m_PQHash[m_PQmin].m_Next;
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -34,8 +34,8 @@ Relabeler<TScalar, TImageDimension>::Relabeler()
 }
 
 template <typename TScalar, unsigned int TImageDimension>
-typename Relabeler<TScalar, TImageDimension>::DataObjectPointer
-Relabeler<TScalar, TImageDimension>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
+auto
+Relabeler<TScalar, TImageDimension>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx)) -> DataObjectPointer
 {
   return ImageType::New().GetPointer();
 }

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -36,8 +36,8 @@ SegmentTreeGenerator<TScalar>::SegmentTreeGenerator()
 }
 
 template <typename TScalar>
-typename SegmentTreeGenerator<TScalar>::DataObjectPointer
-SegmentTreeGenerator<TScalar>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx))
+auto
+SegmentTreeGenerator<TScalar>::MakeOutput(DataObjectPointerArraySizeType itkNotUsed(idx)) -> DataObjectPointer
 {
   return SegmentTreeType::New().GetPointer();
 }

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -1241,8 +1241,8 @@ Segmenter<TInputImage>::Threshold(InputImageTypePointer destination,
   ----------------------------------------------------------------------------
 */
 template <typename TInputImage>
-typename Segmenter<TInputImage>::DataObjectPointer
-Segmenter<TInputImage>::MakeOutput(DataObjectPointerArraySizeType idx)
+auto
+Segmenter<TInputImage>::MakeOutput(DataObjectPointerArraySizeType idx) -> DataObjectPointer
 {
   if (idx == 0)
   {

--- a/Modules/Video/Core/include/itkRingBuffer.hxx
+++ b/Modules/Video/Core/include/itkRingBuffer.hxx
@@ -139,8 +139,8 @@ RingBuffer<TElement>::SetBufferContents(OffsetValueType offset, ElementPointer e
 // GetNumberOfBuffers
 //
 template <typename TElement>
-typename RingBuffer<TElement>::SizeValueType
-RingBuffer<TElement>::GetNumberOfBuffers()
+auto
+RingBuffer<TElement>::GetNumberOfBuffers() -> SizeValueType
 {
   return static_cast<typename RingBuffer<TElement>::SizeValueType>(this->m_PointerVector.size());
 }
@@ -197,8 +197,8 @@ RingBuffer<TElement>::SetNumberOfBuffers(SizeValueType n)
 // GetOffsetBufferIndex
 //
 template <typename TElement>
-typename RingBuffer<TElement>::OffsetValueType
-RingBuffer<TElement>::GetOffsetBufferIndex(OffsetValueType offset)
+auto
+RingBuffer<TElement>::GetOffsetBufferIndex(OffsetValueType offset) -> OffsetValueType
 {
   OffsetValueType moddedOffset = itk::Math::abs(offset) % this->GetNumberOfBuffers();
   auto            signedHeadIndex = static_cast<OffsetValueType>(m_HeadIndex);

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -54,8 +54,8 @@ VideoSource<TOutputVideoStream>::PrintSelf(std::ostream & os, Indent indent) con
 // GetOutput()
 //
 template <typename TOutputVideoStream>
-typename VideoSource<TOutputVideoStream>::OutputVideoStreamType *
-VideoSource<TOutputVideoStream>::GetOutput()
+auto
+VideoSource<TOutputVideoStream>::GetOutput() -> OutputVideoStreamType *
 {
   // Make sure there is at least 1 output
   if (this->GetNumberOfOutputs() < 1)

--- a/Modules/Video/Core/include/itkVideoStream.hxx
+++ b/Modules/Video/Core/include/itkVideoStream.hxx
@@ -219,8 +219,9 @@ VideoStream<TFrameType>::SetFrameNumberOfComponentsPerPixel(SizeValueType frameN
 }
 
 template <typename TFrameType>
-const typename VideoStream<TFrameType>::NumberOfComponentsPerPixelType &
+auto
 VideoStream<TFrameType>::GetFrameNumberOfComponentsPerPixel(SizeValueType frameNumber) const
+  -> const NumberOfComponentsPerPixelType &
 {
   return const_cast<Self *>(this)->m_NumberOfComponentsPerPixelCache[frameNumber];
 }
@@ -358,8 +359,8 @@ VideoStream<TFrameType>::SetFrame(SizeValueType frameNumber, FramePointer frame)
 
 
 template <typename TFrameType>
-typename VideoStream<TFrameType>::FrameType *
-VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber)
+auto
+VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber) -> FrameType *
 {
 
   // Fetch the frame
@@ -370,8 +371,8 @@ VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber)
 
 
 template <typename TFrameType>
-const typename VideoStream<TFrameType>::FrameType *
-VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber) const
+auto
+VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber) const -> const FrameType *
 {
   typename BufferType::ElementPointer element = m_DataObjectBuffer->GetBufferContents(frameNumber);
   FrameConstPointer                   frame = dynamic_cast<FrameType *>(element.GetPointer());

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -116,8 +116,8 @@ VideoFileReader<TOutputVideoStream>::UpdateOutputInformation()
 }
 
 template <typename TOutputVideoStream>
-typename VideoFileReader<TOutputVideoStream>::FrameOffsetType
-VideoFileReader<TOutputVideoStream>::GetCurrentPositionFrame()
+auto
+VideoFileReader<TOutputVideoStream>::GetCurrentPositionFrame() -> FrameOffsetType
 {
   if (m_VideoIO.IsNull())
   {
@@ -127,8 +127,8 @@ VideoFileReader<TOutputVideoStream>::GetCurrentPositionFrame()
 }
 
 template <typename TOutputVideoStream>
-typename VideoFileReader<TOutputVideoStream>::TemporalRatioType
-VideoFileReader<TOutputVideoStream>::GetCurrentPositionRatio()
+auto
+VideoFileReader<TOutputVideoStream>::GetCurrentPositionRatio() -> TemporalRatioType
 {
   if (m_VideoIO.IsNull())
   {
@@ -138,8 +138,8 @@ VideoFileReader<TOutputVideoStream>::GetCurrentPositionRatio()
 }
 
 template <typename TOutputVideoStream>
-typename VideoFileReader<TOutputVideoStream>::TemporalRatioType
-VideoFileReader<TOutputVideoStream>::GetCurrentPositionMSec()
+auto
+VideoFileReader<TOutputVideoStream>::GetCurrentPositionMSec() -> TemporalRatioType
 {
   if (m_VideoIO.IsNull())
   {
@@ -149,8 +149,8 @@ VideoFileReader<TOutputVideoStream>::GetCurrentPositionMSec()
 }
 
 template <typename TOutputVideoStream>
-typename VideoFileReader<TOutputVideoStream>::FrameOffsetType
-VideoFileReader<TOutputVideoStream>::GetNumberOfFrames()
+auto
+VideoFileReader<TOutputVideoStream>::GetNumberOfFrames() -> FrameOffsetType
 {
   if (m_VideoIO.IsNull())
   {
@@ -160,8 +160,8 @@ VideoFileReader<TOutputVideoStream>::GetNumberOfFrames()
 }
 
 template <typename TOutputVideoStream>
-typename VideoFileReader<TOutputVideoStream>::TemporalRatioType
-VideoFileReader<TOutputVideoStream>::GetFramesPerSecond()
+auto
+VideoFileReader<TOutputVideoStream>::GetFramesPerSecond() -> TemporalRatioType
 {
   if (m_VideoIO.IsNull())
   {

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -56,8 +56,8 @@ VideoFileWriter<TInputVideoStream>::SetInput(const VideoStreamType * input)
 }
 
 template <typename TInputVideoStream>
-const typename VideoFileWriter<TInputVideoStream>::VideoStreamType *
-VideoFileWriter<TInputVideoStream>::GetInput()
+auto
+VideoFileWriter<TInputVideoStream>::GetInput() -> const VideoStreamType *
 {
   if (this->GetNumberOfInputs() < 1)
   {


### PR DESCRIPTION
Worked around three categories of VS2017 compile errors, caused by compiler bugs:

> error C2653: '...': is not a class or namespace name
> error C2886: '...': symbol cannot be used in a member using-declaration
> error C2244: unable to match function definition to an existing declaration

The errors were reported by @dzenanz at #2759 "COMP: making it compile on VS2017" , after the merge of pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2567 https://github.com/InsightSoftwareConsortium/ITK/commit/4f309803b9b3c0268679d658e22d2f751f9c7b6c "STYLE: Avoid repeating parent aliases"