### PR TITLE
COMP: fix VS2017 compile error in itkFEMElementStd.h

### DIFF
--- a/Modules/Numerics/FEM/include/itkFEMElementStd.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementStd.h
@@ -72,7 +72,7 @@ public:
   using typename Superclass::Float;
   using typename Superclass::MatrixType;
   using typename Superclass::VectorType;
-  using typename Superclass::LoadType;
+  using LoadType = typename Superclass::LoadType;
   using typename Superclass::LoadPointer;
   using typename Superclass::NodeIDType;
   using typename Superclass::DegreeOfFreedomIDType;


### PR DESCRIPTION
m:\dashboard\itk\modules\numerics\fem\include\itkFEMElementStd.h(75): error C2886: 'FEMLightObject': symbol cannot be used in a member using-declaration [M:\Dashboard\ITK-build\Modules\Numerics\FEM\src\ITKFEM.vcxproj]

Fixes #2789.

