### PR TITLE
Move `BSplineInterpolateImageFunction` member function definitions into class, use `unique_ptr`

### DIFF
--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -28,14 +28,15 @@
 #ifndef itkBSplineInterpolateImageFunction_h
 #define itkBSplineInterpolateImageFunction_h
 
-#include <vector>
-
 #include "itkInterpolateImageFunction.h"
 #include "vnl/vnl_matrix.h"
 
 #include "itkBSplineDecompositionImageFilter.h"
 #include "itkConceptChecking.h"
 #include "itkCovariantVector.h"
+
+#include <memory> // For unique_ptr.
+#include <vector>
 
 namespace itk
 {
@@ -349,7 +350,7 @@ protected:
                                               vnl_matrix<double> &        weightsDerivative) const;
 
   BSplineInterpolateImageFunction();
-  ~BSplineInterpolateImageFunction() override;
+  ~BSplineInterpolateImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -413,10 +414,10 @@ private:
   // derivatives.
   bool m_UseImageDirection;
 
-  ThreadIdType         m_NumberOfWorkUnits;
-  vnl_matrix<long> *   m_ThreadedEvaluateIndex;
-  vnl_matrix<double> * m_ThreadedWeights;
-  vnl_matrix<double> * m_ThreadedWeightsDerivative;
+  ThreadIdType                          m_NumberOfWorkUnits;
+  std::unique_ptr<vnl_matrix<long>[]>   m_ThreadedEvaluateIndex;
+  std::unique_ptr<vnl_matrix<double>[]> m_ThreadedWeights;
+  std::unique_ptr<vnl_matrix<double>[]> m_ThreadedWeightsDerivative;
 };
 } // namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -170,7 +170,11 @@ public:
   }
 
   virtual OutputType
-  EvaluateAtContinuousIndex(const ContinuousIndexType & x, ThreadIdType threadId) const;
+  EvaluateAtContinuousIndex(const ContinuousIndexType & x, ThreadIdType threadId) const
+  {
+    // Pass evaluateIndex, weights by reference. Different threadIDs get different instances.
+    return this->EvaluateAtContinuousIndexInternal(x, m_ThreadedEvaluateIndex[threadId], m_ThreadedWeights[threadId]);
+  }
 
   CovariantVectorType
   EvaluateDerivative(const PointType & point) const
@@ -208,7 +212,11 @@ public:
   }
 
   CovariantVectorType
-  EvaluateDerivativeAtContinuousIndex(const ContinuousIndexType & x, ThreadIdType threadId) const;
+  EvaluateDerivativeAtContinuousIndex(const ContinuousIndexType & x, ThreadIdType threadId) const
+  {
+    return this->EvaluateDerivativeAtContinuousIndexInternal(
+      x, m_ThreadedEvaluateIndex[threadId], m_ThreadedWeights[threadId], m_ThreadedWeightsDerivative[threadId]);
+  }
 
   void
   EvaluateValueAndDerivative(const PointType & point, OutputType & value, CovariantVectorType & deriv) const
@@ -256,7 +264,15 @@ public:
   EvaluateValueAndDerivativeAtContinuousIndex(const ContinuousIndexType & x,
                                               OutputType &                value,
                                               CovariantVectorType &       derivativeValue,
-                                              ThreadIdType                threadId) const;
+                                              ThreadIdType                threadId) const
+  {
+    this->EvaluateValueAndDerivativeAtContinuousIndexInternal(x,
+                                                              value,
+                                                              derivativeValue,
+                                                              m_ThreadedEvaluateIndex[threadId],
+                                                              m_ThreadedWeights[threadId],
+                                                              m_ThreadedWeightsDerivative[threadId]);
+  }
 
   /** Get/Sets the Spline Order, supports 0th - 5th order splines. The default
    *  is a 3rd order spline. */

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -139,48 +139,6 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetNum
 }
 
 template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-typename BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::OutputType
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateAtContinuousIndex(
-  const ContinuousIndexType & x,
-  ThreadIdType                threadId) const
-{
-  vnl_matrix<long> *   evaluateIndex = &(m_ThreadedEvaluateIndex[threadId]);
-  vnl_matrix<double> * weights = &(m_ThreadedWeights[threadId]);
-  // Pass evaluateIndex, weights by reference. Different threadIDs get
-  // different instances.
-  return this->EvaluateAtContinuousIndexInternal(x, *evaluateIndex, *weights);
-}
-
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-typename BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::CovariantVectorType
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateDerivativeAtContinuousIndex(
-  const ContinuousIndexType & x,
-  ThreadIdType                threadId) const
-{
-  vnl_matrix<long> *   evaluateIndex = &(m_ThreadedEvaluateIndex[threadId]);
-  vnl_matrix<double> * weights = &(m_ThreadedWeights[threadId]);
-  vnl_matrix<double> * weightsDerivative = &(m_ThreadedWeightsDerivative[threadId]);
-
-  return this->EvaluateDerivativeAtContinuousIndexInternal(x, *evaluateIndex, *weights, *weightsDerivative);
-}
-
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-void
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::EvaluateValueAndDerivativeAtContinuousIndex(
-  const ContinuousIndexType & x,
-  OutputType &                value,
-  CovariantVectorType &       derivativeValue,
-  ThreadIdType                threadId) const
-{
-  vnl_matrix<long> *   evaluateIndex = &(m_ThreadedEvaluateIndex[threadId]);
-  vnl_matrix<double> * weights = &(m_ThreadedWeights[threadId]);
-  vnl_matrix<double> * weightsDerivative = &(m_ThreadedWeightsDerivative[threadId]);
-
-  this->EvaluateValueAndDerivativeAtContinuousIndexInternal(
-    x, value, derivativeValue, *evaluateIndex, *weights, *weightsDerivative);
-}
-
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 void
 BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::SetInterpolationWeights(
   const ContinuousIndexType & x,

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -46,9 +46,6 @@ template <typename TImageType, typename TCoordRep, typename TCoefficientType>
 BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::BSplineInterpolateImageFunction()
 {
   m_NumberOfWorkUnits = 1;
-  m_ThreadedEvaluateIndex = nullptr;
-  m_ThreadedWeights = nullptr;
-  m_ThreadedWeightsDerivative = nullptr;
 
   m_CoefficientFilter = CoefficientFilter::New();
   m_Coefficients = CoefficientImageType::New();
@@ -57,19 +54,6 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::BSplin
   unsigned int SplineOrder = 3;
   this->SetSplineOrder(SplineOrder);
   this->m_UseImageDirection = true;
-}
-
-template <typename TImageType, typename TCoordRep, typename TCoefficientType>
-BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::~BSplineInterpolateImageFunction()
-{
-  delete[] m_ThreadedEvaluateIndex;
-  m_ThreadedEvaluateIndex = nullptr;
-
-  delete[] m_ThreadedWeights;
-  m_ThreadedWeights = nullptr;
-
-  delete[] m_ThreadedWeightsDerivative;
-  m_ThreadedWeightsDerivative = nullptr;
 }
 
 /**
@@ -385,12 +369,9 @@ BSplineInterpolateImageFunction<TImageType, TCoordRep, TCoefficientType>::Genera
   // m_PointsToIndex is used to convert a sequential location to an N-dimension
   // index vector.  This is precomputed to save time during the interpolation
   // routine.
-  delete[] m_ThreadedEvaluateIndex;
-  m_ThreadedEvaluateIndex = new vnl_matrix<long>[m_NumberOfWorkUnits];
-  delete[] m_ThreadedWeights;
-  m_ThreadedWeights = new vnl_matrix<double>[m_NumberOfWorkUnits];
-  delete[] m_ThreadedWeightsDerivative;
-  m_ThreadedWeightsDerivative = new vnl_matrix<double>[m_NumberOfWorkUnits];
+  m_ThreadedEvaluateIndex = std::make_unique<vnl_matrix<long>[]>(m_NumberOfWorkUnits);
+  m_ThreadedWeights = std::make_unique<vnl_matrix<double>[]>(m_NumberOfWorkUnits);
+  m_ThreadedWeightsDerivative = std::make_unique<vnl_matrix<double>[]>(m_NumberOfWorkUnits);
   for (unsigned int i = 0; i < m_NumberOfWorkUnits; ++i)
   {
     m_ThreadedEvaluateIndex[i].set_size(ImageDimension, m_SplineOrder + 1);


### PR DESCRIPTION
Moved the `threadId` specific member function definitions of `BSplineInterpolateImageFunction` into its class template definition.

Used `unique_ptr` for threaded `BSplineInterpolateImageFunction` data