### PR TITLE
BUG: Add an else clause for DCMTK_USE_ICU variable to overwrite the DCMTK configuration when set to false

### DIFF
--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -72,6 +72,10 @@ if(DCMTK_USE_ICU)
     )
     set(ICU_DEPENDENCY icu)
   endif()
+else(DCMTK_USE_ICU)
+  set(CHARSET_CONVERSION_ARGS
+     -DDCMTK_WITH_ICU:BOOL=OFF
+     )
 endif()
 
 if(APPLE)


### PR DESCRIPTION
Hi everyone,

Pull request related to issue #2877 as suggested by @dzenanz. 
CMakeLists for DCMTK ExtProject has been modified as suggested in the issue thread.

Reminder of the issue:
When building the ITKDCMTK_ExtProject with DCMTK_USE_ICU set to OFF, the configuration doesn't overwrite the DCMTK_WITH_ICU (DCMTK-side) variable. On system where ICU libraries are present, this lead to DCMTK finding and setting itself to DCMTK_WITH_ICU=ON, which in turn lead to linking error when trying to build an application.

The CMakeLists.txt for the project doesn't set anything in case the DCMTK_USE_ICU is OFF.

PR add the following to the CMakeLists

```
if(DCMTK_USE_ICU)
[...]
else(DCMTK_USE_ICU)
   set(CHARSET_CONVERSION_ARGS
      -DDCMTK_WITH_ICU:BOOL=OFF
      )
endif()
```
