### PR TITLE
ENH: Make Parameters empty, do not warn in Transform default-constructor

### DIFF
--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -571,7 +571,9 @@ protected:
   typename LightObject::Pointer
   InternalClone() const override;
 
-  Transform();
+  /** Default-constructor. Creates a transform, having empty `Parameters` and `FixedParameters`. */
+  Transform() = default;
+
   Transform(NumberOfParametersType numberOfParameters);
 #if defined(__GNUC__)
   // A bug in some versions of the GCC and Clang compilers

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -26,16 +26,6 @@ namespace itk
 {
 
 template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::Transform()
-  : m_Parameters(1)
-  , m_FixedParameters()
-{
-  itkWarningMacro(
-    << "Using default transform constructor.  Should specify NOutputDims and NParameters as args to constructor.");
-}
-
-
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::Transform(
   NumberOfParametersType numberOfParameters)
   : m_Parameters(numberOfParameters)

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -190,6 +190,7 @@ set(ITKTransformGTests
   itkEuler3DTransformGTest.cxx
   itkMatrixOffsetTransformBaseGTest.cxx
   itkSimilarityTransformGTest.cxx
+  itkTransformGTest.cxx
   itkTranslationTransformGTest.cxx
 )
 CreateGoogleTestDriver(ITKTransform "${ITKTransform-Test_LIBRARIES}" "${ITKTransformGTests}")

--- a/Modules/Core/Transform/test/itkTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGTest.cxx
@@ -1,0 +1,87 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkTransform.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+class DerivedTransform : public itk::Transform<TParametersValueType, NInputDimensions, NOutputDimensions>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(DerivedTransform);
+
+  using Self = DerivedTransform;
+  using Superclass = itk::Transform<TParametersValueType, NInputDimensions, NOutputDimensions>;
+  using Pointer = itk::SmartPointer<Self>;
+
+  itkNewMacro(Self);
+
+private:
+  DerivedTransform() = default;
+
+  using typename Superclass::FixedParametersType;
+  using typename Superclass::InputPointType;
+  using typename Superclass::JacobianType;
+  using typename Superclass::OutputPointType;
+  using typename Superclass::ParametersType;
+
+  static constexpr const char * exceptionMessage =
+    "This member function is not meant to be called during unit testing!";
+
+  void
+  SetParameters(const ParametersType &) override
+  {
+    itkExceptionMacro(<< exceptionMessage);
+  }
+
+  void
+  SetFixedParameters(const FixedParametersType &) override
+  {
+    itkExceptionMacro(<< exceptionMessage);
+  }
+
+  OutputPointType
+  TransformPoint(const InputPointType &) const override
+  {
+    itkExceptionMacro(<< exceptionMessage);
+  }
+
+  void
+  ComputeJacobianWithRespectToParameters(const InputPointType &, JacobianType &) const override
+  {
+    itkExceptionMacro(<< exceptionMessage);
+  }
+};
+} // namespace
+
+
+// Tests that a transform derived from itk::Transform has empty Parameters and FixedParameters by default.
+TEST(Transform, HasEmptyParametersAndFixedParametersByDefault)
+{
+  const auto expectEmpty = [](const auto & transform) {
+    EXPECT_TRUE(transform.GetParameters().empty());
+    EXPECT_TRUE(transform.GetFixedParameters().empty());
+  };
+
+  expectEmpty(*(DerivedTransform<float, 2, 2>::New()));
+  expectEmpty(*(DerivedTransform<double, 3, 4>::New()));
+}


### PR DESCRIPTION
Defaulted (`= default`) the `Transform` default-constructor, ensuring
that it will make both its `Parameters` and its `FixedParameters` empty.

Allowed calling this default-constructor from a derived transform class
without getting a `itkWarningMacro`.