### PR TITLE
BUG: Fix constexpr linkage issue

### DIFF
--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -87,6 +87,7 @@ public:
 
   /** The support region size: a hypercube of length SplineOrder + 1 */
   static constexpr SizeType SupportSize{ SizeType::Filled(VSplineOrder + 1) };
+  // Declaration here, definition must be outside of class until C++17, see .hxx file for linker definition
 
   /** Evaluate the weights at specified ContinuousIndex position.
    * Subclasses must provide this method. */

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -26,6 +26,20 @@
 
 namespace itk
 {
+
+#if __cplusplus < 201703L
+// For compatibility with pre C++17 International Standards, a constexpr static
+// data member may be redundantly redeclared outside the class with no
+// initializer. This usage is deprecated.
+//
+// For C++14 and earlier, the definition of static constexpr must be outside of
+// class until C++17, see .h file for declaration & initialization
+
+template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
+constexpr typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::SizeType
+  BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::SupportSize;
+#endif
+
 /** Compute weights for interpolation at continuous index position */
 template <typename TCoordRep, unsigned int VSpaceDimension, unsigned int VSplineOrder>
 typename BSplineInterpolationWeightFunction<TCoordRep, VSpaceDimension, VSplineOrder>::WeightsType


### PR DESCRIPTION
Reason: Prior to C++17 one must  provide the definition of the static
constexpr member as well as the declaration. The declaration and the
initializer go inside the class definition, but the member definition
has to be separate.

FAILED: bin/ITKCommon2TestDriver
Undefined symbols for architecture x86_64:
  "itk::BSplineInterpolationWeightFunction<float, 2u, 1u>::SupportSize", referenced from:
      itk::BSplineInterpolationWeightFunction<float, 2u, 1u>::GetSupportSize() const in itkBSplineInterpolationWeightFunctionTest.cxx.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[1081/1334] Building CXX object Modules/Registration/RegistrationMethodsv4/test/CMakeFiles/ITKRegistrationMethodsv4TestDriver.dir/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx.o
ninja: build stopped: subcommand failed.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
