### PR TITLE
ENH: Add wrapping for `itk::GradientDifferenceImageToImageMetric`

### DIFF
--- a/Modules/Registration/Common/wrapping/itkGradientDifferenceImageToImageMetric.wrap
+++ b/Modules/Registration/Common/wrapping/itkGradientDifferenceImageToImageMetric.wrap
@@ -1,0 +1,3 @@
+itk_wrap_class("itk::GradientDifferenceImageToImageMetric" POINTER)
+  itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2 2+)
+itk_end_wrap_class()


### PR DESCRIPTION
Add wrapping for `itk::GradientDifferenceImageToImageMetric`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5