### PR TITLE
BUG: Remove duplicate required input in BlockMatchingImageFilter

### DIFF
--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -48,7 +48,6 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
   this->SetNthOutput(1, similarities.GetPointer());
 
   // all inputs are required
-  this->AddRequiredInputName("FeaturePoints");
   this->SetPrimaryInputName("FeaturePoints");
   this->AddRequiredInputName("FixedImage");
   this->AddRequiredInputName("MovingImage");


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Fixes warning seen in `PythonGetNameOfClass` test.

Prevous behavior: `SetPrimaryInputName` calls `AddRequiredInputName` internally after `AddRequiredInputName` was already called for the same input one line previous, leading to warning about duplicate behavior:
```
WARNING: In /Users/runner/work/1/s/Modules/Core/Common/src/itkProcessObject.cxx, line 852
BlockMatchingImageFilter (0x7fc9c38ab070): Input already "FeaturePoints" already required!
```

Updated behavior: Duplicate `AddRequiredInputName` is removed so that `SetPrimaryInputName` alone adds the input.

Warning does not appear to be reported in CDash by default and does not cause the test to fail. Uncovered in [CTest logs](https://open.cdash.org/test/540703555) from in-progress #2864.

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
