### PR TITLE
ENH: Allow users to have a CMakeUserPresets.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ CMakeLists.txt.user*
 
 # Ignore testing temporary files
 Testing/Temporary/
+
+# CMake user presets
+CMakeUserPresets.json


### PR DESCRIPTION
CMake now provides a mechanism for defining preset confiurations
for selecting and building based on user preferences.

CMakeUserPresets.json should NOT be checked into a version control system.

CMakePresets.json may be tracked in git, but
CMakeUserPresets.json should be added to the .gitignore.


## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
