### PR TITLE
COMP: Duplicate symbol name with #define

### DIFF
--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
@@ -84,8 +84,8 @@ using TetrahedronType = itk::TetrahedronCell<CellType>;
 //  Software Guide : EndLatex
 
 
-#ifndef CustomTriangleVisitor
-#  define CustomTriangleVisitor
+#ifndef CustomTriangleVisitorDefine
+#  define CustomTriangleVisitorDefine
 // Software Guide : BeginCodeSnippet
 class CustomTriangleVisitor
 {
@@ -101,7 +101,7 @@ public:
   virtual ~CustomTriangleVisitor() = default;
 };
 // Software Guide : EndCodeSnippet
-#endif
+#endif // CustomTriangleVisitorDefine
 
 int
 main(int, char *[])

--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
@@ -166,8 +166,8 @@ private:
 //  Software Guide : EndLatex
 
 
-#ifndef CustomTriangleVisitor
-#  define CustomTriangleVisitor
+#ifndef CustomTriangleVisitorDefine
+#  define CustomTriangleVisitorDefine
 // Software Guide : BeginCodeSnippet
 class CustomTriangleVisitor
 {


### PR DESCRIPTION
The class name and the #define symbol must have
different values to avoid preprocessing
the name to an invalid value.
