### PR TITLE
COMP: Fix missing initialization braces warning

### DIFF
--- a/Modules/Core/Common/test/itkMultiThreaderExceptionsTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderExceptionsTest.cxx
@@ -56,7 +56,7 @@ protected:
     TOutputImage * output = nullptr;
     output = this->GetOutput(0);
     typename TOutputImage::RegionType largestPossibleRegion;
-    largestPossibleRegion.SetSize({ 4 });
+    largestPossibleRegion.SetSize({ { 4 } });
     output->SetLargestPossibleRegion(largestPossibleRegion);
   }
 


### PR DESCRIPTION
Fix missing initialization braces warning.

Fixes:
```
[CTest: warning matched]
/Users/builder/externalModules/Core/Common/test/itkMultiThreaderExceptionsTest.cxx:59:37:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
    largestPossibleRegion.SetSize({ 4 });
                                    ^
                                    {}
```

reported at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=7496967

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)