### PR TITLE
COMP: Fix undeclared identifier error

### DIFF
--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
@@ -81,7 +81,7 @@ public:
   itkGetMacro(Direction, unsigned int);
 
   /** Set the direction in which the filter is to be applied. */
-  itkSetClampMacro(Direction, unsigned int, 0, ImageDimension - 1);
+  itkSetClampMacro(Direction, unsigned int, 0, InputImageType::ImageDimension - 1);
 
   /** Get the greatest supported prime factor. */
   virtual SizeValueType

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
@@ -64,7 +64,7 @@ public:
   itkGetMacro(Direction, unsigned int);
 
   /** Set the direction in which the filter is to be applied. */
-  itkSetClampMacro(Direction, unsigned int, 0, ImageDimension - 1);
+  itkSetClampMacro(Direction, unsigned int, 0, InputImageType::ImageDimension - 1);
 
   /** Get the greatest supported prime factor. */
   virtual SizeValueType

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -65,7 +65,7 @@ public:
   itkGetMacro(Direction, unsigned int);
 
   /** Set the direction in which the filter is to be applied. */
-  itkSetClampMacro(Direction, unsigned int, 0, ImageDimension - 1);
+  itkSetClampMacro(Direction, unsigned int, 0, InputImageType::ImageDimension - 1);
 
   /** Get the greatest supported prime factor. */
   virtual SizeValueType


### PR DESCRIPTION
Fix undeclared identifier error.

Fixes:
```
In file included from
/Users/builder/externalModules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx:27:
/Users/builder/externalModules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h:84:48:
error: use of undeclared identifier 'ImageDimension'
  itkSetClampMacro(Direction, unsigned int, 0, ImageDimension - 1);
                                               ^
```

and
```
In file included from
/Users/builder/externalModules/Filtering/FFT/test/itkFFT1DImageFilterTest.cxx:25:
/Users/builder/externalModules/Filtering/FFT/include/itkForward1DFFTImageFilter.h:67:48:
error: use of undeclared identifier 'ImageDimension'
  itkSetClampMacro(Direction, unsigned int, 0, ImageDimension - 1);
                                               ^
```

and
```
In file included from
/Users/builder/externalModules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx:26:
/Users/builder/externalModules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h:68:48:
error: use of undeclared identifier 'ImageDimension'
  itkSetClampMacro(Direction, unsigned int, 0, ImageDimension - 1);
                                               ^
```

reported for example at:
https://open.cdash.org/viewBuildError.php?buildid=7505348

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)