### PR TITLE
STYLE: Remove redundant overrides of Get and Set member functions

### DIFF
--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
@@ -102,32 +102,6 @@ public:
   /** Get stop condition enum */
   itkGetConstReferenceMacro(StopCondition, StopConditionObjectToObjectOptimizerEnum);
 
-  /** Set the number of iterations. */
-  void
-  SetNumberOfIterations(const SizeValueType numberOfIterations) override
-  {
-    itkDebugMacro("setting NumberOfIterations to " << numberOfIterations);
-    if (this->m_NumberOfIterations != numberOfIterations)
-    {
-      this->m_NumberOfIterations = numberOfIterations;
-      this->Modified();
-    }
-  }
-
-  /** Get the number of iterations. */
-  SizeValueType
-  GetNumberOfIterations() const override
-  {
-    return this->m_NumberOfIterations;
-  }
-
-  /** Get the current iteration number. */
-  SizeValueType
-  GetCurrentIteration() const override
-  {
-    return this->m_CurrentIteration;
-  }
-
   /** Start and run the optimization */
   void
   StartOptimization(bool doOnlyInitialization = false) override;

--- a/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
@@ -105,13 +105,6 @@ public:
     }
   }
 
-  /** Get the fixed parameters */
-  const FixedParametersType &
-  GetRequiredFixedParameters() const override
-  {
-    return this->m_RequiredFixedParameters;
-  }
-
   /** Initialize the transform using the specified fixed parameters */
   void
   AdaptTransformParameters() override{};

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -525,13 +525,6 @@ public:
   /** Get Moving Gradient Image. */
   itkGetModifiableObjectMacro(MovingImageGradientImage, MovingImageGradientImageType);
 
-  /** Get number of valid points from most recent update */
-  SizeValueType
-  GetNumberOfValidPoints() const override
-  {
-    return this->m_NumberOfValidPoints;
-  }
-
   /** Get the number of points in the domain used to evaluate
    * the metric. This will differ depending on whether a sampled
    * point set or dense sampling is used, and will be greater than


### PR DESCRIPTION
Removed redundant overrides of the following member functions:

    TransformParametersAdaptorBase::GetRequiredFixedParameters()
    ObjectToObjectMetric::GetNumberOfValidPoints()
    ObjectToObjectOptimizerBaseTemplate::SetNumberOfIterations(SizeValueType)
    ObjectToObjectOptimizerBaseTemplate::GetNumberOfIterations()
    ObjectToObjectOptimizerBaseTemplate::GetCurrentIteration()

These overrides did just the same as the member functions that they did
override.