### PR TITLE
STYLE: Make `ImageLabel` and `ImageNoise` modules test style consistent

### DIFF
--- a/Modules/Filtering/ImageLabel/test/itkBinaryContourImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkBinaryContourImageFilterTest.cxx
@@ -28,72 +28,61 @@ itkBinaryContourImageFilterTest(int argc, char * argv[])
 {
   if (argc != 6)
   {
-    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " intput output fullyConnected fg bg" << std::endl;
-    std::cerr << " input: the input image" << std::endl;
-    std::cerr << " output: the output image" << std::endl;
-    std::cerr << " fullyConnected: 0 or 1" << std::endl;
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
+              << " intputImage outputImage fullyConnected foregroundValue backgroundValue" << std::endl;
     return EXIT_FAILURE;
   }
 
-  constexpr unsigned int dim = 3;
+  constexpr unsigned int Dimension = 3;
 
-  using PType = unsigned char;
-  using IType = itk::Image<PType, dim>;
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader<IType>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  using FilterType = itk::BinaryContourImageFilter<IType, IType>;
+  using FilterType = itk::BinaryContourImageFilter<ImageType, ImageType>;
   auto filter = FilterType::New();
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BinaryContourImageFilter, InPlaceImageFilter);
 
-  // test default values
-  if (filter->GetFullyConnected() != false)
-  {
-    std::cerr << "Wrong default FullyConnected." << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (filter->GetForegroundValue() != 255)
-  {
-    std::cerr << "Wrong default foreground value." << std::endl;
-    return EXIT_FAILURE;
-  }
-  if (filter->GetBackgroundValue() != 0)
-  {
-    std::cerr << "Wrong default background value." << std::endl;
-    return EXIT_FAILURE;
-  }
+  // Test default values
+  ITK_TEST_EXPECT_TRUE(!filter->GetFullyConnected());
+
+  ITK_TEST_EXPECT_TRUE(filter->GetForegroundValue() == itk::NumericTraits<FilterType::OutputImagePixelType>::max());
+
+  ITK_TEST_EXPECT_TRUE(filter->GetBackgroundValue() ==
+                       itk::NumericTraits<FilterType::OutputImagePixelType>::NonpositiveMin());
+
 
   ITK_TRY_EXPECT_EXCEPTION(filter->Update());
 
   ITK_TEST_SET_GET_BOOLEAN(filter, FullyConnected, std::stoi(argv[3]));
 
-  filter->SetForegroundValue(std::stoi(argv[4]));
-  if (filter->GetForegroundValue() != std::stoi(argv[4]))
-  {
-    std::cerr << "Set/Get ForegroundValue problem." << std::endl;
-    return EXIT_FAILURE;
-  }
 
-  filter->SetBackgroundValue(std::stoi(argv[5]));
-  if (filter->GetBackgroundValue() != std::stoi(argv[5]))
-  {
-    std::cerr << "Set/Get BackgroundValue problem." << std::endl;
-    return EXIT_FAILURE;
-  }
+  auto foregroundValue = std::stoi(argv[4]);
+  filter->SetForegroundValue(foregroundValue);
+  ITK_TEST_SET_GET_VALUE(foregroundValue, filter->GetForegroundValue());
+
+  auto backgroundValue = std::stoi(argv[5]);
+  filter->SetBackgroundValue(backgroundValue);
+  ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
+
 
   filter->SetInput(reader->GetOutput());
 
   itk::SimpleFilterWatcher watcher(filter, "filter");
 
-  using WriterType = itk::ImageFileWriter<IType>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculatorTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculatorTest.cxx
@@ -28,19 +28,18 @@ itkPeakSignalToNoiseRatioCalculatorTest(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " intput noisy [expectedValue tolerance]"
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputImage noisyImage [expectedValue] [tolerance]"
               << std::endl;
-    std::cerr << " input: the input image" << std::endl;
-    std::cerr << " noisy: noise with the input image" << std::endl;
     return EXIT_FAILURE;
   }
 
-  constexpr int dim = 2;
+  constexpr unsigned int Dimension = 2;
 
-  using PType = unsigned char;
-  using IType = itk::Image<PType, dim>;
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader<IType>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   reader->Update();
@@ -49,7 +48,7 @@ itkPeakSignalToNoiseRatioCalculatorTest(int argc, char * argv[])
   reader2->SetFileName(argv[2]);
   reader2->Update();
 
-  using CalculatorType = itk::PeakSignalToNoiseRatioCalculator<IType>;
+  using CalculatorType = itk::PeakSignalToNoiseRatioCalculator<ImageType>;
   auto psnr = CalculatorType::New();
   psnr->SetImage(reader->GetOutput());
   psnr->SetNoisyImage(reader2->GetOutput());
@@ -70,5 +69,7 @@ itkPeakSignalToNoiseRatioCalculatorTest(int argc, char * argv[])
     }
   }
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageNoise/test/itkSaltAndPepperNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkSaltAndPepperNoiseImageFilterTest.cxx
@@ -29,9 +29,8 @@ itkSaltAndPepperNoiseImageFilterTest(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " intput output Probability" << std::endl;
-    std::cerr << " input: the input image" << std::endl;
-    std::cerr << " output: the output image" << std::endl;
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage Probability" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -79,5 +78,7 @@ itkSaltAndPepperNoiseImageFilterTest(int argc, char * argv[])
 
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageNoise/test/itkShotNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkShotNoiseImageFilterTest.cxx
@@ -29,7 +29,8 @@ itkShotNoiseImageFilterTest(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output [scale]" << std::endl;
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage [scale]" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -67,5 +68,7 @@ itkShotNoiseImageFilterTest(int argc, char * argv[])
 
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageNoise/test/itkSpeckleNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkSpeckleNoiseImageFilterTest.cxx
@@ -29,7 +29,9 @@ itkSpeckleNoiseImageFilterTest(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " input output [standardDeviation]" << std::endl;
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage [standardDeviation]"
+              << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -66,5 +68,7 @@ itkSpeckleNoiseImageFilterTest(int argc, char * argv[])
 
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Make `ImageLabel` and `ImageNoise` modules test style consistent with
the ITK guidelines:
- Make input argument checking messages consistent.
- Make input argument names consistent: prefer conveying the input
  argument meaning by their names rather than using an additional
  verbose explanation.
- Prefer the image dimension to be an `unsigned int` over an `int`.
- Make the image dimension name and type aliases consistent with the ITK
  style.
- Capitalize the image dimension name as it is a constant.
- Prefer using the `ITK_TEST_EXPECT_TRUE` macro to test member variable
  default values and avoid boilerplate code.
- Prefer using the values as set using the type numeric traits when
  checking the member variable default values.
- Prefer testing the Set/Get methods using the `ITK_TEST_SET_GET_VALUE`
  macro and avoid boilerplate code.
- Add a test finishing message.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes]