### PR TITLE
STYLE: Removing extraneous colons from '::itk' and '::std'.

### DIFF
--- a/Examples/Iterators/ImageRandomConstIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageRandomConstIteratorWithIndex.cxx
@@ -101,7 +101,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   ConstIteratorType inputIt(inputImage, inputImage->GetRequestedRegion());
-  inputIt.SetNumberOfSamples(::std::stoi(argv[2]));
+  inputIt.SetNumberOfSamples(std::stoi(argv[2]));
   inputIt.ReinitializeSeed();
   // Software Guide : EndCodeSnippet
 
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
   {
     mean += static_cast<float>(inputIt.Get());
   }
-  mean = mean / ::std::stod(argv[2]);
+  mean = mean / std::stod(argv[2]);
 
   // Software Guide : EndCodeSnippet
   std::cout << "Mean estimate with " << argv[2] << " samples is " << mean

--- a/Examples/Iterators/ImageRegionIterator.cxx
+++ b/Examples/Iterators/ImageRegionIterator.cxx
@@ -98,11 +98,11 @@ main(int argc, char * argv[])
   ImageType::RegionType::IndexType inputStart;
   ImageType::RegionType::SizeType  size;
 
-  inputStart[0] = ::std::stoi(argv[3]);
-  inputStart[1] = ::std::stoi(argv[4]);
+  inputStart[0] = std::stoi(argv[3]);
+  inputStart[1] = std::stoi(argv[4]);
 
-  size[0] = ::std::stoi(argv[5]);
-  size[1] = ::std::stoi(argv[6]);
+  size[0] = std::stoi(argv[5]);
+  size[1] = std::stoi(argv[6]);
 
   inputRegion.SetSize(size);
   inputRegion.SetIndex(inputStart);

--- a/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
@@ -173,7 +173,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  auto projectionDirection = static_cast<unsigned int>(::std::stoi(argv[3]));
+  auto projectionDirection = static_cast<unsigned int>(std::stoi(argv[3]));
 
   unsigned int i, j;
   unsigned int direction[2];

--- a/Examples/Iterators/NeighborhoodIterators2.cxx
+++ b/Examples/Iterators/NeighborhoodIterators2.cxx
@@ -110,7 +110,7 @@ main(int argc, char ** argv)
 
   // Software Guide : BeginCodeSnippet
   itk::SobelOperator<PixelType, 2> sobelOperator;
-  sobelOperator.SetDirection(::std::stoi(argv[3]));
+  sobelOperator.SetDirection(std::stoi(argv[3]));
   sobelOperator.CreateDirectional();
   // Software Guide : EndCodeSnippet
 

--- a/Examples/Iterators/NeighborhoodIterators3.cxx
+++ b/Examples/Iterators/NeighborhoodIterators3.cxx
@@ -95,7 +95,7 @@ main(int argc, char ** argv)
   output->Allocate();
 
   itk::SobelOperator<PixelType, 2> sobelOperator;
-  sobelOperator.SetDirection(::std::stoi(argv[3]));
+  sobelOperator.SetDirection(std::stoi(argv[3]));
   sobelOperator.CreateDirectional();
 
   itk::NeighborhoodInnerProduct<ImageType> innerProduct;

--- a/Examples/Iterators/NeighborhoodIterators4.cxx
+++ b/Examples/Iterators/NeighborhoodIterators4.cxx
@@ -124,7 +124,7 @@ main(int argc, char ** argv)
 
   // Software Guide : BeginCodeSnippet
   itk::GaussianOperator<PixelType, 2> gaussianOperator;
-  gaussianOperator.SetVariance(::std::stod(argv[3]) * ::std::stod(argv[3]));
+  gaussianOperator.SetVariance(std::stod(argv[3]) * std::stod(argv[3]));
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Iterators/NeighborhoodIterators5.cxx
+++ b/Examples/Iterators/NeighborhoodIterators5.cxx
@@ -115,7 +115,7 @@ main(int argc, char ** argv)
   // Software Guide : BeginCodeSnippet
   itk::GaussianOperator<PixelType, 2> gaussianOperator;
   gaussianOperator.SetDirection(0);
-  gaussianOperator.SetVariance(::std::stod(argv[3]) * ::std::stod(argv[3]));
+  gaussianOperator.SetVariance(std::stod(argv[3]) * std::stod(argv[3]));
   gaussianOperator.CreateDirectional();
   // Software Guide : EndCodeSnippet
 

--- a/Examples/Iterators/NeighborhoodIterators6.cxx
+++ b/Examples/Iterators/NeighborhoodIterators6.cxx
@@ -132,8 +132,8 @@ main(int argc, char ** argv)
 
   // Software Guide : BeginCodeSnippet
   ImageType::IndexType index;
-  index[0] = ::std::stoi(argv[2]);
-  index[1] = ::std::stoi(argv[3]);
+  index[0] = std::stoi(argv[2]);
+  index[1] = std::stoi(argv[3]);
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
@@ -110,7 +110,7 @@ main(int argc, char ** argv)
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  unsigned int element_radius = ::std::stoi(argv[3]);
+  unsigned int element_radius = std::stoi(argv[3]);
   ShapedNeighborhoodIteratorType::RadiusType radius;
   radius.Fill(element_radius);
   // Software Guide : EndCodeSnippet

--- a/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
@@ -52,7 +52,7 @@ main(int argc, char ** argv)
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  unsigned int element_radius = ::std::stoi(argv[3]);
+  unsigned int element_radius = std::stoi(argv[3]);
 
   try
   {

--- a/Examples/Segmentation/CannySegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/CannySegmentationLevelSetImageFilter.cxx
@@ -193,7 +193,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  cannySegmentation->SetAdvectionScaling(::std::stod(argv[6]));
+  cannySegmentation->SetAdvectionScaling(std::stod(argv[6]));
   cannySegmentation->SetCurvatureScaling(1.0);
   cannySegmentation->SetPropagationScaling(0.0);
   //  Software Guide : EndCodeSnippet
@@ -209,7 +209,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   cannySegmentation->SetMaximumRMSError(0.01);
-  cannySegmentation->SetNumberOfIterations(::std::stoi(argv[8]));
+  cannySegmentation->SetNumberOfIterations(std::stoi(argv[8]));
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -225,8 +225,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  cannySegmentation->SetThreshold(::std::stod(argv[4]));
-  cannySegmentation->SetVariance(::std::stod(argv[5]));
+  cannySegmentation->SetThreshold(std::stod(argv[4]));
+  cannySegmentation->SetVariance(std::stod(argv[5]));
   // Software Guide : EndCodeSnippet
 
 
@@ -239,7 +239,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  cannySegmentation->SetIsoSurfaceValue(::std::stod(argv[7]));
+  cannySegmentation->SetIsoSurfaceValue(std::stod(argv[7]));
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex

--- a/Examples/Segmentation/LaplacianSegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/LaplacianSegmentationLevelSetImageFilter.cxx
@@ -187,7 +187,7 @@ main(int argc, char * argv[])
 
   //  Software Guide : BeginCodeSnippet
   laplacianSegmentation->SetCurvatureScaling(1.0);
-  laplacianSegmentation->SetPropagationScaling(::std::stod(argv[6]));
+  laplacianSegmentation->SetPropagationScaling(std::stod(argv[6]));
   //  Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -200,7 +200,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   laplacianSegmentation->SetMaximumRMSError(0.002);
-  laplacianSegmentation->SetNumberOfIterations(::std::stoi(argv[8]));
+  laplacianSegmentation->SetNumberOfIterations(std::stoi(argv[8]));
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -212,7 +212,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  laplacianSegmentation->SetIsoSurfaceValue(::std::stod(argv[7]));
+  laplacianSegmentation->SetIsoSurfaceValue(std::stod(argv[7]));
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex

--- a/Examples/Segmentation/ThresholdSegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/ThresholdSegmentationLevelSetImageFilter.cxx
@@ -235,8 +235,8 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  thresholdSegmentation->SetUpperThreshold(::std::stod(argv[7]));
-  thresholdSegmentation->SetLowerThreshold(::std::stod(argv[6]));
+  thresholdSegmentation->SetUpperThreshold(std::stod(argv[7]));
+  thresholdSegmentation->SetLowerThreshold(std::stod(argv[6]));
   thresholdSegmentation->SetIsoSurfaceValue(0.0);
   // Software Guide : EndCodeSnippet
 

--- a/Modules/Compatibility/Deprecated/include/itkTreeChangeEvent.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeChangeEvent.h
@@ -60,13 +60,13 @@ public:
 
   /** Check the event */
   bool
-  CheckEvent(const ::itk::EventObject * e) const override
+  CheckEvent(const itk::EventObject * e) const override
   {
     return (dynamic_cast<const Self *>(e) != nullptr);
   }
 
   /** Make the event object */
-  ::itk::EventObject *
+  itk::EventObject *
   MakeObject() const override
   {
     return new Self(*m_ChangePosition);
@@ -113,13 +113,13 @@ public:
   }
 
   bool
-  CheckEvent(const ::itk::EventObject * e) const override
+  CheckEvent(const itk::EventObject * e) const override
   {
     auto eSelf = dynamic_cast<const Self *>(e);
     return eSelf != nullptr;
   }
 
-  ::itk::EventObject *
+  itk::EventObject *
   MakeObject() const override
   {
     return new Self(*this->m_ChangePosition);
@@ -162,13 +162,13 @@ public:
 
   /** Check event function */
   bool
-  CheckEvent(const ::itk::EventObject * e) const override
+  CheckEvent(const itk::EventObject * e) const override
   {
     return (dynamic_cast<const Self *>(e) != nullptr);
   }
 
   /** Make the event object */
-  ::itk::EventObject *
+  itk::EventObject *
   MakeObject() const override
   {
     return new Self(*this->m_ChangePosition);
@@ -211,13 +211,13 @@ public:
 
   /** Check the event */
   bool
-  CheckEvent(const ::itk::EventObject * e) const override
+  CheckEvent(const itk::EventObject * e) const override
   {
     return (dynamic_cast<const Self *>(e) != nullptr);
   }
 
   /** Make the event object */
-  ::itk::EventObject *
+  itk::EventObject *
   MakeObject() const override
   {
     return new Self(*this->m_ChangePosition);
@@ -256,12 +256,12 @@ public:
   }
 
   bool
-  CheckEvent(const ::itk::EventObject * e) const override
+  CheckEvent(const itk::EventObject * e) const override
   {
     return (dynamic_cast<const Self *>(e) != nullptr);
   }
 
-  ::itk::EventObject *
+  itk::EventObject *
   MakeObject() const override
   {
     return new Self(*this->m_ChangePosition);

--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.hxx
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.hxx
@@ -335,7 +335,7 @@ TreeIteratorBase<TTreeType> *
 TreeIteratorBase<TTreeType>::Children()
 {
   itkGenericOutputMacro("Not implemented yet");
-  ::itk::ExceptionObject e_(__FILE__, __LINE__, "Not implemented yet", ITK_LOCATION);
+  itk::ExceptionObject e_(__FILE__, __LINE__, "Not implemented yet", ITK_LOCATION);
   throw e_; /* Explicit naming to work around Intel compiler bug.  */
   return nullptr;
 }
@@ -359,7 +359,7 @@ TreeIteratorBase<TTreeType> *
 TreeIteratorBase<TTreeType>::Parents()
 {
   itkGenericOutputMacro("Not implemented yet");
-  ::itk::ExceptionObject e_(__FILE__, __LINE__, "Not implemented yet", ITK_LOCATION);
+  itk::ExceptionObject e_(__FILE__, __LINE__, "Not implemented yet", ITK_LOCATION);
   throw e_; /* Explicit naming to work around Intel compiler bug.  */
   return nullptr;
 }

--- a/Modules/Compatibility/Deprecated/include/itkTreeNode.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeNode.h
@@ -51,7 +51,7 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   using ChildrenListType = std::vector<Pointer>;
-  using ChildIdentifier = ::itk::OffsetValueType;
+  using ChildIdentifier = itk::OffsetValueType;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Compatibility/Deprecated/test/itkBarrierTest.cxx
+++ b/Modules/Compatibility/Deprecated/test/itkBarrierTest.cxx
@@ -131,7 +131,7 @@ itkBarrierTest(int argc, char * argv[])
   itk::ThreadIdType number_of_threads = 4;
   if (argc > 1)
   {
-    number_of_threads = ::std::stoi(argv[1]);
+    number_of_threads = std::stoi(argv[1]);
   }
 
   BarrierTestUserData data(number_of_threads);

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -230,7 +230,7 @@ public:
 
   /**  Return the type of the cell (one of the CellGeometryEnum enums
    *   listed above). */
-  virtual ::itk::CommonEnums::CellGeometry
+  virtual itk::CommonEnums::CellGeometry
   GetType() const = 0;
 
   /** Create a new copy of this cell.  This is provided so that a copy can

--- a/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
+++ b/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
@@ -329,10 +329,10 @@ public:
 //
 
 template <typename TComponent>
-class ITK_TEMPLATE_EXPORT DefaultConvertPixelTraits<::std::complex<TComponent>>
+class ITK_TEMPLATE_EXPORT DefaultConvertPixelTraits<std::complex<TComponent>>
 {
 public:
-  using TargetType = ::std::complex<TComponent>;
+  using TargetType = std::complex<TComponent>;
   using ComponentType = TComponent;
   static unsigned int
   GetNumberOfComponents()

--- a/Modules/Core/Common/include/itkEventObject.h
+++ b/Modules/Core/Common/include/itkEventObject.h
@@ -118,39 +118,39 @@ operator<<(std::ostream & os, const EventObject & e)
  *  Macros for creating new Events
  */
 
-#define itkEventMacroDeclaration(classname, super)           \
-  /** \class classname */                                    \
-  class ITKEvent_EXPORT classname : public super             \
-  {                                                          \
-  public:                                                    \
-    using Self = classname;                                  \
-    using Superclass = super;                                \
-    classname() = default;                                   \
-    classname(const Self & s);                               \
-    virtual ~classname() override;                           \
-    virtual const char *                                     \
-    GetEventName() const override;                           \
-    virtual bool                                             \
-    CheckEvent(const ::itk::EventObject * e) const override; \
-    virtual ::itk::EventObject *                             \
-    MakeObject() const override;                             \
-                                                             \
-  private:                                                   \
-    void                                                     \
-    operator=(const Self &);                                 \
-  };                                                         \
+#define itkEventMacroDeclaration(classname, super)         \
+  /** \class classname */                                  \
+  class ITKEvent_EXPORT classname : public super           \
+  {                                                        \
+  public:                                                  \
+    using Self = classname;                                \
+    using Superclass = super;                              \
+    classname() = default;                                 \
+    classname(const Self & s);                             \
+    virtual ~classname() override;                         \
+    virtual const char *                                   \
+    GetEventName() const override;                         \
+    virtual bool                                           \
+    CheckEvent(const itk::EventObject * e) const override; \
+    virtual itk::EventObject *                             \
+    MakeObject() const override;                           \
+                                                           \
+  private:                                                 \
+    void                                                   \
+    operator=(const Self &);                               \
+  };                                                       \
   static_assert(true, "Compile time eliminated. Used to require a semi-colon at end of macro.")
 
-#define itkEventMacroDefinition(classname, super)                              \
-  classname::classname(const classname & s)                                    \
-    : super(s){};                                                              \
-  classname::~classname() {}                                                   \
-  const char * classname::GetEventName() const { return #classname; }          \
-  bool         classname::CheckEvent(const ::itk::EventObject * e) const       \
-  {                                                                            \
-    return (dynamic_cast<const classname *>(e) != nullptr);                    \
-  }                                                                            \
-  ::itk::EventObject * classname::MakeObject() const { return new classname; } \
+#define itkEventMacroDefinition(classname, super)                            \
+  classname::classname(const classname & s)                                  \
+    : super(s){};                                                            \
+  classname::~classname() {}                                                 \
+  const char * classname::GetEventName() const { return #classname; }        \
+  bool         classname::CheckEvent(const itk::EventObject * e) const       \
+  {                                                                          \
+    return (dynamic_cast<const classname *>(e) != nullptr);                  \
+  }                                                                          \
+  itk::EventObject * classname::MakeObject() const { return new classname; } \
   static_assert(true, "Compile time eliminated. Used to require a semi-colon at end of macro.")
 
 #if !defined(ITK_LEGACY_REMOVE)
@@ -179,11 +179,11 @@ operator<<(std::ostream & os, const EventObject & e)
         return #classname;                                 \
       }                                                    \
       virtual bool                                         \
-      CheckEvent(const ::itk::EventObject * e) const       \
+      CheckEvent(const itk::EventObject * e) const         \
       {                                                    \
         return (dynamic_cast<const Self *>(e) != nullptr); \
       }                                                    \
-      virtual ::itk::EventObject *                         \
+      virtual itk::EventObject *                           \
       MakeObject() const                                   \
       {                                                    \
         return new Self;                                   \

--- a/Modules/Core/Common/include/itkImageIORegion.h
+++ b/Modules/Core/Common/include/itkImageIORegion.h
@@ -58,9 +58,9 @@ public:
 
   /** these types correspond to those of itk::Size, itk::Offset and itk::Index
    */
-  using SizeValueType = ::itk::SizeValueType;
-  using IndexValueType = ::itk::IndexValueType;
-  using OffsetValueType = ::itk::OffsetValueType;
+  using SizeValueType = itk::SizeValueType;
+  using IndexValueType = itk::IndexValueType;
+  using OffsetValueType = itk::OffsetValueType;
 
   /** Index type alias support An index is used to access pixel values. */
   using IndexType = std::vector<IndexValueType>;

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -74,14 +74,14 @@ public:
 
   /** Compatible Index and value type alias */
   using IndexType = Index<VDimension>;
-  using IndexValueType = ::itk::IndexValueType;
+  using IndexValueType = itk::IndexValueType;
 
   /** Compatible Size type alias. */
   using SizeType = Size<VDimension>;
 
   /** Compatible Offset and Offset value type alias. */
   using OffsetType = Offset<VDimension>;
-  using OffsetValueType = ::itk::OffsetValueType;
+  using OffsetValueType = itk::OffsetValueType;
 
   /** Dimension constant */
   static constexpr unsigned int Dimension = VDimension;
@@ -320,7 +320,7 @@ public:
    * so that the Index class can be treated as a container
    * class in a way that is similar to the std::array.
    */
-  using value_type = ::itk::IndexValueType;
+  using value_type = itk::IndexValueType;
   using reference = value_type &;
   using const_reference = const value_type &;
   using iterator = value_type *;

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -313,26 +313,26 @@ namespace itk
   itkCloneMacro(x);         \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkSimpleNewMacro(x)                              \
-  static Pointer New()                                    \
-  {                                                       \
-    Pointer smartPtr = ::itk::ObjectFactory<x>::Create(); \
-    if (smartPtr == nullptr)                              \
-    {                                                     \
-      smartPtr = new x;                                   \
-    }                                                     \
-    smartPtr->UnRegister();                               \
-    return smartPtr;                                      \
-  }                                                       \
+#define itkSimpleNewMacro(x)                            \
+  static Pointer New()                                  \
+  {                                                     \
+    Pointer smartPtr = itk::ObjectFactory<x>::Create(); \
+    if (smartPtr == nullptr)                            \
+    {                                                   \
+      smartPtr = new x;                                 \
+    }                                                   \
+    smartPtr->UnRegister();                             \
+    return smartPtr;                                    \
+  }                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkCreateAnotherMacro(x)                             \
-  ::itk::LightObject::Pointer CreateAnother() const override \
-  {                                                          \
-    ::itk::LightObject::Pointer smartPtr;                    \
-    smartPtr = x::New().GetPointer();                        \
-    return smartPtr;                                         \
-  }                                                          \
+#define itkCreateAnotherMacro(x)                           \
+  itk::LightObject::Pointer CreateAnother() const override \
+  {                                                        \
+    itk::LightObject::Pointer smartPtr;                    \
+    smartPtr = x::New().GetPointer();                      \
+    return smartPtr;                                       \
+  }                                                        \
   ITK_MACROEND_NOOP_STATEMENT
 
 #define itkCloneMacro(x)                                                  \
@@ -355,21 +355,21 @@ namespace itk
  * UnRegister() on the rawPtr to compensate for LightObject's constructor
  * initializing an object's reference count to 1 (needed for proper
  * initialization of process objects and data objects cycles). */
-#define itkFactorylessNewMacro(x)                            \
-  static Pointer New()                                       \
-  {                                                          \
-    Pointer smartPtr;                                        \
-    x *     rawPtr = new x;                                  \
-    smartPtr = rawPtr;                                       \
-    rawPtr->UnRegister();                                    \
-    return smartPtr;                                         \
-  }                                                          \
-  ::itk::LightObject::Pointer CreateAnother() const override \
-  {                                                          \
-    ::itk::LightObject::Pointer smartPtr;                    \
-    smartPtr = x::New().GetPointer();                        \
-    return smartPtr;                                         \
-  }                                                          \
+#define itkFactorylessNewMacro(x)                          \
+  static Pointer New()                                     \
+  {                                                        \
+    Pointer smartPtr;                                      \
+    x *     rawPtr = new x;                                \
+    smartPtr = rawPtr;                                     \
+    rawPtr->UnRegister();                                  \
+    return smartPtr;                                       \
+  }                                                        \
+  itk::LightObject::Pointer CreateAnother() const override \
+  {                                                        \
+    itk::LightObject::Pointer smartPtr;                    \
+    smartPtr = x::New().GetPointer();                      \
+    return smartPtr;                                       \
+  }                                                        \
   ITK_MACROEND_NOOP_STATEMENT
 
 //
@@ -463,12 +463,12 @@ OutputWindowDisplayDebugText(const char *);
 #  define itkDebugMacro(x)                                                     \
     do                                                                         \
     {                                                                          \
-      if (this->GetDebug() && ::itk::Object::GetGlobalWarningDisplay())        \
+      if (this->GetDebug() && itk::Object::GetGlobalWarningDisplay())          \
       {                                                                        \
         std::ostringstream itkmsg;                                             \
         itkmsg << "Debug: In " __FILE__ ", line " << __LINE__ << "\n"          \
                << this->GetNameOfClass() << " (" << this << "): " x << "\n\n"; \
-        ::itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());             \
+        itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());               \
       }                                                                        \
     } while (0)
 
@@ -483,12 +483,12 @@ OutputWindowDisplayDebugText(const char *);
 #define itkWarningMacro(x)                                                   \
   do                                                                         \
   {                                                                          \
-    if (::itk::Object::GetGlobalWarningDisplay())                            \
+    if (itk::Object::GetGlobalWarningDisplay())                              \
     {                                                                        \
       std::ostringstream itkmsg;                                             \
       itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n"        \
              << this->GetNameOfClass() << " (" << this << "): " x << "\n\n"; \
-      ::itk::OutputWindowDisplayWarningText(itkmsg.str().c_str());           \
+      itk::OutputWindowDisplayWarningText(itkmsg.str().c_str());             \
     }                                                                        \
   } while (0)
 
@@ -526,13 +526,13 @@ OutputWindowDisplayDebugText(const char *);
   {                                                                                                                  \
     std::ostringstream exceptionDescriptionOutputStringStream;                                                       \
     exceptionDescriptionOutputStringStream << "ITK ERROR: " x;                                                       \
-    throw ::itk::ExceptionType(                                                                                      \
+    throw itk::ExceptionType(                                                                                        \
       std::string{ __FILE__ }, __LINE__, exceptionDescriptionOutputStringStream.str(), std::string{ ITK_LOCATION }); \
   }                                                                                                                  \
   ITK_MACROEND_NOOP_STATEMENT
 
 #define itkSpecializedExceptionMacro(ExceptionType) \
-  itkSpecializedMessageExceptionMacro(ExceptionType, << ::itk::ExceptionType::default_exception_message)
+  itkSpecializedMessageExceptionMacro(ExceptionType, << itk::ExceptionType::default_exception_message)
 
 /** The itkExceptionMacro macro is used to print error information (i.e., usually
  * a condition that results in program failure). Example usage looks like:
@@ -544,11 +544,11 @@ OutputWindowDisplayDebugText(const char *);
 
 #define itkGenericOutputMacro(x)                                                   \
   {                                                                                \
-    if (::itk::Object::GetGlobalWarningDisplay())                                  \
+    if (itk::Object::GetGlobalWarningDisplay())                                    \
     {                                                                              \
       std::ostringstream itkmsg;                                                   \
       itkmsg << "WARNING: In " __FILE__ ", line " << __LINE__ << "\n" x << "\n\n"; \
-      ::itk::OutputWindowDisplayGenericOutputText(itkmsg.str().c_str());           \
+      itk::OutputWindowDisplayGenericOutputText(itkmsg.str().c_str());             \
     }                                                                              \
   }                                                                                \
   ITK_MACROEND_NOOP_STATEMENT
@@ -556,22 +556,22 @@ OutputWindowDisplayDebugText(const char *);
 //----------------------------------------------------------------------------
 // Macros for simplifying the use of logging
 //
-#define itkLogMacro(x, y)                                \
-  {                                                      \
-    if (this->GetLogger())                               \
-    {                                                    \
-      this->GetLogger()->Write(::itk::LoggerBase::x, y); \
-    }                                                    \
-  }                                                      \
+#define itkLogMacro(x, y)                              \
+  {                                                    \
+    if (this->GetLogger())                             \
+    {                                                  \
+      this->GetLogger()->Write(itk::LoggerBase::x, y); \
+    }                                                  \
+  }                                                    \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define itkLogMacroStatic(obj, x, y)                    \
-  {                                                     \
-    if (obj->GetLogger())                               \
-    {                                                   \
-      obj->GetLogger()->Write(::itk::LoggerBase::x, y); \
-    }                                                   \
-  }                                                     \
+#define itkLogMacroStatic(obj, x, y)                  \
+  {                                                   \
+    if (obj->GetLogger())                             \
+    {                                                 \
+      obj->GetLogger()->Write(itk::LoggerBase::x, y); \
+    }                                                 \
+  }                                                   \
   ITK_MACROEND_NOOP_STATEMENT
 
 //----------------------------------------------------------------------------

--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -227,11 +227,11 @@ ExposeMetaData(const MetaDataDictionary & Dictionary, const std::string key, T &
  * have operator<< defined.
  * \param TYPE_NAME the native type parameter type
  */
-#define ITK_NATIVE_TYPE_METADATAPRINT(TYPE_NAME)                        \
-  template <>                                                           \
-  void ::itk::MetaDataObject<TYPE_NAME>::Print(std::ostream & os) const \
-  {                                                                     \
-    os << this->m_MetaDataObjectValue << std::endl;                     \
+#define ITK_NATIVE_TYPE_METADATAPRINT(TYPE_NAME)                      \
+  template <>                                                         \
+  void itk::MetaDataObject<TYPE_NAME>::Print(std::ostream & os) const \
+  {                                                                   \
+    os << this->m_MetaDataObjectValue << std::endl;                   \
   }
 
 /**

--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -76,11 +76,11 @@ public:
   using ConstIterator = typename AllocatorType::const_iterator;
 
   /** Size and value type alias support */
-  using SizeType = ::itk::Size<VDimension>;
+  using SizeType = itk::Size<VDimension>;
   using SizeValueType = typename SizeType::SizeValueType;
 
   /** Radius type alias support */
-  using RadiusType = ::itk::Size<VDimension>;
+  using RadiusType = itk::Size<VDimension>;
 
   /** Offset type used to reference neighbor locations */
   using OffsetType = Offset<VDimension>;

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -74,7 +74,7 @@ public:
 
   /** Compatible Offset and value type alias. */
   using OffsetType = Offset<VDimension>;
-  using OffsetValueType = ::itk::OffsetValueType;
+  using OffsetValueType = itk::OffsetValueType;
 
   /** Dimension constant */
   static constexpr unsigned int Dimension = VDimension;
@@ -273,7 +273,7 @@ public:
    * so that the Offset class can be treated as a container
    * class in a way that is similar to the std::array.
    */
-  using value_type = ::itk::OffsetValueType;
+  using value_type = itk::OffsetValueType;
   using reference = value_type &;
   using const_reference = const value_type &;
   using iterator = value_type *;

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -76,7 +76,7 @@ public:
 
   /** Compatible Size and value type alias */
   using SizeType = Size<VDimension>;
-  using SizeValueType = ::itk::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
 
   /** Dimension constant */
   static constexpr unsigned int Dimension = VDimension;
@@ -232,7 +232,7 @@ public:
    * so that the Size class can be treated as a container
    * class in a way that is similar to the std::array.
    */
-  using value_type = ::itk::SizeValueType;
+  using value_type = itk::SizeValueType;
   using reference = value_type &;
   using const_reference = const value_type &;
   using iterator = value_type *;

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -406,7 +406,7 @@ MultiThreaderBase::GetGlobalDefaultNumberOfThreadsByPlatform()
 MultiThreaderBase::Pointer
 MultiThreaderBase::New()
 {
-  Pointer smartPtr = ::itk::ObjectFactory<MultiThreaderBase>::Create();
+  Pointer smartPtr = itk::ObjectFactory<MultiThreaderBase>::Create();
   if (smartPtr == nullptr)
   {
     ThreaderEnum threaderType = GetGlobalDefaultThreader();

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -292,7 +292,7 @@ Object::Pointer
 Object::New()
 {
   Pointer  smartPtr;
-  Object * rawPtr = ::itk::ObjectFactory<Object>::Create();
+  Object * rawPtr = itk::ObjectFactory<Object>::Create();
 
   if (rawPtr == nullptr)
   {
@@ -422,7 +422,7 @@ Object::UnRegister() const noexcept
       {
         if (GetGlobalWarningDisplay())
         {
-          ::itk::OutputWindowDisplayWarningText("WARNING: Exception occurred in DeleteEvent Observer!");
+          itk::OutputWindowDisplayWarningText("WARNING: Exception occurred in DeleteEvent Observer!");
         }
       }
       catch (...)

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -39,7 +39,7 @@
 namespace
 {
 
-using FactoryListType = std::list<::itk::ObjectFactoryBase *>;
+using FactoryListType = std::list<itk::ObjectFactoryBase *>;
 
 // Convenience function to synchronize lists and register the new factory,
 // either with `RegisterFactoryInternal()` or with `RegisterFactory()`. Avoid
@@ -72,11 +72,11 @@ SynchronizeList(FactoryListType * output, FactoryListType * input, bool internal
     {
       if (internal == true)
       {
-        ::itk::ObjectFactoryBase::RegisterFactoryInternal(factory);
+        itk::ObjectFactoryBase::RegisterFactoryInternal(factory);
       }
       else
       {
-        ::itk::ObjectFactoryBase::RegisterFactory(factory);
+        itk::ObjectFactoryBase::RegisterFactory(factory);
       }
     }
   }
@@ -103,7 +103,7 @@ struct ObjectFactoryBasePrivate
 {
   ~ObjectFactoryBasePrivate()
   {
-    ::itk::ObjectFactoryBase::UnRegisterAllFactories();
+    itk::ObjectFactoryBase::UnRegisterAllFactories();
     if (m_InternalFactories)
     {
       for (auto & m_InternalFactorie : *m_InternalFactories)
@@ -117,10 +117,10 @@ struct ObjectFactoryBasePrivate
 
   ObjectFactoryBasePrivate() = default;
 
-  std::list<::itk::ObjectFactoryBase *> * m_RegisteredFactories{ nullptr };
-  std::list<::itk::ObjectFactoryBase *> * m_InternalFactories{ nullptr };
-  bool                                    m_Initialized{ false };
-  bool                                    m_StrictVersionChecking{ false };
+  std::list<itk::ObjectFactoryBase *> * m_RegisteredFactories{ nullptr };
+  std::list<itk::ObjectFactoryBase *> * m_InternalFactories{ nullptr };
+  bool                                  m_Initialized{ false };
+  bool                                  m_StrictVersionChecking{ false };
 };
 
 ObjectFactoryBasePrivate *

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -27,7 +27,7 @@ std::once_flag globalSingletonOnceFlag;
 // has been loaded. In some cases, this call will perform the initialization.
 // In other cases, static initializers like the IO factory initialization code
 // will have done the initialization.
-::itk::SingletonIndex * initializedGlobalSingletonIndex = ::itk::SingletonIndex::GetInstance();
+itk::SingletonIndex * initializedGlobalSingletonIndex = itk::SingletonIndex::GetInstance();
 
 /** \class GlobalSingletonIndexInitializer
  *
@@ -38,7 +38,7 @@ class GlobalSingletonIndexInitializer
 {
 public:
   using Self = GlobalSingletonIndexInitializer;
-  using SingletonIndex = ::itk::SingletonIndex;
+  using SingletonIndex = itk::SingletonIndex;
 
   GlobalSingletonIndexInitializer() = default;
 

--- a/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
@@ -141,7 +141,7 @@ GPUKernelManager::LoadProgramFromFile(const char * filename, const char * cPream
            << this->GetNameOfClass() << " (" << this << "): "
            << "OpenCL program build error:" << paramValue
            << "\n\n";
-    ::itk::OutputWindowDisplayErrorText( itkmsg.str().c_str() );
+    itk::OutputWindowDisplayErrorText( itkmsg.str().c_str() );
     */
 
     std::cerr << paramValue << std::endl;
@@ -217,7 +217,7 @@ GPUKernelManager::LoadProgramFromString(const char * cSource, const char * cPrea
            << this->GetNameOfClass() << " (" << this << "): "
            << "OpenCL program build error:" << paramValue
            << "\n\n";
-    ::itk::OutputWindowDisplayErrorText( itkmsg.str().c_str() );
+    itk::OutputWindowDisplayErrorText( itkmsg.str().c_str() );
     */
 
     std::cerr << paramValue << std::endl;

--- a/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
+++ b/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
@@ -348,7 +348,7 @@ OpenCLCheckError(cl_int error, const char * filename, int lineno, const char * l
     {
       errorMsg << "OpenCL Error : Unspecified Error" << std::endl;
     }
-    ::itk::ExceptionObject e_(filename, lineno, errorMsg.str().c_str(), location);
+    itk::ExceptionObject e_(filename, lineno, errorMsg.str().c_str(), location);
     throw e_;
   }
 }

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -508,7 +508,7 @@ private:
   // to have the correct vector length of the image.
   template <typename TPixelType>
   void
-  UpdateAccessor(typename ::itk::VectorImage<TPixelType, ImageDimension> * itkNotUsed(dummy))
+  UpdateAccessor(typename itk::VectorImage<TPixelType, ImageDimension> * itkNotUsed(dummy))
   {
     this->m_PixelAccessor.SetVectorLength(this->m_Image->GetNumberOfComponentsPerPixel());
   }

--- a/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.h
+++ b/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.h
@@ -129,16 +129,16 @@ public:
   using CellAutoPointer = typename CellType::CellAutoPointer;
 
   /** Different kinds of cells. */
-  using VertexCell = ::itk::VertexCell<CellType>;
-  using LineCell = ::itk::LineCell<CellType>;
-  using TriangleCell = ::itk::TriangleCell<CellType>;
-  using QuadrilateralCell = ::itk::QuadrilateralCell<CellType>;
-  using TetrahedronCell = ::itk::TetrahedronCell<CellType>;
-  using HexahedronCell = ::itk::HexahedronCell<CellType>;
+  using VertexCell = itk::VertexCell<CellType>;
+  using LineCell = itk::LineCell<CellType>;
+  using TriangleCell = itk::TriangleCell<CellType>;
+  using QuadrilateralCell = itk::QuadrilateralCell<CellType>;
+  using TetrahedronCell = itk::TetrahedronCell<CellType>;
+  using HexahedronCell = itk::HexahedronCell<CellType>;
 
-  /** This class requires that the mesh being built use ::itk::IdentifierType
+  /** This class requires that the mesh being built use itk::IdentifierType
    * as the identifier type for all its elements. */
-  using IdentifierType = ::itk::IdentifierType;
+  using IdentifierType = itk::IdentifierType;
 
   /** Array of IdentifierType objects used to specify cells. */
   using IdentifierArrayType = Array<IdentifierType>;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.h
@@ -65,8 +65,8 @@ public:
 
   itkSetConstObjectMacro(Mesh, MeshType);
 
-  using IdentifierType = ::itk::IdentifierType;
-  using OffsetValueType = ::itk::OffsetValueType;
+  using IdentifierType = itk::IdentifierType;
+  using OffsetValueType = itk::OffsetValueType;
 
   itkSetMacro(ExpectedNumberOfPoints, PointIdentifier);
   itkSetMacro(ExpectedNumberOfEdges, CellIdentifier);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -59,8 +59,8 @@ public:
   static constexpr unsigned int PointDimension = VPointDimension;
   static constexpr unsigned int MaxTopologicalDimension = VPointDimension;
 
-  using PointIdentifier = ::itk::IdentifierType;
-  using CellIdentifier = ::itk::IdentifierType;
+  using PointIdentifier = itk::IdentifierType;
+  using CellIdentifier = itk::IdentifierType;
 
   using CellFeatureIdentifier = unsigned char; // made small in purpose
 

--- a/Modules/Core/TestKernel/include/itkTestDriverInclude.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverInclude.h
@@ -55,15 +55,15 @@
 #define ITK_TEST_DIMENSION_MAX 6
 
 extern int
-RegressionTestImage(const char *         testImageFilename,
-                    const char *         baselineImageFilename,
-                    int                  reportErrors,
-                    double               intensityTolerance,
-                    ::itk::SizeValueType numberOfPixelsTolerance = 0,
-                    unsigned int         radiusTolerance = 0,
-                    bool                 verifyInputInformation = true,
-                    double               coordinateTolerance = 1.0e-6,
-                    double               directionTolerance = 1.0e-6);
+RegressionTestImage(const char *       testImageFilename,
+                    const char *       baselineImageFilename,
+                    int                reportErrors,
+                    double             intensityTolerance,
+                    itk::SizeValueType numberOfPixelsTolerance = 0,
+                    unsigned int       radiusTolerance = 0,
+                    bool               verifyInputInformation = true,
+                    double             coordinateTolerance = 1.0e-6,
+                    double             directionTolerance = 1.0e-6);
 
 extern int
 HashTestImage(const char * testImageFilename, const std::string md5hash);
@@ -133,15 +133,15 @@ extern void
 GetImageType(const char * fileName, itk::IOPixelEnum & pixelType, itk::IOComponentEnum & componentType);
 
 extern int
-RegressionTestImage(const char *         testImageFilename,
-                    const char *         baselineImageFilename,
-                    int                  reportErrors,
-                    double               intensityTolerance,
-                    ::itk::SizeValueType numberOfPixelsTolerance,
-                    unsigned int         radiusTolerance,
-                    bool                 verifyInputInformation,
-                    double               coordinateTolerance,
-                    double               directionTolerance);
+RegressionTestImage(const char *       testImageFilename,
+                    const char *       baselineImageFilename,
+                    int                reportErrors,
+                    double             intensityTolerance,
+                    itk::SizeValueType numberOfPixelsTolerance,
+                    unsigned int       radiusTolerance,
+                    bool               verifyInputInformation,
+                    double             coordinateTolerance,
+                    double             directionTolerance);
 
 
 extern int

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -456,15 +456,15 @@ GetImageType(const char * fileName, itk::IOPixelEnum & pixelType, itk::IOCompone
 //  otherwise zero is returned if the difference is with in tolerances
 template <typename PixelType>
 int
-RegressionTestHelper(const char *         testImageFilename,
-                     const char *         baselineImageFilename,
-                     int                  reportErrors,
-                     double               intensityTolerance,
-                     ::itk::SizeValueType numberOfPixelsTolerance,
-                     unsigned int         radiusTolerance,
-                     bool                 verifyInputInformation,
-                     double               coordinateTolerance,
-                     double               directionTolerance)
+RegressionTestHelper(const char *       testImageFilename,
+                     const char *       baselineImageFilename,
+                     int                reportErrors,
+                     double             intensityTolerance,
+                     itk::SizeValueType numberOfPixelsTolerance,
+                     unsigned int       radiusTolerance,
+                     bool               verifyInputInformation,
+                     double             coordinateTolerance,
+                     double             directionTolerance)
 {
   // Use the factory mechanism to read the test and baseline files and convert
   // them to double
@@ -706,15 +706,15 @@ RegressionTestHelper(const char *         testImageFilename,
 }
 
 int
-RegressionTestImage(const char *         testImageFilename,
-                    const char *         baselineImageFilename,
-                    int                  reportErrors,
-                    double               intensityTolerance,
-                    ::itk::SizeValueType numberOfPixelsTolerance,
-                    unsigned int         radiusTolerance,
-                    bool                 verifyInputInformation,
-                    double               coordinateTolerance,
-                    double               directionTolerance)
+RegressionTestImage(const char *       testImageFilename,
+                    const char *       baselineImageFilename,
+                    int                reportErrors,
+                    double             intensityTolerance,
+                    itk::SizeValueType numberOfPixelsTolerance,
+                    unsigned int       radiusTolerance,
+                    bool               verifyInputInformation,
+                    double             coordinateTolerance,
+                    double             directionTolerance)
 {
   itk::IOPixelEnum     pixelType;
   itk::IOComponentEnum componentType;

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -128,11 +128,11 @@ public:
   // explicitly.
   // TODO: shouldn't it be done with the Clone() method?
   itkSimpleNewMacro(Self);
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override
   {
-    ::itk::LightObject::Pointer smartPtr;
-    Pointer                     copyPtr = Self::New().GetPointer();
+    itk::LightObject::Pointer smartPtr;
+    Pointer                   copyPtr = Self::New().GetPointer();
     // THE FOLLOWING LINE IS DIFFERENT FROM THE DEFAULT MACRO!
     copyPtr->m_BulkTransform = this->GetBulkTransform();
     smartPtr = static_cast<Pointer>(copyPtr);

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
@@ -199,7 +199,7 @@ public:
    */
   using BoundaryConditionType = ZeroFluxNeumannBoundaryCondition<OutputImageType>;
   using ListAdaptorType =
-    typename ::itk::Statistics::ImageToNeighborhoodSampleAdaptor<OutputImageType, BoundaryConditionType>;
+    typename itk::Statistics::ImageToNeighborhoodSampleAdaptor<OutputImageType, BoundaryConditionType>;
   using PatchRadiusType = typename ListAdaptorType::NeighborhoodRadiusType;
   using InputImagePatchIterator = ConstNeighborhoodIterator<InputImageType, BoundaryConditionType>;
 

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
@@ -28,11 +28,11 @@ template <typename TInputImage, typename TOutputImage>
 auto
 ForwardFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
 {
-  Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
+  Pointer smartPtr = itk::ObjectFactory<Self>::Create();
 
   if (smartPtr.IsNotNull())
   {
-    // Correct extra reference count from ::itk::ObjectFactory<Self>::Create()
+    // Correct extra reference count from itk::ObjectFactory<Self>::Create()
     smartPtr->UnRegister();
   }
 

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -27,11 +27,11 @@ template <typename TInputImage, typename TOutputImage>
 auto
 HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
 {
-  Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
+  Pointer smartPtr = itk::ObjectFactory<Self>::Create();
 
   if (smartPtr.IsNotNull())
   {
-    // Correct extra reference count from ::itk::ObjectFactory<Self>::Create()
+    // Correct extra reference count from itk::ObjectFactory<Self>::Create()
     smartPtr->UnRegister();
   }
 

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
@@ -28,11 +28,11 @@ template <typename TInputImage, typename TOutputImage>
 auto
 InverseFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
 {
-  Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
+  Pointer smartPtr = itk::ObjectFactory<Self>::Create();
 
   if (smartPtr.IsNotNull())
   {
-    // Correct extra reference count from ::itk::ObjectFactory<Self>::Create()
+    // Correct extra reference count from itk::ObjectFactory<Self>::Create()
     smartPtr->UnRegister();
   }
 

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -27,11 +27,11 @@ template <typename TInputImage, typename TOutputImage>
 auto
 RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
 {
-  Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
+  Pointer smartPtr = itk::ObjectFactory<Self>::Create();
 
   if (smartPtr.IsNotNull())
   {
-    // Correct extra reference count from ::itk::ObjectFactory<Self>::Create()
+    // Correct extra reference count from itk::ObjectFactory<Self>::Create()
     smartPtr->UnRegister();
   }
 

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -161,7 +161,7 @@ FFTWGlobalConfiguration::GetInstance()
         message << "itk::ERROR: "
                 << "FFTWGlobalConfiguration"
                 << " Valid FFTWGlobalConfiguration instance not created";
-        ::itk::ExceptionObject e_(__FILE__, __LINE__, message.str().c_str(), ITK_LOCATION);
+        itk::ExceptionObject e_(__FILE__, __LINE__, message.str().c_str(), ITK_LOCATION);
         throw e_; /* Explicit naming to work around Intel compiler bug.  */
       }
     }

--- a/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
@@ -210,11 +210,11 @@ itkSTAPLEImageFilterTest(int argc, char * argv[])
     return -1;
   }
 
-  if (::std::stoi(argv[1]) == 2)
+  if (std::stoi(argv[1]) == 2)
   {
     stapler = new Stapler<2>;
   }
-  else if (::std::stoi(argv[1]) == 3)
+  else if (std::stoi(argv[1]) == 3)
   {
     stapler = new Stapler<3>;
   }

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
@@ -81,7 +81,7 @@ itkVectorGradientMagnitudeImageFilterTest2(int ac, char * av[])
     // Extract one slice to write for regression testing
     CharImage3Type::RegionType extractedRegion = rescale->GetOutput()->GetRequestedRegion();
     extractedRegion.SetSize(2, 1);
-    extractedRegion.SetIndex(2, ::std::stoi(av[4]));
+    extractedRegion.SetIndex(2, std::stoi(av[4]));
 
     auto                       extractedImage = CharImage2Type::New();
     CharImage2Type::RegionType reg;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
@@ -107,7 +107,7 @@ template <typename TPixel>
 void
 Expect_ResampleImageFilter_thows_on_incomplete_configuration(const TPixel inputPixel)
 {
-  EXPECT_THROW(TestThrowErrorOnEmptyResampleSpace(inputPixel, false), ::itk::ExceptionObject);
+  EXPECT_THROW(TestThrowErrorOnEmptyResampleSpace(inputPixel, false), itk::ExceptionObject);
   EXPECT_EQ(TestThrowErrorOnEmptyResampleSpace(inputPixel, true), inputPixel);
 }
 

--- a/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
@@ -404,19 +404,19 @@ public:
   int
   GetElementIS(const unsigned short group,
                const unsigned short element,
-               ::itk::int32_t &     target,
+               itk::int32_t &       target,
                const bool           throwException = true) const;
 
   int
   GetElementSL(const unsigned short group,
                const unsigned short element,
-               ::itk::int32_t &     target,
+               itk::int32_t &       target,
                const bool           throwException = true) const;
 
   int
   GetElementISorOB(const unsigned short group,
                    const unsigned short element,
-                   ::itk::int32_t &     target,
+                   itk::int32_t &       target,
                    const bool           throwException = true) const;
 
   int

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -753,7 +753,7 @@ DCMTKFileReader::GetElementPN(const unsigned short group,
 int
 DCMTKFileReader::GetElementIS(const unsigned short group,
                               const unsigned short element,
-                              ::itk::int32_t &     target,
+                              itk::int32_t &       target,
                               const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
@@ -775,14 +775,14 @@ DCMTKFileReader::GetElementIS(const unsigned short group,
     DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << " " << element
                                 << std::dec);
   }
-  target = static_cast<::itk::int32_t>(_target);
+  target = static_cast<itk::int32_t>(_target);
   return EXIT_SUCCESS;
 }
 
 int
 DCMTKFileReader::GetElementSL(const unsigned short group,
                               const unsigned short element,
-                              ::itk::int32_t &     target,
+                              itk::int32_t &       target,
                               const bool           throwException) const
 {
   DcmTagKey    tagkey(group, element);
@@ -804,14 +804,14 @@ DCMTKFileReader::GetElementSL(const unsigned short group,
     DCMTKExceptionOrErrorReturn(<< "Can't get DecimalString Value at tag " << std::hex << group << " " << element
                                 << std::dec);
   }
-  target = static_cast<::itk::int32_t>(_target);
+  target = static_cast<itk::int32_t>(_target);
   return EXIT_SUCCESS;
 }
 
 int
 DCMTKFileReader::GetElementISorOB(const unsigned short group,
                                   const unsigned short element,
-                                  ::itk::int32_t &     target,
+                                  itk::int32_t &       target,
                                   const bool           throwException) const
 {
   if (this->GetElementIS(group, element, target, false) == EXIT_SUCCESS)

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -200,7 +200,7 @@ readNoPreambleDicom(std::ifstream & file) // NOTE: This file is duplicated in it
   std::ostringstream itkmsg;
   itkmsg << "No DICOM magic number found, but the file appears to be DICOM without a preamble.\n"
          << "Proceeding without caution.";
-  ::itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());
+  itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());
 #endif
   return true;
 }
@@ -356,8 +356,8 @@ DCMTKImageIO::ReadImageInformation()
   }
 
   // check for multiframe > 3D
-  ::itk::int32_t numPhases;
-  unsigned       numDim(3);
+  itk::int32_t numPhases;
+  unsigned     numDim(3);
 
   if (reader.GetElementSL(0x2001, 0x1017, numPhases, false) != EXIT_SUCCESS)
   {

--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -140,8 +140,8 @@ public:
   /** Set/Get the original component type of the image. This differs from
    * ComponentType which may change as a function of rescale slope and
    * intercept. */
-  itkGetEnumMacro(InternalComponentType, ::itk::CommonEnums::IOComponent);
-  itkSetEnumMacro(InternalComponentType, ::itk::CommonEnums::IOComponent);
+  itkGetEnumMacro(InternalComponentType, itk::CommonEnums::IOComponent);
+  itkSetEnumMacro(InternalComponentType, itk::CommonEnums::IOComponent);
 
   /*-------- This part of the interfaces deals with writing data. ----- */
 

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -190,7 +190,7 @@ readNoPreambleDicom(std::ifstream & file) // NOTE: This file is duplicated in it
   std::ostringstream itkmsg;
   itkmsg << "No DICOM magic number found, but the file appears to be DICOM without a preamble.\n"
          << "Proceeding without caution.";
-  ::itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());
+  itk::OutputWindowDisplayDebugText(itkmsg.str().c_str());
 #endif
   return true;
 }

--- a/Modules/IO/HDF5/include/itkHDF5ImageIO.h
+++ b/Modules/IO/HDF5/include/itkHDF5ImageIO.h
@@ -63,7 +63,7 @@ namespace itk
  * \li \/ITKImage\/\<name\>\/Origin     N-D point double
  * \li \/ITKImage\/\<name\>\/Directions N N-vectors double
  * \li \/ITKImage\/\<name\>\/Spacing    N-vector double
- * \li \/ITKImage\/\<name\>\/Dimensions N-vector ::itk::SizeValueType
+ * \li \/ITKImage\/\<name\>\/Dimensions N-vector itk::SizeValueType
  * \li \/ITKImage\/\<name\>\/VoxelType  String representing voxel type.
  *                             This can be inferred from the VoxelData
  *                             type info, but it makes the file more

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -93,8 +93,8 @@ public:
   itkGetStringMacro(FileName);
 
   /** Types for managing image size and image index components. */
-  using IndexValueType = ::itk::IndexValueType;
-  using SizeValueType = ::itk::SizeValueType;
+  using IndexValueType = itk::IndexValueType;
+  using SizeValueType = itk::SizeValueType;
 
   /**
    * \class UnknownType
@@ -233,8 +233,8 @@ public:
    * SCALAR, RGB, RGBA, VECTOR, COVARIANTVECTOR, POINT, INDEX. If
    * the PIXELTYPE is SCALAR, then the NumberOfComponents should be 1.
    * Any other of PIXELTYPE will have more than one component. */
-  itkSetEnumMacro(PixelType, ::itk::CommonEnums::IOPixel);
-  itkGetEnumMacro(PixelType, ::itk::CommonEnums::IOPixel);
+  itkSetEnumMacro(PixelType, itk::CommonEnums::IOPixel);
+  itkGetEnumMacro(PixelType, itk::CommonEnums::IOPixel);
 
   /** Set/Get the component type of the image. This is always a native
    * type. */
@@ -379,11 +379,11 @@ public:
   std::string GetByteOrderAsString(IOByteOrderEnum) const;
 
   /** Type for representing size of bytes, and or positions along a file */
-  using SizeType = ::itk::intmax_t;
+  using SizeType = itk::intmax_t;
 
   /** Type for representing size of bytes, and or positions along a memory
     buffer */
-  using BufferSizeType = ::itk::OffsetValueType;
+  using BufferSizeType = itk::OffsetValueType;
 
   /** Convenient method for accessing the number of bytes to get to
    * the next pixel. Returns m_Strides[1];

--- a/Modules/IO/ImageBase/include/itkImageIOFactory.h
+++ b/Modules/IO/ImageBase/include/itkImageIOFactory.h
@@ -46,7 +46,7 @@ public:
   itkTypeMacro(ImageIOFactory, Object);
 
   /** Convenient type alias. */
-  using ImageIOBasePointer = ::itk::ImageIOBase::Pointer;
+  using ImageIOBasePointer = itk::ImageIOBase::Pointer;
 
   using IOFileModeEnum = itk::IOFileModeEnum;
 #if !defined(ITK_LEGACY_REMOVE)

--- a/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
+++ b/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
@@ -345,10 +345,10 @@ ITK_MESH_DEFAULTCONVERTTRAITS_MATRIX_TYPE_ALL_TYPES_MACRO(Matrix);
 
 #define ITK_MESH_DEFAULTCONVERTTRAITS_COMPLEX_TYPE(componenttype)       \
   template <>                                                           \
-  class MeshConvertPixelTraits<::std::complex<componenttype>>           \
+  class MeshConvertPixelTraits<std::complex<componenttype>>             \
   {                                                                     \
   public:                                                               \
-    using TargetType = ::std::complex<componenttype>;                   \
+    using TargetType = std::complex<componenttype>;                     \
     using ComponentType = componenttype;                                \
     static unsigned int                                                 \
     GetNumberOfComponents()                                             \

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -180,21 +180,21 @@ public:
    * SCALAR, RGB, RGBA, VECTOR, COVARIANTVECTOR, POINT, INDEX. If
    * the PIXELTYPE is SCALAR, then the NumberOfComponents should be 1.
    * Any other of PIXELTYPE will have more than one component. */
-  itkSetEnumMacro(PointPixelType, ::itk::CommonEnums::IOPixel);
-  itkGetEnumMacro(PointPixelType, ::itk::CommonEnums::IOPixel);
-  itkSetEnumMacro(CellPixelType, ::itk::CommonEnums::IOPixel);
-  itkGetEnumMacro(CellPixelType, ::itk::CommonEnums::IOPixel);
+  itkSetEnumMacro(PointPixelType, itk::CommonEnums::IOPixel);
+  itkGetEnumMacro(PointPixelType, itk::CommonEnums::IOPixel);
+  itkSetEnumMacro(CellPixelType, itk::CommonEnums::IOPixel);
+  itkGetEnumMacro(CellPixelType, itk::CommonEnums::IOPixel);
 
   /** Set/Get the component type of the point, cell, point data and cell data.
     This is always a native type. */
-  itkSetEnumMacro(PointComponentType, ::itk::CommonEnums::IOComponent);
-  itkGetEnumMacro(PointComponentType, ::itk::CommonEnums::IOComponent);
-  itkSetEnumMacro(CellComponentType, ::itk::CommonEnums::IOComponent);
-  itkGetEnumMacro(CellComponentType, ::itk::CommonEnums::IOComponent);
-  itkSetEnumMacro(PointPixelComponentType, ::itk::CommonEnums::IOComponent);
-  itkGetEnumMacro(PointPixelComponentType, ::itk::CommonEnums::IOComponent);
-  itkSetEnumMacro(CellPixelComponentType, ::itk::CommonEnums::IOComponent);
-  itkGetEnumMacro(CellPixelComponentType, ::itk::CommonEnums::IOComponent);
+  itkSetEnumMacro(PointComponentType, itk::CommonEnums::IOComponent);
+  itkGetEnumMacro(PointComponentType, itk::CommonEnums::IOComponent);
+  itkSetEnumMacro(CellComponentType, itk::CommonEnums::IOComponent);
+  itkGetEnumMacro(CellComponentType, itk::CommonEnums::IOComponent);
+  itkSetEnumMacro(PointPixelComponentType, itk::CommonEnums::IOComponent);
+  itkGetEnumMacro(PointPixelComponentType, itk::CommonEnums::IOComponent);
+  itkSetEnumMacro(CellPixelComponentType, itk::CommonEnums::IOComponent);
+  itkGetEnumMacro(CellPixelComponentType, itk::CommonEnums::IOComponent);
 
   template <typename T>
   struct MapComponentType

--- a/Modules/IO/MeshBase/include/itkMeshIOFactory.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOFactory.h
@@ -57,7 +57,7 @@ public:
   itkTypeMacro(MeshIOFactory, Object);
 
   /** Convenient type alias. */
-  using MeshIOBasePointer = ::itk::MeshIOBase::Pointer;
+  using MeshIOBasePointer = itk::MeshIOBase::Pointer;
 
   using IOFileModeEnum = itk::IOFileModeEnum;
 #if !defined(ITK_LEGACY_REMOVE)

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -835,7 +835,7 @@ protected:
       }
       else
       {
-        ::itk::ExceptionObject e_(
+        itk::ExceptionObject e_(
           __FILE__, __LINE__, "itk::ERROR: VTKImageIO2: Unsupported number of components in tensor.", ITK_LOCATION);
         throw e_;
       }

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -526,7 +526,7 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * buffer)
     //            of the Exception and prevent the catch() from recognizing it.
     //            For details, see Bug #1872 in the bugtracker.
 
-    ::itk::ExceptionObject excp(__FILE__, __LINE__, "Problem while opening the file.", ITK_LOCATION);
+    itk::ExceptionObject excp(__FILE__, __LINE__, "Problem while opening the file.", ITK_LOCATION);
     throw excp;
   }
 
@@ -550,7 +550,7 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * buffer)
       //            of the Exception and prevent the catch() from recognizing
       // it.
       //            For details, see Bug #1872 in the bugtracker.
-      ::itk::ExceptionObject excp(__FILE__, __LINE__, "PNG supports unsigned char and unsigned short", ITK_LOCATION);
+      itk::ExceptionObject excp(__FILE__, __LINE__, "PNG supports unsigned char and unsigned short", ITK_LOCATION);
       throw excp;
     }
   }

--- a/Modules/IO/RAW/include/itkRawImageIO.hxx
+++ b/Modules/IO/RAW/include/itkRawImageIO.hxx
@@ -102,8 +102,8 @@ RawImageIO<TPixel, VImageDimension>::GetHeaderSize()
     file.seekg(0, std::ios::end);
 
     m_HeaderSize =
-      static_cast<SizeValueType>(static_cast<typename ::itk::intmax_t>(file.tellg()) -
-                                 static_cast<typename ::itk::intmax_t>(this->m_Strides[m_FileDimensionality + 1]));
+      static_cast<SizeValueType>(static_cast<typename itk::intmax_t>(file.tellg()) -
+                                 static_cast<typename itk::intmax_t>(this->m_Strides[m_FileDimensionality + 1]));
   }
 
   return m_HeaderSize;

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -771,7 +771,7 @@ WriteTensorBuffer(std::ostream &              os,
   }
   else
   {
-    ::itk::ExceptionObject e_(
+    itk::ExceptionObject e_(
       __FILE__, __LINE__, "itk::ERROR: VTKImageIO: Unsupported number of components in tensor.", ITK_LOCATION);
     throw e_;
   }

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLineStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLineStress.h
@@ -49,7 +49,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralMembrane.h
@@ -72,7 +72,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStrain.h
@@ -70,7 +70,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStress.h
@@ -72,7 +72,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularMembrane.h
@@ -76,7 +76,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStrain.h
@@ -74,7 +74,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStress.h
@@ -58,7 +58,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStrain.h
@@ -76,7 +76,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStress.h
@@ -73,7 +73,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC1Beam.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC1Beam.h
@@ -54,7 +54,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
 

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronMembrane.h
@@ -61,7 +61,7 @@ public:
    * CreateAnother method will clone the existing instance of this type,
    * including its internal member variables.
    */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronStrain.h
@@ -61,7 +61,7 @@ public:
    * CreateAnother method will clone the existing instance of this type,
    * including its internal member variables.
    */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronMembrane.h
@@ -60,7 +60,7 @@ public:
    * CreateAnother method will clone the existing instance of this type,
    * including its internal member variables.
    */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronStrain.h
@@ -58,7 +58,7 @@ public:
    * CreateAnother method will clone the existing instance of this type,
    * including its internal member variables.
    */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.h
@@ -57,7 +57,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularMembrane.h
@@ -55,7 +55,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementBase.h
@@ -161,7 +161,7 @@ public:
     static Pointer
     New()
     {
-      Pointer smartPtr = ::itk::ObjectFactory<Self>::Create();
+      Pointer smartPtr = itk::ObjectFactory<Self>::Create();
 
       if (smartPtr.IsNull())
       {
@@ -176,7 +176,7 @@ public:
 
     /** CreateAnother method will clone the existing instance of this type,
      * including its internal member variables. */
-    ::itk::LightObject::Pointer
+    itk::LightObject::Pointer
     CreateAnother() const override;
 
     /**

--- a/Modules/Numerics/FEM/include/itkFEMFactoryBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMFactoryBase.h
@@ -89,7 +89,7 @@ public:
           message << "itk::ERROR: "
                   << "FEMFactoryBase"
                   << " instance not created";
-          ::itk::ExceptionObject e_(__FILE__, __LINE__, message.str().c_str(), ITK_LOCATION);
+          itk::ExceptionObject e_(__FILE__, __LINE__, message.str().c_str(), ITK_LOCATION);
           throw e_; /* Explicit naming to work around for Intel compiler bug. */
         }
         ObjectFactoryBase::RegisterFactory(p);

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
@@ -83,7 +83,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   // Necessary type alias for dealing with images BEGIN

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
@@ -26,11 +26,11 @@ namespace fem
 {
 // Overload the CreateAnother() method.
 template <typename TMoving, typename TFixed>
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 ImageMetricLoad<TMoving, TFixed>::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   // Copy Load Contents
   copyPtr->m_MetricGradientImage = this->m_MetricGradientImage;

--- a/Modules/Numerics/FEM/include/itkFEMLoadBC.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBC.h
@@ -49,7 +49,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /** Default constructor */

--- a/Modules/Numerics/FEM/include/itkFEMLoadBCMFC.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBCMFC.h
@@ -71,7 +71,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMLoadEdge.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadEdge.h
@@ -54,7 +54,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
@@ -59,7 +59,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMLoadGrav.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadGrav.h
@@ -81,7 +81,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   vnl_vector<Float> GetGravitationalForceAtPoint(vnl_vector<Float>) override;

--- a/Modules/Numerics/FEM/include/itkFEMLoadLandmark.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadLandmark.h
@@ -53,7 +53,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/include/itkFEMLoadNode.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadNode.h
@@ -92,7 +92,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
 protected:

--- a/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
@@ -50,7 +50,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /** Default constructor. */

--- a/Modules/Numerics/FEM/include/itkFEMLoadTest.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadTest.h
@@ -52,11 +52,11 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override
   {
-    ::itk::LightObject::Pointer smartPtr;
-    Pointer                     copyPtr = Self::New();
+    itk::LightObject::Pointer smartPtr;
+    Pointer                   copyPtr = Self::New();
     for (unsigned int i = 0; i < this->m_Element.size(); ++i)
     {
       copyPtr->AddNextElement(this->m_Element[i]);

--- a/Modules/Numerics/FEM/include/itkFEMMaterialLinearElasticity.h
+++ b/Modules/Numerics/FEM/include/itkFEMMaterialLinearElasticity.h
@@ -52,7 +52,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   /**

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLineStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLineStress.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0LinearLineStress::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralMembrane.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0LinearQuadrilateralMembrane::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStrain.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0LinearQuadrilateralStrain::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStress.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0LinearQuadrilateralStress::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularMembrane.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0LinearTriangularMembrane::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStrain.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0LinearTriangularStrain::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStress.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0LinearTriangularStress::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStrain.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0QuadraticTriangularStrain::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStress.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC0QuadraticTriangularStress::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC1Beam.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC1Beam.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element2DC1Beam::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronMembrane.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element3DC0LinearHexahedronMembrane::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronStrain.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element3DC0LinearHexahedronStrain::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronMembrane.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element3DC0LinearTetrahedronMembrane::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronStrain.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element3DC0LinearTetrahedronStrain::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element3DC0LinearTriangularLaplaceBeltrami::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularMembrane.cxx
@@ -24,11 +24,11 @@ namespace fem
 {
 
 // Overload the CreateAnother() method
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element3DC0LinearTriangularMembrane::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetNode(0, this->GetNode(0));
   copyPtr->SetNode(1, this->GetNode(1));

--- a/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
@@ -497,11 +497,11 @@ Element::PrintSelf(std::ostream & os, Indent indent) const
   }
 }
 
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 Element::Node::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->m_coordinates = this->m_coordinates;
   copyPtr->m_dof = this->m_dof;

--- a/Modules/Numerics/FEM/src/itkFEMLoadBC.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadBC.cxx
@@ -24,11 +24,11 @@ namespace fem
 {
 
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 LoadBC::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   // Copy Load Contents
   copyPtr->m_DegreeOfFreedom = this->m_DegreeOfFreedom;

--- a/Modules/Numerics/FEM/src/itkFEMLoadBCMFC.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadBCMFC.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 LoadBCMFC::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   // Copy Load Contents
   copyPtr->m_Index = this->m_Index;

--- a/Modules/Numerics/FEM/src/itkFEMLoadEdge.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadEdge.cxx
@@ -24,11 +24,11 @@ namespace fem
 {
 
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 LoadEdge::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->m_Edge = this->m_Edge;
 

--- a/Modules/Numerics/FEM/src/itkFEMLoadElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadElementBase.cxx
@@ -24,11 +24,11 @@ namespace fem
 {
 
 // Overload the CreateAnother() method
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 LoadElement::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
   for (auto i : this->m_Element)
   {
     copyPtr->AddNextElement(i);

--- a/Modules/Numerics/FEM/src/itkFEMLoadGrav.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadGrav.cxx
@@ -30,11 +30,11 @@ LoadGrav::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 LoadGravConst::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   // Copy Load Contents
   copyPtr->m_GravityForce = this->m_GravityForce;

--- a/Modules/Numerics/FEM/src/itkFEMLoadLandmark.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadLandmark.cxx
@@ -24,11 +24,11 @@ namespace fem
 {
 
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 LoadLandmark::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   // Copy Load Contents
   copyPtr->m_Eta = this->m_Eta;

--- a/Modules/Numerics/FEM/src/itkFEMLoadNode.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadNode.cxx
@@ -24,11 +24,11 @@ namespace fem
 {
 
 // Overload the CreateAnother() method.
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 LoadNode::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->m_Element = this->m_Element;
   copyPtr->m_Point = this->m_Point;

--- a/Modules/Numerics/FEM/src/itkFEMLoadPoint.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadPoint.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 LoadPoint::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->m_Point = this->m_Point;
   copyPtr->m_ForcePoint = this->m_ForcePoint;

--- a/Modules/Numerics/FEM/src/itkFEMMaterialLinearElasticity.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMMaterialLinearElasticity.cxx
@@ -23,11 +23,11 @@ namespace itk
 namespace fem
 {
 // Overload the CreateAnother() method
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 MaterialLinearElasticity::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->SetYoungsModulus(this->GetYoungsModulus());
   copyPtr->SetCrossSectionalArea(this->GetCrossSectionalArea());

--- a/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
@@ -259,7 +259,7 @@ itkFEMElement2DTest(int argc, char * argv[])
       }
     }
   }
-  catch (::itk::ExceptionObject & err)
+  catch (itk::ExceptionObject & err)
   {
     std::cerr << "ITK exception detected: " << err;
     std::cout << "Test FAILED" << std::endl;

--- a/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
@@ -234,7 +234,7 @@ itkFEMElement3DTest(int argc, char * argv[])
       }
     }
   }
-  catch (::itk::ExceptionObject & err)
+  catch (itk::ExceptionObject & err)
   {
     std::cerr << "ITK exception detected: " << err;
     std::cout << "Test FAILED" << std::endl;

--- a/Modules/Numerics/FEM/test/itkFEMElementTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElementTest.cxx
@@ -370,7 +370,7 @@ itkFEMElementTest(int ac, char * av[])
       std::cout << comment << "Test PASSED" << std::endl;
     }
   }
-  catch (::itk::ExceptionObject & err)
+  catch (itk::ExceptionObject & err)
   {
     std::cerr << "ITK exception detected: " << err;
     std::cout << "Test FAILED" << std::endl;
@@ -503,9 +503,9 @@ PrintU(itk::fem::Solver & S, int s, char comment)
   std::cout << std::endl << comment << "Displacements: " << std::endl;
   std::cout << "u" << s << "=[";
   // changes made - kiran
-  // for( ::itk::fem::Solver::NodeArray::iterator n = S.node.begin();
+  // for( itk::fem::Solver::NodeArray::iterator n = S.node.begin();
   // n!=S.node.end(); n++) {
-  for (::itk::fem::Solver::NodeArray::iterator n = S.GetNodeArray().begin(); n != S.GetNodeArray().end(); ++n)
+  for (itk::fem::Solver::NodeArray::iterator n = S.GetNodeArray().begin(); n != S.GetNodeArray().end(); ++n)
   {
     // changes made - kiran
     if (IDL_OUTPUT)
@@ -513,10 +513,10 @@ PrintU(itk::fem::Solver & S, int s, char comment)
       std::cout << " [";
     }
     /** For each DOF in the node... */
-    for (unsigned int d = 0, dof; (dof = (*n)->GetDegreeOfFreedom(d)) != ::itk::fem::Element::InvalidDegreeOfFreedomID;
+    for (unsigned int d = 0, dof; (dof = (*n)->GetDegreeOfFreedom(d)) != itk::fem::Element::InvalidDegreeOfFreedomID;
          d++)
     {
-      if (d > 0 && d != ::itk::fem::Element::InvalidDegreeOfFreedomID)
+      if (d > 0 && d != itk::fem::Element::InvalidDegreeOfFreedomID)
       {
         std::cout << ", ";
       }
@@ -553,9 +553,9 @@ CheckDisplacements(itk::fem::Solver & S, int s, char comment, double * expectedR
   bool foundError = false;
 
   std::cout << std::endl << comment << "NodeArray: " << std::endl;
-  for (::itk::fem::Solver::NodeArray::iterator n = S.GetNodeArray().begin(); n != S.GetNodeArray().end(); ++n)
+  for (itk::fem::Solver::NodeArray::iterator n = S.GetNodeArray().begin(); n != S.GetNodeArray().end(); ++n)
   {
-    for (unsigned int d = 0, dof; (dof = (*n)->GetDegreeOfFreedom(d)) != ::itk::fem::Element::InvalidDegreeOfFreedomID;
+    for (unsigned int d = 0, dof; (dof = (*n)->GetDegreeOfFreedom(d)) != itk::fem::Element::InvalidDegreeOfFreedomID;
          d++)
     {
       double result = S.GetSolution(dof);

--- a/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
@@ -184,7 +184,7 @@ itkFEMSolverHyperbolicTest(int ac, char * av[])
   {
     SpatialReader->Update();
   }
-  catch (::itk::fem::FEMException & e)
+  catch (itk::fem::FEMException & e)
   {
     std::cout << "Error reading FEM problem: " << av[1] << "!\n";
     e.Print(std::cout);

--- a/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
@@ -103,7 +103,7 @@ public:
   /**
    * Run-time type information (and related methods).
    */
-  itkTypeMacro(CommandIterationUpdatev4, ::itk::Command);
+  itkTypeMacro(CommandIterationUpdatev4, itk::Command);
 
 
   /**

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -115,11 +115,11 @@ public:
   using TotalRelativeFrequencyType = typename FrequencyContainerType::TotalRelativeFrequencyType;
 
   /** Index type alias support An index is used to access pixel values. */
-  using IndexType = Array<::itk::IndexValueType>;
+  using IndexType = Array<itk::IndexValueType>;
   using IndexValueType = typename IndexType::ValueType;
 
   /** size array type */
-  using SizeType = Array<::itk::SizeValueType>;
+  using SizeType = Array<itk::SizeValueType>;
   using SizeValueType = typename SizeType::ValueType;
 
   /** bin min max value storage types */

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -125,7 +125,7 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceI
 
   unsigned int pointsFound = 0;
 
-  ::std::set<InstanceIdentifier>       usedIds;
+  std::set<InstanceIdentifier>         usedIds;
   typename RegionType::OffsetValueType offset;
 
   // The trouble with decoupling the region from the sample is that

--- a/Modules/Numerics/Statistics/test/itkDistanceToCentroidMembershipFunctionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceToCentroidMembershipFunctionTest.cxx
@@ -76,7 +76,7 @@ itkDistanceToCentroidMembershipFunctionTest(int, char *[])
 
   // Test if the distance computed is correct
   MembershipFunctionType::CentroidType origin;
-  ::itk::NumericTraits<MembershipFunctionType::CentroidType>::SetLength(origin, 3);
+  itk::NumericTraits<MembershipFunctionType::CentroidType>::SetLength(origin, 3);
   origin[0] = 1.5;
   origin[1] = 2.3;
   origin[2] = 1.0;
@@ -93,7 +93,7 @@ itkDistanceToCentroidMembershipFunctionTest(int, char *[])
   }
 
   MeasurementVectorType measurement;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
   measurement[0] = 2.5;
   measurement[1] = 3.3;
   measurement[2] = 4.0;

--- a/Modules/Numerics/Statistics/test/itkEuclideanDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkEuclideanDistanceMetricTest.cxx
@@ -34,7 +34,7 @@ itkEuclideanDistanceMetricTest(int, char *[])
   distance->Print(std::cout);
 
   MeasurementVectorType measurementNew;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurementNew, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurementNew, 3);
   measurementNew[0] = 2.5;
   measurementNew[1] = 3.3;
   measurementNew[2] = 4.0;
@@ -64,14 +64,14 @@ itkEuclideanDistanceMetricTest(int, char *[])
 
   // Test if the distance computed is correct
   DistanceMetricType::OriginType origin;
-  ::itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 3);
+  itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 3);
   origin[0] = 1.5;
   origin[1] = 2.3;
   origin[2] = 1.0;
   distance->SetOrigin(origin);
 
   MeasurementVectorType measurement;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
   measurement[0] = 2.5;
   measurement[1] = 3.3;
   measurement[2] = 4.0;
@@ -89,7 +89,7 @@ itkEuclideanDistanceMetricTest(int, char *[])
 
   // Compute distance between two measurement vectors
   MeasurementVectorType measurement2;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement2, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement2, 3);
   measurement2[0] = 1.5;
   measurement2[1] = 3.5;
   measurement2[2] = 3.5;

--- a/Modules/Numerics/Statistics/test/itkEuclideanSquareDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkEuclideanSquareDistanceMetricTest.cxx
@@ -34,7 +34,7 @@ itkEuclideanSquareDistanceMetricTest(int, char *[])
   distance->Print(std::cout);
 
   MeasurementVectorType measurementNew;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurementNew, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurementNew, 3);
   measurementNew[0] = 2.5;
   measurementNew[1] = 3.3;
   measurementNew[2] = 4.0;
@@ -66,14 +66,14 @@ itkEuclideanSquareDistanceMetricTest(int, char *[])
 
   // Test if the distance computed is correct
   DistanceMetricType::OriginType origin;
-  ::itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 3);
+  itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 3);
   origin[0] = 1.5;
   origin[1] = 2.3;
   origin[2] = 1.0;
   distance->SetOrigin(origin);
 
   MeasurementVectorType measurement;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
   measurement[0] = 2.5;
   measurement[1] = 3.3;
   measurement[2] = 4.0;
@@ -91,7 +91,7 @@ itkEuclideanSquareDistanceMetricTest(int, char *[])
 
   // Compute distance between two measurement vectors
   MeasurementVectorType measurement2;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement2, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement2, 3);
   measurement2[0] = 1.5;
   measurement2[1] = 3.5;
   measurement2[2] = 3.5;

--- a/Modules/Numerics/Statistics/test/itkGaussianMembershipFunctionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianMembershipFunctionTest.cxx
@@ -63,7 +63,7 @@ itkGaussianMembershipFunctionTest(int, char *[])
 
   // Test if the membership function value computed is correct
   MembershipFunctionType::MeanVectorType mean;
-  ::itk::NumericTraits<MembershipFunctionType::MeanVectorType>::SetLength(mean, MeasurementVectorSize);
+  itk::NumericTraits<MembershipFunctionType::MeanVectorType>::SetLength(mean, MeasurementVectorSize);
   mean[0] = 1.5;
   function->SetMean(mean);
 
@@ -87,7 +87,7 @@ itkGaussianMembershipFunctionTest(int, char *[])
   }
 
   MeasurementVectorType measurement;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, MeasurementVectorSize);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, MeasurementVectorSize);
   measurement[0] = 1.5;
 
   double trueValue = 0.3989;

--- a/Modules/Numerics/Statistics/test/itkMahalanobisDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMahalanobisDistanceMetricTest.cxx
@@ -43,7 +43,7 @@ itkMahalanobisDistanceMetricTest(int, char *[])
 
   // Test if the distance computed is correct
   DistanceMetricType::OriginType origin;
-  ::itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 3);
+  itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 3);
   origin[0] = 1.5;
   origin[1] = 2.3;
   origin[2] = 1.0;
@@ -60,7 +60,7 @@ itkMahalanobisDistanceMetricTest(int, char *[])
   }
 
   MeasurementVectorType measurement;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
   measurement[0] = 2.5;
   measurement[1] = 3.3;
   measurement[2] = 4.0;
@@ -190,7 +190,7 @@ itkMahalanobisDistanceMetricTest(int, char *[])
 
   distance->SetMeasurementVectorSize(singleComponentMeasurementVectorSize);
 
-  ::itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 1);
+  itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 1);
   origin[0] = 1.5;
   distance->SetMean(origin);
 
@@ -204,7 +204,7 @@ itkMahalanobisDistanceMetricTest(int, char *[])
   distance->SetCovariance(covarianceMatrix);
 
   MeasurementVectorType measurementSingleComponent;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurementSingleComponent, 1);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurementSingleComponent, 1);
   measurementSingleComponent[0] = 2.5;
 
   trueValue = 1.0;
@@ -219,7 +219,7 @@ itkMahalanobisDistanceMetricTest(int, char *[])
 
   // Compute distance between two measurement vectors
   MeasurementVectorType measurementSingleComponent2;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurementSingleComponent2, 1);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurementSingleComponent2, 1);
   measurementSingleComponent2[0] = 1.5;
 
   trueValue = 1.0;
@@ -234,7 +234,7 @@ itkMahalanobisDistanceMetricTest(int, char *[])
 
   // Attempt to compute distance between two unequal size measurement vectors
   MeasurementVectorType measurementSingleComponent3;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurementSingleComponent3, 2);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurementSingleComponent3, 2);
   measurementSingleComponent3[0] = 1.5;
   measurementSingleComponent3[1] = 2.5;
 

--- a/Modules/Numerics/Statistics/test/itkManhattanDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkManhattanDistanceMetricTest.cxx
@@ -34,7 +34,7 @@ itkManhattanDistanceMetricTest(int, char *[])
   distance->Print(std::cout);
 
   MeasurementVectorType measurementNew;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurementNew, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurementNew, 3);
   measurementNew[0] = 2.5;
   measurementNew[1] = 3.3;
   measurementNew[2] = 4.0;
@@ -65,14 +65,14 @@ itkManhattanDistanceMetricTest(int, char *[])
 
   // Test if the distance computed is correct
   DistanceMetricType::OriginType origin;
-  ::itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 3);
+  itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, 3);
   origin[0] = 1.5;
   origin[1] = 2.3;
   origin[2] = 1.0;
   distance->SetOrigin(origin);
 
   MeasurementVectorType measurement;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement, 3);
   measurement[0] = 2.5;
   measurement[1] = 3.3;
   measurement[2] = 4.0;
@@ -90,7 +90,7 @@ itkManhattanDistanceMetricTest(int, char *[])
 
   // Compute distance between two measurement vectors
   MeasurementVectorType measurement2;
-  ::itk::NumericTraits<MeasurementVectorType>::SetLength(measurement2, 3);
+  itk::NumericTraits<MeasurementVectorType>::SetLength(measurement2, 3);
   measurement2[0] = 1.5;
   measurement2[1] = 3.5;
   measurement2[2] = 3.5;

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
@@ -31,7 +31,7 @@ using SubsampleType = itk::Statistics::Subsample<SampleType>;
 
 constexpr unsigned int testDimension = 1;
 
-void resetData(::itk::Image<PixelType, 3>::Pointer image, std::vector<int> & refVector)
+void resetData(itk::Image<PixelType, 3>::Pointer image, std::vector<int> & refVector)
 {
   ImageType::IndexType index;
   ImageType::SizeType  size;
@@ -79,7 +79,7 @@ void resetData(::itk::Image<PixelType, 3>::Pointer image, std::vector<int> & ref
 }
 
 bool
-isSortedOrderCorrect(std::vector<int> & ref, ::itk::Statistics::Subsample<SampleType>::Pointer subsample)
+isSortedOrderCorrect(std::vector<int> & ref, itk::Statistics::Subsample<SampleType>::Pointer subsample)
 {
   bool                    ret = true;
   auto                    viter = ref.begin();

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
@@ -96,7 +96,7 @@ itkWeightedCentroidKdTreeGeneratorTest8(int argc, char * argv[])
   auto                           distanceMetric = DistanceMetricType::New();
   bool                           testFailed = false;
   DistanceMetricType::OriginType origin;
-  ::itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, measurementVectorSize);
+  itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, measurementVectorSize);
 
   for (unsigned int k = 0; k < sample->Size(); ++k)
   {

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
@@ -94,7 +94,7 @@ itkWeightedCentroidKdTreeGeneratorTest9(int argc, char * argv[])
   //
   using DistanceMetricType = itk::Statistics::EuclideanDistanceMetric<MeasurementVectorType>;
   DistanceMetricType::OriginType origin;
-  ::itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, measurementVectorSize);
+  itk::NumericTraits<DistanceMetricType::OriginType>::SetLength(origin, measurementVectorSize);
   auto distanceMetric = DistanceMetricType::New();
 
   bool testFailed = false;

--- a/Modules/Registration/Common/include/itkCommandIterationUpdate.h
+++ b/Modules/Registration/Common/include/itkCommandIterationUpdate.h
@@ -96,7 +96,7 @@ public:
   /**
    * Run-time type information (and related methods).
    */
-  itkTypeMacro(CommandIterationUpdate, ::itk::Command);
+  itkTypeMacro(CommandIterationUpdate, itk::Command);
 
 
   /**

--- a/Modules/Registration/Common/include/itkCommandVnlIterationUpdate.h
+++ b/Modules/Registration/Common/include/itkCommandVnlIterationUpdate.h
@@ -93,7 +93,7 @@ public:
   /**
    * Run-time type information (and related methods).
    */
-  itkTypeMacro(CommandVnlIterationUpdate, ::itk::Command);
+  itkTypeMacro(CommandVnlIterationUpdate, itk::Command);
 
 
   /**

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
@@ -43,7 +43,7 @@ namespace itk
  */
 template <typename TFixedPointSet,
           typename TMovingPointSet,
-          typename TDistanceMap = ::itk::Image<unsigned short, TMovingPointSet::PointDimension>>
+          typename TDistanceMap = itk::Image<unsigned short, TMovingPointSet::PointDimension>>
 class ITK_TEMPLATE_EXPORT EuclideanDistancePointMetric
   : public PointSetToPointSetMetric<TFixedPointSet, TMovingPointSet>
 {

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.h
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.h
@@ -82,7 +82,7 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    *  including its internal member variables. */
-  ::itk::LightObject::Pointer
+  itk::LightObject::Pointer
   CreateAnother() const override;
 
   // Necessary type alias for dealing with images BEGIN

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -37,11 +37,11 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::FiniteDifferenceFunctionLoad()
 }
 
 template <typename TMoving, typename TFixed>
-::itk::LightObject::Pointer
+itk::LightObject::Pointer
 FiniteDifferenceFunctionLoad<TMoving, TFixed>::CreateAnother() const
 {
-  ::itk::LightObject::Pointer smartPtr;
-  Pointer                     copyPtr = Self::New();
+  itk::LightObject::Pointer smartPtr;
+  Pointer                   copyPtr = Self::New();
 
   copyPtr->m_MovingImage = this->m_MovingImage;
   copyPtr->m_FixedImage = this->m_FixedImage;

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
@@ -290,7 +290,7 @@ itkFEMRegistrationFilter2DTest(int argc, char * argv[])
     {
       registrator->RunRegistration();
     }
-    catch (::itk::ExceptionObject & err)
+    catch (itk::ExceptionObject & err)
     {
       std::cerr << "ITK exception detected: " << err;
       std::cout << "Test failed!" << std::endl;

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
@@ -294,7 +294,7 @@ itkFEMRegistrationFilterTest(int argc, char * argv[])
       // Register the images
       registrator->RunRegistration();
     }
-    catch (::itk::ExceptionObject & err)
+    catch (itk::ExceptionObject & err)
     {
       std::cerr << "ITK exception detected: " << err;
       std::cout << "Test FAILED" << std::endl;

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
@@ -317,7 +317,7 @@ itkFEMRegistrationFilterTest2(int argc, char * argv[])
       // Register the images
       registrator->RunRegistration();
     }
-    catch (::itk::ExceptionObject & err)
+    catch (itk::ExceptionObject & err)
     {
       std::cerr << "ITK exception detected: " << err;
       std::cout << "Test failed!" << std::endl;

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetImageFilter.h
@@ -147,7 +147,7 @@ public:
   using typename Superclass::SpeedImageType;
 
   /** Type of the segmentation function */
-  using CannyFunctionType = ::itk::CannySegmentationLevelSetFunction<OutputImageType, FeatureImageType>;
+  using CannyFunctionType = itk::CannySegmentationLevelSetFunction<OutputImageType, FeatureImageType>;
 
   using ScalarValueType = typename CannyFunctionType::ScalarValueType;
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.h
@@ -75,7 +75,7 @@ public:
   static constexpr unsigned int SetDimension = LevelSetType::SetDimension;
 
   /** Index type alias support */
-  using Index = ::itk::Index<Self::SetDimension>;
+  using Index = itk::Index<Self::SetDimension>;
 
   /** AuxVarType type alias support */
   using AuxVarType = AuxVarTypeDefault<TAuxValue, VAuxDimension, Self::SetDimension>;

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -68,10 +68,10 @@ square(unsigned x, unsigned y)
 
 // Evaluates a function at each pixel in the itk image
 void
-evaluate_function(::itk::Image<float, 2> * im, float (*f)(unsigned int, unsigned int))
+evaluate_function(itk::Image<float, 2> * im, float (*f)(unsigned int, unsigned int))
 
 {
-  ::itk::Image<float, 2>::IndexType idx;
+  itk::Image<float, 2>::IndexType idx;
   for (unsigned int x = 0; x < WIDTH; ++x)
   {
     idx[0] = x;
@@ -90,26 +90,26 @@ evaluate_function(::itk::Image<float, 2> * im, float (*f)(unsigned int, unsigned
  *
  * See LevelSetFunction for more information.
  */
-class MorphFunction : public ::itk::LevelSetFunction<::itk::Image<float, 2>>
+class MorphFunction : public itk::LevelSetFunction<itk::Image<float, 2>>
 {
 public:
   void
-  SetDistanceTransform(::itk::Image<float, 2> * d)
+  SetDistanceTransform(itk::Image<float, 2> * d)
   {
     m_DistanceTransform = d;
   }
 
   using Self = MorphFunction;
 
-  using Superclass = ::itk::LevelSetFunction<::itk::Image<float, 2>>;
+  using Superclass = itk::LevelSetFunction<itk::Image<float, 2>>;
   using RadiusType = Superclass::RadiusType;
   using GlobalDataStruct = Superclass::GlobalDataStruct;
 
   /**
    * Smart pointer support for this class.
    */
-  using Pointer = ::itk::SmartPointer<Self>;
-  using ConstPointer = ::itk::SmartPointer<const Self>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
 
   /**
    * Run-time type information (and related methods)
@@ -132,17 +132,17 @@ protected:
   }
 
 private:
-  ::itk::Image<float, 2>::Pointer m_DistanceTransform;
+  itk::Image<float, 2>::Pointer m_DistanceTransform;
   ScalarValueType
   PropagationSpeed(const NeighborhoodType & neighborhood, const FloatOffsetType &, GlobalDataStruct *) const override
   {
-    ::itk::Index<2> idx = neighborhood.GetIndex();
+    itk::Index<2> idx = neighborhood.GetIndex();
     return m_DistanceTransform->GetPixel(idx);
   }
 };
 
 
-class MorphFilter : public ::itk::DenseFiniteDifferenceImageFilter<::itk::Image<float, 2>, ::itk::Image<float, 2>>
+class MorphFilter : public itk::DenseFiniteDifferenceImageFilter<itk::Image<float, 2>, itk::Image<float, 2>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MorphFilter);
@@ -152,8 +152,8 @@ public:
   /**
    * Smart pointer support for this class.
    */
-  using Pointer = ::itk::SmartPointer<Self>;
-  using ConstPointer = ::itk::SmartPointer<const Self>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
 
   /**
    * Run-time type information (and related methods)
@@ -168,7 +168,7 @@ public:
   itkSetMacro(Iterations, unsigned int);
 
   void
-  SetDistanceTransform(::itk::Image<float, 2> * im)
+  SetDistanceTransform(itk::Image<float, 2> * im)
   {
     auto * func = dynamic_cast<MorphFunction *>(this->GetDifferenceFunction().GetPointer());
     if (func == nullptr)
@@ -208,7 +208,7 @@ private:
 int
 itkLevelSetFunctionTest(int, char *[])
 {
-  using ImageType = ::itk::Image<float, 2>;
+  using ImageType = itk::Image<float, 2>;
 
   constexpr int n = 100; // Number of iterations
 

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -77,9 +77,9 @@ cube(unsigned int x, unsigned int y, unsigned int z)
 
 // Evaluates a function at each pixel in the itk volume
 void
-evaluate_function(::itk::Image<float, 3> * im, float (*f)(unsigned int, unsigned int, unsigned int))
+evaluate_function(itk::Image<float, 3> * im, float (*f)(unsigned int, unsigned int, unsigned int))
 {
-  ::itk::Image<float, 3>::IndexType idx;
+  itk::Image<float, 3>::IndexType idx;
   for (unsigned int x = 0; x < WIDTH; ++x)
   {
     idx[0] = x;
@@ -101,26 +101,26 @@ evaluate_function(::itk::Image<float, 3> * im, float (*f)(unsigned int, unsigned
  *
  * See LevelSetFunction for more information.
  */
-class MorphFunction : public ::itk::LevelSetFunction<::itk::Image<float, 3>>
+class MorphFunction : public itk::LevelSetFunction<itk::Image<float, 3>>
 {
 public:
   void
-  SetDistanceTransform(::itk::Image<float, 3> * d)
+  SetDistanceTransform(itk::Image<float, 3> * d)
   {
     m_DistanceTransform = d;
   }
 
   using Self = MorphFunction;
 
-  using Superclass = ::itk::LevelSetFunction<::itk::Image<float, 3>>;
+  using Superclass = itk::LevelSetFunction<itk::Image<float, 3>>;
   using RadiusType = Superclass::RadiusType;
   using GlobalDataStruct = Superclass::GlobalDataStruct;
 
   /**
    * Smart pointer support for this class.
    */
-  using Pointer = ::itk::SmartPointer<Self>;
-  using ConstPointer = ::itk::SmartPointer<const Self>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
 
   /**
    * Run-time type information (and related methods)
@@ -143,16 +143,16 @@ protected:
   }
 
 private:
-  ::itk::Image<float, 3>::Pointer m_DistanceTransform;
+  itk::Image<float, 3>::Pointer m_DistanceTransform;
   ScalarValueType
   PropagationSpeed(const NeighborhoodType & neighborhood, const FloatOffsetType &, GlobalDataStruct *) const override
   {
-    ::itk::Index<3> idx = neighborhood.GetIndex();
+    itk::Index<3> idx = neighborhood.GetIndex();
     return m_DistanceTransform->GetPixel(idx);
   }
 };
 
-class MorphFilter : public ::itk::ParallelSparseFieldLevelSetImageFilter<::itk::Image<float, 3>, ::itk::Image<float, 3>>
+class MorphFilter : public itk::ParallelSparseFieldLevelSetImageFilter<itk::Image<float, 3>, itk::Image<float, 3>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MorphFilter);
@@ -162,8 +162,8 @@ public:
   /**
    * Smart pointer support for this class.
    */
-  using Pointer = ::itk::SmartPointer<Self>;
-  using ConstPointer = ::itk::SmartPointer<const Self>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
 
   /**
    * Run-time type information (and related methods)
@@ -178,7 +178,7 @@ public:
   itkSetMacro(Iterations, unsigned int);
 
   void
-  SetDistanceTransform(::itk::Image<float, 3> * im)
+  SetDistanceTransform(itk::Image<float, 3> * im)
   {
     auto * func = dynamic_cast<MorphFunction *>(this->GetDifferenceFunction().GetPointer());
     if (func == nullptr)
@@ -224,7 +224,7 @@ itkParallelSparseFieldLevelSetImageFilterTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  using ImageType = ::itk::Image<float, 3>;
+  using ImageType = itk::Image<float, 3>;
 
   constexpr int n = 100;                // Number of iterations
   constexpr int numberOfWorkUnits = 11; // Number of work units to be used

--- a/Modules/Video/BridgeVXL/include/vidl_itk_istream.h
+++ b/Modules/Video/BridgeVXL/include/vidl_itk_istream.h
@@ -46,7 +46,7 @@ public:
   using VideoStreamType = TVideoStream;
   using Self = vidl_itk_istream<VideoStreamType>;
   using FrameType = typename VideoStreamType::FrameType;
-  using FrameOffsetType = ::itk::SizeValueType;
+  using FrameOffsetType = itk::SizeValueType;
   using PixelType = typename FrameType::PixelType;
   static constexpr unsigned int Dimensions = FrameType::ImageDimension;
 

--- a/Modules/Video/Core/include/itkRingBuffer.h
+++ b/Modules/Video/Core/include/itkRingBuffer.h
@@ -54,8 +54,8 @@ public:
   using ElementType = TElement;
   using ElementPointer = typename ElementType::Pointer;
 
-  using SizeValueType = ::itk::SizeValueType;
-  using OffsetValueType = ::itk::OffsetValueType;
+  using SizeValueType = itk::SizeValueType;
+  using OffsetValueType = itk::OffsetValueType;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Video/Core/include/itkTemporalRegion.h
+++ b/Modules/Video/Core/include/itkTemporalRegion.h
@@ -50,7 +50,7 @@ public:
   itkTypeMacro(TemporalRegion, Region);
 
   /** Typedef for frame offsets */
-  using FrameOffsetType = ::itk::SizeValueType;
+  using FrameOffsetType = itk::SizeValueType;
 
   /** Get/Set RealStart */
   void

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -28,8 +28,8 @@ namespace itk
 namespace TemporalProcessObjectTest
 {
 
-using SizeValueType = ::itk::SizeValueType;
-using OffsetValueType = ::itk::OffsetValueType;
+using SizeValueType = itk::SizeValueType;
+using OffsetValueType = itk::OffsetValueType;
 
 /**\class CallRecordEnumms
  * \brief Contains all enum classes for CallRecord class.
@@ -528,8 +528,8 @@ int
 itkTemporalProcessObjectTest(int, char *[])
 {
 
-  using SizeValueType = ::itk::SizeValueType;
-  using OffsetValueType = ::itk::OffsetValueType;
+  using SizeValueType = itk::SizeValueType;
+  using OffsetValueType = itk::OffsetValueType;
   //////
   // Set up pipeline
   //////

--- a/Modules/Video/IO/include/itkVideoIOBase.h
+++ b/Modules/Video/IO/include/itkVideoIOBase.h
@@ -75,7 +75,7 @@ public:
   using Self = VideoIOBase;
   using Superclass = ImageIOBase;
   using Pointer = SmartPointer<Self>;
-  using SizeValueType = ::itk::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
 
   /** Frame offset type alias */
   using TemporalOffsetType = double;


### PR DESCRIPTION
This is accomplished from a `bash` prompt with these commands:
```bash
fgrep -Rl ::itk | egrep '\.(h|c)(xx|pp)?$' | fgrep -v ThirdParty |
   xargs sed -i -e 's/::itk\(::[A-Za-z_]\+\)/itk\1/g'
fgrep -Rl ::std | egrep '\.(h|c)(xx|pp)?$' | fgrep -v ThirdParty |
   xargs sed -i -e 's/::std\(::[A-Za-z_]\+\)/std\1/g'
```

- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)