### PR TITLE
COMP: Remove unreachable code

### DIFF
--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -116,7 +116,6 @@ GPUReduction<TElement>::GetReductionKernel(int whichKernel, int blockSize, int i
   if (whichKernel != 5 && whichKernel != 6)
   {
     itkExceptionMacro(<< "Reduction kernel undefined!");
-    return 0;
   }
 
   std::ostringstream defines;

--- a/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
@@ -98,6 +98,16 @@ itkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
   const char *      outputImageFileName = argv[2];
   const std::string pixelTypeString(argv[3]);
 
+  // Test streaming enumeration for ComplexToComplexFFTImageFilterEnums::TransformDirection elements
+  const std::set<itk::ComplexToComplexFFTImageFilterEnums::TransformDirection> allTransformDirection{
+    itk::ComplexToComplexFFTImageFilterEnums::TransformDirection::FORWARD,
+    itk::ComplexToComplexFFTImageFilterEnums::TransformDirection::INVERSE
+  };
+  for (const auto & ee : allTransformDirection)
+  {
+    std::cout << "STREAMED ENUM VALUE ComplexToComplexFFTImageFilterEnums::TransformDirection: " << ee << std::endl;
+  }
+
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(inputImageFileName, itk::ImageIOFactory::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(inputImageFileName);
@@ -116,7 +126,6 @@ itkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
         std::cerr << "Unknown image dimension." << std::endl;
         return EXIT_FAILURE;
     }
-    return EXIT_SUCCESS;
   }
   else if (pixelTypeString.compare("double") == 0)
   {
@@ -130,23 +139,10 @@ itkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
         std::cerr << "Unknown image dimension." << std::endl;
         return EXIT_FAILURE;
     }
-    return EXIT_SUCCESS;
   }
   else
   {
     std::cerr << "Unknown pixel type string." << std::endl;
     return EXIT_FAILURE;
   }
-
-  // Test streaming enumeration for ComplexToComplexFFTImageFilterEnums::TransformDirection elements
-  const std::set<itk::ComplexToComplexFFTImageFilterEnums::TransformDirection> allTransformDirection{
-    itk::ComplexToComplexFFTImageFilterEnums::TransformDirection::FORWARD,
-    itk::ComplexToComplexFFTImageFilterEnums::TransformDirection::INVERSE
-  };
-  for (const auto & ee : allTransformDirection)
-  {
-    std::cout << "STREAMED ENUM VALUE ComplexToComplexFFTImageFilterEnums::TransformDirection: " << ee << std::endl;
-  }
-
-  return EXIT_FAILURE;
 }

--- a/Modules/IO/MINC/test/itkMINCImageIOTest_2D.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest_2D.cxx
@@ -153,8 +153,4 @@ itkMINCImageIOTest_2D(int argc, char * argv[])
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
   }
-
-
-  std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
 }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -54,16 +54,10 @@ constexpr unsigned char LEFT = 128;    /*Bit pattern 1 0 0  00000*/
 constexpr unsigned char ANTERIOR = 64; /*Bit pattern 0 1 0  00000*/
 constexpr unsigned char SUPERIOR = 32; /*Bit pattern 0 0 1  00000*/
 
+// The only specializations of this function template that may be called are given below.
 template <unsigned int TDimension>
 typename itk::ImageBase<TDimension>::DirectionType
-PreFillDirection()
-{
-  typename itk::ImageBase<TDimension>::DirectionType myDirection;
-  myDirection.Fill(0.0);
-  myDirection.SetIdentity();
-  itkGenericExceptionMacro("This template should never be used. Only valid values are given below.");
-  return myDirection;
-}
+PreFillDirection() = delete;
 
 template <>
 itk::ImageBase<1>::DirectionType

--- a/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
@@ -153,18 +153,16 @@ public:
 
   /**  Method to transform a vector. */
   OutputVectorType
-  TransformVector(const InputVectorType & vector, const InputPointType &) const override
+  TransformVector(const InputVectorType &, const InputPointType &) const override
   {
     itkExceptionMacro(<< "Not Implemented");
-    return vector;
   }
 
   /**  Method to transform a vector. */
   OutputVnlVectorType
-  TransformVector(const InputVnlVectorType & vector, const InputPointType &) const override
+  TransformVector(const InputVnlVectorType &, const InputPointType &) const override
   {
     itkExceptionMacro(<< "Not Implemented");
-    return vector;
   }
 
   /**  Method to transform a vector. */
@@ -190,18 +188,16 @@ public:
 
   /**  Method to transform a vector. */
   OutputVectorPixelType
-  TransformVector(const InputVectorPixelType & vector, const InputPointType &) const override
+  TransformVector(const InputVectorPixelType &, const InputPointType &) const override
   {
     itkExceptionMacro(<< "Not Implemented");
-    return vector;
   }
 
   /**  Method to transform a CovariantVector. */
   OutputCovariantVectorType
-  TransformCovariantVector(const InputCovariantVectorType & vector, const InputPointType &) const override
+  TransformCovariantVector(const InputCovariantVectorType &, const InputPointType &) const override
   {
     itkExceptionMacro(<< "Not Implemented");
-    return vector;
   }
 
   /**  Method to transform a CovariantVector. */
@@ -220,10 +216,9 @@ public:
 
   /**  Method to transform a CovariantVector. */
   OutputVectorPixelType
-  TransformCovariantVector(const InputVectorPixelType & vector, const InputPointType &) const override
+  TransformCovariantVector(const InputVectorPixelType &, const InputPointType &) const override
   {
     itkExceptionMacro(<< "Not Implemented");
-    return vector;
   }
 
   /** Set the transformation to an Identity
@@ -251,7 +246,6 @@ public:
   {
     // this transform is defined by XFM file
     itkExceptionMacro(<< "Not Defined");
-    return 0;
   }
 
   /** Set the Transformation Parameters
@@ -266,7 +260,6 @@ public:
   GetParameters() const override
   {
     itkExceptionMacro(<< "Not Implemented");
-    return m_Parameters;
   }
 
   void


### PR DESCRIPTION
Removed code that would produce MSVC warning C4702, "unreachable code"
(if this warning would have been enabled), from Visual Studio 2019.

Explicitly deleted (`= delete`) the function template
`PreFillDirection()`, which also had unreachable code.

Most of these changes were already suggested by Lee Newberg (@Leengit) at
https://github.com/InsightSoftwareConsortium/ITK/pull/2865#issuecomment-966483880

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2865
commit ad64a79f657ecbf59fec980ca37c700222008ebc
"STYLE: Do not do `return;` directly after throwing an exception"