### PR TITLE
STYLE: Use the `itkNameOfTestExecutableMacro` macro in tests

### DIFF
--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -23,11 +23,11 @@
 
 
 int
-itkSymmetricSecondRankTensorImageReadTest(int ac, char * av[])
+itkSymmetricSecondRankTensorImageReadTest(int argc, char * argv[])
 {
-  if (ac < 1)
+  if (argc < 1)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
   }
 
@@ -85,8 +85,8 @@ itkSymmetricSecondRankTensorImageReadTest(int ac, char * av[])
 
   try
   {
-    itk::WriteImage(matrixImage, av[1]);
-    const TensorImageType::ConstPointer tensorImage = itk::ReadImage<TensorImageType>(av[1]);
+    itk::WriteImage(matrixImage, argv[1]);
+    const TensorImageType::ConstPointer tensorImage = itk::ReadImage<TensorImageType>(argv[1]);
 
     // Compare the read values to the original values
     const float tolerance = 1e-5;

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -26,7 +27,7 @@ itkSymmetricSecondRankTensorImageReadTest(int ac, char * av[])
 {
   if (ac < 1)
   {
-    std::cerr << "Usage: " << av[0] << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 // Write a 2D SymmetricSecondRankTensor image to file and read it back again.
@@ -27,7 +28,7 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int ac, char * av[])
 {
   if (ac < 1)
   {
-    std::cerr << "Usage: " << av[0] << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -24,11 +24,11 @@
 
 // Write a 2D SymmetricSecondRankTensor image to file and read it back again.
 int
-itkSymmetricSecondRankTensorImageWriteReadTest(int ac, char * av[])
+itkSymmetricSecondRankTensorImageWriteReadTest(int argc, char * argv[])
 {
-  if (ac < 1)
+  if (argc < 1)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
   }
 
@@ -70,8 +70,8 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int ac, char * av[])
 
   try
   {
-    itk::WriteImage(tensorImageInput, av[1]);
-    const TensorImageType::ConstPointer tensorImageOutput = itk::ReadImage<TensorImageType>(av[1]);
+    itk::WriteImage(tensorImageInput, argv[1]);
+    const TensorImageType::ConstPointer tensorImageOutput = itk::ReadImage<TensorImageType>(argv[1]);
 
     // Compare the read values to the original values
     const float tolerance = 1e-5;

--- a/Modules/Core/Mesh/test/itkVTKPolyDataReaderTest.cxx
+++ b/Modules/Core/Mesh/test/itkVTKPolyDataReaderTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkVTKPolyDataReader.h"
+#include "itkTestingMacros.h"
 
 #include <iostream>
 
@@ -25,7 +26,7 @@ itkVTKPolyDataReaderTest(int argc, char * argv[])
 {
   if (argc != 2)
   {
-    std::cerr << "Usage: itkVTKPolyDataReaderTest inputFilename" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Core/QuadEdgeMesh/test/itkVTKPolyDataIOQuadEdgeMeshTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkVTKPolyDataIOQuadEdgeMeshTest.cxx
@@ -19,6 +19,7 @@
 #include "itkQuadEdgeMesh.h"
 #include "itkVTKPolyDataReader.h"
 #include "itkVTKPolyDataWriter.h"
+#include "itkTestingMacros.h"
 
 #include <iostream>
 
@@ -35,7 +36,7 @@ itkVTKPolyDataIOQuadEdgeMeshTest(int argc, char * argv[])
 
   if (argc != 3)
   {
-    std::cerr << "Usage: itkVTKPolyDataReaderTest inputFilename outputFilename" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFilename outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
   else

--- a/Modules/Core/QuadEdgeMesh/test/itkVTKPolyDataReaderQuadEdgeMeshTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkVTKPolyDataReaderQuadEdgeMeshTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkQuadEdgeMesh.h"
 #include "itkVTKPolyDataReader.h"
+#include "itkTestingMacros.h"
 
 #include <iostream>
 
@@ -26,7 +27,7 @@ itkVTKPolyDataReaderQuadEdgeMeshTest(int argc, char * argv[])
 {
   if (argc != 2)
   {
-    std::cerr << "Usage: itkVTKPolyDataReaderTest inputFilename" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest2.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest2.cxx
@@ -23,6 +23,7 @@
 #include "itkImageFileWriter.h"
 #include "itkChangeInformationImageFilter.h"
 #include "itkTestingComparisonImageFilter.h"
+#include "itkTestingMacros.h"
 #include <fstream>
 
 using PixelType = float;
@@ -68,7 +69,7 @@ itkGradientAnisotropicDiffusionImageFilterTest2(int ac, char * av[])
 {
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage OutputImage\n";
     return -1;
   }
 

--- a/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterTest.cxx
@@ -25,13 +25,14 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkNormalizedCorrelationImageFilterTest(int ac, char * av[])
 {
   if (ac < 4)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage MaskImage OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage MaskImage OutputImage\n";
     return -1;
   }
 

--- a/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterTest.cxx
@@ -28,11 +28,11 @@
 #include "itkTestingMacros.h"
 
 int
-itkNormalizedCorrelationImageFilterTest(int ac, char * av[])
+itkNormalizedCorrelationImageFilterTest(int argc, char * argv[])
 {
-  if (ac < 4)
+  if (argc < 4)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage MaskImage OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage MaskImage OutputImage\n";
     return -1;
   }
 
@@ -44,7 +44,7 @@ itkNormalizedCorrelationImageFilterTest(int ac, char * av[])
   using CorrelationImageType = itk::Image<CorrelationPixelType, Dimension>;
 
   itk::ImageFileReader<InputImageType>::Pointer input = itk::ImageFileReader<InputImageType>::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
   input->Update();
 
   // define an operator
@@ -58,7 +58,7 @@ itkNormalizedCorrelationImageFilterTest(int ac, char * av[])
 
   // create a mask
   itk::ImageFileReader<InputImageType>::Pointer mask = itk::ImageFileReader<InputImageType>::New();
-  mask->SetFileName(av[2]);
+  mask->SetFileName(argv[2]);
 
   // resample the mask to be the size of the input
   using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<InputImageType>;
@@ -97,7 +97,7 @@ itkNormalizedCorrelationImageFilterTest(int ac, char * av[])
   itk::ImageFileWriter<InputImageType>::Pointer writer;
   writer = itk::ImageFileWriter<InputImageType>::New();
   writer->SetInput(threshold->GetOutput());
-  writer->SetFileName(av[3]);
+  writer->SetFileName(argv[3]);
 
   try
   {

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest2.cxx
@@ -21,13 +21,14 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkBilateralImageFilterTest2(int ac, char * av[])
 {
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage OutputImage\n";
     return -1;
   }
 

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest3.cxx
@@ -20,6 +20,7 @@
 #include "itkBilateralImageFilter.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -27,7 +28,7 @@ itkBilateralImageFilterTest3(int ac, char * av[])
 {
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BaselineImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage\n";
     return -1;
   }
 

--- a/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
@@ -25,11 +25,11 @@
 #include "itkTestingMacros.h"
 
 int
-itkMaskNeighborhoodOperatorImageFilterTest(int ac, char * av[])
+itkMaskNeighborhoodOperatorImageFilterTest(int argc, char * argv[])
 {
-  if (ac < 3)
+  if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage\n";
     return -1;
   }
 
@@ -41,7 +41,7 @@ itkMaskNeighborhoodOperatorImageFilterTest(int ac, char * av[])
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
   itk::ImageFileReader<InputImageType>::Pointer input = itk::ImageFileReader<InputImageType>::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
   input->Update();
 
   // create a mask the size of the input file
@@ -126,7 +126,7 @@ itkMaskNeighborhoodOperatorImageFilterTest(int ac, char * av[])
   // Generate test image
   itk::ImageFileWriter<OutputImageType>::Pointer writer = itk::ImageFileWriter<OutputImageType>::New();
   writer->SetInput(rescaler->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
 
   try
   {

--- a/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
@@ -29,7 +29,7 @@ itkMaskNeighborhoodOperatorImageFilterTest(int ac, char * av[])
 {
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage OutputImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage OutputImage\n";
     return -1;
   }
 

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
@@ -41,7 +41,7 @@ itkVectorGradientMagnitudeImageFilterTest2(int ac, char * av[])
 
   if (ac < 5)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage OutputImage Mode SliceToExtract\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage OutputImage Mode SliceToExtract\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
@@ -37,7 +37,7 @@ itkVectorGradientMagnitudeImageFilterTest3(int ac, char * av[])
 
   if (ac < 4)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage OutputImage Mode\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage OutputImage Mode\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImage2DTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImage2DTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkCentralDifferenceImageFunction.h"
+#include "itkTestingMacros.h"
 
 int
 itkOrientedImage2DTest(int ac, char * av[])
@@ -25,7 +26,7 @@ itkOrientedImage2DTest(int ac, char * av[])
 
   if (ac < 12)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage  "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage  "
               << "corner1x corner1y "
               << "corner2x corner2y "
               << "corner3x corner3y "

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImage2DTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImage2DTest.cxx
@@ -21,12 +21,12 @@
 #include "itkTestingMacros.h"
 
 int
-itkOrientedImage2DTest(int ac, char * av[])
+itkOrientedImage2DTest(int argc, char * argv[])
 {
 
-  if (ac < 12)
+  if (argc < 12)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage  "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage  "
               << "corner1x corner1y "
               << "corner2x corner2y "
               << "corner3x corner3y "
@@ -47,7 +47,7 @@ itkOrientedImage2DTest(int ac, char * av[])
 
   auto reader = ReaderType::New();
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -98,7 +98,7 @@ itkOrientedImage2DTest(int ac, char * av[])
 
     for (unsigned int dim = 0; dim < Dimension; ++dim)
     {
-      const double expectedValue = std::stod(av[element++]);
+      const double expectedValue = std::stod(argv[element++]);
       const double currentValue = physicalPoint[dim];
       const double difference = currentValue - expectedValue;
       if (itk::Math::abs(difference) > tolerance)
@@ -141,7 +141,7 @@ itkOrientedImage2DTest(int ac, char * av[])
 
     for (unsigned int dim = 0; dim < Dimension; ++dim)
     {
-      const double expectedValue = std::stod(av[element++]);
+      const double expectedValue = std::stod(argv[element++]);
       const double currentValue = gradient1a[dim];
       const double difference = currentValue - expectedValue;
       if (itk::Math::abs(difference) > tolerance)
@@ -166,7 +166,7 @@ itkOrientedImage2DTest(int ac, char * av[])
 
     for (unsigned int dim = 0; dim < Dimension; ++dim)
     {
-      const double expectedValue = std::stod(av[element++]);
+      const double expectedValue = std::stod(argv[element++]);
       const double currentValue = gradient1b[dim];
       const double difference = currentValue - expectedValue;
       if (itk::Math::abs(difference) > tolerance)

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImage3DTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImage3DTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkCentralDifferenceImageFunction.h"
+#include "itkTestingMacros.h"
 
 int
 itkOrientedImage3DTest(int ac, char * av[])
@@ -25,7 +26,7 @@ itkOrientedImage3DTest(int ac, char * av[])
 
   if (ac < 20)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage  "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage  "
               << "corner1x corner1y corner1z "
               << "corner2x corner2y corner2z "
               << "corner3x corner3y corner3z "

--- a/Modules/Filtering/ImageGrid/test/itkOrientedImage3DTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientedImage3DTest.cxx
@@ -21,12 +21,12 @@
 #include "itkTestingMacros.h"
 
 int
-itkOrientedImage3DTest(int ac, char * av[])
+itkOrientedImage3DTest(int argc, char * argv[])
 {
 
-  if (ac < 20)
+  if (argc < 20)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage  "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage  "
               << "corner1x corner1y corner1z "
               << "corner2x corner2y corner2z "
               << "corner3x corner3y corner3z "
@@ -47,7 +47,7 @@ itkOrientedImage3DTest(int ac, char * av[])
 
   auto reader = ReaderType::New();
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -106,7 +106,7 @@ itkOrientedImage3DTest(int ac, char * av[])
 
     for (unsigned int dim = 0; dim < Dimension; ++dim)
     {
-      const double expectedValue = std::stod(av[element++]);
+      const double expectedValue = std::stod(argv[element++]);
       const double currentValue = physicalPoint[dim];
       const double difference = currentValue - expectedValue;
       if (itk::Math::abs(difference) > tolerance)
@@ -149,7 +149,7 @@ itkOrientedImage3DTest(int ac, char * av[])
 
     for (unsigned int dim = 0; dim < Dimension; ++dim)
     {
-      const double expectedValue = std::stod(av[element++]);
+      const double expectedValue = std::stod(argv[element++]);
       const double currentValue = gradient1a[dim];
       const double difference = currentValue - expectedValue;
       if (itk::Math::abs(difference) > tolerance)
@@ -174,7 +174,7 @@ itkOrientedImage3DTest(int ac, char * av[])
 
     for (unsigned int dim = 0; dim < Dimension; ++dim)
     {
-      const double expectedValue = std::stod(av[element++]);
+      const double expectedValue = std::stod(argv[element++]);
       const double currentValue = gradient1b[dim];
       const double difference = currentValue - expectedValue;
       if (itk::Math::abs(difference) > tolerance)

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
@@ -26,14 +26,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkGrayscaleDilateImageFilterTest(int ac, char * av[])
+itkGrayscaleDilateImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 6)
+  if (argc < 6)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
     return -1;
   }
 
@@ -42,7 +42,7 @@ itkGrayscaleDilateImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   // Create a filter
   using SRType = itk::FlatStructuringElement<dim>;
@@ -78,19 +78,19 @@ itkGrayscaleDilateImageFilterTest(int ac, char * av[])
     writer->SetInput(filter->GetOutput());
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
-    writer->SetFileName(av[2]);
+    writer->SetFileName(argv[2]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
-    writer->SetFileName(av[3]);
+    writer->SetFileName(argv[3]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
-    writer->SetFileName(av[4]);
+    writer->SetFileName(argv[4]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
-    writer->SetFileName(av[5]);
+    writer->SetFileName(argv[5]);
     writer->Update();
   }
   catch (const itk::ExceptionObject & e)
@@ -103,7 +103,7 @@ itkGrayscaleDilateImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkGrayscaleDilateImageFilterTest(int ac, char * av[])
@@ -32,7 +33,7 @@ itkGrayscaleDilateImageFilterTest(int ac, char * av[])
 
   if (ac < 6)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
@@ -26,14 +26,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkGrayscaleErodeImageFilterTest(int ac, char * av[])
+itkGrayscaleErodeImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 6)
+  if (argc < 6)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
     return -1;
   }
 
@@ -42,7 +42,7 @@ itkGrayscaleErodeImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   // Create a filter
   using SRType = itk::FlatStructuringElement<dim>;
@@ -78,19 +78,19 @@ itkGrayscaleErodeImageFilterTest(int ac, char * av[])
     writer->SetInput(filter->GetOutput());
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
-    writer->SetFileName(av[2]);
+    writer->SetFileName(argv[2]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
-    writer->SetFileName(av[3]);
+    writer->SetFileName(argv[3]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
-    writer->SetFileName(av[4]);
+    writer->SetFileName(argv[4]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
-    writer->SetFileName(av[5]);
+    writer->SetFileName(argv[5]);
     writer->Update();
   }
   catch (const itk::ExceptionObject & e)
@@ -103,7 +103,7 @@ itkGrayscaleErodeImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkGrayscaleErodeImageFilterTest(int ac, char * av[])
@@ -32,7 +33,7 @@ itkGrayscaleErodeImageFilterTest(int ac, char * av[])
 
   if (ac < 6)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkGrayscaleMorphologicalClosingImageFilterTest2(int ac, char * av[])
@@ -32,7 +33,8 @@ itkGrayscaleMorphologicalClosingImageFilterTest2(int ac, char * av[])
 
   if (ac < 7)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
+              << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkGrayscaleMorphologicalOpeningImageFilterTest2(int ac, char * av[])
@@ -32,7 +33,8 @@ itkGrayscaleMorphologicalOpeningImageFilterTest2(int ac, char * av[])
 
   if (ac < 7)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
+              << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkMapGrayscaleDilateImageFilterTest(int ac, char * av[])
@@ -32,7 +33,7 @@ itkMapGrayscaleDilateImageFilterTest(int ac, char * av[])
 
   if (ac < 6)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
@@ -26,14 +26,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkMapGrayscaleDilateImageFilterTest(int ac, char * av[])
+itkMapGrayscaleDilateImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 6)
+  if (argc < 6)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
     return -1;
   }
 
@@ -42,7 +42,7 @@ itkMapGrayscaleDilateImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   // Create a filter
   using SRType = itk::FlatStructuringElement<dim>;
@@ -78,19 +78,19 @@ itkMapGrayscaleDilateImageFilterTest(int ac, char * av[])
     writer->SetInput(filter->GetOutput());
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
-    writer->SetFileName(av[2]);
+    writer->SetFileName(argv[2]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
-    writer->SetFileName(av[3]);
+    writer->SetFileName(argv[3]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
-    writer->SetFileName(av[4]);
+    writer->SetFileName(argv[4]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
-    writer->SetFileName(av[5]);
+    writer->SetFileName(argv[5]);
     writer->Update();
   }
   catch (const itk::ExceptionObject & e)
@@ -103,7 +103,7 @@ itkMapGrayscaleDilateImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkMapGrayscaleErodeImageFilterTest(int ac, char * av[])
@@ -32,7 +33,7 @@ itkMapGrayscaleErodeImageFilterTest(int ac, char * av[])
 
   if (ac < 6)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
@@ -26,14 +26,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkMapGrayscaleErodeImageFilterTest(int ac, char * av[])
+itkMapGrayscaleErodeImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 6)
+  if (argc < 6)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
     return -1;
   }
 
@@ -42,7 +42,7 @@ itkMapGrayscaleErodeImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   // Create a filter
   using SRType = itk::FlatStructuringElement<dim>;
@@ -78,19 +78,19 @@ itkMapGrayscaleErodeImageFilterTest(int ac, char * av[])
     writer->SetInput(filter->GetOutput());
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
-    writer->SetFileName(av[2]);
+    writer->SetFileName(argv[2]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
-    writer->SetFileName(av[3]);
+    writer->SetFileName(argv[3]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
-    writer->SetFileName(av[4]);
+    writer->SetFileName(argv[4]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
-    writer->SetFileName(av[5]);
+    writer->SetFileName(argv[5]);
     writer->Update();
   }
   catch (const itk::ExceptionObject & e)
@@ -103,7 +103,7 @@ itkMapGrayscaleErodeImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
@@ -26,14 +26,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkMapGrayscaleMorphologicalClosingImageFilterTest(int ac, char * av[])
+itkMapGrayscaleMorphologicalClosingImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 7)
+  if (argc < 7)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
               << std::endl;
     return -1;
   }
@@ -43,7 +43,7 @@ itkMapGrayscaleMorphologicalClosingImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   // Create a filter
   using SRType = itk::FlatStructuringElement<dim>;
@@ -79,26 +79,26 @@ itkMapGrayscaleMorphologicalClosingImageFilterTest(int ac, char * av[])
   try
   {
     filter->SetRadius(20);
-    filter->SetSafeBorder(std::stoi(av[6]));
+    filter->SetSafeBorder(std::stoi(argv[6]));
 
     using WriterType = itk::ImageFileWriter<ImageType>;
     auto writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
-    writer->SetFileName(av[2]);
+    writer->SetFileName(argv[2]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
-    writer->SetFileName(av[3]);
+    writer->SetFileName(argv[3]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
-    writer->SetFileName(av[4]);
+    writer->SetFileName(argv[4]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
-    writer->SetFileName(av[5]);
+    writer->SetFileName(argv[5]);
     writer->Update();
   }
   catch (const itk::ExceptionObject & e)
@@ -111,7 +111,7 @@ itkMapGrayscaleMorphologicalClosingImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkMapGrayscaleMorphologicalClosingImageFilterTest(int ac, char * av[])
@@ -32,7 +33,8 @@ itkMapGrayscaleMorphologicalClosingImageFilterTest(int ac, char * av[])
 
   if (ac < 7)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
+              << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkFlatStructuringElement.h"
+#include "itkTestingMacros.h"
 
 int
 itkMapGrayscaleMorphologicalOpeningImageFilterTest(int ac, char * av[])
@@ -32,7 +33,8 @@ itkMapGrayscaleMorphologicalOpeningImageFilterTest(int ac, char * av[])
 
   if (ac < 7)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
+              << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
@@ -26,14 +26,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkMapGrayscaleMorphologicalOpeningImageFilterTest(int ac, char * av[])
+itkMapGrayscaleMorphologicalOpeningImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 7)
+  if (argc < 7)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
               << std::endl;
     return -1;
   }
@@ -43,7 +43,7 @@ itkMapGrayscaleMorphologicalOpeningImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   // Create a filter
   using SRType = itk::FlatStructuringElement<dim>;
@@ -79,26 +79,26 @@ itkMapGrayscaleMorphologicalOpeningImageFilterTest(int ac, char * av[])
   try
   {
     filter->SetRadius(20);
-    filter->SetSafeBorder(std::stoi(av[6]));
+    filter->SetSafeBorder(std::stoi(argv[6]));
 
     using WriterType = itk::ImageFileWriter<ImageType>;
     auto writer = WriterType::New();
     writer->SetInput(filter->GetOutput());
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::BASIC);
-    writer->SetFileName(av[2]);
+    writer->SetFileName(argv[2]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::HISTO);
-    writer->SetFileName(av[3]);
+    writer->SetFileName(argv[3]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::ANCHOR);
-    writer->SetFileName(av[4]);
+    writer->SetFileName(argv[4]);
     writer->Update();
 
     filter->SetAlgorithm(FilterType::AlgorithmEnum::VHGW);
-    writer->SetFileName(av[5]);
+    writer->SetFileName(argv[5]);
     writer->Update();
   }
   catch (const itk::ExceptionObject & e)
@@ -111,7 +111,7 @@ itkMapGrayscaleMorphologicalOpeningImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkMapMaskedRankImageFilterTest(int ac, char * av[])
+itkMapMaskedRankImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 5)
+  if (argc < 5)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage maskImage BaselineImage radius"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage maskImage BaselineImage radius"
               << std::endl;
     return -1;
   }
@@ -41,10 +41,10 @@ itkMapMaskedRankImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto input = ReaderType::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   auto input2 = ReaderType::New();
-  input2->SetFileName(av[2]);
+  input2->SetFileName(argv[2]);
 
   // Create a filter
   using SEType = itk::FlatStructuringElement<2>;
@@ -132,7 +132,7 @@ itkMapMaskedRankImageFilterTest(int ac, char * av[])
 
   try
   {
-    int r = std::stoi(av[4]);
+    int r = std::stoi(argv[4]);
     filter->SetInput(input->GetOutput());
     filter->SetMaskImage(input2->GetOutput());
     filter->SetRadius(r);
@@ -152,7 +152,7 @@ itkMapMaskedRankImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[3]);
+  writer->SetFileName(argv[3]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkMapMaskedRankImageFilterTest(int ac, char * av[])
@@ -31,7 +32,8 @@ itkMapMaskedRankImageFilterTest(int ac, char * av[])
 
   if (ac < 5)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage maskImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage maskImage BaselineImage radius"
+              << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkMapRankImageFilterTest(int ac, char * av[])
+itkMapRankImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 4)
+  if (argc < 4)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
     return -1;
   }
 
@@ -40,7 +40,7 @@ itkMapRankImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto input = ReaderType::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using SEType = itk::FlatStructuringElement<2>;
@@ -92,7 +92,7 @@ itkMapRankImageFilterTest(int ac, char * av[])
 
   try
   {
-    int r = std::stoi(av[3]);
+    int r = std::stoi(argv[3]);
     filter->SetInput(input->GetOutput());
     filter->SetRadius(r);
     filter->SetRank(0.5);
@@ -108,7 +108,7 @@ itkMapRankImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkMapRankImageFilterTest(int ac, char * av[])
@@ -31,7 +32,7 @@ itkMapRankImageFilterTest(int ac, char * av[])
 
   if (ac < 4)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage radius" << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkMaskedRankImageFilterTest(int ac, char * av[])
+itkMaskedRankImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 5)
+  if (argc < 5)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage maskImage BaselineImage radius"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage maskImage BaselineImage radius"
               << std::endl;
     return -1;
   }
@@ -41,10 +41,10 @@ itkMaskedRankImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto input = ReaderType::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   auto input2 = ReaderType::New();
-  input2->SetFileName(av[2]);
+  input2->SetFileName(argv[2]);
 
   // Create a filter
   using FilterType = itk::MaskedRankImageFilter<ImageType, ImageType, ImageType>;
@@ -131,7 +131,7 @@ itkMaskedRankImageFilterTest(int ac, char * av[])
 
   try
   {
-    int r = std::stoi(av[4]);
+    int r = std::stoi(argv[4]);
     filter->SetInput(input->GetOutput());
     filter->SetMaskImage(input2->GetOutput());
     filter->SetRadius(r);
@@ -151,7 +151,7 @@ itkMaskedRankImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[3]);
+  writer->SetFileName(argv[3]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkMaskedRankImageFilterTest(int ac, char * av[])
@@ -31,7 +32,8 @@ itkMaskedRankImageFilterTest(int ac, char * av[])
 
   if (ac < 5)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage maskImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage maskImage BaselineImage radius"
+              << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkRankImageFilterTest(int ac, char * av[])
@@ -31,7 +32,7 @@ itkRankImageFilterTest(int ac, char * av[])
 
   if (ac < 4)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage radius" << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkRankImageFilterTest(int ac, char * av[])
+itkRankImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 4)
+  if (argc < 4)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
     return -1;
   }
 
@@ -40,7 +40,7 @@ itkRankImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto input = ReaderType::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using FilterType = itk::RankImageFilter<ImageType, ImageType>;
@@ -90,7 +90,7 @@ itkRankImageFilterTest(int ac, char * av[])
 
   try
   {
-    int r = std::stoi(av[3]);
+    int r = std::stoi(argv[3]);
     filter->SetInput(input->GetOutput());
     filter->SetRadius(r);
     filter->SetRank(0.5);
@@ -106,7 +106,7 @@ itkRankImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkBoxMeanImageFilterTest(int ac, char * av[])
@@ -31,7 +32,7 @@ itkBoxMeanImageFilterTest(int ac, char * av[])
 
   if (ac < 4)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage radius" << std::endl;
     return -1;
   }
 

--- a/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkBoxMeanImageFilterTest(int ac, char * av[])
+itkBoxMeanImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 4)
+  if (argc < 4)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
     return -1;
   }
 
@@ -40,7 +40,7 @@ itkBoxMeanImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto input = ReaderType::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using FilterType = itk::BoxMeanImageFilter<ImageType, ImageType>;
@@ -78,7 +78,7 @@ itkBoxMeanImageFilterTest(int ac, char * av[])
 
   try
   {
-    int r = std::stoi(av[3]);
+    int r = std::stoi(argv[3]);
     filter->SetInput(input->GetOutput());
     filter->SetRadius(r);
     filter->Update();
@@ -93,7 +93,7 @@ itkBoxMeanImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkBoxSigmaImageFilterTest(int ac, char * av[])
+itkBoxSigmaImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 4)
+  if (argc < 4)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
     return -1;
   }
 
@@ -40,7 +40,7 @@ itkBoxSigmaImageFilterTest(int ac, char * av[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto input = ReaderType::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using FilterType = itk::BoxSigmaImageFilter<ImageType, ImageType>;
@@ -78,7 +78,7 @@ itkBoxSigmaImageFilterTest(int ac, char * av[])
 
   try
   {
-    int r = std::stoi(av[3]);
+    int r = std::stoi(argv[3]);
     filter->SetInput(input->GetOutput());
     filter->SetRadius(r);
     filter->Update();
@@ -93,7 +93,7 @@ itkBoxSigmaImageFilterTest(int ac, char * av[])
   using WriterType = itk::ImageFileWriter<ImageType>;
   auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkBoxSigmaImageFilterTest(int ac, char * av[])
@@ -31,7 +32,7 @@ itkBoxSigmaImageFilterTest(int ac, char * av[])
 
   if (ac < 4)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BaselineImage radius" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage radius" << std::endl;
     return -1;
   }
 

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOMultiFrameImageTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOMultiFrameImageTest.cxx
@@ -84,19 +84,19 @@ Equal(SpacingType spacing1, SpacingType spacing2)
 // known to exist in the test file in order to ensure that
 // they're properly read out of the functional group.
 int
-itkDCMTKImageIOMultiFrameImageTest(int ac, char * av[])
+itkDCMTKImageIOMultiFrameImageTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " multiframeImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " multiframeImage" << std::endl;
     return EXIT_FAILURE;
   }
 
   auto dcmImageIO = ImageIOType::New();
 
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
   reader->SetImageIO(dcmImageIO);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIONoPreambleTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIONoPreambleTest.cxx
@@ -26,13 +26,13 @@
  *  DICOM files that contain no preamble
  */
 int
-itkDCMTKImageIONoPreambleTest(int ac, char * av[])
+itkDCMTKImageIONoPreambleTest(int argc, char * argv[])
 {
 
-  if (ac < 2)
+  if (argc < 2)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DicomImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -42,7 +42,7 @@ itkDCMTKImageIONoPreambleTest(int ac, char * av[])
   using ImageIOType = itk::DCMTKImageIO;
 
   auto dcmImageIO = ImageIOType::New();
-  bool canRead = dcmImageIO->CanReadFile(av[1]);
+  bool canRead = dcmImageIO->CanReadFile(argv[1]);
   if (!canRead)
   {
     std::cerr << "Cannot read file " << std::endl;
@@ -50,7 +50,7 @@ itkDCMTKImageIONoPreambleTest(int ac, char * av[])
   }
 
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
   reader->SetImageIO(dcmImageIO);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOOrthoDirTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOOrthoDirTest.cxx
@@ -27,13 +27,13 @@
  *  computed in itkDCMTKImageIO are orthogonal
  */
 int
-itkDCMTKImageIOOrthoDirTest(int ac, char * av[])
+itkDCMTKImageIOOrthoDirTest(int argc, char * argv[])
 {
 
-  if (ac < 2)
+  if (argc < 2)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DicomImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -45,7 +45,7 @@ itkDCMTKImageIOOrthoDirTest(int ac, char * av[])
   auto dcmImageIO = ImageIOType::New();
 
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
   reader->SetImageIO(dcmImageIO);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOSlopeInterceptTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOSlopeInterceptTest.cxx
@@ -26,12 +26,12 @@
 #include "itkTestingMacros.h"
 
 int
-itkDCMTKImageIOSlopeInterceptTest(int ac, char * av[])
+itkDCMTKImageIOSlopeInterceptTest(int argc, char * argv[])
 {
-  if (ac < 3)
+  if (argc < 3)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " originalImage slopeInterceptImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " originalImage slopeInterceptImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -49,7 +49,7 @@ itkDCMTKImageIOSlopeInterceptTest(int ac, char * av[])
   for (unsigned i = 0; i < 2; ++i)
   {
     auto reader = ReaderType::New();
-    reader->SetFileName(av[i + 1]);
+    reader->SetFileName(argv[i + 1]);
     reader->SetImageIO(dcmImageIO);
 
     ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOTest.cxx
@@ -27,13 +27,13 @@
 // Specific ImageIO test
 
 int
-itkDCMTKImageIOTest(int ac, char * av[])
+itkDCMTKImageIOTest(int argc, char * argv[])
 {
 
-  if (ac < 5)
+  if (argc < 5)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " DicomImage OutputDicomImage OutputImage RescalDicomImage" << std::endl;
     return EXIT_FAILURE;
   }
@@ -46,7 +46,7 @@ itkDCMTKImageIOTest(int ac, char * av[])
   auto dcmtkImageIO = ImageIOType::New();
 
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
   reader->SetImageIO(dcmtkImageIO);
   // reader->DebugOn();
 
@@ -67,7 +67,7 @@ itkDCMTKImageIOTest(int ac, char * av[])
   using Writer2Type = itk::ImageFileWriter<WriteImageType>;
   auto writer2 = Writer2Type::New();
   // writer2->DebugOn();
-  writer2->SetFileName(av[3]);
+  writer2->SetFileName(argv[3]);
   writer2->SetInput(rescaler->GetOutput());
 
   ITK_TRY_EXPECT_NO_EXCEPTION(writer2->Update());

--- a/Modules/IO/DCMTK/test/itkDCMTKRGBImageIOTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKRGBImageIOTest.cxx
@@ -28,13 +28,13 @@
 // Specific ImageIO test
 
 int
-itkDCMTKRGBImageIOTest(int ac, char * av[])
+itkDCMTKRGBImageIOTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
     std::cerr << "Missing Parameters" << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage OutputImage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DicomImage OutputImage" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -46,7 +46,7 @@ itkDCMTKRGBImageIOTest(int ac, char * av[])
   auto dcmtkImageIO = ImageIOType::New();
 
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
   reader->SetImageIO(dcmtkImageIO);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
@@ -55,7 +55,7 @@ itkDCMTKRGBImageIOTest(int ac, char * av[])
   using WriteImageType = itk::Image<PixelType, 2>;
   using Writer2Type = itk::ImageFileWriter<WriteImageType>;
   auto writer2 = Writer2Type::New();
-  writer2->SetFileName(av[2]);
+  writer2->SetFileName(argv[2]);
   writer2->SetInput(reader->GetOutput());
 
   ITK_TRY_EXPECT_NO_EXCEPTION(writer2->Update());

--- a/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkGDCMImageIO.h"
+#include "itkTestingMacros.h"
 
 #include <fstream>
 
@@ -30,7 +31,7 @@ itkGDCMImageIONoCrashTest(int ac, char * av[])
 
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " DicomImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
@@ -26,12 +26,12 @@
 // Specific ImageIO test
 
 int
-itkGDCMImageIONoCrashTest(int ac, char * av[])
+itkGDCMImageIONoCrashTest(int argc, char * argv[])
 {
 
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DicomImage\n";
     return EXIT_FAILURE;
   }
 
@@ -43,7 +43,7 @@ itkGDCMImageIONoCrashTest(int ac, char * av[])
   using ImageIOType = itk::GDCMImageIO;
   auto gdcmImageIO = ImageIOType::New();
 
-  const std::string inputFile{ av[1] };
+  const std::string inputFile{ argv[1] };
 
   auto reader = ReaderType::New();
   reader->SetFileName(inputFile);

--- a/Modules/IO/GDCM/test/itkGDCMImageIOOrthoDirTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOOrthoDirTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileReader.h"
 #include "itkGDCMImageIO.h"
 #include "itkVersor.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -31,7 +32,7 @@ itkGDCMImageIOOrthoDirTest(int ac, char * av[])
 
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " DicomImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/GDCM/test/itkGDCMImageIOOrthoDirTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOOrthoDirTest.cxx
@@ -27,12 +27,12 @@
  *  computed in itkGDCMImageIO are orthogonal
  */
 int
-itkGDCMImageIOOrthoDirTest(int ac, char * av[])
+itkGDCMImageIOOrthoDirTest(int argc, char * argv[])
 {
 
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " DicomImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DicomImage\n";
     return EXIT_FAILURE;
   }
 
@@ -44,7 +44,7 @@ itkGDCMImageIOOrthoDirTest(int ac, char * av[])
   auto dcmImageIO = ImageIOType::New();
 
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
   reader->SetImageIO(dcmImageIO);
 
   try

--- a/Modules/IO/GE/test/itkGEImageIOTest.cxx
+++ b/Modules/IO/GE/test/itkGEImageIOTest.cxx
@@ -36,7 +36,7 @@ using ImageReaderType = itk::ImageFileReader<ImageType>;
 using ImageWriterType = itk::ImageFileWriter<ImageType>;
 
 int
-itkGEImageIOFactoryTest(int ac, char * av[])
+itkGEImageIOFactoryTest(int argc, char * argv[])
 {
   static bool firstTime = true;
   if (firstTime)
@@ -47,11 +47,11 @@ itkGEImageIOFactoryTest(int ac, char * av[])
     itk::ObjectFactoryBase::RegisterFactory(itk::SiemensVisionImageIOFactory::New());
     firstTime = false;
   }
-  if (ac < 2)
+  if (argc < 2)
   {
     return EXIT_FAILURE;
   }
-  char * filename = *++av;
+  char * filename = *++argv;
 
   ImagePointer input;
   auto         imageReader = ImageReaderType::New();
@@ -72,24 +72,24 @@ itkGEImageIOFactoryTest(int ac, char * av[])
 }
 
 int
-itkGEImageIOTest(int ac, char * av[])
+itkGEImageIOTest(int argc, char * argv[])
 {
   //
   // first argument is passing in the writable directory to do all testing
-  if (ac > 1)
+  if (argc > 1)
   {
-    char * testdir = *++av;
-    --ac;
+    char * testdir = *++argv;
+    --argc;
     itksys::SystemTools::ChangeDirectory(testdir);
   }
 
-  if ((ac != 5) && (ac != 4))
+  if ((argc != 5) && (argc != 4))
   {
     return EXIT_FAILURE;
   }
-  std::string               failmode(av[1]);
-  std::string               filetype(av[2]);
-  std::string               filename(av[3]);
+  std::string               failmode(argv[1]);
+  std::string               filetype(argv[2]);
+  std::string               filename(argv[3]);
   bool                      Failmode = failmode == std::string("true");
   itk::ImageIOBase::Pointer io;
   if (filetype == "GE4")
@@ -142,7 +142,7 @@ itkGEImageIOTest(int ac, char * av[])
   {
     auto writer = ImageWriterType::New();
     writer->SetInput(input);
-    writer->SetFileName(av[4]);
+    writer->SetFileName(argv[4]);
     writer->Update();
   }
 

--- a/Modules/IO/GIPL/test/itkGiplImageIOTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -29,7 +30,7 @@ itkGiplImageIOTest(int ac, char * av[])
 
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/GIPL/test/itkGiplImageIOTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOTest.cxx
@@ -25,12 +25,12 @@
 // Specific ImageIO test
 
 int
-itkGiplImageIOTest(int ac, char * av[])
+itkGiplImageIOTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -43,7 +43,7 @@ itkGiplImageIOTest(int ac, char * av[])
 
   itk::ImageFileReader<myImage>::Pointer reader = itk::ImageFileReader<myImage>::New();
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -67,7 +67,7 @@ itkGiplImageIOTest(int ac, char * av[])
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -229,13 +229,13 @@ HDF5ReadWriteTest2(const char * fileName)
 }
 
 int
-itkHDF5ImageIOStreamingReadWriteTest(int ac, char * av[])
+itkHDF5ImageIOStreamingReadWriteTest(int argc, char * argv[])
 {
   std::string prefix("");
-  if (ac > 1)
+  if (argc > 1)
   {
-    prefix = *++av;
-    --ac;
+    prefix = *++argv;
+    --argc;
     itksys::SystemTools::ChangeDirectory(prefix.c_str());
   }
   itk::ObjectFactoryBase::RegisterFactory(itk::HDF5ImageIOFactory::New());

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -340,13 +340,13 @@ HDF5ReuseReadWriteTest(const char * fileName)
 }
 
 int
-itkHDF5ImageIOTest(int ac, char * av[])
+itkHDF5ImageIOTest(int argc, char * argv[])
 {
   std::string prefix("");
-  if (ac > 1)
+  if (argc > 1)
   {
-    prefix = *++av;
-    --ac;
+    prefix = *++argv;
+    --argc;
     itksys::SystemTools::ChangeDirectory(prefix.c_str());
   }
   itk::ObjectFactoryBase::RegisterFactory(itk::HDF5ImageIOFactory::New());

--- a/Modules/IO/ImageBase/test/itkImageFileReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderDimensionsTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 // This test is designed to test reading and writing of miss matched
 // dimensions
@@ -28,7 +29,8 @@ itkImageFileReaderDimensionsTest(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cout << "usage: itkIOTests itkImageFileReaderTest inputFileName outputDirectory outputExtension" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
+              << " itkIOTests itkImageFileReaderTest inputFileName outputDirectory outputExtension" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageFileReaderPositiveSpacingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderPositiveSpacingTest.cxx
@@ -25,12 +25,12 @@
 #include "metaImage.h"
 
 int
-itkImageFileReaderPositiveSpacingTest(int ac, char * av[])
+itkImageFileReaderPositiveSpacingTest(int argc, char * argv[])
 {
 
-  if (ac < 1)
+  if (argc < 1)
   {
-    std::cout << "Usage: " << itkNameOfTestExecutableMacro(av) << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -38,7 +38,7 @@ itkImageFileReaderPositiveSpacingTest(int ac, char * av[])
   using ReaderType = itk::ImageFileReader<ImageNDType>;
 
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
   reader->Update();
   ImageNDType::Pointer image = reader->GetOutput();
   image->DisconnectPipeline();
@@ -58,9 +58,9 @@ itkImageFileReaderPositiveSpacingTest(int ac, char * av[])
             << direction << std::endl;
 
   MetaImage metaImage;
-  if (!metaImage.Read(av[1], false))
+  if (!metaImage.Read(argv[1], false))
   {
-    std::cerr << "File cannot be opened " << av[1] << " for reading." << std::endl
+    std::cerr << "File cannot be opened " << argv[1] << " for reading." << std::endl
               << "Reason: " << itksys::SystemTools::GetLastSystemError();
     return EXIT_FAILURE;
   }

--- a/Modules/IO/ImageBase/test/itkImageFileReaderPositiveSpacingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderPositiveSpacingTest.cxx
@@ -21,6 +21,7 @@
 #include <itkTestingComparisonImageFilter.h>
 #include <itkMath.h>
 #include <itkNumericTraits.h>
+#include "itkTestingMacros.h"
 #include "metaImage.h"
 
 int
@@ -29,7 +30,7 @@ itkImageFileReaderPositiveSpacingTest(int ac, char * av[])
 
   if (ac < 1)
   {
-    std::cout << "usage: ITKImageIOBaseTestDriver itkImageFileReaderPositiveSpacingTest" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(av) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
@@ -21,12 +21,12 @@
 
 
 int
-itkImageFileWriterTest(int ac, char * av[])
+itkImageFileWriterTest(int argc, char * argv[])
 {
 
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cout << "Usage: " << itkNameOfTestExecutableMacro(av) << " outputFileName " << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputFileName " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -113,7 +113,7 @@ itkImageFileWriterTest(int ac, char * av[])
   {
     auto writer = WriterType::New();
     writer->SetInput(image);
-    writer->SetFileName(av[1]);
+    writer->SetFileName(argv[1]);
     writer->Update();
   }
   catch (const itk::ExceptionObject & ex)
@@ -134,7 +134,7 @@ itkImageFileWriterTest(int ac, char * av[])
   {
     auto writer = WriterType::New();
     writer->SetInput(image);
-    writer->SetFileName(av[1]);
+    writer->SetFileName(argv[1]);
     writer->UpdateLargestPossibleRegion();
   }
   catch (const itk::ExceptionObject & ex)

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
@@ -17,6 +17,8 @@
  *=========================================================================*/
 
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int
 itkImageFileWriterTest(int ac, char * av[])
@@ -24,7 +26,7 @@ itkImageFileWriterTest(int ac, char * av[])
 
   if (ac < 2)
   {
-    std::cout << "usage: itkIOTests itkImageFileWriterTest outputFileName" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(av) << " outputFileName " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageIODirection2DTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIODirection2DTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -27,7 +28,7 @@ itkImageIODirection2DTest(int ac, char * av[])
 
   if (ac < 6)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage  (4 direction cosines terms) "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage  (4 direction cosines terms) "
               << "[outputImage]" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/IO/ImageBase/test/itkImageIODirection2DTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIODirection2DTest.cxx
@@ -23,12 +23,12 @@
 // Specific ImageIO test
 
 int
-itkImageIODirection2DTest(int ac, char * av[])
+itkImageIODirection2DTest(int argc, char * argv[])
 {
 
-  if (ac < 6)
+  if (argc < 6)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage  (4 direction cosines terms) "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage  (4 direction cosines terms) "
               << "[outputImage]" << std::endl;
     return EXIT_FAILURE;
   }
@@ -41,7 +41,7 @@ itkImageIODirection2DTest(int ac, char * av[])
 
   auto reader = ReaderType::New();
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -66,7 +66,7 @@ itkImageIODirection2DTest(int ac, char * av[])
   {
     for (unsigned int col = 0; col < Dimension; ++col)
     {
-      const double expectedValue = std::stod(av[element++]);
+      const double expectedValue = std::stod(argv[element++]);
       const double currentValue = directionCosines[row][col];
       const double difference = currentValue - expectedValue;
       if (itk::Math::abs(difference) > tolerance)
@@ -79,11 +79,11 @@ itkImageIODirection2DTest(int ac, char * av[])
     }
   }
 
-  if (ac > 6)
+  if (argc > 6)
   {
     using WriterType = itk::ImageFileWriter<ImageType>;
     auto writer = WriterType::New();
-    writer->SetFileName(av[6]);
+    writer->SetFileName(argv[6]);
     writer->SetInput(reader->GetOutput());
 
     try

--- a/Modules/IO/ImageBase/test/itkImageIODirection3DTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIODirection3DTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -27,7 +28,7 @@ itkImageIODirection3DTest(int ac, char * av[])
 
   if (ac < 11)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage  (9 direction cosines terms) "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage  (9 direction cosines terms) "
               << "[outputImage]" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/IO/ImageBase/test/itkImageIODirection3DTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIODirection3DTest.cxx
@@ -23,12 +23,12 @@
 // Specific ImageIO test
 
 int
-itkImageIODirection3DTest(int ac, char * av[])
+itkImageIODirection3DTest(int argc, char * argv[])
 {
 
-  if (ac < 11)
+  if (argc < 11)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage  (9 direction cosines terms) "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage  (9 direction cosines terms) "
               << "[outputImage]" << std::endl;
     return EXIT_FAILURE;
   }
@@ -41,7 +41,7 @@ itkImageIODirection3DTest(int ac, char * av[])
 
   auto reader = ReaderType::New();
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -66,7 +66,7 @@ itkImageIODirection3DTest(int ac, char * av[])
   {
     for (unsigned int col = 0; col < Dimension; ++col)
     {
-      const double expectedValue = std::stod(av[element++]);
+      const double expectedValue = std::stod(argv[element++]);
       const double currentValue = directionCosines[row][col];
       const double difference = currentValue - expectedValue;
       if (itk::Math::abs(difference) > tolerance)
@@ -80,11 +80,11 @@ itkImageIODirection3DTest(int ac, char * av[])
   }
 
 
-  if (ac > 11)
+  if (argc > 11)
   {
     using WriterType = itk::ImageFileWriter<ImageType>;
     auto writer = WriterType::New();
-    writer->SetFileName(av[11]);
+    writer->SetFileName(argv[11]);
     writer->SetInput(reader->GetOutput());
 
     try

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkImageSeriesReader.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -25,7 +26,7 @@ itkImageSeriesReaderDimensionsTest(int ac, char * av[])
 
   if (ac < 3)
   {
-    std::cerr << "usage: itkIOTests itkImageSeriesReaderDimensionsTest inputFileName(s)" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " inputFileName(s)" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
@@ -21,12 +21,12 @@
 
 
 int
-itkImageSeriesReaderDimensionsTest(int ac, char * av[])
+itkImageSeriesReaderDimensionsTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " inputFileName(s)" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName(s)" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -42,11 +42,11 @@ itkImageSeriesReaderDimensionsTest(int ac, char * av[])
   using Reader5DType = itk::ImageSeriesReader<Image5DType>;
 
   Reader2DType::FileNamesContainer fname;
-  fname.push_back(av[1]);
+  fname.push_back(argv[1]);
 
   Reader2DType::FileNamesContainer fnames;
-  for (int i = 1; i < ac; ++i)
-    fnames.push_back(av[i]);
+  for (int i = 1; i < argc; ++i)
+    fnames.push_back(argv[i]);
 
 
   std::cout << "testing reading a single 2D image to 2D" << std::endl;

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkImageSeriesReader.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageSeriesReaderSamplingTest(int ac, char * av[])
@@ -24,7 +25,7 @@ itkImageSeriesReaderSamplingTest(int ac, char * av[])
 
   if (ac < 3)
   {
-    std::cerr << "usage: itkIOTests itkImageSeriesReaderSamplingTest inputFileName(s)" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " inputFileName(s) " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
@@ -20,12 +20,12 @@
 #include "itkTestingMacros.h"
 
 int
-itkImageSeriesReaderSamplingTest(int ac, char * av[])
+itkImageSeriesReaderSamplingTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " inputFileName(s) " << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName(s) " << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -34,10 +34,10 @@ itkImageSeriesReaderSamplingTest(int ac, char * av[])
   using Reader3DType = itk::ImageSeriesReader<Image3DType>;
 
   Reader3DType::FileNamesContainer fnames;
-  for (int i = 1; i < ac; ++i)
+  for (int i = 1; i < argc; ++i)
   {
-    std::cout << av[i] << std::endl;
-    fnames.push_back(av[i]);
+    std::cout << argv[i] << std::endl;
+    fnames.push_back(argv[i]);
   }
 
   std::cout << "testing reading a series of 2D images to 3D with extra slices" << std::endl;

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkImageSeriesReader.h"
+#include "itkTestingMacros.h"
 
 int
 itkImageSeriesReaderVectorTest(int ac, char * av[])
@@ -24,7 +25,7 @@ itkImageSeriesReaderVectorTest(int ac, char * av[])
 
   if (ac < 3)
   {
-    std::cerr << "usage: itkIOTests itkImageSeriesReaderDimensionsTest inputFileName(s)" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " inputFileName(s)" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
@@ -20,12 +20,12 @@
 #include "itkTestingMacros.h"
 
 int
-itkImageSeriesReaderVectorTest(int ac, char * av[])
+itkImageSeriesReaderVectorTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " inputFileName(s)" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName(s)" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -34,8 +34,8 @@ itkImageSeriesReaderVectorTest(int ac, char * av[])
   using VectorImageSeriesReader = itk::ImageSeriesReader<VectorImageType>;
 
   VectorImageSeriesReader::FileNamesContainer fnames;
-  for (int i = 1; i < ac; ++i)
-    fnames.push_back(av[i]);
+  for (int i = 1; i < argc; ++i)
+    fnames.push_back(argv[i]);
 
 
   std::cout << "testing reading a image series into VecorImage" << std::endl;

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
 #include "itkTimeProbesCollectorBase.h"
+#include "itkTestingMacros.h"
 
 int
 itkLargeImageWriteConvertReadTest(int ac, char * av[])
@@ -26,7 +27,7 @@ itkLargeImageWriteConvertReadTest(int ac, char * av[])
 
   if (ac < 3)
   {
-    std::cout << "usage: itkIOTests itkLargeImageWriteConvertReadTest outputFileName numberOfPixelsInOneDimension"
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(av) << " outputFileName numberOfPixelsInOneDimension"
               << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
@@ -22,12 +22,12 @@
 #include "itkTestingMacros.h"
 
 int
-itkLargeImageWriteConvertReadTest(int ac, char * av[])
+itkLargeImageWriteConvertReadTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
-    std::cout << "Usage: " << itkNameOfTestExecutableMacro(av) << " outputFileName numberOfPixelsInOneDimension"
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " outputFileName numberOfPixelsInOneDimension"
               << std::endl;
     return EXIT_FAILURE;
   }
@@ -47,7 +47,7 @@ itkLargeImageWriteConvertReadTest(int ac, char * av[])
     OutputImageType::SizeType   size;
 
 
-    const size_t numberOfPixelsInOneDimension = atol(av[2]);
+    const size_t numberOfPixelsInOneDimension = atol(argv[2]);
 
     size.Fill(static_cast<OutputImageType::SizeValueType>(numberOfPixelsInOneDimension));
     index.Fill(0);
@@ -82,7 +82,7 @@ itkLargeImageWriteConvertReadTest(int ac, char * av[])
     {
       auto writer = WriterType::New();
       writer->SetInput(image);
-      writer->SetFileName(av[1]);
+      writer->SetFileName(argv[1]);
       chronometer.Start("Write");
       writer->Update();
       chronometer.Stop("Write");
@@ -97,7 +97,7 @@ itkLargeImageWriteConvertReadTest(int ac, char * av[])
 
   std::cout << "Trying to read the image back from disk" << std::endl;
   auto reader = ReaderType::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
 #include "itkTimeProbesCollectorBase.h"
+#include "itkTestingMacros.h"
 
 
 namespace
@@ -163,9 +164,8 @@ itkLargeImageWriteReadTest(int ac, char * argv[])
 
   if (ac < 3)
   {
-    std::cout
-      << "usage: itkIOTests itkLargeImageWriteReadTest outputFileName numberOfPixelsInOneDimension [numberOfZslices]"
-      << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
+              << " outputFileName numberOfPixelsInOneDimension [numberOfZslices]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -159,10 +159,10 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
 } // namespace
 
 int
-itkLargeImageWriteReadTest(int ac, char * argv[])
+itkLargeImageWriteReadTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
     std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " outputFileName numberOfPixelsInOneDimension [numberOfZslices]" << std::endl;
@@ -171,7 +171,7 @@ itkLargeImageWriteReadTest(int ac, char * argv[])
 
   const std::string filename = argv[1];
 
-  if (ac == 3)
+  if (argc == 3)
   {
     constexpr unsigned int Dimension = 2;
 

--- a/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -26,7 +27,7 @@ itkMatrixImageWriteReadTest(int ac, char * av[])
 {
   if (ac < 1)
   {
-    std::cerr << "Usage: " << av[0] << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
@@ -23,11 +23,11 @@
 
 
 int
-itkMatrixImageWriteReadTest(int ac, char * av[])
+itkMatrixImageWriteReadTest(int argc, char * argv[])
 {
-  if (ac < 1)
+  if (argc < 1)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
   }
 
@@ -85,7 +85,7 @@ itkMatrixImageWriteReadTest(int ac, char * av[])
   auto matrixWriter = MatrixWriterType::New();
 
   matrixWriter->SetInput(matrixImage1);
-  matrixWriter->SetFileName(av[1]);
+  matrixWriter->SetFileName(argv[1]);
 
   try
   {
@@ -102,7 +102,7 @@ itkMatrixImageWriteReadTest(int ac, char * av[])
 
   auto matrixReader = MatrixReaderType::New();
 
-  matrixReader->SetFileName(av[1]);
+  matrixReader->SetFileName(argv[1]);
 
   try
   {

--- a/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
@@ -26,14 +26,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkNoiseImageFilterTest(int ac, char * av[])
+itkNoiseImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 3)
+  if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage\n";
     return -1;
   }
 
@@ -42,7 +42,7 @@ itkNoiseImageFilterTest(int ac, char * av[])
   using myImageOut = itk::Image<float, 2>;
   using myImageChar = itk::Image<unsigned char, 2>;
   itk::ImageFileReader<myImageIn>::Pointer input = itk::ImageFileReader<myImageIn>::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using FilterType = itk::NoiseImageFilter<myImageIn, myImageOut>;
@@ -74,7 +74,7 @@ itkNoiseImageFilterTest(int ac, char * av[])
   itk::ImageFileWriter<myImageChar>::Pointer writer;
   writer = itk::ImageFileWriter<myImageChar>::New();
   writer->SetInput(rescale->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
@@ -23,6 +23,7 @@
 #include "itkTextOutput.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkNoiseImageFilterTest(int ac, char * av[])
@@ -32,7 +33,7 @@ itkNoiseImageFilterTest(int ac, char * av[])
 
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BaselineImage\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage\n";
     return -1;
   }
 

--- a/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
@@ -20,18 +20,18 @@
 #include "itkTestingMacros.h"
 
 int
-itkRegularExpressionSeriesFileNamesTest(int ac, char * av[])
+itkRegularExpressionSeriesFileNamesTest(int argc, char * argv[])
 {
 
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Directory\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Directory\n";
     return EXIT_FAILURE;
   }
 
 
   itk::RegularExpressionSeriesFileNames::Pointer fit = itk::RegularExpressionSeriesFileNames::New();
-  fit->SetDirectory(av[1]);
+  fit->SetDirectory(argv[1]);
   fit->SetRegularExpression("[^.]*.(.*)");
   fit->SetSubMatch(1);
 

--- a/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkRegularExpressionSeriesFileNames.h"
+#include "itkTestingMacros.h"
 
 int
 itkRegularExpressionSeriesFileNamesTest(int ac, char * av[])
@@ -24,7 +25,7 @@ itkRegularExpressionSeriesFileNamesTest(int ac, char * av[])
 
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Directory\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Directory\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest.cxx
@@ -25,12 +25,12 @@
 // Specific ImageIO test
 
 int
-itkJPEGImageIOTest(int ac, char * av[])
+itkJPEGImageIOTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -42,7 +42,7 @@ itkJPEGImageIOTest(int ac, char * av[])
 
   itk::ImageFileReader<myImage>::Pointer reader = itk::ImageFileReader<myImage>::New();
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -66,7 +66,7 @@ itkJPEGImageIOTest(int ac, char * av[])
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -29,7 +30,7 @@ itkJPEGImageIOTest(int ac, char * av[])
 
   if (ac < 3)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -761,14 +761,14 @@ MINCReadWriteTestVector(const char * fileName,
 }
 
 int
-itkMINCImageIOTest(int ac, char * av[])
+itkMINCImageIOTest(int argc, char * argv[])
 {
   std::string prefix("");
 
-  if (ac > 1)
+  if (argc > 1)
   {
-    prefix = *++av;
-    --ac;
+    prefix = *++argv;
+    --argc;
     itksys::SystemTools::ChangeDirectory(prefix.c_str());
   }
 

--- a/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
+++ b/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
@@ -160,10 +160,10 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
 } // namespace
 
 int
-itkLargeMetaImageWriteReadTest(int ac, char * argv[])
+itkLargeMetaImageWriteReadTest(int argc, char * argv[])
 {
 
-  if (ac < 3)
+  if (argc < 3)
   {
     std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " outputFileName numberOfPixelsInOneDimension "
@@ -174,7 +174,7 @@ itkLargeMetaImageWriteReadTest(int ac, char * argv[])
 
   const std::string filename = argv[1];
 
-  if (ac == 3)
+  if (argc == 3)
   {
     constexpr unsigned int Dimension = 2;
 

--- a/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
+++ b/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkTimeProbesCollectorBase.h"
 #include "itkMetaImageIO.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -164,7 +165,8 @@ itkLargeMetaImageWriteReadTest(int ac, char * argv[])
 
   if (ac < 3)
   {
-    std::cout << "usage: itkIOTests itkLargeMetaImageWriteReadTest outputFileName numberOfPixelsInOneDimension "
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
+              << " outputFileName numberOfPixelsInOneDimension "
                  "[numberOfZslices]"
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/IO/Meta/test/itkMetaImageIOGzTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOGzTest.cxx
@@ -25,16 +25,16 @@
 // Specific ImageIO test
 
 int
-itkMetaImageIOGzTest(int ac, char * av[])
+itkMetaImageIOGzTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << "testDataDirectory" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << "testDataDirectory" << std::endl;
   }
   int result(0);
   std::cout << "Test whether MetaIO will search for a compressed data file" << std::endl
             << "if it can't find the uncompressed data file" << std::endl;
-  std::string headerName(av[1]);
+  std::string headerName(argv[1]);
   headerName += "/GzTest.mhd";
   std::ofstream hdr(headerName.c_str());
   hdr << "ObjectType = Image" << std::endl
@@ -43,7 +43,7 @@ itkMetaImageIOGzTest(int ac, char * av[])
       << "ElementType = MET_USHORT" << std::endl
       << "ElementDataFile = GzTest.raw" << std::endl;
   hdr.close();
-  std::string dataName(av[1]);
+  std::string dataName(argv[1]);
   dataName += "/GzTest.raw.gz";
   gzFile compressed = gzopen(dataName.c_str(), "wb");
   for (unsigned short i = 0; i < (32 * 32); ++i)
@@ -78,7 +78,7 @@ itkMetaImageIOGzTest(int ac, char * av[])
   }
   std::cout << "Test whether absolute path in MetaIO header works" << std::endl;
   // re-write header
-  headerName = av[1];
+  headerName = argv[1];
   headerName += "/AbsPathTest.mhd";
   std::ofstream hdr2(headerName.c_str());
   hdr2 << "ObjectType = Image" << std::endl

--- a/Modules/IO/Meta/test/itkMetaImageIOGzTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOGzTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkMetaImageIO.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -28,7 +29,7 @@ itkMetaImageIOGzTest(int ac, char * av[])
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: itkMetaImageIOGzTest testDataDirectory" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << "testDataDirectory" << std::endl;
   }
   int result(0);
   std::cout << "Test whether MetaIO will search for a compressed data file" << std::endl

--- a/Modules/IO/Meta/test/itkMetaImageStreamingIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageStreamingIOTest.cxx
@@ -22,10 +22,19 @@
 #include "itkStreamingImageFilter.h"
 #include "itkMedianImageFilter.h"
 #include "itkMetaImageIO.h"
+#include "itkTestingMacros.h"
 
 int
 itkMetaImageStreamingIOTest(int ac, char * av[])
 {
+  if (ac < 3)
+  {
+    std::cerr << "Missing Parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " inputFilename outputFilename [numberOfDataPieces]"
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
   //  Image types are defined below.
   using InputPixelType = unsigned char;
   using OutputPixelType = unsigned char;

--- a/Modules/IO/Meta/test/itkMetaImageStreamingIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageStreamingIOTest.cxx
@@ -25,12 +25,12 @@
 #include "itkTestingMacros.h"
 
 int
-itkMetaImageStreamingIOTest(int ac, char * av[])
+itkMetaImageStreamingIOTest(int argc, char * argv[])
 {
-  if (ac < 3)
+  if (argc < 3)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " inputFilename outputFilename [numberOfDataPieces]"
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFilename outputFilename [numberOfDataPieces]"
               << std::endl;
     return EXIT_FAILURE;
   }
@@ -63,8 +63,8 @@ itkMetaImageStreamingIOTest(int ac, char * av[])
   reader->SetImageIO(metaIn);
   writer->SetImageIO(metaOut);
 
-  const std::string inputFilename = av[1];
-  const std::string outputFilename = av[2];
+  const std::string inputFilename = argv[1];
+  const std::string outputFilename = argv[2];
 
   reader->SetFileName(inputFilename);
   reader->SetUseStreaming(true);
@@ -98,9 +98,9 @@ itkMetaImageStreamingIOTest(int ac, char * av[])
   // By default we decide to use 4 pieces, but this value can
   // be changed from the command line.
   unsigned int numberOfDataPieces = 4;
-  if (ac > 3)
+  if (argc > 3)
   {
-    numberOfDataPieces = std::stoi(av[3]);
+    numberOfDataPieces = std::stoi(argv[3]);
   }
 
   streamer->SetNumberOfStreamDivisions(numberOfDataPieces);

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
@@ -98,24 +98,24 @@ Equal(const double a, const double b)
 }
 
 int
-itkNiftiImageIOTest(int ac, char * av[])
+itkNiftiImageIOTest(int argc, char * argv[])
 {
   itk::ObjectFactoryBase::UnRegisterAllFactories();
   itk::NiftiImageIOFactory::RegisterOneFactory();
   int rval = 0;
   //
   // first argument is passing in the writable directory to do all testing
-  if (ac > 1)
+  if (argc > 1)
   {
-    char * testdir = *++av;
-    --ac;
+    char * testdir = *++argv;
+    --argc;
     itksys::SystemTools::ChangeDirectory(testdir);
   }
   std::string prefix = "";
-  if (ac > 1)
+  if (argc > 1)
   {
-    prefix = *++av;
-    --ac;
+    prefix = *++argv;
+    --argc;
   }
   static bool firstTime = true;
   if (firstTime)
@@ -123,7 +123,7 @@ itkNiftiImageIOTest(int ac, char * av[])
     itk::ObjectFactoryBase::RegisterFactory(itk::NiftiImageIOFactory::New());
     firstTime = false;
   }
-  if (ac > 1) // This is a mechanism for reading unsigned char images for testing.
+  if (argc > 1) // This is a mechanism for reading unsigned char images for testing.
   {
     using ImageType = itk::Image<unsigned char, 3>;
     ImageType::Pointer         input;
@@ -135,9 +135,9 @@ itkNiftiImageIOTest(int ac, char * av[])
     // Enable old behavior of NIFTI reader
     imageIO->SetLegacyAnalyze75Mode(itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4);
 
-    for (int imagenameindex = 1; imagenameindex < ac; ++imagenameindex)
+    for (int imagenameindex = 1; imagenameindex < argc; ++imagenameindex)
     {
-      auto fileName = std::string(av[imagenameindex]);
+      auto fileName = std::string(argv[imagenameindex]);
 
       // The way the test is structured, we cannot know the expected file
       // type, so just print it

--- a/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
@@ -229,17 +229,17 @@ ReadImage(const std::string &                     fileName,
 
 
 int
-itkNiftiAnalyzeContentsAndCoordinatesTest(char *                                                   av[],
+itkNiftiAnalyzeContentsAndCoordinatesTest(char *                                                   argv[],
                                           unsigned char                                            hist_orient_code,
                                           itk::SpatialOrientation::ValidCoordinateOrientationFlags expected_code,
                                           itk::NiftiImageIOEnums::Analyze75Flavor                  analyze_mode,
                                           bool                                                     flip_x = false)
 {
-  std::string hdrName(av[1]);
+  std::string hdrName(argv[1]);
   hdrName += "/littleEndian_";
   hdrName += codeToString[expected_code];
   hdrName += ".hdr";
-  std::string imgName(av[1]);
+  std::string imgName(argv[1]);
   imgName += "/littleEndian_";
   imgName += codeToString[expected_code];
   imgName += ".img";
@@ -323,9 +323,9 @@ itkNiftiAnalyzeContentsAndCoordinatesTest(char *                                
 }
 
 int
-itkNiftiReadAnalyzeTest(int ac, char * av[])
+itkNiftiReadAnalyzeTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
     std::cerr << "itkNiftiReadAnalyzeTest: Missing test directory argument" << std::endl;
     return EXIT_FAILURE;
@@ -338,93 +338,93 @@ itkNiftiReadAnalyzeTest(int ac, char * av[])
   // https://web.archive.org/web/20121116093304/http://wideman-one.com/gw/brain/analyze/formatdoc.htm Analyze code 5
   // should have been PSR but it was revised in NIFTI somehow to PIL
 
-  return itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+  return itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                    0,
                                                    itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI,
                                                    itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeReject) !=
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        1,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        2,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIR,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        3,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        4,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSP,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        5,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIL,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM) ==
                EXIT_FAILURE ||
              // ITK4 default behaviour: reader should ignore orientation code and always produce RAI ,
              // there should be a warning on console
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4Warning) ==
                EXIT_FAILURE ||
              // ITK4 reader should ignore orientation code and always produce RAI
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        1,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        2,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        3,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        5,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        5,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4) ==
                EXIT_FAILURE ||
              // flip X  axis , SPM reader should respect this
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LPI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeSPM,
                                                        true) == EXIT_FAILURE ||
              // flip X  axis , ITK4 reader should respect this
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LAI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeITK4,
                                                        true) == EXIT_FAILURE ||
              // flip X  axis , FSL reader should ignore this
-             itkNiftiAnalyzeContentsAndCoordinatesTest(av,
+             itkNiftiAnalyzeContentsAndCoordinatesTest(argv,
                                                        0,
                                                        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI,
                                                        itk::NiftiImageIOEnums::Analyze75Flavor::AnalyzeFSL,

--- a/Modules/IO/NIFTI/test/itkNiftiReadWriteDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadWriteDirectionTest.cxx
@@ -26,25 +26,25 @@
 #include <map>
 
 int
-itkNiftiReadWriteDirectionTest(int ac, char * av[])
+itkNiftiReadWriteDirectionTest(int argc, char * argv[])
 {
-  if (ac < 5)
+  if (argc < 5)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << "imageWithBothQAndSForms imageWithNoQform imageWithNoSform testOutputDir" << std::endl;
-    std::cerr << "5 arguments required, received " << ac << std::endl;
-    for (int i = 0; i < ac; ++i)
+    std::cerr << "5 arguments required, received " << argc << std::endl;
+    for (int i = 0; i < argc; ++i)
     {
-      std::cerr << "\t" << i << " : " << av[i] << std::endl;
+      std::cerr << "\t" << i << " : " << argv[i] << std::endl;
     }
     return EXIT_FAILURE;
   }
 
   using TestImageType = itk::Image<float, 3>;
-  TestImageType::Pointer inputImage = itk::ReadImage<TestImageType>(av[1]);
-  TestImageType::Pointer inputImageNoQform = itk::ReadImage<TestImageType>(av[2]);
-  TestImageType::Pointer inputImageNoSform = itk::ReadImage<TestImageType>(av[3]);
+  TestImageType::Pointer inputImage = itk::ReadImage<TestImageType>(argv[1]);
+  TestImageType::Pointer inputImageNoQform = itk::ReadImage<TestImageType>(argv[2]);
+  TestImageType::Pointer inputImageNoSform = itk::ReadImage<TestImageType>(argv[3]);
 
   const auto inputImageDirection = inputImage->GetDirection();
   const auto inputImageNoQformDirection = inputImageNoQform->GetDirection();
@@ -74,7 +74,7 @@ itkNiftiReadWriteDirectionTest(int ac, char * av[])
   }
 
   // Write image that originally had no sform direction representation into a file with both sform and qform
-  const std::string                            testOutputDir = av[4];
+  const std::string                            testOutputDir = argv[4];
   const std::string                            testFilename = testOutputDir + "/test_filled_sform.nii.gz";
   itk::ImageFileWriter<TestImageType>::Pointer writer = itk::ImageFileWriter<TestImageType>::New();
   ITK_TRY_EXPECT_NO_EXCEPTION(itk::WriteImage(inputImageNoSform, testFilename));

--- a/Modules/IO/NRRD/test/itkNrrdComplexImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdComplexImageReadTest.cxx
@@ -24,11 +24,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdComplexImageReadTest(int ac, char * av[])
+itkNrrdComplexImageReadTest(int argc, char * argv[])
 {
-  if (ac < 1)
+  if (argc < 1)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
   }
 
@@ -41,7 +41,7 @@ itkNrrdComplexImageReadTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {

--- a/Modules/IO/NRRD/test/itkNrrdComplexImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdComplexImageReadTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -27,7 +28,7 @@ itkNrrdComplexImageReadTest(int ac, char * av[])
 {
   if (ac < 1)
   {
-    std::cerr << "Usage: " << av[0] << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdComplexImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdComplexImageReadWriteTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -28,7 +29,7 @@ itkNrrdComplexImageReadWriteTest(int ac, char * av[])
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdComplexImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdComplexImageReadWriteTest.cxx
@@ -25,11 +25,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdComplexImageReadWriteTest(int ac, char * av[])
+itkNrrdComplexImageReadWriteTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -42,7 +42,7 @@ itkNrrdComplexImageReadWriteTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -63,7 +63,7 @@ itkNrrdComplexImageReadWriteTest(int ac, char * av[])
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetImageIO(itk::NrrdImageIO::New());
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   try
   {
     writer->Update();

--- a/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadTest.cxx
@@ -24,11 +24,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdCovariantVectorImageReadTest(int ac, char * av[])
+itkNrrdCovariantVectorImageReadTest(int argc, char * argv[])
 {
-  if (ac < 1)
+  if (argc < 1)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
   }
 
@@ -41,7 +41,7 @@ itkNrrdCovariantVectorImageReadTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {

--- a/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -27,7 +28,7 @@ itkNrrdCovariantVectorImageReadTest(int ac, char * av[])
 {
   if (ac < 1)
   {
-    std::cerr << "Usage: " << av[0] << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadWriteTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -28,7 +29,7 @@ itkNrrdCovariantVectorImageReadWriteTest(int ac, char * av[])
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadWriteTest.cxx
@@ -25,11 +25,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdCovariantVectorImageReadWriteTest(int ac, char * av[])
+itkNrrdCovariantVectorImageReadWriteTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -42,7 +42,7 @@ itkNrrdCovariantVectorImageReadWriteTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -63,7 +63,7 @@ itkNrrdCovariantVectorImageReadWriteTest(int ac, char * av[])
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetImageIO(itk::NrrdImageIO::New());
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   try
   {
     writer->Update();

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -28,7 +29,7 @@ itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest(int ac, char 
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest.cxx
@@ -25,11 +25,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest(int ac, char * av[])
+itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -42,7 +42,7 @@ itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest(int ac, char 
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -63,7 +63,7 @@ itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest(int ac, char 
   writer = itk::ImageFileWriter<InImage>::New();
   writer->SetImageIO(itk::NrrdImageIO::New());
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   try
   {
     writer->Update();

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -27,7 +28,7 @@ itkNrrdDiffusionTensor3DImageReadTest(int ac, char * av[])
 {
   if (ac < 1)
   {
-    std::cerr << "Usage: " << av[0] << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTest.cxx
@@ -24,11 +24,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdDiffusionTensor3DImageReadTest(int ac, char * av[])
+itkNrrdDiffusionTensor3DImageReadTest(int argc, char * argv[])
 {
-  if (ac < 1)
+  if (argc < 1)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
   }
 
@@ -41,7 +41,7 @@ itkNrrdDiffusionTensor3DImageReadTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadWriteTest.cxx
@@ -25,11 +25,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdDiffusionTensor3DImageReadWriteTest(int ac, char * av[])
+itkNrrdDiffusionTensor3DImageReadWriteTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -42,7 +42,7 @@ itkNrrdDiffusionTensor3DImageReadWriteTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -63,7 +63,7 @@ itkNrrdDiffusionTensor3DImageReadWriteTest(int ac, char * av[])
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetImageIO(itk::NrrdImageIO::New());
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   try
   {
     writer->Update();

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadWriteTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -28,7 +29,7 @@ itkNrrdDiffusionTensor3DImageReadWriteTest(int ac, char * av[])
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdImageIOTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdImageIOTest.cxx
@@ -26,18 +26,18 @@
 // images of various data types, dimensionalities and sizes, write these images
 // as NRRDs, read them back, and compare the read images with the originals.
 int
-itkNrrdImageIOTest(int ac, char * av[])
+itkNrrdImageIOTest(int argc, char * argv[])
 {
   std::string inputFile;
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Output\n";
     return EXIT_FAILURE;
   }
 
-  if (ac > 2)
+  if (argc > 2)
   {
-    inputFile = std::string(av[2]);
+    inputFile = std::string(argv[2]);
   }
   else
   {
@@ -46,61 +46,61 @@ itkNrrdImageIOTest(int ac, char * av[])
   constexpr int sz = 10;
   int           ret = EXIT_SUCCESS;
 
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<char, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<signed short, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<int, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned long, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<long, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned long long, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<long long, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<float, 2>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<double, 2>(std::string(av[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<char, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<signed short, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<int, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned long, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<long, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned long long, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<long long, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<float, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<double, 2>(std::string(argv[1]), sz, inputFile);
 
-  ret += itkNrrdImageIOTestReadWriteTest<char, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<signed short, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<int, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<long, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned long, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<long long, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned long long, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<float, 3>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<double, 3>(std::string(av[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<char, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<signed short, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<int, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<long, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned long, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<long long, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned long long, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<float, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<double, 3>(std::string(argv[1]), sz, inputFile);
 
-  ret += itkNrrdImageIOTestReadWriteTest<char, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<signed short, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<int, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<long, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned long, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<long long, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned long long, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<float, 4>(std::string(av[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<double, 4>(std::string(av[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<char, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<signed short, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<int, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<long, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned long, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<long long, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned long long, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<float, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<double, 4>(std::string(argv[1]), sz, inputFile);
 
   // Test with compression on
-  ret += itkNrrdImageIOTestReadWriteTest<char, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<signed short, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<int, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<long, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned long, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<long long, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<unsigned long long, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<float, 4>(std::string(av[1]), sz, inputFile, true);
-  ret += itkNrrdImageIOTestReadWriteTest<double, 4>(std::string(av[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<char, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<signed short, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<int, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<long, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned long, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<long long, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<unsigned long long, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<float, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<double, 4>(std::string(argv[1]), sz, inputFile, true);
 
   // Now we try to read a file which doen't exist
-  ret += !(itkNrrdImageIOTestReadWriteTest<double, 4>(std::string(av[1]), sz, "IDontExist.nrrd"));
+  ret += !(itkNrrdImageIOTestReadWriteTest<double, 4>(std::string(argv[1]), sz, "IDontExist.nrrd"));
 
   if (ret == EXIT_SUCCESS)
   {

--- a/Modules/IO/NRRD/test/itkNrrdImageIOTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdImageIOTest.cxx
@@ -19,6 +19,7 @@
 // Specific ImageIO test
 
 #include "itkNrrdImageIOTest.h"
+#include "itkTestingMacros.h"
 
 
 // This test is for the NRRD image IO.  The strategy is to generate random
@@ -30,7 +31,7 @@ itkNrrdImageIOTest(int ac, char * av[])
   std::string inputFile;
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdImageReadWriteTest.cxx
@@ -25,12 +25,12 @@
 // Specific ImageIO test
 
 int
-itkNrrdImageReadWriteTest(int ac, char * av[])
+itkNrrdImageReadWriteTest(int argc, char * argv[])
 {
-  if (ac < 3)
+  if (argc < 3)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -46,7 +46,7 @@ itkNrrdImageReadWriteTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
@@ -60,7 +60,7 @@ itkNrrdImageReadWriteTest(int ac, char * av[])
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetImageIO(itk::NrrdImageIO::New());
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 

--- a/Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx
@@ -30,10 +30,10 @@
  * If this test succeeds, this bug has been fixed.
  */
 int
-itkNrrdMetaDataTest(int ac, char * av[])
+itkNrrdMetaDataTest(int argc, char * argv[])
 {
 
-  if (ac < 2)
+  if (argc < 2)
   {
     std::cerr << "Missing data directory argument" << std::endl;
     return EXIT_FAILURE;
@@ -58,7 +58,7 @@ itkNrrdMetaDataTest(int ac, char * av[])
   using ImageReaderType = itk::ImageFileReader<ImageType>;
 
   // test uses 1st arg to specify where to drop data
-  std::string fname = av[1];
+  std::string fname = argv[1];
   fname += "/metadatatest.nrrd";
   // set up writer
   auto writer = ImageWriterType::New();

--- a/Modules/IO/NRRD/test/itkNrrdRGBAImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdRGBAImageReadWriteTest.cxx
@@ -27,11 +27,11 @@
 //
 
 int
-itkNrrdRGBAImageReadWriteTest(int ac, char * av[])
+itkNrrdRGBAImageReadWriteTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -39,7 +39,7 @@ itkNrrdRGBAImageReadWriteTest(int ac, char * av[])
   using myImage = itk::Image<PixelType, 2>;
 
   itk::ImageFileReader<myImage>::Pointer reader = itk::ImageFileReader<myImage>::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -59,7 +59,7 @@ itkNrrdRGBAImageReadWriteTest(int ac, char * av[])
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   try
   {
     writer->Update();

--- a/Modules/IO/NRRD/test/itkNrrdRGBAImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdRGBAImageReadWriteTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 //
 // This test needs to use more than one file format,
@@ -30,7 +31,7 @@ itkNrrdRGBAImageReadWriteTest(int ac, char * av[])
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdRGBImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdRGBImageReadWriteTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 //
 // This test needs to use more than one file format,
@@ -30,7 +31,7 @@ itkNrrdRGBImageReadWriteTest(int ac, char * av[])
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdRGBImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdRGBImageReadWriteTest.cxx
@@ -27,11 +27,11 @@
 //
 
 int
-itkNrrdRGBImageReadWriteTest(int ac, char * av[])
+itkNrrdRGBImageReadWriteTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -39,7 +39,7 @@ itkNrrdRGBImageReadWriteTest(int ac, char * av[])
   using myImage = itk::Image<PixelType, 2>;
 
   itk::ImageFileReader<myImage>::Pointer reader = itk::ImageFileReader<myImage>::New();
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -59,7 +59,7 @@ itkNrrdRGBImageReadWriteTest(int ac, char * av[])
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   try
   {
     writer->Update();

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageReadTest.cxx
@@ -24,11 +24,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdVectorImageReadTest(int ac, char * av[])
+itkNrrdVectorImageReadTest(int argc, char * argv[])
 {
-  if (ac < 1)
+  if (argc < 1)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
   }
 
@@ -41,7 +41,7 @@ itkNrrdVectorImageReadTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageReadTest.cxx
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "itkImageFileReader.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -27,7 +28,7 @@ itkNrrdVectorImageReadTest(int ac, char * av[])
 {
   if (ac < 1)
   {
-    std::cerr << "Usage: " << av[0] << " Input\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageReadWriteTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNrrdImageIO.h"
+#include "itkTestingMacros.h"
 
 // Specific ImageIO test
 
@@ -28,7 +29,7 @@ itkNrrdVectorImageReadWriteTest(int ac, char * av[])
 {
   if (ac < 2)
   {
-    std::cerr << "Usage: " << av[0] << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageReadWriteTest.cxx
@@ -25,11 +25,11 @@
 // Specific ImageIO test
 
 int
-itkNrrdVectorImageReadWriteTest(int ac, char * av[])
+itkNrrdVectorImageReadWriteTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " Input Output\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
     return EXIT_FAILURE;
   }
 
@@ -42,7 +42,7 @@ itkNrrdVectorImageReadWriteTest(int ac, char * av[])
 
   reader->SetImageIO(itk::NrrdImageIO::New());
 
-  reader->SetFileName(av[1]);
+  reader->SetFileName(argv[1]);
 
   try
   {
@@ -63,7 +63,7 @@ itkNrrdVectorImageReadWriteTest(int ac, char * av[])
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetImageIO(itk::NrrdImageIO::New());
   writer->SetInput(reader->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   try
   {
     writer->Update();

--- a/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
@@ -141,12 +141,12 @@ testPolygonGroupEquivalence(PolygonGroup3DPointer & p1, PolygonGroup3DPointer & 
   return EXIT_SUCCESS;
 }
 int
-itkPolygonGroupSpatialObjectXMLFileTest(int ac, char * av[])
+itkPolygonGroupSpatialObjectXMLFileTest(int argc, char * argv[])
 {
-  if (ac < 2)
+  if (argc < 2)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " XMLfile" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " XMLfile" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -159,7 +159,7 @@ itkPolygonGroupSpatialObjectXMLFileTest(int ac, char * av[])
     return EXIT_FAILURE;
   }
 
-  std::string xmlfilename(av[1]);
+  std::string xmlfilename(argv[1]);
   xmlfilename = xmlfilename + "/PolygonGroupSpatialObjectXMLFileTest.xml";
   try
   {

--- a/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkVectorThresholdSegmentationLevelSetImageFilterTest(int ac, char * av[])
+itkVectorThresholdSegmentationLevelSetImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 6)
+  if (argc < 6)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " InputInitialImage InputColorImage BaselineImage threshold curvatureScaling\n";
     return -1;
   }
@@ -56,8 +56,8 @@ itkVectorThresholdSegmentationLevelSetImageFilterTest(int ac, char * av[])
   auto rgbReader = RGBReaderType::New();
   auto inputReader = InputReaderType::New();
 
-  inputReader->SetFileName(av[1]);
-  rgbReader->SetFileName(av[2]);
+  inputReader->SetFileName(argv[1]);
+  rgbReader->SetFileName(argv[2]);
 
   // Create a filter
   using FilterType = itk::VectorThresholdSegmentationLevelSetImageFilter<InputImageType, RGBImageType, OutputPixelType>;
@@ -94,11 +94,11 @@ itkVectorThresholdSegmentationLevelSetImageFilterTest(int ac, char * av[])
 
   filter->SetCovariance(covariance);
 
-  const double threshold = std::stod(av[4]);
+  const double threshold = std::stod(argv[4]);
 
   filter->SetThreshold(threshold);
 
-  const double curvatureScaling = std::stod(av[5]);
+  const double curvatureScaling = std::stod(argv[5]);
 
   filter->SetCurvatureScaling(curvatureScaling);
 
@@ -137,7 +137,7 @@ itkVectorThresholdSegmentationLevelSetImageFilterTest(int ac, char * av[])
   auto writer = WriterType::New();
 
   writer->SetInput(rescaler->GetOutput());
-  writer->SetFileName(av[3]);
+  writer->SetFileName(argv[3]);
   writer->Update();
 
   std::cout << "Test PASSED !" << std::endl;

--- a/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkTextOutput.h"
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkVectorThresholdSegmentationLevelSetImageFilterTest(int ac, char * av[])
@@ -31,7 +32,8 @@ itkVectorThresholdSegmentationLevelSetImageFilterTest(int ac, char * av[])
 
   if (ac < 6)
   {
-    std::cerr << "Usage: " << av[0] << " InputInitialImage InputColorImage BaselineImage threshold curvatureScaling\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
+              << " InputInitialImage InputColorImage BaselineImage threshold curvatureScaling\n";
     return -1;
   }
 

--- a/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkConfidenceConnectedImageFilterTest(int ac, char * av[])
@@ -31,7 +32,7 @@ itkConfidenceConnectedImageFilterTest(int ac, char * av[])
 
   if (ac < 5)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BaselineImage seed_x seed_y\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage seed_x seed_y\n";
     return -1;
   }
 

--- a/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkConfidenceConnectedImageFilterTest(int ac, char * av[])
+itkConfidenceConnectedImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 5)
+  if (argc < 5)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage BaselineImage seed_x seed_y\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage seed_x seed_y\n";
     return -1;
   }
 
@@ -40,7 +40,7 @@ itkConfidenceConnectedImageFilterTest(int ac, char * av[])
   using myImage = itk::Image<PixelType, 2>;
 
   itk::ImageFileReader<myImage>::Pointer input = itk::ImageFileReader<myImage>::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using FilterType = itk::ConfidenceConnectedImageFilter<myImage, myImage>;
@@ -52,8 +52,8 @@ itkConfidenceConnectedImageFilterTest(int ac, char * av[])
   filter->SetInitialNeighborhoodRadius(3); // measured in pixels
 
   FilterType::IndexType seed;
-  seed[0] = std::stoi(av[3]);
-  seed[1] = std::stoi(av[4]);
+  seed[0] = std::stoi(argv[3]);
+  seed[1] = std::stoi(argv[4]);
   //  FilterType::IndexType seed; seed[0] = 56; seed[1] = 90;
   //  FilterType::IndexType seed; seed[0] = 96; seed[1] = 214;
   filter->SetSeed(seed);
@@ -103,7 +103,7 @@ itkConfidenceConnectedImageFilterTest(int ac, char * av[])
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   // Exercise AddSeed() method

--- a/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
@@ -24,11 +24,11 @@
 #include "itkTestingMacros.h"
 
 int
-itkIsolatedConnectedImageFilterTest(int ac, char * av[])
+itkIsolatedConnectedImageFilterTest(int argc, char * argv[])
 {
-  if (ac < 8)
+  if (argc < 8)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " InputImage OutputImage FindUpper(true,false) seed1_x seed1_y seed2_x seed2_y [seed1_x2 seed1_y2 "
                  "seed2_x2 seed2_y2]*\n";
     return -1;
@@ -37,7 +37,7 @@ itkIsolatedConnectedImageFilterTest(int ac, char * av[])
   using PixelType = unsigned char;
   using myImage = itk::Image<PixelType, 2>;
   itk::ImageFileReader<myImage>::Pointer input = itk::ImageFileReader<myImage>::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using FilterType = itk::IsolatedConnectedImageFilter<myImage, myImage>;
@@ -50,26 +50,26 @@ itkIsolatedConnectedImageFilterTest(int ac, char * av[])
   FilterType::IndexType seed1;
 
 #if !defined(ITK_LEGACY_REMOVE)
-  seed1[0] = std::stoi(av[4]);
-  seed1[1] = std::stoi(av[5]);
+  seed1[0] = std::stoi(argv[4]);
+  seed1[1] = std::stoi(argv[5]);
   filter->SetSeed1(seed1); // deprecated method
 
-  seed1[0] = std::stoi(av[6]);
-  seed1[1] = std::stoi(av[7]);
+  seed1[0] = std::stoi(argv[6]);
+  seed1[1] = std::stoi(argv[7]);
   filter->SetSeed2(seed1); // deprecated method
 #endif
 
   // Clear the seeds and then add all of the seeds
   filter->ClearSeeds1();
   filter->ClearSeeds2();
-  for (int i = 4; i < ac; i += 4)
+  for (int i = 4; i < argc; i += 4)
   {
-    seed1[0] = std::stoi(av[i]);
-    seed1[1] = std::stoi(av[i + 1]);
+    seed1[0] = std::stoi(argv[i]);
+    seed1[1] = std::stoi(argv[i + 1]);
     filter->AddSeed1(seed1);
 
-    seed1[0] = std::stoi(av[i + 2]);
-    seed1[1] = std::stoi(av[i + 3]);
+    seed1[0] = std::stoi(argv[i + 2]);
+    seed1[1] = std::stoi(argv[i + 3]);
     filter->AddSeed2(seed1);
   }
 
@@ -85,7 +85,7 @@ itkIsolatedConnectedImageFilterTest(int ac, char * av[])
   filter->SetIsolatedValueTolerance(1);
 
   // Test SetMacro
-  std::string findUpper = av[3];
+  std::string findUpper = argv[3];
   if (findUpper == "true")
   {
     filter->FindUpperThresholdOn();
@@ -140,7 +140,7 @@ itkIsolatedConnectedImageFilterTest(int ac, char * av[])
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
 

--- a/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
@@ -21,13 +21,14 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkIsolatedConnectedImageFilterTest(int ac, char * av[])
 {
   if (ac < 8)
   {
-    std::cerr << "Usage: " << av[0]
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
               << " InputImage OutputImage FindUpper(true,false) seed1_x seed1_y seed2_x seed2_y [seed1_x2 seed1_y2 "
                  "seed2_x2 seed2_y2]*\n";
     return -1;

--- a/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
@@ -24,18 +24,18 @@
 #include "itkTestingMacros.h"
 
 int
-itkNeighborhoodConnectedImageFilterTest(int ac, char * av[])
+itkNeighborhoodConnectedImageFilterTest(int argc, char * argv[])
 {
-  if (ac < 5)
+  if (argc < 5)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage OutputImage seed_x seed_y\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage seed_x seed_y\n";
     return -1;
   }
 
   using PixelType = unsigned char;
   using myImage = itk::Image<PixelType, 2>;
   itk::ImageFileReader<myImage>::Pointer input = itk::ImageFileReader<myImage>::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using FilterType = itk::NeighborhoodConnectedImageFilter<myImage, myImage>;
@@ -47,8 +47,8 @@ itkNeighborhoodConnectedImageFilterTest(int ac, char * av[])
 
   FilterType::IndexType seed;
 
-  seed[0] = std::stoi(av[3]);
-  seed[1] = std::stoi(av[4]);
+  seed[0] = std::stoi(argv[3]);
+  seed[1] = std::stoi(argv[4]);
   filter->SetSeed(seed);
 
   filter->SetLower(0);
@@ -88,7 +88,7 @@ itkNeighborhoodConnectedImageFilterTest(int ac, char * av[])
   itk::ImageFileWriter<myImage>::Pointer writer;
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
@@ -21,13 +21,14 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkNeighborhoodConnectedImageFilterTest(int ac, char * av[])
 {
   if (ac < 5)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage OutputImage seed_x seed_y\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av) << " InputImage OutputImage seed_x seed_y\n";
     return -1;
   }
 

--- a/Modules/Segmentation/RegionGrowing/test/itkVectorConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkVectorConfidenceConnectedImageFilterTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTextOutput.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkVectorConfidenceConnectedImageFilterTest(int ac, char * av[])
@@ -31,7 +32,8 @@ itkVectorConfidenceConnectedImageFilterTest(int ac, char * av[])
 
   if (ac < 9)
   {
-    std::cerr << "Usage: " << av[0] << " InputImage BaselineImage seed1X seed1Y seed2X seed2Y multiplier iterations\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
+              << " InputImage BaselineImage seed1X seed1Y seed2X seed2Y multiplier iterations\n";
     return -1;
   }
 

--- a/Modules/Segmentation/RegionGrowing/test/itkVectorConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkVectorConfidenceConnectedImageFilterTest.cxx
@@ -25,14 +25,14 @@
 #include "itkTestingMacros.h"
 
 int
-itkVectorConfidenceConnectedImageFilterTest(int ac, char * av[])
+itkVectorConfidenceConnectedImageFilterTest(int argc, char * argv[])
 {
   // Comment the following if you want to use the itk text output window
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
-  if (ac < 9)
+  if (argc < 9)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(av)
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " InputImage BaselineImage seed1X seed1Y seed2X seed2Y multiplier iterations\n";
     return -1;
   }
@@ -50,7 +50,7 @@ itkVectorConfidenceConnectedImageFilterTest(int ac, char * av[])
   using ReaderType = itk::ImageFileReader<ImageType>;
 
   auto input = ReaderType::New();
-  input->SetFileName(av[1]);
+  input->SetFileName(argv[1]);
 
   // Create a filter
   using FilterType = itk::VectorConfidenceConnectedImageFilter<ImageType, OutputImageType>;
@@ -64,18 +64,18 @@ itkVectorConfidenceConnectedImageFilterTest(int ac, char * av[])
   FilterType::IndexType seed1;
   FilterType::IndexType seed2;
 
-  seed1[0] = std::stoi(av[3]);
-  seed1[1] = std::stoi(av[4]);
+  seed1[0] = std::stoi(argv[3]);
+  seed1[1] = std::stoi(argv[4]);
 
-  seed2[0] = std::stoi(av[5]);
-  seed2[1] = std::stoi(av[6]);
+  seed2[0] = std::stoi(argv[5]);
+  seed2[1] = std::stoi(argv[6]);
 
   filter->AddSeed(seed1);
   filter->AddSeed(seed2);
 
   filter->SetReplaceValue(255);
-  filter->SetMultiplier(std::stod(av[7]));
-  filter->SetNumberOfIterations(std::stoi(av[8]));
+  filter->SetMultiplier(std::stod(argv[7]));
+  filter->SetNumberOfIterations(std::stoi(argv[8]));
 
   try
   {
@@ -107,7 +107,7 @@ itkVectorConfidenceConnectedImageFilterTest(int ac, char * av[])
   auto writer = WriterType::New();
 
   writer->SetInput(filter->GetOutput());
-  writer->SetFileName(av[2]);
+  writer->SetFileName(argv[2]);
   writer->Update();
 
   // Exercise SetSeed() method
@@ -118,7 +118,7 @@ itkVectorConfidenceConnectedImageFilterTest(int ac, char * av[])
 
   using VectorReaderType = itk::ImageFileReader<VectorImageType>;
   auto vinput = VectorReaderType::New();
-  vinput->SetFileName(av[1]);
+  vinput->SetFileName(argv[1]);
 
   using VectorFilterType = itk::VectorConfidenceConnectedImageFilter<VectorImageType, OutputImageType>;
   auto vFilter = VectorFilterType::New();
@@ -128,8 +128,8 @@ itkVectorConfidenceConnectedImageFilterTest(int ac, char * av[])
   vFilter->AddSeed(seed1);
   vFilter->AddSeed(seed2);
   vFilter->SetReplaceValue(255);
-  vFilter->SetMultiplier(std::stod(av[7]));
-  vFilter->SetNumberOfIterations(std::stoi(av[8]));
+  vFilter->SetMultiplier(std::stod(argv[7]));
+  vFilter->SetNumberOfIterations(std::stoi(argv[8]));
   vFilter->Update();
 
 


### PR DESCRIPTION
- STYLE: Use the `itkNameOfTestExecutableMacro` macro in tests 
- STYLE: Use `argc` and `argv` to name test argument variables 

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)