### PR TITLE
BUG: GDCM IO: reset internal variables

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -441,6 +441,11 @@ GDCMImageIO::Read(void * pointer)
 void
 GDCMImageIO::InternalReadImageInformation()
 {
+  // Reset, a user can re-use IO.
+  m_RescaleIntercept = 0.0;
+  m_RescaleSlope = 1.0;
+  m_SingleBit = false;
+
   // ensure file can be opened for reading, before doing any more work
   std::ifstream inputFileStream;
   // let any exceptions propagate


### PR DESCRIPTION
It is safer to reset internal variables on _InternalReadImageInformation_,
because a user can re-use the IO.

Example of such re-using from this [post](https://discourse.itk.org/t/encountering-undefined-behavior-when-writing-dicom-images/4587?u=mihail.isakov)

```
	ImageIOType::Pointer dcmIOsingleFiles = ImageIOType::New();

	// Read files one by one
	// Read all headers of all DICOM files in fileNames
	for (std::string filename : fileNames) {
		dcmIOsingleFiles->SetFileName(filename);
		dcmIOsingleFiles->ReadImageInformation();
```


