### PR TITLE
ENH: Default override VNL 1D FFT class destructors

### DIFF
--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
@@ -57,8 +57,8 @@ public:
   itkTypeMacro(VnlComplexToComplex1DFFTImageFilter, ComplexToComplex1DFFTImageFilter);
 
 protected:
-  VnlComplexToComplex1DFFTImageFilter() {}
-  ~VnlComplexToComplex1DFFTImageFilter() override{};
+  VnlComplexToComplex1DFFTImageFilter() = default;
+  ~VnlComplexToComplex1DFFTImageFilter() override = default;
 
   void
   GenerateData() override;

--- a/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
@@ -58,8 +58,8 @@ protected:
   void
   GenerateData() override;
 
-  VnlForward1DFFTImageFilter() {}
-  ~VnlForward1DFFTImageFilter() override{};
+  VnlForward1DFFTImageFilter() = default;
+  ~VnlForward1DFFTImageFilter() override = default;
 
 private:
 };


### PR DESCRIPTION
- COMP: Mark class destructors with `override`
- STYLE: Prefer = default to explicitly trivial implementations 

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
