### PR TITLE
ENH: Added interface files for wrapped Python classes and methods.

### DIFF
--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -315,6 +315,9 @@ macro(itk_end_wrap_module_swig_interface)
   set(mdx_file "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${WRAPPER_LIBRARY_NAME}.mdx")
   set(module_interface_file "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${WRAPPER_LIBRARY_NAME}.i")
   set(module_interface_ext_file "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${WRAPPER_LIBRARY_NAME}_ext.i")
+  set(ITK_STUB_DIR "${ITK_DIR}/Wrapping/Generators/Python/itk-stubs")
+
+  set(ITK_STUB_PYI_FILE "${ITK_STUB_DIR}/${WRAPPER_LIBRARY_NAME}.pyi")
 
   foreach(module ${SWIG_INTERFACE_MODULES})
     # create the swig interface
@@ -361,8 +364,9 @@ macro(itk_end_wrap_module_swig_interface)
       else()
         unset(snake_case_config_file)
       endif()
+
     add_custom_command(
-      OUTPUT ${i_files} ${typedef_files} ${idx_files} ${snake_case_config_file}
+      OUTPUT ${i_files} ${typedef_files} ${idx_files} ${snake_case_config_file} ${ITK_STUB_PYI_FILE}
       COMMAND ${Python3_EXECUTABLE} ${IGENERATOR}
         ${mdx_opts}
         ${swig_libs}
@@ -374,6 +378,7 @@ macro(itk_end_wrap_module_swig_interface)
         --interface-output-dir "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}"
         --library-output-dir "${WRAPPER_LIBRARY_OUTPUT_DIR}"
         --submodule-order "${WRAPPER_SUBMODULE_ORDER}"
+        --pyi_dir "${ITK_STUB_DIR}"
         DEPENDS ${ITK_WRAP_DOC_DOCSTRING_FILES} ${xml_files} ${IGENERATOR} ${typedef_in_files}
         WORKING_DIRECTORY / # Arguments to WORKING_DIRECTORY may use generator expressions
       VERBATIM


### PR DESCRIPTION
Wrapped Python classes and methods, have introspection enabled typehints to allow auto-completion in IDE's.
    
Logic was added to the igenerator.py file to produce stubs for wrapped ITK classes in Python.
    
A large number of available ITK classes are currently supported by this feature, with more being worked on.
    
The itk-stubs directory is created with a __init__.pyi file that provides all the interface stubs to tools that can utilize stub files. The included interface files provide information needed for IDE's like Pycharm. Once built there should be no extra setup needed to get the hinting functionality.  The hints for type selection factories use Template and Proxy names  appended to them to differentiate them from the actual ITK classes. The  interfaces may provide hints for types that are not valid in some cases.  The interfaces suggest potentially correct input options.  For example methods may only accept a double or character depending on the object type, but the hints will suggest both leaving it up to the user to determine which type is valid.
    
NOTE: Stub files must use relative imports for .pyi files in order to expose the imported symbols.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
