### PR TITLE
STYLE: Make CMake flag help text third-party toolkit names consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,9 +396,9 @@ if(ITK_USE_MKL)
   # the command line. Otherwise, the first CMake run will always initialize
   # these variables to false. The error message will help the user to set
   # the appropriate values.
-  set(ITK_USE_FFTWD ON CACHE BOOL "Use double precision fftw if found")
-  set(ITK_USE_FFTWF ON CACHE BOOL "Use single precision fftw if found")
-  set(ITK_USE_SYSTEM_FFTW ON CACHE BOOL "Use an installed version of fftw")
+  set(ITK_USE_FFTWD ON CACHE BOOL "Use double precision FFTW if found")
+  set(ITK_USE_FFTWF ON CACHE BOOL "Use single precision FFTW if found")
+  set(ITK_USE_SYSTEM_FFTW ON CACHE BOOL "Use an installed version of FFTW")
   if(NOT ITK_USE_FFTWD OR NOT ITK_USE_FFTWF OR NOT ITK_USE_SYSTEM_FFTW)
     message(FATAL_ERROR "ITK_USE_MKL is set to ON. ITK_USE_FFTWD, ITK_USE_FFTWF\
  and ITK_USE_SYSTEM_FFTW must be set to ON, too.")
@@ -411,39 +411,39 @@ if(ITK_USE_CUFFTW)
   # the command line. Otherwise, the first CMake run will always initialize
   # these variables to false. The error message will help the user to set
   # the appropriate values.
-  set(ITK_USE_FFTWD ON CACHE BOOL "Use double precision fftw if found")
-  set(ITK_USE_FFTWF ON CACHE BOOL "Use single precision fftw if found")
-  set(ITK_USE_SYSTEM_FFTW ON CACHE BOOL "Use an installed version of fftw")
+  set(ITK_USE_FFTWD ON CACHE BOOL "Use double precision FFTW if found")
+  set(ITK_USE_FFTWF ON CACHE BOOL "Use single precision FFTW if found")
+  set(ITK_USE_SYSTEM_FFTW ON CACHE BOOL "Use an installed version of FFTW")
   if(NOT ITK_USE_FFTWD OR NOT ITK_USE_FFTWF OR NOT ITK_USE_SYSTEM_FFTW)
     message(FATAL_ERROR "ITK_USE_CUFFTW is set to ON. ITK_USE_FFTWD, ITK_USE_FFTWF\
  and ITK_USE_SYSTEM_FFTW must be set to ON, too.")
   endif()
 endif()
-# ITK_USE_FFTWD -- use double precision fftw
+# ITK_USE_FFTWD -- use double precision FFTW
 if(DEFINED USE_FFTWD)
   set(ITK_USE_FFTWD_DEFAULT ${USE_FFTWD})
 else()
   set(ITK_USE_FFTWD_DEFAULT OFF)
 endif()
-option(ITK_USE_FFTWD "Use double precision fftw if found" ${ITK_USE_FFTWD_DEFAULT})
+option(ITK_USE_FFTWD "Use double precision FFTW if found" ${ITK_USE_FFTWD_DEFAULT})
 mark_as_advanced(ITK_USE_FFTWD)
 #
-# ITK_USE_FFTWF -- use single precision fftw
+# ITK_USE_FFTWF -- use single precision FFTW
 if(DEFINED USE_FFTWF)
   set(ITK_USE_FFTWF_DEFAULT ${USE_FFTWF})
 else()
   set(ITK_USE_FFTWF_DEFAULT OFF)
 endif()
-option(ITK_USE_FFTWF "Use single precision fftw if found" ${ITK_USE_FFTWF_DEFAULT})
+option(ITK_USE_FFTWF "Use single precision FFTW if found" ${ITK_USE_FFTWF_DEFAULT})
 mark_as_advanced(ITK_USE_FFTWF)
 
-# ITK_USE_SYSTEM_FFTW -- locate a readybuilt fftw installation
+# ITK_USE_SYSTEM_FFTW -- locate a readybuilt FFTW installation
 if(DEFINED USE_SYSTEM_FFTW)
   set(ITK_USE_SYSTEM_FFTW_DEFAULT ${USE_SYSTEM_FFTW})
 else()
   set(ITK_USE_SYSTEM_FFTW_DEFAULT ${ITK_USE_SYSTEM_LIBRARIES})
 endif()
-option(ITK_USE_SYSTEM_FFTW "Use an installed version of fftw" ${ITK_USE_SYSTEM_FFTW_DEFAULT})
+option(ITK_USE_SYSTEM_FFTW "Use an installed version of FFTW" ${ITK_USE_SYSTEM_FFTW_DEFAULT})
 mark_as_advanced(ITK_USE_SYSTEM_FFTW)
 
 

--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CMakeParseArguments)
 
 
 if(DCMTK_USE_ICU)
-  option(ITK_USE_SYSTEM_ICU "Use an installed version of icu" OFF)
+  option(ITK_USE_SYSTEM_ICU "Use an installed version of ICU" OFF)
   if(NOT ITK_USE_SYSTEM_ICU)
     set(ITKDCMTK_PREREQS ${ITKDCMTK_BINARY_DIR}/DCMTK_Prereqs)
     set(ITKDCMTK_ICU_LIBRARIES )


### PR DESCRIPTION
Make CMake flag help text third-party toolkit names consistent:
capitalize ICU and FFTW toolkit names.

Capitalize them in the comments as well.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)