### PR TITLE
ENH: Default override 1D FFT class destructors

### DIFF
--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
@@ -92,7 +92,7 @@ public:
 
 protected:
   ComplexToComplex1DFFTImageFilter();
-  ~ComplexToComplex1DFFTImageFilter() override{};
+  ~ComplexToComplex1DFFTImageFilter() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
@@ -75,7 +75,7 @@ public:
 
 protected:
   Forward1DFFTImageFilter();
-  ~Forward1DFFTImageFilter() override{};
+  ~Forward1DFFTImageFilter() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -76,7 +76,7 @@ public:
 
 protected:
   Inverse1DFFTImageFilter();
-  ~Inverse1DFFTImageFilter() override{};
+  ~Inverse1DFFTImageFilter() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
@@ -59,8 +59,8 @@ protected:
   void
   GenerateData() override;
 
-  VnlInverse1DFFTImageFilter() {}
-  ~VnlInverse1DFFTImageFilter() override{};
+  VnlInverse1DFFTImageFilter() = default;
+  ~VnlInverse1DFFTImageFilter() override = default;
 };
 
 } // end namespace itk


### PR DESCRIPTION
- COMP: Mark class destructors with `override`
- STYLE: Prefer = default to explicitly trivial implementations 

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)