### PR TITLE
STYLE: Do not do `return;` directly after throwing an exception

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -125,7 +125,6 @@ VTKImageImport<TOutputImage>::PropagateRequestedRegion(DataObject * outputPtr)
   if (!output)
   {
     itkExceptionMacro(<< "Downcast from DataObject to my Image type failed.");
-    return;
   }
   Superclass::PropagateRequestedRegion(output);
   if (m_PropagateUpdateExtentCallback)

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -129,7 +129,6 @@ ByteSwapper<T>::SwapRangeFromSystemToBigEndian(T * p, BufferSizeType num)
       return;
     default:
       itkGenericExceptionMacro(<< "Cannot swap number of bytes requested");
-      return;
   }
 }
 

--- a/Modules/Core/Common/include/itkImageDuplicator.hxx
+++ b/Modules/Core/Common/include/itkImageDuplicator.hxx
@@ -40,7 +40,6 @@ ImageDuplicator<TInputImage>::Update()
   if (!m_InputImage)
   {
     itkExceptionMacro(<< "Input image has not been connected");
-    return;
   }
 
   // Update only if the input image has been modified

--- a/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
+++ b/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
@@ -44,7 +44,6 @@ ResourceProbesCollectorBase<TProbe>::Stop(const char * id)
   if (pos == this->m_Probes.end())
   {
     itkGenericExceptionMacro(<< "The probe \"" << id << "\" does not exist. It can not be stopped.");
-    return;
   }
   pos->second.Stop();
 }

--- a/Modules/Core/Common/include/itkSmapsFileParser.hxx
+++ b/Modules/Core/Common/include/itkSmapsFileParser.hxx
@@ -149,7 +149,6 @@ VMMapFileParser<TVMMapDataType>::ReadFile(const std::string & mapFileLocation)
       if (inputFile.is_open() == false)
       {
         itkGenericExceptionMacro(<< "The VMap file " << mapFileLocation << " could not be open");
-        return;
       }
       // load the file
       inputFile >> this->m_MapData;

--- a/Modules/Core/Common/include/itkStreamingImageFilter.hxx
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.hxx
@@ -120,7 +120,6 @@ StreamingImageFilter<TInputImage, TOutputImage>::UpdateOutputData(DataObject * i
   {
     itkExceptionMacro(<< "At least " << this->GetNumberOfRequiredInputs() << " inputs are required but only " << ninputs
                       << " are specified.");
-    return;
   }
 
   /**

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
@@ -60,7 +60,6 @@ PlatformMultiThreader::MultipleMethodExecute()
     if (m_MultipleMethod[thread_loop] == (ThreadFunctionType) nullptr)
     {
       itkExceptionMacro(<< "No multiple method set for: " << thread_loop);
-      return;
     }
   }
 

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
@@ -49,7 +49,6 @@ PlatformMultiThreader::MultipleMethodExecute()
     if (m_MultipleMethod[thread_loop] == (ThreadFunctionType)0)
     {
       itkExceptionMacro(<< "No multiple method set for: " << thread_loop);
-      return;
     }
   }
 

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
@@ -54,7 +54,6 @@ PlatformMultiThreader::MultipleMethodExecute()
     if (m_MultipleMethod[threadCount] == nullptr)
     {
       itkExceptionMacro(<< "No multiple method set for: " << threadCount);
-      return;
     }
   }
   // Using _beginthreadex on a PC

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1197,7 +1197,6 @@ RayCastHelper<TInputImage, TCoordRep>::InitialiseVoxelPointers()
       err.SetDescription("The ray traversal direction is unset "
                          "- InitialiseVoxelPointers().");
       throw err;
-      return;
     }
   }
 }

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
@@ -72,7 +72,6 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
   if (this->m_FileName.empty())
   {
     itkExceptionMacro("No FileName");
-    return;
   }
 
   //
@@ -85,7 +84,6 @@ VTKPolyDataWriter<TInputMesh>::GenerateData()
     itkExceptionMacro("Unable to open file\n"
                       "outputFilename= "
                       << this->m_FileName);
-    return;
   }
 
   outputFile.imbue(std::locale::classic());

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
@@ -59,7 +59,6 @@ SpatialObjectDuplicator<TInputSpatialObject>::Update()
   if (!m_Input)
   {
     itkExceptionMacro(<< "Input SpatialObject has not been connected");
-    return;
   }
 
   // Update only if the input SpatialObject has been modified

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -60,7 +60,6 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateDa
   if (m_OutputMinimum > m_OutputMaximum)
   {
     itkExceptionMacro(<< "Minimum output value cannot be greater than Maximum output value.");
-    return;
   }
 
   const TInputImage * inputImage = this->GetInput();

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -47,17 +47,14 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
   if (!this->m_Transform)
   {
     itkExceptionMacro(<< "Transform has not been set.");
-    return;
   }
   if (!this->m_Image)
   {
     itkExceptionMacro(<< "Image has not been set.");
-    return;
   }
   if (TImage::GetImageDimension() != SpaceDimension)
   {
     itkExceptionMacro(<< "Image dimensionality does not match the transform.");
-    return;
   }
 
   OriginType             transformDomainOrigin;

--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.hxx
@@ -52,7 +52,6 @@ RescaleIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateDa
   if (this->m_OutputMinimum > this->m_OutputMaximum)
   {
     itkExceptionMacro(<< "Minimum output value cannot be greater than Maximum output value.");
-    return;
   }
 
   using CalculatorType = MinimumMaximumImageCalculator<TInputImage>;

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
@@ -49,7 +49,6 @@ VectorRescaleIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGene
   if (m_OutputMaximumMagnitude < NumericTraits<OutputRealType>::ZeroValue())
   {
     itkExceptionMacro(<< "Maximum output value cannot be negative. You are passing " << m_OutputMaximumMagnitude);
-    return;
   }
 
   InputImagePointer inputImage = this->GetInput();

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.hxx
@@ -40,7 +40,6 @@ AnchorErodeDilateImageFilter<TImage, TKernel, TFunction1>::DynamicThreadedGenera
   if (!this->GetKernel().GetDecomposable())
   {
     itkExceptionMacro("Anchor morphology only works with decomposable structuring elements");
-    return;
   }
   // TFunction1 will be < for erosions
   // TFunction2 will be <=

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -42,7 +42,6 @@ AnchorOpenCloseImageFilter<TImage, TKernel, TCompare1, TCompare2>::DynamicThread
   if (!this->GetKernel().GetDecomposable())
   {
     itkExceptionMacro("Anchor morphology only works with decomposable structuring elements");
-    return;
   }
   // TFunction1 will be < for erosions
   // TFunction2 will be <=

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx
@@ -42,7 +42,6 @@ VanHerkGilWermanErodeDilateImageFilter<TImage, TKernel, TFunction1>::DynamicThre
   if (!this->GetKernel().GetDecomposable())
   {
     itkExceptionMacro("VanHerkGilWerman morphology only works with decomposable structuring elements");
-    return;
   }
 
   // TFunction1 will be < for erosions

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -202,7 +202,6 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
     default:
     {
       itkExceptionMacro(<< "Unknown Order");
-      return;
     }
   }
 }

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
@@ -95,7 +95,6 @@ IntermodesThresholdCalculator<THistogram, TOutput>::GenerateData()
     if (smIter > m_MaximumSmoothingIterations)
     {
       itkGenericExceptionMacro(<< "Exceeded maximum iterations for histogram smoothing.");
-      return;
     }
   }
 

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
@@ -81,7 +81,6 @@ ThresholdImageFilter<TImage>::ThresholdOutside(const PixelType & lower, const Pi
   if (lower > upper)
   {
     itkExceptionMacro(<< "Lower threshold cannot be greater than upper threshold.");
-    return;
   }
 
   if (Math::NotExactlyEquals(m_Lower, lower) || Math::NotExactlyEquals(m_Upper, upper))

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -132,7 +132,6 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
     }
     ImageFileReaderException e(__FILE__, __LINE__, msg.str().c_str(), ITK_LOCATION);
     throw e;
-    return;
   }
 
   // Got to allocate space for the image. Determine the characteristics of
@@ -270,7 +269,6 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::TestFileExistanceAndReadabili
     msg << "The file doesn't exist. " << std::endl << "Filename = " << this->GetFileName() << std::endl;
     e.SetDescription(msg.str().c_str());
     throw e;
-    return;
   }
 
   // Test if the file can be open for reading access.
@@ -283,7 +281,6 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::TestFileExistanceAndReadabili
     msg << "The file couldn't be opened for reading. " << std::endl << "Filename: " << this->GetFileName() << std::endl;
     ImageFileReaderException e(__FILE__, __LINE__, msg.str().c_str(), ITK_LOCATION);
     throw e;
-    return;
   }
   readTester.close();
 }
@@ -517,7 +514,6 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::DoConvertBuffer(void * inputD
     e.SetDescription(msg.str().c_str());
     e.SetLocation(ITK_LOCATION);
     throw e;
-    return;
   }
 #undef ITK_CONVERT_BUFFER_IF_BLOCK
 }

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -244,7 +244,6 @@ ImageSeriesWriter<TInputImage, TOutputImage>::WriteFiles()
   {
     itkExceptionMacro(<< "The number of filenames passed is " << m_FileNames.size() << " but " << expectedNumberOfFiles
                       << " were expected ");
-    return;
   }
 
   itkDebugMacro(<< "Number of files to write = " << m_FileNames.size());

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -89,7 +89,6 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Te
     msg << "The file doesn't exist. " << std::endl << "Filename = " << m_FileName << std::endl;
     e.SetDescription(msg.str().c_str());
     throw e;
-    return;
   }
 
   // Test if the file can be open for reading access.
@@ -102,7 +101,6 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Te
     msg << "The file couldn't be opened for reading. " << std::endl << "Filename: " << m_FileName << std::endl;
     MeshFileReaderException e(__FILE__, __LINE__, msg.str().c_str(), ITK_LOCATION);
     throw e;
-    return;
   }
   readTester.close();
 }
@@ -509,7 +507,6 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Ge
 
     MeshFileReaderException e(__FILE__, __LINE__, msg.str().c_str(), ITK_LOCATION);
     throw e;
-    return;
   }
 }
 
@@ -859,7 +856,6 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Co
     e.SetDescription(msg.str().c_str());
     e.SetLocation(ITK_LOCATION);
     throw e;
-    return;
   }
 #undef ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK
 }
@@ -931,7 +927,6 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Co
     e.SetDescription(msg.str().c_str());
     e.SetLocation(ITK_LOCATION);
     throw e;
-    return;
   }
 #undef ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK
 }

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -210,7 +210,6 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   if (normAB2 < 1e-10)
   {
     itkExceptionMacro("||AB||^2 = " << normAB2 << "\nRisk of division by zero");
-    return;
   }
 
   double E[3];
@@ -338,19 +337,16 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     if (normAB2 < 1e-10)
     {
       itkExceptionMacro("normAB2 " << normAB2);
-      return;
     }
 
     if (normBC2 < 1e-10)
     {
       itkExceptionMacro("normBC2 " << normBC2);
-      return;
     }
 
     if (normCA2 < 1e-10)
     {
       itkExceptionMacro("normCA2 " << normCA2);
-      return;
     }
 
     normAB = std::sqrt(normAB2);
@@ -368,19 +364,16 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     if (cosABC <= -1.0 || cosABC >= 1.0)
     {
       itkExceptionMacro("cosABC= " << cosABC);
-      return;
     }
 
     if (cosBCA <= -1.0 || cosBCA >= 1.0)
     {
       itkExceptionMacro("cosBCA= " << cosBCA);
-      return;
     }
 
     if (cosCAB <= -1.0 || cosCAB >= 1.0)
     {
       itkExceptionMacro("cosCAB= " << cosCAB);
-      return;
     }
 
     sinABC = std::sqrt(1.0 - cosABC * cosABC);
@@ -390,19 +383,16 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     if (sinABC < 1e-10)
     {
       itkExceptionMacro("sinABC= " << sinABC);
-      return;
     }
 
     if (sinBCA < 1e-10)
     {
       itkExceptionMacro("sinBCA= " << sinBCA);
-      return;
     }
 
     if (sinCAB < 1e-10)
     {
       itkExceptionMacro("sinCAB= " << sinCAB);
-      return;
     }
 
     cotgABC = cosABC / sinABC;

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
@@ -110,7 +110,6 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::StartOptimiz
   if (this->m_Metric.IsNull())
   {
     itkExceptionMacro("m_Metric must be set.");
-    return;
   }
 
   /* Estimate the parameter scales if requested. */

--- a/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.hxx
@@ -203,7 +203,6 @@ BSplineTransformParametersAdaptor<TTransform>::AdaptTransformParameters()
   if (!this->m_Transform)
   {
     itkExceptionMacro("Transform has not been set.");
-    return;
   }
 
   if (this->m_RequiredFixedParameters == this->m_Transform->GetFixedParameters())

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
@@ -30,17 +30,14 @@ CenteredTransformInitializer<TTransform, TFixedImage, TMovingImage>::InitializeT
   if (!m_FixedImage)
   {
     itkExceptionMacro("Fixed Image has not been set");
-    return;
   }
   if (!m_MovingImage)
   {
     itkExceptionMacro("Moving Image has not been set");
-    return;
   }
   if (!m_Transform)
   {
     itkExceptionMacro("Transform has not been set");
-    return;
   }
 
   // If images come from filters, then update those filters.

--- a/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.hxx
@@ -185,7 +185,6 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::AdaptTransformParam
   if (!this->m_Transform)
   {
     itkExceptionMacro("Transform has not been set.");
-    return;
   }
 
   if (this->m_RequiredFixedParameters == this->m_Transform->GetFixedParameters())

--- a/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.hxx
@@ -181,7 +181,6 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::AdaptTransformParameter
   if (!this->m_Transform)
   {
     itkExceptionMacro("Transform has not been set.");
-    return;
   }
 
   if (this->m_RequiredFixedParameters == this->m_Transform->GetFixedParameters())

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -350,12 +350,10 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   if (ImageDimension != 3)
   {
     itkExceptionMacro("Transform is VersorRigid3DTransform and Fixed image dimension is not 3");
-    return;
   }
   if (MovingImageType::ImageDimension != 3)
   {
     itkExceptionMacro("Transform is VersorRigid3DTransform and Moving image dimension is not 3");
-    return;
   }
 
   // --- compute the necessary transform to match the two sets of landmarks
@@ -536,12 +534,10 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   if (ImageDimension != 2)
   {
     itkExceptionMacro("Transform is Rigid2DTransfrom and Fixed image dimension is not 2");
-    return;
   }
   if (MovingImageType::ImageDimension != 2)
   {
     itkExceptionMacro("Transform is Rigid2DTransform and Moving image dimension is not 2");
-    return;
   }
 
   const double PI = 4.0 * std::atan(1.0);
@@ -663,12 +659,10 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Initia
   if (!m_Transform)
   {
     itkExceptionMacro("Transform has not been set");
-    return;
   }
   if (m_FixedLandmarks.size() != m_MovingLandmarks.size())
   {
     itkExceptionMacro("Different number of fixed and moving landmarks");
-    return;
   }
   this->InternalInitializeTransform(static_cast<TTransform *>(nullptr));
 }

--- a/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.hxx
@@ -181,7 +181,6 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::AdaptTransformPa
   if (!this->m_Transform)
   {
     itkExceptionMacro("Transform has not been set.");
-    return;
   }
 
   if (this->m_RequiredFixedParameters == this->m_Transform->GetFixedParameters())

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -302,7 +302,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   if (ImageDim > 3)
   {
     itkExceptionMacro("GPUSmoothDisplacementField supports 1/2/3D images.");
-    return;
   }
   for (int i = 0; i < ImageDim; ++i)
   {
@@ -530,7 +529,6 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
   if (ImageDim > 3)
   {
     itkExceptionMacro("GPUSmoothDisplacementField supports 1/2/3D images.");
-    return;
   }
   for (int i = 0; i < ImageDim; ++i)
   {

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -65,7 +65,6 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
   if (numberOfClasses == 0)
   {
     itkExceptionMacro("The number of components in the input Membership image is Zero !");
-    return;
   }
 
   this->AllocateOutputs();

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
@@ -55,19 +55,16 @@ ClassifierBase<TDataContainer>::Update()
   if (m_NumberOfClasses == 0)
   {
     itkExceptionMacro("Zero class");
-    return;
   }
 
   if (m_MembershipFunctions.empty())
   {
     itkExceptionMacro("No membership function");
-    return;
   }
 
   if (m_NumberOfClasses != m_MembershipFunctions.size())
   {
     itkExceptionMacro("The number of classes and the number of membership mismatch.");
-    return;
   }
 
   this->GenerateData();

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -315,7 +315,6 @@ VideoFileReader<TOutputVideoStream>::DoConvertBuffer(void * inputData, FrameOffs
     e.SetDescription(msg.str().c_str());
     e.SetLocation(ITK_LOCATION);
     throw e;
-    return;
   }
 #undef ITK_CONVERT_BUFFER_IF_BLOCK
 }


### PR DESCRIPTION
Any return statement directly after a `throw` (possibly from a call to `itkExceptionMacro` or `itkGenericExceptionMacro`) is unreachable, by definition.