### PR TITLE
STYLE: ITK_FUTURE_LEGACY_REMOVE itkStaticConstMacro

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -804,7 +804,12 @@ compilers.
  * and is beneficial in other cases where a value can be constant.
  *
  * \ingroup ITKCommon */
-#  define itkStaticConstMacro(name, type, value) static constexpr type name = value
+#  ifdef ITK_FUTURE_LEGACY_REMOVE
+#    define itkStaticConstMacro(name, type, value) \
+      "Replace itkStaticConstMacro(name, type, value) with static constexpr type name = value"
+#  else
+#    define itkStaticConstMacro(name, type, value) static constexpr type name = value
+#  endif
 
 #  define itkGetStaticConstMacro(name) (Self::name)
 #endif


### PR DESCRIPTION
itkStaticConstMacro(name, type, value) is now unconditional in its
behavior.

Use C++11 language syntax directly.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
