### PR TITLE
COMP: Use `itk::Math::abs` for floating point type argument

### DIFF
--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -616,7 +616,7 @@ itkAffineTransformTest(int, char *[])
   {
     for (unsigned int j = 0; j < Affine3DType::MatrixType::ColumnDimensions; ++j)
     {
-      if (abs(jaffInverseJacobianPosition[i][j] - matrix3invTruth[i][j]) > 1e-13)
+      if (itk::Math::abs(jaffInverseJacobianPosition[i][j] - matrix3invTruth[i][j]) > 1e-13)
       {
         std::cout << "Failed ComputeInverseJacobianWithRespectToPosition." << std::endl
                   << "jaffInverseJacobianPosition: " << jaffInverseJacobianPosition << std::endl


### PR DESCRIPTION
Use `itk::Math::abs` instead of `abs` for floating point type argument.

Fixes:
```
[CTest: warning matched]
/Users/builder/externalModules/Core/Transform/test/itkAffineTransformTest.cxx:619:11:
warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
      if (abs(jaffInverseJacobianPosition[i][j] - matrix3invTruth[i][j]) > 1e-13)
          ^
[CTest: warning matched]
/Users/builder/externalModules/Core/Transform/test/itkAffineTransformTest.cxx:619:11:
note: use function 'std::abs' instead
      if (abs(jaffInverseJacobianPosition[i][j] - matrix3invTruth[i][j]) > 1e-13)
          ^~~
          std::abs
[CTest: warning suppressed] 1 warning generated.
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&onlydeltap&buildid=7615457

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)