### PR TITLE
COMP: Fix KWStyle check errors from cxx files Modules/Core/Common/CMake

### DIFF
--- a/Modules/Core/Common/CMake/itkCheckHasFeenableexcept.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFeenableexcept.cxx
@@ -1,3 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
 #include <cfenv>
 
 int

--- a/Modules/Core/Common/CMake/itkCheckHasFegetenv.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFegetenv.cxx
@@ -1,3 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
 #include <fenv.h>
 
 int

--- a/Modules/Core/Common/CMake/itkCheckHasFenvtStructMember.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFenvtStructMember.cxx
@@ -1,3 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
 #include <fenv.h>
 
 int

--- a/Modules/Core/Common/CMake/itkCheckHasFeraiseexcept.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFeraiseexcept.cxx
@@ -1,3 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
 #include <fenv.h>
 
 int

--- a/Modules/Core/Common/CMake/itkCheckHasFesetenv.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFesetenv.cxx
@@ -1,3 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
 #include <fenv.h>
 
 int

--- a/Modules/Core/Common/CMake/itkCheckHasGNUAttributeAligned.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasGNUAttributeAligned.cxx
@@ -1,3 +1,26 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+namespace itk
+{
+// Opened this namespace, just to avoid KWStyle check error, "namespace not defined".
+}
+
 //
 // Check if the compoler support the GNU attribute extension for
 // alignment, and does not contain a bug which causes internal
@@ -38,7 +61,7 @@ class foo
 
 // This structure will generate a compiler error if the template
 // argument is false
-template <bool t>
+template <bool V>
 struct OnlyTrue;
 template <>
 struct OnlyTrue<true>

--- a/Modules/Core/Common/CMake/itkCheckHasMallinfo.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasMallinfo.cxx
@@ -1,3 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
 #include <malloc.h>
 
 int

--- a/Modules/Core/Common/CMake/itkCheckHasMallinfo2.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasMallinfo2.cxx
@@ -1,3 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
 #include <malloc.h>
 
 int

--- a/Modules/Core/Common/CMake/itkGetCXXCompilerVersion.cxx
+++ b/Modules/Core/Common/CMake/itkGetCXXCompilerVersion.cxx
@@ -1,3 +1,21 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
 #include <iostream>
 
 int


### PR DESCRIPTION
Fixed KWStyle check "Header mismatch" errors, by adding a copyright
notice header to each cxx file in Modules/Core/Common/CMake

Fixed two more KWStyle check errors in itkCheckHasGNUAttributeAligned.cxx:
- line 17: error: namespace not defined
- line 59: error: Template definition (t) doesn't match regular expression