### PR TITLE
COMP: GetCell before SetCell to avoid memory leak

### DIFF
--- a/Modules/Core/Mesh/test/itkTriangleMeshCurvatureCalculatorTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshCurvatureCalculatorTest.cxx
@@ -151,6 +151,13 @@ itkTriangleMeshCurvatureCalculatorTest(int argc, char * argv[])
   CellType::CellAutoPointer cellpointer;
 
   // Insert a Tetrahedron Cell in the mesh
+
+  // First obtain the cell on that index to be deleted to avoid memory leak
+  CellType::CellAutoPointer cellToDelete;
+  triangleMesh->GetCell(0, cellToDelete);
+  cellToDelete.TakeOwnership();
+
+  // Next insert a Tetrahedron Cell on that index
   cellpointer.TakeOwnership(new TetrahedronType);
   cellpointer->SetPointId(0, 0);
   cellpointer->SetPointId(1, 1);


### PR DESCRIPTION
Minor modification in the itkTriangleMeshCurvatureCalculatorTest to avoid memory leak.
GetCell is called before SetCell to avoid memory leak while inserting Tetrahedron Cell.
Refer to [SetCell](https://itk.org/Doxygen/html/classitk_1_1Mesh.html) documentation. 
<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [X] Added test (or behavior not changed)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
