### PR TITLE
DOC: Remove lingering Ultrasound dependency

### DIFF
--- a/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
@@ -38,7 +38,8 @@ namespace fftw
  * \class Interface
  * \brief Wrapper for FFTW API
  *
- * \ingroup Ultrasound
+ * \ingroup ITKFFT
+ * \ingroup FourierTransform
  */
 template <typename TPixel>
 class ComplexToComplexProxy


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Follow up to #2866 removing lingering Ultrasound dependency for 1D FFT.

Unlike the classes addressed in #2866, `itk::ComplexToComplexProxy` is not wrapped for Python so the Doxygen group will only affect documentation and not load dependencies.


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] Updated API documentation (or API not changed)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
