### PR TITLE
COMP: No longer disable MSVC warning C4503 on "decorated name length"

### DIFF
--- a/Modules/Core/Common/include/itkWin32Header.h
+++ b/Modules/Core/Common/include/itkWin32Header.h
@@ -53,9 +53,6 @@
 // 'conversion' : truncation of constant value
 #  pragma warning(disable : 4309)
 
-// decorated name length exceeded, name was truncated
-#  pragma warning(disable : 4503)
-
 // unreferenced local function has been removed
 #  pragma warning(disable : 4505)
 


### PR DESCRIPTION
According to
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=msvc-160

> Compiler Warning (level 1) C4503
> 'identifier' : decorated name length exceeded, name was truncated
>
> This compiler warning is obsolete and is not generated in
> Visual Studio 2017 and later compilers.

VS2015 may still produce this warning, but ITK dropped VS2015 support
with commit 4e812d60743a3ed7c09647e7f3f0e8498583c2da June 1, 2021
"COMP: Require compiler versions that support C++14"