### PR TITLE
COMP: No longer delete (`= delete`) PreFillDirection() function template

### DIFF
--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -54,23 +54,10 @@ constexpr unsigned char LEFT = 128;    /*Bit pattern 1 0 0  00000*/
 constexpr unsigned char ANTERIOR = 64; /*Bit pattern 0 1 0  00000*/
 constexpr unsigned char SUPERIOR = 32; /*Bit pattern 0 0 1  00000*/
 
-// The only specializations of this function template that may be called are given below.
+// Specializations of this function template are only implemented for 1D to 4D (defined in the cxx file).
 template <unsigned int TDimension>
 typename itk::ImageBase<TDimension>::DirectionType
-PreFillDirection() = delete;
-
-template <>
-itk::ImageBase<1>::DirectionType
-PreFillDirection<1>();
-template <>
-itk::ImageBase<2>::DirectionType
-PreFillDirection<2>();
-template <>
-itk::ImageBase<3>::DirectionType
-PreFillDirection<3>();
-template <>
-itk::ImageBase<4>::DirectionType
-PreFillDirection<4>();
+PreFillDirection();
 
 template <typename T>
 int


### PR DESCRIPTION
Pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2869 commit af32a779c4586304e52ddc27eb81656b949c9eeb ("COMP: Remove unreachable code") "deleted" the `PreFillDirection()` function template definition, by `= delete`. This appeared to cause compilation errors on the following sites/builds:

  Site: RogueResearch7
  Build Name: Mac10.11-AppleClang-rel-x86_64-static
  Build Name: Mac10.11-AppleClang-dbg-x86_64-static

As reported by Jon Haitz Legarreta Gorroño (@jhlegarreta) at https://github.com/InsightSoftwareConsortium/ITK/pull/2869#issuecomment-970306179

The error messages included:

    /Users/builder/externalModules/IO/NIFTI/test/itkNiftiImageIOTest.cxx:26:1: error: redefinition of 'PreFillDirection'
    PreFillDirection<1>()
    ^
    [CTest: warning matched] /Users/builder/externalModules/IO/NIFTI/test/itkNiftiImageIOTest.h:64:1: note: previous definition is here
    PreFillDirection<1>();
    ^