### PR TITLE
COMP: Use modern macro name for GetModifiableObjectMacro

### DIFF
--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h
@@ -107,7 +107,7 @@ public:
   itkSetObjectMacro(TriangleMesh, InputMeshType);
 
   /** Get Gauss curvature. */
-  itkGetObjectMacro(GaussCurvatureData, DoubleVectorContainer);
+  itkGetModifiableObjectMacro(GaussCurvatureData, DoubleVectorContainer);
 
   /** Set the curvature type to Guass. */
   void

--- a/Modules/Core/Mesh/test/itkTriangleMeshCurvatureCalculatorTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshCurvatureCalculatorTest.cxx
@@ -42,7 +42,6 @@ itkTriangleMeshCurvatureCalculatorTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(curvCalculator, TriangleMeshCurvatureCalculator, Object);
 
   using DoubleVectorContainerPointer = typename CurvatureCalculatorType::DoubleVectorContainerPointer;
-  DoubleVectorContainerPointer gaussCurvatureData;
 
   // Test for empty mesh, curvature data should be null.
   TriangleMeshType::Pointer triangleMesh = TriangleMeshType::New();
@@ -69,7 +68,7 @@ itkTriangleMeshCurvatureCalculatorTest(int argc, char * argv[])
   curvCalculator->Compute();
 
   // Output should be null for empty mesh.
-  gaussCurvatureData = curvCalculator->GetGaussCurvatureData();
+  DoubleVectorContainerPointer gaussCurvatureData = curvCalculator->GetModifiableGaussCurvatureData();
   ITK_TEST_EXPECT_TRUE(gaussCurvatureData == nullptr);
 
 


### PR DESCRIPTION
Compilation error when future legacy is enabled.

In file included from ../Modules/Core/Mesh/src/itkTriangleMeshCurvatureCalculator.cxx:18:
../Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h:110:3: error: use of undeclared identifier purposeful_error
  itkGetObjectMacro(GaussCurvatureData, DoubleVectorContainer);
  ^
../Modules/Core/Common/include/itkMacro.h:1128:7: note: expanded from macro itkGetObjectMacro
      purposeful_error("itkGetObjectMacro should be replaced with itkGetModifiableObjectMacro.");
## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
