### PR TITLE
BUG: Add missing single argument ImageAdaptor Transform member functions

### DIFF
--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -381,6 +381,14 @@ public:
   bool
   VerifyRequestedRegion() override;
 
+  /** Returns the continuous index from a physical point. */
+  template <typename TIndexRep, typename TCoordRep>
+  ContinuousIndex<TIndexRep, TImage::ImageDimension>
+  TransformPhysicalPointToContinuousIndex(const Point<TCoordRep, TImage::ImageDimension> & point) const
+  {
+    return m_Image->template TransformPhysicalPointToContinuousIndex<TIndexRep>(point);
+  }
+
   /** \brief Get the continuous index from a physical point
    *
    * Returns true if the resulting index is within the image, false otherwise.
@@ -391,6 +399,14 @@ public:
                                           ContinuousIndex<TCoordRep, Self::ImageDimension> & index) const
   {
     return m_Image->TransformPhysicalPointToContinuousIndex(point, index);
+  }
+
+  /** Returns the index (discrete) of a voxel from a physical point. */
+  template <typename TCoordRep>
+  IndexType
+  TransformPhysicalPointToIndex(const Point<TCoordRep, Self::ImageDimension> & point) const
+  {
+    return m_Image->TransformPhysicalPointToIndex(point);
   }
 
   /** Get the index (discrete) from a physical point.
@@ -416,6 +432,14 @@ public:
     m_Image->TransformContinuousIndexToPhysicalPoint(index, point);
   }
 
+  /** Returns a physical point from a continuous index (in the index space) */
+  template <typename TCoordRep, typename TIndexRep>
+  Point<TCoordRep, TImage::ImageDimension>
+  TransformContinuousIndexToPhysicalPoint(const ContinuousIndex<TIndexRep, Self::ImageDimension> & index) const
+  {
+    return m_Image->template TransformContinuousIndexToPhysicalPoint<TIndexRep>(index);
+  }
+
   /** Get a physical point (in the space which
    * the origin and spacing information comes from)
    * from a discrete index (in the index space)
@@ -426,6 +450,14 @@ public:
   TransformIndexToPhysicalPoint(const IndexType & index, Point<TCoordRep, Self::ImageDimension> & point) const
   {
     m_Image->TransformIndexToPhysicalPoint(index, point);
+  }
+
+  /** Returns a physical point from a discrete index (in the index space) */
+  template <typename TCoordRep>
+  Point<TCoordRep, Self::ImageDimension>
+  TransformIndexToPhysicalPoint(const IndexType & index) const
+  {
+    return m_Image->template TransformIndexToPhysicalPoint<TCoordRep>(index);
   }
 
   template <typename TCoordRep>

--- a/Modules/Core/ImageAdaptors/test/CMakeLists.txt
+++ b/Modules/Core/ImageAdaptors/test/CMakeLists.txt
@@ -23,3 +23,9 @@ itk_add_test(NAME itkComplexConjugateImageAdaptorTest
       COMMAND ITKImageAdaptorsTestDriver itkComplexConjugateImageAdaptorTest)
 itk_add_test(NAME itkVectorImageToImageAdaptorTest
       COMMAND ITKImageAdaptorsTestDriver itkVectorImageToImageAdaptorTest)
+
+set(ITKImageAdaptorsGTests
+      itkImageAdaptorGTest.cxx
+)
+
+CreateGoogleTestDriver(ITKImageAdaptors "${ITKImageAdaptors-Test_LIBRARIES}" "${ITKImageAdaptorsGTests}")

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
@@ -1,0 +1,186 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkImageBase.h"
+
+#include "itkCovariantVector.h"
+#include "itkImage.h"
+#include "itkImageAdaptor.h"
+#include "itkVector.h"
+
+#include <gtest/gtest.h>
+#include <type_traits> // For is_same.
+
+
+namespace
+{
+template <typename TPixelType>
+class DummyPixelAccessor
+{
+public:
+  using ExternalType = TPixelType;
+  using InternalType = TPixelType;
+
+  static void
+  Set(TPixelType & output, const TPixelType & input)
+  {
+    output = input;
+  }
+
+  static TPixelType
+  Get(const TPixelType & input)
+  {
+    return input;
+  }
+};
+
+
+template <typename T1, typename T2>
+void
+Expect_same_type_and_equal_value(T1 && value1, T2 && value2)
+{
+  static_assert(std::is_same<T1, T2>::value, "Expect the same type!");
+  EXPECT_EQ(value1, value2);
+}
+
+
+template <typename TImage, typename TAccessor, typename TCoordRep>
+void
+Expect_TransformPhysicalPoint_member_functions_return_the_same_for_ImageAdapter_as_for_image(
+  const itk::ImageAdaptor<TImage, TAccessor> &          imageAdaptor,
+  const TImage &                                        image,
+  const itk::Point<TCoordRep, TImage::ImageDimension> & point)
+{
+  Expect_same_type_and_equal_value(imageAdaptor.TransformPhysicalPointToIndex(point),
+                                   image.TransformPhysicalPointToIndex(point));
+  Expect_same_type_and_equal_value(imageAdaptor.template TransformPhysicalPointToContinuousIndex<float>(point),
+                                   image.template TransformPhysicalPointToContinuousIndex<float>(point));
+  Expect_same_type_and_equal_value(imageAdaptor.template TransformPhysicalPointToContinuousIndex<double>(point),
+                                   image.template TransformPhysicalPointToContinuousIndex<double>(point));
+}
+
+
+template <typename TImage, typename TAccessor, typename TIndexRep>
+void
+Expect_TransformContinuousIndexToPhysicalPoint_returns_the_same_for_ImageAdapter_as_for_image(
+  const itk::ImageAdaptor<TImage, TAccessor> &                    imageAdaptor,
+  const TImage &                                                  image,
+  const itk::ContinuousIndex<TIndexRep, TImage::ImageDimension> & continuousIndex)
+{
+  Expect_same_type_and_equal_value(
+    imageAdaptor.template TransformContinuousIndexToPhysicalPoint<float>(continuousIndex),
+    image.template TransformContinuousIndexToPhysicalPoint<float>(continuousIndex));
+  Expect_same_type_and_equal_value(
+    imageAdaptor.template TransformContinuousIndexToPhysicalPoint<double>(continuousIndex),
+    image.template TransformContinuousIndexToPhysicalPoint<double>(continuousIndex));
+}
+
+
+template <typename TImage, typename TAccessor>
+void
+Expect_TransformIndexToPhysicalPoint_returns_the_same_for_ImageAdapter_as_for_image(
+  const itk::ImageAdaptor<TImage, TAccessor> & imageAdaptor,
+  const TImage &                               image,
+  const itk::Index<TImage::ImageDimension> &   index)
+{
+  Expect_same_type_and_equal_value(imageAdaptor.template TransformIndexToPhysicalPoint<float>(index),
+                                   image.template TransformIndexToPhysicalPoint<float>(index));
+  Expect_same_type_and_equal_value(imageAdaptor.template TransformIndexToPhysicalPoint<double>(index),
+                                   image.template TransformIndexToPhysicalPoint<double>(index));
+}
+
+
+template <typename TImage, typename TAccessor, typename TVector>
+void
+Expect_TransformLocalVectorToPhysicalVector_returns_the_same_for_ImageAdapter_as_for_image(
+  const itk::ImageAdaptor<TImage, TAccessor> & imageAdaptor,
+  const TImage &                               image,
+  const TVector &                              localVector)
+{
+  Expect_same_type_and_equal_value(imageAdaptor.TransformLocalVectorToPhysicalVector(localVector),
+                                   image.TransformLocalVectorToPhysicalVector(localVector));
+}
+
+
+template <typename TImage>
+void
+Expect_Transform_member_functions_return_the_same_for_an_ImageAdapter_as_for_its_image(TImage & image)
+{
+  const auto ImageDimension = TImage::ImageDimension;
+  using IndexType = itk::Index<ImageDimension>;
+
+  const auto imageAdaptor = itk::ImageAdaptor<TImage, DummyPixelAccessor<typename TImage::PixelType>>::New();
+  imageAdaptor->SetImage(&image);
+
+  for (const auto & point : { itk::Point<double, ImageDimension>(), itk::Point<double, ImageDimension>(1.0) })
+  {
+    Expect_TransformPhysicalPoint_member_functions_return_the_same_for_ImageAdapter_as_for_image(
+      *imageAdaptor, image, point);
+  }
+
+  for (const auto & continuousIndex : { itk::ContinuousIndex<double, ImageDimension>(),
+                                        itk::ContinuousIndex<double, ImageDimension>(IndexType::Filled(1)) })
+  {
+    Expect_TransformContinuousIndexToPhysicalPoint_returns_the_same_for_ImageAdapter_as_for_image(
+      *imageAdaptor, image, continuousIndex);
+  }
+
+  for (const auto & index : { IndexType(), IndexType::Filled(1) })
+  {
+    Expect_TransformIndexToPhysicalPoint_returns_the_same_for_ImageAdapter_as_for_image(*imageAdaptor, image, index);
+  }
+
+  for (const auto & fixedArray :
+       { itk::FixedArray<float, ImageDimension>(), itk::FixedArray<float, ImageDimension>::Filled(1.0f) })
+  {
+    Expect_TransformLocalVectorToPhysicalVector_returns_the_same_for_ImageAdapter_as_for_image(
+      *imageAdaptor, image, fixedArray);
+  }
+
+  for (const auto & fixedArray :
+       { itk::FixedArray<double, ImageDimension>(), itk::FixedArray<double, ImageDimension>::Filled(1.0) })
+  {
+    Expect_TransformLocalVectorToPhysicalVector_returns_the_same_for_ImageAdapter_as_for_image(
+      *imageAdaptor, image, fixedArray);
+  }
+
+  Expect_TransformLocalVectorToPhysicalVector_returns_the_same_for_ImageAdapter_as_for_image(
+    *imageAdaptor, image, itk::Vector<double, ImageDimension>());
+  Expect_TransformLocalVectorToPhysicalVector_returns_the_same_for_ImageAdapter_as_for_image(
+    *imageAdaptor, image, itk::CovariantVector<double, ImageDimension>());
+}
+
+} // end namespace
+
+
+// Tests that any single parameter Transform member function of ImageAdapter return the same as the corresponding
+// function call on its image.
+TEST(ImageAdapter, TransformMemberFunctionsReturnSameAsForImage)
+{
+  // Test both 2D and 3D, for different pixel types, origins and spacings:
+  const auto image2D = itk::Image<double>::New();
+
+  image2D->SetSpacing(itk::MakeVector(2.0, 3.0));
+  image2D->SetOrigin(itk::MakePoint(-1.0, 1.0));
+
+  Expect_Transform_member_functions_return_the_same_for_an_ImageAdapter_as_for_its_image(*image2D);
+
+  const auto image3D = itk::Image<unsigned char, 3>::New();
+  Expect_Transform_member_functions_return_the_same_for_an_ImageAdapter_as_for_its_image(*image3D);
+}


### PR DESCRIPTION
Added the four missing single parameter overloads of point/index/vector
conversion member functions to `ImageAdaptor`, which were already there
for `ImageBase` with ITK version 5.0:

    TransformPhysicalPointToIndex
    TransformPhysicalPointToContinuousIndex
    TransformContinuousIndexToPhysicalPoint
    TransformIndexToPhysicalPoint

Included a GoogleTest unit test.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/868
commit 65233e36b64ac7835fe2b80de2a6b981204554f4
"ENH: Convenience overloads for ImageBase Transform member functions" (by me)

And pull request https://github.com/InsightSoftwareConsortium/ITK/pull/1207
commit 55f8ac2b2701a6138c91615c2ca20006cd3e65e8
"BUG: Missing ImageAdapter function signatures" by Hans Johnson (@hjmjohnson)