### PR TITLE
COMP: Use itk.ULL in Windows Platform

### DIFF
--- a/Modules/Core/Mesh/wrapping/test/itkMeshArrayPixelTypeTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshArrayPixelTypeTest.py
@@ -27,7 +27,13 @@ MeshType = itk.Mesh[PixelType, Dimension]
 mesh = MeshType.New()
 
 # Create Vector Container and Store values in it for each Point
-v = itk.VectorContainer[itk.UL, PixelType].New()
+# For windows use itk.ULL
+if hasattr(itk.VectorContainer, 'ULAD'):
+    IdentifierType = itk.UL
+else:
+    IdentifierType = itk.ULL
+
+v = itk.VectorContainer[IdentifierType, PixelType].New()
 v.Reserve(NumberOfPoints)
 
 for i in range(NumberOfPoints):


### PR DESCRIPTION
Fix for Python test in Windows platform.
itk.ULL is used in windows while itk.UL is used in Ubuntu and MacOS. Refer: [WrapBasicTypes.cmake](https://github.com/InsightSoftwareConsortium/ITK/blob/047fa6934ac32711d1d7b84fa6eb81c72db01960/Wrapping/WrapBasicTypes.cmake#L190)

In another test, a message is printed if the required wrapping is un-available, Refer: [itkPyVectorContainerTest](https://github.com/InsightSoftwareConsortium/ITK/blob/895fc718e814527aa156f7ff63ca8d5e15761d26/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py#L44)

This is a follow-up to #2953 and #2957.

## PR Checklist
- [X] Added test (or behavior not changed)

