### PR TITLE
ENH: add a new ContinuousIntegration build: LinuxLegacyRemoved

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -80,3 +80,78 @@ jobs:
         testRunTitle: 'CTest $(Agent.OS)'
       condition: succeededOrFailed()
       displayName: 'Publish test results'
+
+- job: LinuxLegacyRemoved
+  timeoutInMinutes: 0
+  cancelTimeoutInMinutes: 300
+  pool:
+    vmImage: ubuntu-18.04
+  steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 5
+    - bash: |
+        set -x
+        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+          git checkout $(System.PullRequest.SourceCommitId)
+        fi
+      displayName: 'Checkout pull request HEAD'
+
+    - bash: |
+        set -x
+        sudo pip3 install ninja
+        sudo apt-get update
+        sudo apt-get install -y python3-venv
+        sudo python3 -m pip install --upgrade setuptools
+        sudo python3 -m pip install scikit-ci-addons
+      displayName: 'Install dependencies'
+
+    - bash: |
+        set -x
+        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+
+        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
+        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
+        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/MD5 $(Build.SourcesDirectory)/.ExternalData/MD5
+      workingDirectory: $(Agent.BuildDirectory)
+      displayName: 'Download dashboard script and testing data'
+
+    - bash: |
+        cat > dashboard.cmake << EOF
+        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(BUILD_NAME_SUFFIX "LegacyRemoved")
+        set(dashboard_cache "
+          ITK_LEGACY_REMOVE:BOOL=ON
+          BUILD_SHARED_LIBS:BOOL=OFF
+          BUILD_EXAMPLES:BOOL=OFF
+          ITK_WRAP_PYTHON:BOOL=OFF
+        ")
+        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
+        EOF
+        cat dashboard.cmake
+      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
+      displayName: 'Configure CTest script'
+
+    - bash: |
+        set -x
+
+        c++ --version
+        cmake --version
+
+        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
+      displayName: 'Build and test'
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+
+    - script: |
+        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
+      condition: succeededOrFailed()
+      displayName: 'Format CTest output in JUnit format'
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
+        testRunTitle: 'CTest $(Agent.OS) LegacyRemoved'
+      condition: succeededOrFailed()
+      displayName: 'Publish test results'


### PR DESCRIPTION
It has happened several times that ITK fails to build
on one of the dashboard machines which has ITK_LEGACY_REMOVE=ON.
This could be avoided if we had a CI build without legacy.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

