### PR TITLE
ENH: Add UTF-8 support for ImageSeriesReader when reading series of i…

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -275,7 +275,12 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::TestFileExistanceAndReadabili
 
   // Test if the file can be open for reading access.
   std::ifstream readTester;
+#ifdef _MSC_VER
+  const std::wstring uncpath = itksys::SystemTools::ConvertToWindowsExtendedPath(this->GetFileName().c_str());
+  readTester.open(uncpath.c_str(), std::ios::binary);
+#else
   readTester.open(this->GetFileName().c_str());
+#endif
   if (readTester.fail())
   {
     readTester.close();

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -641,7 +641,12 @@ ImageIOBase::OpenFileForReading(std::ifstream & inputStream, const std::string &
     mode |= std::ios::binary;
   }
 
+#ifdef _MSC_VER
+  const std::wstring uncpath = itksys::SystemTools::ConvertToWindowsExtendedPath(filename.c_str());
+  inputStream.open(uncpath.c_str(), std::ios::binary);
+#else
   inputStream.open(filename.c_str(), mode);
+#endif
 
   if (!inputStream.is_open() || inputStream.fail())
   {


### PR DESCRIPTION
On Windows ImageSeriesReader is not able to open images in folders that contain non-ASCII characters. As seen on many other places in ITK and GDCM code, we can use std::ifstream constructor that takes wchar_t* for filename, which is nonstandard but available only on Windows with Microsoft compiler. That way, if user pass utf8 filename any folder/filename can be opened.

This can also be related to:
https://discourse.itk.org/t/gdcmseriesfilenames-fails-to-read-folder-with-non-ascii-characters/2365
