### PR TITLE
PERF: Use the faster `TransformPhysicalPointToContinuousIndex` overload

### DIFF
--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -208,8 +208,9 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
   {
     numberOfInputCorners *= 2;
   }
-  using ContinuousInputIndexType = ContinuousIndex<double, InputImageType::ImageDimension>;
-  using ContinuousOutputIndexType = ContinuousIndex<double, OutputImageType::ImageDimension>;
+  using ContinuousIndexValueType = double;
+  using ContinuousInputIndexType = ContinuousIndex<ContinuousIndexValueType, InputImageType::ImageDimension>;
+  using ContinuousOutputIndexType = ContinuousIndex<ContinuousIndexValueType, OutputImageType::ImageDimension>;
 
   std::vector<ContinuousOutputIndexType> outputCorners(numberOfInputCorners);
 
@@ -260,7 +261,8 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
         outputPoint[d] = inputPoint[d];
       }
     }
-    outputImage->TransformPhysicalPointToContinuousIndex(outputPoint, outputCorners[count]);
+    outputCorners[count] =
+      outputImage->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(outputPoint);
   }
 
   // Compute a rectangular region from the vector of corner indexes

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -142,9 +142,8 @@ public:
   OutputType
   Evaluate(const PointType & point) const override
   {
-    ContinuousIndexType index;
-
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     // No thread info passed in, so call method that doesn't need thread ID.
     return (this->EvaluateAtContinuousIndex(index));
   }
@@ -152,9 +151,8 @@ public:
   virtual OutputType
   Evaluate(const PointType & point, ThreadIdType threadId) const
   {
-    ContinuousIndexType index;
-
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     return (this->EvaluateAtContinuousIndex(index, threadId));
   }
 
@@ -187,9 +185,8 @@ public:
   CovariantVectorType
   EvaluateDerivative(const PointType & point, ThreadIdType threadId) const
   {
-    ContinuousIndexType index;
-
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     return (this->EvaluateDerivativeAtContinuousIndex(index, threadId));
   }
 
@@ -230,9 +227,8 @@ public:
                              CovariantVectorType & deriv,
                              ThreadIdType          threadId) const
   {
-    ContinuousIndexType index;
-
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     this->EvaluateValueAndDerivativeAtContinuousIndex(index, value, deriv, threadId);
   }
 

--- a/Modules/Core/ImageFunction/include/itkExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkExtrapolateImageFunction.h
@@ -86,9 +86,8 @@ public:
   OutputType
   Evaluate(const PointType & point) const override
   {
-    ContinuousIndexType index;
-
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     return (this->EvaluateAtContinuousIndex(index));
   }
 

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -406,9 +406,9 @@ template <typename TInputImage, typename TOutput>
 TOutput
 GaussianBlurImageFunction<TInputImage, TOutput>::Evaluate(const PointType & point) const
 {
-  ContinuousIndexType cindex;
-
-  this->m_InternalImage->TransformPhysicalPointToContinuousIndex(point, cindex);
+  const ContinuousIndexType cindex =
+    this->m_InternalImage->template TransformPhysicalPointToContinuousIndex<typename ContinuousIndexType::ValueType>(
+      point);
 
   return this->EvaluateAtContinuousIndex(cindex);
 }

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -171,8 +171,7 @@ public:
   virtual bool
   IsInsideBuffer(const PointType & point) const
   {
-    ContinuousIndexType index;
-    m_Image->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     /* Call IsInsideBuffer to test against BufferedRegion bounds.
      * TransformPhysicalPointToContinuousIndex tests against
      * LargestPossibleRegion */
@@ -184,9 +183,7 @@ public:
   void
   ConvertPointToNearestIndex(const PointType & point, IndexType & index) const
   {
-    ContinuousIndexType cindex;
-
-    m_Image->TransformPhysicalPointToContinuousIndex(point, cindex);
+    const ContinuousIndexType cindex = m_Image->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     this->ConvertContinuousIndexToNearestIndex(cindex, index);
   }
 

--- a/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
@@ -95,9 +95,8 @@ public:
   OutputType
   Evaluate(const PointType & point) const override
   {
-    ContinuousIndexType index;
-
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     return (this->EvaluateAtContinuousIndex(index));
   }
 

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -96,9 +96,8 @@ public:
   OutputType
   Evaluate(const PointType & point) const override
   {
-    ContinuousIndexType index;
-
-    this->GetInputImage()->TransformPhysicalPointToContinuousIndex(point, index);
+    const ContinuousIndexType index =
+      this->GetInputImage()->template TransformPhysicalPointToContinuousIndex<TCoordRep>(point);
     return (this->EvaluateAtContinuousIndex(index));
   }
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -400,14 +400,14 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::RasterizeTriangles()
   auto                    NewPointSet = PointSetType::New();
   PointSetType::PointType newpoint;
 
-  // the index value type must match the point value type
-  ContinuousIndex<PointType::ValueType, 3> ind;
-  unsigned int                             pointId = 0;
+  unsigned int pointId = 0;
 
   while (points != myPoints->End())
   {
     PointType p = points.Value();
-    OutputImage->TransformPhysicalPointToContinuousIndex(p, ind);
+    // the index value type must match the point value type
+    const ContinuousIndex<PointType::ValueType, 3> ind =
+      OutputImage->template TransformPhysicalPointToContinuousIndex<PointType::ValueType>(p);
     NewPoints->InsertElement(pointId++, ind);
 
     ++points;

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -249,9 +249,8 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::
                                                          WeightsType &             weights,
                                                          ParameterIndexArrayType & indexes) const
 {
-  ContinuousIndexType index;
-
-  this->m_CoefficientImages[0]->TransformPhysicalPointToContinuousIndex(point, index);
+  ContinuousIndexType index =
+    this->m_CoefficientImages[0]->template TransformPhysicalPointToContinuousIndex<TParametersValueType>(point);
 
   // NOTE: if the support region does not lie totally within the grid
   // we assume zero displacement and return the input point

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -482,8 +482,8 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Tra
     itkExceptionMacro("B-spline coefficients have not been set");
   }
 
-  ContinuousIndexType index;
-  this->m_CoefficientImages[0]->TransformPhysicalPointToContinuousIndex(inputPoint, index);
+  ContinuousIndexType index =
+    this->m_CoefficientImages[0]->template TransformPhysicalPointToContinuousIndex<TParametersValueType>(inputPoint);
 
   // NOTE: if the support region does not lie totally within the grid
   // we assume zero displacement and return the input point
@@ -563,8 +563,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Com
   supportSize.Fill(SplineOrder + 1);
   supportRegion.SetSize(supportSize);
 
-  ContinuousIndexType index;
-  this->m_CoefficientImages[0]->TransformPhysicalPointToContinuousIndex(point, index);
+  ContinuousIndexType index =
+    this->m_CoefficientImages[0]
+      ->template TransformPhysicalPointToContinuousIndex<typename ContinuousIndexType::ValueType>(point);
 
   // NOTE: if the support region does not lie totally within the grid we assume
   // zero displacement and do no computations beyond zeroing out the value

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -522,8 +522,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoin
 
   if (this->m_CoefficientImages[0]->GetBufferPointer())
   {
-    ContinuousIndexType index;
-    this->m_CoefficientImages[0]->TransformPhysicalPointToContinuousIndex(point, index);
+    ContinuousIndexType index =
+      this->m_CoefficientImages[0]
+        ->template TransformPhysicalPointToContinuousIndex<typename ContinuousIndexType::ValueType>(point);
 
     // NOTE: if the support region does not lie totally within the grid
     // we assume zero displacement and return the input point
@@ -613,8 +614,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::ComputeJacobi
   supportSize.Fill(SplineOrder + 1);
   supportRegion.SetSize(supportSize);
 
-  ContinuousIndexType index;
-  this->m_CoefficientImages[0]->TransformPhysicalPointToContinuousIndex(point, index);
+  ContinuousIndexType index =
+    this->m_CoefficientImages[0]
+      ->template TransformPhysicalPointToContinuousIndex<typename ContinuousIndexType::ValueType>(point);
 
   // NOTE: if the support region does not lie totally within the grid we assume
   // zero displacement and do no computations beyond zeroing out the value

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -235,12 +235,13 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
         weight = static_cast<typename WeightsContainerType::Element>(confidenceImage->GetPixel(index));
       }
 
-      ContinuousIndexType                   cidx;
       PointType                             parametricPoint;
       typename InputPointSetType::PointType physicalPoint;
 
       inputField->TransformIndexToPhysicalPoint(index, physicalPoint);
-      bsplinePhysicalDomainField->TransformPhysicalPointToContinuousIndex(physicalPoint, cidx);
+      const ContinuousIndexType cidx =
+        bsplinePhysicalDomainField
+          ->template TransformPhysicalPointToContinuousIndex<typename InputFieldPointType::CoordRepType>(physicalPoint);
       bsplineParametricDomainField->TransformContinuousIndexToPhysicalPoint(cidx, parametricPoint);
 
       bool isInside = true;

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -76,8 +76,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::TransformPoint(co
     itkExceptionMacro("No interpolator is specified.");
   }
 
-  typename InterpolatorType::ContinuousIndexType cidx;
-  typename InterpolatorType::PointType           point;
+  typename InterpolatorType::PointType point;
   point.CastFrom(inputPoint);
 
   OutputPointType outputPoint;
@@ -85,7 +84,10 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::TransformPoint(co
 
   if (this->m_Interpolator->IsInsideBuffer(point))
   {
-    this->m_DisplacementField->TransformPhysicalPointToContinuousIndex(point, cidx);
+    const typename InterpolatorType::ContinuousIndexType cidx =
+      this->m_DisplacementField
+        ->template TransformPhysicalPointToContinuousIndex<typename InterpolatorType::ContinuousIndexType::ValueType>(
+          point);
     typename InterpolatorType::OutputType displacement = this->m_Interpolator->EvaluateAtContinuousIndex(cidx);
     for (unsigned int ii = 0; ii < NDimensions; ++ii)
     {

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -184,8 +184,8 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::EvaluateDisplace
   const DisplacementFieldType * fieldPtr,
   DisplacementType &            output)
 {
-  ContinuousIndex<double, ImageDimension> index;
-  fieldPtr->TransformPhysicalPointToContinuousIndex(point, index);
+  const ContinuousIndex<double, ImageDimension> index =
+    fieldPtr->template TransformPhysicalPointToContinuousIndex<double>(point);
   unsigned int dim; // index over dimension
   /**
    * Compute base index = closest index below point

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromIndexShift.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromIndexShift.hxx
@@ -91,17 +91,23 @@ void
 RegistrationParameterScalesFromIndexShift<TMetric>::TransformPointToContinuousIndex(const VirtualPointType & point,
                                                                                     TContinuousIndexType & mappedIndex)
 {
+  using ContinuousIndexValueType = typename TContinuousIndexType::ValueType;
+
   if (this->GetTransformForward())
   {
     MovingPointType mappedPoint;
     mappedPoint = this->m_Metric->GetMovingTransform()->TransformPoint(point);
-    this->m_Metric->GetMovingImage()->TransformPhysicalPointToContinuousIndex(mappedPoint, mappedIndex);
+    mappedIndex =
+      this->m_Metric->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(
+        mappedPoint);
   }
   else
   {
     FixedPointType mappedPoint;
     mappedPoint = this->m_Metric->GetFixedTransform()->TransformPoint(point);
-    this->m_Metric->GetFixedImage()->TransformPhysicalPointToContinuousIndex(mappedPoint, mappedIndex);
+    mappedIndex =
+      this->m_Metric->GetFixedImage()->template TransformPhysicalPointToContinuousIndex<ContinuousIndexValueType>(
+        mappedPoint);
   }
 }
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -1064,8 +1064,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::ComputeImageDerivatives(const Mov
   {
     if (m_ComputeGradient)
     {
-      ContinuousIndex<double, MovingImageDimension> tempIndex;
-      m_MovingImage->TransformPhysicalPointToContinuousIndex(mappedPoint, tempIndex);
+      const ContinuousIndex<double, MovingImageDimension> tempIndex =
+        m_MovingImage->template TransformPhysicalPointToContinuousIndex<double>(mappedPoint);
       MovingImageIndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
       gradient = m_GradientImage->GetPixel(mappedIndex);

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -249,8 +249,8 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -156,8 +156,8 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -258,8 +258,8 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
@@ -142,8 +142,8 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDerivative(
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -242,8 +242,8 @@ MeanSquaresPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValueAndDeriv
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -257,8 +257,8 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -445,8 +445,8 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->m_MovingImage->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->m_MovingImage->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -200,8 +200,8 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetDer
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->GetMovingImage()->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);
@@ -346,8 +346,8 @@ NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetVal
       using CoordRepType = typename OutputPointType::CoordRepType;
       using MovingImageContinuousIndexType = ContinuousIndex<CoordRepType, MovingImageType::ImageDimension>;
 
-      MovingImageContinuousIndexType tempIndex;
-      this->GetMovingImage()->TransformPhysicalPointToContinuousIndex(transformedPoint, tempIndex);
+      const MovingImageContinuousIndexType tempIndex =
+        this->GetMovingImage()->template TransformPhysicalPointToContinuousIndex<CoordRepType>(transformedPoint);
 
       typename MovingImageType::IndexType mappedIndex;
       mappedIndex.CopyWithRound(tempIndex);


### PR DESCRIPTION
Replaced `image->TransformPhysicalPointToContinuousIndex(point, index)`
calls by `image->TransformPhysicalPointToContinuousIndex<T>(point)`,
which is slightly faster, as it does not figure out whether or not the
point is inside the image.

Declared variables that are initialized by
`image->TransformPhysicalPointToContinuousIndex<T>(point)` `const`, when
possible.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2873
commit eb6ac88c8209ff6cfb3f280bb25e8388f236e211
"PERF: Use the faster TransformPhysicalPointToIndex overload in filter"