### PR TITLE
Fix vxl debug test failure

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 3.4.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 3.5.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_levenberg_marquardt.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_levenberg_marquardt.cxx
@@ -75,7 +75,7 @@ vnl_levenberg_marquardt::lmdif_lsqfun(long * n,     // I   Number of residuals
   assert(*p == (int)f->get_number_of_unknowns());
   assert(*n == (int)f->get_number_of_residuals());
   assert(*p > 0);
-  assert(*n > *p);
+  assert(*n >= *p);
   vnl_vector_ref<double> ref_x(*p, const_cast<double *>(x));
   vnl_vector_ref<double> ref_fx(*n, fx);
 
@@ -248,7 +248,7 @@ vnl_levenberg_marquardt::lmder_lsqfun(long * n,    // I   Number of residuals
   assert(*p == (int)f->get_number_of_unknowns());
   assert(*n == (int)f->get_number_of_residuals());
   assert(*p > 0);
-  assert(*n > *p);
+  assert(*n >= *p);
   vnl_vector_ref<double> ref_x(*p, (double *)x); // const violation!
   vnl_vector_ref<double> ref_fx(*n, fx);
   vnl_matrix_ref<double> ref_fJ(*n, *p, fJ);


### PR DESCRIPTION
New assertions for recently added caused test_levenberg_marquardt
test to fail when run in debug mode.  Fixed assertions to allow test to pass.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

