### PR TITLE
ENH: Adding Test for Array PixelType in Mesh Wrapping

### DIFF
--- a/Modules/Core/Mesh/wrapping/test/CMakeLists.txt
+++ b/Modules/Core/Mesh/wrapping/test/CMakeLists.txt
@@ -25,4 +25,6 @@ if(ITK_WRAP_PYTHON)
    EXPRESSION "instance = itk.RegularSphereMeshSource.New()")
   itk_python_expression_add_test(NAME itkSphereMeshSourcePythonTest
    EXPRESSION "instance = itk.SphereMeshSource.New()")
+
+  itk_python_add_test(NAME itkMeshArrayPixelTypePythonTest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkMeshArrayPixelTypeTest.py)
 endif()

--- a/Modules/Core/Mesh/wrapping/test/itkMeshArrayPixelTypeTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshArrayPixelTypeTest.py
@@ -1,0 +1,62 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+import itk
+import numpy as np
+
+Dimension = 3
+PixelType = itk.Array.D
+NumberOfPoints = 10
+PixelDataSize = 5
+
+MeshType = itk.Mesh[PixelType, Dimension]
+mesh = MeshType.New()
+
+# Create Vector Container and Store values in it for each Point
+v = itk.VectorContainer[itk.UL, PixelType].New()
+v.Reserve(NumberOfPoints)
+
+for i in range(NumberOfPoints):
+    pixel_data_reference = v.CreateElementAt(i)
+    pixel_data_reference.SetSize(PixelDataSize)
+    pixel_data_reference.Fill(0)
+    pixel_data_reference[0] = i
+    pixel_data_reference[4] = i+4
+
+# Set the point data container
+mesh.SetPointData(v)
+
+assert mesh.GetPointData().Size() == NumberOfPoints
+assert mesh.GetPointData().ElementAt(0)[0] == 0
+assert mesh.GetPointData().ElementAt(0)[4] == 4
+assert mesh.GetPointData().ElementAt(2)[0] == 2+0
+assert mesh.GetPointData().ElementAt(2)[4] == 2+4
+
+# resize the PixelDataSize to see if it can be altered succesfully
+PixelDataSize = 10
+for i in range(NumberOfPoints):
+    pixel_data_reference = v.CreateElementAt(i)
+    pixel_data_reference.SetSize(PixelDataSize)
+    pixel_data_reference.Fill(0)
+    pixel_data_reference[0] = i
+    pixel_data_reference[9] = i+10
+
+assert mesh.GetPointData().Size() == NumberOfPoints
+assert mesh.GetPointData().ElementAt(0)[0] == 0
+assert mesh.GetPointData().ElementAt(0)[9] == 10
+assert mesh.GetPointData().ElementAt(2)[0] == 2+0
+assert mesh.GetPointData().ElementAt(2)[9] == 2+10


### PR DESCRIPTION
Added test in Python to demonstrate the usage of Array PixelType in Mesh.
Usage of Array allows to change the size of pixeldata as per requirements later.
Using Array, however breaks the API support for SetElement and SetPointData in PointSet.
The only way to alter the data is through reference and for that CreateElementAt method is
used in the VectorContainer.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [X] Added test (or behavior not changed)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
