### PR TITLE
Use the faster `TransformPhysicalPointToIndex` overload

### DIFF
--- a/Modules/Core/Common/test/itkTimeProbesTest.cxx
+++ b/Modules/Core/Common/test/itkTimeProbesTest.cxx
@@ -62,7 +62,7 @@ TestTransformPhysicalPointToIndex(T * image)
       for (int i = 0; i < 1000; ++i)
       {
         point3D[0] = static_cast<typename itk::NumericTraits<typename T::PointType>::ValueType>(i);
-        image->TransformPhysicalPointToIndex(point3D, index3D);
+        index3D = image->TransformPhysicalPointToIndex(point3D);
       }
     }
     if (k == 5)

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -202,8 +202,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
       const bool isZero = (itk::Math::ExactlyEquals(value, itk::NumericTraits<PixelType>::ZeroValue()));
       if ((isInside && isZero) || (!isInside && !isZero))
       {
-        ImageType::IndexType pointIndex;
-        image->TransformPhysicalPointToIndex(point, pointIndex);
+        ImageType::IndexType pointIndex = image->TransformPhysicalPointToIndex(point);
         std::cerr
           << "Error in the evaluation ValueAt and IsInside (all the points inside the mask shall have non-zero value) "
           << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -74,12 +74,10 @@ itkImageMaskSpatialObjectTest3(int, char *[])
   imageMaskSpatialObject->Update();
 
   ImageMaskSpatialObjectType::PointType bndMin = imageMaskSpatialObject->GetMyBoundingBoxInWorldSpace()->GetMinimum();
-  ImageMaskSpatialObjectType::IndexType bndMinI;
-  image->TransformPhysicalPointToIndex(bndMin, bndMinI);
+  ImageMaskSpatialObjectType::IndexType bndMinI = image->TransformPhysicalPointToIndex(bndMin);
 
   ImageMaskSpatialObjectType::PointType bndMax = imageMaskSpatialObject->GetMyBoundingBoxInWorldSpace()->GetMaximum();
-  ImageMaskSpatialObjectType::IndexType bndMaxI;
-  image->TransformPhysicalPointToIndex(bndMax, bndMaxI);
+  ImageMaskSpatialObjectType::IndexType bndMaxI = image->TransformPhysicalPointToIndex(bndMax);
 
   ImageMaskSpatialObjectType::RegionType::SizeType regionSize;
   ImageMaskSpatialObjectType::IndexType::IndexType regionIndex;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -397,8 +397,7 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   DisplacementTransformType::OutputPointType deformOutput, deformTruth;
 
   // Test a point with non-zero displacement
-  FieldType::IndexType idx;
-  field->TransformPhysicalPointToIndex(testPoint, idx);
+  FieldType::IndexType idx = field->TransformPhysicalPointToIndex(testPoint);
   deformTruth = testPoint + field->GetPixel(idx);
 
   deformOutput = displacementTransform->TransformPoint(testPoint);

--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
@@ -142,8 +142,7 @@ itkInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
     p2[0] = p1[0] + fp1[0];
     p2[1] = p1[1] + fp1[1];
 
-    DisplacementFieldType::IndexType id2;
-    filter->GetOutput()->TransformPhysicalPointToIndex(p2, id2);
+    DisplacementFieldType::IndexType id2 = filter->GetOutput()->TransformPhysicalPointToIndex(p2);
     DisplacementFieldType::PixelType fp2 = filter->GetOutput()->GetPixel(id2);
 
     if (std::abs(fp2[0] + fp1[0]) > 0.001 || std::abs(fp2[1] + fp1[1]) > 0.001)

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -108,9 +108,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
     PointType center;
     center.Fill(0.0);
 
-    IndexType centerIndex;
-
-    outputImage->TransformPhysicalPointToIndex(center, centerIndex);
+    IndexType centerIndex = outputImage->TransformPhysicalPointToIndex(center);
 
     // Irrespective of the scale, the Hxx component should be the same
     double centerHxx = outputImage->GetPixel(centerIndex)[0];
@@ -165,9 +163,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
     PointType center;
     center.Fill(0.0);
 
-    IndexType centerIndex;
-
-    outputImage->TransformPhysicalPointToIndex(center, centerIndex);
+    IndexType centerIndex = outputImage->TransformPhysicalPointToIndex(center);
 
     // Irrespective of the scale, the Hxx component should be the same
     double centerHxx = outputImage->GetPixel(centerIndex)[0];

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
@@ -165,10 +165,9 @@ itkExpandImageFilterTest(int, char *[])
     {
 
       ImageType::PointType point;
-      ImageType::IndexType inputIndex;
       expanderOutput->TransformIndexToPhysicalPoint(outIter.GetIndex(), point);
-      input->TransformPhysicalPointToIndex(point, inputIndex);
-      double trueValue = pattern.Evaluate(inputIndex);
+      ImageType::IndexType inputIndex = input->TransformPhysicalPointToIndex(point);
+      double               trueValue = pattern.Evaluate(inputIndex);
 
       if (itk::Math::abs(trueValue - value) > 1e-4)
       {

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImageProfileTest1.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImageProfileTest1.cxx
@@ -78,7 +78,7 @@ itkOrientedImageProfileTest1(int, char *[])
   while (!itr.IsAtEnd())
   {
     image->TransformIndexToPhysicalPoint(itr.GetIndex(), point);
-    image->TransformPhysicalPointToIndex(point, index);
+    index = image->TransformPhysicalPointToIndex(point);
     ++itr;
   }
 

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImageProfileTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImageProfileTest2.cxx
@@ -82,7 +82,7 @@ itkOrientedImageProfileTest2(int, char *[])
   while (!itr.IsAtEnd())
   {
     image->TransformIndexToPhysicalPoint(itr.GetIndex(), point);
-    image->TransformPhysicalPointToIndex(point, index);
+    index = image->TransformPhysicalPointToIndex(point);
     ++itr;
   }
 

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImageProfileTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImageProfileTest3.cxx
@@ -84,7 +84,7 @@ itkOrientedImageProfileTest3(int, char *[])
   while (!itr.IsAtEnd())
   {
     image->TransformIndexToPhysicalPoint(itr.GetIndex(), point);
-    image->TransformPhysicalPointToIndex(point, index);
+    index = image->TransformPhysicalPointToIndex(point);
     ++itr;
   }
 

--- a/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
@@ -184,10 +184,9 @@ itkVectorExpandImageFilterTest(int, char *[])
     {
 
       ImageType::PointType point;
-      ImageType::IndexType inputIndex;
       expanderOutput->TransformIndexToPhysicalPoint(outIter.GetIndex(), point);
-      input->TransformPhysicalPointToIndex(point, inputIndex);
-      double baseValue = pattern.Evaluate(inputIndex);
+      ImageType::IndexType inputIndex = input->TransformPhysicalPointToIndex(point);
+      double               baseValue = pattern.Evaluate(inputIndex);
 
       for (k = 0; k < VectorDimension; ++k)
       {

--- a/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.h
@@ -117,7 +117,7 @@ protected:
         point[i] = static_cast<OffsetValueType>(position[i]); // FIXME: use next line instead.
         // point[i] = static_cast<CoordinateType>( position[i] );
       }
-      this->GetOutput()->TransformPhysicalPointToIndex(point, idx);
+      idx = this->GetOutput()->TransformPhysicalPointToIndex(point);
     }
     else
     {

--- a/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
@@ -209,8 +209,8 @@ itkBlockMatchingImageFilterTest(int argc, char * argv[])
   {
     if (outputImage->TransformPhysicalPointToIndex(pointItr.Value(), index))
     {
-      OutputImageType::IndexType displ;
-      outputImage->TransformPhysicalPointToIndex(pointItr.Value() + displItr.Value(), displ);
+      OutputImageType::IndexType displ =
+        outputImage->TransformPhysicalPointToIndex(pointItr.Value() + displItr.Value());
 
       // draw line between old and new location of a point in blue
       itk::LineIterator<OutputImageType> lineIter(outputImage, index, displ);

--- a/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
@@ -176,7 +176,7 @@ public:
     while (it != m_PointList.end())
     {
       PointType transformedPoint = this->m_Transform->TransformPoint(*it);
-      this->m_FixedImage->TransformPhysicalPointToIndex(transformedPoint, index);
+      index = this->m_FixedImage->TransformPhysicalPointToIndex(transformedPoint);
       if (index[0] > 0L && index[1] > 0L &&
           index[0] < static_cast<signed long>(this->m_FixedImage->GetLargestPossibleRegion().GetSize()[0]) &&
           index[1] < static_cast<signed long>(this->m_FixedImage->GetLargestPossibleRegion().GetSize()[1]))

--- a/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
@@ -120,7 +120,7 @@ itkBinaryMaskToNarrowBandPointSetFilterTest(int, char *[])
 
     const PointType & p = point.Value();
 
-    binaryMask->TransformPhysicalPointToIndex(p, index);
+    index = binaryMask->TransformPhysicalPointToIndex(p);
 
     if ((!binaryMask->GetPixel(index) && data.Value() > 0) || (binaryMask->GetPixel(index) && data.Value() < 0))
     {

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -150,7 +150,7 @@ itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
   adaptor3->Initialize();
   LevelSetType::Pointer levelSet3 = adaptor3->GetModifiableLevelSet();
 
-  input->TransformPhysicalPointToIndex(binary->GetOrigin(), index);
+  index = input->TransformPhysicalPointToIndex(binary->GetOrigin());
   InputImageType::OffsetType offset;
   for (unsigned int i = 0; i < Dimension; ++i)
   {

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -141,7 +141,7 @@ itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
   adaptor1->Initialize();
   LevelSetType::Pointer levelSet1 = adaptor1->GetModifiableLevelSet();
 
-  input->TransformPhysicalPointToIndex(binary->GetOrigin(), index);
+  index = input->TransformPhysicalPointToIndex(binary->GetOrigin());
   InputImageType::OffsetType offset;
   for (unsigned int i = 0; i < Dimension; ++i)
   {

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -141,7 +141,7 @@ itkMultiLevelSetShiImageSubset2DTest(int, char *[])
   adaptor1->Initialize();
   LevelSetType::Pointer levelSet1 = adaptor1->GetModifiableLevelSet();
 
-  input->TransformPhysicalPointToIndex(binary->GetOrigin(), index);
+  index = input->TransformPhysicalPointToIndex(binary->GetOrigin());
   InputImageType::OffsetType offset;
   for (unsigned int i = 0; i < Dimension; ++i)
   {

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -141,7 +141,7 @@ itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
   adaptor1->Initialize();
   LevelSetType::Pointer levelSet1 = adaptor1->GetModifiableLevelSet();
 
-  input->TransformPhysicalPointToIndex(binary->GetOrigin(), index);
+  index = input->TransformPhysicalPointToIndex(binary->GetOrigin());
   InputImageType::OffsetType offset;
   for (unsigned int i = 0; i < Dimension; ++i)
   {

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithCurvatureTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithCurvatureTest.cxx
@@ -109,7 +109,7 @@ itkSingleLevelSetWhitakerImage2DWithCurvatureTest(int argc, char * argv[])
   SparseLevelSetType::Pointer level_set = adaptor->GetModifiableLevelSet();
 
 
-  input->TransformPhysicalPointToIndex(binary->GetOrigin(), index);
+  index = input->TransformPhysicalPointToIndex(binary->GetOrigin());
   OffsetType offset;
   for (unsigned int i = 0; i < Dimension; ++i)
   {


### PR DESCRIPTION
Replaced `image->TransformPhysicalPointToIndex(point, index)` calls by
`image->TransformPhysicalPointToIndex(point)`, which is slightly faster,
as it does not figure out whether or not the point is inside the image.

Follow-up to pull request #993
commit 0703516
"STYLE: Use image->TransformPhysicalPointToIndex(point), returning index"