### PR TITLE
STYLE: Mark FFTW 1D FFT class destructors with `override`

### DIFF
--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
@@ -68,7 +68,7 @@ public:
 
 protected:
   FFTWComplexToComplex1DFFTImageFilter();
-  virtual ~FFTWComplexToComplex1DFFTImageFilter();
+  ~FFTWComplexToComplex1DFFTImageFilter() override;
 
   void
   BeforeThreadedGenerateData() override;

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
@@ -70,7 +70,7 @@ public:
 
 protected:
   FFTWForward1DFFTImageFilter();
-  virtual ~FFTWForward1DFFTImageFilter();
+  ~FFTWForward1DFFTImageFilter() override;
 
   void
   BeforeThreadedGenerateData() override;

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
@@ -70,7 +70,7 @@ public:
 
 protected:
   FFTWInverse1DFFTImageFilter();
-  virtual ~FFTWInverse1DFFTImageFilter();
+  ~FFTWInverse1DFFTImageFilter() override;
 
   void
   BeforeThreadedGenerateData() override;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Extend changes from [https://github.com/InsightSoftwareConsortium/ITK/pull/2815#pullrequestreview-779789397](https://github.com/InsightSoftwareConsortium/ITK/pull/2815#pullrequestreview-779789397) to FFTW classes.

Note that FFTW class implementation details are conditioned on compiler directives for using the FFTW backend. Constructors and destructors are defined in respective header template files and are not default.

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
