### PR TITLE
BUG: Replace deprecated macro in 1D FFT classes

### DIFF
--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
@@ -42,7 +42,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT ComplexToComplex1DFFTImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ComplexToComplex1DFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ComplexToComplex1DFFTImageFilter);
 
   /** Standard class type alias. */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
@@ -38,7 +38,7 @@ template <typename TInputImage,
 class ITK_TEMPLATE_EXPORT FFTWForward1DFFTImageFilter : public Forward1DFFTImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FFTWForward1DFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FFTWForward1DFFTImageFilter);
 
   using Self = FFTWForward1DFFTImageFilter;
   using Superclass = Forward1DFFTImageFilter<TInputImage, TOutputImage>;

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
@@ -38,7 +38,7 @@ template <typename TInputImage,
 class ITK_TEMPLATE_EXPORT FFTWInverse1DFFTImageFilter : public Inverse1DFFTImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FFTWInverse1DFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FFTWInverse1DFFTImageFilter);
 
   using Self = FFTWInverse1DFFTImageFilter;
   using Superclass = Inverse1DFFTImageFilter<TInputImage, TOutputImage>;

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
@@ -36,7 +36,7 @@ template <typename TInputImage,
 class ITK_TEMPLATE_EXPORT Forward1DFFTImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(Forward1DFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(Forward1DFFTImageFilter);
 
   /** Standard class type alias. */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -37,7 +37,7 @@ template <typename TInputImage,
 class ITK_TEMPLATE_EXPORT Inverse1DFFTImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(Inverse1DFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(Inverse1DFFTImageFilter);
 
   /** Standard class type alias. */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
@@ -36,7 +36,7 @@ class ITK_TEMPLATE_EXPORT VnlComplexToComplex1DFFTImageFilter
   : public ComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VnlComplexToComplex1DFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VnlComplexToComplex1DFFTImageFilter);
 
   /** Standard class type alias. */
   using Self = VnlComplexToComplex1DFFTImageFilter;

--- a/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
@@ -36,7 +36,7 @@ template <typename TInputImage,
 class ITK_TEMPLATE_EXPORT VnlForward1DFFTImageFilter : public Forward1DFFTImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VnlForward1DFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VnlForward1DFFTImageFilter);
 
   /** Standard class type alias. */
   using Self = VnlForward1DFFTImageFilter;

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
@@ -37,7 +37,7 @@ template <typename TInputImage,
 class ITK_TEMPLATE_EXPORT VnlInverse1DFFTImageFilter : public Inverse1DFFTImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VnlInverse1DFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VnlInverse1DFFTImageFilter);
 
   /** Standard class type alias. */
   using Self = VnlInverse1DFFTImageFilter;


### PR DESCRIPTION
Fixes static assert build failures in Mac11.0-AppleClang-dbg nightly build

https://open.cdash.org/viewBuildError.php?type=0&buildid=7500725

Example failure:
> In file included from /Users/builder/externalModules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx:27: /Users/builder/externalModules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h:45:3: error: static_assert failed "Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE"   ITK_DISALLOW_COPY_AND_ASSIGN(ComplexToComplex1DFFTImageFilter);   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--


<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
