### PR TITLE
BUG: fix filter progress overflowing due to bad logic in atomic add

### DIFF
--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1157,9 +1157,9 @@ ProcessObject::IncrementProgress(float increment)
   // Clamp the value to be between 0 and 1.
   uint32_t integerIncrement = progressFloatToFixed(increment);
 
-  uint32_t oldProgress = m_Progress;
+  uint32_t oldProgress = m_Progress.fetch_add(integerIncrement);
 
-  uint32_t updatedProgress = m_Progress.fetch_add(integerIncrement);
+  uint32_t updatedProgress = m_Progress;
 
   // check if progress overflowed
   if (oldProgress > updatedProgress)

--- a/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
+++ b/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
@@ -171,6 +171,17 @@ itkDataObjectAndProcessObjectTest(int, char *[])
   process->UpdateProgress(0.0);
   ITK_TEST_SET_GET_VALUE(0.0, process->GetProgress());
 
+  // verify no progress overflow
+  for (size_t i = 0; i < 10; ++i)
+  {
+    process->IncrementProgress(0.1);
+  }
+  if (!itk::Math::FloatAlmostEqual(process->GetProgress(), 1.0f))
+  {
+    std::cerr << "Progress is not reported correctly!" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // shouldn't do anything: there is no output at this point
   mtime = process->GetMTime();
   process->Update();


### PR DESCRIPTION
fetch_add returns the value before the increment, not after.

Closes #2874.
