### PR TITLE
STYLE: Remove `TimeStamp` default-constructor, assignment (Rule of Zero)

### DIFF
--- a/Modules/Core/Common/include/itkTimeStamp.h
+++ b/Modules/Core/Common/include/itkTimeStamp.h
@@ -70,10 +70,6 @@ public:
   static Self *
   New();
 
-  /** Constructor must remain public because classes instantiate
-   * TimeStamps implicitly in their construction.  */
-  TimeStamp() { m_ModifiedTime = 0; }
-
   /** Destoy this instance. */
   void
   Delete()
@@ -120,17 +116,12 @@ public:
   /** Allow for typecasting to unsigned long.  */
   operator ModifiedTimeType() const { return m_ModifiedTime; }
 
-  /** Assignment operator, allows to initialize one time stamp by copying from
-   * another. */
-  Self &
-  operator=(const Self & other) = default;
-
 private:
   /** Set/Get the pointer to GlobalTimeStamp.
    * Note that SetGlobalTimeStamp is not concurrent thread safe. */
   itkGetGlobalDeclarationMacro(GlobalTimeStampType, GlobalTimeStamp);
 
-  ModifiedTimeType m_ModifiedTime;
+  ModifiedTimeType m_ModifiedTime{ 0 };
 
   /** The static GlobalTimeStamp. This is initialized to NULL as the first
    * stage of static initialization. It is then populated on the first call to

--- a/Modules/Core/Common/test/itkTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkTimeStampTest.cxx
@@ -16,10 +16,16 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkTimeStamp.h"
 #include "itkMultiThreaderBase.h"
 
+#include <iostream>
+#include <type_traits>
+
+static_assert(std::is_nothrow_default_constructible<itk::TimeStamp>::value, "Check TimeStamp default-constructibility");
+static_assert(std::is_trivially_copy_constructible<itk::TimeStamp>::value, "Check TimeStamp copy-constructibility");
+static_assert(std::is_trivially_copy_assignable<itk::TimeStamp>::value, "Check TimeStamp copy-assignability");
+static_assert(std::is_trivially_destructible<itk::TimeStamp>::value, "Check TimeStamp destructibility");
 
 // A helper struct for the test, the idea is to have one timestamp per thread.
 // To ease the writing of the test, we use  MultiThreaderBase::SingleMethodExecute


### PR DESCRIPTION
Allowed the compiler to generate the default-constructor and assignment
operator of `TimeStamp` implicitly, followed C++ Core Guidelines,
August 19, 2021:

"If you can avoid defining default operations, do"
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c20-if-you-can-avoid-defining-default-operations-do

Added compile-time checks of the type traits of the special member
functions of `TimeStamp`.