### PR TITLE
BUG: BresenhamLine was producing more indices than necessary

### DIFF
--- a/Modules/Core/Common/include/itkBresenhamLine.h
+++ b/Modules/Core/Common/include/itkBresenhamLine.h
@@ -24,9 +24,21 @@
 
 namespace itk
 {
-/* A simple class that will return an array of indices that are
- * offsets along the line. The line will be described by a vector and a
- * length. */
+
+/** \class BresenhamLine
+ * \brief Compute indices along a line in n dimensions.
+ *
+ * Returns an array of indices that are offsets along the line.
+ * The line can be described by a direction vector and a length.
+ * The line can be described by starting and ending indices.
+ *
+ * \ingroup ImageAccess
+ * \ingroup ITKCommon
+ *
+ * \sphinx
+ * \sphinxexample{Core/Common/BresenhamLine,Bresenham Line}
+ * \endsphinx
+ */
 template <unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT BresenhamLine
 {

--- a/Modules/Core/Common/include/itkBresenhamLine.h
+++ b/Modules/Core/Common/include/itkBresenhamLine.h
@@ -24,10 +24,9 @@
 
 namespace itk
 {
-/* a simple class that will return an array of indexes that are
+/* A simple class that will return an array of indices that are
  * offsets along the line. The line will be described by a vector and a
- * length */
-
+ * length. */
 template <unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT BresenhamLine
 {
@@ -46,7 +45,7 @@ public:
 
   /** Build a line in a specified Direction. */
   OffsetArray
-  BuildLine(LType Direction, unsigned int length);
+  BuildLine(LType Direction, IdentifierType length);
 
   /** Build a line between two pixels. */
   IndexArray

--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -27,7 +27,7 @@ namespace itk
 {
 template <unsigned int VDimension>
 auto
-BresenhamLine<VDimension>::BuildLine(LType Direction, unsigned int length) -> OffsetArray
+BresenhamLine<VDimension>::BuildLine(LType Direction, IdentifierType length) -> OffsetArray
 {
   // copied from the line iterator
   /** Variables that drive the Bresenham-Algorithm */
@@ -118,19 +118,29 @@ BresenhamLine<VDimension>::BuildLine(IndexType p0, IndexType p1) -> IndexArray
 {
   itk::Point<float, VDimension> point0;
   itk::Point<float, VDimension> point1;
+  IdentifierType                maxDistance = 0;
   for (unsigned int i = 0; i < VDimension; ++i)
   {
     point0[i] = p0[i];
     point1[i] = p1[i];
+    IdentifierType distance = std::abs(p0[i] - p1[i]) + 1;
+    if (distance > maxDistance)
+    {
+      maxDistance = distance;
+    }
   }
 
-  const auto  distance = itk::Math::RoundHalfIntegerToEven<unsigned int, double>(point0.EuclideanDistanceTo(point1));
-  OffsetArray offsets = this->BuildLine(point1 - point0, distance);
+  OffsetArray offsets = this->BuildLine(point1 - point0, maxDistance + 1);
 
-  IndexArray indices(offsets.size());
+  IndexArray indices;
+  indices.reserve(offsets.size()); // we might not have to use the last one
   for (unsigned int i = 0; i < offsets.size(); ++i)
   {
-    indices[i] = p0 + offsets[i];
+    indices.push_back(p0 + offsets[i]);
+    if (indices.back() == p1)
+    {
+      break;
+    }
   }
   return indices;
 }

--- a/Modules/Core/Common/test/itkBresenhamLineTest.cxx
+++ b/Modules/Core/Common/test/itkBresenhamLineTest.cxx
@@ -57,19 +57,19 @@ itkBresenhamLineTest(int, char *[])
     p0[1] = 0;
 
     itk::Index<2> p1;
-    p1[0] = 3;
-    p1[1] = 3;
+    p1[0] = 39;
+    p1[1] = 39;
 
     itk::BresenhamLine<2>      line;
     std::vector<itk::Index<2>> indices = line.BuildLine(p0, p1);
 
-    if (indices.size() != 4)
+    if (indices.size() != 40)
     {
-      std::cerr << "Test failed! 'indices' should be length 4 and it is " << indices.size() << std::endl;
+      std::cerr << "Test failed! 'indices' should be length 40 and it is " << indices.size() << std::endl;
       return EXIT_FAILURE;
     }
 
-    for (int i = 0; i < 4; ++i)
+    for (int i = 0; i < 40; ++i)
     {
       if (indices[i][0] != i || indices[i][1] != i)
       {


### PR DESCRIPTION
While this PR changes the signature, it should only grow the size of the `length` parameter.

Closes #2926.

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

