### PR TITLE
ENH: Spatial object to image filter preserve index

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
@@ -50,6 +50,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   using OutputImageType = TOutputImage;
+  using IndexType = typename OutputImageType::IndexType;
   using SizeType = typename OutputImageType::SizeType;
   using PointType = typename OutputImageType::PointType;
   using OutputImagePointer = typename OutputImageType::Pointer;
@@ -100,6 +101,7 @@ public:
     this->SetOrigin(refImage->GetOrigin());
     this->SetSpacing(refImage->GetSpacing());
     this->SetDirection(refImage->GetDirection());
+    this->SetIndex(refImage->GetLargestPossibleRegion().GetIndex());
     this->SetSize(refImage->GetLargestPossibleRegion().GetSize());
   }
 
@@ -161,6 +163,12 @@ public:
   virtual const double *
   GetOrigin() const;
 
+  /** The index of the output image. The index is the pixel
+   * coordinates of the image region.
+   * \sa GetSize() */
+  itkSetMacro(Index, IndexType);
+  itkGetConstMacro(Index, IndexType);
+
   /** The spatial object being transformed can be part of a hierarchy.
    * How deep in the hierarchy should we descend in generating the
    * image?  A ChildrenDepth of 0 means to only include the object
@@ -188,6 +196,7 @@ protected:
   void
   GenerateData() override;
 
+  IndexType     m_Index;
   SizeType      m_Size;
   double        m_Spacing[OutputImageDimension];
   double        m_Origin[OutputImageDimension];

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -32,6 +32,7 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::SpatialObjectToIm
   this->SetNumberOfRequiredInputs(1);
   m_ChildrenDepth = TInputSpatialObject::MaximumDepth;
   m_Size.Fill(0);
+  m_Index.Fill(0);
   m_Direction.SetIdentity();
 
   for (unsigned int i = 0; i < OutputImageDimension; ++i)
@@ -285,8 +286,6 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GenerateData()
                                          InputObject->GetFamilyBoundingBoxInWorldSpace()->GetMinimum()[i]);
   }
 
-  typename OutputImageType::IndexType index;
-  index.Fill(0);
   typename OutputImageType::RegionType region;
 
   // If the size of the output has been explicitly specified, the filter
@@ -312,7 +311,27 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GenerateData()
   {
     region.SetSize(size);
   }
-  region.SetIndex(index);
+
+  IndexType index;
+  index.Fill(0);
+  specified = false;
+  for (i = 0; i < OutputImageDimension; ++i)
+  {
+    if (m_Index[i] != 0)
+    {
+      specified = true;
+      break;
+    }
+  }
+
+  if (specified)
+  {
+    region.SetIndex(m_Index);
+  }
+  else
+  {
+    region.SetIndex(index);
+  }
 
   OutputImage->SetLargestPossibleRegion(region); //
   OutputImage->SetBufferedRegion(region);        // set the region
@@ -379,6 +398,7 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::PrintSelf(std::os
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Size : " << m_Size << std::endl;
+  os << indent << "Index : " << m_Index << std::endl;
   os << indent << "Children depth : " << m_ChildrenDepth << std::endl;
   os << indent << "Inside Value : " << m_InsideValue << std::endl;
   os << indent << "Outside Value : " << m_OutsideValue << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
@@ -70,6 +70,12 @@ itkSpatialObjectToImageFilterTest(int, char *[])
   imageFilter->SetChildrenDepth(childrenDepth);
   ITK_TEST_SET_GET_VALUE(childrenDepth, imageFilter->GetChildrenDepth());
 
+  ImageType::IndexType indx;
+  indx[0] = 10;
+  indx[1] = 10;
+  imageFilter->SetIndex(indx);
+  ITK_TEST_SET_GET_VALUE(indx, imageFilter->GetIndex());
+
   ImageType::SizeType size;
   size[0] = 50;
   size[1] = 50;


### PR DESCRIPTION
The base class for SpatialObjectToImage filtering didn't use the index
of the reference image.  As a result, when, for example, rendering a
spatial object into an image, if the reference image had a non-zero
index, the generated image would not match the spatial extent of the
reference image.

- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)