### PR TITLE
STYLE: clang-format AlignEscapedNewlines Left (for macro definitions)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,7 @@ AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Right
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
 # clang 9.0 AllowAllArgumentsOnNextLine: true

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.h
@@ -21,15 +21,15 @@
 #include "itkImageSource.h"
 #include "itkImportImageContainer.h"
 
-#define itkSetMacro2(name, type)                                                                                       \
-  virtual void Set##name(type _arg)                                                                                    \
-  {                                                                                                                    \
-    itkDebugMacro("setting " #name " to " << _arg);                                                                    \
-    if (this->m_##name != _arg)                                                                                        \
-    {                                                                                                                  \
-      this->m_##name = _arg;                                                                                           \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
+#define itkSetMacro2(name, type)                    \
+  virtual void Set##name(type _arg)                 \
+  {                                                 \
+    itkDebugMacro("setting " #name " to " << _arg); \
+    if (this->m_##name != _arg)                     \
+    {                                               \
+      this->m_##name = _arg;                        \
+      this->Modified();                             \
+    }                                               \
   }
 
 namespace itk

--- a/Modules/Core/Common/CMake/itkCheckHasFenvtStructMember.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFenvtStructMember.cxx
@@ -30,7 +30,7 @@ main()
   (void)sizeof(fenv.__cw);
 #else
   (void)fenv;
-#  error                                                                                                               \
+#  error \
     "Unknown fenv_t struct member test: Make sure to specify a compile definition of the form -DITK_CHECK_FENV_T_xxx"
 #endif
   return 0;

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -29,52 +29,52 @@
 // Define a macro for CellInterface sub-classes to use
 // to define the Accept and GetTopologyId virtuals used
 // by the MultiVisitor class
-#define itkCellVisitMacro(TopologyId)                                                                                  \
-  static constexpr CellGeometryEnum GetTopologyId() { return TopologyId; }                                             \
-  virtual void Accept(CellIdentifier cellid, typename CellInterface<PixelType, CellTraits>::MultiVisitor * mv)         \
-    override                                                                                                           \
-  {                                                                                                                    \
-    typename CellInterfaceVisitor<PixelType, CellTraits>::Pointer v = mv->GetVisitor(TopologyId);                      \
-    if (v)                                                                                                             \
-    {                                                                                                                  \
-      v->VisitFromCell(cellid, this);                                                                                  \
-    }                                                                                                                  \
+#define itkCellVisitMacro(TopologyId)                                                                          \
+  static constexpr CellGeometryEnum GetTopologyId() { return TopologyId; }                                     \
+  virtual void Accept(CellIdentifier cellid, typename CellInterface<PixelType, CellTraits>::MultiVisitor * mv) \
+    override                                                                                                   \
+  {                                                                                                            \
+    typename CellInterfaceVisitor<PixelType, CellTraits>::Pointer v = mv->GetVisitor(TopologyId);              \
+    if (v)                                                                                                     \
+    {                                                                                                          \
+      v->VisitFromCell(cellid, this);                                                                          \
+    }                                                                                                          \
   }
 
 // Define a macro for the common type alias required by the
 // classes deriving form CellInterface (included).
-#define itkCellCommonTypedefs(celltype)                                                                                \
-  using Self = celltype;                                                                                               \
-  using ConstSelfAutoPointer = AutoPointer<const Self>;                                                                \
-  using SelfAutoPointer = AutoPointer<Self>;                                                                           \
-  using RawPointer = Self *;                                                                                           \
+#define itkCellCommonTypedefs(celltype)                 \
+  using Self = celltype;                                \
+  using ConstSelfAutoPointer = AutoPointer<const Self>; \
+  using SelfAutoPointer = AutoPointer<Self>;            \
+  using RawPointer = Self *;                            \
   using ConstRawPointer = const Self *
 
 // Define a macro for the common type alias required by the
 // classes deriving form CellInterface (excluded).
-#define itkCellInheritedTypedefs(superclassArg)                                                                        \
-  using Superclass = superclassArg;                                                                                    \
-  using typename Superclass::PixelType;                                                                                \
-  using CellType = typename Superclass::CellType;                                                                      \
-  using typename Superclass::CellAutoPointer;                                                                          \
-  using typename Superclass::CellConstAutoPointer;                                                                     \
-  using typename Superclass::CellRawPointer;                                                                           \
-  using typename Superclass::CellConstRawPointer;                                                                      \
-  using typename Superclass::CellTraits;                                                                               \
-  using typename Superclass::CoordRepType;                                                                             \
-  using typename Superclass::InterpolationWeightType;                                                                  \
-  using typename Superclass::PointIdentifier;                                                                          \
-  using typename Superclass::PointIdIterator;                                                                          \
-  using typename Superclass::PointIdConstIterator;                                                                     \
-  using typename Superclass::CellIdentifier;                                                                           \
-  using typename Superclass::CellFeatureIdentifier;                                                                    \
-  using CellFeatureCount = typename Superclass::CellFeatureIdentifier;                                                 \
-  using typename Superclass::PointType;                                                                                \
-  using typename Superclass::VectorType;                                                                               \
-  using typename Superclass::PointsContainer;                                                                          \
-  using typename Superclass::UsingCellsContainer;                                                                      \
-  using typename Superclass::ParametricCoordArrayType;                                                                 \
-  using typename Superclass::ShapeFunctionsArrayType;                                                                  \
+#define itkCellInheritedTypedefs(superclassArg)                        \
+  using Superclass = superclassArg;                                    \
+  using typename Superclass::PixelType;                                \
+  using CellType = typename Superclass::CellType;                      \
+  using typename Superclass::CellAutoPointer;                          \
+  using typename Superclass::CellConstAutoPointer;                     \
+  using typename Superclass::CellRawPointer;                           \
+  using typename Superclass::CellConstRawPointer;                      \
+  using typename Superclass::CellTraits;                               \
+  using typename Superclass::CoordRepType;                             \
+  using typename Superclass::InterpolationWeightType;                  \
+  using typename Superclass::PointIdentifier;                          \
+  using typename Superclass::PointIdIterator;                          \
+  using typename Superclass::PointIdConstIterator;                     \
+  using typename Superclass::CellIdentifier;                           \
+  using typename Superclass::CellFeatureIdentifier;                    \
+  using CellFeatureCount = typename Superclass::CellFeatureIdentifier; \
+  using typename Superclass::PointType;                                \
+  using typename Superclass::VectorType;                               \
+  using typename Superclass::PointsContainer;                          \
+  using typename Superclass::UsingCellsContainer;                      \
+  using typename Superclass::ParametricCoordArrayType;                 \
+  using typename Superclass::ShapeFunctionsArrayType;                  \
   static constexpr unsigned int PointDimension = Superclass::PointDimension
 
 namespace itk
@@ -537,15 +537,15 @@ public:
   using PointIdConstIterator = const PointIdentifier *;
 };
 
-#define itkMakeCellTraitsMacro                                                                                         \
-  CellTraitsInfo<Self::PointDimension,                                                                                 \
-                 CoordRepType,                                                                                         \
-                 InterpolationWeightType,                                                                              \
-                 PointIdentifier,                                                                                      \
-                 CellIdentifier,                                                                                       \
-                 CellFeatureIdentifier,                                                                                \
-                 PointType,                                                                                            \
-                 PointsContainer,                                                                                      \
+#define itkMakeCellTraitsMacro            \
+  CellTraitsInfo<Self::PointDimension,    \
+                 CoordRepType,            \
+                 InterpolationWeightType, \
+                 PointIdentifier,         \
+                 CellIdentifier,          \
+                 CellFeatureIdentifier,   \
+                 PointType,               \
+                 PointsContainer,         \
                  UsingCellsContainer>
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkConceptChecking.h
+++ b/Modules/Core/Common/include/itkConceptChecking.h
@@ -56,17 +56,17 @@
 // Leave ()'s off the sizeof to force the caller to pass them in the
 // concept argument of the itkConceptMacro.  This is necessary because
 // the argument may contain commas.
-#  define itkConceptConstraintsMacro()                                                                                 \
-    template <void (Constraints::*)()>                                                                                 \
-    struct Enforcer                                                                                                    \
-    {};                                                                                                                \
-    using EnforcerInstantiation = Enforcer<&Constraints::constraints>;                                                 \
+#  define itkConceptConstraintsMacro()                                 \
+    template <void (Constraints::*)()>                                 \
+    struct Enforcer                                                    \
+    {};                                                                \
+    using EnforcerInstantiation = Enforcer<&Constraints::constraints>; \
     ITK_MACROEND_NOOP_STATEMENT
-#  define itkConceptMacro(name, concept)                                                                               \
-    enum                                                                                                               \
-    {                                                                                                                  \
-      name = sizeof concept                                                                                            \
-    };                                                                                                                 \
+#  define itkConceptMacro(name, concept) \
+    enum                                 \
+    {                                    \
+      name = sizeof concept              \
+    };                                   \
     ITK_MACROEND_NOOP_STATEMENT
 
 #elif defined(ITK_CONCEPT_IMPLEMENTATION_VTABLE)
@@ -76,32 +76,32 @@
  * run-time overhead.  The "vtable" approach was invented for this
  * project by Brad King at Kitware.
  */
-#  define itkConceptConstraintsMacro()                                                                                 \
+#  define itkConceptConstraintsMacro() \
     virtual void Enforcer() { &Constraints::constraints; }
-#  define itkConceptMacro(name, concept)                                                                               \
-    enum                                                                                                               \
-    {                                                                                                                  \
-      name = sizeof concept                                                                                            \
+#  define itkConceptMacro(name, concept) \
+    enum                                 \
+    {                                    \
+      name = sizeof concept              \
     }
 
 #elif defined(ITK_CONCEPT_IMPLEMENTATION_CALL)
 
 /** Not implemented.  */
 #  define itkConceptConstraintsMacro()
-#  define itkConceptMacro(name, concept)                                                                               \
-    enum                                                                                                               \
-    {                                                                                                                  \
-      name = 0                                                                                                         \
+#  define itkConceptMacro(name, concept) \
+    enum                                 \
+    {                                    \
+      name = 0                           \
     }
 
 #else
 
 /** Disable concept checking.  */
 #  define itkConceptConstraintsMacro()
-#  define itkConceptMacro(name, concept)                                                                               \
-    enum                                                                                                               \
-    {                                                                                                                  \
-      name = 0                                                                                                         \
+#  define itkConceptMacro(name, concept) \
+    enum                                 \
+    {                                    \
+      name = 0                           \
     }
 
 #endif

--- a/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
+++ b/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
@@ -79,37 +79,37 @@ public:
   }
 };
 
-#define ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(type)                                                                  \
-  template <>                                                                                                          \
-  class ITK_TEMPLATE_EXPORT DefaultConvertPixelTraits<type>                                                            \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using ComponentType = type;                                                                                        \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents()                                                                                            \
-    {                                                                                                                  \
-      return 1;                                                                                                        \
-    }                                                                                                                  \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents(const type)                                                                                  \
-    {                                                                                                                  \
-      return 1;                                                                                                        \
-    }                                                                                                                  \
-    static void                                                                                                        \
-    SetNthComponent(int, type & pixel, const ComponentType & v)                                                        \
-    {                                                                                                                  \
-      pixel = v;                                                                                                       \
-    }                                                                                                                  \
-    static type                                                                                                        \
-    GetNthComponent(int, const type pixel)                                                                             \
-    {                                                                                                                  \
-      return pixel;                                                                                                    \
-    }                                                                                                                  \
-    static type                                                                                                        \
-    GetScalarValue(const type & pixel)                                                                                 \
-    {                                                                                                                  \
-      return pixel;                                                                                                    \
-    }                                                                                                                  \
+#define ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(type)           \
+  template <>                                                   \
+  class ITK_TEMPLATE_EXPORT DefaultConvertPixelTraits<type>     \
+  {                                                             \
+  public:                                                       \
+    using ComponentType = type;                                 \
+    static unsigned int                                         \
+    GetNumberOfComponents()                                     \
+    {                                                           \
+      return 1;                                                 \
+    }                                                           \
+    static unsigned int                                         \
+    GetNumberOfComponents(const type)                           \
+    {                                                           \
+      return 1;                                                 \
+    }                                                           \
+    static void                                                 \
+    SetNthComponent(int, type & pixel, const ComponentType & v) \
+    {                                                           \
+      pixel = v;                                                \
+    }                                                           \
+    static type                                                 \
+    GetNthComponent(int, const type pixel)                      \
+    {                                                           \
+      return pixel;                                             \
+    }                                                           \
+    static type                                                 \
+    GetScalarValue(const type & pixel)                          \
+    {                                                           \
+      return pixel;                                             \
+    }                                                           \
   };
 
 ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(float)
@@ -161,38 +161,38 @@ public:
 //  Default traits for the pixel types deriving from FixedArray<>
 //
 
-#define ITK_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(type)                                                                 \
-  template <typename TComponentType, unsigned VDimension>                                                              \
-  class ITK_TEMPLATE_EXPORT DefaultConvertPixelTraits<type<TComponentType, VDimension>>                                \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using TargetType = type<TComponentType, VDimension>;                                                               \
-    using ComponentType = TComponentType;                                                                              \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents()                                                                                            \
-    {                                                                                                                  \
-      return VDimension;                                                                                               \
-    }                                                                                                                  \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents(const TargetType)                                                                            \
-    {                                                                                                                  \
-      return VDimension;                                                                                               \
-    }                                                                                                                  \
-    static void                                                                                                        \
-    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)                                                \
-    {                                                                                                                  \
-      pixel[i] = v;                                                                                                    \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetNthComponent(int i, const TargetType pixel)                                                                     \
-    {                                                                                                                  \
-      return pixel[i];                                                                                                 \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetScalarValue(const TargetType & pixel)                                                                           \
-    {                                                                                                                  \
-      return pixel[0];                                                                                                 \
-    }                                                                                                                  \
+#define ITK_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(type)                                  \
+  template <typename TComponentType, unsigned VDimension>                               \
+  class ITK_TEMPLATE_EXPORT DefaultConvertPixelTraits<type<TComponentType, VDimension>> \
+  {                                                                                     \
+  public:                                                                               \
+    using TargetType = type<TComponentType, VDimension>;                                \
+    using ComponentType = TComponentType;                                               \
+    static unsigned int                                                                 \
+    GetNumberOfComponents()                                                             \
+    {                                                                                   \
+      return VDimension;                                                                \
+    }                                                                                   \
+    static unsigned int                                                                 \
+    GetNumberOfComponents(const TargetType)                                             \
+    {                                                                                   \
+      return VDimension;                                                                \
+    }                                                                                   \
+    static void                                                                         \
+    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)                 \
+    {                                                                                   \
+      pixel[i] = v;                                                                     \
+    }                                                                                   \
+    static ComponentType                                                                \
+    GetNthComponent(int i, const TargetType pixel)                                      \
+    {                                                                                   \
+      return pixel[i];                                                                  \
+    }                                                                                   \
+    static ComponentType                                                                \
+    GetScalarValue(const TargetType & pixel)                                            \
+    {                                                                                   \
+      return pixel[0];                                                                  \
+    }                                                                                   \
   }
 
 ITK_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(Vector);

--- a/Modules/Core/Common/include/itkEventObject.h
+++ b/Modules/Core/Common/include/itkEventObject.h
@@ -118,39 +118,39 @@ operator<<(std::ostream & os, const EventObject & e)
  *  Macros for creating new Events
  */
 
-#define itkEventMacroDeclaration(classname, super)                                                                     \
-  /** \class classname */                                                                                              \
-  class ITKEvent_EXPORT classname : public super                                                                       \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using Self = classname;                                                                                            \
-    using Superclass = super;                                                                                          \
-    classname() = default;                                                                                             \
-    classname(const Self & s);                                                                                         \
-    virtual ~classname() override;                                                                                     \
-    virtual const char *                                                                                               \
-    GetEventName() const override;                                                                                     \
-    virtual bool                                                                                                       \
-    CheckEvent(const ::itk::EventObject * e) const override;                                                           \
-    virtual ::itk::EventObject *                                                                                       \
-    MakeObject() const override;                                                                                       \
-                                                                                                                       \
-  private:                                                                                                             \
-    void                                                                                                               \
-    operator=(const Self &);                                                                                           \
-  };                                                                                                                   \
+#define itkEventMacroDeclaration(classname, super)           \
+  /** \class classname */                                    \
+  class ITKEvent_EXPORT classname : public super             \
+  {                                                          \
+  public:                                                    \
+    using Self = classname;                                  \
+    using Superclass = super;                                \
+    classname() = default;                                   \
+    classname(const Self & s);                               \
+    virtual ~classname() override;                           \
+    virtual const char *                                     \
+    GetEventName() const override;                           \
+    virtual bool                                             \
+    CheckEvent(const ::itk::EventObject * e) const override; \
+    virtual ::itk::EventObject *                             \
+    MakeObject() const override;                             \
+                                                             \
+  private:                                                   \
+    void                                                     \
+    operator=(const Self &);                                 \
+  };                                                         \
   static_assert(true, "Compile time eliminated. Used to require a semi-colon at end of macro.")
 
-#define itkEventMacroDefinition(classname, super)                                                                      \
-  classname::classname(const classname & s)                                                                            \
-    : super(s){};                                                                                                      \
-  classname::~classname() {}                                                                                           \
-  const char * classname::GetEventName() const { return #classname; }                                                  \
-  bool         classname::CheckEvent(const ::itk::EventObject * e) const                                               \
-  {                                                                                                                    \
-    return (dynamic_cast<const classname *>(e) != nullptr);                                                            \
-  }                                                                                                                    \
-  ::itk::EventObject * classname::MakeObject() const { return new classname; }                                         \
+#define itkEventMacroDefinition(classname, super)                              \
+  classname::classname(const classname & s)                                    \
+    : super(s){};                                                              \
+  classname::~classname() {}                                                   \
+  const char * classname::GetEventName() const { return #classname; }          \
+  bool         classname::CheckEvent(const ::itk::EventObject * e) const       \
+  {                                                                            \
+    return (dynamic_cast<const classname *>(e) != nullptr);                    \
+  }                                                                            \
+  ::itk::EventObject * classname::MakeObject() const { return new classname; } \
   static_assert(true, "Compile time eliminated. Used to require a semi-colon at end of macro.")
 
 #if !defined(ITK_LEGACY_REMOVE)
@@ -164,36 +164,36 @@ operator<<(std::ostream & os, const EventObject & e)
 // file). This new approach guarantees that only one copy of the
 // implementation will be present.
 //
-#  define itkEventMacro(classname, super)                                                                              \
-    /** \class classname */                                                                                            \
-    class ITKEvent_EXPORT classname : public super                                                                     \
-    {                                                                                                                  \
-    public:                                                                                                            \
-      using Self = classname;                                                                                          \
-      using Superclass = super;                                                                                        \
-      classname() {}                                                                                                   \
-      virtual ~classname() {}                                                                                          \
-      virtual const char *                                                                                             \
-      GetEventName() const                                                                                             \
-      {                                                                                                                \
-        return #classname;                                                                                             \
-      }                                                                                                                \
-      virtual bool                                                                                                     \
-      CheckEvent(const ::itk::EventObject * e) const                                                                   \
-      {                                                                                                                \
-        return (dynamic_cast<const Self *>(e) != nullptr);                                                             \
-      }                                                                                                                \
-      virtual ::itk::EventObject *                                                                                     \
-      MakeObject() const                                                                                               \
-      {                                                                                                                \
-        return new Self;                                                                                               \
-      }                                                                                                                \
-      classname(const Self & s)                                                                                        \
-        : super(s){};                                                                                                  \
-                                                                                                                       \
-    private:                                                                                                           \
-      void                                                                                                             \
-      operator=(const Self &);                                                                                         \
+#  define itkEventMacro(classname, super)                  \
+    /** \class classname */                                \
+    class ITKEvent_EXPORT classname : public super         \
+    {                                                      \
+    public:                                                \
+      using Self = classname;                              \
+      using Superclass = super;                            \
+      classname() {}                                       \
+      virtual ~classname() {}                              \
+      virtual const char *                                 \
+      GetEventName() const                                 \
+      {                                                    \
+        return #classname;                                 \
+      }                                                    \
+      virtual bool                                         \
+      CheckEvent(const ::itk::EventObject * e) const       \
+      {                                                    \
+        return (dynamic_cast<const Self *>(e) != nullptr); \
+      }                                                    \
+      virtual ::itk::EventObject *                         \
+      MakeObject() const                                   \
+      {                                                    \
+        return new Self;                                   \
+      }                                                    \
+      classname(const Self & s)                            \
+        : super(s){};                                      \
+                                                           \
+    private:                                               \
+      void                                                 \
+      operator=(const Self &);                             \
     };
 #endif
 /**

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -76,17 +76,17 @@ namespace itk
  *  in places where raw statements (i.e. 'do{} while(0)') are
  *  not allowed (i.e. after class member function definitions).
  *  */
-#  define ITK_NOOP_STATEMENT static_assert(true, "")
+#define ITK_NOOP_STATEMENT static_assert(true, "")
 
 
 #if defined(ITK_FUTURE_LEGACY_REMOVE)
 
 #  define ITK_MACROEND_NOOP_STATEMENT ITK_NOOP_STATEMENT
 #else
-   /* NOTE:  The ITK_MACROEND_NOOP_STATEMENT must be defined to nothing
-    * in order to maintain backwards compatibility with earlier macro
-    * uses that may or may not have ';' after the macro is used. */
-    /* Purposefully empty */
+/* NOTE:  The ITK_MACROEND_NOOP_STATEMENT must be defined to nothing
+ * in order to maintain backwards compatibility with earlier macro
+ * uses that may or may not have ';' after the macro is used. */
+/* Purposefully empty */
 #  define ITK_MACROEND_NOOP_STATEMENT
 #endif
 // clang-format on
@@ -177,7 +177,7 @@ namespace itk
 #if defined(__MWERKS__)
 #  error "The MetroWerks compiler is not supported in ITKv4 and above"
 #endif
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) &&                                          \
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && \
   ((__GNUC__ < 5) || ((__GNUC__ == 5) && (__GNUC_MINOR__ < 1)))
 #  error "GCC < 5.1 is not supported under ITKv5.3"
 #endif
@@ -233,7 +233,7 @@ namespace itk
 
 #ifndef ITK_FORWARD_EXPORT
 // If build with shared libraries, on MacOS, if USE_COMPILER_HIDDEN_VISIBILITY is ON
-#  if defined(__APPLE__) && defined(ITK_TEMPLATE_VISIBILITY_DEFAULT) && defined(ITK_BUILD_SHARED_LIBS) &&              \
+#  if defined(__APPLE__) && defined(ITK_TEMPLATE_VISIBILITY_DEFAULT) && defined(ITK_BUILD_SHARED_LIBS) && \
     defined(USE_COMPILER_HIDDEN_VISIBILITY)
 #    define ITK_FORWARD_EXPORT __attribute__((visibility("default")))
 #  else
@@ -307,40 +307,40 @@ namespace itk
  * Break the methods into itkSimpleNewMacro and itkCreateAnotherMacro
  * so we can selectively overload CreateAnother() without having to
  * provide a definition for New(). */
-#define itkNewMacro(x)                                                                                                 \
-  itkSimpleNewMacro(x);                                                                                                \
-  itkCreateAnotherMacro(x);                                                                                            \
-  itkCloneMacro(x);                                                                                                    \
+#define itkNewMacro(x)      \
+  itkSimpleNewMacro(x);     \
+  itkCreateAnotherMacro(x); \
+  itkCloneMacro(x);         \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkSimpleNewMacro(x)                                                                                           \
-  static Pointer New()                                                                                                 \
-  {                                                                                                                    \
-    Pointer smartPtr = ::itk::ObjectFactory<x>::Create();                                                              \
-    if (smartPtr == nullptr)                                                                                           \
-    {                                                                                                                  \
-      smartPtr = new x;                                                                                                \
-    }                                                                                                                  \
-    smartPtr->UnRegister();                                                                                            \
-    return smartPtr;                                                                                                   \
-  }                                                                                                                    \
+#define itkSimpleNewMacro(x)                              \
+  static Pointer New()                                    \
+  {                                                       \
+    Pointer smartPtr = ::itk::ObjectFactory<x>::Create(); \
+    if (smartPtr == nullptr)                              \
+    {                                                     \
+      smartPtr = new x;                                   \
+    }                                                     \
+    smartPtr->UnRegister();                               \
+    return smartPtr;                                      \
+  }                                                       \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkCreateAnotherMacro(x)                                                                                       \
-  ::itk::LightObject::Pointer CreateAnother() const override                                                           \
-  {                                                                                                                    \
-    ::itk::LightObject::Pointer smartPtr;                                                                              \
-    smartPtr = x::New().GetPointer();                                                                                  \
-    return smartPtr;                                                                                                   \
-  }                                                                                                                    \
+#define itkCreateAnotherMacro(x)                             \
+  ::itk::LightObject::Pointer CreateAnother() const override \
+  {                                                          \
+    ::itk::LightObject::Pointer smartPtr;                    \
+    smartPtr = x::New().GetPointer();                        \
+    return smartPtr;                                         \
+  }                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkCloneMacro(x)                                                                                               \
-  Pointer Clone() const                                                                                                \
-  {                                                                                                                    \
-    Pointer rval = dynamic_cast<x *>(this->InternalClone().GetPointer());                                              \
-    return rval;                                                                                                       \
-  }                                                                                                                    \
+#define itkCloneMacro(x)                                                  \
+  Pointer Clone() const                                                   \
+  {                                                                       \
+    Pointer rval = dynamic_cast<x *>(this->InternalClone().GetPointer()); \
+    return rval;                                                          \
+  }                                                                       \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Define two object creation methods.  The first method, New(),
@@ -355,21 +355,21 @@ namespace itk
  * UnRegister() on the rawPtr to compensate for LightObject's constructor
  * initializing an object's reference count to 1 (needed for proper
  * initialization of process objects and data objects cycles). */
-#define itkFactorylessNewMacro(x)                                                                                      \
-  static Pointer New()                                                                                                 \
-  {                                                                                                                    \
-    Pointer smartPtr;                                                                                                  \
-    x *     rawPtr = new x;                                                                                            \
-    smartPtr = rawPtr;                                                                                                 \
-    rawPtr->UnRegister();                                                                                              \
-    return smartPtr;                                                                                                   \
-  }                                                                                                                    \
-  ::itk::LightObject::Pointer CreateAnother() const override                                                           \
-  {                                                                                                                    \
-    ::itk::LightObject::Pointer smartPtr;                                                                              \
-    smartPtr = x::New().GetPointer();                                                                                  \
-    return smartPtr;                                                                                                   \
-  }                                                                                                                    \
+#define itkFactorylessNewMacro(x)                            \
+  static Pointer New()                                       \
+  {                                                          \
+    Pointer smartPtr;                                        \
+    x *     rawPtr = new x;                                  \
+    smartPtr = rawPtr;                                       \
+    rawPtr->UnRegister();                                    \
+    return smartPtr;                                         \
+  }                                                          \
+  ::itk::LightObject::Pointer CreateAnother() const override \
+  {                                                          \
+    ::itk::LightObject::Pointer smartPtr;                    \
+    smartPtr = x::New().GetPointer();                        \
+    return smartPtr;                                         \
+  }                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
 //
@@ -381,16 +381,16 @@ namespace itk
 // prohibits the use of copy/move construction and copy/move assignment
 // functions.
 //
-#define ITK_DISALLOW_COPY_AND_MOVE(TypeName)                                                                           \
-  TypeName(const TypeName &) = delete;                                                                                 \
-  TypeName & operator=(const TypeName &) = delete;                                                                     \
-  TypeName(TypeName &&) = delete;                                                                                      \
+#define ITK_DISALLOW_COPY_AND_MOVE(TypeName)       \
+  TypeName(const TypeName &) = delete;             \
+  TypeName & operator=(const TypeName &) = delete; \
+  TypeName(TypeName &&) = delete;                  \
   TypeName & operator=(TypeName &&) = delete
 
 #if !defined(ITK_FUTURE_LEGACY_REMOVE)
 #  define ITK_DISALLOW_COPY_AND_ASSIGN(TypeName) ITK_DISALLOW_COPY_AND_MOVE(TypeName)
 #else
-#  define ITK_DISALLOW_COPY_AND_ASSIGN(TypeName)                                                                       \
+#  define ITK_DISALLOW_COPY_AND_ASSIGN(TypeName) \
     static_assert(false, "Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE")
 #endif
 
@@ -413,19 +413,19 @@ namespace itk
 #else
 // For C++14 and C++17, this macro defines an operator!= member function that
 // just calls the corresponding operator== member function.
-#  define ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TypeName)                                                               \
-    bool operator!=(const TypeName & other) const { return !(this->operator==(other)); }                               \
+#  define ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(TypeName)                                 \
+    bool operator!=(const TypeName & other) const { return !(this->operator==(other)); } \
     ITK_MACROEND_NOOP_STATEMENT
 #endif
 
 /** Macro used to add standard methods to all classes, mainly type
  * information. */
-#define itkTypeMacro(thisClass, superclass)                                                                            \
-  const char * GetNameOfClass() const override { return #thisClass; }                                                  \
+#define itkTypeMacro(thisClass, superclass)                           \
+  const char * GetNameOfClass() const override { return #thisClass; } \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkTypeMacroNoParent(thisClass)                                                                                \
-  virtual const char * GetNameOfClass() const { return #thisClass; }                                                   \
+#define itkTypeMacroNoParent(thisClass)                              \
+  virtual const char * GetNameOfClass() const { return #thisClass; } \
   ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk
@@ -460,16 +460,16 @@ OutputWindowDisplayDebugText(const char *);
 #  define itkDebugMacro(x) ITK_NOOP_STATEMENT
 #  define itkDebugStatement(x) ITK_NOOP_STATEMENT
 #else
-#  define itkDebugMacro(x)                                                                                             \
-    do                                                                                                                 \
-    {                                                                                                                  \
-      if (this->GetDebug() && ::itk::Object::GetGlobalWarningDisplay())                                                \
-      {                                                                                                                \
-        std::ostringstream itkmsg;                                                                                     \
-        itkmsg << "Debug: In " __FILE__ ", line " << __LINE__ << "\n"                                                  \
-               << this->GetNameOfClass() << " (" << this << "): " x << "\n\n";                                         \
-        ::itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());                                                     \
-      }                                                                                                                \
+#  define itkDebugMacro(x)                                                     \
+    do                                                                         \
+    {                                                                          \
+      if (this->GetDebug() && ::itk::Object::GetGlobalWarningDisplay())        \
+      {                                                                        \
+        std::ostringstream itkmsg;                                             \
+        itkmsg << "Debug: In " __FILE__ ", line " << __LINE__ << "\n"          \
+               << this->GetNameOfClass() << " (" << this << "): " x << "\n\n"; \
+        ::itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());             \
+      }                                                                        \
     } while (0)
 
 // The itkDebugStatement is to be used to protect code that is only
@@ -480,16 +480,16 @@ OutputWindowDisplayDebugText(const char *);
 /** This macro is used to print warning information (i.e., unusual circumstance
  * but not necessarily fatal.) Example usage looks like:
  * itkWarningMacro(<< "this is warning info" << this->SomeVariable); */
-#define itkWarningMacro(x)                                                                                             \
-  do                                                                                                                   \
-  {                                                                                                                    \
-    if (::itk::Object::GetGlobalWarningDisplay())                                                                      \
-    {                                                                                                                  \
-      std::ostringstream itkmsg;                                                                                       \
-      itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n"                                                  \
-             << this->GetNameOfClass() << " (" << this << "): " x << "\n\n";                                           \
-      ::itk::OutputWindowDisplayWarningText(itkmsg.str().c_str());                                                     \
-    }                                                                                                                  \
+#define itkWarningMacro(x)                                                   \
+  do                                                                         \
+  {                                                                          \
+    if (::itk::Object::GetGlobalWarningDisplay())                            \
+    {                                                                        \
+      std::ostringstream itkmsg;                                             \
+      itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n"        \
+             << this->GetNameOfClass() << " (" << this << "): " x << "\n\n"; \
+      ::itk::OutputWindowDisplayWarningText(itkmsg.str().c_str());           \
+    }                                                                        \
   } while (0)
 
 #define itkWarningStatement(x) x
@@ -506,72 +506,72 @@ OutputWindowDisplayDebugText(const char *);
 #  define ITK_LOCATION "unknown"
 #endif
 
-#define itkDeclareExceptionMacro(newexcp, parentexcp, whatmessage)                                                     \
-  namespace itk                                                                                                        \
-  {                                                                                                                    \
-  class newexcp : public parentexcp                                                                                    \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    /* default message provides backward compatibility for a given exception type */                                   \
-    static constexpr const char * const default_exception_message = whatmessage;                                       \
-    /* Inherit the constructors from its base class. */                                                                \
-    using parentexcp::parentexcp;                                                                                      \
-    itkTypeMacro(newexcp, parentexcp);                                                                                 \
-  };                                                                                                                   \
-  }                                                                                                                    \
+#define itkDeclareExceptionMacro(newexcp, parentexcp, whatmessage)                   \
+  namespace itk                                                                      \
+  {                                                                                  \
+  class newexcp : public parentexcp                                                  \
+  {                                                                                  \
+  public:                                                                            \
+    /* default message provides backward compatibility for a given exception type */ \
+    static constexpr const char * const default_exception_message = whatmessage;     \
+    /* Inherit the constructors from its base class. */                              \
+    using parentexcp::parentexcp;                                                    \
+    itkTypeMacro(newexcp, parentexcp);                                               \
+  };                                                                                 \
+  }                                                                                  \
   ITK_MACROEND_NOOP_STATEMENT
 
 
-#define itkSpecializedMessageExceptionMacro(ExceptionType, x)                                                          \
-  {                                                                                                                    \
-    std::ostringstream exceptionDescriptionOutputStringStream;                                                         \
-    exceptionDescriptionOutputStringStream << "ITK ERROR: " x;                                                         \
-    throw ::itk::ExceptionType(                                                                                        \
-      std::string{ __FILE__ }, __LINE__, exceptionDescriptionOutputStringStream.str(), std::string{ ITK_LOCATION });   \
-  }                                                                                                                    \
+#define itkSpecializedMessageExceptionMacro(ExceptionType, x)                                                        \
+  {                                                                                                                  \
+    std::ostringstream exceptionDescriptionOutputStringStream;                                                       \
+    exceptionDescriptionOutputStringStream << "ITK ERROR: " x;                                                       \
+    throw ::itk::ExceptionType(                                                                                      \
+      std::string{ __FILE__ }, __LINE__, exceptionDescriptionOutputStringStream.str(), std::string{ ITK_LOCATION }); \
+  }                                                                                                                  \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkSpecializedExceptionMacro(ExceptionType)                                                                    \
+#define itkSpecializedExceptionMacro(ExceptionType) \
   itkSpecializedMessageExceptionMacro(ExceptionType, << ::itk::ExceptionType::default_exception_message)
 
 /** The itkExceptionMacro macro is used to print error information (i.e., usually
  * a condition that results in program failure). Example usage looks like:
  * itkExceptionMacro(<< "this is error info" << this->SomeVariable); */
-#define itkExceptionMacro(x)                                                                                           \
+#define itkExceptionMacro(x) \
   itkSpecializedMessageExceptionMacro(ExceptionObject, << this->GetNameOfClass() << "(" << this << "): " x)
 
 #define itkGenericExceptionMacro(x) itkSpecializedMessageExceptionMacro(ExceptionObject, x)
 
-#define itkGenericOutputMacro(x)                                                                                       \
-  {                                                                                                                    \
-    if (::itk::Object::GetGlobalWarningDisplay())                                                                      \
-    {                                                                                                                  \
-      std::ostringstream itkmsg;                                                                                       \
-      itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n" x << "\n\n";                                     \
-      ::itk::OutputWindowDisplayGenericOutputText(itkmsg.str().c_str());                                               \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define itkGenericOutputMacro(x)                                                   \
+  {                                                                                \
+    if (::itk::Object::GetGlobalWarningDisplay())                                  \
+    {                                                                              \
+      std::ostringstream itkmsg;                                                   \
+      itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n" x << "\n\n"; \
+      ::itk::OutputWindowDisplayGenericOutputText(itkmsg.str().c_str());           \
+    }                                                                              \
+  }                                                                                \
   ITK_MACROEND_NOOP_STATEMENT
 
 //----------------------------------------------------------------------------
 // Macros for simplifying the use of logging
 //
-#define itkLogMacro(x, y)                                                                                              \
-  {                                                                                                                    \
-    if (this->GetLogger())                                                                                             \
-    {                                                                                                                  \
-      this->GetLogger()->Write(::itk::LoggerBase::x, y);                                                               \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define itkLogMacro(x, y)                                \
+  {                                                      \
+    if (this->GetLogger())                               \
+    {                                                    \
+      this->GetLogger()->Write(::itk::LoggerBase::x, y); \
+    }                                                    \
+  }                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkLogMacroStatic(obj, x, y)                                                                                   \
-  {                                                                                                                    \
-    if (obj->GetLogger())                                                                                              \
-    {                                                                                                                  \
-      obj->GetLogger()->Write(::itk::LoggerBase::x, y);                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define itkLogMacroStatic(obj, x, y)                    \
+  {                                                     \
+    if (obj->GetLogger())                               \
+    {                                                   \
+      obj->GetLogger()->Write(::itk::LoggerBase::x, y); \
+    }                                                   \
+  }                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
 //----------------------------------------------------------------------------
@@ -643,15 +643,15 @@ OutputWindowDisplayDebugText(const char *);
 #  define itkGenericLegacyBodyMacro(method, version) ITK_NOOP_STATEMENT
 #  define itkGenericLegacyReplaceBodyMacro(method, version, replace) ITK_NOOP_STATEMENT
 #else
-#  define itkLegacyBodyMacro(method, version)                                                                          \
+#  define itkLegacyBodyMacro(method, version) \
     itkWarningMacro(#method " was deprecated for ITK " #version " and will be removed in a future version.")
-#  define itkLegacyReplaceBodyMacro(method, version, replace)                                                          \
-    itkWarningMacro(#method " was deprecated for ITK " #version                                                        \
+#  define itkLegacyReplaceBodyMacro(method, version, replace)   \
+    itkWarningMacro(#method " was deprecated for ITK " #version \
                             " and will be removed in a future version.  Use " #replace " instead.")
-#  define itkGenericLegacyBodyMacro(method, version)                                                                   \
+#  define itkGenericLegacyBodyMacro(method, version) \
     itkGenericOutputMacro(#method " was deprecated for ITK " #version " and will be removed in a future version.")
-#  define itkGenericLegacyReplaceBodyMacro(method, version, replace)                                                   \
-    itkGenericOutputMacro(#method " was deprecated for ITK " #version                                                  \
+#  define itkGenericLegacyReplaceBodyMacro(method, version, replace)  \
+    itkGenericOutputMacro(#method " was deprecated for ITK " #version \
                                   " and will be removed in a future version.  Use " #replace " instead.")
 #endif
 
@@ -667,10 +667,10 @@ OutputWindowDisplayDebugText(const char *);
 // Each struct will take up some multiple of cacheline sizes.
 // This is particularly useful for arrays of thread private variables.
 //
-#define itkPadStruct(mincachesize, oldtype, newtype)                                                                   \
-  struct newtype : public oldtype                                                                                      \
-  {                                                                                                                    \
-    char _StructPadding[mincachesize - (sizeof(oldtype) % mincachesize)];                                              \
+#define itkPadStruct(mincachesize, oldtype, newtype)                      \
+  struct newtype : public oldtype                                         \
+  {                                                                       \
+    char _StructPadding[mincachesize - (sizeof(oldtype) % mincachesize)]; \
   };
 
 //
@@ -726,11 +726,11 @@ compilers.
 // assignment, by using the DestinationElementType as the casting type.
 // Source and destination array types must have defined operator[] in their
 // API.
-#define itkForLoopAssignmentMacro(                                                                                     \
-  DestinationType, SourceType, DestinationElementType, DestinationArray, SourceArray, NumberOfIterations)              \
-  for (unsigned int i = 0; i < NumberOfIterations; ++i)                                                                \
-  {                                                                                                                    \
-    DestinationArray[i] = static_cast<DestinationElementType>(SourceArray[i]);                                         \
+#define itkForLoopAssignmentMacro(                                                                        \
+  DestinationType, SourceType, DestinationElementType, DestinationArray, SourceArray, NumberOfIterations) \
+  for (unsigned int i = 0; i < NumberOfIterations; ++i)                                                   \
+  {                                                                                                       \
+    DestinationArray[i] = static_cast<DestinationElementType>(SourceArray[i]);                            \
   }
 
 //--------------------------------------------------------------------------------
@@ -742,11 +742,11 @@ compilers.
 // the casting type.
 // Source and destination array types must have defined operator[] in their
 // API.
-#define itkForLoopRoundingAndAssignmentMacro(                                                                          \
-  DestinationType, Sourcrnd_halfintup, DestinationElementType, DestinationArray, SourceArray, NumberOfIterations)      \
-  for (unsigned int i = 0; i < NumberOfIterations; ++i)                                                                \
-  {                                                                                                                    \
-    DestinationArray[i] = itk::Math::Round<DestinationElementType>(SourceArray[i]);                                    \
+#define itkForLoopRoundingAndAssignmentMacro(                                                                     \
+  DestinationType, Sourcrnd_halfintup, DestinationElementType, DestinationArray, SourceArray, NumberOfIterations) \
+  for (unsigned int i = 0; i < NumberOfIterations; ++i)                                                           \
+  {                                                                                                               \
+    DestinationArray[i] = itk::Math::Round<DestinationElementType>(SourceArray[i]);                               \
   }
 
 // end of Template Meta Programming helper macros
@@ -763,13 +763,13 @@ compilers.
 #  define itkAssertInDebugOrThrowInReleaseMacro(msg) itkGenericExceptionMacro(<< msg);
 #endif
 
-#define itkAssertOrThrowMacro(test, message)                                                                           \
-  if (!(test))                                                                                                         \
-  {                                                                                                                    \
-    std::ostringstream msgstr;                                                                                         \
-    msgstr << message;                                                                                                 \
-    itkAssertInDebugOrThrowInReleaseMacro(msgstr.str().c_str());                                                       \
-  }                                                                                                                    \
+#define itkAssertOrThrowMacro(test, message)                     \
+  if (!(test))                                                   \
+  {                                                              \
+    std::ostringstream msgstr;                                   \
+    msgstr << message;                                           \
+    itkAssertInDebugOrThrowInReleaseMacro(msgstr.str().c_str()); \
+  }                                                              \
   ITK_MACROEND_NOOP_STATEMENT
 
 #ifndef NDEBUG
@@ -786,7 +786,7 @@ compilers.
 //  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #ifdef ITK_FUTURE_LEGACY_REMOVE
-#  define itkStaticConstMacro(name, type, value)                                                                       \
+#  define itkStaticConstMacro(name, type, value) \
     "Replace itkStaticConstMacro(name, type, value) with `static constexpr type name = value`"
 #  define itkGetStaticConstMacro(name) "Replace itkGetStaticConstMacro(name) with `Self::name`"
 #else
@@ -810,257 +810,257 @@ compilers.
 #endif
 
 /** Set an input. This defines the Set"name"() method */
-#define itkSetInputMacro(name, type)                                                                                   \
-  virtual void Set##name(const type * _arg)                                                                            \
-  {                                                                                                                    \
-    itkDebugMacro("setting input " #name " to " << _arg);                                                              \
-    if (_arg != itkDynamicCastInDebugMode<type *>(this->ProcessObject::GetInput(#name)))                               \
-    {                                                                                                                  \
-      this->ProcessObject::SetInput(#name, const_cast<type *>(_arg));                                                  \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define itkSetInputMacro(name, type)                                                     \
+  virtual void Set##name(const type * _arg)                                              \
+  {                                                                                      \
+    itkDebugMacro("setting input " #name " to " << _arg);                                \
+    if (_arg != itkDynamicCastInDebugMode<type *>(this->ProcessObject::GetInput(#name))) \
+    {                                                                                    \
+      this->ProcessObject::SetInput(#name, const_cast<type *>(_arg));                    \
+      this->Modified();                                                                  \
+    }                                                                                    \
+  }                                                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Get an input. This defines the Get"name"() method */
-#define itkGetInputMacro(name, type)                                                                                   \
-  virtual const type * Get##name() const                                                                               \
-  {                                                                                                                    \
-    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name));                         \
-    return itkDynamicCastInDebugMode<const type *>(this->ProcessObject::GetInput(#name));                              \
-  }                                                                                                                    \
+#define itkGetInputMacro(name, type)                                                           \
+  virtual const type * Get##name() const                                                       \
+  {                                                                                            \
+    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name)); \
+    return itkDynamicCastInDebugMode<const type *>(this->ProcessObject::GetInput(#name));      \
+  }                                                                                            \
   ITK_MACROEND_NOOP_STATEMENT
 
 // clang-format off
 /** Set a decorated input. This defines the Set"name"() and a Set"name"Input() method */
-#define itkSetDecoratedInputMacro(name, type)                                                                          \
-  virtual void Set##name##Input(const SimpleDataObjectDecorator<type> * _arg)                                          \
-  {                                                                                                                    \
-    itkDebugMacro("setting input " #name " to " << _arg);                                                              \
-    if (_arg != itkDynamicCastInDebugMode<SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name)))    \
-    {                                                                                                                  \
-      this->ProcessObject::SetInput(#name, const_cast<SimpleDataObjectDecorator<type> *>(_arg));                       \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
-  virtual void Set##name(const SimpleDataObjectDecorator<type> * _arg) { this->Set##name##Input(_arg); }               \
-  virtual void Set##name(const type & _arg)                                                                            \
-  {                                                                                                                    \
-    using DecoratorType = SimpleDataObjectDecorator<type>;                                                             \
-    itkDebugMacro("setting input " #name " to " << _arg);                                                              \
-    const DecoratorType * oldInput =                                                                                   \
-      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                          \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal                                                                                        \
-    if (oldInput && oldInput->Get() == _arg)                                                                           \
-    {                                                                                                                  \
-      return;                                                                                                          \
-    }                                                                                                                  \
-    CLANG_PRAGMA_POP                                                                                                   \
-    typename DecoratorType::Pointer newInput = DecoratorType::New();                                                   \
-    newInput->Set(_arg);                                                                                               \
-    this->Set##name##Input(newInput);                                                                                  \
-  }                                                                                                                    \
+#define itkSetDecoratedInputMacro(name, type)                                                                       \
+  virtual void Set##name##Input(const SimpleDataObjectDecorator<type> * _arg)                                       \
+  {                                                                                                                 \
+    itkDebugMacro("setting input " #name " to " << _arg);                                                           \
+    if (_arg != itkDynamicCastInDebugMode<SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name))) \
+    {                                                                                                               \
+      this->ProcessObject::SetInput(#name, const_cast<SimpleDataObjectDecorator<type> *>(_arg));                    \
+      this->Modified();                                                                                             \
+    }                                                                                                               \
+  }                                                                                                                 \
+  virtual void Set##name(const SimpleDataObjectDecorator<type> * _arg) { this->Set##name##Input(_arg); }            \
+  virtual void Set##name(const type & _arg)                                                                         \
+  {                                                                                                                 \
+    using DecoratorType = SimpleDataObjectDecorator<type>;                                                          \
+    itkDebugMacro("setting input " #name " to " << _arg);                                                           \
+    const DecoratorType * oldInput =                                                                                \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                       \
+    CLANG_PRAGMA_PUSH                                                                                               \
+    CLANG_SUPPRESS_Wfloat_equal                                                                                     \
+    if (oldInput && oldInput->Get() == _arg)                                                                        \
+    {                                                                                                               \
+      return;                                                                                                       \
+    }                                                                                                               \
+    CLANG_PRAGMA_POP                                                                                                \
+    typename DecoratorType::Pointer newInput = DecoratorType::New();                                                \
+    newInput->Set(_arg);                                                                                            \
+    this->Set##name##Input(newInput);                                                                               \
+  }                                                                                                                 \
   ITK_MACROEND_NOOP_STATEMENT
 // clang-format on
 
 /** Set a decorated input. This defines the Set"name"() and Set"name"Input() method */
-#define itkGetDecoratedInputMacro(name, type)                                                                          \
-  virtual const SimpleDataObjectDecorator<type> * Get##name##Input() const                                             \
-  {                                                                                                                    \
-    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name));                         \
-    return itkDynamicCastInDebugMode<const SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name));   \
-  }                                                                                                                    \
-  virtual const type & Get##name() const                                                                               \
-  {                                                                                                                    \
-    itkDebugMacro("Getting input " #name);                                                                             \
-    using DecoratorType = SimpleDataObjectDecorator<type>;                                                             \
-    const DecoratorType * input =                                                                                      \
-      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                          \
-    if (input == nullptr)                                                                                              \
-    {                                                                                                                  \
-      itkExceptionMacro(<< "input" #name " is not set");                                                               \
-    }                                                                                                                  \
-    return input->Get();                                                                                               \
-  }                                                                                                                    \
+#define itkGetDecoratedInputMacro(name, type)                                                                        \
+  virtual const SimpleDataObjectDecorator<type> * Get##name##Input() const                                           \
+  {                                                                                                                  \
+    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name));                       \
+    return itkDynamicCastInDebugMode<const SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name)); \
+  }                                                                                                                  \
+  virtual const type & Get##name() const                                                                             \
+  {                                                                                                                  \
+    itkDebugMacro("Getting input " #name);                                                                           \
+    using DecoratorType = SimpleDataObjectDecorator<type>;                                                           \
+    const DecoratorType * input =                                                                                    \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                        \
+    if (input == nullptr)                                                                                            \
+    {                                                                                                                \
+      itkExceptionMacro(<< "input" #name " is not set");                                                             \
+    }                                                                                                                \
+    return input->Get();                                                                                             \
+  }                                                                                                                  \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Set a decorated input. This defines the Set"name"() and Set"name"Input() method
  * and Get"name" and Get"name"Input methods */
-#define itkSetGetDecoratedInputMacro(name, type)                                                                       \
-  itkSetDecoratedInputMacro(name, type);                                                                               \
+#define itkSetGetDecoratedInputMacro(name, type) \
+  itkSetDecoratedInputMacro(name, type);         \
   itkGetDecoratedInputMacro(name, type)
 
 /** Set a decorated input that derives from itk::Object, but not from
  * itk::DataObject. This defines the Set"name"() and Set"name"Input
  * methods.
  */
-#define itkSetDecoratedObjectInputMacro(name, type)                                                                    \
-  virtual void Set##name##Input(const DataObjectDecorator<type> * _arg)                                                \
-  {                                                                                                                    \
-    itkDebugMacro("setting input " #name " to " << _arg);                                                              \
-    if (_arg != itkDynamicCastInDebugMode<DataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name)))          \
-    {                                                                                                                  \
-      this->ProcessObject::SetInput(#name, const_cast<DataObjectDecorator<type> *>(_arg));                             \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
-  virtual void Set##name(const type * _arg)                                                                            \
-  {                                                                                                                    \
-    using DecoratorType = DataObjectDecorator<type>;                                                                   \
-    itkDebugMacro("setting input " #name " to " << _arg);                                                              \
-    const DecoratorType * oldInput =                                                                                   \
-      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                          \
-    if (oldInput && oldInput->Get() == _arg)                                                                           \
-    {                                                                                                                  \
-      return;                                                                                                          \
-    }                                                                                                                  \
-    typename DecoratorType::Pointer newInput = DecoratorType::New();                                                   \
-    newInput->Set(_arg);                                                                                               \
-    this->Set##name##Input(newInput);                                                                                  \
-  }                                                                                                                    \
+#define itkSetDecoratedObjectInputMacro(name, type)                                                           \
+  virtual void Set##name##Input(const DataObjectDecorator<type> * _arg)                                       \
+  {                                                                                                           \
+    itkDebugMacro("setting input " #name " to " << _arg);                                                     \
+    if (_arg != itkDynamicCastInDebugMode<DataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name))) \
+    {                                                                                                         \
+      this->ProcessObject::SetInput(#name, const_cast<DataObjectDecorator<type> *>(_arg));                    \
+      this->Modified();                                                                                       \
+    }                                                                                                         \
+  }                                                                                                           \
+  virtual void Set##name(const type * _arg)                                                                   \
+  {                                                                                                           \
+    using DecoratorType = DataObjectDecorator<type>;                                                          \
+    itkDebugMacro("setting input " #name " to " << _arg);                                                     \
+    const DecoratorType * oldInput =                                                                          \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                 \
+    if (oldInput && oldInput->Get() == _arg)                                                                  \
+    {                                                                                                         \
+      return;                                                                                                 \
+    }                                                                                                         \
+    typename DecoratorType::Pointer newInput = DecoratorType::New();                                          \
+    newInput->Set(_arg);                                                                                      \
+    this->Set##name##Input(newInput);                                                                         \
+  }                                                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Get a decorated input that derives from itk::Object, but not from
  * itk::DataObject. This defines the Get"name"() and Get"name"Input
  * methods.
  */
-#define itkGetDecoratedObjectInputMacro(name, type)                                                                    \
-  virtual const DataObjectDecorator<type> * Get##name##Input() const                                                   \
-  {                                                                                                                    \
-    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name));                         \
-    return itkDynamicCastInDebugMode<const DataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name));         \
-  }                                                                                                                    \
-  virtual const type * Get##name() const                                                                               \
-  {                                                                                                                    \
-    itkDebugMacro("Getting input " #name);                                                                             \
-    using DecoratorType = DataObjectDecorator<type>;                                                                   \
-    const DecoratorType * input =                                                                                      \
-      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                          \
-    if (input == nullptr)                                                                                              \
-    {                                                                                                                  \
-      return nullptr;                                                                                                  \
-    }                                                                                                                  \
-    return input->Get();                                                                                               \
-  }                                                                                                                    \
+#define itkGetDecoratedObjectInputMacro(name, type)                                                            \
+  virtual const DataObjectDecorator<type> * Get##name##Input() const                                           \
+  {                                                                                                            \
+    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name));                 \
+    return itkDynamicCastInDebugMode<const DataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name)); \
+  }                                                                                                            \
+  virtual const type * Get##name() const                                                                       \
+  {                                                                                                            \
+    itkDebugMacro("Getting input " #name);                                                                     \
+    using DecoratorType = DataObjectDecorator<type>;                                                           \
+    const DecoratorType * input =                                                                              \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                  \
+    if (input == nullptr)                                                                                      \
+    {                                                                                                          \
+      return nullptr;                                                                                          \
+    }                                                                                                          \
+    return input->Get();                                                                                       \
+  }                                                                                                            \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Set a decorated input. This defines the Set"name"() and Set"name"Input() method
  * and Get"name" and Get"name"Input methods */
-#define itkSetGetDecoratedObjectInputMacro(name, type)                                                                 \
-  itkSetDecoratedObjectInputMacro(name, type);                                                                         \
+#define itkSetGetDecoratedObjectInputMacro(name, type) \
+  itkSetDecoratedObjectInputMacro(name, type);         \
   itkGetDecoratedObjectInputMacro(name, type)
 
 /** Set built-in type.  Creates member Set"name"() (e.g., SetVisibility()); */
 // clang-format off
-#define itkSetMacro(name, type)                                                                                        \
-  virtual void Set##name(const type _arg)                                                                              \
-  {                                                                                                                    \
-    itkDebugMacro("setting " #name " to " << _arg);                                                                    \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal                                                                                        \
-    if (this->m_##name != _arg)                                                                                        \
-    {                                                                                                                  \
-      this->m_##name = _arg;                                                                                           \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-    CLANG_PRAGMA_POP                                                                                                   \
-  }                                                                                                                    \
+#define itkSetMacro(name, type)                     \
+  virtual void Set##name(const type _arg)           \
+  {                                                 \
+    itkDebugMacro("setting " #name " to " << _arg); \
+    CLANG_PRAGMA_PUSH                               \
+    CLANG_SUPPRESS_Wfloat_equal                     \
+    if (this->m_##name != _arg)                     \
+    {                                               \
+      this->m_##name = _arg;                        \
+      this->Modified();                             \
+    }                                               \
+    CLANG_PRAGMA_POP                                \
+  }                                                 \
   ITK_MACROEND_NOOP_STATEMENT
 // clang-format on
 /** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility()); */
-#define itkGetMacro(name, type)                                                                                        \
-  virtual type Get##name() { return this->m_##name; }                                                                  \
+#define itkGetMacro(name, type)                       \
+  virtual type Get##name() { return this->m_##name; } \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility());
  * This is the "const" form of the itkGetMacro.  It should be used unless
  * the member can be changed through the "Get" access routine. */
-#define itkGetConstMacro(name, type)                                                                                   \
-  virtual type Get##name() const { return this->m_##name; }                                                            \
+#define itkGetConstMacro(name, type)                        \
+  virtual type Get##name() const { return this->m_##name; } \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility());
  * This is the "const" form of the itkGetMacro.  It should be used unless
  * the member can be changed through the "Get" access routine.
  * This versions returns a const reference to the variable. */
-#define itkGetConstReferenceMacro(name, type)                                                                          \
-  virtual const type & Get##name() const { return this->m_##name; }                                                    \
+#define itkGetConstReferenceMacro(name, type)                       \
+  virtual const type & Get##name() const { return this->m_##name; } \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Set built-in type.  Creates member Set"name"() (e.g., SetVisibility());
  * This should be used when the type is an enum. It is used to avoid warnings on
  * some compilers with non specified enum types passed to
  * itkDebugMacro. */
-#define itkSetEnumMacro(name, type)                                                                                    \
-  virtual void Set##name(const type _arg)                                                                              \
-  {                                                                                                                    \
-    itkDebugMacro("setting " #name " to " << static_cast<long>(_arg));                                                 \
-    if (this->m_##name != _arg)                                                                                        \
-    {                                                                                                                  \
-      this->m_##name = _arg;                                                                                           \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define itkSetEnumMacro(name, type)                                    \
+  virtual void Set##name(const type _arg)                              \
+  {                                                                    \
+    itkDebugMacro("setting " #name " to " << static_cast<long>(_arg)); \
+    if (this->m_##name != _arg)                                        \
+    {                                                                  \
+      this->m_##name = _arg;                                           \
+      this->Modified();                                                \
+    }                                                                  \
+  }                                                                    \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility());
  * This should be use when the type is an enum. It is use to avoid warnings on
  * some compilers with non specified enum types passed to
  * itkDebugMacro. */
-#define itkGetEnumMacro(name, type)                                                                                    \
-  virtual type Get##name() const { return this->m_##name; }                                                            \
+#define itkGetEnumMacro(name, type)                         \
+  virtual type Get##name() const { return this->m_##name; } \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Set character string.  Creates member Set"name"()
  * (e.g., SetFilename(char *)). The macro assumes that
  * the class member (name) is declared a type std::string. */
-#define itkSetStringMacro(name)                                                                                        \
-  virtual void Set##name(const char * _arg)                                                                            \
-  {                                                                                                                    \
-    if (_arg && (_arg == this->m_##name))                                                                              \
-    {                                                                                                                  \
-      return;                                                                                                          \
-    }                                                                                                                  \
-    if (_arg)                                                                                                          \
-    {                                                                                                                  \
-      this->m_##name = _arg;                                                                                           \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      this->m_##name = "";                                                                                             \
-    }                                                                                                                  \
-    this->Modified();                                                                                                  \
-  }                                                                                                                    \
-  virtual void Set##name(const std::string & _arg) { this->Set##name(_arg.c_str()); }                                  \
+#define itkSetStringMacro(name)                                                       \
+  virtual void Set##name(const char * _arg)                                           \
+  {                                                                                   \
+    if (_arg && (_arg == this->m_##name))                                             \
+    {                                                                                 \
+      return;                                                                         \
+    }                                                                                 \
+    if (_arg)                                                                         \
+    {                                                                                 \
+      this->m_##name = _arg;                                                          \
+    }                                                                                 \
+    else                                                                              \
+    {                                                                                 \
+      this->m_##name = "";                                                            \
+    }                                                                                 \
+    this->Modified();                                                                 \
+  }                                                                                   \
+  virtual void Set##name(const std::string & _arg) { this->Set##name(_arg.c_str()); } \
   ITK_MACROEND_NOOP_STATEMENT
 
 
 /** Get character string.  Creates member Get"name"()
  * (e.g., SetFilename(char *)). The macro assumes that
  * the class member (name) is declared as a type std::string. */
-#define itkGetStringMacro(name)                                                                                        \
-  virtual const char * Get##name() const { return this->m_##name.c_str(); }                                            \
+#define itkGetStringMacro(name)                                             \
+  virtual const char * Get##name() const { return this->m_##name.c_str(); } \
   ITK_MACROEND_NOOP_STATEMENT
 
 // clang-format off
 /** Set built-in type where value is constrained between min/max limits.
  * Create member Set"name"() (e.q., SetRadius()). \#defines are
  * convenience for clamping open-ended values. */
-#define itkSetClampMacro(name, type, min, max)                                                                         \
-  virtual void Set##name(type _arg)                                                                                    \
-  {                                                                                                                    \
-    const type temp_extrema = (_arg < min ? min : (_arg > max ? max : _arg));                                          \
-    itkDebugMacro("setting " << #name " to " << _arg);                                                                 \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal                                                                                        \
-    if (this->m_##name != temp_extrema)                                                                                \
-    {                                                                                                                  \
-      this->m_##name = temp_extrema;                                                                                   \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-    CLANG_PRAGMA_POP                                                                                                   \
-  }                                                                                                                    \
+#define itkSetClampMacro(name, type, min, max)                                \
+  virtual void Set##name(type _arg)                                           \
+  {                                                                           \
+    const type temp_extrema = (_arg < min ? min : (_arg > max ? max : _arg)); \
+    itkDebugMacro("setting " << #name " to " << _arg);                        \
+    CLANG_PRAGMA_PUSH                                                         \
+    CLANG_SUPPRESS_Wfloat_equal                                               \
+    if (this->m_##name != temp_extrema)                                       \
+    {                                                                         \
+      this->m_##name = temp_extrema;                                          \
+      this->Modified();                                                       \
+    }                                                                         \
+    CLANG_PRAGMA_POP                                                          \
+  }                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 // clang-format on
 
@@ -1070,19 +1070,19 @@ compilers.
  * Creates method Set"name"() (e.g., SetPoints()). Note that using
  * smart pointers requires using real pointers when setting input,
  * but returning smart pointers on output. */
-#define itkSetObjectMacro(name, type)                                                                                  \
-  virtual void Set##name(type * _arg)                                                                                  \
-  {                                                                                                                    \
-    itkDebugMacro("setting " << #name " to " << _arg);                                                                 \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal                                                                                        \
-    if (this->m_##name != _arg)                                                                                        \
-    {                                                                                                                  \
-      this->m_##name = _arg;                                                                                           \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-    CLANG_PRAGMA_POP                                                                                                   \
-  }                                                                                                                    \
+#define itkSetObjectMacro(name, type)                  \
+  virtual void Set##name(type * _arg)                  \
+  {                                                    \
+    itkDebugMacro("setting " << #name " to " << _arg); \
+    CLANG_PRAGMA_PUSH                                  \
+    CLANG_SUPPRESS_Wfloat_equal                        \
+    if (this->m_##name != _arg)                        \
+    {                                                  \
+      this->m_##name = _arg;                           \
+      this->Modified();                                \
+    }                                                  \
+    CLANG_PRAGMA_POP                                   \
+  }                                                    \
   ITK_MACROEND_NOOP_STATEMENT
 // clang-format on
 
@@ -1111,8 +1111,8 @@ compilers.
 
 /** Get a smart const pointer to an object.  Creates the member
  * Get"name"() (e.g., GetPoints()). */
-#define itkGetConstObjectMacro(name, type)                                                                             \
-  virtual const type * Get##name() const { return this->m_##name.GetPointer(); }                                       \
+#define itkGetConstObjectMacro(name, type)                                       \
+  virtual const type * Get##name() const { return this->m_##name.GetPointer(); } \
   ITK_MACROEND_NOOP_STATEMENT
 
 
@@ -1122,25 +1122,25 @@ compilers.
 // through manual setting of a compiler define -DITK_FUTURE_LEGACY_REMOVE
 // ("/DITK_FUTURE_LEGACY_REMOVE /EHsc" with Visual Studio)
 // to ease the transition from the historical GetObjectMacro to the GetModifiableObjectMacro
-#  define itkGetObjectMacro(name, type)                                                                                \
-    virtual type * Get##name()                                                                                         \
-    {                                                                                                                  \
-      purposeful_error("itkGetObjectMacro should be replaced with itkGetModifiableObjectMacro.");                      \
+#  define itkGetObjectMacro(name, type)                                                           \
+    virtual type * Get##name()                                                                    \
+    {                                                                                             \
+      purposeful_error("itkGetObjectMacro should be replaced with itkGetModifiableObjectMacro."); \
     }
 
-#  define itkGetModifiableObjectMacro(name, type)                                                                      \
-    virtual type * GetModifiable##name() { return this->m_##name.GetPointer(); }                                       \
+#  define itkGetModifiableObjectMacro(name, type)                                \
+    virtual type * GetModifiable##name() { return this->m_##name.GetPointer(); } \
     itkGetConstObjectMacro(name, type)
 
 #else // defined ( ITK_FUTURE_LEGACY_REMOVE )
 /** Get a smart pointer to an object.  Creates the member
  * Get"name"() (e.g., GetPoints()). */
-#  define itkGetObjectMacro(name, type)                                                                                \
-    virtual type * Get##name() { return this->m_##name.GetPointer(); }                                                 \
+#  define itkGetObjectMacro(name, type)                                \
+    virtual type * Get##name() { return this->m_##name.GetPointer(); } \
     ITK_MACROEND_NOOP_STATEMENT
-#  define itkGetModifiableObjectMacro(name, type)                                                                      \
-    virtual type * GetModifiable##name() { return this->m_##name.GetPointer(); }                                       \
-    itkGetConstObjectMacro(name, type);                                                                                \
+#  define itkGetModifiableObjectMacro(name, type)                                \
+    virtual type * GetModifiable##name() { return this->m_##name.GetPointer(); } \
+    itkGetConstObjectMacro(name, type);                                          \
     itkGetObjectMacro(name, type)
 #endif // defined ( ITK_FUTURE_LEGACY_REMOVE )
 
@@ -1150,66 +1150,66 @@ compilers.
 
 /** Get a const reference to a smart pointer to an object.
  * Creates the member Get"name"() (e.g., GetPoints()). */
-#define itkGetConstReferenceObjectMacro(name, type)                                                                    \
-  virtual const typename type::Pointer & Get##name() const { return this->m_##name; }                                  \
+#define itkGetConstReferenceObjectMacro(name, type)                                   \
+  virtual const typename type::Pointer & Get##name() const { return this->m_##name; } \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Set const pointer to object; uses Object reference counting methodology.
  * Creates method Set"name"() (e.g., SetPoints()). Note that using
  * smart pointers requires using real pointers when setting input,
  * but returning smart pointers on output. */
-#define itkSetConstObjectMacro(name, type)                                                                             \
-  virtual void Set##name(const type * _arg)                                                                            \
-  {                                                                                                                    \
-    itkDebugMacro("setting " << #name " to " << _arg);                                                                 \
-    if (this->m_##name != _arg)                                                                                        \
-    {                                                                                                                  \
-      this->m_##name = _arg;                                                                                           \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define itkSetConstObjectMacro(name, type)             \
+  virtual void Set##name(const type * _arg)            \
+  {                                                    \
+    itkDebugMacro("setting " << #name " to " << _arg); \
+    if (this->m_##name != _arg)                        \
+    {                                                  \
+      this->m_##name = _arg;                           \
+      this->Modified();                                \
+    }                                                  \
+  }                                                    \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Create members "name"On() and "name"Off() (e.g., DebugOn() DebugOff()).
  * Set method must be defined to use this macro. */
-#define itkBooleanMacro(name)                                                                                          \
-  virtual void name##On() { this->Set##name(true); }                                                                   \
+#define itkBooleanMacro(name)                        \
+  virtual void name##On() { this->Set##name(true); } \
   virtual void name##Off() { this->Set##name(false); }
 
 // clang-format off
 /** General set vector macro creates a single method that copies specified
  * number of values into object.
  * Examples: void SetColor(c,3) */
-#define itkSetVectorMacro(name, type, count)                                                                           \
-  virtual void Set##name(type data[])                                                                                  \
-  {                                                                                                                    \
-    unsigned int i;                                                                                                    \
-    for (i = 0; i < count; ++i)                                                                                        \
-    {                                                                                                                  \
-      CLANG_PRAGMA_PUSH                                                                                                \
-      CLANG_SUPPRESS_Wfloat_equal                                                                                      \
-      if (data[i] != this->m_##name[i])                                                                                \
-      {                                                                                                                \
-        break;                                                                                                         \
-      }                                                                                                                \
-      CLANG_PRAGMA_POP                                                                                                 \
-    }                                                                                                                  \
-    if (i < count)                                                                                                     \
-    {                                                                                                                  \
-      this->Modified();                                                                                                \
-      for (i = 0; i < count; ++i)                                                                                      \
-      {                                                                                                                \
-        this->m_##name[i] = data[i];                                                                                   \
-      }                                                                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define itkSetVectorMacro(name, type, count) \
+  virtual void Set##name(type data[])        \
+  {                                          \
+    unsigned int i;                          \
+    for (i = 0; i < count; ++i)              \
+    {                                        \
+      CLANG_PRAGMA_PUSH                      \
+      CLANG_SUPPRESS_Wfloat_equal            \
+      if (data[i] != this->m_##name[i])      \
+      {                                      \
+        break;                               \
+      }                                      \
+      CLANG_PRAGMA_POP                       \
+    }                                        \
+    if (i < count)                           \
+    {                                        \
+      this->Modified();                      \
+      for (i = 0; i < count; ++i)            \
+      {                                      \
+        this->m_##name[i] = data[i];         \
+      }                                      \
+    }                                        \
+  }                                          \
   ITK_MACROEND_NOOP_STATEMENT
 // clang-format on
 
 /** Get vector macro. Returns pointer to type (i.e., array of type).
  * This is for efficiency. */
-#define itkGetVectorMacro(name, type, count)                                                                           \
-  virtual type * Get##name() const { return this->m_##name; }                                                          \
+#define itkGetVectorMacro(name, type, count)                  \
+  virtual type * Get##name() const { return this->m_##name; } \
   ITK_MACROEND_NOOP_STATEMENT
 
 /**\def itkGPUKernelClassMacro
@@ -1223,89 +1223,89 @@ compilers.
  * then without adding the `class` keyword. Useful when an export specifier
  * needs to be added between the `class` keyword and the class name.
  */
-#define itkGPUKernelMacro(kernel)                                                                                      \
-  kernel                                                                                                               \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    ITK_DISALLOW_COPY_AND_MOVE(kernel);                                                                                \
-    kernel() = delete;                                                                                                 \
-    ~kernel() = delete;                                                                                                \
-    static const char * GetOpenCLSource();                                                                             \
+#define itkGPUKernelMacro(kernel)          \
+  kernel                                   \
+  {                                        \
+  public:                                  \
+    ITK_DISALLOW_COPY_AND_MOVE(kernel);    \
+    kernel() = delete;                     \
+    ~kernel() = delete;                    \
+    static const char * GetOpenCLSource(); \
   }
 
-#define itkGetOpenCLSourceFromKernelMacro(kernel)                                                                      \
+#define itkGetOpenCLSourceFromKernelMacro(kernel) \
   static const char * GetOpenCLSource() { return kernel::GetOpenCLSource(); }
 
 // A useful macro in the PrintSelf method for printing member variables
 // which are pointers to object based on the LightObject class.
-#define itkPrintSelfObjectMacro(name)                                                                                  \
-  if (static_cast<const LightObject *>(this->m_##name) == nullptr)                                                     \
-  {                                                                                                                    \
-    os << indent << #name << ": (null)" << std::endl;                                                                  \
-  }                                                                                                                    \
-  else                                                                                                                 \
-  {                                                                                                                    \
-    os << indent << #name << ": " << std::endl;                                                                        \
-    this->m_##name->Print(os, indent.GetNextIndent());                                                                 \
-  }                                                                                                                    \
+#define itkPrintSelfObjectMacro(name)                              \
+  if (static_cast<const LightObject *>(this->m_##name) == nullptr) \
+  {                                                                \
+    os << indent << #name << ": (null)" << std::endl;              \
+  }                                                                \
+  else                                                             \
+  {                                                                \
+    os << indent << #name << ": " << std::endl;                    \
+    this->m_##name->Print(os, indent.GetNextIndent());             \
+  }                                                                \
   ITK_MACROEND_NOOP_STATEMENT
 
 
 /** Set a decorated output. This defines the Set"name"() and a Set"name"Output() method */
-#define itkSetDecoratedOutputMacro(name, type)                                                                         \
-  virtual void Set##name##Output(const SimpleDataObjectDecorator<type> * _arg)                                         \
-  {                                                                                                                    \
-    itkDebugMacro("setting output " #name " to " << _arg);                                                             \
-    if (_arg != itkDynamicCastInDebugMode<SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetOutput(#name)))   \
-    {                                                                                                                  \
-      this->ProcessObject::SetOutput(#name, const_cast<SimpleDataObjectDecorator<type> *>(_arg));                      \
-      this->Modified();                                                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
-  virtual void Set##name(const type & _arg)                                                                            \
-  {                                                                                                                    \
-    using DecoratorType = SimpleDataObjectDecorator<type>;                                                             \
-    itkDebugMacro("setting output " #name " to " << _arg);                                                             \
-    DecoratorType * output = itkDynamicCastInDebugMode<DecoratorType *>(this->ProcessObject::GetOutput(#name));        \
-    if (output)                                                                                                        \
-    {                                                                                                                  \
-      if (output->Get() == _arg)                                                                                       \
-      {                                                                                                                \
-        return;                                                                                                        \
-      }                                                                                                                \
-      else                                                                                                             \
-      {                                                                                                                \
-        output->Set(_arg);                                                                                             \
-      }                                                                                                                \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      typename DecoratorType::Pointer newOutput = DecoratorType::New();                                                \
-      newOutput->Set(_arg);                                                                                            \
-      this->Set##name##Output(newOutput);                                                                              \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define itkSetDecoratedOutputMacro(name, type)                                                                       \
+  virtual void Set##name##Output(const SimpleDataObjectDecorator<type> * _arg)                                       \
+  {                                                                                                                  \
+    itkDebugMacro("setting output " #name " to " << _arg);                                                           \
+    if (_arg != itkDynamicCastInDebugMode<SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetOutput(#name))) \
+    {                                                                                                                \
+      this->ProcessObject::SetOutput(#name, const_cast<SimpleDataObjectDecorator<type> *>(_arg));                    \
+      this->Modified();                                                                                              \
+    }                                                                                                                \
+  }                                                                                                                  \
+  virtual void Set##name(const type & _arg)                                                                          \
+  {                                                                                                                  \
+    using DecoratorType = SimpleDataObjectDecorator<type>;                                                           \
+    itkDebugMacro("setting output " #name " to " << _arg);                                                           \
+    DecoratorType * output = itkDynamicCastInDebugMode<DecoratorType *>(this->ProcessObject::GetOutput(#name));      \
+    if (output)                                                                                                      \
+    {                                                                                                                \
+      if (output->Get() == _arg)                                                                                     \
+      {                                                                                                              \
+        return;                                                                                                      \
+      }                                                                                                              \
+      else                                                                                                           \
+      {                                                                                                              \
+        output->Set(_arg);                                                                                           \
+      }                                                                                                              \
+    }                                                                                                                \
+    else                                                                                                             \
+    {                                                                                                                \
+      typename DecoratorType::Pointer newOutput = DecoratorType::New();                                              \
+      newOutput->Set(_arg);                                                                                          \
+      this->Set##name##Output(newOutput);                                                                            \
+    }                                                                                                                \
+  }                                                                                                                  \
   ITK_MACROEND_NOOP_STATEMENT
 
 /** Set a decorated output. This defines the Get"name"() and Get"name"Output() method */
-#define itkGetDecoratedOutputMacro(name, type)                                                                         \
-  virtual const SimpleDataObjectDecorator<type> * Get##name##Output() const                                            \
-  {                                                                                                                    \
-    itkDebugMacro("returning output " << #name " of " << this->ProcessObject::GetOutput(#name));                       \
-    return itkDynamicCastInDebugMode<const SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetOutput(#name));  \
-  }                                                                                                                    \
-  virtual const type & Get##name() const                                                                               \
-  {                                                                                                                    \
-    itkDebugMacro("Getting output " #name);                                                                            \
-    using DecoratorType = SimpleDataObjectDecorator<type>;                                                             \
-    const DecoratorType * output =                                                                                     \
-      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetOutput(#name));                         \
-    if (output == nullptr)                                                                                             \
-    {                                                                                                                  \
-      itkExceptionMacro(<< "output" #name " is not set");                                                              \
-    }                                                                                                                  \
-    return output->Get();                                                                                              \
-  }                                                                                                                    \
+#define itkGetDecoratedOutputMacro(name, type)                                                                        \
+  virtual const SimpleDataObjectDecorator<type> * Get##name##Output() const                                           \
+  {                                                                                                                   \
+    itkDebugMacro("returning output " << #name " of " << this->ProcessObject::GetOutput(#name));                      \
+    return itkDynamicCastInDebugMode<const SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetOutput(#name)); \
+  }                                                                                                                   \
+  virtual const type & Get##name() const                                                                              \
+  {                                                                                                                   \
+    itkDebugMacro("Getting output " #name);                                                                           \
+    using DecoratorType = SimpleDataObjectDecorator<type>;                                                            \
+    const DecoratorType * output =                                                                                    \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetOutput(#name));                        \
+    if (output == nullptr)                                                                                            \
+    {                                                                                                                 \
+      itkExceptionMacro(<< "output" #name " is not set");                                                             \
+    }                                                                                                                 \
+    return output->Get();                                                                                             \
+  }                                                                                                                   \
   ITK_MACROEND_NOOP_STATEMENT
 
 

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -101,23 +101,23 @@ static constexpr float float_sqrteps = vnl_math::float_sqrteps;
 /** A useful macro to generate a template floating point to integer
  *  conversion templated on the return type and using either the 32
  *  bit, the 64 bit or the vanilla version */
-#define itkTemplateFloatingToIntegerMacro(name)                                                                        \
-  template <typename TReturn, typename TInput>                                                                         \
-  inline TReturn name(TInput x)                                                                                        \
-  {                                                                                                                    \
-                                                                                                                       \
-    if (sizeof(TReturn) <= 4)                                                                                          \
-    {                                                                                                                  \
-      return static_cast<TReturn>(Detail::name##_32(x));                                                               \
-    }                                                                                                                  \
-    else if (sizeof(TReturn) <= 8)                                                                                     \
-    {                                                                                                                  \
-      return static_cast<TReturn>(Detail::name##_64(x));                                                               \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      return static_cast<TReturn>(Detail::name##_base<TReturn, TInput>(x));                                            \
-    }                                                                                                                  \
+#define itkTemplateFloatingToIntegerMacro(name)                             \
+  template <typename TReturn, typename TInput>                              \
+  inline TReturn name(TInput x)                                             \
+  {                                                                         \
+                                                                            \
+    if (sizeof(TReturn) <= 4)                                               \
+    {                                                                       \
+      return static_cast<TReturn>(Detail::name##_32(x));                    \
+    }                                                                       \
+    else if (sizeof(TReturn) <= 8)                                          \
+    {                                                                       \
+      return static_cast<TReturn>(Detail::name##_64(x));                    \
+    }                                                                       \
+    else                                                                    \
+    {                                                                       \
+      return static_cast<TReturn>(Detail::name##_base<TReturn, TInput>(x)); \
+    }                                                                       \
   }
 
 /** \brief Round towards nearest integer

--- a/Modules/Core/Common/include/itkMathDetail.h
+++ b/Modules/Core/Common/include/itkMathDetail.h
@@ -54,7 +54,7 @@
 // Turn on 32-bit and 64-bit asm impl when using GCC/clang on x86 platform with the
 // following exception:
 //   GCCXML
-#if defined(__GNUC__) && !defined(ITK_WRAPPING_PARSER) &&                                                              \
+#if defined(__GNUC__) && !defined(ITK_WRAPPING_PARSER) && \
   (defined(__i386__) || defined(__i386) || defined(__x86_64__) || defined(__x86_64))
 #  define GCC_USE_ASM_32IMPL 1
 #  define GCC_USE_ASM_64IMPL 1

--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -227,11 +227,11 @@ ExposeMetaData(const MetaDataDictionary & Dictionary, const std::string key, T &
  * have operator<< defined.
  * \param TYPE_NAME the native type parameter type
  */
-#define ITK_NATIVE_TYPE_METADATAPRINT(TYPE_NAME)                                                                       \
-  template <>                                                                                                          \
-  void ::itk::MetaDataObject<TYPE_NAME>::Print(std::ostream & os) const                                                \
-  {                                                                                                                    \
-    os << this->m_MetaDataObjectValue << std::endl;                                                                    \
+#define ITK_NATIVE_TYPE_METADATAPRINT(TYPE_NAME)                        \
+  template <>                                                           \
+  void ::itk::MetaDataObject<TYPE_NAME>::Print(std::ostream & os) const \
+  {                                                                     \
+    os << this->m_MetaDataObjectValue << std::endl;                     \
   }
 
 /**
@@ -242,11 +242,11 @@ ExposeMetaData(const MetaDataDictionary & Dictionary, const std::string key, T &
  * \param TYPE_NAME_PART1
  * \param TYPE_NAME_PART2
  */
-#define ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(TYPE_NAME_PART1, TYPE_NAME_PART2)                                         \
-  template <>                                                                                                          \
-  void itk::MetaDataObject<TYPE_NAME_PART1, TYPE_NAME_PART2>::Print(std::ostream & os) const                           \
-  {                                                                                                                    \
-    this->m_MetaDataObjectValue->Print(os);                                                                            \
+#define ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(TYPE_NAME_PART1, TYPE_NAME_PART2)               \
+  template <>                                                                                \
+  void itk::MetaDataObject<TYPE_NAME_PART1, TYPE_NAME_PART2>::Print(std::ostream & os) const \
+  {                                                                                          \
+    this->m_MetaDataObjectValue->Print(os);                                                  \
   }
 
 /**
@@ -256,14 +256,14 @@ ExposeMetaData(const MetaDataDictionary & Dictionary, const std::string key, T &
  * itk::Image\<STORAGE_TYPE,[1-8]\>\::Pointer
  * \param STORAGE_TYPE The storage type of the image type to print.
  */
-#define ITK_IMAGE_TYPE_METADATAPRINT(STORAGE_TYPE)                                                                     \
-  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 1>::Pointer)                                           \
-  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 2>::Pointer)                                           \
-  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 3>::Pointer)                                           \
-  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 4>::Pointer)                                           \
-  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 5>::Pointer)                                           \
-  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 6>::Pointer)                                           \
-  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 7>::Pointer)                                           \
+#define ITK_IMAGE_TYPE_METADATAPRINT(STORAGE_TYPE)                           \
+  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 1>::Pointer) \
+  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 2>::Pointer) \
+  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 3>::Pointer) \
+  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 4>::Pointer) \
+  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 5>::Pointer) \
+  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 6>::Pointer) \
+  ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 7>::Pointer) \
   ITK_OBJECT_TYPE_METADATAPRINT_1COMMA(itk::Image<STORAGE_TYPE, 8>::Pointer)
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -23,10 +23,10 @@
 #undef min
 #undef max
 
-#define itkNUMERIC_TRAITS_MIN_MAX_MACRO()                                                                              \
-  static constexpr ValueType min(ValueType) { return std::numeric_limits<ValueType>::min(); }                          \
-  static constexpr ValueType max(ValueType) { return std::numeric_limits<ValueType>::max(); }                          \
-  static constexpr ValueType min() { return std::numeric_limits<ValueType>::min(); }                                   \
+#define itkNUMERIC_TRAITS_MIN_MAX_MACRO()                                                     \
+  static constexpr ValueType min(ValueType) { return std::numeric_limits<ValueType>::min(); } \
+  static constexpr ValueType max(ValueType) { return std::numeric_limits<ValueType>::max(); } \
+  static constexpr ValueType min() { return std::numeric_limits<ValueType>::min(); }          \
   static constexpr ValueType max() { return std::numeric_limits<ValueType>::max(); }
 
 #include <limits> // for std::numeric_limits

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -198,28 +198,28 @@ public:
 //       a temporary variable that is initialized from the
 //       constexpr [Zero|One] to be passed by const reference
 //       to the GENERIC_ARRAY<T,D> constructor.
-#define itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, D)                                                   \
-  template <>                                                                                                          \
-  ITKCommon_EXPORT const GENERIC_ARRAY<T, D> NumericTraits<GENERIC_ARRAY<T, D>>::Zero =                                \
-    GENERIC_ARRAY<T, D>((T)(NumericTraits<T>::Zero));                                                                  \
-  template <>                                                                                                          \
-  ITKCommon_EXPORT const GENERIC_ARRAY<T, D> NumericTraits<GENERIC_ARRAY<T, D>>::One =                                 \
+#define itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, D)                    \
+  template <>                                                                           \
+  ITKCommon_EXPORT const GENERIC_ARRAY<T, D> NumericTraits<GENERIC_ARRAY<T, D>>::Zero = \
+    GENERIC_ARRAY<T, D>((T)(NumericTraits<T>::Zero));                                   \
+  template <>                                                                           \
+  ITKCommon_EXPORT const GENERIC_ARRAY<T, D> NumericTraits<GENERIC_ARRAY<T, D>>::One =  \
     GENERIC_ARRAY<T, D>((T)(NumericTraits<T>::One));
 
 //
 // List here the array dimension specializations of these static
 // Traits:
 //
-#define itkStaticNumericTraitsGenericArrayDimensionsMacro(GENERIC_ARRAY, T)                                            \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 1);                                                        \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 2);                                                        \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 3);                                                        \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 4);                                                        \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 5);                                                        \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 6);                                                        \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 7);                                                        \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 8);                                                        \
-  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 9);                                                        \
+#define itkStaticNumericTraitsGenericArrayDimensionsMacro(GENERIC_ARRAY, T) \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 1);             \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 2);             \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 3);             \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 4);             \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 5);             \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 6);             \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 7);             \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 8);             \
+  itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 9);             \
   itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, 10);
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkPromoteType.h
+++ b/Modules/Core/Common/include/itkPromoteType.h
@@ -55,11 +55,11 @@ struct Identity
  * \ingroup MetaProgrammingLibrary
  * \ingroup ITKCommon
  */
-#define ITK_ASSOCIATE(N, Typed)                                                                                        \
-  template <typename TA, typename TB>                                                                                  \
-  struct SizeToType<N, TA, TB>                                                                                         \
-  {                                                                                                                    \
-    using Type = Typed;                                                                                                \
+#define ITK_ASSOCIATE(N, Typed)       \
+  template <typename TA, typename TB> \
+  struct SizeToType<N, TA, TB>        \
+  {                                   \
+    using Type = Typed;               \
   };
 
 ITK_ASSOCIATE(1, TA);

--- a/Modules/Core/Common/include/itkSingletonMacro.h
+++ b/Modules/Core/Common/include/itkSingletonMacro.h
@@ -25,42 +25,42 @@
 #ifndef itkSingletonMacro_h
 #define itkSingletonMacro_h
 
-#define itkInitGlobalsMacro(VarName)                                                                                   \
-  {                                                                                                                    \
-    static auto * staticGlobals = Get##VarName##Pointer();                                                             \
-    (void)staticGlobals;                                                                                               \
-  }                                                                                                                    \
+#define itkInitGlobalsMacro(VarName)                       \
+  {                                                        \
+    static auto * staticGlobals = Get##VarName##Pointer(); \
+    (void)staticGlobals;                                   \
+  }                                                        \
   ITK_MACROEND_NOOP_STATEMENT
 
 #define itkGetGlobalDeclarationMacro(Type, VarName) static Type * Get##VarName##Pointer()
 
 #define itkGetGlobalSimpleMacro(Class, Type, Name) itkGetGlobalInitializeMacro(Class, Type, Name, Class, (void)0)
 
-#define itkGetGlobalValueMacro(Class, Type, Name, Value)                                                               \
+#define itkGetGlobalValueMacro(Class, Type, Name, Value) \
   itkGetGlobalInitializeMacro(Class, Type, Name, Name, *m_##Name = Value)
 
-#define itkGetGlobalInitializeMacro(Class, Type, VarName, SingletonName, Init)                                         \
-  Type * Class::Get##VarName##Pointer()                                                                                \
-  {                                                                                                                    \
-    if (m_##VarName == nullptr)                                                                                        \
-    {                                                                                                                  \
-      static auto setLambda = [](void * a) {                                                                           \
-        delete m_##VarName;                                                                                            \
-        m_##VarName = static_cast<Type *>(a);                                                                          \
-      };                                                                                                               \
-      static auto deleteLambda = []() {                                                                                \
-        delete m_##VarName;                                                                                            \
-        m_##VarName = nullptr;                                                                                         \
-      };                                                                                                               \
-      auto * old_instance = SingletonIndex::GetInstance()->GetGlobalInstance<Type>(#SingletonName);                    \
-      m_##VarName = Singleton<Type>(#SingletonName, setLambda, deleteLambda);                                          \
-      if (old_instance == nullptr)                                                                                     \
-      {                                                                                                                \
-        Init;                                                                                                          \
-      }                                                                                                                \
-    }                                                                                                                  \
-    return m_##VarName;                                                                                                \
-  }                                                                                                                    \
+#define itkGetGlobalInitializeMacro(Class, Type, VarName, SingletonName, Init)                      \
+  Type * Class::Get##VarName##Pointer()                                                             \
+  {                                                                                                 \
+    if (m_##VarName == nullptr)                                                                     \
+    {                                                                                               \
+      static auto setLambda = [](void * a) {                                                        \
+        delete m_##VarName;                                                                         \
+        m_##VarName = static_cast<Type *>(a);                                                       \
+      };                                                                                            \
+      static auto deleteLambda = []() {                                                             \
+        delete m_##VarName;                                                                         \
+        m_##VarName = nullptr;                                                                      \
+      };                                                                                            \
+      auto * old_instance = SingletonIndex::GetInstance()->GetGlobalInstance<Type>(#SingletonName); \
+      m_##VarName = Singleton<Type>(#SingletonName, setLambda, deleteLambda);                       \
+      if (old_instance == nullptr)                                                                  \
+      {                                                                                             \
+        Init;                                                                                       \
+      }                                                                                             \
+    }                                                                                               \
+    return m_##VarName;                                                                             \
+  }                                                                                                 \
   ITK_MACROEND_NOOP_STATEMENT
 
 #endif

--- a/Modules/Core/Common/include/itkVersion.h
+++ b/Modules/Core/Common/include/itkVersion.h
@@ -33,8 +33,8 @@
 
 #define ITK_VERSION_TO_STRING(x) ITK_VERSION_TO_STRING0(x)
 #define ITK_VERSION_TO_STRING0(x) #x
-#define ITK_VERSION                                                                                                    \
-  ITK_VERSION_TO_STRING(ITK_VERSION_MAJOR)                                                                             \
+#define ITK_VERSION                        \
+  ITK_VERSION_TO_STRING(ITK_VERSION_MAJOR) \
   "." ITK_VERSION_TO_STRING(ITK_VERSION_MINOR) "." ITK_VERSION_TO_STRING(ITK_VERSION_PATCH)
 #define ITK_SOURCE_VERSION "itk version " ITK_VERSION
 

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -61,7 +61,7 @@ http://graphviz.sourcearchive.com/documentation/2.16/gvrender__pango_8c-source.h
 
 // We do not have ITK_HAS_FEENABLEEXCEPT, and we do not have a workaround
 // implemented, e.g. ARMv8 with MUSL
-#if !defined(ITK_HAS_FEENABLEEXCEPT) && !defined(__ppc__) && !defined(__ppc64__) && !defined(__i386__) &&              \
+#if !defined(ITK_HAS_FEENABLEEXCEPT) && !defined(__ppc__) && !defined(__ppc64__) && !defined(__i386__) && \
   !defined(__x86_64__)
 #  define ITK_FEENABLEEXCEPT_NOOP
 #endif

--- a/Modules/Core/Common/src/itkNumericTraitsDiffusionTensor3DPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsDiffusionTensor3DPixel.cxx
@@ -26,12 +26,12 @@ namespace itk
 // NumericTraits<>.
 //
 
-#define DIFFUSIONTENSOR3DPIXELSTATICTRAITSMACRO(T)                                                                     \
-  template <>                                                                                                          \
-  ITKCommon_EXPORT const DiffusionTensor3D<T> NumericTraits<DiffusionTensor3D<T>>::Zero =                              \
-    DiffusionTensor3D<T>(NumericTraits<T>::Zero);                                                                      \
-  template <>                                                                                                          \
-  ITKCommon_EXPORT const DiffusionTensor3D<T> NumericTraits<DiffusionTensor3D<T>>::One =                               \
+#define DIFFUSIONTENSOR3DPIXELSTATICTRAITSMACRO(T)                                        \
+  template <>                                                                             \
+  ITKCommon_EXPORT const DiffusionTensor3D<T> NumericTraits<DiffusionTensor3D<T>>::Zero = \
+    DiffusionTensor3D<T>(NumericTraits<T>::Zero);                                         \
+  template <>                                                                             \
+  ITKCommon_EXPORT const DiffusionTensor3D<T> NumericTraits<DiffusionTensor3D<T>>::One =  \
     DiffusionTensor3D<T>(NumericTraits<T>::One);
 
 //

--- a/Modules/Core/Common/src/itkNumericTraitsRGBAPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsRGBAPixel.cxx
@@ -27,10 +27,10 @@ namespace itk
 // Helper macro for initializing the Zero and One static member of the
 // NumericTraits<>.
 //
-#define RGBAPIXELSTATICTRAITSMACRO(T)                                                                                  \
-  template <>                                                                                                          \
-  ITKCommon_EXPORT const RGBAPixel<T> NumericTraits<RGBAPixel<T>>::Zero = RGBAPixel<T>(NumericTraits<T>::Zero);        \
-  template <>                                                                                                          \
+#define RGBAPIXELSTATICTRAITSMACRO(T)                                                                           \
+  template <>                                                                                                   \
+  ITKCommon_EXPORT const RGBAPixel<T> NumericTraits<RGBAPixel<T>>::Zero = RGBAPixel<T>(NumericTraits<T>::Zero); \
+  template <>                                                                                                   \
   ITKCommon_EXPORT const RGBAPixel<T> NumericTraits<RGBAPixel<T>>::One = RGBAPixel<T>(NumericTraits<T>::One);
 
 //

--- a/Modules/Core/Common/src/itkNumericTraitsRGBPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsRGBPixel.cxx
@@ -27,10 +27,10 @@ namespace itk
 // Helper macro for initializing the Zero and One static member of the
 // NumericTraits<>.
 //
-#define RGBPIXELSTATICTRAITSMACRO(T)                                                                                   \
-  template <>                                                                                                          \
-  ITKCommon_EXPORT const RGBPixel<T> NumericTraits<RGBPixel<T>>::Zero = RGBPixel<T>(NumericTraits<T>::Zero);           \
-  template <>                                                                                                          \
+#define RGBPIXELSTATICTRAITSMACRO(T)                                                                         \
+  template <>                                                                                                \
+  ITKCommon_EXPORT const RGBPixel<T> NumericTraits<RGBPixel<T>>::Zero = RGBPixel<T>(NumericTraits<T>::Zero); \
+  template <>                                                                                                \
   ITKCommon_EXPORT const RGBPixel<T> NumericTraits<RGBPixel<T>>::One = RGBPixel<T>(NumericTraits<T>::One);
 
 //

--- a/Modules/Core/Common/src/itkRealTimeInterval.cxx
+++ b/Modules/Core/Common/src/itkRealTimeInterval.cxx
@@ -21,17 +21,17 @@
 // This macro ensures that the sign of the seconds is the same as the sign of
 // the microseconds. In other words, both of them are measured toward the same
 // direction of time.
-#define ALIGN_THE_ARROW_OF_TIME(seconds, micro_seconds)                                                                \
-  if (seconds > 0 && micro_seconds < 0)                                                                                \
-  {                                                                                                                    \
-    seconds -= 1;                                                                                                      \
-    micro_seconds = 1000000L - micro_seconds;                                                                          \
-  }                                                                                                                    \
-  if (seconds < 0 && micro_seconds > 0)                                                                                \
-  {                                                                                                                    \
-    seconds += 1;                                                                                                      \
-    micro_seconds = 1000000L + micro_seconds;                                                                          \
-  }                                                                                                                    \
+#define ALIGN_THE_ARROW_OF_TIME(seconds, micro_seconds) \
+  if (seconds > 0 && micro_seconds < 0)                 \
+  {                                                     \
+    seconds -= 1;                                       \
+    micro_seconds = 1000000L - micro_seconds;           \
+  }                                                     \
+  if (seconds < 0 && micro_seconds > 0)                 \
+  {                                                     \
+    seconds += 1;                                       \
+    micro_seconds = 1000000L + micro_seconds;           \
+  }                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk

--- a/Modules/Core/Common/src/itkRealTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkRealTimeStamp.cxx
@@ -23,41 +23,41 @@
 // remainder of microseconds will be kept. It also ensures that if the number
 // of microseconds is negative, then we decrement the number of seconds and
 // assign to the microseconds variable the complement that is a positive number.
-#define CARRY_UNITS_OVER_UNSIGNED(seconds, micro_seconds)                                                              \
-  if (micro_seconds > 1000000L)                                                                                        \
-  {                                                                                                                    \
-    seconds += 1;                                                                                                      \
-    micro_seconds -= 1000000L;                                                                                         \
-  }                                                                                                                    \
+#define CARRY_UNITS_OVER_UNSIGNED(seconds, micro_seconds) \
+  if (micro_seconds > 1000000L)                           \
+  {                                                       \
+    seconds += 1;                                         \
+    micro_seconds -= 1000000L;                            \
+  }                                                       \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define CARRY_UNITS_OVER_SIGNED(seconds, micro_seconds)                                                                \
-  if (micro_seconds > 1000000L)                                                                                        \
-  {                                                                                                                    \
-    seconds += 1;                                                                                                      \
-    micro_seconds -= 1000000L;                                                                                         \
-  }                                                                                                                    \
-  if (micro_seconds < 0)                                                                                               \
-  {                                                                                                                    \
-    seconds -= 1;                                                                                                      \
-    micro_seconds += 1000000L;                                                                                         \
-  }                                                                                                                    \
+#define CARRY_UNITS_OVER_SIGNED(seconds, micro_seconds) \
+  if (micro_seconds > 1000000L)                         \
+  {                                                     \
+    seconds += 1;                                       \
+    micro_seconds -= 1000000L;                          \
+  }                                                     \
+  if (micro_seconds < 0)                                \
+  {                                                     \
+    seconds -= 1;                                       \
+    micro_seconds += 1000000L;                          \
+  }                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
 // This macro ensures that the sign of the seconds is the same as the sign of
 // the microseconds. In other words, both of them are measured toward the same
 // direction of time.
-#define ALIGN_THE_ARROW_OF_TIME(seconds, micro_seconds)                                                                \
-  if (seconds > 0 && micro_seconds < 0)                                                                                \
-  {                                                                                                                    \
-    seconds -= 1;                                                                                                      \
-    micro_seconds = 1000000L - micro_seconds;                                                                          \
-  }                                                                                                                    \
-  if (seconds < 0 && micro_seconds > 0)                                                                                \
-  {                                                                                                                    \
-    seconds += 1;                                                                                                      \
-    micro_seconds = 1000000L + micro_seconds;                                                                          \
-  }                                                                                                                    \
+#define ALIGN_THE_ARROW_OF_TIME(seconds, micro_seconds) \
+  if (seconds > 0 && micro_seconds < 0)                 \
+  {                                                     \
+    seconds -= 1;                                       \
+    micro_seconds = 1000000L - micro_seconds;           \
+  }                                                     \
+  if (seconds < 0 && micro_seconds > 0)                 \
+  {                                                     \
+    seconds += 1;                                       \
+    micro_seconds = 1000000L + micro_seconds;           \
+  }                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk

--- a/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineKernelFunctionTest.cxx
@@ -61,26 +61,26 @@ itkBSplineKernelFunctionTest(int, char *[])
 
 
   // Testing the output of BSplineKernelFunction
-#define TEST_BSPLINE_KERNEL(ORDERNUM)                                                                                  \
-  {                                                                                                                    \
-    using FunctionType = itk::BSplineKernelFunction<ORDERNUM>;                                                         \
-    FunctionType::Pointer function = FunctionType::New();                                                              \
-                                                                                                                       \
-    function->Print(std::cout);                                                                                        \
-    for (unsigned j = 0; j < npoints; ++j)                                                                             \
-    {                                                                                                                  \
-      double results = function->Evaluate(x[j]);                                                                       \
-      /* compare with external results */                                                                              \
-      if (itk::Math::abs(results - b##ORDERNUM[j]) > 1e-6)                                                             \
-      {                                                                                                                \
-        std::cout << "Error with " << ORDERNUM << " order BSplineKernelFunction" << std::endl;                         \
-        std::cout << "Expected: " << b##ORDERNUM[j] << " but got " << results;                                         \
-        std::cout << " at x = " << x[j] << std::endl;                                                                  \
-        std::cout << "Test failed" << std::endl;                                                                       \
-        return EXIT_FAILURE;                                                                                           \
-      }                                                                                                                \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define TEST_BSPLINE_KERNEL(ORDERNUM)                                                          \
+  {                                                                                            \
+    using FunctionType = itk::BSplineKernelFunction<ORDERNUM>;                                 \
+    FunctionType::Pointer function = FunctionType::New();                                      \
+                                                                                               \
+    function->Print(std::cout);                                                                \
+    for (unsigned j = 0; j < npoints; ++j)                                                     \
+    {                                                                                          \
+      double results = function->Evaluate(x[j]);                                               \
+      /* compare with external results */                                                      \
+      if (itk::Math::abs(results - b##ORDERNUM[j]) > 1e-6)                                     \
+      {                                                                                        \
+        std::cout << "Error with " << ORDERNUM << " order BSplineKernelFunction" << std::endl; \
+        std::cout << "Expected: " << b##ORDERNUM[j] << " but got " << results;                 \
+        std::cout << " at x = " << x[j] << std::endl;                                          \
+        std::cout << "Test failed" << std::endl;                                               \
+        return EXIT_FAILURE;                                                                   \
+      }                                                                                        \
+    }                                                                                          \
+  }                                                                                            \
   ITK_MACROEND_NOOP_STATEMENT
 
   TEST_BSPLINE_KERNEL(0);

--- a/Modules/Core/Common/test/itkFactoryTestLib.cxx
+++ b/Modules/Core/Common/test/itkFactoryTestLib.cxx
@@ -171,11 +171,11 @@ public:
   }
 
 private:
-#define OverrideTypeMacro(t)                                                                                           \
-  this->RegisterOverride(typeid(itk::ImportImageContainer<unsigned long, t>).name(),                                   \
-                         typeid(TestImportImageContainer<unsigned long, t>).name(),                                    \
-                         "Test ImportImageContainerOverride",                                                          \
-                         true,                                                                                         \
+#define OverrideTypeMacro(t)                                                         \
+  this->RegisterOverride(typeid(itk::ImportImageContainer<unsigned long, t>).name(), \
+                         typeid(TestImportImageContainer<unsigned long, t>).name(),  \
+                         "Test ImportImageContainerOverride",                        \
+                         true,                                                       \
                          itk::CreateObjectFunction<TestImportImageContainer<unsigned long, t>>::New())
 
 

--- a/Modules/Core/Common/test/itkFixedArrayTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest.cxx
@@ -137,15 +137,15 @@ itkFixedArrayTest(int, char *[])
   }
 
   // Try all index types
-#define TRY_INDEX_CONST(T)                                                                                             \
-  {                                                                                                                    \
-    T in = 10;                                                                                                         \
-    if (array20[in] != 10)                                                                                             \
-    {                                                                                                                  \
-      std::cerr << "index failed" << std::endl;                                                                        \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define TRY_INDEX_CONST(T)                      \
+  {                                             \
+    T in = 10;                                  \
+    if (array20[in] != 10)                      \
+    {                                           \
+      std::cerr << "index failed" << std::endl; \
+      return EXIT_FAILURE;                      \
+    }                                           \
+  }                                             \
   ITK_MACROEND_NOOP_STATEMENT
 
   TRY_INDEX_CONST(short);
@@ -156,11 +156,11 @@ itkFixedArrayTest(int, char *[])
   TRY_INDEX_CONST(unsigned long);
   TRY_INDEX_CONST(long long);
   TRY_INDEX_CONST(unsigned long long);
-#define TRY_INDEX(T)                                                                                                   \
-  {                                                                                                                    \
-    T in = 10;                                                                                                         \
-    array20[in] = 10;                                                                                                  \
-  }                                                                                                                    \
+#define TRY_INDEX(T)  \
+  {                   \
+    T in = 10;        \
+    array20[in] = 10; \
+  }                   \
   ITK_MACROEND_NOOP_STATEMENT
 
   TRY_INDEX(short);

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -113,123 +113,123 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
 
   itk::TimeProbesCollectorBase collector;
 
-#define TRY_FAST_INDEX(dim)                                                                                            \
-  {                                                                                                                    \
-    using PixelType = char;                                                                                            \
-    using ImageType = itk::Image<PixelType, dim>;                                                                      \
-    ImageType::Pointer    myImage = ImageType::New();                                                                  \
-    ImageType::SizeType   size;                                                                                        \
-    ImageType::IndexType  index;                                                                                       \
-    ImageType::RegionType region;                                                                                      \
-    size.Fill(50);                                                                                                     \
-    index.Fill(0);                                                                                                     \
-    region.SetSize(size);                                                                                              \
-    region.SetIndex(index);                                                                                            \
-    myImage->SetLargestPossibleRegion(region);                                                                         \
-    myImage->SetBufferedRegion(region);                                                                                \
-    myImage->SetRequestedRegion(region);                                                                               \
-    myImage->Allocate();                                                                                               \
-    collector.Start("ComputeIndexFast " #dim "D");                                                                     \
-    unsigned int totalSize = 1;                                                                                        \
-    for (unsigned int i = 0; i < dim; ++i)                                                                             \
-      totalSize *= size[i];                                                                                            \
-    unsigned int repeat = 1000;                                                                                        \
-    if (dim > 2)                                                                                                       \
-      repeat = 100;                                                                                                    \
-    if (dim > 3)                                                                                                       \
-      repeat = 10;                                                                                                     \
-    if (dim > 4)                                                                                                       \
-      repeat = 1;                                                                                                      \
-    ComputeFastIndex<ImageType>(myImage, totalSize, repeat);                                                           \
-    collector.Stop("ComputeIndexFast " #dim "D");                                                                      \
-  }                                                                                                                    \
+#define TRY_FAST_INDEX(dim)                                  \
+  {                                                          \
+    using PixelType = char;                                  \
+    using ImageType = itk::Image<PixelType, dim>;            \
+    ImageType::Pointer    myImage = ImageType::New();        \
+    ImageType::SizeType   size;                              \
+    ImageType::IndexType  index;                             \
+    ImageType::RegionType region;                            \
+    size.Fill(50);                                           \
+    index.Fill(0);                                           \
+    region.SetSize(size);                                    \
+    region.SetIndex(index);                                  \
+    myImage->SetLargestPossibleRegion(region);               \
+    myImage->SetBufferedRegion(region);                      \
+    myImage->SetRequestedRegion(region);                     \
+    myImage->Allocate();                                     \
+    collector.Start("ComputeIndexFast " #dim "D");           \
+    unsigned int totalSize = 1;                              \
+    for (unsigned int i = 0; i < dim; ++i)                   \
+      totalSize *= size[i];                                  \
+    unsigned int repeat = 1000;                              \
+    if (dim > 2)                                             \
+      repeat = 100;                                          \
+    if (dim > 3)                                             \
+      repeat = 10;                                           \
+    if (dim > 4)                                             \
+      repeat = 1;                                            \
+    ComputeFastIndex<ImageType>(myImage, totalSize, repeat); \
+    collector.Stop("ComputeIndexFast " #dim "D");            \
+  }                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define TRY_INDEX(dim)                                                                                                 \
-  {                                                                                                                    \
-    using PixelType = char;                                                                                            \
-    using ImageType = itk::Image<PixelType, dim>;                                                                      \
-    ImageType::Pointer    myImage = ImageType::New();                                                                  \
-    ImageType::SizeType   size;                                                                                        \
-    ImageType::IndexType  index;                                                                                       \
-    ImageType::RegionType region;                                                                                      \
-    size.Fill(50);                                                                                                     \
-    index.Fill(0);                                                                                                     \
-    region.SetSize(size);                                                                                              \
-    region.SetIndex(index);                                                                                            \
-    myImage->SetLargestPossibleRegion(region);                                                                         \
-    myImage->SetBufferedRegion(region);                                                                                \
-    myImage->SetRequestedRegion(region);                                                                               \
-    myImage->Allocate();                                                                                               \
-    collector.Start("ComputeIndex " #dim "D");                                                                         \
-    unsigned int totalSize = 1;                                                                                        \
-    for (unsigned int i = 0; i < dim; ++i)                                                                             \
-      totalSize *= size[i];                                                                                            \
-    unsigned int repeat = 1000;                                                                                        \
-    if (dim > 2)                                                                                                       \
-      repeat = 100;                                                                                                    \
-    if (dim > 3)                                                                                                       \
-      repeat = 10;                                                                                                     \
-    if (dim > 4)                                                                                                       \
-      repeat = 1;                                                                                                      \
-    ComputeIndex<ImageType>(myImage, totalSize, repeat);                                                               \
-    collector.Stop("ComputeIndex " #dim "D");                                                                          \
-  }                                                                                                                    \
+#define TRY_INDEX(dim)                                   \
+  {                                                      \
+    using PixelType = char;                              \
+    using ImageType = itk::Image<PixelType, dim>;        \
+    ImageType::Pointer    myImage = ImageType::New();    \
+    ImageType::SizeType   size;                          \
+    ImageType::IndexType  index;                         \
+    ImageType::RegionType region;                        \
+    size.Fill(50);                                       \
+    index.Fill(0);                                       \
+    region.SetSize(size);                                \
+    region.SetIndex(index);                              \
+    myImage->SetLargestPossibleRegion(region);           \
+    myImage->SetBufferedRegion(region);                  \
+    myImage->SetRequestedRegion(region);                 \
+    myImage->Allocate();                                 \
+    collector.Start("ComputeIndex " #dim "D");           \
+    unsigned int totalSize = 1;                          \
+    for (unsigned int i = 0; i < dim; ++i)               \
+      totalSize *= size[i];                              \
+    unsigned int repeat = 1000;                          \
+    if (dim > 2)                                         \
+      repeat = 100;                                      \
+    if (dim > 3)                                         \
+      repeat = 10;                                       \
+    if (dim > 4)                                         \
+      repeat = 1;                                        \
+    ComputeIndex<ImageType>(myImage, totalSize, repeat); \
+    collector.Stop("ComputeIndex " #dim "D");            \
+  }                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define TRY_FAST_OFFSET(dim)                                                                                           \
-  {                                                                                                                    \
-    using PixelType = char;                                                                                            \
-    using ImageType = itk::Image<PixelType, dim>;                                                                      \
-    ImageType::Pointer    myImage = ImageType::New();                                                                  \
-    ImageType::SizeType   size;                                                                                        \
-    ImageType::IndexType  index;                                                                                       \
-    ImageType::RegionType region;                                                                                      \
-    size.Fill(50);                                                                                                     \
-    index.Fill(0);                                                                                                     \
-    region.SetSize(size);                                                                                              \
-    region.SetIndex(index);                                                                                            \
-    myImage->SetLargestPossibleRegion(region);                                                                         \
-    myImage->SetBufferedRegion(region);                                                                                \
-    myImage->SetRequestedRegion(region);                                                                               \
-    myImage->Allocate();                                                                                               \
-    collector.Start("ComputeOffsetFast " #dim "D");                                                                    \
-    unsigned int repeat = 1;                                                                                           \
-    if (dim < 4)                                                                                                       \
-      repeat = 100;                                                                                                    \
-    unsigned int totalSize = 1;                                                                                        \
-    for (unsigned int i = 0; i < dim; ++i)                                                                             \
-      totalSize *= size[i];                                                                                            \
-    ComputeFastOffset<ImageType>(myImage, size[0], totalSize * repeat);                                                \
-    collector.Stop("ComputeOffsetFast " #dim "D");                                                                     \
-  }                                                                                                                    \
+#define TRY_FAST_OFFSET(dim)                                            \
+  {                                                                     \
+    using PixelType = char;                                             \
+    using ImageType = itk::Image<PixelType, dim>;                       \
+    ImageType::Pointer    myImage = ImageType::New();                   \
+    ImageType::SizeType   size;                                         \
+    ImageType::IndexType  index;                                        \
+    ImageType::RegionType region;                                       \
+    size.Fill(50);                                                      \
+    index.Fill(0);                                                      \
+    region.SetSize(size);                                               \
+    region.SetIndex(index);                                             \
+    myImage->SetLargestPossibleRegion(region);                          \
+    myImage->SetBufferedRegion(region);                                 \
+    myImage->SetRequestedRegion(region);                                \
+    myImage->Allocate();                                                \
+    collector.Start("ComputeOffsetFast " #dim "D");                     \
+    unsigned int repeat = 1;                                            \
+    if (dim < 4)                                                        \
+      repeat = 100;                                                     \
+    unsigned int totalSize = 1;                                         \
+    for (unsigned int i = 0; i < dim; ++i)                              \
+      totalSize *= size[i];                                             \
+    ComputeFastOffset<ImageType>(myImage, size[0], totalSize * repeat); \
+    collector.Stop("ComputeOffsetFast " #dim "D");                      \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
-#define TRY_OFFSET(dim)                                                                                                \
-  {                                                                                                                    \
-    using PixelType = char;                                                                                            \
-    using ImageType = itk::Image<PixelType, dim>;                                                                      \
-    ImageType::Pointer    myImage = ImageType::New();                                                                  \
-    ImageType::SizeType   size;                                                                                        \
-    ImageType::IndexType  index;                                                                                       \
-    ImageType::RegionType region;                                                                                      \
-    size.Fill(50);                                                                                                     \
-    index.Fill(0);                                                                                                     \
-    region.SetSize(size);                                                                                              \
-    region.SetIndex(index);                                                                                            \
-    myImage->SetLargestPossibleRegion(region);                                                                         \
-    myImage->SetBufferedRegion(region);                                                                                \
-    myImage->SetRequestedRegion(region);                                                                               \
-    myImage->Allocate();                                                                                               \
-    collector.Start("ComputeOffset " #dim "D");                                                                        \
-    unsigned int repeat = 1;                                                                                           \
-    if (dim < 4)                                                                                                       \
-      repeat = 100;                                                                                                    \
-    unsigned int totalSize = 1;                                                                                        \
-    for (unsigned int i = 0; i < dim; ++i)                                                                             \
-      totalSize *= size[i];                                                                                            \
-    ComputeOffset<ImageType>(myImage, size[0], totalSize * repeat);                                                    \
-    collector.Stop("ComputeOffset " #dim "D");                                                                         \
-  }                                                                                                                    \
+#define TRY_OFFSET(dim)                                             \
+  {                                                                 \
+    using PixelType = char;                                         \
+    using ImageType = itk::Image<PixelType, dim>;                   \
+    ImageType::Pointer    myImage = ImageType::New();               \
+    ImageType::SizeType   size;                                     \
+    ImageType::IndexType  index;                                    \
+    ImageType::RegionType region;                                   \
+    size.Fill(50);                                                  \
+    index.Fill(0);                                                  \
+    region.SetSize(size);                                           \
+    region.SetIndex(index);                                         \
+    myImage->SetLargestPossibleRegion(region);                      \
+    myImage->SetBufferedRegion(region);                             \
+    myImage->SetRequestedRegion(region);                            \
+    myImage->Allocate();                                            \
+    collector.Start("ComputeOffset " #dim "D");                     \
+    unsigned int repeat = 1;                                        \
+    if (dim < 4)                                                    \
+      repeat = 100;                                                 \
+    unsigned int totalSize = 1;                                     \
+    for (unsigned int i = 0; i < dim; ++i)                          \
+      totalSize *= size[i];                                         \
+    ComputeOffset<ImageType>(myImage, size[0], totalSize * repeat); \
+    collector.Stop("ComputeOffset " #dim "D");                      \
+  }                                                                 \
   ITK_MACROEND_NOOP_STATEMENT
 
   TRY_INDEX(1);

--- a/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
@@ -26,20 +26,20 @@ itkMathRoundTestHelperFunction(double x)
   return static_cast<int>(x >= 0. ? x : (itk::Math::ExactlyEquals(x, static_cast<int>(x)) ? x : x - 1.));
 }
 
-#define itkRoundMacro(x, y)                                                                                            \
-  if (x >= 0.5)                                                                                                        \
-  {                                                                                                                    \
-    y = static_cast<int>(x + 0.5);                                                                                     \
-  }                                                                                                                    \
-  else                                                                                                                 \
-  {                                                                                                                    \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal if ((x + 0.5) == static_cast<int>(x + 0.5)) CLANG_PRAGMA_POP                           \
-    {                                                                                                                  \
-      y = static_cast<int>(x + 0.5);                                                                                   \
-    }                                                                                                                  \
-    else { y = static_cast<int>(x - 0.5); }                                                                            \
-  }                                                                                                                    \
+#define itkRoundMacro(x, y)                                                                  \
+  if (x >= 0.5)                                                                              \
+  {                                                                                          \
+    y = static_cast<int>(x + 0.5);                                                           \
+  }                                                                                          \
+  else                                                                                       \
+  {                                                                                          \
+    CLANG_PRAGMA_PUSH                                                                        \
+    CLANG_SUPPRESS_Wfloat_equal if ((x + 0.5) == static_cast<int>(x + 0.5)) CLANG_PRAGMA_POP \
+    {                                                                                        \
+      y = static_cast<int>(x + 0.5);                                                         \
+    }                                                                                        \
+    else { y = static_cast<int>(x - 0.5); }                                                  \
+  }                                                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
 int

--- a/Modules/Core/Common/test/itkMathRoundTest2.cxx
+++ b/Modules/Core/Common/test/itkMathRoundTest2.cxx
@@ -19,13 +19,13 @@
 #include "itkMath.h"
 #include <iostream>
 
-#define RoundTestHelperMacro(rndname, input, output)                                                                   \
-  if (rndname((input)) != (output))                                                                                    \
-  {                                                                                                                    \
-    std::cout << "Failure! " << #rndname << "(" << (int)(input) << ") expected " << (int)(output) << " but got "       \
-              << (int)rndname((input)) << std::endl;                                                                   \
-    ok = false;                                                                                                        \
-  }                                                                                                                    \
+#define RoundTestHelperMacro(rndname, input, output)                                                             \
+  if (rndname((input)) != (output))                                                                              \
+  {                                                                                                              \
+    std::cout << "Failure! " << #rndname << "(" << (int)(input) << ") expected " << (int)(output) << " but got " \
+              << (int)rndname((input)) << std::endl;                                                             \
+    ok = false;                                                                                                  \
+  }                                                                                                              \
   ITK_MACROEND_NOOP_STATEMENT
 
 namespace

--- a/Modules/Core/Common/test/itkMultiThreaderBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderBaseTest.cxx
@@ -88,16 +88,16 @@ SetAndVerify(int number)
   return result;
 }
 
-#define TEST_SINGLE_CLASS(ClassName)                                                                                   \
-  {                                                                                                                    \
-    itk::ClassName::Pointer threader = itk::ClassName::New();                                                          \
-    if (threader.IsNull())                                                                                             \
-    {                                                                                                                  \
-      result = false;                                                                                                  \
-    }                                                                                                                  \
-                                                                                                                       \
-    ITK_EXERCISE_BASIC_OBJECT_METHODS(threader, ClassName, MultiThreaderBase);                                         \
-  }                                                                                                                    \
+#define TEST_SINGLE_CLASS(ClassName)                                           \
+  {                                                                            \
+    itk::ClassName::Pointer threader = itk::ClassName::New();                  \
+    if (threader.IsNull())                                                     \
+    {                                                                          \
+      result = false;                                                          \
+    }                                                                          \
+                                                                               \
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(threader, ClassName, MultiThreaderBase); \
+  }                                                                            \
   ITK_MACROEND_NOOP_STATEMENT
 
 int

--- a/Modules/Core/Common/test/itkObjectFactoryTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest.cxx
@@ -20,14 +20,14 @@
 #include "itkImage.h"
 #include <list>
 
-#define CHECK_FOR_VALUE(a, b)                                                                                          \
-  {                                                                                                                    \
-    if (a != b)                                                                                                        \
-    {                                                                                                                  \
-      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define CHECK_FOR_VALUE(a, b)                                                            \
+  {                                                                                      \
+    if (a != b)                                                                          \
+    {                                                                                    \
+      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl; \
+      return EXIT_FAILURE;                                                               \
+    }                                                                                    \
+  }                                                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
 template <typename TPixel, unsigned int VImageDimension = 2>

--- a/Modules/Core/Common/test/itkRealTimeIntervalTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeIntervalTest.cxx
@@ -21,28 +21,28 @@
 #include "itkMacro.h"
 #include "itkNumericTraits.h"
 
-#define CHECK_FOR_VALUE(a, b)                                                                                          \
-  {                                                                                                                    \
-    double eps = 4.0 * itk::NumericTraits<double>::epsilon();                                                          \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal eps = (b == 0.0) ? eps : std::fabs(b * eps);                                           \
-    CLANG_PRAGMA_POP                                                                                                   \
-    if (std::fabs(a - b) > eps)                                                                                        \
-    {                                                                                                                  \
-      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define CHECK_FOR_VALUE(a, b)                                                            \
+  {                                                                                      \
+    double eps = 4.0 * itk::NumericTraits<double>::epsilon();                            \
+    CLANG_PRAGMA_PUSH                                                                    \
+    CLANG_SUPPRESS_Wfloat_equal eps = (b == 0.0) ? eps : std::fabs(b * eps);             \
+    CLANG_PRAGMA_POP                                                                     \
+    if (std::fabs(a - b) > eps)                                                          \
+    {                                                                                    \
+      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl; \
+      return EXIT_FAILURE;                                                               \
+    }                                                                                    \
+  }                                                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define CHECK_FOR_BOOLEAN(x, expected)                                                                                 \
-  {                                                                                                                    \
-    if ((x) != expected)                                                                                               \
-    {                                                                                                                  \
-      std::cerr << "Error in " #x << std::endl;                                                                        \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define CHECK_FOR_BOOLEAN(x, expected)          \
+  {                                             \
+    if ((x) != expected)                        \
+    {                                           \
+      std::cerr << "Error in " #x << std::endl; \
+      return EXIT_FAILURE;                      \
+    }                                           \
+  }                                             \
   ITK_MACROEND_NOOP_STATEMENT
 
 

--- a/Modules/Core/Common/test/itkRealTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeStampTest.cxx
@@ -20,28 +20,28 @@
 #include "itkRealTimeStamp.h"
 #include "itkNumericTraits.h"
 
-#define CHECK_FOR_VALUE(a, b)                                                                                          \
-  {                                                                                                                    \
-    double eps = 4.0 * itk::NumericTraits<double>::epsilon();                                                          \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal eps = (b == 0.0) ? eps : std::fabs(b * eps);                                           \
-    CLANG_PRAGMA_POP                                                                                                   \
-    if (std::fabs(a - b) > eps)                                                                                        \
-    {                                                                                                                  \
-      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define CHECK_FOR_VALUE(a, b)                                                            \
+  {                                                                                      \
+    double eps = 4.0 * itk::NumericTraits<double>::epsilon();                            \
+    CLANG_PRAGMA_PUSH                                                                    \
+    CLANG_SUPPRESS_Wfloat_equal eps = (b == 0.0) ? eps : std::fabs(b * eps);             \
+    CLANG_PRAGMA_POP                                                                     \
+    if (std::fabs(a - b) > eps)                                                          \
+    {                                                                                    \
+      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl; \
+      return EXIT_FAILURE;                                                               \
+    }                                                                                    \
+  }                                                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define CHECK_FOR_BOOLEAN(x, expected)                                                                                 \
-  {                                                                                                                    \
-    if ((x) != expected)                                                                                               \
-    {                                                                                                                  \
-      std::cerr << "Error in " #x << std::endl;                                                                        \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define CHECK_FOR_BOOLEAN(x, expected)          \
+  {                                             \
+    if ((x) != expected)                        \
+    {                                           \
+      std::cerr << "Error in " #x << std::endl; \
+      return EXIT_FAILURE;                      \
+    }                                           \
+  }                                             \
   ITK_MACROEND_NOOP_STATEMENT
 
 int

--- a/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
@@ -30,15 +30,15 @@ itkVNLRoundTestHelperFunction(double x)
   return static_cast<int>(x - 0.5f);
 }
 
-#define itkRoundMacro(x, y)                                                                                            \
-  if (x >= 0.0)                                                                                                        \
-  {                                                                                                                    \
-    y = static_cast<int>(x + 0.5f);                                                                                    \
-  }                                                                                                                    \
-  else                                                                                                                 \
-  {                                                                                                                    \
-    y = static_cast<int>(x - 0.5f);                                                                                    \
-  }                                                                                                                    \
+#define itkRoundMacro(x, y)         \
+  if (x >= 0.0)                     \
+  {                                 \
+    y = static_cast<int>(x + 0.5f); \
+  }                                 \
+  else                              \
+  {                                 \
+    y = static_cast<int>(x - 0.5f); \
+  }                                 \
   ITK_MACROEND_NOOP_STATEMENT
 
 

--- a/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
@@ -20,14 +20,14 @@
 #include "itkVariableLengthVector.h"
 #include "itkMath.h"
 
-#define ASSERT(cond, text)                                                                                             \
-  CLANG_PRAGMA_PUSH                                                                                                    \
-  CLANG_SUPPRESS_Wfloat_equal if (!(cond)) CLANG_PRAGMA_POP                                                            \
-  {                                                                                                                    \
-    std::cerr << __FILE__ << ":" << __LINE__ << ":"                                                                    \
-              << "Assertion failed: " << #cond << ": " << text << std::endl;                                           \
-    result = EXIT_FAILURE;                                                                                             \
-  }                                                                                                                    \
+#define ASSERT(cond, text)                                                   \
+  CLANG_PRAGMA_PUSH                                                          \
+  CLANG_SUPPRESS_Wfloat_equal if (!(cond)) CLANG_PRAGMA_POP                  \
+  {                                                                          \
+    std::cerr << __FILE__ << ":" << __LINE__ << ":"                          \
+              << "Assertion failed: " << #cond << ": " << text << std::endl; \
+    result = EXIT_FAILURE;                                                   \
+  }                                                                          \
   ITK_MACROEND_NOOP_STATEMENT
 
 int

--- a/Modules/Core/GPUCommon/include/itkGPUImage.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImage.h
@@ -250,11 +250,11 @@ public:
   }
 
 private:
-#define OverrideImageTypeMacro(pt, dm)                                                                                 \
-  this->RegisterOverride(typeid(itk::Image<pt, dm>).name(),                                                            \
-                         typeid(itk::GPUImage<pt, dm>).name(),                                                         \
-                         "GPU Image Override",                                                                         \
-                         true,                                                                                         \
+#define OverrideImageTypeMacro(pt, dm)                         \
+  this->RegisterOverride(typeid(itk::Image<pt, dm>).name(),    \
+                         typeid(itk::GPUImage<pt, dm>).name(), \
+                         "GPU Image Override",                 \
+                         true,                                 \
                          itk::CreateObjectFunction<GPUImage<pt, dm>>::New())
 
   GPUImageFactory()

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
@@ -27,21 +27,21 @@
 // FIXME: Maybe variations of these macros should be moved into
 // itkMacro.h
 //
-#define itkQEDebugMacro(x)                                                                                             \
-  {                                                                                                                    \
-    std::ostringstream itkmsg;                                                                                         \
-    itkmsg << "Debug: In " __FILE__ ", line " << __LINE__ << "\n"                                                      \
-           << " (" << this << "): " x << "\n\n";                                                                       \
-    OutputWindowDisplayDebugText(itkmsg.str().c_str());                                                                \
-  }                                                                                                                    \
+#define itkQEDebugMacro(x)                                        \
+  {                                                               \
+    std::ostringstream itkmsg;                                    \
+    itkmsg << "Debug: In " __FILE__ ", line " << __LINE__ << "\n" \
+           << " (" << this << "): " x << "\n\n";                  \
+    OutputWindowDisplayDebugText(itkmsg.str().c_str());           \
+  }                                                               \
   ITK_MACROEND_NOOP_STATEMENT
-#define itkQEWarningMacro(x)                                                                                           \
-  {                                                                                                                    \
-    std::ostringstream itkmsg;                                                                                         \
-    itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n"                                                    \
-           << " (" << this << "): " x << "\n\n";                                                                       \
-    OutputWindowDisplayWarningText(itkmsg.str().c_str());                                                              \
-  }                                                                                                                    \
+#define itkQEWarningMacro(x)                                        \
+  {                                                                 \
+    std::ostringstream itkmsg;                                      \
+    itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n" \
+           << " (" << this << "): " x << "\n\n";                    \
+    OutputWindowDisplayWarningText(itkmsg.str().c_str());           \
+  }                                                                 \
   ITK_MACROEND_NOOP_STATEMENT
 
 // -------------------------------------------------------------------------
@@ -54,64 +54,64 @@
  * @param dt Dual edge type.
  * \todo Should this macro be added to doxygen macros?
  */
-#define itkQEAccessorsMacro(st, pt, dt)                                                                                \
-  pt * GetOnext() { return (dynamic_cast<pt *>(this->st::GetOnext())); }                                               \
-                                                                                                                       \
-  dt * GetRot() { return (dynamic_cast<dt *>(this->st::GetRot())); }                                                   \
-                                                                                                                       \
-  pt * GetSym() { return (dynamic_cast<pt *>(this->st::GetSym())); }                                                   \
-                                                                                                                       \
-  pt * GetLnext() { return (dynamic_cast<pt *>(this->st::GetLnext())); }                                               \
-                                                                                                                       \
-  pt * GetRnext() { return (dynamic_cast<pt *>(this->st::GetRnext())); }                                               \
-                                                                                                                       \
-  pt * GetDnext() { return (dynamic_cast<pt *>(this->st::GetDnext())); }                                               \
-                                                                                                                       \
-  pt * GetOprev() { return (dynamic_cast<pt *>(this->st::GetOprev())); }                                               \
-                                                                                                                       \
-  pt * GetLprev() { return (dynamic_cast<pt *>(this->st::GetLprev())); }                                               \
-                                                                                                                       \
-  pt * GetRprev() { return (dynamic_cast<pt *>(this->st::GetRprev())); }                                               \
-                                                                                                                       \
-  pt * GetDprev() { return (dynamic_cast<pt *>(this->st::GetDprev())); }                                               \
-                                                                                                                       \
-  dt * GetInvRot() { return (dynamic_cast<dt *>(this->st::GetInvRot())); }                                             \
-                                                                                                                       \
-  pt * GetInvOnext() { return (dynamic_cast<pt *>(this->st::GetInvOnext())); }                                         \
-                                                                                                                       \
-  pt * GetInvLnext() { return (dynamic_cast<pt *>(this->st::GetInvLnext())); }                                         \
-                                                                                                                       \
-  pt * GetInvRnext() { return (dynamic_cast<pt *>(this->st::GetInvRnext())); }                                         \
-                                                                                                                       \
-  pt *       GetInvDnext() { return (dynamic_cast<pt *>(this->st::GetInvDnext())); }                                   \
-  const pt * GetOnext() const { return (dynamic_cast<const pt *>(this->st::GetOnext())); }                             \
-                                                                                                                       \
-  const dt * GetRot() const { return (dynamic_cast<const dt *>(this->st::GetRot())); }                                 \
-                                                                                                                       \
-  const pt * GetSym() const { return (dynamic_cast<const pt *>(this->st::GetSym())); }                                 \
-                                                                                                                       \
-  const pt * GetLnext() const { return (dynamic_cast<const pt *>(this->st::GetLnext())); }                             \
-                                                                                                                       \
-  const pt * GetRnext() const { return (dynamic_cast<const pt *>(this->st::GetRnext())); }                             \
-                                                                                                                       \
-  const pt * GetDnext() const { return (dynamic_cast<const pt *>(this->st::GetDnext())); }                             \
-                                                                                                                       \
-  const pt * GetOprev() const { return (dynamic_cast<const pt *>(this->st::GetOprev())); }                             \
-                                                                                                                       \
-  const pt * GetLprev() const { return (dynamic_cast<const pt *>(this->st::GetLprev())); }                             \
-                                                                                                                       \
-  const pt * GetRprev() const { return (dynamic_cast<const pt *>(this->st::GetRprev())); }                             \
-                                                                                                                       \
-  const pt * GetDprev() const { return (dynamic_cast<const pt *>(this->st::GetDprev())); }                             \
-                                                                                                                       \
-  const dt * GetInvRot() const { return (dynamic_cast<const dt *>(this->st::GetInvRot())); }                           \
-                                                                                                                       \
-  const pt * GetInvOnext() const { return (dynamic_cast<const pt *>(this->st::GetInvOnext())); }                       \
-                                                                                                                       \
-  const pt * GetInvLnext() const { return (dynamic_cast<const pt *>(this->st::GetInvLnext())); }                       \
-                                                                                                                       \
-  const pt * GetInvRnext() const { return (dynamic_cast<const pt *>(this->st::GetInvRnext())); }                       \
-                                                                                                                       \
+#define itkQEAccessorsMacro(st, pt, dt)                                                          \
+  pt * GetOnext() { return (dynamic_cast<pt *>(this->st::GetOnext())); }                         \
+                                                                                                 \
+  dt * GetRot() { return (dynamic_cast<dt *>(this->st::GetRot())); }                             \
+                                                                                                 \
+  pt * GetSym() { return (dynamic_cast<pt *>(this->st::GetSym())); }                             \
+                                                                                                 \
+  pt * GetLnext() { return (dynamic_cast<pt *>(this->st::GetLnext())); }                         \
+                                                                                                 \
+  pt * GetRnext() { return (dynamic_cast<pt *>(this->st::GetRnext())); }                         \
+                                                                                                 \
+  pt * GetDnext() { return (dynamic_cast<pt *>(this->st::GetDnext())); }                         \
+                                                                                                 \
+  pt * GetOprev() { return (dynamic_cast<pt *>(this->st::GetOprev())); }                         \
+                                                                                                 \
+  pt * GetLprev() { return (dynamic_cast<pt *>(this->st::GetLprev())); }                         \
+                                                                                                 \
+  pt * GetRprev() { return (dynamic_cast<pt *>(this->st::GetRprev())); }                         \
+                                                                                                 \
+  pt * GetDprev() { return (dynamic_cast<pt *>(this->st::GetDprev())); }                         \
+                                                                                                 \
+  dt * GetInvRot() { return (dynamic_cast<dt *>(this->st::GetInvRot())); }                       \
+                                                                                                 \
+  pt * GetInvOnext() { return (dynamic_cast<pt *>(this->st::GetInvOnext())); }                   \
+                                                                                                 \
+  pt * GetInvLnext() { return (dynamic_cast<pt *>(this->st::GetInvLnext())); }                   \
+                                                                                                 \
+  pt * GetInvRnext() { return (dynamic_cast<pt *>(this->st::GetInvRnext())); }                   \
+                                                                                                 \
+  pt *       GetInvDnext() { return (dynamic_cast<pt *>(this->st::GetInvDnext())); }             \
+  const pt * GetOnext() const { return (dynamic_cast<const pt *>(this->st::GetOnext())); }       \
+                                                                                                 \
+  const dt * GetRot() const { return (dynamic_cast<const dt *>(this->st::GetRot())); }           \
+                                                                                                 \
+  const pt * GetSym() const { return (dynamic_cast<const pt *>(this->st::GetSym())); }           \
+                                                                                                 \
+  const pt * GetLnext() const { return (dynamic_cast<const pt *>(this->st::GetLnext())); }       \
+                                                                                                 \
+  const pt * GetRnext() const { return (dynamic_cast<const pt *>(this->st::GetRnext())); }       \
+                                                                                                 \
+  const pt * GetDnext() const { return (dynamic_cast<const pt *>(this->st::GetDnext())); }       \
+                                                                                                 \
+  const pt * GetOprev() const { return (dynamic_cast<const pt *>(this->st::GetOprev())); }       \
+                                                                                                 \
+  const pt * GetLprev() const { return (dynamic_cast<const pt *>(this->st::GetLprev())); }       \
+                                                                                                 \
+  const pt * GetRprev() const { return (dynamic_cast<const pt *>(this->st::GetRprev())); }       \
+                                                                                                 \
+  const pt * GetDprev() const { return (dynamic_cast<const pt *>(this->st::GetDprev())); }       \
+                                                                                                 \
+  const dt * GetInvRot() const { return (dynamic_cast<const dt *>(this->st::GetInvRot())); }     \
+                                                                                                 \
+  const pt * GetInvOnext() const { return (dynamic_cast<const pt *>(this->st::GetInvOnext())); } \
+                                                                                                 \
+  const pt * GetInvLnext() const { return (dynamic_cast<const pt *>(this->st::GetInvLnext())); } \
+                                                                                                 \
+  const pt * GetInvRnext() const { return (dynamic_cast<const pt *>(this->st::GetInvRnext())); } \
+                                                                                                 \
   const pt * GetInvDnext() const { return (dynamic_cast<const pt *>(this->st::GetInvDnext())); }
 
 namespace itk

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -21,31 +21,31 @@
 #include "itkMacro.h"
 
 // -------------------------------------------------------------------------
-#define itkQEDefineIteratorMethodsMacro(Op)                                                                            \
-  virtual Iterator Begin##Op() { return Iterator(this, Self::Iterator::Operator##Op, true); }                          \
-                                                                                                                       \
-  virtual ConstIterator Begin##Op() const { return ConstIterator(this, Self::ConstIterator::Operator##Op, true); }     \
-                                                                                                                       \
-  virtual Iterator End##Op() { return Iterator(this, Self::Iterator::Operator##Op, false); }                           \
-                                                                                                                       \
-  virtual ConstIterator End##Op() const { return ConstIterator(this, Self::ConstIterator::Operator##Op, false); }      \
+#define itkQEDefineIteratorMethodsMacro(Op)                                                                        \
+  virtual Iterator Begin##Op() { return Iterator(this, Self::Iterator::Operator##Op, true); }                      \
+                                                                                                                   \
+  virtual ConstIterator Begin##Op() const { return ConstIterator(this, Self::ConstIterator::Operator##Op, true); } \
+                                                                                                                   \
+  virtual Iterator End##Op() { return Iterator(this, Self::Iterator::Operator##Op, false); }                       \
+                                                                                                                   \
+  virtual ConstIterator End##Op() const { return ConstIterator(this, Self::ConstIterator::Operator##Op, false); }  \
   ITK_MACROEND_NOOP_STATEMENT
 
 // -------------------------------------------------------------------------
-#define itkQEDefineIteratorGeomMethodsMacro(Op)                                                                        \
-  virtual IteratorGeom BeginGeom##Op() { return IteratorGeom(this, Self::IteratorGeom::Operator##Op, true); }          \
-                                                                                                                       \
-  virtual ConstIteratorGeom BeginGeom##Op() const                                                                      \
-  {                                                                                                                    \
-    return ConstIteratorGeom(this, Self::ConstIteratorGeom::Operator##Op, true);                                       \
-  }                                                                                                                    \
-                                                                                                                       \
-  virtual IteratorGeom EndGeom##Op() { return IteratorGeom(this, Self::IteratorGeom::Operator##Op, false); }           \
-                                                                                                                       \
-  virtual ConstIteratorGeom EndGeom##Op() const                                                                        \
-  {                                                                                                                    \
-    return ConstIteratorGeom(this, Self::ConstIteratorGeom::Operator##Op, false);                                      \
-  }                                                                                                                    \
+#define itkQEDefineIteratorGeomMethodsMacro(Op)                                                               \
+  virtual IteratorGeom BeginGeom##Op() { return IteratorGeom(this, Self::IteratorGeom::Operator##Op, true); } \
+                                                                                                              \
+  virtual ConstIteratorGeom BeginGeom##Op() const                                                             \
+  {                                                                                                           \
+    return ConstIteratorGeom(this, Self::ConstIteratorGeom::Operator##Op, true);                              \
+  }                                                                                                           \
+                                                                                                              \
+  virtual IteratorGeom EndGeom##Op() { return IteratorGeom(this, Self::IteratorGeom::Operator##Op, false); }  \
+                                                                                                              \
+  virtual ConstIteratorGeom EndGeom##Op() const                                                               \
+  {                                                                                                           \
+    return ConstIteratorGeom(this, Self::ConstIteratorGeom::Operator##Op, false);                             \
+  }                                                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -21,40 +21,40 @@
 #include "itkMapContainer.h"
 
 // -------------------------------------------------------------------------
-#define itkQEDefineFrontIteratorMethodsMacro(MeshTypeArg)                                                              \
-  /* Dual definition placed before others because of .NET that cannot */                                               \
-  /* cope with definition of FrontIterator (that further hides the    */                                               \
-  /* definition of the template).                                     */                                               \
-  using QEDualType = typename MeshTypeArg::QEDual;                                                                     \
-  using QEPrimalType = typename MeshTypeArg::QEPrimal;                                                                 \
-  using FrontDualIterator = QuadEdgeMeshFrontIterator<MeshTypeArg, QEDualType>;                                        \
-  using ConstFrontDualIterator = QuadEdgeMeshConstFrontIterator<MeshTypeArg, QEDualType>;                              \
-  using FrontIterator = QuadEdgeMeshFrontIterator<MeshTypeArg, QEPrimalType>;                                          \
-  using ConstFrontIterator = QuadEdgeMeshConstFrontIterator<MeshTypeArg, QEPrimalType>;                                \
-                                                                                                                       \
-  virtual FrontIterator BeginFront(QEPrimalType * seed = (QEPrimalType *)0)                                            \
-  {                                                                                                                    \
-    return (FrontIterator(this, true, seed));                                                                          \
-  }                                                                                                                    \
-                                                                                                                       \
-  virtual ConstFrontIterator BeginFront(QEPrimalType * seed) const { return (ConstFrontIterator(this, true, seed)); }  \
-                                                                                                                       \
-  virtual FrontIterator EndFront() { return (FrontIterator(this, false)); }                                            \
-                                                                                                                       \
-  virtual ConstFrontIterator EndFront() const { return (ConstFrontIterator(this, false)); }                            \
-                                                                                                                       \
-  virtual FrontDualIterator BeginDualFront(QEDualType * seed = (QEDualType *)0)                                        \
-  {                                                                                                                    \
-    return (FrontDualIterator(this, true, seed));                                                                      \
-  }                                                                                                                    \
-                                                                                                                       \
-  virtual ConstFrontDualIterator BeginDualFront(QEDualType * seed) const                                               \
-  {                                                                                                                    \
-    return (ConstFrontDualIterator(this, true, seed));                                                                 \
-  }                                                                                                                    \
-                                                                                                                       \
-  virtual FrontDualIterator EndDualFront() { return (FrontDualIterator(this, false)); }                                \
-                                                                                                                       \
+#define itkQEDefineFrontIteratorMethodsMacro(MeshTypeArg)                                                             \
+  /* Dual definition placed before others because of .NET that cannot */                                              \
+  /* cope with definition of FrontIterator (that further hides the    */                                              \
+  /* definition of the template).                                     */                                              \
+  using QEDualType = typename MeshTypeArg::QEDual;                                                                    \
+  using QEPrimalType = typename MeshTypeArg::QEPrimal;                                                                \
+  using FrontDualIterator = QuadEdgeMeshFrontIterator<MeshTypeArg, QEDualType>;                                       \
+  using ConstFrontDualIterator = QuadEdgeMeshConstFrontIterator<MeshTypeArg, QEDualType>;                             \
+  using FrontIterator = QuadEdgeMeshFrontIterator<MeshTypeArg, QEPrimalType>;                                         \
+  using ConstFrontIterator = QuadEdgeMeshConstFrontIterator<MeshTypeArg, QEPrimalType>;                               \
+                                                                                                                      \
+  virtual FrontIterator BeginFront(QEPrimalType * seed = (QEPrimalType *)0)                                           \
+  {                                                                                                                   \
+    return (FrontIterator(this, true, seed));                                                                         \
+  }                                                                                                                   \
+                                                                                                                      \
+  virtual ConstFrontIterator BeginFront(QEPrimalType * seed) const { return (ConstFrontIterator(this, true, seed)); } \
+                                                                                                                      \
+  virtual FrontIterator EndFront() { return (FrontIterator(this, false)); }                                           \
+                                                                                                                      \
+  virtual ConstFrontIterator EndFront() const { return (ConstFrontIterator(this, false)); }                           \
+                                                                                                                      \
+  virtual FrontDualIterator BeginDualFront(QEDualType * seed = (QEDualType *)0)                                       \
+  {                                                                                                                   \
+    return (FrontDualIterator(this, true, seed));                                                                     \
+  }                                                                                                                   \
+                                                                                                                      \
+  virtual ConstFrontDualIterator BeginDualFront(QEDualType * seed) const                                              \
+  {                                                                                                                   \
+    return (ConstFrontDualIterator(this, true, seed));                                                                \
+  }                                                                                                                   \
+                                                                                                                      \
+  virtual FrontDualIterator EndDualFront() { return (FrontDualIterator(this, false)); }                               \
+                                                                                                                      \
   virtual ConstFrontDualIterator EndDualFront() const { return (ConstFrontDualIterator(this, false)); }
 
 namespace itk

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshMacro.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshMacro.h
@@ -44,25 +44,25 @@ namespace itk
  *          itk::itkQEMeshForAllPointsMacro macro.
  *
  */
-#define itkQEMeshForAllPointsMacro(MeshType, MeshInstance, PointVariable, PointIndex)                                  \
-  {                                                                                                                    \
-    using PointType = typename MeshType::PointType;                                                                    \
-    using PointIdentifier = typename MeshType::PointIdentifier;                                                        \
-    using PointsContainer = typename MeshType::PointsContainer;                                                        \
-    using PointsContainerIterator = typename MeshType::PointsContainerIterator;                                        \
-                                                                                                                       \
-    PointsContainer * points = (MeshInstance)->GetPoints();                                                            \
-    /* If no points container are present, do nothing */                                                               \
-    if (!points)                                                                                                       \
-    {                                                                                                                  \
-      itkWarningMacro("No point container in itkQEMeshForAllPointsMacro");                                             \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      PointsContainerIterator pointIterator = points->Begin();                                                         \
-      while (pointIterator != points->End())                                                                           \
-      {                                                                                                                \
-        PointType       PointVariable = pointIterator.Value();                                                         \
+#define itkQEMeshForAllPointsMacro(MeshType, MeshInstance, PointVariable, PointIndex) \
+  {                                                                                   \
+    using PointType = typename MeshType::PointType;                                   \
+    using PointIdentifier = typename MeshType::PointIdentifier;                       \
+    using PointsContainer = typename MeshType::PointsContainer;                       \
+    using PointsContainerIterator = typename MeshType::PointsContainerIterator;       \
+                                                                                      \
+    PointsContainer * points = (MeshInstance)->GetPoints();                           \
+    /* If no points container are present, do nothing */                              \
+    if (!points)                                                                      \
+    {                                                                                 \
+      itkWarningMacro("No point container in itkQEMeshForAllPointsMacro");            \
+    }                                                                                 \
+    else                                                                              \
+    {                                                                                 \
+      PointsContainerIterator pointIterator = points->Begin();                        \
+      while (pointIterator != points->End())                                          \
+      {                                                                               \
+        PointType       PointVariable = pointIterator.Value();                        \
         PointIdentifier PointIndex = pointIterator.Index();
 
 /** \def itkQEMeshForAllPointsEndMacro
@@ -71,10 +71,10 @@ namespace itk
  * \warning Should only be used with the corresponding
  *          itk::itkQEMeshForAllPointsMacro
  */
-#define itkQEMeshForAllPointsEndMacro                                                                                  \
-  pointIterator++;                                                                                                     \
-  } /* while */                                                                                                        \
-  } /* if */                                                                                                           \
+#define itkQEMeshForAllPointsEndMacro \
+  pointIterator++;                    \
+  } /* while */                       \
+  } /* if */                          \
   }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -97,20 +97,20 @@ namespace itk
  *          itk::itkQEMeshForAllCellsEndMacro macro.
  * \sa itk::itkQEMeshForAllPrimalEdgesMacro
  */
-#define itkQEMeshForAllCellsMacro(MeshType, MeshInstance, cellIterator)                                                \
-  {                                                                                                                    \
-    using CellsContainer = typename MeshType::CellsContainer;                                                          \
-    using CellsContainerIterator = typename MeshType::CellsContainerIterator;                                          \
-    /* If no cells are present, do nothing */                                                                          \
-    if (!MeshInstance->GetCells())                                                                                     \
-    {                                                                                                                  \
-      itkWarningMacro("No Cells container in itkQEMeshForAllCellsMacro");                                              \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      CellsContainerIterator cellIterator = MeshInstance->GetCells()->Begin();                                         \
-      while (cellIterator != MeshInstance->GetCells()->End())                                                          \
-      {                                                                                                                \
+#define itkQEMeshForAllCellsMacro(MeshType, MeshInstance, cellIterator)        \
+  {                                                                            \
+    using CellsContainer = typename MeshType::CellsContainer;                  \
+    using CellsContainerIterator = typename MeshType::CellsContainerIterator;  \
+    /* If no cells are present, do nothing */                                  \
+    if (!MeshInstance->GetCells())                                             \
+    {                                                                          \
+      itkWarningMacro("No Cells container in itkQEMeshForAllCellsMacro");      \
+    }                                                                          \
+    else                                                                       \
+    {                                                                          \
+      CellsContainerIterator cellIterator = MeshInstance->GetCells()->Begin(); \
+      while (cellIterator != MeshInstance->GetCells()->End())                  \
+      {                                                                        \
     /* Users code comes here: */
 
 /** \def itkQEMeshForAllCellsEndMacro
@@ -119,10 +119,10 @@ namespace itk
  * \warning Should only be used with the corresponding
  *          itk::itkQEMeshForAllCellsMacro
  */
-#define itkQEMeshForAllCellsEndMacro(cellIterator)                                                                     \
-  cellIterator++;                                                                                                      \
-  } /* while */                                                                                                        \
-  } /* if */                                                                                                           \
+#define itkQEMeshForAllCellsEndMacro(cellIterator) \
+  cellIterator++;                                  \
+  } /* while */                                    \
+  } /* if */                                       \
   }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -142,14 +142,14 @@ namespace itk
  * \warning Don't forget to close the opened block with the corresponding
  *          itk::itkQEMeshForAllPrimalEdgesMacro macro.
  */
-#define itkQEMeshForAllPrimalEdgesMacro(MeshType, MeshInstance, EdgeVariable)                                          \
-  {                                                                                                                    \
-    using QEPrimal = typename MeshType::QEPrimal;                                                                      \
-                                                                                                                       \
-    itkQEMeshForAllCellsMacro(MeshType, MeshInstance, cellIterator)                                                    \
-    {                                                                                                                  \
-      if (QEPrimal * EdgeVariable = dynamic_cast<QEPrimal *>(cellIterator.Value()))                                    \
-      {                                                                                                                \
+#define itkQEMeshForAllPrimalEdgesMacro(MeshType, MeshInstance, EdgeVariable)       \
+  {                                                                                 \
+    using QEPrimal = typename MeshType::QEPrimal;                                   \
+                                                                                    \
+    itkQEMeshForAllCellsMacro(MeshType, MeshInstance, cellIterator)                 \
+    {                                                                               \
+      if (QEPrimal * EdgeVariable = dynamic_cast<QEPrimal *>(cellIterator.Value())) \
+      {                                                                             \
       /* Users code comes here: */
 
 /** \def itkQEMeshForAllPrimalEdgesEndMacro
@@ -158,10 +158,10 @@ namespace itk
  * \warning Should only be used with the corresponding
  *          itk::itkQEMeshForAllPrimalEdgesMacro
  */
-#define itkQEMeshForAllPrimalEdgesEndMacro                                                                             \
-  } /* fi */                                                                                                           \
-  }                                                                                                                    \
-  itkQEMeshForAllCellsEndMacro                                                                                         \
+#define itkQEMeshForAllPrimalEdgesEndMacro \
+  } /* fi */                               \
+  }                                        \
+  itkQEMeshForAllCellsEndMacro             \
   }
 } // namespace itk
 

--- a/Modules/Core/TestKernel/include/itkGTestPredicate.h
+++ b/Modules/Core/TestKernel/include/itkGTestPredicate.h
@@ -30,7 +30,7 @@
  * verifies that the root mean squares error between the two array-like
  * objects doesn't exceed the given error.
  */
-#define ITK_EXPECT_VECTOR_NEAR(val1, val2, rmsError)                                                                   \
+#define ITK_EXPECT_VECTOR_NEAR(val1, val2, rmsError) \
   EXPECT_PRED_FORMAT3(itk::GTest::Predicate::VectorDoubleRMSPredFormat, val1, val2, rmsError)
 
 

--- a/Modules/Core/TestKernel/include/itkTestingMacros.h
+++ b/Modules/Core/TestKernel/include/itkTestingMacros.h
@@ -41,7 +41,7 @@ namespace itk
 #  define TRY_EXPECT_NO_EXCEPTION "Replace TRY_EXPECT_NO_EXCEPTION with ITK_TRY_EXPECT_NO_EXCEPTION"
 #  define TEST_EXPECT_TRUE_STATUS_VALUE "Replace TEST_EXPECT_TRUE_STATUS_VALUE with ITK_TEST_EXPECT_TRUE_STATUS_VALUE"
 #  define TEST_EXPECT_TRUE "Replace TEST_EXPECT_TRUE with ITK_TEST_EXPECT_TRUE"
-#  define TEST_EXPECT_EQUAL_STATUS_VALUE                                                                               \
+#  define TEST_EXPECT_EQUAL_STATUS_VALUE \
     "Replace TEST_EXPECT_EQUAL_STATUS_VALUE with ITK_TEST_EXPECT_EQUAL_STATUS_VALUE"
 #  define TEST_EXPECT_EQUAL "Replace TEST_EXPECT_EQUAL with ITK_TEST_EXPECT_EQUAL"
 #  define TEST_SET_GET "Replace TEST_SET_GET with ITK_TEST_SET_GET"
@@ -104,171 +104,171 @@ namespace itk
 #endif // GCC
 /* clang-format on */
 
-#define ITK_TRY_EXPECT_EXCEPTION(command)                                                                              \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    std::cout << "Trying " << #command << std::endl;                                                                   \
-    command;                                                                                                           \
-    std::cerr << "Failed to catch expected exception" << std::endl;                                                    \
-    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;                                                  \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & excp)                                                                            \
-  {                                                                                                                    \
-    std::cout << "Caught expected exception" << std::endl;                                                             \
-    std::cout << excp << std::endl;                                                                                    \
-  }                                                                                                                    \
+#define ITK_TRY_EXPECT_EXCEPTION(command)                             \
+  try                                                                 \
+  {                                                                   \
+    std::cout << "Trying " << #command << std::endl;                  \
+    command;                                                          \
+    std::cerr << "Failed to catch expected exception" << std::endl;   \
+    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl; \
+    return EXIT_FAILURE;                                              \
+  }                                                                   \
+  catch (const itk::ExceptionObject & excp)                           \
+  {                                                                   \
+    std::cout << "Caught expected exception" << std::endl;            \
+    std::cout << excp << std::endl;                                   \
+  }                                                                   \
   ITK_MACROEND_NOOP_STATEMENT
 
 
-#define ITK_TRY_EXPECT_NO_EXCEPTION(command)                                                                           \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    std::cout << "Trying " << #command << std::endl;                                                                   \
-    command;                                                                                                           \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & excp)                                                                            \
-  {                                                                                                                    \
-    std::cerr << excp << std::endl;                                                                                    \
-    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;                                                  \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define ITK_TRY_EXPECT_NO_EXCEPTION(command)                          \
+  try                                                                 \
+  {                                                                   \
+    std::cout << "Trying " << #command << std::endl;                  \
+    command;                                                          \
+  }                                                                   \
+  catch (const itk::ExceptionObject & excp)                           \
+  {                                                                   \
+    std::cerr << excp << std::endl;                                   \
+    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl; \
+    return EXIT_FAILURE;                                              \
+  }                                                                   \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define ITK_TEST_EXPECT_TRUE_STATUS_VALUE(command, statusVal)                                                          \
-  {                                                                                                                    \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal bool _ITK_TEST_EXPECT_TRUE_command(command);                                           \
-    CLANG_PRAGMA_POP                                                                                                   \
-    if (!(_ITK_TEST_EXPECT_TRUE_command))                                                                              \
-    {                                                                                                                  \
-      std::cerr << "Error in " << #command << std::endl;                                                               \
-      std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;                                                \
-      std::cerr << "Expected true" << std::endl;                                                                       \
-      std::cerr << "  but got  " << _ITK_TEST_EXPECT_TRUE_command << std::endl;                                        \
-      statusVal = EXIT_FAILURE;                                                                                        \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define ITK_TEST_EXPECT_TRUE_STATUS_VALUE(command, statusVal)                   \
+  {                                                                             \
+    CLANG_PRAGMA_PUSH                                                           \
+    CLANG_SUPPRESS_Wfloat_equal bool _ITK_TEST_EXPECT_TRUE_command(command);    \
+    CLANG_PRAGMA_POP                                                            \
+    if (!(_ITK_TEST_EXPECT_TRUE_command))                                       \
+    {                                                                           \
+      std::cerr << "Error in " << #command << std::endl;                        \
+      std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;         \
+      std::cerr << "Expected true" << std::endl;                                \
+      std::cerr << "  but got  " << _ITK_TEST_EXPECT_TRUE_command << std::endl; \
+      statusVal = EXIT_FAILURE;                                                 \
+    }                                                                           \
+  }                                                                             \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define ITK_TEST_EXPECT_TRUE(command)                                                                                  \
-  {                                                                                                                    \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal bool _ITK_TEST_EXPECT_TRUE_command(command);                                           \
-    CLANG_PRAGMA_POP                                                                                                   \
-    if (!(_ITK_TEST_EXPECT_TRUE_command))                                                                              \
-    {                                                                                                                  \
-      std::cerr << "Error in " << #command << std::endl;                                                               \
-      std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;                                                \
-      std::cerr << "Expected true" << std::endl;                                                                       \
-      std::cerr << "  but got  " << _ITK_TEST_EXPECT_TRUE_command << std::endl;                                        \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
-  ITK_MACROEND_NOOP_STATEMENT
-
-
-#define ITK_TEST_EXPECT_EQUAL_STATUS_VALUE(lh, rh, statusVal)                                                          \
-  {                                                                                                                    \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal bool _ITK_TEST_EXPECT_EQUAL_result((lh) == (rh));                                      \
-    CLANG_PRAGMA_POP                                                                                                   \
-    if (!(_ITK_TEST_EXPECT_EQUAL_result))                                                                              \
-    {                                                                                                                  \
-      std::cerr << "Error in " << #lh << " == " << #rh << std::endl;                                                   \
-      std::cerr << "\tIn " __FILE__ ", line " << __LINE__ << std::endl;                                                \
-      std::cerr << "\tlh: " << (lh) << std::endl;                                                                      \
-      std::cerr << "\trh: " << (rh) << std::endl;                                                                      \
-      std::cerr << "Expression is not equal" << std::endl;                                                             \
-      statusVal = EXIT_FAILURE;                                                                                        \
-    }                                                                                                                  \
-  }                                                                                                                    \
-  ITK_MACROEND_NOOP_STATEMENT
-
-#define ITK_TEST_EXPECT_EQUAL(lh, rh)                                                                                  \
-  {                                                                                                                    \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal bool _ITK_TEST_EXPECT_EQUAL_result((lh) == (rh));                                      \
-    CLANG_PRAGMA_POP                                                                                                   \
-    if (!(_ITK_TEST_EXPECT_EQUAL_result))                                                                              \
-    {                                                                                                                  \
-      std::cerr << "Error in " << #lh << " == " << #rh << std::endl;                                                   \
-      std::cerr << "\tIn " __FILE__ ", line " << __LINE__ << std::endl;                                                \
-      std::cerr << "\tlh: " << (lh) << std::endl;                                                                      \
-      std::cerr << "\trh: " << (rh) << std::endl;                                                                      \
-      std::cerr << "Expression is not equal" << std::endl;                                                             \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define ITK_TEST_EXPECT_TRUE(command)                                           \
+  {                                                                             \
+    CLANG_PRAGMA_PUSH                                                           \
+    CLANG_SUPPRESS_Wfloat_equal bool _ITK_TEST_EXPECT_TRUE_command(command);    \
+    CLANG_PRAGMA_POP                                                            \
+    if (!(_ITK_TEST_EXPECT_TRUE_command))                                       \
+    {                                                                           \
+      std::cerr << "Error in " << #command << std::endl;                        \
+      std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;         \
+      std::cerr << "Expected true" << std::endl;                                \
+      std::cerr << "  but got  " << _ITK_TEST_EXPECT_TRUE_command << std::endl; \
+      return EXIT_FAILURE;                                                      \
+    }                                                                           \
+  }                                                                             \
   ITK_MACROEND_NOOP_STATEMENT
 
 
-#define ITK_TEST_SET_GET(variable, command)                                                                            \
-  if (variable != command)                                                                                             \
-  {                                                                                                                    \
-    std::cerr << "Error in " << #command << std::endl;                                                                 \
-    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;                                                  \
-    std::cerr << "Expected " << variable.GetPointer() << std::endl;                                                    \
-    std::cerr << "but got  " << command << std::endl;                                                                  \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define ITK_TEST_EXPECT_EQUAL_STATUS_VALUE(lh, rh, statusVal)                     \
+  {                                                                               \
+    CLANG_PRAGMA_PUSH                                                             \
+    CLANG_SUPPRESS_Wfloat_equal bool _ITK_TEST_EXPECT_EQUAL_result((lh) == (rh)); \
+    CLANG_PRAGMA_POP                                                              \
+    if (!(_ITK_TEST_EXPECT_EQUAL_result))                                         \
+    {                                                                             \
+      std::cerr << "Error in " << #lh << " == " << #rh << std::endl;              \
+      std::cerr << "\tIn " __FILE__ ", line " << __LINE__ << std::endl;           \
+      std::cerr << "\tlh: " << (lh) << std::endl;                                 \
+      std::cerr << "\trh: " << (rh) << std::endl;                                 \
+      std::cerr << "Expression is not equal" << std::endl;                        \
+      statusVal = EXIT_FAILURE;                                                   \
+    }                                                                             \
+  }                                                                               \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define ITK_TEST_EXPECT_EQUAL(lh, rh)                                             \
+  {                                                                               \
+    CLANG_PRAGMA_PUSH                                                             \
+    CLANG_SUPPRESS_Wfloat_equal bool _ITK_TEST_EXPECT_EQUAL_result((lh) == (rh)); \
+    CLANG_PRAGMA_POP                                                              \
+    if (!(_ITK_TEST_EXPECT_EQUAL_result))                                         \
+    {                                                                             \
+      std::cerr << "Error in " << #lh << " == " << #rh << std::endl;              \
+      std::cerr << "\tIn " __FILE__ ", line " << __LINE__ << std::endl;           \
+      std::cerr << "\tlh: " << (lh) << std::endl;                                 \
+      std::cerr << "\trh: " << (rh) << std::endl;                                 \
+      std::cerr << "Expression is not equal" << std::endl;                        \
+      return EXIT_FAILURE;                                                        \
+    }                                                                             \
+  }                                                                               \
   ITK_MACROEND_NOOP_STATEMENT
 
 
-#define ITK_TEST_SET_GET_VALUE(variable, command)                                                                      \
-  CLANG_PRAGMA_PUSH                                                                                                    \
-  CLANG_SUPPRESS_Wfloat_equal if (variable != command) CLANG_PRAGMA_POP                                                \
-  {                                                                                                                    \
-    std::cerr << "Error in " << #command << std::endl;                                                                 \
-    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;                                                  \
-    std::cerr << "Expected " << variable << std::endl;                                                                 \
-    std::cerr << "but got  " << command << std::endl;                                                                  \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define ITK_TEST_SET_GET(variable, command)                           \
+  if (variable != command)                                            \
+  {                                                                   \
+    std::cerr << "Error in " << #command << std::endl;                \
+    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl; \
+    std::cerr << "Expected " << variable.GetPointer() << std::endl;   \
+    std::cerr << "but got  " << command << std::endl;                 \
+    return EXIT_FAILURE;                                              \
+  }                                                                   \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define ITK_TEST_SET_GET_NULL_VALUE(command)                                                                           \
-  if (nullptr != command)                                                                                              \
-  {                                                                                                                    \
-    std::cerr << "Error in " << #command << std::endl;                                                                 \
-    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;                                                  \
-    std::cerr << "Expected "                                                                                           \
-              << "nullptr" << std::endl;                                                                               \
-    std::cerr << "but got  " << command << std::endl;                                                                  \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+
+#define ITK_TEST_SET_GET_VALUE(variable, command)                       \
+  CLANG_PRAGMA_PUSH                                                     \
+  CLANG_SUPPRESS_Wfloat_equal if (variable != command) CLANG_PRAGMA_POP \
+  {                                                                     \
+    std::cerr << "Error in " << #command << std::endl;                  \
+    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl;   \
+    std::cerr << "Expected " << variable << std::endl;                  \
+    std::cerr << "but got  " << command << std::endl;                   \
+    return EXIT_FAILURE;                                                \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define ITK_TEST_SET_GET_BOOLEAN(object, variable, value)                                                              \
-  object->Set##variable(false);                                                                                        \
-  object->Set##variable(true);                                                                                         \
-  if (object->Get##variable() != 1)                                                                                    \
-  {                                                                                                                    \
-    std::cerr << "Error in Set/Get" #variable << ", Get" #variable << " is " << object->Get##variable()                \
-              << " instead of 1" << std::endl;                                                                         \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
-  object->Set##variable(false);                                                                                        \
-  if (object->Get##variable() != 0)                                                                                    \
-  {                                                                                                                    \
-    std::cerr << "Error in Set/Get" #variable << ", Get" #variable << " is " << object->Get##variable()                \
-              << " instead of 0" << std::endl;                                                                         \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
-  object->variable##On();                                                                                              \
-  if (object->Get##variable() != 1)                                                                                    \
-  {                                                                                                                    \
-    std::cerr << "Error in On/Get" #variable << ", Get" #variable << " is " << object->Get##variable()                 \
-              << " instead of 1" << std::endl;                                                                         \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
-  object->variable##Off();                                                                                             \
-  if (object->Get##variable() != 0)                                                                                    \
-  {                                                                                                                    \
-    std::cerr << "Error in Off/Get" #variable << ", Get" #variable << " is " << object->Get##variable()                \
-              << " instead of 0" << std::endl;                                                                         \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define ITK_TEST_SET_GET_NULL_VALUE(command)                          \
+  if (nullptr != command)                                             \
+  {                                                                   \
+    std::cerr << "Error in " << #command << std::endl;                \
+    std::cerr << "  In " __FILE__ ", line " << __LINE__ << std::endl; \
+    std::cerr << "Expected "                                          \
+              << "nullptr" << std::endl;                              \
+    std::cerr << "but got  " << command << std::endl;                 \
+    return EXIT_FAILURE;                                              \
+  }                                                                   \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define ITK_TEST_SET_GET_BOOLEAN(object, variable, value)                                               \
+  object->Set##variable(false);                                                                         \
+  object->Set##variable(true);                                                                          \
+  if (object->Get##variable() != 1)                                                                     \
+  {                                                                                                     \
+    std::cerr << "Error in Set/Get" #variable << ", Get" #variable << " is " << object->Get##variable() \
+              << " instead of 1" << std::endl;                                                          \
+    return EXIT_FAILURE;                                                                                \
+  }                                                                                                     \
+  object->Set##variable(false);                                                                         \
+  if (object->Get##variable() != 0)                                                                     \
+  {                                                                                                     \
+    std::cerr << "Error in Set/Get" #variable << ", Get" #variable << " is " << object->Get##variable() \
+              << " instead of 0" << std::endl;                                                          \
+    return EXIT_FAILURE;                                                                                \
+  }                                                                                                     \
+  object->variable##On();                                                                               \
+  if (object->Get##variable() != 1)                                                                     \
+  {                                                                                                     \
+    std::cerr << "Error in On/Get" #variable << ", Get" #variable << " is " << object->Get##variable()  \
+              << " instead of 1" << std::endl;                                                          \
+    return EXIT_FAILURE;                                                                                \
+  }                                                                                                     \
+  object->variable##Off();                                                                              \
+  if (object->Get##variable() != 0)                                                                     \
+  {                                                                                                     \
+    std::cerr << "Error in Off/Get" #variable << ", Get" #variable << " is " << object->Get##variable() \
+              << " instead of 0" << std::endl;                                                          \
+    return EXIT_FAILURE;                                                                                \
+  }                                                                                                     \
   object->Set##variable(value)
 
 /** The name of the executable, argv[0], is not always available as argv[0] may be null.

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -253,9 +253,9 @@ itkBSplineDeformableTransformTest1()
    */
   using JacobianType = TransformType::JacobianType;
 
-#define PRINT_VALUE(R, C)                                                                                              \
-  std::cout << "Jacobian[" #R "," #C "] = ";                                                                           \
-  std::cout << jacobian[R][C] << std::endl;                                                                            \
+#define PRINT_VALUE(R, C)                    \
+  std::cout << "Jacobian[" #R "," #C "] = "; \
+  std::cout << jacobian[R][C] << std::endl;  \
   ITK_MACROEND_NOOP_STATEMENT
 
   {

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -289,9 +289,9 @@ itkBSplineTransformTest1()
    */
   using JacobianType = TransformType::JacobianType;
 
-#define PRINT_VALUE(R, C)                                                                                              \
-  std::cout << "Jacobian[" #R "," #C "] = ";                                                                           \
-  std::cout << jacobian[R][C] << std::endl;                                                                            \
+#define PRINT_VALUE(R, C)                    \
+  std::cout << "Jacobian[" #R "," #C "] = "; \
+  std::cout << jacobian[R][C] << std::endl;  \
   ITK_MACROEND_NOOP_STATEMENT
 
   {

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilterFactory.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilterFactory.h
@@ -68,16 +68,16 @@ public:
   }
 
 private:
-#define GradientAnisotropicDiffusionImageFilterTypeMacro(ipt, opt, dm)                                                 \
-  {                                                                                                                    \
-    using InputImageType = itk::Image<ipt, dm>;                                                                        \
-    using OutputImageType = itk::Image<opt, dm>;                                                                       \
-    this->RegisterOverride(                                                                                            \
-      typeid(itk::GradientAnisotropicDiffusionImageFilter<InputImageType, OutputImageType>).name(),                    \
-      typeid(itk::GPUGradientAnisotropicDiffusionImageFilter<InputImageType, OutputImageType>).name(),                 \
-      "GPU GradientAnisotropicDiffusionImageFilter Override",                                                          \
-      true,                                                                                                            \
-      itk::CreateObjectFunction<GPUGradientAnisotropicDiffusionImageFilter<InputImageType, OutputImageType>>::New());  \
+#define GradientAnisotropicDiffusionImageFilterTypeMacro(ipt, opt, dm)                                                \
+  {                                                                                                                   \
+    using InputImageType = itk::Image<ipt, dm>;                                                                       \
+    using OutputImageType = itk::Image<opt, dm>;                                                                      \
+    this->RegisterOverride(                                                                                           \
+      typeid(itk::GradientAnisotropicDiffusionImageFilter<InputImageType, OutputImageType>).name(),                   \
+      typeid(itk::GPUGradientAnisotropicDiffusionImageFilter<InputImageType, OutputImageType>).name(),                \
+      "GPU GradientAnisotropicDiffusionImageFilter Override",                                                         \
+      true,                                                                                                           \
+      itk::CreateObjectFunction<GPUGradientAnisotropicDiffusionImageFilter<InputImageType, OutputImageType>>::New()); \
   }
 
   GPUGradientAnisotropicDiffusionImageFilterFactory()

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUMeanImageFilter.h
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUMeanImageFilter.h
@@ -137,16 +137,16 @@ public:
   }
 
 private:
-#define OverrideMeanFilterTypeMacro(ipt, opt, dm)                                                                      \
-  {                                                                                                                    \
-    using InputImageType = Image<ipt, dm>;                                                                             \
-    using OutputImageType = Image<opt, dm>;                                                                            \
-    this->RegisterOverride(typeid(MeanImageFilter<InputImageType, OutputImageType>).name(),                            \
-                           typeid(GPUMeanImageFilter<InputImageType, OutputImageType>).name(),                         \
-                           "GPU Mean Image Filter Override",                                                           \
-                           true,                                                                                       \
-                           CreateObjectFunction<GPUMeanImageFilter<InputImageType, OutputImageType>>::New());          \
-  }                                                                                                                    \
+#define OverrideMeanFilterTypeMacro(ipt, opt, dm)                                                             \
+  {                                                                                                           \
+    using InputImageType = Image<ipt, dm>;                                                                    \
+    using OutputImageType = Image<opt, dm>;                                                                   \
+    this->RegisterOverride(typeid(MeanImageFilter<InputImageType, OutputImageType>).name(),                   \
+                           typeid(GPUMeanImageFilter<InputImageType, OutputImageType>).name(),                \
+                           "GPU Mean Image Filter Override",                                                  \
+                           true,                                                                              \
+                           CreateObjectFunction<GPUMeanImageFilter<InputImageType, OutputImageType>>::New()); \
+  }                                                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
   GPUMeanImageFilterFactory()

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
@@ -190,17 +190,17 @@ public:
   }
 
 private:
-#define OverrideThresholdFilterTypeMacro(ipt, opt, dm)                                                                 \
-  {                                                                                                                    \
-    using InputImageType = itk::Image<ipt, dm>;                                                                        \
-    using OutputImageType = itk::Image<opt, dm>;                                                                       \
-    this->RegisterOverride(                                                                                            \
-      typeid(itk::BinaryThresholdImageFilter<InputImageType, OutputImageType>).name(),                                 \
-      typeid(itk::GPUBinaryThresholdImageFilter<InputImageType, OutputImageType>).name(),                              \
-      "GPU Binary Threshold Image Filter Override",                                                                    \
-      true,                                                                                                            \
-      itk::CreateObjectFunction<GPUBinaryThresholdImageFilter<InputImageType, OutputImageType>>::New());               \
-  }                                                                                                                    \
+#define OverrideThresholdFilterTypeMacro(ipt, opt, dm)                                                   \
+  {                                                                                                      \
+    using InputImageType = itk::Image<ipt, dm>;                                                          \
+    using OutputImageType = itk::Image<opt, dm>;                                                         \
+    this->RegisterOverride(                                                                              \
+      typeid(itk::BinaryThresholdImageFilter<InputImageType, OutputImageType>).name(),                   \
+      typeid(itk::GPUBinaryThresholdImageFilter<InputImageType, OutputImageType>).name(),                \
+      "GPU Binary Threshold Image Filter Override",                                                      \
+      true,                                                                                              \
+      itk::CreateObjectFunction<GPUBinaryThresholdImageFilter<InputImageType, OutputImageType>>::New()); \
+  }                                                                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
   GPUBinaryThresholdImageFilterFactory()

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -27,13 +27,13 @@ using DisplacementFieldType = itk::Image<itk::Vector<double, 3>, 3>;
 using WarpFilterType = itk::WarpImageFilter<ImageType, ImageType, DisplacementFieldType>;
 
 using MonitorFilter = itk::PipelineMonitorImageFilter<ImageType>;
-#define AllocateImageFromRegionAndSpacing(ImageType, rval, region, spacing)                                            \
-  {                                                                                                                    \
-    rval = ImageType::New();                                                                                           \
-    rval->SetSpacing(spacing);                                                                                         \
-    rval->SetRegions(region);                                                                                          \
-    rval->Allocate();                                                                                                  \
-  }                                                                                                                    \
+#define AllocateImageFromRegionAndSpacing(ImageType, rval, region, spacing) \
+  {                                                                         \
+    rval = ImageType::New();                                                \
+    rval->SetSpacing(spacing);                                              \
+    rval->SetRegions(region);                                               \
+    rval->Allocate();                                                       \
+  }                                                                         \
   ITK_MACROEND_NOOP_STATEMENT
 
 namespace

--- a/Modules/Filtering/LabelMap/include/itkLabelMapUtilities.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapUtilities.h
@@ -27,177 +27,177 @@
  *
  */
 
-#define itkShapeLabelMapFilterDispatchMacro()                                                                          \
-  case LabelObjectType::LABEL:                                                                                         \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::LabelLabelObjectAccessor<LabelObjectType>;                                  \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::NUMBER_OF_PIXELS:                                                                              \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::NumberOfPixelsLabelObjectAccessor<LabelObjectType>;                         \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::PHYSICAL_SIZE:                                                                                 \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::PhysicalSizeLabelObjectAccessor<LabelObjectType>;                           \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::NUMBER_OF_PIXELS_ON_BORDER:                                                                    \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::NumberOfPixelsOnBorderLabelObjectAccessor<LabelObjectType>;                 \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::PERIMETER_ON_BORDER:                                                                           \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::PerimeterOnBorderLabelObjectAccessor<LabelObjectType>;                      \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::FERET_DIAMETER:                                                                                \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::FeretDiameterLabelObjectAccessor<LabelObjectType>;                          \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::ELONGATION:                                                                                    \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::ElongationLabelObjectAccessor<LabelObjectType>;                             \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::PERIMETER:                                                                                     \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::PerimeterLabelObjectAccessor<LabelObjectType>;                              \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::ROUNDNESS:                                                                                     \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::RoundnessLabelObjectAccessor<LabelObjectType>;                              \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::EQUIVALENT_SPHERICAL_RADIUS:                                                                   \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::EquivalentSphericalRadiusLabelObjectAccessor<LabelObjectType>;              \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::EQUIVALENT_SPHERICAL_PERIMETER:                                                                \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::EquivalentSphericalPerimeterLabelObjectAccessor<LabelObjectType>;           \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::FLATNESS:                                                                                      \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::FlatnessLabelObjectAccessor<LabelObjectType>;                               \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::PERIMETER_ON_BORDER_RATIO:                                                                     \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::PerimeterOnBorderRatioLabelObjectAccessor<LabelObjectType>;                 \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
+#define itkShapeLabelMapFilterDispatchMacro()                                                                \
+  case LabelObjectType::LABEL:                                                                               \
+  {                                                                                                          \
+    using AccessorType = typename Functor::LabelLabelObjectAccessor<LabelObjectType>;                        \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::NUMBER_OF_PIXELS:                                                                    \
+  {                                                                                                          \
+    using AccessorType = typename Functor::NumberOfPixelsLabelObjectAccessor<LabelObjectType>;               \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::PHYSICAL_SIZE:                                                                       \
+  {                                                                                                          \
+    using AccessorType = typename Functor::PhysicalSizeLabelObjectAccessor<LabelObjectType>;                 \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::NUMBER_OF_PIXELS_ON_BORDER:                                                          \
+  {                                                                                                          \
+    using AccessorType = typename Functor::NumberOfPixelsOnBorderLabelObjectAccessor<LabelObjectType>;       \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::PERIMETER_ON_BORDER:                                                                 \
+  {                                                                                                          \
+    using AccessorType = typename Functor::PerimeterOnBorderLabelObjectAccessor<LabelObjectType>;            \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::FERET_DIAMETER:                                                                      \
+  {                                                                                                          \
+    using AccessorType = typename Functor::FeretDiameterLabelObjectAccessor<LabelObjectType>;                \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::ELONGATION:                                                                          \
+  {                                                                                                          \
+    using AccessorType = typename Functor::ElongationLabelObjectAccessor<LabelObjectType>;                   \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::PERIMETER:                                                                           \
+  {                                                                                                          \
+    using AccessorType = typename Functor::PerimeterLabelObjectAccessor<LabelObjectType>;                    \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::ROUNDNESS:                                                                           \
+  {                                                                                                          \
+    using AccessorType = typename Functor::RoundnessLabelObjectAccessor<LabelObjectType>;                    \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::EQUIVALENT_SPHERICAL_RADIUS:                                                         \
+  {                                                                                                          \
+    using AccessorType = typename Functor::EquivalentSphericalRadiusLabelObjectAccessor<LabelObjectType>;    \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::EQUIVALENT_SPHERICAL_PERIMETER:                                                      \
+  {                                                                                                          \
+    using AccessorType = typename Functor::EquivalentSphericalPerimeterLabelObjectAccessor<LabelObjectType>; \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::FLATNESS:                                                                            \
+  {                                                                                                          \
+    using AccessorType = typename Functor::FlatnessLabelObjectAccessor<LabelObjectType>;                     \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
+  }                                                                                                          \
+  case LabelObjectType::PERIMETER_ON_BORDER_RATIO:                                                           \
+  {                                                                                                          \
+    using AccessorType = typename Functor::PerimeterOnBorderRatioLabelObjectAccessor<LabelObjectType>;       \
+    AccessorType accessor;                                                                                   \
+    this->TemplatedGenerateData(accessor);                                                                   \
+    break;                                                                                                   \
   }
 
 
-#define itkStatisticsLabelMapFilterDispatchMacro()                                                                     \
-  case LabelObjectType::MINIMUM:                                                                                       \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::MinimumLabelObjectAccessor<LabelObjectType>;                                \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::MAXIMUM:                                                                                       \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::MaximumLabelObjectAccessor<LabelObjectType>;                                \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::MEAN:                                                                                          \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::MeanLabelObjectAccessor<LabelObjectType>;                                   \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::SUM:                                                                                           \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::SumLabelObjectAccessor<LabelObjectType>;                                    \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::STANDARD_DEVIATION:                                                                            \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::StandardDeviationLabelObjectAccessor<LabelObjectType>;                      \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::VARIANCE:                                                                                      \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::VarianceLabelObjectAccessor<LabelObjectType>;                               \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::MEDIAN:                                                                                        \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::MedianLabelObjectAccessor<LabelObjectType>;                                 \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::KURTOSIS:                                                                                      \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::KurtosisLabelObjectAccessor<LabelObjectType>;                               \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::SKEWNESS:                                                                                      \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::SkewnessLabelObjectAccessor<LabelObjectType>;                               \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::WEIGHTED_ELONGATION:                                                                           \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::WeightedElongationLabelObjectAccessor<LabelObjectType>;                     \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case LabelObjectType::WEIGHTED_FLATNESS:                                                                             \
-  {                                                                                                                    \
-    using AccessorType = typename Functor::WeightedFlatnessLabelObjectAccessor<LabelObjectType>;                       \
-    AccessorType accessor;                                                                                             \
-    this->TemplatedGenerateData(accessor);                                                                             \
-    break;                                                                                                             \
+#define itkStatisticsLabelMapFilterDispatchMacro()                                                 \
+  case LabelObjectType::MINIMUM:                                                                   \
+  {                                                                                                \
+    using AccessorType = typename Functor::MinimumLabelObjectAccessor<LabelObjectType>;            \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::MAXIMUM:                                                                   \
+  {                                                                                                \
+    using AccessorType = typename Functor::MaximumLabelObjectAccessor<LabelObjectType>;            \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::MEAN:                                                                      \
+  {                                                                                                \
+    using AccessorType = typename Functor::MeanLabelObjectAccessor<LabelObjectType>;               \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::SUM:                                                                       \
+  {                                                                                                \
+    using AccessorType = typename Functor::SumLabelObjectAccessor<LabelObjectType>;                \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::STANDARD_DEVIATION:                                                        \
+  {                                                                                                \
+    using AccessorType = typename Functor::StandardDeviationLabelObjectAccessor<LabelObjectType>;  \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::VARIANCE:                                                                  \
+  {                                                                                                \
+    using AccessorType = typename Functor::VarianceLabelObjectAccessor<LabelObjectType>;           \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::MEDIAN:                                                                    \
+  {                                                                                                \
+    using AccessorType = typename Functor::MedianLabelObjectAccessor<LabelObjectType>;             \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::KURTOSIS:                                                                  \
+  {                                                                                                \
+    using AccessorType = typename Functor::KurtosisLabelObjectAccessor<LabelObjectType>;           \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::SKEWNESS:                                                                  \
+  {                                                                                                \
+    using AccessorType = typename Functor::SkewnessLabelObjectAccessor<LabelObjectType>;           \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::WEIGHTED_ELONGATION:                                                       \
+  {                                                                                                \
+    using AccessorType = typename Functor::WeightedElongationLabelObjectAccessor<LabelObjectType>; \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
+  }                                                                                                \
+  case LabelObjectType::WEIGHTED_FLATNESS:                                                         \
+  {                                                                                                \
+    using AccessorType = typename Functor::WeightedFlatnessLabelObjectAccessor<LabelObjectType>;   \
+    AccessorType accessor;                                                                         \
+    this->TemplatedGenerateData(accessor);                                                         \
+    break;                                                                                         \
   }
 
 #endif

--- a/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
@@ -43,16 +43,16 @@ class DcmDictEntry;
 // Don't print error messages if you're not throwing
 // an exception
 //     std::cerr body;
-#define DCMTKExceptionOrErrorReturn(body)                                                                              \
-  {                                                                                                                    \
-    if (throwException)                                                                                                \
-    {                                                                                                                  \
-      itkGenericExceptionMacro(body);                                                                                  \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
+#define DCMTKExceptionOrErrorReturn(body) \
+  {                                       \
+    if (throwException)                   \
+    {                                     \
+      itkGenericExceptionMacro(body);     \
+    }                                     \
+    else                                  \
+    {                                     \
+      return EXIT_FAILURE;                \
+    }                                     \
   }
 
 namespace itk

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -79,11 +79,11 @@ GetType()
   itkGenericExceptionMacro(<< "Type not handled "
                            << "in HDF5 File: " << typeid(TScalar).name());
 }
-#define GetH5TypeSpecialize(CXXType, H5Type)                                                                           \
-  template <>                                                                                                          \
-  H5::PredType GetType<CXXType>()                                                                                      \
-  {                                                                                                                    \
-    return H5Type;                                                                                                     \
+#define GetH5TypeSpecialize(CXXType, H5Type) \
+  template <>                                \
+  H5::PredType GetType<CXXType>()            \
+  {                                          \
+    return H5Type;                           \
   }
 
 GetH5TypeSpecialize(float, H5::PredType::NATIVE_FLOAT) GetH5TypeSpecialize(double, H5::PredType::NATIVE_DOUBLE)
@@ -1015,7 +1015,7 @@ HDF5ImageIO ::WriteImageInformation()
     this->CloseDataSet();
 
     H5::FileAccPropList fapl;
-#if (H5_VERS_MAJOR > 1) || (H5_VERS_MAJOR == 1) && (H5_VERS_MINOR > 10) ||                                             \
+#if (H5_VERS_MAJOR > 1) || (H5_VERS_MAJOR == 1) && (H5_VERS_MINOR > 10) || \
   (H5_VERS_MAJOR == 1) && (H5_VERS_MINOR == 10) && (H5_VERS_RELEASE >= 2)
     // File format which is backwards compatible with HDF5 version 1.8
     // Only HDF5 v1.10.2 has both setLibverBounds method and H5F_LIBVER_V18 constant

--- a/Modules/IO/IPL/include/itkIPLCommonImageIO.h
+++ b/Modules/IO/IPL/include/itkIPLCommonImageIO.h
@@ -197,23 +197,23 @@ protected:
   hdr2Double(char * hdr);
 };
 } // end namespace itk
-#define RAISE_EXCEPTION()                                                                                              \
-  {                                                                                                                    \
-    ExceptionObject exception(__FILE__, __LINE__);                                                                     \
-    exception.SetDescription("File cannot be read");                                                                   \
-    throw exception;                                                                                                   \
-  }                                                                                                                    \
+#define RAISE_EXCEPTION()                            \
+  {                                                  \
+    ExceptionObject exception(__FILE__, __LINE__);   \
+    exception.SetDescription("File cannot be read"); \
+    throw exception;                                 \
+  }                                                  \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define IOCHECK()                                                                                                      \
-  if (f.fail())                                                                                                        \
-  {                                                                                                                    \
-    if (f.is_open())                                                                                                   \
-    {                                                                                                                  \
-      f.close();                                                                                                       \
-    }                                                                                                                  \
-    RAISE_EXCEPTION();                                                                                                 \
-  }                                                                                                                    \
+#define IOCHECK()      \
+  if (f.fail())        \
+  {                    \
+    if (f.is_open())   \
+    {                  \
+      f.close();       \
+    }                  \
+    RAISE_EXCEPTION(); \
+  }                    \
   ITK_MACROEND_NOOP_STATEMENT
 
 #endif // itkIPLCommonImageIO_h

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -39,17 +39,17 @@
 /** Set built-in type.  Creates member Set"name"() (e.g., SetVisibility()); */
 #define IPLSetMacroDeclaration(name, type) virtual void Set##name(const type _arg);
 
-#define IPLSetMacroDefinition(class, name, type)                                                                       \
-  void class ::Set##name(const type _arg)                                                                              \
-  {                                                                                                                    \
-    CLANG_PRAGMA_PUSH                                                                                                  \
-    CLANG_SUPPRESS_Wfloat_equal if (this->m_##name != _arg) CLANG_PRAGMA_POP { this->m_##name = _arg; }                \
+#define IPLSetMacroDefinition(class, name, type)                                                        \
+  void class ::Set##name(const type _arg)                                                               \
+  {                                                                                                     \
+    CLANG_PRAGMA_PUSH                                                                                   \
+    CLANG_SUPPRESS_Wfloat_equal if (this->m_##name != _arg) CLANG_PRAGMA_POP { this->m_##name = _arg; } \
   }
 
 /** Get built-in type.  Creates member Get"name"() (e.g., GetVisibility()); */
 #define IPLGetMacroDeclaration(name, type) virtual type Get##name();
 
-#define IPLGetMacroDefinition(class, name, type)                                                                       \
+#define IPLGetMacroDefinition(class, name, type) \
   type class ::Get##name() { return this->m_##name; }
 
 namespace itk

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -463,19 +463,19 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::DoConvertBuffer(void * inputD
   // VectorImage needs to copy out the buffer differently.. The buffer is of
   // type InternalPixelType, but each pixel is really 'k' consecutive pixels.
 
-#define ITK_CONVERT_BUFFER_IF_BLOCK(_CType, type)                                                                      \
-  else if (m_ImageIO->GetComponentType() == _CType)                                                                    \
-  {                                                                                                                    \
-    if (isVectorImage)                                                                                                 \
-    {                                                                                                                  \
-      ConvertPixelBuffer<type, OutputImagePixelType, ConvertPixelTraits>::ConvertVectorImage(                          \
-        static_cast<type *>(inputData), m_ImageIO->GetNumberOfComponents(), outputData, numberOfPixels);               \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      ConvertPixelBuffer<type, OutputImagePixelType, ConvertPixelTraits>::Convert(                                     \
-        static_cast<type *>(inputData), m_ImageIO->GetNumberOfComponents(), outputData, numberOfPixels);               \
-    }                                                                                                                  \
+#define ITK_CONVERT_BUFFER_IF_BLOCK(_CType, type)                                                        \
+  else if (m_ImageIO->GetComponentType() == _CType)                                                      \
+  {                                                                                                      \
+    if (isVectorImage)                                                                                   \
+    {                                                                                                    \
+      ConvertPixelBuffer<type, OutputImagePixelType, ConvertPixelTraits>::ConvertVectorImage(            \
+        static_cast<type *>(inputData), m_ImageIO->GetNumberOfComponents(), outputData, numberOfPixels); \
+    }                                                                                                    \
+    else                                                                                                 \
+    {                                                                                                    \
+      ConvertPixelBuffer<type, OutputImagePixelType, ConvertPixelTraits>::Convert(                       \
+        static_cast<type *>(inputData), m_ImageIO->GetNumberOfComponents(), outputData, numberOfPixels); \
+    }                                                                                                    \
   }
 
   if (false)

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -911,11 +911,11 @@ ReadRawBytesAfterSwapping(IOComponentEnum componentType,
                           IOByteOrderEnum byteOrder,
                           SizeValueType   numberOfComponents);
 
-#define IMAGEIOBASE_TYPEMAP(type, ctype)                                                                               \
-  template <>                                                                                                          \
-  struct ImageIOBase::MapPixelType<type>                                                                               \
-  {                                                                                                                    \
-    static constexpr IOComponentEnum CType = ctype;                                                                    \
+#define IMAGEIOBASE_TYPEMAP(type, ctype)            \
+  template <>                                       \
+  struct ImageIOBase::MapPixelType<type>            \
+  {                                                 \
+    static constexpr IOComponentEnum CType = ctype; \
   }
 
 // the following typemaps are not platform independent

--- a/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
+++ b/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
@@ -45,7 +45,7 @@
 // * VS7.x and MinGW have _wopen and _wfopen but cannot open a
 //   (i/o)fstream using a wide string. They can however compile fdstream
 
-#if defined(ITK_SUPPORTS_WCHAR_T_FILENAME_CSTYLEIO) &&                                                                 \
+#if defined(ITK_SUPPORTS_WCHAR_T_FILENAME_CSTYLEIO) && \
   (defined(ITK_SUPPORTS_WCHAR_T_FILENAME_IOSTREAMS_CONSTRUCTORS) || defined(ITK_SUPPORTS_FDSTREAM_HPP))
 #  define LOCAL_USE_WIN32_WOPEN 1
 #  include <windows.h> // required by winnls.h

--- a/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
@@ -28,7 +28,7 @@
 // Macro to check that two arrays have the same size at compile time. It doesn't compile if they don't
 // as it tries to create an array of size(-1)
 // https://scaryreasoner.wordpress.com/2009/02/28/checking-sizeof-at-compile-time/
-#define CHECK_ARRAYS_HAVE_SAME_SIZE_AT_COMPILE_TIME(array1, array2)                                                    \
+#define CHECK_ARRAYS_HAVE_SAME_SIZE_AT_COMPILE_TIME(array1, array2) \
   ((void)sizeof(char[1 - 2 * !!(sizeof(array1) / sizeof(*array1) - sizeof(array2) / sizeof(*array2))]))
 
 int

--- a/Modules/IO/ImageBase/test/itkUnicodeIOTest.cxx
+++ b/Modules/IO/ImageBase/test/itkUnicodeIOTest.cxx
@@ -20,7 +20,7 @@
 #include <cstring>
 
 // Some utility functions for the test
-#if defined(ITK_SUPPORTS_WCHAR_T_FILENAME_CSTYLEIO) &&                                                                 \
+#if defined(ITK_SUPPORTS_WCHAR_T_FILENAME_CSTYLEIO) && \
   (defined(ITK_SUPPORTS_WCHAR_T_FILENAME_IOSTREAMS_CONSTRUCTORS) || defined(ITK_SUPPORTS_FDSTREAM_HPP))
 #  define LOCAL_USE_WIN32_WOPEN 1
 #else

--- a/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
+++ b/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
@@ -84,37 +84,37 @@ public:
   }
 };
 
-#define ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(type)                                                                  \
-  template <>                                                                                                          \
-  class MeshConvertPixelTraits<type>                                                                                   \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using ComponentType = type;                                                                                        \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents()                                                                                            \
-    {                                                                                                                  \
-      return 1;                                                                                                        \
-    }                                                                                                                  \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents(const type & itkNotUsed(pixel))                                                              \
-    {                                                                                                                  \
-      return 1;                                                                                                        \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetNthComponent(int itkNotUsed(c), const type & pixel)                                                             \
-    {                                                                                                                  \
-      return pixel;                                                                                                    \
-    }                                                                                                                  \
-    static void                                                                                                        \
-    SetNthComponent(int, type & pixel, const ComponentType & v)                                                        \
-    {                                                                                                                  \
-      pixel = v;                                                                                                       \
-    }                                                                                                                  \
-    static type                                                                                                        \
-    GetScalarValue(const type & pixel)                                                                                 \
-    {                                                                                                                  \
-      return pixel;                                                                                                    \
-    }                                                                                                                  \
+#define ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(type)           \
+  template <>                                                   \
+  class MeshConvertPixelTraits<type>                            \
+  {                                                             \
+  public:                                                       \
+    using ComponentType = type;                                 \
+    static unsigned int                                         \
+    GetNumberOfComponents()                                     \
+    {                                                           \
+      return 1;                                                 \
+    }                                                           \
+    static unsigned int                                         \
+    GetNumberOfComponents(const type & itkNotUsed(pixel))       \
+    {                                                           \
+      return 1;                                                 \
+    }                                                           \
+    static ComponentType                                        \
+    GetNthComponent(int itkNotUsed(c), const type & pixel)      \
+    {                                                           \
+      return pixel;                                             \
+    }                                                           \
+    static void                                                 \
+    SetNthComponent(int, type & pixel, const ComponentType & v) \
+    {                                                           \
+      pixel = v;                                                \
+    }                                                           \
+    static type                                                 \
+    GetScalarValue(const type & pixel)                          \
+    {                                                           \
+      return pixel;                                             \
+    }                                                           \
   }
 
 ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(char);
@@ -138,38 +138,38 @@ ITK_DEFAULTCONVERTTRAITS_NATIVE_SPECIAL(double);
 //  Default traits for the Offset<> pixel type
 //
 
-#define ITK_MESH_DEFAULTCONVERTTRAITS_OFFSET_TYPE(dimension)                                                           \
-  template <>                                                                                                          \
-  class MeshConvertPixelTraits<Offset<dimension>>                                                                      \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using TargetType = Offset<dimension>;                                                                              \
-    using ComponentType = TargetType::OffsetValueType;                                                                 \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents()                                                                                            \
-    {                                                                                                                  \
-      return dimension;                                                                                                \
-    }                                                                                                                  \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents(const TargetType & itkNotUsed(pixel))                                                        \
-    {                                                                                                                  \
-      return dimension;                                                                                                \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetNthComponent(int c, const TargetType & pixel)                                                                   \
-    {                                                                                                                  \
-      return pixel[c];                                                                                                 \
-    }                                                                                                                  \
-    static void                                                                                                        \
-    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)                                                \
-    {                                                                                                                  \
-      pixel[i] = v;                                                                                                    \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetScalarValue(const TargetType & pixel)                                                                           \
-    {                                                                                                                  \
-      return pixel[0];                                                                                                 \
-    }                                                                                                                  \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_OFFSET_TYPE(dimension)            \
+  template <>                                                           \
+  class MeshConvertPixelTraits<Offset<dimension>>                       \
+  {                                                                     \
+  public:                                                               \
+    using TargetType = Offset<dimension>;                               \
+    using ComponentType = TargetType::OffsetValueType;                  \
+    static unsigned int                                                 \
+    GetNumberOfComponents()                                             \
+    {                                                                   \
+      return dimension;                                                 \
+    }                                                                   \
+    static unsigned int                                                 \
+    GetNumberOfComponents(const TargetType & itkNotUsed(pixel))         \
+    {                                                                   \
+      return dimension;                                                 \
+    }                                                                   \
+    static ComponentType                                                \
+    GetNthComponent(int c, const TargetType & pixel)                    \
+    {                                                                   \
+      return pixel[c];                                                  \
+    }                                                                   \
+    static void                                                         \
+    SetNthComponent(int i, TargetType & pixel, const ComponentType & v) \
+    {                                                                   \
+      pixel[i] = v;                                                     \
+    }                                                                   \
+    static ComponentType                                                \
+    GetScalarValue(const TargetType & pixel)                            \
+    {                                                                   \
+      return pixel[0];                                                  \
+    }                                                                   \
   };
 
 
@@ -184,38 +184,38 @@ ITK_MESH_DEFAULTCONVERTTRAITS_OFFSET_TYPE(5)
 //  Default traits for the pixel types deriving from FixedArray<>
 //
 
-#define ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(type, componenttype, dimension)                                  \
-  template <>                                                                                                          \
-  class MeshConvertPixelTraits<type<componenttype, dimension>>                                                         \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using TargetType = type<componenttype, dimension>;                                                                 \
-    using ComponentType = componenttype;                                                                               \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents()                                                                                            \
-    {                                                                                                                  \
-      return dimension;                                                                                                \
-    }                                                                                                                  \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents(const TargetType & itkNotUsed(pixel))                                                        \
-    {                                                                                                                  \
-      return dimension;                                                                                                \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetNthComponent(int c, const TargetType & pixel)                                                                   \
-    {                                                                                                                  \
-      return pixel[c];                                                                                                 \
-    }                                                                                                                  \
-    static void                                                                                                        \
-    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)                                                \
-    {                                                                                                                  \
-      pixel[i] = v;                                                                                                    \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetScalarValue(const TargetType & pixel)                                                                           \
-    {                                                                                                                  \
-      return pixel[0];                                                                                                 \
-    }                                                                                                                  \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(type, componenttype, dimension) \
+  template <>                                                                         \
+  class MeshConvertPixelTraits<type<componenttype, dimension>>                        \
+  {                                                                                   \
+  public:                                                                             \
+    using TargetType = type<componenttype, dimension>;                                \
+    using ComponentType = componenttype;                                              \
+    static unsigned int                                                               \
+    GetNumberOfComponents()                                                           \
+    {                                                                                 \
+      return dimension;                                                               \
+    }                                                                                 \
+    static unsigned int                                                               \
+    GetNumberOfComponents(const TargetType & itkNotUsed(pixel))                       \
+    {                                                                                 \
+      return dimension;                                                               \
+    }                                                                                 \
+    static ComponentType                                                              \
+    GetNthComponent(int c, const TargetType & pixel)                                  \
+    {                                                                                 \
+      return pixel[c];                                                                \
+    }                                                                                 \
+    static void                                                                       \
+    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)               \
+    {                                                                                 \
+      pixel[i] = v;                                                                   \
+    }                                                                                 \
+    static ComponentType                                                              \
+    GetScalarValue(const TargetType & pixel)                                          \
+    {                                                                                 \
+      return pixel[0];                                                                \
+    }                                                                                 \
   };
 
 //
@@ -224,27 +224,27 @@ ITK_MESH_DEFAULTCONVERTTRAITS_OFFSET_TYPE(5)
 // These classes include: Vector, CovariantVector and Point.
 //
 //
-#define ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, Type)                                       \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 1)                                                    \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 2)                                                    \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 3)                                                    \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 4)                                                    \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 5)                                                    \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, Type) \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 1)              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 2)              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 3)              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 4)              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 5)              \
   ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE(ArrayType, Type, 6)
 
-#define ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_TYPES_MACRO(ArrayType)                                       \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, char);                                            \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, signed char);                                     \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned char);                                   \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, short int);                                       \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned short int);                              \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, int);                                             \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned int);                                    \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, long int);                                        \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned long int);                               \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, long long int);                                   \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned long long int);                          \
-  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, float);                                           \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_TYPES_MACRO(ArrayType)              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, char);                   \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, signed char);            \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned char);          \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, short int);              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned short int);     \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, int);                    \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned int);           \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, long int);               \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned long int);      \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, long long int);          \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, unsigned long long int); \
+  ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, float);                  \
   ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_MACRO(ArrayType, double);
 
 ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_TYPES_MACRO(Vector);
@@ -262,42 +262,42 @@ ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_TYPES_MACRO(FixedArray);
 //  Default traits for the pixel types deriving from Matrix<>
 //
 
-#define ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(type, componenttype, rows, cols)                                     \
-  template <>                                                                                                          \
-  class MeshConvertPixelTraits<type<componenttype, rows, cols>>                                                        \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using TargetType = type<componenttype, rows, cols>;                                                                \
-    using ComponentType = componenttype;                                                                               \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents()                                                                                            \
-    {                                                                                                                  \
-      return rows * cols;                                                                                              \
-    }                                                                                                                  \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents(const TargetType & itkNotUsed(pixel))                                                        \
-    {                                                                                                                  \
-      return rows * cols;                                                                                              \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetNthComponent(int c, const TargetType & pixel)                                                                   \
-    {                                                                                                                  \
-      const unsigned int row = c / cols;                                                                               \
-      const unsigned int col = c % cols;                                                                               \
-      return pixel[row][col];                                                                                          \
-    }                                                                                                                  \
-    static void                                                                                                        \
-    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)                                                \
-    {                                                                                                                  \
-      const unsigned int row = i / cols;                                                                               \
-      const unsigned int col = i % cols;                                                                               \
-      pixel[row][col] = v;                                                                                             \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetScalarValue(const TargetType & pixel)                                                                           \
-    {                                                                                                                  \
-      return pixel[0][0];                                                                                              \
-    }                                                                                                                  \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(type, componenttype, rows, cols) \
+  template <>                                                                      \
+  class MeshConvertPixelTraits<type<componenttype, rows, cols>>                    \
+  {                                                                                \
+  public:                                                                          \
+    using TargetType = type<componenttype, rows, cols>;                            \
+    using ComponentType = componenttype;                                           \
+    static unsigned int                                                            \
+    GetNumberOfComponents()                                                        \
+    {                                                                              \
+      return rows * cols;                                                          \
+    }                                                                              \
+    static unsigned int                                                            \
+    GetNumberOfComponents(const TargetType & itkNotUsed(pixel))                    \
+    {                                                                              \
+      return rows * cols;                                                          \
+    }                                                                              \
+    static ComponentType                                                           \
+    GetNthComponent(int c, const TargetType & pixel)                               \
+    {                                                                              \
+      const unsigned int row = c / cols;                                           \
+      const unsigned int col = c % cols;                                           \
+      return pixel[row][col];                                                      \
+    }                                                                              \
+    static void                                                                    \
+    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)            \
+    {                                                                              \
+      const unsigned int row = i / cols;                                           \
+      const unsigned int col = i % cols;                                           \
+      pixel[row][col] = v;                                                         \
+    }                                                                              \
+    static ComponentType                                                           \
+    GetScalarValue(const TargetType & pixel)                                       \
+    {                                                                              \
+      return pixel[0][0];                                                          \
+    }                                                                              \
   };
 
 //
@@ -305,27 +305,27 @@ ITK_MESH_DEFAULTCONVERTTRAITS_FIXEDARRAY_TYPE_ALL_TYPES_MACRO(FixedArray);
 // Define traits for Classed deriving from Matrix from dimensions 1 to 6
 //
 //
-#define ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, Type)                                           \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 1, 1)                                                     \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 2, 2)                                                     \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 3, 3)                                                     \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 4, 4)                                                     \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 5, 5)                                                     \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, Type) \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 1, 1)           \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 2, 2)           \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 3, 3)           \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 4, 4)           \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 5, 5)           \
   ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE(ArrayType, Type, 6, 6)
 
-#define ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_TYPES_MACRO(ArrayType)                                           \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, char);                                                \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, signed char);                                         \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned char);                                       \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, short int);                                           \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned short int);                                  \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, int);                                                 \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned int);                                        \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, long int);                                            \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned long int);                                   \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, long long int);                                       \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned long long int);                              \
-  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, float);                                               \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_TYPES_MACRO(ArrayType)              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, char);                   \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, signed char);            \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned char);          \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, short int);              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned short int);     \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, int);                    \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned int);           \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, long int);               \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned long int);      \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, long long int);          \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, unsigned long long int); \
+  ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, float);                  \
   ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_MACRO(ArrayType, double);
 
 //
@@ -343,104 +343,104 @@ ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_TYPES_MACRO(Matrix);
 //  Default traits for the pixel types deriving from std::complex<>
 //
 
-#define ITK_MESH_DEFAULTCONVERTTRAITS_COMPLEX_TYPE(componenttype)                                                      \
-  template <>                                                                                                          \
-  class MeshConvertPixelTraits<::std::complex<componenttype>>                                                          \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using TargetType = ::std::complex<componenttype>;                                                                  \
-    using ComponentType = componenttype;                                                                               \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents()                                                                                            \
-    {                                                                                                                  \
-      return 2;                                                                                                        \
-    }                                                                                                                  \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents(const TargetType & itkNotUsed(pixel))                                                        \
-    {                                                                                                                  \
-      return 2;                                                                                                        \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetNthComponent(int i, TargetType & pixel)                                                                         \
-    {                                                                                                                  \
-      if (i == 0)                                                                                                      \
-      {                                                                                                                \
-        return pixel.imag();                                                                                           \
-      }                                                                                                                \
-      else                                                                                                             \
-      {                                                                                                                \
-        return pixel.real();                                                                                           \
-      }                                                                                                                \
-    }                                                                                                                  \
-    static void                                                                                                        \
-    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)                                                \
-    {                                                                                                                  \
-      if (i == 0)                                                                                                      \
-      {                                                                                                                \
-        pixel = TargetType(v, pixel.imag());                                                                           \
-      }                                                                                                                \
-      else                                                                                                             \
-      {                                                                                                                \
-        pixel = TargetType(pixel.real(), v);                                                                           \
-      }                                                                                                                \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetScalarValue(const TargetType & pixel)                                                                           \
-    {                                                                                                                  \
-      return std::norm(pixel);                                                                                         \
-    }                                                                                                                  \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_COMPLEX_TYPE(componenttype)       \
+  template <>                                                           \
+  class MeshConvertPixelTraits<::std::complex<componenttype>>           \
+  {                                                                     \
+  public:                                                               \
+    using TargetType = ::std::complex<componenttype>;                   \
+    using ComponentType = componenttype;                                \
+    static unsigned int                                                 \
+    GetNumberOfComponents()                                             \
+    {                                                                   \
+      return 2;                                                         \
+    }                                                                   \
+    static unsigned int                                                 \
+    GetNumberOfComponents(const TargetType & itkNotUsed(pixel))         \
+    {                                                                   \
+      return 2;                                                         \
+    }                                                                   \
+    static ComponentType                                                \
+    GetNthComponent(int i, TargetType & pixel)                          \
+    {                                                                   \
+      if (i == 0)                                                       \
+      {                                                                 \
+        return pixel.imag();                                            \
+      }                                                                 \
+      else                                                              \
+      {                                                                 \
+        return pixel.real();                                            \
+      }                                                                 \
+    }                                                                   \
+    static void                                                         \
+    SetNthComponent(int i, TargetType & pixel, const ComponentType & v) \
+    {                                                                   \
+      if (i == 0)                                                       \
+      {                                                                 \
+        pixel = TargetType(v, pixel.imag());                            \
+      }                                                                 \
+      else                                                              \
+      {                                                                 \
+        pixel = TargetType(pixel.real(), v);                            \
+      }                                                                 \
+    }                                                                   \
+    static ComponentType                                                \
+    GetScalarValue(const TargetType & pixel)                            \
+    {                                                                   \
+      return std::norm(pixel);                                          \
+    }                                                                   \
   };
 
 ITK_MESH_DEFAULTCONVERTTRAITS_COMPLEX_TYPE(float);
 ITK_MESH_DEFAULTCONVERTTRAITS_COMPLEX_TYPE(double);
 
-#define ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(type, componenttype)                                                  \
-  template <>                                                                                                          \
-  class MeshConvertPixelTraits<type<componenttype>>                                                                    \
-  {                                                                                                                    \
-  public:                                                                                                              \
-    using TargetType = type<componenttype>;                                                                            \
-    using ComponentType = componenttype;                                                                               \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents()                                                                                            \
-    {                                                                                                                  \
-      return 0;                                                                                                        \
-    }                                                                                                                  \
-    static unsigned int                                                                                                \
-    GetNumberOfComponents(const TargetType & pixel)                                                                    \
-    {                                                                                                                  \
-      return pixel.Size();                                                                                             \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetNthComponent(int c, const TargetType & pixel)                                                                   \
-    {                                                                                                                  \
-      return pixel[c];                                                                                                 \
-    }                                                                                                                  \
-    static void                                                                                                        \
-    SetNthComponent(int i, TargetType & pixel, const ComponentType & v)                                                \
-    {                                                                                                                  \
-      pixel[i] = v;                                                                                                    \
-    }                                                                                                                  \
-    static ComponentType                                                                                               \
-    GetScalarValue(const TargetType & pixel)                                                                           \
-    {                                                                                                                  \
-      return pixel[0];                                                                                                 \
-    }                                                                                                                  \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(type, componenttype)   \
+  template <>                                                           \
+  class MeshConvertPixelTraits<type<componenttype>>                     \
+  {                                                                     \
+  public:                                                               \
+    using TargetType = type<componenttype>;                             \
+    using ComponentType = componenttype;                                \
+    static unsigned int                                                 \
+    GetNumberOfComponents()                                             \
+    {                                                                   \
+      return 0;                                                         \
+    }                                                                   \
+    static unsigned int                                                 \
+    GetNumberOfComponents(const TargetType & pixel)                     \
+    {                                                                   \
+      return pixel.Size();                                              \
+    }                                                                   \
+    static ComponentType                                                \
+    GetNthComponent(int c, const TargetType & pixel)                    \
+    {                                                                   \
+      return pixel[c];                                                  \
+    }                                                                   \
+    static void                                                         \
+    SetNthComponent(int i, TargetType & pixel, const ComponentType & v) \
+    {                                                                   \
+      pixel[i] = v;                                                     \
+    }                                                                   \
+    static ComponentType                                                \
+    GetScalarValue(const TargetType & pixel)                            \
+    {                                                                   \
+      return pixel[0];                                                  \
+    }                                                                   \
   };
 
-#define ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE_ALL_TYPES_MACRO(ArrayType)                                            \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, char);                                                           \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, signed char);                                                    \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned char);                                                  \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, short int);                                                      \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned short int);                                             \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, int);                                                            \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned int);                                                   \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, long int);                                                       \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned long int);                                              \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, long long int);                                                  \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned long long int);                                         \
-  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, float);                                                          \
+#define ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE_ALL_TYPES_MACRO(ArrayType)    \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, char);                   \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, signed char);            \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned char);          \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, short int);              \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned short int);     \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, int);                    \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned int);           \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, long int);               \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned long int);      \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, long long int);          \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, unsigned long long int); \
+  ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, float);                  \
   ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE(ArrayType, double);
 
 ITK_MESH_DEFAULTCONVERTTRAITS_ARRAY_TYPE_ALL_TYPES_MACRO(Array);

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -811,11 +811,11 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Co
   // class to convert the data block to TOutputMesh's pixel type
   // see DefaultConvertPixelTraits and ConvertPixelBuffer
 
-#define ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(CType, type)                                                           \
-  else if (m_MeshIO->GetPointPixelComponentType() == CType)                                                            \
-  {                                                                                                                    \
-    ConvertPixelBuffer<type, OutputPointPixelType, ConvertPointPixelTraits>::Convert(                                  \
-      static_cast<type *>(inputData), m_MeshIO->GetNumberOfPointPixelComponents(), outputData, numberOfPixels);        \
+#define ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(CType, type)                                                    \
+  else if (m_MeshIO->GetPointPixelComponentType() == CType)                                                     \
+  {                                                                                                             \
+    ConvertPixelBuffer<type, OutputPointPixelType, ConvertPointPixelTraits>::Convert(                           \
+      static_cast<type *>(inputData), m_MeshIO->GetNumberOfPointPixelComponents(), outputData, numberOfPixels); \
   }
 
   if (false)
@@ -883,11 +883,11 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Co
   // class to convert the data block to TOutputMesh's pixel type
   // see DefaultConvertPixelTraits and ConvertPixelBuffer
 
-#define ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(CType, type)                                                            \
-  else if (m_MeshIO->GetCellPixelComponentType() == CType)                                                             \
-  {                                                                                                                    \
-    ConvertPixelBuffer<type, OutputCellPixelType, ConvertCellPixelTraits>::Convert(                                    \
-      static_cast<type *>(inputData), m_MeshIO->GetNumberOfCellPixelComponents(), outputData, numberOfPixels);         \
+#define ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(CType, type)                                                    \
+  else if (m_MeshIO->GetCellPixelComponentType() == CType)                                                     \
+  {                                                                                                            \
+    ConvertPixelBuffer<type, OutputCellPixelType, ConvertCellPixelTraits>::Convert(                            \
+      static_cast<type *>(inputData), m_MeshIO->GetNumberOfCellPixelComponents(), outputData, numberOfPixels); \
   }
 
   if (false)

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -856,11 +856,11 @@ private:
   ArrayOfExtensionsType m_SupportedReadExtensions;
   ArrayOfExtensionsType m_SupportedWriteExtensions;
 };
-#define MESHIOBASE_TYPEMAP(type, ctype)                                                                                \
-  template <>                                                                                                          \
-  struct MeshIOBase::MapComponentType<type>                                                                            \
-  {                                                                                                                    \
-    static constexpr IOComponentEnum CType = ctype;                                                                    \
+#define MESHIOBASE_TYPEMAP(type, ctype)             \
+  template <>                                       \
+  struct MeshIOBase::MapComponentType<type>         \
+  {                                                 \
+    static constexpr IOComponentEnum CType = ctype; \
   }
 
 MESHIOBASE_TYPEMAP(unsigned char, IOComponentEnum::UCHAR);

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -686,71 +686,71 @@ VTKPolyDataMeshIO ::ReadMeshInformation()
   inputFile.close();
 }
 
-#define CASE_INVOKE_BY_TYPE(function, param)                                                                           \
-  case IOComponentEnum::UCHAR:                                                                                         \
-  {                                                                                                                    \
-    function(param, static_cast<unsigned char *>(buffer));                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::CHAR:                                                                                          \
-  {                                                                                                                    \
-    function(param, static_cast<char *>(buffer));                                                                      \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::USHORT:                                                                                        \
-  {                                                                                                                    \
-    function(param, static_cast<unsigned short *>(buffer));                                                            \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::SHORT:                                                                                         \
-  {                                                                                                                    \
-    function(param, static_cast<short *>(buffer));                                                                     \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::UINT:                                                                                          \
-  {                                                                                                                    \
-    function(param, static_cast<unsigned int *>(buffer));                                                              \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::INT:                                                                                           \
-  {                                                                                                                    \
-    function(param, static_cast<int *>(buffer));                                                                       \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::ULONG:                                                                                         \
-  {                                                                                                                    \
-    function(param, static_cast<unsigned long *>(buffer));                                                             \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LONG:                                                                                          \
-  {                                                                                                                    \
-    function(param, static_cast<long *>(buffer));                                                                      \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::ULONGLONG:                                                                                     \
-  {                                                                                                                    \
-    function(param, static_cast<unsigned long long *>(buffer));                                                        \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LONGLONG:                                                                                      \
-  {                                                                                                                    \
-    function(param, static_cast<long long *>(buffer));                                                                 \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::FLOAT:                                                                                         \
-  {                                                                                                                    \
-    function(param, static_cast<float *>(buffer));                                                                     \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::DOUBLE:                                                                                        \
-  {                                                                                                                    \
-    function(param, static_cast<double *>(buffer));                                                                    \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LDOUBLE:                                                                                       \
-  {                                                                                                                    \
-    function(param, static_cast<long double *>(buffer));                                                               \
-    break;                                                                                                             \
+#define CASE_INVOKE_BY_TYPE(function, param)                    \
+  case IOComponentEnum::UCHAR:                                  \
+  {                                                             \
+    function(param, static_cast<unsigned char *>(buffer));      \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::CHAR:                                   \
+  {                                                             \
+    function(param, static_cast<char *>(buffer));               \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::USHORT:                                 \
+  {                                                             \
+    function(param, static_cast<unsigned short *>(buffer));     \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::SHORT:                                  \
+  {                                                             \
+    function(param, static_cast<short *>(buffer));              \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::UINT:                                   \
+  {                                                             \
+    function(param, static_cast<unsigned int *>(buffer));       \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::INT:                                    \
+  {                                                             \
+    function(param, static_cast<int *>(buffer));                \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::ULONG:                                  \
+  {                                                             \
+    function(param, static_cast<unsigned long *>(buffer));      \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::LONG:                                   \
+  {                                                             \
+    function(param, static_cast<long *>(buffer));               \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::ULONGLONG:                              \
+  {                                                             \
+    function(param, static_cast<unsigned long long *>(buffer)); \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::LONGLONG:                               \
+  {                                                             \
+    function(param, static_cast<long long *>(buffer));          \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::FLOAT:                                  \
+  {                                                             \
+    function(param, static_cast<float *>(buffer));              \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::DOUBLE:                                 \
+  {                                                             \
+    function(param, static_cast<double *>(buffer));             \
+    break;                                                      \
+  }                                                             \
+  case IOComponentEnum::LDOUBLE:                                \
+  {                                                             \
+    function(param, static_cast<long double *>(buffer));        \
+    break;                                                      \
   }
 
 void
@@ -1154,71 +1154,71 @@ VTKPolyDataMeshIO ::WriteMeshInformation()
   outputFile.close();
 }
 
-#define CASE_INVOKE_WITH_COMPONENT_TYPE(function)                                                                      \
-  case IOComponentEnum::UCHAR:                                                                                         \
-  {                                                                                                                    \
-    function(outputFile, static_cast<unsigned char *>(buffer), " unsigned_char");                                      \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::CHAR:                                                                                          \
-  {                                                                                                                    \
-    function(outputFile, static_cast<char *>(buffer), " char");                                                        \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::USHORT:                                                                                        \
-  {                                                                                                                    \
-    function(outputFile, static_cast<unsigned short *>(buffer), " unsigned_short");                                    \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::SHORT:                                                                                         \
-  {                                                                                                                    \
-    function(outputFile, static_cast<short *>(buffer), " short");                                                      \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::UINT:                                                                                          \
-  {                                                                                                                    \
-    function(outputFile, static_cast<unsigned int *>(buffer), " unsigned_int");                                        \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::INT:                                                                                           \
-  {                                                                                                                    \
-    function(outputFile, static_cast<int *>(buffer), " int");                                                          \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::ULONG:                                                                                         \
-  {                                                                                                                    \
-    function(outputFile, static_cast<unsigned long *>(buffer), " unsigned_long");                                      \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LONG:                                                                                          \
-  {                                                                                                                    \
-    function(outputFile, static_cast<long *>(buffer), " long");                                                        \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::ULONGLONG:                                                                                     \
-  {                                                                                                                    \
-    function(outputFile, static_cast<unsigned long long *>(buffer), " vtktypeuint64");                                 \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LONGLONG:                                                                                      \
-  {                                                                                                                    \
-    function(outputFile, static_cast<long long *>(buffer), " vtktypeint64");                                           \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::FLOAT:                                                                                         \
-  {                                                                                                                    \
-    function(outputFile, static_cast<float *>(buffer), " float");                                                      \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::DOUBLE:                                                                                        \
-  {                                                                                                                    \
-    function(outputFile, static_cast<double *>(buffer), " double");                                                    \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LDOUBLE:                                                                                       \
-  {                                                                                                                    \
-    function(outputFile, static_cast<long double *>(buffer), " long_double");                                          \
-    break;                                                                                                             \
+#define CASE_INVOKE_WITH_COMPONENT_TYPE(function)                                      \
+  case IOComponentEnum::UCHAR:                                                         \
+  {                                                                                    \
+    function(outputFile, static_cast<unsigned char *>(buffer), " unsigned_char");      \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::CHAR:                                                          \
+  {                                                                                    \
+    function(outputFile, static_cast<char *>(buffer), " char");                        \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::USHORT:                                                        \
+  {                                                                                    \
+    function(outputFile, static_cast<unsigned short *>(buffer), " unsigned_short");    \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::SHORT:                                                         \
+  {                                                                                    \
+    function(outputFile, static_cast<short *>(buffer), " short");                      \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::UINT:                                                          \
+  {                                                                                    \
+    function(outputFile, static_cast<unsigned int *>(buffer), " unsigned_int");        \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::INT:                                                           \
+  {                                                                                    \
+    function(outputFile, static_cast<int *>(buffer), " int");                          \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::ULONG:                                                         \
+  {                                                                                    \
+    function(outputFile, static_cast<unsigned long *>(buffer), " unsigned_long");      \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::LONG:                                                          \
+  {                                                                                    \
+    function(outputFile, static_cast<long *>(buffer), " long");                        \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::ULONGLONG:                                                     \
+  {                                                                                    \
+    function(outputFile, static_cast<unsigned long long *>(buffer), " vtktypeuint64"); \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::LONGLONG:                                                      \
+  {                                                                                    \
+    function(outputFile, static_cast<long long *>(buffer), " vtktypeint64");           \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::FLOAT:                                                         \
+  {                                                                                    \
+    function(outputFile, static_cast<float *>(buffer), " float");                      \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::DOUBLE:                                                        \
+  {                                                                                    \
+    function(outputFile, static_cast<double *>(buffer), " double");                    \
+    break;                                                                             \
+  }                                                                                    \
+  case IOComponentEnum::LDOUBLE:                                                       \
+  {                                                                                    \
+    function(outputFile, static_cast<long double *>(buffer), " long_double");          \
+    break;                                                                             \
   }
 
 void
@@ -1276,84 +1276,84 @@ VTKPolyDataMeshIO ::WritePoints(void * buffer)
   outputFile.close();
 }
 
-#define CASE_UPDATE_AND_WRITE(function)                                                                                \
-  case IOComponentEnum::UCHAR:                                                                                         \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<unsigned char *>(buffer));                                                       \
-    function(outputFile, static_cast<unsigned char *>(buffer));                                                        \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::CHAR:                                                                                          \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<char *>(buffer));                                                                \
-    function(outputFile, static_cast<char *>(buffer));                                                                 \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::USHORT:                                                                                        \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<unsigned short *>(buffer));                                                      \
-    function(outputFile, static_cast<unsigned short *>(buffer));                                                       \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::SHORT:                                                                                         \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<short *>(buffer));                                                               \
-    function(outputFile, static_cast<short *>(buffer));                                                                \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::UINT:                                                                                          \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<unsigned int *>(buffer));                                                        \
-    function(outputFile, static_cast<unsigned int *>(buffer));                                                         \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::INT:                                                                                           \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<int *>(buffer));                                                                 \
-    function(outputFile, static_cast<int *>(buffer));                                                                  \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::ULONG:                                                                                         \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<unsigned long *>(buffer));                                                       \
-    function(outputFile, static_cast<unsigned long *>(buffer));                                                        \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LONG:                                                                                          \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<long *>(buffer));                                                                \
-    function(outputFile, static_cast<long *>(buffer));                                                                 \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::ULONGLONG:                                                                                     \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<unsigned long long *>(buffer));                                                  \
-    function(outputFile, static_cast<unsigned long long *>(buffer));                                                   \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LONGLONG:                                                                                      \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<long long *>(buffer));                                                           \
-    function(outputFile, static_cast<long long *>(buffer));                                                            \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::FLOAT:                                                                                         \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<float *>(buffer));                                                               \
-    function(outputFile, static_cast<float *>(buffer));                                                                \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::DOUBLE:                                                                                        \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<double *>(buffer));                                                              \
-    function(outputFile, static_cast<double *>(buffer));                                                               \
-    break;                                                                                                             \
-  }                                                                                                                    \
-  case IOComponentEnum::LDOUBLE:                                                                                       \
-  {                                                                                                                    \
-    UpdateCellInformation(static_cast<long double *>(buffer));                                                         \
-    function(outputFile, static_cast<long double *>(buffer));                                                          \
-    break;                                                                                                             \
+#define CASE_UPDATE_AND_WRITE(function)                               \
+  case IOComponentEnum::UCHAR:                                        \
+  {                                                                   \
+    UpdateCellInformation(static_cast<unsigned char *>(buffer));      \
+    function(outputFile, static_cast<unsigned char *>(buffer));       \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::CHAR:                                         \
+  {                                                                   \
+    UpdateCellInformation(static_cast<char *>(buffer));               \
+    function(outputFile, static_cast<char *>(buffer));                \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::USHORT:                                       \
+  {                                                                   \
+    UpdateCellInformation(static_cast<unsigned short *>(buffer));     \
+    function(outputFile, static_cast<unsigned short *>(buffer));      \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::SHORT:                                        \
+  {                                                                   \
+    UpdateCellInformation(static_cast<short *>(buffer));              \
+    function(outputFile, static_cast<short *>(buffer));               \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::UINT:                                         \
+  {                                                                   \
+    UpdateCellInformation(static_cast<unsigned int *>(buffer));       \
+    function(outputFile, static_cast<unsigned int *>(buffer));        \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::INT:                                          \
+  {                                                                   \
+    UpdateCellInformation(static_cast<int *>(buffer));                \
+    function(outputFile, static_cast<int *>(buffer));                 \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::ULONG:                                        \
+  {                                                                   \
+    UpdateCellInformation(static_cast<unsigned long *>(buffer));      \
+    function(outputFile, static_cast<unsigned long *>(buffer));       \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::LONG:                                         \
+  {                                                                   \
+    UpdateCellInformation(static_cast<long *>(buffer));               \
+    function(outputFile, static_cast<long *>(buffer));                \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::ULONGLONG:                                    \
+  {                                                                   \
+    UpdateCellInformation(static_cast<unsigned long long *>(buffer)); \
+    function(outputFile, static_cast<unsigned long long *>(buffer));  \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::LONGLONG:                                     \
+  {                                                                   \
+    UpdateCellInformation(static_cast<long long *>(buffer));          \
+    function(outputFile, static_cast<long long *>(buffer));           \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::FLOAT:                                        \
+  {                                                                   \
+    UpdateCellInformation(static_cast<float *>(buffer));              \
+    function(outputFile, static_cast<float *>(buffer));               \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::DOUBLE:                                       \
+  {                                                                   \
+    UpdateCellInformation(static_cast<double *>(buffer));             \
+    function(outputFile, static_cast<double *>(buffer));              \
+    break;                                                            \
+  }                                                                   \
+  case IOComponentEnum::LDOUBLE:                                      \
+  {                                                                   \
+    UpdateCellInformation(static_cast<long double *>(buffer));        \
+    function(outputFile, static_cast<long double *>(buffer));         \
+    break;                                                            \
   }
 
 void

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -20,12 +20,12 @@
 #include "itksys/SystemTools.hxx"
 #include "itkMetaDataObject.h"
 #include "itkIOCommon.h"
-#define RAISE_EXCEPTION(s)                                                                                             \
-  {                                                                                                                    \
-    ExceptionObject exception(__FILE__, __LINE__);                                                                     \
-    exception.SetDescription(s);                                                                                       \
-    throw exception;                                                                                                   \
-  }                                                                                                                    \
+#define RAISE_EXCEPTION(s)                         \
+  {                                                \
+    ExceptionObject exception(__FILE__, __LINE__); \
+    exception.SetDescription(s);                   \
+    throw exception;                               \
+  }                                                \
   ITK_MACROEND_NOOP_STATEMENT
 
 namespace itk

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1190,21 +1190,21 @@ TIFFImageIO::ReadTIFFTags()
                   << value_count << " " << raw_data);
 
 
-#define itkEncapsulate(T1, T2)                                                                                         \
-  if (value_count > 1)                                                                                                 \
-  {                                                                                                                    \
-    auto      v_c = static_cast<size_t>(value_count);                                                                  \
-    Array<T1> a(v_c);                                                                                                  \
-    for (unsigned int cnt = 0; cnt < v_c; ++cnt)                                                                       \
-    {                                                                                                                  \
-      a[cnt] = (static_cast<const T2 *>(raw_data))[cnt];                                                               \
-    }                                                                                                                  \
-    EncapsulateMetaData<itk::Array<T1>>(dict, field_name, a);                                                          \
-  }                                                                                                                    \
-  else                                                                                                                 \
-  {                                                                                                                    \
-    EncapsulateMetaData<T1>(dict, field_name, (static_cast<const T2 *>(raw_data))[0]);                                 \
-  }                                                                                                                    \
+#define itkEncapsulate(T1, T2)                                                         \
+  if (value_count > 1)                                                                 \
+  {                                                                                    \
+    auto      v_c = static_cast<size_t>(value_count);                                  \
+    Array<T1> a(v_c);                                                                  \
+    for (unsigned int cnt = 0; cnt < v_c; ++cnt)                                       \
+    {                                                                                  \
+      a[cnt] = (static_cast<const T2 *>(raw_data))[cnt];                               \
+    }                                                                                  \
+    EncapsulateMetaData<itk::Array<T1>>(dict, field_name, a);                          \
+  }                                                                                    \
+  else                                                                                 \
+  {                                                                                    \
+    EncapsulateMetaData<T1>(dict, field_name, (static_cast<const T2 *>(raw_data))[0]); \
+  }                                                                                    \
   ITK_MACROEND_NOOP_STATEMENT
 
     try

--- a/Modules/IO/TransformFactory/test/itkTransformFactoryBaseTest.cxx
+++ b/Modules/IO/TransformFactory/test/itkTransformFactoryBaseTest.cxx
@@ -22,7 +22,7 @@
 #include "itkVersion.h"
 #include "itkTransformFactoryBase.h"
 
-#define itkPushIfTransformDim(str, D)                                                                                  \
+#define itkPushIfTransformDim(str, D) \
   (D <= (ITK_TRANSFORM_FACTORY_MAX_DIM)) ? defaultTransforms.push_back(str) : ((void)0)
 
 int

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -411,7 +411,7 @@ HDF5TransformIOTemplate<TParametersValueType>::Write()
   try
   {
     H5::FileAccPropList fapl;
-#if (H5_VERS_MAJOR > 1) || (H5_VERS_MAJOR == 1) && (H5_VERS_MINOR > 10) ||                                             \
+#if (H5_VERS_MAJOR > 1) || (H5_VERS_MAJOR == 1) && (H5_VERS_MINOR > 10) || \
   (H5_VERS_MAJOR == 1) && (H5_VERS_MINOR == 10) && (H5_VERS_RELEASE >= 2)
     // File format which is backwards compatible with HDF5 version 1.8
     // Only HDF5 v1.10.2 has both setLibverBounds method and H5F_LIBVER_V18 constant

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -816,43 +816,43 @@ VTKImageIO::WriteBufferAsASCII(std::ostream &              os,
   }
 }
 
-#define WriteVTKImageBinaryBlockMACRO(storageType)                                                                     \
-  {                                                                                                                    \
-    const ImageIOBase::BufferSizeType numbytes =                                                                       \
-      static_cast<ImageIOBase::BufferSizeType>(this->GetImageSizeInBytes());                                           \
-    const ImageIOBase::BufferSizeType numberImageComponents =                                                          \
-      static_cast<ImageIOBase::BufferSizeType>(this->GetImageSizeInComponents());                                      \
-    const bool    isSymmetricSecondRankTensor = (this->GetPixelType() == IOPixelEnum::SYMMETRICSECONDRANKTENSOR);      \
-    storageType * tempmemory = new storageType[numberImageComponents];                                                 \
-    memcpy(tempmemory, buffer, numbytes);                                                                              \
-    ByteSwapper<storageType>::SwapRangeFromSystemToBigEndian(tempmemory, numberImageComponents);                       \
-    /* write the image */                                                                                              \
-    if (isSymmetricSecondRankTensor)                                                                                   \
-    {                                                                                                                  \
-      this->WriteSymmetricTensorBufferAsBinary(file, tempmemory, numbytes);                                            \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      if (!this->WriteBufferAsBinary(file, tempmemory, numbytes))                                                      \
-      {                                                                                                                \
-        itkExceptionMacro(<< "Could not write file: " << m_FileName);                                                  \
-      }                                                                                                                \
-    }                                                                                                                  \
-    delete[] tempmemory;                                                                                               \
+#define WriteVTKImageBinaryBlockMACRO(storageType)                                                                \
+  {                                                                                                               \
+    const ImageIOBase::BufferSizeType numbytes =                                                                  \
+      static_cast<ImageIOBase::BufferSizeType>(this->GetImageSizeInBytes());                                      \
+    const ImageIOBase::BufferSizeType numberImageComponents =                                                     \
+      static_cast<ImageIOBase::BufferSizeType>(this->GetImageSizeInComponents());                                 \
+    const bool    isSymmetricSecondRankTensor = (this->GetPixelType() == IOPixelEnum::SYMMETRICSECONDRANKTENSOR); \
+    storageType * tempmemory = new storageType[numberImageComponents];                                            \
+    memcpy(tempmemory, buffer, numbytes);                                                                         \
+    ByteSwapper<storageType>::SwapRangeFromSystemToBigEndian(tempmemory, numberImageComponents);                  \
+    /* write the image */                                                                                         \
+    if (isSymmetricSecondRankTensor)                                                                              \
+    {                                                                                                             \
+      this->WriteSymmetricTensorBufferAsBinary(file, tempmemory, numbytes);                                       \
+    }                                                                                                             \
+    else                                                                                                          \
+    {                                                                                                             \
+      if (!this->WriteBufferAsBinary(file, tempmemory, numbytes))                                                 \
+      {                                                                                                           \
+        itkExceptionMacro(<< "Could not write file: " << m_FileName);                                             \
+      }                                                                                                           \
+    }                                                                                                             \
+    delete[] tempmemory;                                                                                          \
   }
 
-#define StreamWriteVTKImageBinaryBlockMACRO(storageType)                                                               \
-  {                                                                                                                    \
-    const ImageIOBase::BufferSizeType numbytes =                                                                       \
-      static_cast<ImageIOBase::BufferSizeType>(this->GetIORegionSizeInBytes());                                        \
-    const ImageIOBase::BufferSizeType numberImageComponents =                                                          \
-      static_cast<ImageIOBase::BufferSizeType>(this->GetIORegionSizeInComponents());                                   \
-    storageType * tempmemory = new storageType[numberImageComponents];                                                 \
-    memcpy(tempmemory, buffer, numbytes);                                                                              \
-    ByteSwapper<storageType>::SwapRangeFromSystemToBigEndian(tempmemory, numberImageComponents);                       \
-    /* write the image */                                                                                              \
-    this->StreamWriteBufferAsBinary(file, tempmemory);                                                                 \
-    delete[] tempmemory;                                                                                               \
+#define StreamWriteVTKImageBinaryBlockMACRO(storageType)                                         \
+  {                                                                                              \
+    const ImageIOBase::BufferSizeType numbytes =                                                 \
+      static_cast<ImageIOBase::BufferSizeType>(this->GetIORegionSizeInBytes());                  \
+    const ImageIOBase::BufferSizeType numberImageComponents =                                    \
+      static_cast<ImageIOBase::BufferSizeType>(this->GetIORegionSizeInComponents());             \
+    storageType * tempmemory = new storageType[numberImageComponents];                           \
+    memcpy(tempmemory, buffer, numbytes);                                                        \
+    ByteSwapper<storageType>::SwapRangeFromSystemToBigEndian(tempmemory, numberImageComponents); \
+    /* write the image */                                                                        \
+    this->StreamWriteBufferAsBinary(file, tempmemory);                                           \
+    delete[] tempmemory;                                                                         \
   }
 
 void

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -292,14 +292,14 @@ itkVTKImageIOStreamTest(int argc, char * argv[])
   unsigned int numberOfStreams = 2;
   int          status = 0;
 
-#define ReadWriteTestMACRO(scalarType)                                                                                 \
-  status += TestStreamWrite<scalarType, 2>(argv[1], 0);                                                                \
-  status += TestStreamWrite<scalarType, 2>(argv[1], numberOfStreams);                                                  \
-  status += TestStreamWrite<scalarType, 3>(argv[1], 0);                                                                \
-  status += TestStreamWrite<scalarType, 3>(argv[1], numberOfStreams);                                                  \
-  status += TestStreamRead<scalarType, 2>(argv[1], 0);                                                                 \
-  status += TestStreamRead<scalarType, 2>(argv[1], numberOfStreams);                                                   \
-  status += TestStreamRead<scalarType, 3>(argv[1], 0);                                                                 \
+#define ReadWriteTestMACRO(scalarType)                                \
+  status += TestStreamWrite<scalarType, 2>(argv[1], 0);               \
+  status += TestStreamWrite<scalarType, 2>(argv[1], numberOfStreams); \
+  status += TestStreamWrite<scalarType, 3>(argv[1], 0);               \
+  status += TestStreamWrite<scalarType, 3>(argv[1], numberOfStreams); \
+  status += TestStreamRead<scalarType, 2>(argv[1], 0);                \
+  status += TestStreamRead<scalarType, 2>(argv[1], numberOfStreams);  \
+  status += TestStreamRead<scalarType, 3>(argv[1], 0);                \
   status += TestStreamRead<scalarType, 3>(argv[1], numberOfStreams);
 
   ReadWriteTestMACRO(float) ReadWriteTestMACRO(double) ReadWriteTestMACRO(unsigned char) ReadWriteTestMACRO(char)

--- a/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
@@ -18,54 +18,54 @@
 
 #include "itkMeasurementVectorTraits.h"
 
-#define itkSetGetLengthVerificationMacro(measure, type, len1, len2)                                                    \
-  itk::NumericTraits<type>::SetLength((measure), len1);                                                                \
-  if (itk::NumericTraits<type>::GetLength((measure)) != len2)                                                          \
-  {                                                                                                                    \
-    std::cerr << "Set/GetLength() failed in measure " << std::endl;                                                    \
-  }                                                                                                                    \
+#define itkSetGetLengthVerificationMacro(measure, type, len1, len2) \
+  itk::NumericTraits<type>::SetLength((measure), len1);             \
+  if (itk::NumericTraits<type>::GetLength((measure)) != len2)       \
+  {                                                                 \
+    std::cerr << "Set/GetLength() failed in measure " << std::endl; \
+  }                                                                 \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkSetLengthExceptionMacro(measure, type, len)                                                                 \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    itk::NumericTraits<type>::SetLength((measure), len);                                                               \
-    std::cerr << "Failed to get expected exception for SetLength() ";                                                  \
-    std::cerr << std::endl;                                                                                            \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
-  catch (itk::ExceptionObject &)                                                                                       \
-  {}                                                                                                                   \
+#define itkSetLengthExceptionMacro(measure, type, len)                \
+  try                                                                 \
+  {                                                                   \
+    itk::NumericTraits<type>::SetLength((measure), len);              \
+    std::cerr << "Failed to get expected exception for SetLength() "; \
+    std::cerr << std::endl;                                           \
+    return EXIT_FAILURE;                                              \
+  }                                                                   \
+  catch (itk::ExceptionObject &)                                      \
+  {}                                                                  \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkAssertLengthExceptionMacro(m1, m2)                                                                          \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    itk::Statistics::MeasurementVectorTraits::Assert((m1), (m2));                                                      \
-    std::cerr << "Failed to get expected exception for Assert() ";                                                     \
-    std::cerr << std::endl;                                                                                            \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
-  catch (itk::ExceptionObject &)                                                                                       \
-  {}                                                                                                                   \
+#define itkAssertLengthExceptionMacro(m1, m2)                      \
+  try                                                              \
+  {                                                                \
+    itk::Statistics::MeasurementVectorTraits::Assert((m1), (m2));  \
+    std::cerr << "Failed to get expected exception for Assert() "; \
+    std::cerr << std::endl;                                        \
+    return EXIT_FAILURE;                                           \
+  }                                                                \
+  catch (itk::ExceptionObject &)                                   \
+  {}                                                               \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkAssertLengthSameValueReturn(m1, type1, m2)                                                                  \
-  if (itk::Statistics::MeasurementVectorTraits::Assert((m1), (m2)) != itk::NumericTraits<type1>::GetLength((m1)))      \
-  {                                                                                                                    \
-    std::cerr << "Failed to get expected VLenght for Assert() ";                                                       \
-    std::cerr << std::endl;                                                                                            \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define itkAssertLengthSameValueReturn(m1, type1, m2)                                                             \
+  if (itk::Statistics::MeasurementVectorTraits::Assert((m1), (m2)) != itk::NumericTraits<type1>::GetLength((m1))) \
+  {                                                                                                               \
+    std::cerr << "Failed to get expected VLenght for Assert() ";                                                  \
+    std::cerr << std::endl;                                                                                       \
+    return EXIT_FAILURE;                                                                                          \
+  }                                                                                                               \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkAssertSameLengthTest(m1, m2)                                                                                \
-  if (itk::Statistics::MeasurementVectorTraits::Assert((m1), (m2)) != 0)                                               \
-  {                                                                                                                    \
-    std::cerr << "Failed to recognize same length in Assert() ";                                                       \
-    std::cerr << std::endl;                                                                                            \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define itkAssertSameLengthTest(m1, m2)                                  \
+  if (itk::Statistics::MeasurementVectorTraits::Assert((m1), (m2)) != 0) \
+  {                                                                      \
+    std::cerr << "Failed to recognize same length in Assert() ";         \
+    std::cerr << std::endl;                                              \
+    return EXIT_FAILURE;                                                 \
+  }                                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
 

--- a/Modules/Numerics/Statistics/test/itkStatisticsTypesTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsTypesTest.cxx
@@ -18,17 +18,17 @@
 
 #include "itkMeasurementVectorTraits.h"
 
-#define declareType(_x)                                                                                                \
-  using _x = itk::Statistics::MeasurementVectorTraits::_x;                                                             \
-  std::cout << #_x << " = " << sizeof(_x) << " bytes ";                                                                \
-  if (itk::NumericTraits<_x>::is_integer)                                                                              \
-  {                                                                                                                    \
-    std::cout << " Integer type " << std::endl;                                                                        \
-  }                                                                                                                    \
-  else                                                                                                                 \
-  {                                                                                                                    \
-    std::cout << " Real type " << std::endl;                                                                           \
-  }                                                                                                                    \
+#define declareType(_x)                                    \
+  using _x = itk::Statistics::MeasurementVectorTraits::_x; \
+  std::cout << #_x << " = " << sizeof(_x) << " bytes ";    \
+  if (itk::NumericTraits<_x>::is_integer)                  \
+  {                                                        \
+    std::cout << " Integer type " << std::endl;            \
+  }                                                        \
+  else                                                     \
+  {                                                        \
+    std::cout << " Real type " << std::endl;               \
+  }                                                        \
   ITK_MACROEND_NOOP_STATEMENT
 
 int

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
@@ -114,26 +114,26 @@ itkImageRegistrationMethodTest(int, char *[])
    * Test out initialization errors
    ****************************************************/
 
-#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent)                                          \
-  registration->Set##ComponentName(badComponent);                                                                      \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    pass = false;                                                                                                      \
-    registration->Update();                                                                                            \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & err)                                                                             \
-  {                                                                                                                    \
-    std::cout << "Caught expected ExceptionObject" << std::endl;                                                       \
-    std::cout << err << std::endl;                                                                                     \
-    pass = true;                                                                                                       \
-  }                                                                                                                    \
-  registration->Set##ComponentName(goodComponent);                                                                     \
-                                                                                                                       \
-  if (!pass)                                                                                                           \
-  {                                                                                                                    \
-    std::cout << "Test failed." << std::endl;                                                                          \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
+  registration->Set##ComponentName(badComponent);                             \
+  try                                                                         \
+  {                                                                           \
+    pass = false;                                                             \
+    registration->Update();                                                   \
+  }                                                                           \
+  catch (const itk::ExceptionObject & err)                                    \
+  {                                                                           \
+    std::cout << "Caught expected ExceptionObject" << std::endl;              \
+    std::cout << err << std::endl;                                            \
+    pass = true;                                                              \
+  }                                                                           \
+  registration->Set##ComponentName(goodComponent);                            \
+                                                                              \
+  if (!pass)                                                                  \
+  {                                                                           \
+    std::cout << "Test failed." << std::endl;                                 \
+    return EXIT_FAILURE;                                                      \
+  }                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(InitialTransformParameters, badParameters, initialParameters);

--- a/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
@@ -341,26 +341,26 @@ itkMeanSquaresImageMetricTest(int, char *[])
   }
 
   bool pass;
-#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent)                                          \
-  metric->Set##ComponentName(badComponent);                                                                            \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    pass = false;                                                                                                      \
-    metric->Initialize();                                                                                              \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & err)                                                                             \
-  {                                                                                                                    \
-    std::cout << "Caught expected ExceptionObject" << std::endl;                                                       \
-    std::cout << err << std::endl;                                                                                     \
-    pass = true;                                                                                                       \
-  }                                                                                                                    \
-  metric->Set##ComponentName(goodComponent);                                                                           \
-                                                                                                                       \
-  if (!pass)                                                                                                           \
-  {                                                                                                                    \
-    std::cout << "Test failed." << std::endl;                                                                          \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
+  metric->Set##ComponentName(badComponent);                                   \
+  try                                                                         \
+  {                                                                           \
+    pass = false;                                                             \
+    metric->Initialize();                                                     \
+  }                                                                           \
+  catch (const itk::ExceptionObject & err)                                    \
+  {                                                                           \
+    std::cout << "Caught expected ExceptionObject" << std::endl;              \
+    std::cout << err << std::endl;                                            \
+    pass = true;                                                              \
+  }                                                                           \
+  metric->Set##ComponentName(goodComponent);                                  \
+                                                                              \
+  if (!pass)                                                                  \
+  {                                                                           \
+    std::cout << "Test failed." << std::endl;                                 \
+    return EXIT_FAILURE;                                                      \
+  }                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(Transform, nullptr, transform);

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
@@ -136,26 +136,26 @@ itkMultiResolutionImageRegistrationMethodTest(int, char *[])
    * Test out initialization errors
    ****************************************************/
 
-#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent)                                          \
-  registration->Set##ComponentName(badComponent);                                                                      \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    pass = false;                                                                                                      \
-    registration->Update();                                                                                            \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & err)                                                                             \
-  {                                                                                                                    \
-    std::cout << "Caught expected ExceptionObject" << std::endl;                                                       \
-    std::cout << err << std::endl;                                                                                     \
-    pass = true;                                                                                                       \
-  }                                                                                                                    \
-  registration->Set##ComponentName(goodComponent);                                                                     \
-                                                                                                                       \
-  if (!pass)                                                                                                           \
-  {                                                                                                                    \
-    std::cout << "Test failed." << std::endl;                                                                          \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
+  registration->Set##ComponentName(badComponent);                             \
+  try                                                                         \
+  {                                                                           \
+    pass = false;                                                             \
+    registration->Update();                                                   \
+  }                                                                           \
+  catch (const itk::ExceptionObject & err)                                    \
+  {                                                                           \
+    std::cout << "Caught expected ExceptionObject" << std::endl;              \
+    std::cout << err << std::endl;                                            \
+    pass = true;                                                              \
+  }                                                                           \
+  registration->Set##ComponentName(goodComponent);                            \
+                                                                              \
+  if (!pass)                                                                  \
+  {                                                                           \
+    std::cout << "Test failed." << std::endl;                                 \
+    return EXIT_FAILURE;                                                      \
+  }                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(Metric, nullptr, metric);

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.h
@@ -190,20 +190,20 @@ public:
   }
 
 private:
-#define OverrideDemonsRegistrationFilterTypeMacro(ipt, opt, dm)                                                        \
-  {                                                                                                                    \
-    using InputImageType = GPUImage<ipt, dm>;                                                                          \
-    using OutputImageType = GPUImage<opt, dm>;                                                                         \
-    using VectorPixelType = Vector<float, dm>;                                                                         \
-    using DisplacementFieldType = GPUImage<VectorPixelType, dm>;                                                       \
-    this->RegisterOverride(                                                                                            \
-      typeid(DemonsRegistrationFilter<InputImageType, OutputImageType, DisplacementFieldType>).name(),                 \
-      typeid(GPUDemonsRegistrationFilter<InputImageType, OutputImageType, DisplacementFieldType>).name(),              \
-      "GPU Demons Registration Filter Override",                                                                       \
-      true,                                                                                                            \
-      CreateObjectFunction<                                                                                            \
-        GPUDemonsRegistrationFilter<InputImageType, OutputImageType, DisplacementFieldType>>::New());                  \
-  }                                                                                                                    \
+#define OverrideDemonsRegistrationFilterTypeMacro(ipt, opt, dm)                                           \
+  {                                                                                                       \
+    using InputImageType = GPUImage<ipt, dm>;                                                             \
+    using OutputImageType = GPUImage<opt, dm>;                                                            \
+    using VectorPixelType = Vector<float, dm>;                                                            \
+    using DisplacementFieldType = GPUImage<VectorPixelType, dm>;                                          \
+    this->RegisterOverride(                                                                               \
+      typeid(DemonsRegistrationFilter<InputImageType, OutputImageType, DisplacementFieldType>).name(),    \
+      typeid(GPUDemonsRegistrationFilter<InputImageType, OutputImageType, DisplacementFieldType>).name(), \
+      "GPU Demons Registration Filter Override",                                                          \
+      true,                                                                                               \
+      CreateObjectFunction<                                                                               \
+        GPUDemonsRegistrationFilter<InputImageType, OutputImageType, DisplacementFieldType>>::New());     \
+  }                                                                                                       \
   ITK_MACROEND_NOOP_STATEMENT
 
   GPUDemonsRegistrationFilterFactory()

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -118,14 +118,14 @@ protected:
 } // end namespace itk
 
 // Define instantiation macro for this template.
-#define ITK_TEMPLATE_PointSetFunction(_, EXPORT, x, y)                                                                 \
-  namespace itk                                                                                                        \
-  {                                                                                                                    \
-  _(3(class EXPORT PointSetFunction<ITK_TEMPLATE_3 x>))                                                                \
-  namespace Templates                                                                                                  \
-  {                                                                                                                    \
-  using PointSetFunction##y = PointSetFunction<ITK_TEMPLATE_3 x>;                                                      \
-  }                                                                                                                    \
+#define ITK_TEMPLATE_PointSetFunction(_, EXPORT, x, y)            \
+  namespace itk                                                   \
+  {                                                               \
+  _(3(class EXPORT PointSetFunction<ITK_TEMPLATE_3 x>))           \
+  namespace Templates                                             \
+  {                                                               \
+  using PointSetFunction##y = PointSetFunction<ITK_TEMPLATE_3 x>; \
+  }                                                               \
   }
 
 

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -154,25 +154,25 @@ test_RegionGrowKLMExceptionHandling()
   bool passed;
 
 #undef LOCAL_TEST_EXCEPTION_MACRO
-#define LOCAL_TEST_EXCEPTION_MACRO(MSG, FILTER)                                                                        \
-  passed = false;                                                                                                      \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    std::cout << MSG << std::endl;                                                                                     \
-    FILTER->Update();                                                                                                  \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & err)                                                                             \
-  {                                                                                                                    \
-    std::cout << "Caught expected error." << std::endl;                                                                \
-    std::cout << err << std::endl;                                                                                     \
-    FILTER->ResetPipeline();                                                                                           \
-    passed = true;                                                                                                     \
-  }                                                                                                                    \
-  if (!passed)                                                                                                         \
-  {                                                                                                                    \
-    std::cout << "Test FAILED" << std::endl;                                                                           \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define LOCAL_TEST_EXCEPTION_MACRO(MSG, FILTER)         \
+  passed = false;                                       \
+  try                                                   \
+  {                                                     \
+    std::cout << MSG << std::endl;                      \
+    FILTER->Update();                                   \
+  }                                                     \
+  catch (const itk::ExceptionObject & err)              \
+  {                                                     \
+    std::cout << "Caught expected error." << std::endl; \
+    std::cout << err << std::endl;                      \
+    FILTER->ResetPipeline();                            \
+    passed = true;                                      \
+  }                                                     \
+  if (!passed)                                          \
+  {                                                     \
+    std::cout << "Test FAILED" << std::endl;            \
+    return EXIT_FAILURE;                                \
+  }                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
   // maximum number of regions must be greater than 1
@@ -285,17 +285,17 @@ test_regiongrowKLM1D()
   KLMFilter->SetGridSize(gridSize);
 
 #undef LOCAL_TEST_EXCEPTION_MACRO
-#define LOCAL_TEST_EXCEPTION_MACRO(FILTER)                                                                             \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    FILTER->Update();                                                                                                  \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & err)                                                                             \
-  {                                                                                                                    \
-    std::cout << "Caught unexpected error." << std::endl;                                                              \
-    std::cout << err << std::endl;                                                                                     \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define LOCAL_TEST_EXCEPTION_MACRO(FILTER)                \
+  try                                                     \
+  {                                                       \
+    FILTER->Update();                                     \
+  }                                                       \
+  catch (const itk::ExceptionObject & err)                \
+  {                                                       \
+    std::cout << "Caught unexpected error." << std::endl; \
+    std::cout << err << std::endl;                        \
+    return EXIT_FAILURE;                                  \
+  }                                                       \
   std::cout << std::endl << "Filter has been udpated" << std::endl
 
   std::cout << std::endl << "First test, lambda = 0" << std::endl;

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
@@ -389,27 +389,27 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest(int, char *[])
   //
   bool pass;
 
-#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent)                                          \
-  filter->Set##ComponentName(badComponent);                                                                            \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    pass = false;                                                                                                      \
-    filter->Update();                                                                                                  \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & err)                                                                             \
-  {                                                                                                                    \
-    std::cout << "Caught expected ExceptionObject" << std::endl;                                                       \
-    std::cout << err << std::endl;                                                                                     \
-    pass = true;                                                                                                       \
-    filter->ResetPipeline();                                                                                           \
-  }                                                                                                                    \
-  filter->Set##ComponentName(goodComponent);                                                                           \
-                                                                                                                       \
-  if (!pass)                                                                                                           \
-  {                                                                                                                    \
-    std::cout << "Test failed." << std::endl;                                                                          \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
+  filter->Set##ComponentName(badComponent);                                   \
+  try                                                                         \
+  {                                                                           \
+    pass = false;                                                             \
+    filter->Update();                                                         \
+  }                                                                           \
+  catch (const itk::ExceptionObject & err)                                    \
+  {                                                                           \
+    std::cout << "Caught expected ExceptionObject" << std::endl;              \
+    std::cout << err << std::endl;                                            \
+    pass = true;                                                              \
+    filter->ResetPipeline();                                                  \
+  }                                                                           \
+  filter->Set##ComponentName(goodComponent);                                  \
+                                                                              \
+  if (!pass)                                                                  \
+  {                                                                           \
+    std::cout << "Test failed." << std::endl;                                 \
+    return EXIT_FAILURE;                                                      \
+  }                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(ShapeFunction, nullptr, shape);

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
@@ -225,26 +225,26 @@ itkShapePriorMAPCostFunctionTest(int, char *[])
 
   bool pass;
 
-#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent)                                          \
-  costFunction->Set##ComponentName(badComponent);                                                                      \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    pass = false;                                                                                                      \
-    costFunction->Initialize();                                                                                        \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & err)                                                                             \
-  {                                                                                                                    \
-    std::cout << "Caught expected ExceptionObject" << std::endl;                                                       \
-    std::cout << err << std::endl;                                                                                     \
-    pass = true;                                                                                                       \
-  }                                                                                                                    \
-  costFunction->Set##ComponentName(goodComponent);                                                                     \
-                                                                                                                       \
-  if (!pass)                                                                                                           \
-  {                                                                                                                    \
-    std::cout << "Test failed." << std::endl;                                                                          \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
+  costFunction->Set##ComponentName(badComponent);                             \
+  try                                                                         \
+  {                                                                           \
+    pass = false;                                                             \
+    costFunction->Initialize();                                               \
+  }                                                                           \
+  catch (const itk::ExceptionObject & err)                                    \
+  {                                                                           \
+    std::cout << "Caught expected ExceptionObject" << std::endl;              \
+    std::cout << err << std::endl;                                            \
+    pass = true;                                                              \
+  }                                                                           \
+  costFunction->Set##ComponentName(goodComponent);                            \
+                                                                              \
+  if (!pass)                                                                  \
+  {                                                                           \
+    std::cout << "Test failed." << std::endl;                                 \
+    return EXIT_FAILURE;                                                      \
+  }                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
   TEST_INITIALIZATION_ERROR(ShapeFunction, nullptr, shape);

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
@@ -209,26 +209,26 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   // Exercise error testing
   bool pass;
 
-#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent)                                          \
-  shape->Set##ComponentName(badComponent);                                                                             \
-  try                                                                                                                  \
-  {                                                                                                                    \
-    pass = false;                                                                                                      \
-    shape->Initialize();                                                                                               \
-  }                                                                                                                    \
-  catch (const itk::ExceptionObject & err)                                                                             \
-  {                                                                                                                    \
-    std::cout << "Caught expected ExceptionObject" << std::endl;                                                       \
-    std::cout << err << std::endl;                                                                                     \
-    pass = true;                                                                                                       \
-  }                                                                                                                    \
-  shape->Set##ComponentName(goodComponent);                                                                            \
-                                                                                                                       \
-  if (!pass)                                                                                                           \
-  {                                                                                                                    \
-    std::cout << "Test failed." << std::endl;                                                                          \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
+#define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
+  shape->Set##ComponentName(badComponent);                                    \
+  try                                                                         \
+  {                                                                           \
+    pass = false;                                                             \
+    shape->Initialize();                                                      \
+  }                                                                           \
+  catch (const itk::ExceptionObject & err)                                    \
+  {                                                                           \
+    std::cout << "Caught expected ExceptionObject" << std::endl;              \
+    std::cout << err << std::endl;                                            \
+    pass = true;                                                              \
+  }                                                                           \
+  shape->Set##ComponentName(goodComponent);                                   \
+                                                                              \
+  if (!pass)                                                                  \
+  {                                                                           \
+    std::cout << "Test failed." << std::endl;                                 \
+    return EXIT_FAILURE;                                                      \
+  }                                                                           \
   ITK_MACROEND_NOOP_STATEMENT
 
   // nullptr MeanImage

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.hxx
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.hxx
@@ -50,14 +50,14 @@ OpenCVImageBridge::IplImageToITKImage(const IplImage * in)
   // Do the conversion
   typename ImageType::Pointer out = ImageType::New();
 
-#define CONVERSION_CASE(iplInputDepthID, itkOutputPixelType)                                                           \
-  case (iplInputDepthID):                                                                                              \
-  {                                                                                                                    \
-    static_assert((iplInputDepthID) <= NumericTraits<DepthIDType>::max() &&                                            \
-                    (iplInputDepthID) >= NumericTraits<DepthIDType>::min(),                                            \
-                  "Invalid IPL depth ID: " #iplInputDepthID);                                                          \
-    ITKConvertIplImageBuffer<ImageType, itkOutputPixelType>(in, out.GetPointer(), (iplInputDepthID));                  \
-    break;                                                                                                             \
+#define CONVERSION_CASE(iplInputDepthID, itkOutputPixelType)                                          \
+  case (iplInputDepthID):                                                                             \
+  {                                                                                                   \
+    static_assert((iplInputDepthID) <= NumericTraits<DepthIDType>::max() &&                           \
+                    (iplInputDepthID) >= NumericTraits<DepthIDType>::min(),                           \
+                  "Invalid IPL depth ID: " #iplInputDepthID);                                         \
+    ITKConvertIplImageBuffer<ImageType, itkOutputPixelType>(in, out.GetPointer(), (iplInputDepthID)); \
+    break;                                                                                            \
   }
 
   switch (static_cast<DepthIDType>(in->depth))
@@ -92,14 +92,14 @@ OpenCVImageBridge::CVMatToITKImage(const cv::Mat & in)
 
   typename ImageType::Pointer out = ImageType::New();
 
-#define CONVERSION_CASE(inputDepthID, itkOutputPixelType)                                                              \
-  case (inputDepthID):                                                                                                 \
-  {                                                                                                                    \
-    static_assert((inputDepthID) <= NumericTraits<DepthIDType>::max() &&                                               \
-                    (inputDepthID) >= NumericTraits<DepthIDType>::min(),                                               \
-                  "Invalid Mat depth ID: " #inputDepthID);                                                             \
-    ITKConvertMatImageBuffer<ImageType, itkOutputPixelType>(in, out.GetPointer());                                     \
-    break;                                                                                                             \
+#define CONVERSION_CASE(inputDepthID, itkOutputPixelType)                          \
+  case (inputDepthID):                                                             \
+  {                                                                                \
+    static_assert((inputDepthID) <= NumericTraits<DepthIDType>::max() &&           \
+                    (inputDepthID) >= NumericTraits<DepthIDType>::min(),           \
+                  "Invalid Mat depth ID: " #inputDepthID);                         \
+    ITKConvertMatImageBuffer<ImageType, itkOutputPixelType>(in, out.GetPointer()); \
+    break;                                                                         \
   }
 
   switch (static_cast<DepthIDType>(in.depth()))

--- a/Modules/Video/BridgeVXL/test/vidl_itk_istreamTest.cxx
+++ b/Modules/Video/BridgeVXL/test/vidl_itk_istreamTest.cxx
@@ -41,11 +41,11 @@ TestFormat(vidl_pixel_format expectedFormat)
   return out;
 }
 
-#define TestFormatMacro(PixelType, expectedFormat)                                                                     \
-  if (!TestFormat<PixelType>(expectedFormat))                                                                          \
-  {                                                                                                                    \
-    std::cerr << "format() did not return expected result for pixel type " << typeid(PixelType).name() << std::endl;   \
-    return EXIT_FAILURE;                                                                                               \
+#define TestFormatMacro(PixelType, expectedFormat)                                                                   \
+  if (!TestFormat<PixelType>(expectedFormat))                                                                        \
+  {                                                                                                                  \
+    std::cerr << "format() did not return expected result for pixel type " << typeid(PixelType).name() << std::endl; \
+    return EXIT_FAILURE;                                                                                             \
   }
 
 //
@@ -117,10 +117,10 @@ vidl_itk_istreamTestWithPixelType(char * argv[], vidl_pixel_format expectedForma
   return EXIT_SUCCESS;
 }
 
-#define TemplatedTestMacro(PixelType, expectedFormat)                                                                  \
-  if (vidl_itk_istreamTestWithPixelType<PixelType>(argv, expectedFormat) == EXIT_FAILURE)                              \
-  {                                                                                                                    \
-    return EXIT_FAILURE;                                                                                               \
+#define TemplatedTestMacro(PixelType, expectedFormat)                                     \
+  if (vidl_itk_istreamTestWithPixelType<PixelType>(argv, expectedFormat) == EXIT_FAILURE) \
+  {                                                                                       \
+    return EXIT_FAILURE;                                                                  \
   }
 
 //

--- a/Modules/Video/Core/test/itkTemporalDataObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalDataObjectTest.cxx
@@ -25,27 +25,27 @@ int
 itkTemporalDataObjectTest(int, char *[])
 {
 
-#define CHECK_FOR_VALUE(a, b)                                                                                          \
-  {                                                                                                                    \
-    if (a != b)                                                                                                        \
-    {                                                                                                                  \
-      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define CHECK_FOR_VALUE(a, b)                                                            \
+  {                                                                                      \
+    if (a != b)                                                                          \
+    {                                                                                    \
+      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl; \
+      return EXIT_FAILURE;                                                               \
+    }                                                                                    \
+  }                                                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define ITK_CHECK_FOR_VALUE(a, b)                                                                                      \
-  {                                                                                                                    \
-    if (a != b)                                                                                                        \
-    {                                                                                                                  \
-      std::cerr << "Error in " #a << std::endl;                                                                        \
-      a.Print(std::cerr);                                                                                              \
-      std::cerr << " != " << std::endl;                                                                                \
-      b.Print(std::cerr);                                                                                              \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define ITK_CHECK_FOR_VALUE(a, b)               \
+  {                                             \
+    if (a != b)                                 \
+    {                                           \
+      std::cerr << "Error in " #a << std::endl; \
+      a.Print(std::cerr);                       \
+      std::cerr << " != " << std::endl;         \
+      b.Print(std::cerr);                       \
+      return EXIT_FAILURE;                      \
+    }                                           \
+  }                                             \
   ITK_MACROEND_NOOP_STATEMENT
 
   // TODO HACK FIXME

--- a/Modules/Video/Core/test/itkTemporalRegionTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalRegionTest.cxx
@@ -24,14 +24,14 @@ int
 itkTemporalRegionTest(int, char *[])
 {
 
-#define CHECK_FOR_VALUE(a, b)                                                                                          \
-  {                                                                                                                    \
-    if (a != b)                                                                                                        \
-    {                                                                                                                  \
-      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl;                               \
-      return EXIT_FAILURE;                                                                                             \
-    }                                                                                                                  \
-  }                                                                                                                    \
+#define CHECK_FOR_VALUE(a, b)                                                            \
+  {                                                                                      \
+    if (a != b)                                                                          \
+    {                                                                                    \
+      std::cerr << "Error in " #a << " expected " << b << " but got " << a << std::endl; \
+      return EXIT_FAILURE;                                                               \
+    }                                                                                    \
+  }                                                                                      \
   ITK_MACROEND_NOOP_STATEMENT
 
   // Test arrays for frame durations

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -263,19 +263,19 @@ VideoFileReader<TOutputVideoStream>::DoConvertBuffer(void * inputData, FrameOffs
   PixelType *  outputData = this->GetOutput()->GetFrame(frameNumber)->GetPixelContainer()->GetBufferPointer();
   unsigned int numberOfPixels = this->GetOutput()->GetFrame(frameNumber)->GetPixelContainer()->Size();
   bool         isVectorImage(strcmp(this->GetOutput()->GetFrame(frameNumber)->GetNameOfClass(), "VectorImage") == 0);
-#define ITK_CONVERT_BUFFER_IF_BLOCK(_CType, type)                                                                      \
-  else if (m_VideoIO->GetComponentType() == _CType)                                                                    \
-  {                                                                                                                    \
-    if (isVectorImage)                                                                                                 \
-    {                                                                                                                  \
-      ConvertPixelBuffer<type, PixelType, ConvertPixelTraits>::ConvertVectorImage(                                     \
-        static_cast<type *>(inputData), m_VideoIO->GetNumberOfComponents(), outputData, numberOfPixels);               \
-    }                                                                                                                  \
-    else                                                                                                               \
-    {                                                                                                                  \
-      ConvertPixelBuffer<type, PixelType, ConvertPixelTraits>::Convert(                                                \
-        static_cast<type *>(inputData), m_VideoIO->GetNumberOfComponents(), outputData, numberOfPixels);               \
-    }                                                                                                                  \
+#define ITK_CONVERT_BUFFER_IF_BLOCK(_CType, type)                                                        \
+  else if (m_VideoIO->GetComponentType() == _CType)                                                      \
+  {                                                                                                      \
+    if (isVectorImage)                                                                                   \
+    {                                                                                                    \
+      ConvertPixelBuffer<type, PixelType, ConvertPixelTraits>::ConvertVectorImage(                       \
+        static_cast<type *>(inputData), m_VideoIO->GetNumberOfComponents(), outputData, numberOfPixels); \
+    }                                                                                                    \
+    else                                                                                                 \
+    {                                                                                                    \
+      ConvertPixelBuffer<type, PixelType, ConvertPixelTraits>::Convert(                                  \
+        static_cast<type *>(inputData), m_VideoIO->GetNumberOfComponents(), outputData, numberOfPixels); \
+    }                                                                                                    \
   }
 
   if (false)

--- a/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
+++ b/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
@@ -57,8 +57,8 @@ extern "C"
 
 static void ** _ITKCommonPython_API;
 
-#  define _ITKCommonPython_GetGlobalSingletonIndex                                                                     \
-    (*(_ITKCommonPython_GetGlobalSingletonIndex_RETURN(*) _ITKCommonPython_GetGlobalSingletonIndex_PROTO)              \
+#  define _ITKCommonPython_GetGlobalSingletonIndex                                                        \
+    (*(_ITKCommonPython_GetGlobalSingletonIndex_RETURN(*) _ITKCommonPython_GetGlobalSingletonIndex_PROTO) \
        _ITKCommonPython_API[_ITKCommonPython_GetGlobalSingletonIndex_NUM])
 /* Return -1 on error, 0 on success.
  * PyCapsule_Import will set an exception if there's an error.


### PR DESCRIPTION
Aligns escaped (`\`) newlines as far left as possible, according to
https://clang.llvm.org/docs/ClangFormatStyleOptions.html
Applies especially to macro definitions.

Aims to fix a kwrobot-v1/ghostflow-check-master error at pull request
#2785
"Remove virtual from Get/Set macro definitions", as reported by
Dženan Zukić:

> commit 8f26661 creates blob [...] at Modules/Core/Common/include/itkMacro.h
> with size 101090 bytes (98.72 KiB) which is greater than the maximum
> size 100000 bytes (97.66 KiB). If the file is intended to be
> committed, set the hooks-max-size attribute on its path.

Tip of the day: when looking at the diff ([Files changed](https://github.com/InsightSoftwareConsortium/ITK/pull/2790/files)) in GitHub, you may like to switch from "Split" to "Unified" view.