### PR TITLE
STYLE: Make `IODCMTK` module test style consistent

### DIFF
--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOMultiFrameImageTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOMultiFrameImageTest.cxx
@@ -24,6 +24,7 @@
 #include "itkSubtractImageFilter.h"
 #include "itkStatisticsImageFilter.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 using PixelType = short;
 using ImageType = itk::Image<PixelType, 3>;
@@ -87,7 +88,8 @@ itkDCMTKImageIOMultiFrameImageTest(int ac, char * av[])
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " <multiframe image>" << std::endl;
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " multiframeImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -97,16 +99,9 @@ itkDCMTKImageIOMultiFrameImageTest(int ac, char * av[])
   reader->SetFileName(av[1]);
   reader->SetImageIO(dcmImageIO);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file reader " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+
   ImageType::Pointer im = reader->GetOutput();
   DirectionType      dir = im->GetDirection();
   SpacingType        spacing = im->GetSpacing();
@@ -143,5 +138,8 @@ itkDCMTKImageIOMultiFrameImageTest(int ac, char * av[])
               << spacing << std::endl;
     return EXIT_FAILURE;
   }
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIONoPreambleTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIONoPreambleTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkDCMTKImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -30,7 +31,8 @@ itkDCMTKImageIONoPreambleTest(int ac, char * av[])
 
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " DicomImage\n";
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -51,16 +53,8 @@ itkDCMTKImageIONoPreambleTest(int ac, char * av[])
   reader->SetFileName(av[1]);
   reader->SetImageIO(dcmImageIO);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file reader " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   InputImageType::SizeType extentSize;
   extentSize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
@@ -72,5 +66,7 @@ itkDCMTKImageIONoPreambleTest(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOOrthoDirTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOOrthoDirTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileReader.h"
 #include "itkDCMTKImageIO.h"
 #include "itkVersor.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -31,7 +32,8 @@ itkDCMTKImageIOOrthoDirTest(int ac, char * av[])
 
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " DicomImage\n";
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -46,16 +48,8 @@ itkDCMTKImageIOOrthoDirTest(int ac, char * av[])
   reader->SetFileName(av[1]);
   reader->SetImageIO(dcmImageIO);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file reader " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   InputImageType::DirectionType directionCosines;
   directionCosines = reader->GetOutput()->GetDirection();
@@ -64,16 +58,9 @@ itkDCMTKImageIOOrthoDirTest(int ac, char * av[])
 
   itk::Versor<itk::SpacePrecisionType> rotation;
 
-  try
-  {
-    rotation.Set(directionCosines);
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception setting matrix" << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(rotation.Set(directionCosines));
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOSlopeInterceptTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOSlopeInterceptTest.cxx
@@ -23,13 +23,15 @@
 #include "itkAddImageFilter.h"
 #include "itkSubtractImageFilter.h"
 #include "itkStatisticsImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkDCMTKImageIOSlopeInterceptTest(int ac, char * av[])
 {
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " <original image> <slope intercept image>" << std::endl;
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " originalImage slopeInterceptImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -50,16 +52,9 @@ itkDCMTKImageIOSlopeInterceptTest(int ac, char * av[])
     reader->SetFileName(av[i + 1]);
     reader->SetImageIO(dcmImageIO);
 
-    try
-    {
-      reader->Update();
-    }
-    catch (const itk::ExceptionObject & e)
-    {
-      std::cerr << "exception in file reader " << std::endl;
-      std::cerr << e << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+
     images[i] = reader->GetOutput();
   }
 
@@ -84,5 +79,8 @@ itkDCMTKImageIOSlopeInterceptTest(int ac, char * av[])
       return EXIT_FAILURE;
     }
   }
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileWriter.h"
 #include "itkDCMTKImageIO.h"
 #include "itkRescaleIntensityImageFilter.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -31,7 +32,9 @@ itkDCMTKImageIOTest(int ac, char * av[])
 
   if (ac < 5)
   {
-    std::cerr << "Usage: " << av[0] << " DicomImage OutputDicomImage OutputImage RescalDicomImage\n";
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
+              << " DicomImage OutputDicomImage OutputImage RescalDicomImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -47,16 +50,8 @@ itkDCMTKImageIOTest(int ac, char * av[])
   reader->SetImageIO(dcmtkImageIO);
   // reader->DebugOn();
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file reader " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   // Rescale intensities and rewrite the image in another format
   //
@@ -75,16 +70,8 @@ itkDCMTKImageIOTest(int ac, char * av[])
   writer2->SetFileName(av[3]);
   writer2->SetInput(rescaler->GetOutput());
 
-  try
-  {
-    writer2->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file writer " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer2->Update());
+
 
   dcmtkImageIO->Print(std::cout);
 

--- a/Modules/IO/DCMTK/test/itkDCMTKLoggerTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKLoggerTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include <iostream>
 #include "itkDCMTKImageIO.h"
+#include "itkTestingMacros.h"
 
 static int
 TestLogLevel(itk::DCMTKImageIO::Pointer & io, itk::DCMTKImageIO::LogLevelEnum ll)
@@ -56,19 +57,13 @@ itkDCMTKLoggerTest(int, char *[])
   {
     return EXIT_FAILURE;
   }
-  try
-  {
-    // use C-style cast because C++ casts complain.
-    auto illegalVal = (itk::DCMTKImageIO::LogLevelEnum)((unsigned)itk::DCMTKImageIO::LogLevelEnum::OFF_LOG_LEVEL + 99);
-    TestLogLevel(io, illegalVal);
-    //
-    // expected exception
-    std::cerr << "Failed to detect invalid assignment of " << static_cast<int>(illegalVal) << " to LogLevel"
-              << std::endl;
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Expected exception (illegal log level assignment)" << std::endl << e << std::endl;
-  }
+
+  // use C-style cast because C++ casts complain.
+  auto illegalVal = (itk::DCMTKImageIO::LogLevelEnum)((unsigned)itk::DCMTKImageIO::LogLevelEnum::OFF_LOG_LEVEL + 99);
+
+  ITK_TRY_EXPECT_EXCEPTION(TestLogLevel(io, illegalVal));
+
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/DCMTK/test/itkDCMTKMultiFrame4DTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKMultiFrame4DTest.cxx
@@ -21,15 +21,16 @@
 #include "itkDCMTKImageIO.h"
 #include "itkSubtractImageFilter.h"
 #include "itkStatisticsImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkDCMTKMultiFrame4DTest(int argc, char * argv[])
 {
   if (argc != 3)
   {
-    std::cerr << "Missing filenames" << std::endl
-              << "itkDCMTKMultiFram4DTest"
-              << " <inputDicomFile> <outputFile>" << std::endl;
+    std::cerr << "Missing Parameters" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " itkDCMTKMultiFram4DTest"
+              << " inputDicomFile" << std::endl;
     return EXIT_FAILURE;
   }
   using ImageType = itk::Image<unsigned short, 4>;
@@ -37,41 +38,21 @@ itkDCMTKMultiFrame4DTest(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<ImageType>;
 
   ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
   reader->SetImageIO(itk::DCMTKImageIO::New());
   reader->SetFileName(argv[1]);
-  writer->SetFileName(argv[2]);
 
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file reader" << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
 
   ImageType::Pointer im = reader->GetOutput();
   std::cout << im;
-  writer->SetInput(im);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file writer" << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
-  catch (...)
-  {
-    return EXIT_FAILURE;
-  }
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(im);
+  writer->SetFileName(argv[2]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   // don't want to set imageIO so re-instantiate reader
   reader = ReaderType::New();
@@ -87,21 +68,17 @@ itkDCMTKMultiFrame4DTest(int argc, char * argv[])
   StatisticsFilterType::Pointer statisticsFilter = StatisticsFilterType::New();
 
   statisticsFilter->SetInput(subtractFilter->GetOutput());
-  try
-  {
-    statisticsFilter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception checking files " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(statisticsFilter->Update());
+
+
   if (statisticsFilter->GetMinimum() != 0.0 || statisticsFilter->GetMaximum() != 0.0)
   {
     std::cerr << "file written doesn't match file read." << std::endl
               << "min(" << statisticsFilter->GetMinimum() << ") max(" << statisticsFilter->GetMaximum() << std::endl;
     return EXIT_FAILURE;
   }
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/DCMTK/test/itkDCMTKRGBImageIOTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKRGBImageIOTest.cxx
@@ -21,6 +21,7 @@
 #include "itkDCMTKImageIO.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkRGBPixel.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -32,7 +33,8 @@ itkDCMTKRGBImageIOTest(int ac, char * av[])
 
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " DicomImage OutputImage\n";
+    std::cerr << "Missing Parameters" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage OutputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -47,16 +49,8 @@ itkDCMTKRGBImageIOTest(int ac, char * av[])
   reader->SetFileName(av[1]);
   reader->SetImageIO(dcmtkImageIO);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file reader " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   using WriteImageType = itk::Image<PixelType, 2>;
   using Writer2Type = itk::ImageFileWriter<WriteImageType>;
@@ -64,18 +58,12 @@ itkDCMTKRGBImageIOTest(int ac, char * av[])
   writer2->SetFileName(av[2]);
   writer2->SetInput(reader->GetOutput());
 
-  try
-  {
-    writer2->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file writer " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer2->Update());
+
 
   dcmtkImageIO->Print(std::cout);
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Make `IODCMTK` module test style consistent with ITK guidelines:
- Use the `ITK_TRY_EXPECT_NO_EXCEPTION` and `ITK_TRY_EXPECT_EXCEPTION`
  macros to avoid boilerplate code.
- Use the `itkNameOfTestExecutableMacro` macro to get the test name and
  prevent the test from crashing when `argv[0]` is null.
- Improve the style to make them more consistent (e.g. input argument
  checking or test finishing message, input argument naming).
- Remove unused input argument in `itkDCMTKMultiFrame4DTest.cxx`.
- Declare variables closer to where they are used.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)