### PR TITLE
ENH: Update to newer third-party update script

### DIFF
--- a/Utilities/Maintenance/update-third-party.bash
+++ b/Utilities/Maintenance/update-third-party.bash
@@ -85,7 +85,8 @@ disable_custom_gitattributes() {
     pushd "${extractdir}/${name}-reduced"
     # Git does not allow custom attributes in a subdirectory where we
     # are about to merge the `.gitattributes` file, so disable them.
-    sed -i '/^\[attr\]/ {s/^/#/;}' .gitattributes
+    sed -i.bak -e '/^\[attr\]/ {s/^/#/;}' .gitattributes
+    rm .gitattributes.bak
     popd
 }
 


### PR DESCRIPTION
Update to `update-common.sh` from commit `159297a9bfd` in

    https://gitlab.kitware.com/utils/git-import-third-party

Manually preserve ITK's change from commit 5dccc2207e (BUG: Do not gpg
sign third party updates, 2018-11-19, `v5.0b02~82^2~1`).
