### PR TITLE
BUG: MeshCellVisitor Examples failing: #define used class name

### DIFF
--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
@@ -84,8 +84,8 @@ using TetrahedronType = itk::TetrahedronCell<CellType>;
 //  Software Guide : EndLatex
 
 
-#ifndef CustomTriangleVisitor
-#  define CustomTriangleVisitor
+#ifndef CustomTriangleVisitor_Class
+#  define CustomTriangleVisitor_Class
 // Software Guide : BeginCodeSnippet
 class CustomTriangleVisitor
 {

--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
@@ -166,8 +166,8 @@ private:
 //  Software Guide : EndLatex
 
 
-#ifndef CustomTriangleVisitor
-#  define CustomTriangleVisitor
+#ifndef CustomTriangleVisitor_Class
+#  define CustomTriangleVisitor_Class
 // Software Guide : BeginCodeSnippet
 class CustomTriangleVisitor
 {
@@ -183,7 +183,7 @@ public:
       std::cout << "  point id = " << *pit << std::endl;
       ++pit;
     }
-  }
+  };
   virtual ~CustomTriangleVisitor() = default;
 };
 // Software Guide : EndCodeSnippet


### PR DESCRIPTION
The compiler #ifndef/#define directive used to avoid redundant
definition of a class used a variable that was the
same as the class name in MeshCellVisitor and MeshCellVisitor2
examples.  As a result, the actual class name in the code was getting
overwritten by the compiler directive.

The errors reported by VS2019 were
C:\src\ITK\Examples\DataRepresentation\Mesh\MeshCellVisitor.cxx(100): error C2059: syntax error: ')'
and
C:\src\ITK\Examples\DataRepresentation\Mesh\MeshCellVisitor2.cxx(187): error C2059: syntax error: '('