### PR TITLE
COMP: Fix error: constexpr variable 'ImageIOFactoryRegisterRegisterList'

### DIFF
--- a/CMake/itkImageIOFactoryRegisterManager.h.in
+++ b/CMake/itkImageIOFactoryRegisterManager.h.in
@@ -46,7 +46,7 @@ class ImageIOFactoryRegisterManager
 // ITK-based applications and not in ITK itself.
 //
 
-constexpr void (*ImageIOFactoryRegisterRegisterList[])(void) = {
+void (* const ImageIOFactoryRegisterRegisterList[])(void) = {
   @LIST_OF_FACTORY_NAMES@
   nullptr};
 const ImageIOFactoryRegisterManager ImageIOFactoryRegisterManagerInstance(ImageIOFactoryRegisterRegisterList);

--- a/CMake/itkMeshIOFactoryRegisterManager.h.in
+++ b/CMake/itkMeshIOFactoryRegisterManager.h.in
@@ -46,7 +46,7 @@ class MeshIOFactoryRegisterManager
 // ITK-based applications and not in ITK itself.
 //
 
-constexpr void (*MeshIOFactoryRegisterRegisterList[])(void) = {
+void (* const MeshIOFactoryRegisterRegisterList[])(void) = {
   @LIST_OF_FACTORY_NAMES@
   nullptr};
 const MeshIOFactoryRegisterManager MeshIOFactoryRegisterManagerInstance(MeshIOFactoryRegisterRegisterList);

--- a/CMake/itkTransformIOFactoryRegisterManager.h.in
+++ b/CMake/itkTransformIOFactoryRegisterManager.h.in
@@ -46,7 +46,7 @@ class TransformIOFactoryRegisterManager
 // ITK-based applications and not in ITK itself.
 //
 
-constexpr void (*TransformIOFactoryRegisterRegisterList[])(void) = {
+void (* const TransformIOFactoryRegisterRegisterList[])(void) = {
   @LIST_OF_FACTORY_NAMES@
   nullptr};
 const TransformIOFactoryRegisterManager TransformIOFactoryRegisterManagerInstance(TransformIOFactoryRegisterRegisterList);


### PR DESCRIPTION
Replaced `constexpr` by `const` in itk*IOFactoryRegisterManager.h.in
files, in order to work around ITK.Windows.Python CI errors at
Azure.fv-az77-327, build Windows_NT-Build2622-master-Python (Visual
Studio 2019 v16.11.4, MSVC 19.29.30136.0) at
https://open.cdash.org/viewBuildError.php?buildid=7515599 saying:

> D:/a/1/s-build/Wrapping/ITKFactoryRegistration\itkImageIOFactoryRegisterManager.h:49:18: error: constexpr variable 'ImageIOFactoryRegisterRegisterList' must be initialized by a constant expression

These errors occurred after pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2811
"Fix various Clang-Tidy warnings from the three
itk*IOFactoryRegisterManager.h.in files" commit f56cc7ef17d27804932e61e4b4aa764858047013
"COMP: Add "const" to `IOFactoryRegisterManager` implementations"