### PR TITLE
STYLE: Use exit return codes consistently in tests

### DIFF
--- a/Modules/Core/Common/test/itkOctreeTest.cxx
+++ b/Modules/Core/Common/test/itkOctreeTest.cxx
@@ -90,7 +90,7 @@ itkOctreeTest(int, char *[])
       if (mapped != y)
       {
         std::cerr << "Error comparing Input and Output of Octree" << std::endl;
-        return -1;
+        return EXIT_FAILURE;
       }
       ++ri;
       ++ri2;

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkBinaryDilateImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkBinaryDilateImageFilterTest(int, char *[])
@@ -143,33 +144,26 @@ itkBinaryDilateImageFilterTest(int, char *[])
   std::cout << "filter->GetDilateValue(): " << value << std::endl;
 
   // Execute the filter
-  try
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
+
+  // Create an iterator for going through the image output
+  myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+
+  //  Print the content of the result image
+  std::cout << "Result " << std::endl;
+  i = 0;
+  while (!it2.IsAtEnd())
   {
+    std::cout << it2.Get() << "  ";
+    ++it2;
 
-    filter->Update();
-    // Create an iterator for going through the image output
-    myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
-
-    //  Print the content of the result image
-    std::cout << "Result " << std::endl;
-    i = 0;
-    while (!it2.IsAtEnd())
+    if (++i % 20 == 0)
     {
-      std::cout << it2.Get() << "  ";
-      ++it2;
-
-      if (++i % 20 == 0)
-      {
-        std::cout << std::endl;
-      }
+      std::cout << std::endl;
     }
   }
 
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during filter Update\n" << e;
-    return -1;
-  }
 
   // All objects should be automatically destroyed at this point
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkBinaryErodeImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkBinaryErodeImageFilterTest(int, char *[])
@@ -143,32 +144,24 @@ itkBinaryErodeImageFilterTest(int, char *[])
   std::cout << "filter->GetErodeValue(): " << value << std::endl;
 
   // Execute the filter
-  try
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
+
+  // Create an iterator for going through the image output
+  myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+
+  //  Print the content of the result image
+  std::cout << "Result " << std::endl;
+  i = 0;
+  while (!it2.IsAtEnd())
   {
+    std::cout << it2.Get() << "  ";
+    ++it2;
 
-    filter->Update();
-    // Create an iterator for going through the image output
-    myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
-
-    //  Print the content of the result image
-    std::cout << "Result " << std::endl;
-    i = 0;
-    while (!it2.IsAtEnd())
+    if (++i % 20 == 0)
     {
-      std::cout << it2.Get() << "  ";
-      ++it2;
-
-      if (++i % 20 == 0)
-      {
-        std::cout << std::endl;
-      }
+      std::cout << std::endl;
     }
-  }
-
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during filter Update\n" << e;
-    return -1;
   }
 
   // All objects should be automatically destroyed at this point

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkErodeObjectMorphologyImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
 
 int
 itkErodeObjectMorphologyImageFilterTest(int, char *[])
@@ -158,31 +159,23 @@ itkErodeObjectMorphologyImageFilterTest(int, char *[])
   std::cout << "filter->GetErodeValue(): " << value << std::endl;
 
   // Execute the filter
-  try
-  {
-    filter->Update();
-    // Create an iterator for going through the image output
-    myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
 
-    //  Print the content of the result image
-    std::cout << "Result " << std::endl;
-    i = 0;
-    while (!it2.IsAtEnd())
+  // Create an iterator for going through the image output
+  myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+
+  //  Print the content of the result image
+  std::cout << "Result " << std::endl;
+  i = 0;
+  while (!it2.IsAtEnd())
+  {
+    std::cout << it2.Get() << "  ";
+    ++it2;
+
+    if (++i % 20 == 0)
     {
-      std::cout << it2.Get() << "  ";
-      ++it2;
-
-      if (++i % 20 == 0)
-      {
-        std::cout << std::endl;
-      }
+      std::cout << std::endl;
     }
-  }
-
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during filter Update\n" << e;
-    return -1;
   }
 
   // All objects should be automatically destroyed at this point

--- a/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterTest.cxx
@@ -33,7 +33,7 @@ itkNormalizedCorrelationImageFilterTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage MaskImage OutputImage\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   constexpr unsigned int Dimension = 2;
@@ -99,20 +99,8 @@ itkNormalizedCorrelationImageFilterTest(int argc, char * argv[])
   writer->SetInput(threshold->GetOutput());
   writer->SetFileName(argv[3]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
-  catch (...)
-  {
-    std::cerr << "Some other exception occurred" << std::endl;
-    return -2;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
@@ -165,33 +165,20 @@ Stapler<VDimension>::Execute()
   // Set the inputs
   for (i = 0; i < number_of_files; ++i)
   {
-    try
-    {
-      reader = itk::ImageFileReader<InputImageType>::New();
-      reader->SetFileName(m_Files[i].c_str());
-      reader->Update();
-      m_Stapler->SetInput(itk::Math::CastWithRangeCheck<unsigned int>(i), reader->GetOutput());
-    }
-    catch (const itk::ExceptionObject & e)
-    {
-      std::cerr << e << std::endl;
-      return -1;
-    }
+    reader = itk::ImageFileReader<InputImageType>::New();
+    reader->SetFileName(m_Files[i].c_str());
+
+    ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+    m_Stapler->SetInput(itk::Math::CastWithRangeCheck<unsigned int>(i), reader->GetOutput());
   }
 
-  try
-  {
-    writer->SetFileName(m_OutputFile.c_str());
-    writer->SetInput(m_Stapler->GetOutput());
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << e << std::endl;
-    return -2;
-  }
+  writer->SetFileName(m_OutputFile.c_str());
+  writer->SetInput(m_Stapler->GetOutput());
 
-  return 0;
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+  return EXIT_SUCCESS;
 }
 
 
@@ -207,7 +194,7 @@ itkSTAPLEImageFilterTest(int argc, char * argv[])
               << " file_dimensionality output.mhd foreground_value confidence_weight "
                  "file1 file2 ... fileN"
               << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   if (::std::stoi(argv[1]) == 2)
@@ -221,7 +208,7 @@ itkSTAPLEImageFilterTest(int argc, char * argv[])
   else
   {
     std::cerr << "Only 2D and 3D data is currently supported" << std::endl;
-    return -2;
+    return EXIT_FAILURE;
   }
 
   for (i = 0; i < argc - 5; ++i)
@@ -235,10 +222,10 @@ itkSTAPLEImageFilterTest(int argc, char * argv[])
 
   // Execute the stapler
   int ret = stapler->Execute();
-  if (ret != 0)
+  if (ret != EXIT_SUCCESS)
   {
-    std::cerr << "Stapler failed!  Returned error code " << ret << "." << std::endl;
-    return -3;
+    std::cerr << "Stapler failed!" << std::endl;
+    return EXIT_FAILURE;
   }
 
   double avg_p = 0.0;

--- a/Modules/Filtering/ImageFeature/test/itkLaplacianRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianRecursiveGaussianImageFilterTest.cxx
@@ -31,7 +31,7 @@ itkLaplacianRecursiveGaussianImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << std::endl;
     std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage " << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   const char * inputFilename = argv[1];
@@ -99,16 +99,8 @@ itkLaplacianRecursiveGaussianImageFilterTest(int argc, char * argv[])
   bool bNormalizeAcrossScale = lapFilter->GetNormalizeAcrossScale();
   std::cout << "lapFilter->GetNormalizeAcrossScale(): " << bNormalizeAcrossScale << std::endl;
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
@@ -30,7 +30,7 @@ itkMaskNeighborhoodOperatorImageFilterTest(int argc, char * argv[])
   if (argc < 3)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   constexpr unsigned int Dimension = 2;
@@ -128,20 +128,7 @@ itkMaskNeighborhoodOperatorImageFilterTest(int argc, char * argv[])
   writer->SetInput(rescaler->GetOutput());
   writer->SetFileName(argv[2]);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
-  catch (...)
-  {
-    std::cerr << "Some other exception occurred" << std::endl;
-    return -2;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include "itkChangeInformationImageFilter.h"
+#include "itkTestingMacros.h"
 
 constexpr unsigned int ImageDimension = 3;
 using ImageType = itk::Image<float, ImageDimension>;
@@ -220,77 +221,71 @@ itkChangeInformationImageFilterTest(int, char *[])
   const itk::OffsetValueType * outputOffset = filter->GetOutputOffset().m_InternalArray;
   std::cout << "filter->GetOutputOffset(): " << outputOffset << std::endl;
 
-  // Catch any exceptions
-  try
-  {
-    std::cout << "-----------filter: " << filter << std::endl;
-    filter->Update();
-    std::cout << "-----------Default behavior: " << std::endl;
-    PrintInformation(inputImage, filter->GetOutput());
 
-    filter->ChangeAll();
-    filter->ChangeRegionOff();
-    filter->Update();
-    std::cout << "-----------ChangeAll(), ChangeRegionOff(): " << std::endl;
-    PrintInformation(inputImage, filter->GetOutput());
+  std::cout << "-----------filter: " << filter << std::endl;
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------Default behavior: " << std::endl;
+  PrintInformation(inputImage, filter->GetOutput());
 
-    filter->CenterImageOn();
-    filter->Update();
-    std::cout << "-----------CenterImageOn(): " << std::endl;
-    PrintInformation(inputImage, filter->GetOutput());
+  filter->ChangeAll();
+  filter->ChangeRegionOff();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------ChangeAll(), ChangeRegionOff(): " << std::endl;
+  PrintInformation(inputImage, filter->GetOutput());
 
-    filter->CenterImageOn();
-    filter->ChangeSpacingOff();
-    filter->Update();
-    std::cout << "-----------CenterImageOn(), ChangeSpacingOff(): " << std::endl;
-    PrintInformation(inputImage, filter->GetOutput());
+  filter->CenterImageOn();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------CenterImageOn(): " << std::endl;
+  PrintInformation(inputImage, filter->GetOutput());
 
-    filter->CenterImageOn();
-    filter->ChangeSpacingOn();
-    filter->ChangeOriginOff();
-    filter->Update();
-    std::cout << "-----------CenterImageOn(), ChangeOriginOff(): " << std::endl;
-    PrintInformation(inputImage, filter->GetOutput());
+  filter->CenterImageOn();
+  filter->ChangeSpacingOff();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------CenterImageOn(), ChangeSpacingOff(): " << std::endl;
+  PrintInformation(inputImage, filter->GetOutput());
 
-    filter->CenterImageOff();
-    filter->ChangeNone();
-    filter->Update();
-    std::cout << "-----------ChangeNone(): " << std::endl;
-    PrintInformation(inputImage, filter->GetOutput());
+  filter->CenterImageOn();
+  filter->ChangeSpacingOn();
+  filter->ChangeOriginOff();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------CenterImageOn(), ChangeOriginOff(): " << std::endl;
+  PrintInformation(inputImage, filter->GetOutput());
 
-    filter->CenterImageOff();
-    filter->UseReferenceImageOn();
-    filter->Update();
-    std::cout << "-----------ChangeNone(), UseReferenceOn(): " << std::endl;
-    PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
+  filter->CenterImageOff();
+  filter->ChangeNone();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------ChangeNone(): " << std::endl;
+  PrintInformation(inputImage, filter->GetOutput());
 
-    filter->ChangeOriginOn();
-    filter->Update();
-    std::cout << "-----------ChangeOriginOn(), UseReferenceOn(): " << std::endl;
-    PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
+  filter->CenterImageOff();
+  filter->UseReferenceImageOn();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------ChangeNone(), UseReferenceOn(): " << std::endl;
+  PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
 
-    filter->ChangeOriginOff();
-    filter->ChangeSpacingOn();
-    filter->Update();
-    std::cout << "-----------ChangeSpacingOn(), UseReferenceOn(): " << std::endl;
-    PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
+  filter->ChangeOriginOn();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------ChangeOriginOn(), UseReferenceOn(): " << std::endl;
+  PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
 
-    filter->ChangeOriginOff();
-    filter->ChangeSpacingOff();
-    filter->ChangeDirectionOn();
-    filter->Update();
-    std::cout << "-----------ChangeDirectionOn(), UseReferenceOn(): " << std::endl;
-    PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
+  filter->ChangeOriginOff();
+  filter->ChangeSpacingOn();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------ChangeSpacingOn(), UseReferenceOn(): " << std::endl;
+  PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
 
-    filter->ChangeAll();
-    filter->UpdateLargestPossibleRegion();
-    std::cout << "-----------ChangeAll(), UseReferenceOn(): " << std::endl;
-    PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e;
-    return -1;
-  }
+  filter->ChangeOriginOff();
+  filter->ChangeSpacingOff();
+  filter->ChangeDirectionOn();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+  std::cout << "-----------ChangeDirectionOn(), UseReferenceOn(): " << std::endl;
+  PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
+
+  filter->ChangeAll();
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->UpdateLargestPossibleRegion());
+  std::cout << "-----------ChangeAll(), UseReferenceOn(): " << std::endl;
+  PrintInformation3(inputImage, filter->GetOutput(), referenceImage);
+
+
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -104,7 +104,7 @@ itkOrientImageFilterTest(int, char *[])
         ImageType::PixelType orig = randImage->GetPixel(originalIndex);
         ImageType::PixelType xfrm = IRP->GetPixel(transformedIndex);
         if (orig != xfrm)
-          return -1;
+          return EXIT_FAILURE;
       }
     }
   }
@@ -135,7 +135,7 @@ itkOrientImageFilterTest(int, char *[])
         ImageType::PixelType orig = randImage->GetPixel(originalIndex);
         ImageType::PixelType xfrm = LIP->GetPixel(transformedIndex);
         if (orig != xfrm)
-          return -1;
+          return EXIT_FAILURE;
       }
     }
   }

--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterTest.cxx
@@ -30,7 +30,7 @@ itkPasteImageFilterTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " DestinationImage SourceImage OutputImage\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   constexpr unsigned int Dimension = 2;
@@ -92,20 +92,8 @@ itkPasteImageFilterTest(int argc, char * argv[])
   streamer->SetNumberOfStreamDivisions(25);
   streamer->SetRegionSplitter(splitter);
 
-  try
-  {
-    streamer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
-  catch (...)
-  {
-    std::cerr << "Some other exception occurred" << std::endl;
-    return -2;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(streamer->Update());
+
 
   // Generate test image
   itk::ImageFileWriter<ImageType>::Pointer writer;

--- a/Modules/Filtering/ImageIntensity/test/itkPromoteDimensionImageTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPromoteDimensionImageTest.cxx
@@ -29,7 +29,7 @@ itkPromoteDimensionImageTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << std::endl;
     std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImage outputImage " << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   const char * inputFilename = argv[1];
@@ -75,17 +75,8 @@ itkPromoteDimensionImageTest(int argc, char * argv[])
   toChar->SetInput(rescale->GetOutput());
   writer->SetInput(toChar->GetOutput());
 
-  try
-  {
-    writer->Update();
-    // toChar->GetOutput()->Print(std::cout);
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
@@ -21,8 +21,9 @@
 
 #include "itkShiftScaleImageFilter.h"
 #include "itkRandomImageSource.h"
-
 #include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
+
 int
 itkShiftScaleImageFilterTest(int, char *[])
 {
@@ -90,15 +91,9 @@ itkShiftScaleImageFilterTest(int, char *[])
 
   filter->SetInput(source->GetOutput());
   filter->SetScale(4.0);
-  try
-  {
-    filter->UpdateLargestPossibleRegion();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e;
-    return -1;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->UpdateLargestPossibleRegion());
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkVectorIndexSelectionCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorIndexSelectionCastImageFilterTest.cxx
@@ -20,8 +20,8 @@
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-
 #include "itkVectorIndexSelectionCastImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkVectorIndexSelectionCastImageFilterTest(int argc, char * argv[])
@@ -62,15 +62,7 @@ itkVectorIndexSelectionCastImageFilterTest(int argc, char * argv[])
 
   filter->SetIndex(index);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e;
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test the exception if the index is too large" << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkGrayscaleDilateImageFilterTest(int argc, char * argv[])
   if (argc < 6)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   unsigned int const dim = 2;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkGrayscaleErodeImageFilterTest(int argc, char * argv[])
   if (argc < 6)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   unsigned int const dim = 2;

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int
 itkGrayscaleFunctionDilateImageFilterTest(int argc, char * argv[])
@@ -137,34 +138,25 @@ itkGrayscaleFunctionDilateImageFilterTest(int argc, char * argv[])
   // Get the Smart Pointer to the Filter Output
   myImageType::Pointer outputImage = filter->GetOutput();
 
-
   // Execute the filter
-  try
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
+
+  // Create an iterator for going through the image output
+  myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+
+  //  Print the content of the result image
+  std::cout << "Result " << std::endl;
+  i = 0;
+  while (!it2.IsAtEnd())
   {
+    std::cout << it2.Get() << "  ";
+    ++it2;
 
-    filter->Update();
-    // Create an iterator for going through the image output
-    myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
-
-    //  Print the content of the result image
-    std::cout << "Result " << std::endl;
-    i = 0;
-    while (!it2.IsAtEnd())
+    if (++i % 20 == 0)
     {
-      std::cout << it2.Get() << "  ";
-      ++it2;
-
-      if (++i % 20 == 0)
-      {
-        std::cout << std::endl;
-      }
+      std::cout << std::endl;
     }
-  }
-
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during filter Update\n" << e;
-    return -1;
   }
 
   // if there is a file name specified as an argument, write the data

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
@@ -20,6 +20,7 @@
 #include "itkBinaryBallStructuringElement.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 int
 itkGrayscaleFunctionErodeImageFilterTest(int argc, char * argv[])
@@ -137,34 +138,25 @@ itkGrayscaleFunctionErodeImageFilterTest(int argc, char * argv[])
   // Get the Smart Pointer to the Filter Output
   myImageType::Pointer outputImage = filter->GetOutput();
 
-
   // Execute the filter
-  try
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
+
+  // Create an iterator for going through the image output
+  myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
+
+  //  Print the content of the result image
+  std::cout << "Result " << std::endl;
+  i = 0;
+  while (!it2.IsAtEnd())
   {
+    std::cout << it2.Get() << "  ";
+    ++it2;
 
-    filter->Update();
-    // Create an iterator for going through the image output
-    myIteratorType it2(outputImage, outputImage->GetBufferedRegion());
-
-    //  Print the content of the result image
-    std::cout << "Result " << std::endl;
-    i = 0;
-    while (!it2.IsAtEnd())
+    if (++i % 20 == 0)
     {
-      std::cout << it2.Get() << "  ";
-      ++it2;
-
-      if (++i % 20 == 0)
-      {
-        std::cout << std::endl;
-      }
+      std::cout << std::endl;
     }
-  }
-
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception caught during filter Update\n" << e;
-    return -1;
   }
 
   if (argc == 2)

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkMapGrayscaleDilateImageFilterTest(int argc, char * argv[])
   if (argc < 6)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   unsigned int const dim = 2;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkMapGrayscaleErodeImageFilterTest(int argc, char * argv[])
   if (argc < 6)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   unsigned int const dim = 2;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
@@ -35,7 +35,7 @@ itkMapGrayscaleMorphologicalClosingImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
               << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   unsigned int const dim = 2;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
@@ -35,7 +35,7 @@ itkMapGrayscaleMorphologicalOpeningImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BASIC HISTO ANCHOR VHGW SafeBorder"
               << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   unsigned int const dim = 2;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkMapMaskedRankImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage maskImage BaselineImage radius"
               << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using ImageType = itk::Image<unsigned short, 2>;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
@@ -33,7 +33,7 @@ itkMapRankImageFilterTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using ImageType = itk::Image<unsigned short, 2>;

--- a/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkMaskedRankImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage maskImage BaselineImage radius"
               << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
@@ -33,7 +33,7 @@ itkRankImageFilterTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
@@ -33,7 +33,7 @@ itkBoxMeanImageFilterTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
@@ -33,7 +33,7 @@ itkBoxSigmaImageFilterTest(int argc, char * argv[])
   if (argc < 4)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage radius" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnTensorsTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnTensorsTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkRecursiveGaussianImageFilter.h"
 #include "itkSymmetricSecondRankTensor.h"
+#include "itkTestingMacros.h"
 
 int
 itkRecursiveGaussianImageFiltersOnTensorsTest(int, char *[])
@@ -91,16 +92,9 @@ itkRecursiveGaussianImageFiltersOnTensorsTest(int, char *[])
   filterY->SetInput(filterX->GetOutput());
   filterX->SetSigma(sigma);
   filterY->SetSigma(sigma);
-  try
-  {
-    filterY->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught a !" << std::endl;
-    std::cout << err << std::endl;
-    return -1;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filterY->Update());
+
 
   // Test a few pixels of the  fitlered image
   //

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFiltersOnVectorImageTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkRecursiveGaussianImageFilter.h"
 #include "itkVectorImage.h"
+#include "itkTestingMacros.h"
 
 int
 itkRecursiveGaussianImageFiltersOnVectorImageTest(int, char *[])
@@ -90,16 +91,9 @@ itkRecursiveGaussianImageFiltersOnVectorImageTest(int, char *[])
   filterY->SetInput(filterX->GetOutput());
   filterX->SetSigma(sigma);
   filterY->SetSigma(sigma);
-  try
-  {
-    filterY->Update();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught a !" << std::endl;
-    std::cout << err << std::endl;
-    return -1;
-  }
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filterY->Update());
+
 
   // Test a few pixels of the  fitlered image
   //

--- a/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkNoiseImageFilterTest(int argc, char * argv[])
   if (argc < 3)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   itk::Size<2> radius;

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -155,7 +155,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   if (argc < 2)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " WarpedImage\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   //--------------------------------------------------------

--- a/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkVectorThresholdSegmentationLevelSetImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " InputInitialImage InputColorImage BaselineImage threshold curvatureScaling\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   constexpr unsigned int Dimension = 2;
@@ -102,16 +102,10 @@ itkVectorThresholdSegmentationLevelSetImageFilterTest(int argc, char * argv[])
 
   filter->SetCurvatureScaling(curvatureScaling);
 
-  try
-  {
-    rgbReader->Update();
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(rgbReader->Update());
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   // Test the GetMacros
   if (itk::Math::NotExactlyEquals(filter->GetThreshold(), threshold))

--- a/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
@@ -33,7 +33,7 @@ itkConfidenceConnectedImageFilterTest(int argc, char * argv[])
   if (argc < 5)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage BaselineImage seed_x seed_y\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using PixelType = unsigned char;
@@ -68,16 +68,10 @@ itkConfidenceConnectedImageFilterTest(int argc, char * argv[])
   }
   std::cout << std::endl;
 
-  try
-  {
-    input->Update();
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(input->Update());
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   // Test the GetMacros
   double doubleMultiplier = filter->GetMultiplier();

--- a/Modules/Segmentation/RegionGrowing/test/itkConnectedThresholdImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConnectedThresholdImageFilterTest.cxx
@@ -32,7 +32,7 @@ itkConnectedThresholdImageFilterTest(int argc, char * argv[])
               << "seed_x seed_y "
               << "LowerConnectedThreshold UpperConnectedThreshold "
               << "Connectivity[1=Full,0=Face]" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
 

--- a/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
@@ -31,7 +31,7 @@ itkIsolatedConnectedImageFilterTest(int argc, char * argv[])
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " InputImage OutputImage FindUpper(true,false) seed1_x seed1_y seed2_x seed2_y [seed1_x2 seed1_y2 "
                  "seed2_x2 seed2_y2]*\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using PixelType = unsigned char;

--- a/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
@@ -29,7 +29,7 @@ itkNeighborhoodConnectedImageFilterTest(int argc, char * argv[])
   if (argc < 5)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " InputImage OutputImage seed_x seed_y\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   using PixelType = unsigned char;
@@ -72,17 +72,10 @@ itkNeighborhoodConnectedImageFilterTest(int argc, char * argv[])
   const SizeType & radius2 = filter->GetRadius();
   std::cout << "filter->GetRadius(): " << radius2 << std::endl;
 
+  ITK_TRY_EXPECT_NO_EXCEPTION(input->Update());
 
-  try
-  {
-    input->Update();
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   // Generate test image
   itk::ImageFileWriter<myImage>::Pointer writer;

--- a/Modules/Segmentation/RegionGrowing/test/itkVectorConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkVectorConfidenceConnectedImageFilterTest.cxx
@@ -34,7 +34,7 @@ itkVectorConfidenceConnectedImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " InputImage BaselineImage seed1X seed1Y seed2X seed2Y multiplier iterations\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 
   constexpr unsigned int Dimension = 2;
@@ -77,16 +77,10 @@ itkVectorConfidenceConnectedImageFilterTest(int argc, char * argv[])
   filter->SetMultiplier(std::stod(argv[7]));
   filter->SetNumberOfIterations(std::stoi(argv[8]));
 
-  try
-  {
-    input->Update();
-    filter->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "Exception detected: " << e.GetDescription();
-    return -1;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(input->Update());
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
 
   // Test the GetMacros
   double doubleMultiplier = filter->GetMultiplier();


### PR DESCRIPTION
Use exit return codes consistently in tests.

Use the `ITK_TRY_EXPECT_NO_EXCEPTION` macro where appropriate to avoid
boilerplate code.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)