### PR TITLE
ENH: Add ANTSNeighborhoodCorrelation metric wrapping

### DIFF
--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.h
@@ -114,7 +114,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(Self, Superclass);
+  itkTypeMacro(ANTSNeighborhoodCorrelationImageToImageMetricv4, ImageToImageMetricv4);
 
   /** superclass types */
   using typename Superclass::MeasureType;

--- a/Modules/Registration/Metricsv4/wrapping/itkANTSNeighborhoodCorrelationImageToImageMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkANTSNeighborhoodCorrelationImageToImageMetricv4.wrap
@@ -1,0 +1,3 @@
+itk_wrap_class("itk::ANTSNeighborhoodCorrelationImageToImageMetricv4" POINTER)
+  itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
+itk_end_wrap_class()


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


Adds Python wrapping for `itk::ANTSNeighborhoodCorrelationMetricToMetricv4`.

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
