### PR TITLE
ENH: Added template parameter for texture mask type

### DIFF
--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
@@ -90,7 +90,9 @@ namespace Statistics
  * \ingroup ITKStatistics
  */
 
-template <typename TImageType, typename THistogramFrequencyContainer = DenseFrequencyContainer2>
+template <typename TImageType,
+          typename THistogramFrequencyContainer = DenseFrequencyContainer2,
+          typename TMaskImageType = TImageType>
 class ITK_TEMPLATE_EXPORT ScalarImageToCooccurrenceMatrixFilter : public ProcessObject
 {
 public:
@@ -118,6 +120,10 @@ public:
   using OffsetVector = VectorContainer<unsigned char, OffsetType>;
   using OffsetVectorPointer = typename OffsetVector::Pointer;
   using OffsetVectorConstPointer = typename OffsetVector::ConstPointer;
+  using MaskImageType = TMaskImageType;
+  using MaskPointer = typename MaskImageType::Pointer;
+  using MaskConstPointer = typename MaskImageType::ConstPointer;
+  using MaskPixelType = typename MaskImageType::PixelType;
 
   using MeasurementType = typename NumericTraits<PixelType>::RealType;
 
@@ -164,9 +170,9 @@ public:
 
   /** Method to set/get the mask image */
   void
-  SetMaskImage(const ImageType * image);
+  SetMaskImage(const MaskImageType * image);
 
-  const ImageType *
+  const MaskImageType *
   GetMaskImage() const;
 
   /** method to get the Histogram */
@@ -175,8 +181,8 @@ public:
 
   /** Set the pixel value of the mask that should be considered "inside" the
     object. Defaults to one. */
-  itkSetMacro(InsidePixelValue, PixelType);
-  itkGetConstMacro(InsidePixelValue, PixelType);
+  itkSetMacro(InsidePixelValue, MaskPixelType);
+  itkGetConstMacro(InsidePixelValue, MaskPixelType);
 
 protected:
   ScalarImageToCooccurrenceMatrixFilter();
@@ -188,7 +194,7 @@ protected:
   FillHistogram(RadiusType radius, RegionType region);
 
   virtual void
-  FillHistogramWithMask(RadiusType radius, RegionType region, const ImageType * maskImage);
+  FillHistogramWithMask(RadiusType radius, RegionType region, const MaskImageType * maskImage);
 
   /** Standard itk::ProcessObject subclass method. */
   using DataObjectPointer = DataObject::Pointer;
@@ -215,7 +221,7 @@ private:
   MeasurementVectorType m_UpperBound;
   bool                  m_Normalize;
 
-  PixelType m_InsidePixelValue;
+  MaskPixelType m_InsidePixelValue;
 };
 } // end of namespace Statistics
 } // end of namespace itk

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
@@ -27,8 +27,9 @@ namespace itk
 {
 namespace Statistics
 {
-template <typename TImageType, typename THistogramFrequencyContainer>
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::ScalarImageToCooccurrenceMatrixFilter()
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::
+  ScalarImageToCooccurrenceMatrixFilter()
 {
   this->SetNumberOfRequiredInputs(1);
   this->SetNumberOfRequiredOutputs(1);
@@ -59,9 +60,10 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   this->m_Normalize = false;
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::SetOffset(const OffsetType offset)
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetOffset(
+  const OffsetType offset)
 {
   OffsetVectorPointer offsetVector = OffsetVector::New();
 
@@ -69,39 +71,41 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   this->SetOffsets(offsetVector);
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::SetInput(const ImageType * image)
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetInput(
+  const ImageType * image)
 {
   // Process object is not const-correct so the const_cast is required here
   this->ProcessObject::SetNthInput(0, const_cast<ImageType *>(image));
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::SetMaskImage(const ImageType * image)
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetMaskImage(
+  const MaskImageType * image)
 {
   // Process object is not const-correct so the const_cast is required here
-  this->ProcessObject::SetNthInput(1, const_cast<ImageType *>(image));
+  this->ProcessObject::SetNthInput(1, const_cast<MaskImageType *>(image));
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 const TImageType *
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::GetInput() const
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::GetInput() const
 {
   return itkDynamicCastInDebugMode<const ImageType *>(this->GetPrimaryInput());
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
-const TImageType *
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::GetMaskImage() const
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+const TMaskImageType *
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::GetMaskImage() const
 {
-  return static_cast<const ImageType *>(this->ProcessObject::GetInput(1));
+  return static_cast<const MaskImageType *>(this->ProcessObject::GetInput(1));
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 auto
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::GetOutput() const
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::GetOutput() const
   -> const HistogramType *
 {
   const auto * output = static_cast<const HistogramType *>(this->ProcessObject::GetOutput(0));
@@ -109,17 +113,18 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   return output;
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
-typename ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::DataObjectPointer
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::MakeOutput(
-  DataObjectPointerArraySizeType itkNotUsed(idx))
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+typename ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::
+  DataObjectPointer
+  ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::MakeOutput(
+    DataObjectPointerArraySizeType itkNotUsed(idx))
 {
   return HistogramType::New().GetPointer();
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::GenerateData()
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::GenerateData()
 {
   auto * output = static_cast<HistogramType *>(this->ProcessObject::GetOutput(0));
 
@@ -153,7 +158,7 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   RadiusType radius;
   radius.Fill(minRadius);
 
-  const ImageType * maskImage = nullptr;
+  const MaskImageType * maskImage = nullptr;
 
   // Check if a mask image has been provided
   //
@@ -179,10 +184,11 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   }
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::FillHistogram(RadiusType radius,
-                                                                                               RegionType region)
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::FillHistogram(
+  RadiusType radius,
+  RegionType region)
 {
   // Iterate over all of those pixels and offsets, adding each
   // co-occurrence pair to the histogram
@@ -240,12 +246,12 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   }
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::FillHistogramWithMask(
-  RadiusType        radius,
-  RegionType        region,
-  const ImageType * maskImage)
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::FillHistogramWithMask(
+  RadiusType            radius,
+  RegionType            region,
+  const MaskImageType * maskImage)
 {
   // Iterate over all of those pixels and offsets, adding each
   // co-occurrence pair to the histogram
@@ -257,9 +263,9 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   // Iterate over all of those pixels and offsets, adding each
   // co-occurrence pair to the histogram
   using NeighborhoodIteratorType = ConstNeighborhoodIterator<ImageType>;
-  NeighborhoodIteratorType neighborIt, maskNeighborIt;
-  neighborIt = NeighborhoodIteratorType(radius, input, region);
-  maskNeighborIt = NeighborhoodIteratorType(radius, maskImage, region);
+  NeighborhoodIteratorType neighborIt = NeighborhoodIteratorType(radius, input, region);
+  using MaskNeighborhoodIteratorType = ConstNeighborhoodIterator<MaskImageType>;
+  MaskNeighborhoodIteratorType maskNeighborIt = MaskNeighborhoodIteratorType(radius, maskImage, region);
 
   MeasurementVectorType             cooccur(output->GetMeasurementVectorSize());
   typename HistogramType::IndexType index;
@@ -317,9 +323,9 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   }
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::NormalizeHistogram()
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::NormalizeHistogram()
 {
   auto * output = static_cast<HistogramType *>(this->ProcessObject::GetOutput(0));
 
@@ -333,10 +339,11 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   }
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::SetPixelValueMinMax(PixelType min,
-                                                                                                     PixelType max)
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetPixelValueMinMax(
+  PixelType min,
+  PixelType max)
 {
   itkDebugMacro("setting Min to " << min << "and Max to " << max);
   m_Min = min;
@@ -346,10 +353,11 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>:
   this->Modified();
 }
 
-template <typename TImageType, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer>::PrintSelf(std::ostream & os,
-                                                                                           Indent         indent) const
+ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::PrintSelf(
+  std::ostream & os,
+  Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Offsets: " << this->GetOffsets() << std::endl;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
@@ -105,7 +105,9 @@ namespace Statistics
  * \endsphinx
  */
 
-template <typename TImageType, typename THistogramFrequencyContainer = DenseFrequencyContainer2>
+template <typename TImageType,
+          typename THistogramFrequencyContainer = DenseFrequencyContainer2,
+          typename TMaskImageType = TImageType>
 class ITK_TEMPLATE_EXPORT ScalarImageToTextureFeaturesFilter : public ProcessObject
 {
 public:
@@ -124,6 +126,9 @@ public:
   using FrequencyContainerType = THistogramFrequencyContainer;
   using ImageType = TImageType;
   using ImagePointer = typename ImageType::Pointer;
+  using MaskImageType = TMaskImageType;
+  using MaskPointer = typename MaskImageType::Pointer;
+  using MaskPixelType = typename MaskImageType::PixelType;
 
   using PixelType = typename ImageType::PixelType;
   using OffsetType = typename ImageType::OffsetType;
@@ -131,7 +136,8 @@ public:
   using OffsetVectorPointer = typename OffsetVector::Pointer;
   using OffsetVectorConstPointer = typename OffsetVector::ConstPointer;
 
-  using CooccurrenceMatrixFilterType = ScalarImageToCooccurrenceMatrixFilter<ImageType, FrequencyContainerType>;
+  using CooccurrenceMatrixFilterType =
+    ScalarImageToCooccurrenceMatrixFilter<ImageType, FrequencyContainerType, MaskImageType>;
 
   using HistogramType = typename CooccurrenceMatrixFilterType::HistogramType;
   using TextureFeaturesFilterType = HistogramToTextureFeaturesFilter<HistogramType>;
@@ -193,15 +199,15 @@ public:
   /** Connects the mask image for which the histogram is going to be computed.
       Optional; for default value see above. */
   void
-  SetMaskImage(const ImageType *);
+  SetMaskImage(const MaskImageType *);
 
-  const ImageType *
+  const MaskImageType *
   GetMaskImage() const;
 
   /** Set the pixel value of the mask that should be considered "inside" the
       object. Optional; for default value see above. */
   void
-  SetInsidePixelValue(PixelType insidePixelValue);
+  SetInsidePixelValue(MaskPixelType insidePixelValue);
 
   itkGetConstMacro(FastCalculations, bool);
   itkSetMacro(FastCalculations, bool);

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -26,8 +26,9 @@ namespace itk
 {
 namespace Statistics
 {
-template <typename TImage, typename THistogramFrequencyContainer>
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::ScalarImageToTextureFeaturesFilter()
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::
+  ScalarImageToTextureFeaturesFilter()
 {
   this->SetNumberOfRequiredInputs(1);
   this->SetNumberOfRequiredOutputs(1);
@@ -84,17 +85,17 @@ ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::Scalar
   m_FastCalculations = false;
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
-typename ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::DataObjectPointer
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::MakeOutput(
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+typename ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::DataObjectPointer
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::MakeOutput(
   DataObjectPointerArraySizeType itkNotUsed(idx))
 {
   return FeatureValueVectorDataObjectType::New().GetPointer();
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::GenerateData()
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::GenerateData()
 {
   if (m_FastCalculations)
   {
@@ -106,9 +107,9 @@ ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::Genera
   }
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::FullCompute()
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::FullCompute()
 {
   size_t    numOffsets = m_Offsets->size();
   size_t    numFeatures = m_RequestedFeatures->size();
@@ -202,9 +203,9 @@ ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::FullCo
   delete[] features;
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::FastCompute()
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::FastCompute()
 {
   // Compute the feature for the first offset
   typename OffsetVector::ConstIterator offsetIt = m_Offsets->Begin();
@@ -230,9 +231,10 @@ ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::FastCo
   standardDeviationOutputObject->Set(m_FeatureStandardDeviations);
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::SetInput(const ImageType * image)
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetInput(
+  const ImageType * image)
 {
   // Process object is not const-correct so the const_cast is required here
   this->ProcessObject::SetNthInput(0, const_cast<ImageType *>(image));
@@ -240,9 +242,9 @@ ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::SetInp
   m_GLCMGenerator->SetInput(image);
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::SetNumberOfBinsPerAxis(
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetNumberOfBinsPerAxis(
   unsigned int numberOfBins)
 {
   itkDebugMacro("setting NumberOfBinsPerAxis to " << numberOfBins);
@@ -250,70 +252,75 @@ ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::SetNum
   this->Modified();
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::SetPixelValueMinMax(PixelType min,
-                                                                                              PixelType max)
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetPixelValueMinMax(
+  PixelType min,
+  PixelType max)
 {
   itkDebugMacro("setting Min to " << min << "and Max to " << max);
   m_GLCMGenerator->SetPixelValueMinMax(min, max);
   this->Modified();
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::SetMaskImage(const ImageType * image)
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetMaskImage(
+  const MaskImageType * image)
 {
   // Process object is not const-correct so the const_cast is required here
-  this->ProcessObject::SetNthInput(1, const_cast<ImageType *>(image));
+  this->ProcessObject::SetNthInput(1, const_cast<MaskImageType *>(image));
 
   m_GLCMGenerator->SetMaskImage(image);
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
-const TImage *
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::GetInput() const
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+const TImageType *
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::GetInput() const
 {
   return itkDynamicCastInDebugMode<const ImageType *>(this->GetPrimaryInput());
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
-const typename ScalarImageToTextureFeaturesFilter<TImage,
-                                                  THistogramFrequencyContainer>::FeatureValueVectorDataObjectType *
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::GetFeatureMeansOutput() const
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+const typename ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::
+  FeatureValueVectorDataObjectType *
+  ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::GetFeatureMeansOutput()
+    const
 {
   return itkDynamicCastInDebugMode<const FeatureValueVectorDataObjectType *>(this->ProcessObject::GetOutput(0));
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
-const typename ScalarImageToTextureFeaturesFilter<TImage,
-                                                  THistogramFrequencyContainer>::FeatureValueVectorDataObjectType *
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::GetFeatureStandardDeviationsOutput() const
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+const typename ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::
+  FeatureValueVectorDataObjectType *
+  ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::
+    GetFeatureStandardDeviationsOutput() const
 {
   return itkDynamicCastInDebugMode<const FeatureValueVectorDataObjectType *>(this->ProcessObject::GetOutput(1));
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
-const TImage *
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::GetMaskImage() const
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
+const TMaskImageType *
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::GetMaskImage() const
 {
-  return static_cast<const ImageType *>(this->ProcessObject::GetInput(1));
+  return static_cast<const MaskImageType *>(this->ProcessObject::GetInput(1));
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::SetInsidePixelValue(
-  PixelType insidePixelValue)
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::SetInsidePixelValue(
+  MaskPixelType insidePixelValue)
 {
   itkDebugMacro("setting InsidePixelValue to " << insidePixelValue);
   m_GLCMGenerator->SetInsidePixelValue(insidePixelValue);
   this->Modified();
 }
 
-template <typename TImage, typename THistogramFrequencyContainer>
+template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 void
-ScalarImageToTextureFeaturesFilter<TImage, THistogramFrequencyContainer>::PrintSelf(std::ostream & os,
-                                                                                    Indent         indent) const
+ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::PrintSelf(
+  std::ostream & os,
+  Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "RequestedFeatures: " << this->GetRequestedFeatures() << std::endl;

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -36,8 +36,10 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
   // Create a simple test images
   //------------------------------------------------------
   using InputImageType = itk::Image<unsigned char, NDIMENSION>;
+  using MaskImageType = itk::Image<bool, NDIMENSION>;
 
   using InputImageIterator = itk::ImageRegionIterator<InputImageType>;
+  using MaskImageIterator = itk::ImageRegionIterator<MaskImageType>;
 
 
   auto image = InputImageType::New();
@@ -81,17 +83,17 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
   //  1 1 1 1 1
   //--------------------------------------------------------------------------
 
-  auto mask = InputImageType::New();
+  auto mask = MaskImageType::New();
   mask->SetRegions(region);
   mask->Allocate();
 
   // setup the iterator
-  InputImageIterator maskIt(mask, mask->GetBufferedRegion());
+  MaskImageIterator maskIt(mask, mask->GetBufferedRegion());
   maskIt.GoToBegin();
   for (int i = 0; i < 5; ++i)
     for (int j = 0; j < 5; j++, ++maskIt)
     {
-      maskIt.Set(1);
+      maskIt.Set(bool{ 1 });
     }
 
   //--------------------------------------------------------------------------
@@ -102,8 +104,8 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
   try
   {
 
-    using TextureFilterType =
-      itk::Statistics::ScalarImageToTextureFeaturesFilter<InputImageType, itk::Statistics::DenseFrequencyContainer2>;
+    using TextureFilterType = itk::Statistics::
+      ScalarImageToTextureFeaturesFilter<InputImageType, itk::Statistics::DenseFrequencyContainer2, MaskImageType>;
 
     // First test: just use the defaults.
     auto texFilter = TextureFilterType::New();
@@ -223,7 +225,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
     {
       if (itk::Math::abs(expectedDeviations[counter] - sIt.Value()) > 0.0001)
       {
-        std::cerr << "Error. Deiviation for feature " << counter << " is " << sIt.Value() << ", expected "
+        std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
                   << expectedDeviations[counter] << "." << std::endl;
         passed = false;
       }
@@ -252,7 +254,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
     {
       if (itk::Math::abs(expectedDeviations2[counter] - sIt.Value()) > 0.0001)
       {
-        std::cerr << "Error. Deiviation for feature " << counter << " is " << sIt.Value() << ", expected "
+        std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
                   << expectedDeviations2[counter] << "." << std::endl;
         passed = false;
       }
@@ -306,7 +308,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
     {
       if (itk::Math::abs(expectedDeviations3[counter] - sIt.Value()) > 0.0001)
       {
-        std::cerr << "Error. Deiviation for feature " << counter << " is " << sIt.Value() << ", expected "
+        std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
                   << expectedDeviations3[counter] << "." << std::endl;
         passed = false;
       }


### PR DESCRIPTION
Currently `ScalarImageToCooccurrenceMatrixFilter` assumes that the mask image would be the same type as the gray value image. This is not ideal because masks do not necessarily have to be of the same type. This limits the usability of the current design. What is more important is that forcing the mask to be of the same type can be problematic when working with floating-point types.

This PR extends `ScalarImageToCooccurrenceMatrixFilter` to add a template parameter for the mask image type, and uses the updated filter in `ScalarImageToTextureFeaturesFilter`.

This is my first contribution to ITK and I do not feel confident to say if the PR is breaking the API. It *does* add a new template parameter (with a default value) in front of an existing template parameter. So people that used both parameters before will not be able to build against this change.

Suggestions for how to change this PR would be very welcome!

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
