### PR TITLE
BUG: Fix 1D FFT doxygen groups

### DIFF
--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
@@ -35,8 +35,8 @@ namespace itk
  * The dimension along which to apply to filter can be specified with
  * SetDirection() and GetDirection().
  *
+ * \ingroup ITKFFT
  * \ingroup FourierTransform
- * \ingroup Ultrasound
  */
 template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT ComplexToComplex1DFFTImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
@@ -31,7 +31,8 @@ namespace itk
 /** \class FFTWComplexToComplex1DFFTImageFilter
  * \brief only do FFT along one dimension using FFTW as a backend.
  *
- * \ingroup Ultrasound
+ * \ingroup ITKFFT
+ * \ingroup FourierTransform
  */
 template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT FFTWComplexToComplex1DFFTImageFilter

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
@@ -29,7 +29,8 @@ namespace itk
 /** \class FFTWInverse1DFFTImageFilter
  * \brief only do FFT along one dimension using FFTW as a backend.
  *
- * \ingroup Ultrasound
+ * \ingroup ITKFFT
+ * \ingroup FourierTransform
  */
 
 template <typename TInputImage,

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
@@ -35,8 +35,8 @@ namespace itk
  * \sa itkVnlForward1DFFTImageFilter
  * \sa itkFFTWForward1DFFTImageFilter
  *
+ * \ingroup ITKFFT
  * \ingroup FourierTransform
- * \ingroup Ultrasound
  */
 template <typename TInputImage,
           typename TOutputImage = Image<std::complex<typename TInputImage::PixelType>, TInputImage::ImageDimension>>

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -28,8 +28,8 @@ namespace itk
  * \brief Perform the Fast Fourier Transform, in the reverse direction, with
  * real output, but only along one dimension.
  *
+ * \ingroup ITKFFT
  * \ingroup FourierTransform
- * \ingroup Ultrasound
  */
 template <typename TInputImage,
           typename TOutputImage =

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
@@ -29,7 +29,8 @@ namespace itk
  * \brief Perform the FFT along one dimension of an image using Vnl as a
  * backend.
  *
- * \ingroup Ultrasound
+ * \ingroup ITKFFT
+ * \ingroup FourierTransform
  */
 template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT VnlComplexToComplex1DFFTImageFilter

--- a/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
@@ -30,7 +30,8 @@ namespace itk
  * \brief Perform the FFT along one dimension of an image using Vnl as a
  * backend.
  *
- * \ingroup Ultrasound
+ * \ingroup ITKFFT
+ * \ingroup FourierTransform
  */
 template <typename TInputImage,
           typename TOutputImage = Image<std::complex<typename TInputImage::PixelType>, TInputImage::ImageDimension>>

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
@@ -29,7 +29,8 @@ namespace itk
  * \brief Perform the FFT along one dimension of an image using Vnl as a
  * backend.
  *
- * \ingroup Ultrasound
+ * \ingroup ITKFFT
+ * \ingroup FourierTransform
  */
 template <typename TInputImage,
           typename TOutputImage =


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Fixes issue where some 1D FFT image filters moved from ITKUltrasound still referenced the Ultrasound group in header comments. This causes issues in Python module wrappings as the FFT module tries to load the Ultrasound module at init.


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
