### PR TITLE
ENH: Wrap PointSet To PointSet Metric and RegistrationMethod

### DIFF
--- a/Modules/Registration/Common/wrapping/itkPointSetToPointSetMetric.wrap
+++ b/Modules/Registration/Common/wrapping/itkPointSetToPointSetMetric.wrap
@@ -1,0 +1,10 @@
+itk_wrap_include("itkPointSet.h")
+UNIQUE(types "${WRAP_ITK_REAL};D")
+
+itk_wrap_class("itk::PointSetToPointSetMetric" POINTER_WITH_2_SUPERCLASSES)
+  foreach(d ${ITK_WRAP_DIMS})
+    foreach(t ${types})
+      itk_wrap_template("PS${ITKM_${t}}${d}" "itk::PointSet< ${ITKT_${t}},${d} >, itk::PointSet< ${ITKT_${t}},${d} >")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/Modules/Registration/Common/wrapping/itkPointSetToPointSetRegistrationMethod.wrap
+++ b/Modules/Registration/Common/wrapping/itkPointSetToPointSetRegistrationMethod.wrap
@@ -1,0 +1,14 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
+itk_wrap_include("itkPointSetToPointSetRegistrationMethod.h")
+itk_wrap_include("itkPointSet.h")
+
+UNIQUE(types "${WRAP_ITK_REAL};D")
+
+itk_wrap_class("itk::PointSetToPointSetRegistrationMethod" POINTER)
+  foreach(d ${ITK_WRAP_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("REG${ITKM_${t}}${d}${ITKM_${t}}${d}"
+                        "itk::PointSet< ${ITKT_${t}}, ${d} >, itk::PointSet< ${ITKT_${t}}, ${d} >")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
PointSetToPointSetMetric and PointSetToPointSetRegistrationMethod Python wrapping added as requested in [ITK Discourse](https://discourse.itk.org/t/bspline-free-form-deformable-registration/4586/56?u=dzenanz).


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
