### PR TITLE
PERF: Use "magic statics" instead of Singleton in TimeStamp::Modified()

### DIFF
--- a/Modules/Core/Common/include/itkTimeStamp.h
+++ b/Modules/Core/Common/include/itkTimeStamp.h
@@ -31,7 +31,6 @@
 #include "itkMacro.h"
 #include "itkIntTypes.h"
 #include <atomic>
-#include "itkSingletonMacro.h"
 
 namespace itk
 {
@@ -126,17 +125,7 @@ public:
   operator=(const Self & other) = default;
 
 private:
-  /** Set/Get the pointer to GlobalTimeStamp.
-   * Note that SetGlobalTimeStamp is not concurrent thread safe. */
-  itkGetGlobalDeclarationMacro(GlobalTimeStampType, GlobalTimeStamp);
-
   ModifiedTimeType m_ModifiedTime;
-
-  /** The static GlobalTimeStamp. This is initialized to NULL as the first
-   * stage of static initialization. It is then populated on the first call to
-   * itk::TimeStamp::Modified() but it can be overridden with SetGlobalTimeStamp().
-   * */
-  static GlobalTimeStampType * m_GlobalTimeStamp;
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/src/itkTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkTimeStamp.cxx
@@ -27,13 +27,8 @@
  *=========================================================================*/
 #include "itkTimeStamp.h"
 
-#include "itkSingleton.h"
-
 namespace itk
 {
-
-itkGetGlobalValueMacro(TimeStamp, TimeStamp::GlobalTimeStampType, GlobalTimeStamp, 0);
-
 
 /**
  * Instance creation.
@@ -51,12 +46,10 @@ TimeStamp::New()
 void
 TimeStamp::Modified()
 {
-  // This is called once, on-demand to ensure that m_GlobalTimeStamp is
-  // initialized.
-  itkInitGlobalsMacro(GlobalTimeStamp);
-  this->m_ModifiedTime = ++(*m_GlobalTimeStamp);
-}
+  // Initialization in a thread-safe way, by "magic statics" (as introduced with C++11).
+  static std::atomic<ModifiedTimeType> staticModifiedTime{};
 
-TimeStamp::GlobalTimeStampType * TimeStamp::m_GlobalTimeStamp;
+  this->m_ModifiedTime = ++staticModifiedTime;
+}
 
 } // end namespace itk

--- a/Modules/Core/Common/src/itkTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkTimeStamp.cxx
@@ -30,6 +30,8 @@
 namespace itk
 {
 
+static std::atomic<ModifiedTimeType> modifiedTime{};
+
 /**
  * Instance creation.
  */
@@ -46,10 +48,7 @@ TimeStamp::New()
 void
 TimeStamp::Modified()
 {
-  // Initialization in a thread-safe way, by "magic statics" (as introduced with C++11).
-  static std::atomic<ModifiedTimeType> staticModifiedTime{};
-
-  this->m_ModifiedTime = ++staticModifiedTime;
+  this->m_ModifiedTime = ++modifiedTime;
 }
 
 } // end namespace itk


### PR DESCRIPTION
Avoids pointer indirection and read/write access to global data inside
this frequently called Core member function.