### PR TITLE
ENH: Adding Python wrapping for CellInterface VectorContainer

### DIFF
--- a/Modules/Core/Mesh/wrapping/itkMeshBase.wrap
+++ b/Modules/Core/Mesh/wrapping/itkMeshBase.wrap
@@ -58,6 +58,7 @@ itk_wrap_class("itk::VectorContainer" POINTER)
     foreach(pixel_type ${types})
       itk_wrap_template("${ITKM_IT}CI${mangle_CellInterface_VectorContainer}" "${ITKT_IT}, itk::CellInterface< ${type_CellInterface_VectorContainer} > *")
     endforeach()
+    itk_wrap_template("${ITKM_IT}CI${mangle_CellInterface_Array_VectorContainer}" "${ITKT_IT}, itk::CellInterface< ${type_CellInterface_Array_VectorContainer} > *")
   endforeach()
 itk_end_wrap_class()
 


### PR DESCRIPTION
Adding Python wrapping for VectorContainer of CellInterface for Array Pixel Type in Mesh.
Required as warnings are seen during compilation stage in Windows Platform and CI was failing due to it. 

Refer: PR [2953](https://github.com/InsightSoftwareConsortium/ITK/pull/2953)

Have to check why warning was not raised for linux.

@jhlegarreta @dzenanz 


## PR Checklist
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
