### PR TITLE
STYLE: Do not use double underscore defines

### DIFF
--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
@@ -84,8 +84,8 @@ using TetrahedronType = itk::TetrahedronCell<CellType>;
 //  Software Guide : EndLatex
 
 
-#ifndef __CustomTriangleVisitor
-#  define __CustomTriangleVisitor
+#ifndef CustomTriangleVisitor
+#  define CustomTriangleVisitor
 // Software Guide : BeginCodeSnippet
 class CustomTriangleVisitor
 {

--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
@@ -166,8 +166,8 @@ private:
 //  Software Guide : EndLatex
 
 
-#ifndef __CustomTriangleVisitor
-#  define __CustomTriangleVisitor
+#ifndef CustomTriangleVisitor
+#  define CustomTriangleVisitor
 // Software Guide : BeginCodeSnippet
 class CustomTriangleVisitor
 {

--- a/Modules/Core/Common/include/VNLIterativeSparseSolverTraits.h
+++ b/Modules/Core/Common/include/VNLIterativeSparseSolverTraits.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __VNLIterativeSparseSolverTraits_h
-#define __VNLIterativeSparseSolverTraits_h
+#ifndef VNLIterativeSparseSolverTraits_h
+#define VNLIterativeSparseSolverTraits_h
 
 #include "vnl/vnl_vector.h"
 #include "vnl/vnl_sparse_matrix.h"

--- a/Modules/Core/Common/include/VNLSparseLUSolverTraits.h
+++ b/Modules/Core/Common/include/VNLSparseLUSolverTraits.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __VNLSparseLUSolverTraits_h
-#define __VNLSparseLUSolverTraits_h
+#ifndef VNLSparseLUSolverTraits_h
+#define VNLSparseLUSolverTraits_h
 
 #include "vnl/vnl_vector.h"
 #include "vnl/vnl_sparse_matrix.h"

--- a/Modules/Core/ImageFunction/test/makeRandomImageBsplineInterpolator.h
+++ b/Modules/Core/ImageFunction/test/makeRandomImageBsplineInterpolator.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __makeRandomImageBsplineInterpolator_h
-#define __makeRandomImageBsplineInterpolator_h
+#ifndef makeRandomImageBsplineInterpolator_h
+#define makeRandomImageBsplineInterpolator_h
 
 #include "itkBSplineResampleImageFunction.h"
 #include "itkRandomImageSource.h"

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
@@ -329,8 +329,8 @@ OrientImageFilter<TInputImage, TOutputImage>::NeedToFlip()
   return false;
 }
 
-//#define __DEBUG_ORIENT__
-#if defined(__DEBUG_ORIENT__)
+//#define DefinedDebugOrient
+#if defined(DefinedDebugOrient)
 #  define DEBUG_EXECUTE(X) X
 
 using SO_OrientationType = itk::SpatialOrientation::ValidCoordinateOrientationFlags;
@@ -461,7 +461,7 @@ DumpDirections(const std::string & prompt, const typename ImageType::Pointer & i
   }
 }
 
-#else //__DEBUG_ORIENT__
+#else // DefinedDebugOrient
 #  define DEBUG_EXECUTE(X)
 #endif
 

--- a/Modules/IO/NIFTI/test/BigEndian_hdr.h
+++ b/Modules/IO/NIFTI/test/BigEndian_hdr.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __BigEndian_hdr_h
-#define __BigEndian_hdr_h
+#ifndef BigEndian_hdr_h
+#define BigEndian_hdr_h
 
 static unsigned char BigEndian_hdr[] = {
   0, 0,  1,   92, 70, 76, 79,  65, 84, 0,   0,   0, 0, 0,  0,   0, 0, 0,  0,   0,   0, 0, 0,  0,   0, 0, 0,  0,   0,

--- a/Modules/IO/NIFTI/test/BigEndian_img.h
+++ b/Modules/IO/NIFTI/test/BigEndian_img.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __BigEndian_img_h
-#define __BigEndian_img_h
+#ifndef BigEndian_img_h
+#define BigEndian_img_h
 
 const unsigned char BigEndian_img[] = {
   67, 16,  0, 0, 67, 16,  0, 0, 67, 16,  0, 0, 65, 128, 0, 0, 65, 128, 0, 0, 65, 128, 0, 0, 67, 16,  0, 0,

--- a/Modules/IO/NIFTI/test/LittleEndian_hdr.h
+++ b/Modules/IO/NIFTI/test/LittleEndian_hdr.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __LittleEndian_hdr_h
-#define __LittleEndian_hdr_h
+#ifndef LittleEndian_hdr_h
+#define LittleEndian_hdr_h
 
 static unsigned char LittleEndian_hdr[] = {
   92, 1, 0, 0,   70, 76, 79, 65,  84, 0,   0, 0,   0,  0, 0,  0,   0,  0, 0, 0,   0,   0,  0, 0, 0,   0,  0, 0, 0,

--- a/Modules/IO/NIFTI/test/LittleEndian_img.h
+++ b/Modules/IO/NIFTI/test/LittleEndian_img.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __LittleEndian_img_h
-#define __LittleEndian_img_h
+#ifndef LittleEndian_img_h
+#define LittleEndian_img_h
 
 const unsigned char LittleEndian_img[] = {
   0, 0, 16,  67, 0, 0, 16,  67, 0, 0, 16,  67, 0, 0, 128, 65, 0, 0, 128, 65, 0, 0, 128, 65, 0, 0, 16,  67,

--- a/Modules/Nonunit/IntegratedTest/test/itkShrinkImagePreserveObjectPhysicalLocations.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkShrinkImagePreserveObjectPhysicalLocations.cxx
@@ -211,8 +211,8 @@ itkShrinkImagePreserveObjectPhysicalLocations(int, char *[])
   smootherShrinkfilter->Update();
   TImageType::Pointer GaussianShrinkSmallImage = smootherShrinkfilter->GetOutput();
 
-//#define __WRITE_DEBUG_IMAGING__
-#ifdef __WRITE_DEBUG_IMAGING__
+//#define WriteDebugImaging
+#ifdef WriteDebugImaging
   using WriterType = itk::ImageFileWriter<WImageType>;
   auto                                                  writer = WriterType::New();
   itk::CastImageFilter<TImageType, WImageType>::Pointer castFilter =

--- a/Modules/Video/BridgeVXL/include/vidl_itk_istream.hxx
+++ b/Modules/Video/BridgeVXL/include/vidl_itk_istream.hxx
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __vidl_itk_istream_hxx
-#define __vidl_itk_istream_hxx
+#ifndef vidl_itk_istream_hxx
+#define vidl_itk_istream_hxx
 
 #include "itkNumericTraits.h"
 #include "vidl_itk_istream.h"

--- a/Wrapping/Generators/Explicit/Explicit.cxx.in
+++ b/Wrapping/Generators/Explicit/Explicit.cxx.in
@@ -1,4 +1,4 @@
-#define __@WRAPPER_LIBRARY_NAME@Explicit_@module@
+#define @WRAPPER_LIBRARY_NAME@Explicit_@module@
 #include "@WRAPPER_LIBRARY_NAME@Explicit.h"
 
 @EXPLICIT_INSTANTIATES@

--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -1541,8 +1541,8 @@ if _version_info < (3, 7, 0):
     def create_typedefheader(self, usedSources):
         # create the typedef header
         typedefFile = StringIO()
-        typedefFile.write(f"#ifndef __{self.submoduleName}SwigInterface_h\n")
-        typedefFile.write(f"#define __{self.submoduleName}SwigInterface_h\n")
+        typedefFile.write(f"#ifndef {self.submoduleName}SwigInterface_h\n")
+        typedefFile.write(f"#define {self.submoduleName}SwigInterface_h\n")
         typedefInput = os.path.join(
             options.library_output_dir, self.submoduleName + "SwigInterface.h.in"
         )


### PR DESCRIPTION
From Programming in C++, Rules and Recommendations : The use of two
underscores (`__') in identifiers is reserved for the compiler's
internal use according to the ANSI-C standard.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

