### PR TITLE
BUG: Wrong inverse matrix in MatrixOffsetTransformBase::ComputeInverseJacobianWithRespectToPosition

### DIFF
--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -197,6 +197,11 @@ public:
   using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
+  using InverseTransformType = MatrixOffsetTransformBase<TParametersValueType, NOutputDimensions, NInputDimensions>;
+  /** InverseTransformType must be a friend to allow the generation of a transformation
+   * from its inverse (function GetInverse). */
+  friend class MatrixOffsetTransformBase<TParametersValueType, NOutputDimensions, NInputDimensions>;
+
   /** Set the transformation to an Identity
    *
    * This sets the matrix to identity and the Offset to null. */
@@ -471,7 +476,7 @@ public:
    *
    */
   bool
-  GetInverse(Self * inverse) const;
+  GetInverse(InverseTransformType * inverse) const;
 
   /** Return an inverse of this transform. */
   InverseTransformBasePointer

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -417,7 +417,8 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 
 template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 bool
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverse(Self * inverse) const
+MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverse(
+  InverseTransformType * inverse) const
 {
   if (!inverse)
   {
@@ -446,7 +447,7 @@ typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutp
   InverseTransformBasePointer
   MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverseTransform() const
 {
-  Pointer inv = New();
+  auto inv = InverseTransformType::New();
 
   return GetInverse(inv) ? inv.GetPointer() : nullptr;
 }
@@ -604,7 +605,7 @@ void
 MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
   ComputeInverseJacobianWithRespectToPosition(const InputPointType &, InverseJacobianPositionType & jac) const
 {
-  jac = this->GetMatrix().GetVnlMatrix();
+  jac = this->GetInverseMatrix().GetVnlMatrix();
 }
 
 

--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -24,6 +24,7 @@
 
 using Matrix2Type = itk::Matrix<double, 2, 2>;
 using Vector2Type = itk::Vector<double, 2>;
+using Matrix3Type = itk::Matrix<double, 3, 3>;
 
 namespace
 {
@@ -571,18 +572,55 @@ itkAffineTransformTest(int, char *[])
   }
 
   /* Test ComputeJacobianWithRespectToPosition. Should return Matrix. */
-  const Affine3DType::MatrixType     jaffMatrix = jaff->GetMatrix();
+  matrix3Truth[0][0] = 1;
+  matrix3Truth[0][1] = 2;
+  matrix3Truth[0][2] = 3;
+  matrix3Truth[1][0] = 4;
+  matrix3Truth[1][1] = 5;
+  matrix3Truth[1][2] = 6;
+  matrix3Truth[2][0] = 7;
+  matrix3Truth[2][1] = 8;
+  matrix3Truth[2][2] = 8;
+
+  jaff->SetMatrix(matrix3Truth);
   Affine3DType::JacobianPositionType jaffJacobianPosition;
   jaff->ComputeJacobianWithRespectToPosition(jpoint, jaffJacobianPosition);
   for (unsigned int i = 0; i < Affine3DType::MatrixType::RowDimensions; ++i)
   {
     for (unsigned int j = 0; j < Affine3DType::MatrixType::ColumnDimensions; ++j)
     {
-      if (!testValue(jaffJacobianPosition[i][j], jaffMatrix[i][j]))
+      if (!testValue(jaffJacobianPosition[i][j], matrix3Truth[i][j]))
       {
         std::cout << "Failed ComputeJacobianWithRespectToPosition." << std::endl
                   << "jaffJacobianPosition: " << jaffJacobianPosition << std::endl
-                  << "jaffMatrix: " << jaffMatrix << std::endl;
+                  << "matrix3Truth: " << matrix3Truth << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+  }
+
+  /* Test ComputeInverseJacobianWithRespectToPosition. Should return the inverse Matrix. */
+  Matrix3Type matrix3invTruth;
+  matrix3invTruth[0][0] = -8. / 3.;
+  matrix3invTruth[0][1] = 8. / 3.;
+  matrix3invTruth[0][2] = -1;
+  matrix3invTruth[1][0] = 10. / 3.;
+  matrix3invTruth[1][1] = -13. / 3.;
+  matrix3invTruth[1][2] = 2;
+  matrix3invTruth[2][0] = -1;
+  matrix3invTruth[2][1] = 2;
+  matrix3invTruth[2][2] = -1;
+  Affine3DType::JacobianPositionType jaffInverseJacobianPosition;
+  jaff->ComputeInverseJacobianWithRespectToPosition(jpoint, jaffInverseJacobianPosition);
+  for (unsigned int i = 0; i < Affine3DType::MatrixType::RowDimensions; ++i)
+  {
+    for (unsigned int j = 0; j < Affine3DType::MatrixType::ColumnDimensions; ++j)
+    {
+      if (abs(jaffInverseJacobianPosition[i][j] - matrix3invTruth[i][j]) > 1e-13)
+      {
+        std::cout << "Failed ComputeInverseJacobianWithRespectToPosition." << std::endl
+                  << "jaffInverseJacobianPosition: " << jaffInverseJacobianPosition << std::endl
+                  << "matrix3invTruth: " << matrix3invTruth << std::endl;
         return EXIT_FAILURE;
       }
     }


### PR DESCRIPTION
itk::MatrixOffsetTransformBase::ComputeInverseJacobianWithRespectToPosition was returning directly m_Matrix, the same as the (non-inverse) ComputeJacobianWithRespectToPosition. This has been corrected to return the inverse matrix.

This correction has required also the correction of a few function return and parameters' Types. 
Those corrected Types were inconsistent when instantiated with input and output of different dimensions.

In addition, the generation of the inverse transformation required declaring the same template class, but with the input and output dimensions interchanged, as friend class.

Apparently the bug was inadvertently introduced in 
Change-Id: Ib4d253de1a592693ed253a3e7e95ddbe21df76c4 (PERF: Improve MatrixOffset Jacobian computation performance)
and subsequently not fixed but got mixed with wrong JacobianTypes in
Change-Id: I3c99bd36f915f97d3e9488d5071cb272e2f7743e (PERF: Change type of Jacobian w.r. position to vnl_matrix_fixed).