### PR TITLE
BUG: Resolve ITK `make` build error with Python Wrappings. 

### DIFF
--- a/CMake/ITKModuleExternal.cmake
+++ b/CMake/ITKModuleExternal.cmake
@@ -64,6 +64,9 @@ if(ITK_WRAPPING)
     # create the directory to avoid loosing case on windows
     file(MAKE_DIRECTORY ${ITK_WRAP_PYTHON_ROOT_BINARY_DIR})
 
+    set(ITK_STUB_DIR "${ITK_WRAP_PYTHON_ROOT_BINARY_DIR}/itk-stubs")
+    file(MAKE_DIRECTORY ${ITK_STUB_DIR})
+
     set(ITK_PYTHON_PACKAGE_DIR "${ITK_WRAP_PYTHON_ROOT_BINARY_DIR}/itk")
     # create the directory to avoid loosing case on windows
     file(MAKE_DIRECTORY ${ITK_PYTHON_PACKAGE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,9 @@ if(ITK_WRAPPING)
     # create the directory to avoid loosing case on windows
     file(MAKE_DIRECTORY ${ITK_WRAP_PYTHON_ROOT_BINARY_DIR})
 
+    set(ITK_STUB_DIR "${ITK_WRAP_PYTHON_ROOT_BINARY_DIR}/itk-stubs")
+    file(MAKE_DIRECTORY ${ITK_STUB_DIR})
+
     set(ITK_PYTHON_PACKAGE_DIR "${ITK_WRAP_PYTHON_ROOT_BINARY_DIR}/itk")
     # create the directory to avoid loosing case on windows
     file(MAKE_DIRECTORY ${ITK_PYTHON_PACKAGE_DIR})

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -317,7 +317,7 @@ macro(itk_end_wrap_module_swig_interface)
   set(module_interface_ext_file "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${WRAPPER_LIBRARY_NAME}_ext.i")
   set(ITK_STUB_DIR "${ITK_DIR}/Wrapping/Generators/Python/itk-stubs")
 
-  set(ITK_STUB_PYI_FILE "${ITK_STUB_DIR}/${WRAPPER_LIBRARY_NAME}.pyi")
+  set(ITK_STUB_PYI_FILES )
 
   foreach(module ${SWIG_INTERFACE_MODULES})
     # create the swig interface
@@ -326,6 +326,8 @@ macro(itk_end_wrap_module_swig_interface)
     list(APPEND idx_files "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${module}.idx")
     list(APPEND typedef_in_files "${WRAPPER_LIBRARY_OUTPUT_DIR}/${module}SwigInterface.h.in")
     list(APPEND typedef_files "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${module}SwigInterface.h")
+    list(APPEND ITK_STUB_PYI_FILES "${ITK_STUB_DIR}/${module}.pyi")
+
 
     if(${module_prefix}_WRAP_EXPLICIT)
       list(APPEND opts --include "${WRAPPER_LIBRARY_NAME}Explicit.h")
@@ -365,8 +367,8 @@ macro(itk_end_wrap_module_swig_interface)
         unset(snake_case_config_file)
       endif()
 
-    add_custom_command(
-      OUTPUT ${i_files} ${typedef_files} ${idx_files} ${snake_case_config_file} ${ITK_STUB_PYI_FILE}
+      add_custom_command(
+      OUTPUT ${i_files} ${typedef_files} ${idx_files} ${snake_case_config_file} ${ITK_STUB_PYI_FILES}
       COMMAND ${Python3_EXECUTABLE} ${IGENERATOR}
         ${mdx_opts}
         ${swig_libs}


### PR DESCRIPTION
Resolved a few small bugs causing `make` builds to fail when python wrapping is enabled. 

The following was changed:
1. The itk-stubs directory is generated via cmake during build configuration before igenerator.py is ran.
2. The .pyi output files in the igenerator custom command were corrected. 
3. The typehint generation code was reformatted to prevent duplicate definitions from being saved to several files. 

This should fix #2908. 
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)


<!-- **Thanks for contributing to ITK!** -->
