### PR TITLE
BUG: Correct extra reference count from ObjectFactory<Self>::Create()

### DIFF
--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.hxx
@@ -86,6 +86,11 @@ ComplexToComplexFFTImageFilter<TImage>::New() -> Pointer
     smartPtr =
       DispatchFFTW_Complex_New<Pointer, TImage, typename NumericTraits<typename TImage::PixelType>::ValueType>::Apply();
   }
+  else
+  {
+    // Correct extra reference count from ObjectFactory<Self>::Create()
+    smartPtr->UnRegister();
+  }
 
   return smartPtr;
 }

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
@@ -74,6 +74,11 @@ ForwardFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
       DispatchFFTW_Forward_New<Pointer, TInputImage, TOutputImage, typename NumericTraits<OutputPixelType>::ValueType>::
         Apply();
   }
+  else
+  {
+    // Correct extra reference count from ::itk::ObjectFactory<Self>::Create()
+    smartPtr->UnRegister();
+  }
 
   return smartPtr;
 }

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -72,6 +72,11 @@ HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::New() -> Po
   {
     smartPtr = Dispatch_C2R_New<Pointer, TInputImage, TOutputImage, OutputPixelType>::Apply();
   }
+  else
+  {
+    // Correct extra reference count from ::itk::ObjectFactory<Self>::Create()
+    smartPtr->UnRegister();
+  }
 
   return smartPtr;
 }

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
@@ -73,6 +73,11 @@ InverseFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
   {
     smartPtr = Dispatch_Inverse_New<Pointer, TInputImage, TOutputImage, OutputPixelType>::Apply();
   }
+  else
+  {
+    // Correct extra reference count from ::itk::ObjectFactory<Self>::Create()
+    smartPtr->UnRegister();
+  }
 
   return smartPtr;
 }

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -73,6 +73,11 @@ RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::New() -> Po
       DispatchFFTW_R2C_New<Pointer, TInputImage, TOutputImage, typename NumericTraits<OutputPixelType>::ValueType>::
         Apply();
   }
+  else
+  {
+    // Correct extra reference count from ::itk::ObjectFactory<Self>::Create()
+    smartPtr->UnRegister();
+  }
 
   return smartPtr;
 }


### PR DESCRIPTION
As discussed in #2744, calls to `ObjectFactory<Self>::Create()` that return a non-null `SmartPointer` require a call to `UnRegister()` prior to being returned by a `New()` method.  The present pull request adds the call to `UnRegister()` to code that should have had that.

N.B. 1: This has not shown up as a memory leak.  I believe it is the case that `Create()` path for creating these objects always produced a null pointer in our test suite, and thus the bug was never applicable.

N.B. 2: In contrast, PR #2744 will eventually change the functionality of `Create()` and similar methods so that the reference counts come back ready to be returned by `New()`.  That pull request has been deferred to ITK 6.0.0, at which point the instances of `UnRegister()` added here, and those already present in other places, will be removed.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
