### PR TITLE
ENH: Adding Python Wrapping for itkImageRegistrationMethodv4 with Mesh

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/wrapping/itkImageRegistrationMethodv4.wrap
+++ b/Modules/Registration/RegistrationMethodsv4/wrapping/itkImageRegistrationMethodv4.wrap
@@ -4,6 +4,7 @@ itk_wrap_simple_class("itk::ImageRegistrationMethodv4Enums")
 itk_wrap_include("itkDisplacementFieldTransform.h")
 itk_wrap_include("itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h")
 itk_wrap_include("itkDataObjectDecorator.h")
+itk_wrap_include("itkMesh.h")
 
 itk_wrap_class("itk::DataObjectDecorator" POINTER)
   foreach(d ${ITK_WRAP_DIMS})
@@ -19,6 +20,8 @@ itk_wrap_class("itk::ImageRegistrationMethodv4" POINTER)
     foreach(t ${WRAP_ITK_REAL})
       itk_wrap_template("REGv4${ITKM_${t}}${d}${ITKM_${t}}${d}"
                         "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >")
+      itk_wrap_template("REGv4${ITKM_${t}}${d}${ITKM_${t}}${d}T${ITKM_D}${d}${ITKM_${t}}${d}M${ITKM_D}${d}"
+                        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Transform< ${ITKT_D}, ${d}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Mesh< ${ITKT_D}, ${d} >")
       itk_wrap_template("REGv4${ITKM_${t}}${d}${ITKM_${t}}${d}DFT${ITKM_D}${d}"
                         "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::DisplacementFieldTransform< ${ITKT_D}, ${d} >")
       itk_wrap_template("REGv4${ITKM_${t}}${d}${ITKM_${t}}${d}BSOUDFT${ITKM_D}${d}"


### PR DESCRIPTION
Python wrapping for ImageRegistrationMethodv4 with Mesh is needed for ThinShellDemons based Mesh Registration.
Transform and Mesh are wrapped only with Double to reduce combinations.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
