### PR TITLE
COMP: Fix unsigned<0 warning for itkSetClampMacro.

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1047,20 +1047,20 @@ compilers.
 /** Set built-in type where value is constrained between min/max limits.
  * Create member Set"name"() (e.q., SetRadius()). \#defines are
  * convenience for clamping open-ended values. */
-#define itkSetClampMacro(name, type, min, max)                                \
-  virtual void Set##name(type _arg)                                           \
-  {                                                                           \
-    const type temp_extrema = (_arg < min ? min : (_arg > max ? max : _arg)); \
-    itkDebugMacro("setting " << #name " to " << _arg);                        \
-    CLANG_PRAGMA_PUSH                                                         \
-    CLANG_SUPPRESS_Wfloat_equal                                               \
-    if (this->m_##name != temp_extrema)                                       \
-    {                                                                         \
-      this->m_##name = temp_extrema;                                          \
-      this->Modified();                                                       \
-    }                                                                         \
-    CLANG_PRAGMA_POP                                                          \
-  }                                                                           \
+#define itkSetClampMacro(name, type, min, max)                                  \
+  virtual void Set##name(type _arg)                                             \
+  {                                                                             \
+    const type temp_extrema = (_arg <= min ? min : (_arg >= max ? max : _arg)); \
+    itkDebugMacro("setting " << #name " to " << _arg);                          \
+    CLANG_PRAGMA_PUSH                                                           \
+    CLANG_SUPPRESS_Wfloat_equal                                                 \
+    if (this->m_##name != temp_extrema)                                         \
+    {                                                                           \
+      this->m_##name = temp_extrema;                                            \
+      this->Modified();                                                         \
+    }                                                                           \
+    CLANG_PRAGMA_POP                                                            \
+  }                                                                             \
   ITK_MACROEND_NOOP_STATEMENT
 // clang-format on
 


### PR DESCRIPTION
## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
