### PR TITLE
BUG: Runge-Kutta wrong TimeBounds implementation

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.h
@@ -144,6 +144,18 @@ public:
    */
   itkGetConstMacro(NumberOfIntegrationSteps, unsigned int);
 
+  /**
+   * Get/Set a flag to interpret LowerTimeBound and UpperTimeBound as rates
+   * in the velocity field time span. This is equivalent to consider that the velocity
+   * field is defined in the normalized time interval [0, 1], ignoring the input origin
+   * and spacing in the temporal dimension.
+   *
+   * The default is true for backwards compatibility.
+   */
+  itkSetMacro(TimeBoundsAsRates, bool);
+  itkGetConstMacro(TimeBoundsAsRates, bool);
+  itkBooleanMacro(TimeBoundsAsRates);
+
 protected:
   TimeVaryingVelocityFieldIntegrationImageFilter();
   ~TimeVaryingVelocityFieldIntegrationImageFilter() override = default;
@@ -174,6 +186,8 @@ protected:
   unsigned int m_NumberOfTimePoints;
 
   DisplacementFieldInterpolatorPointer m_DisplacementFieldInterpolator;
+
+  bool m_TimeBoundsAsRates{ true };
 
 private:
   VelocityFieldInterpolatorPointer m_VelocityFieldInterpolator;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -179,11 +179,6 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
     }
   }
 
-  if (this->m_UpperTimeBound == this->m_LowerTimeBound)
-  {
-    return displacement;
-  }
-
   // Perform the integration
   // Need to know how to map the time dimension of the input image to the
   // assumed domain of [0,1].

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -179,42 +179,40 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
     }
   }
 
-  // Perform the integration
-  // Need to know how to map the time dimension of the input image to the
-  // assumed domain of [0,1].
+  // Perform the integration.
+  // With TimeBoundsAsRates On, we need to map the time dimension of the input image to the
+  // normalized domain of [0,1].
 
-
-  typename TimeVaryingVelocityFieldType::PointType spaceTimeOrigin = inputField->GetOrigin();
-
-  using RegionType = typename TimeVaryingVelocityFieldType::RegionType;
-
-  RegionType region = inputField->GetLargestPossibleRegion();
-
-  typename RegionType::IndexType lastIndex = region.GetIndex();
-  typename RegionType::SizeType  size = region.GetSize();
-  for (unsigned d = 0; d < InputImageDimension; ++d)
+  RealType timeOrigin = 0.;
+  RealType timeScale = 1.;
+  if (m_TimeBoundsAsRates)
   {
-    lastIndex[d] += (size[d] - 1);
+    typename TimeVaryingVelocityFieldType::PointType spaceTimeOrigin = inputField->GetOrigin();
+
+    using RegionType = typename TimeVaryingVelocityFieldType::RegionType;
+    RegionType region = inputField->GetLargestPossibleRegion();
+
+    typename RegionType::IndexType lastIndex = region.GetIndex();
+    typename RegionType::SizeType  size = region.GetSize();
+    for (unsigned d = 0; d < InputImageDimension; ++d)
+    {
+      lastIndex[d] += (size[d] - 1);
+    }
+
+    typename TimeVaryingVelocityFieldType::PointType spaceTimeEnd;
+    inputField->TransformIndexToPhysicalPoint(lastIndex, spaceTimeEnd);
+
+    timeOrigin = spaceTimeOrigin[InputImageDimension - 1];
+    const RealType timeEnd = spaceTimeEnd[InputImageDimension - 1];
+    timeScale = timeEnd - timeOrigin;
   }
 
-  typename TimeVaryingVelocityFieldType::PointType spaceTimeEnd;
-  inputField->TransformIndexToPhysicalPoint(lastIndex, spaceTimeEnd);
-
-  const RealType timeOrigin = spaceTimeOrigin[InputImageDimension - 1];
-  const RealType timeEnd = spaceTimeEnd[InputImageDimension - 1];
-  const RealType timeSpan = timeEnd - timeOrigin;
-  RealType       timeSign = 1.0;
-  if (this->m_UpperTimeBound < this->m_LowerTimeBound)
-  {
-    timeSign = -1.0;
-  }
-
-  RealType timePointInImage = timeOrigin + this->m_LowerTimeBound * timeSpan;
+  RealType timePointInImage = timeOrigin + this->m_LowerTimeBound * timeScale;
 
   // Calculate the delta time used for integration
-  const RealType deltaTime = timeSign * itk::Math::abs(this->m_UpperTimeBound - this->m_LowerTimeBound) /
-                             static_cast<RealType>(this->m_NumberOfIntegrationSteps);
-  const RealType deltaTimeInImage = timeSpan * deltaTime;
+  const RealType deltaTime =
+    (this->m_UpperTimeBound - this->m_LowerTimeBound) / static_cast<RealType>(this->m_NumberOfIntegrationSteps);
+  const RealType deltaTimeInImage = timeScale * deltaTime;
 
   for (unsigned int n = 0; n < this->m_NumberOfIntegrationSteps; ++n)
   {

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkTimeVaryingVelocityFieldIntegrationImageFilter_hxx
 #define itkTimeVaryingVelocityFieldIntegrationImageFilter_hxx
 
-
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkVectorLinearInterpolateImageFunction.h"
 
@@ -136,13 +135,9 @@ void
 TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDisplacementField>::
   DynamicThreadedGenerateData(const OutputRegionType & region)
 {
-  if (Math::ExactlyEquals(this->m_LowerTimeBound, this->m_UpperTimeBound))
+  if (Math::ExactlyEquals(this->m_LowerTimeBound, this->m_UpperTimeBound) || this->m_NumberOfIntegrationSteps == 0)
   {
-    return;
-  }
-
-  if (this->m_NumberOfIntegrationSteps == 0)
-  {
+    this->GetOutput()->FillBuffer(itk::NumericTraits<typename DisplacementFieldType::PixelType>::Zero);
     return;
   }
 
@@ -175,13 +170,18 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 
   // Initial conditions
 
-  PointType startingSpatialPoint = initialSpatialPoint;
+  VectorType displacement = zeroVector;
   if (!this->m_InitialDiffeomorphism.IsNull())
   {
-    if (this->m_DisplacementFieldInterpolator->IsInsideBuffer(startingSpatialPoint))
+    if (this->m_DisplacementFieldInterpolator->IsInsideBuffer(initialSpatialPoint))
     {
-      startingSpatialPoint += this->m_DisplacementFieldInterpolator->Evaluate(startingSpatialPoint);
+      displacement = this->m_DisplacementFieldInterpolator->Evaluate(initialSpatialPoint);
     }
+  }
+
+  if (this->m_UpperTimeBound == this->m_LowerTimeBound)
+  {
+    return displacement;
   }
 
   // Perform the integration
@@ -203,18 +203,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
   }
 
   typename TimeVaryingVelocityFieldType::PointType spaceTimeEnd;
-  typename TimeVaryingVelocityFieldType::PointType pointIn2;
-  typename TimeVaryingVelocityFieldType::PointType pointIn3;
   inputField->TransformIndexToPhysicalPoint(lastIndex, spaceTimeEnd);
-
-  // Calculate the delta time used for integration
-  const RealType deltaTime = itk::Math::abs(this->m_UpperTimeBound - this->m_LowerTimeBound) /
-                             static_cast<RealType>(this->m_NumberOfIntegrationSteps);
-
-  if (deltaTime == 0.0)
-  {
-    return zeroVector;
-  }
 
   const RealType timeOrigin = spaceTimeOrigin[InputImageDimension - 1];
   const RealType timeEnd = spaceTimeEnd[InputImageDimension - 1];
@@ -225,18 +214,12 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
     timeSign = -1.0;
   }
 
-  VectorType displacement = zeroVector;
+  RealType timePointInImage = timeOrigin + this->m_LowerTimeBound * timeSpan;
 
-  RealType timePoint = timeOrigin + this->m_LowerTimeBound * timeSpan;
-
-  RealType intervalTimePoint = (timePoint + 1.0) / static_cast<RealType>(this->m_NumberOfTimePoints);
-
-  /** Windows not registering + operation so use a loop explicitly */
-  PointType spatialPoint = startingSpatialPoint;
-  for (unsigned int d = 0; d < OutputImageDimension; ++d)
-  {
-    spatialPoint[d] += displacement[d];
-  }
+  // Calculate the delta time used for integration
+  const RealType deltaTime = timeSign * itk::Math::abs(this->m_UpperTimeBound - this->m_LowerTimeBound) /
+                             static_cast<RealType>(this->m_NumberOfIntegrationSteps);
+  const RealType deltaTimeInImage = timeSpan * deltaTime;
 
   for (unsigned int n = 0; n < this->m_NumberOfIntegrationSteps; ++n)
   {
@@ -245,40 +228,18 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
     typename TimeVaryingVelocityFieldType::PointType x3;
     typename TimeVaryingVelocityFieldType::PointType x4;
 
-    RealType intervalTimePointMinusDeltaTime = intervalTimePoint - timeSign * deltaTime;
-    RealType intervalTimePointMinusHalfDeltaTime = intervalTimePoint - timeSign * deltaTime * 0.5;
-    if (intervalTimePointMinusHalfDeltaTime < 0.0)
-    {
-      intervalTimePointMinusHalfDeltaTime = 0.0;
-    }
-    if (intervalTimePointMinusHalfDeltaTime > 1.0)
-    {
-      intervalTimePointMinusHalfDeltaTime = 1.0;
-    }
-    if (intervalTimePointMinusDeltaTime < 0.0)
-    {
-      intervalTimePointMinusDeltaTime = 0.0;
-    }
-    if (intervalTimePointMinusDeltaTime > 1.0)
-    {
-      intervalTimePointMinusDeltaTime = 1.0;
-    }
-
     for (unsigned int d = 0; d < OutputImageDimension; ++d)
     {
-      x1[d] = spatialPoint[d] + displacement[d];
-      x2[d] = spatialPoint[d] + displacement[d];
-      x3[d] = spatialPoint[d] + displacement[d];
-      x4[d] = spatialPoint[d] + displacement[d];
-      pointIn2[d] = spatialPoint[d] + displacement[d];
+      x1[d] = initialSpatialPoint[d] + displacement[d];
+      x2[d] = x1[d];
+      x3[d] = x1[d];
+      x4[d] = x1[d];
     }
 
-    x1[OutputImageDimension] = intervalTimePointMinusDeltaTime * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
-    x2[OutputImageDimension] =
-      intervalTimePointMinusHalfDeltaTime * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
-    x3[OutputImageDimension] =
-      intervalTimePointMinusHalfDeltaTime * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
-    x4[OutputImageDimension] = intervalTimePoint * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
+    x1[OutputImageDimension] = timePointInImage;
+    x2[OutputImageDimension] = timePointInImage + 0.5 * deltaTimeInImage;
+    x3[OutputImageDimension] = timePointInImage + 0.5 * deltaTimeInImage;
+    x4[OutputImageDimension] = timePointInImage + deltaTimeInImage;
 
     VectorType f1 = zeroVector;
     if (this->m_VelocityFieldInterpolator->IsInsideBuffer(x1))
@@ -318,12 +279,11 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 
     for (unsigned int jj = 0; jj < OutputImageDimension; ++jj)
     {
-      pointIn3[jj] = pointIn2[jj] + timeSign * deltaTime / 6.0 * (f1[jj] + 2.0 * f2[jj] + 2.0 * f3[jj] + f4[jj]);
-      displacement[jj] = pointIn3[jj] - startingSpatialPoint[jj];
+      x1[jj] += deltaTime / 6.0 * (f1[jj] + 2.0 * f2[jj] + 2.0 * f3[jj] + f4[jj]);
+      displacement[jj] = x1[jj] - initialSpatialPoint[jj];
     }
-    pointIn3[OutputImageDimension] = intervalTimePoint * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
 
-    intervalTimePoint += deltaTime * timeSign;
+    timePointInImage += deltaTimeInImage;
   }
   return displacement;
 }

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -123,7 +123,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   size[0] = 3;
   size[1] = 3;
   size[2] = 401;
-  size[3] = 41;
+  size[3] = 61;
   ImportFilterType::IndexType start;
   start.Fill(0);
 
@@ -136,7 +136,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   origin.Fill(0.);
   importFilter->SetOrigin(origin);
 
-  double spaceTimeSpan[4] = { 20., 20., 20., 1. };
+  double spaceTimeSpan[4] = { 20., 20., 20., 1.5 };
   for (unsigned int i = 0; i < 4; i++)
   {
     spacing[i] = spaceTimeSpan[i] / (size[i] - 1);
@@ -151,8 +151,8 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   {
     for (unsigned int z = 0; z < size[2]; ++z)
     {
-      const double zz = static_cast<double>(z) * spacing[2];
-      const double kappa = zz / (1 + t * spacing[3]);
+      const double zz = spacing[2] * z;
+      const double kappa = zz / (1 + spacing[3] * t);
       for (unsigned int y = 0; y < size[1]; ++y)
       {
         for (unsigned int x = 0; x < size[0]; ++x, ++it)
@@ -173,6 +173,11 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   integrator->SetInput(timeVaryingVelocityField);
   integrator->SetLowerTimeBound(0.2);
   integrator->SetUpperTimeBound(0.8);
+  /* This time bounds are meant to be absolute
+   * for the velocity field original time span [0, 1.5].
+   * Thus, we need to switch off the default rescaling
+   * to the normalized time span [0, 1] */
+  integrator->TimeBoundsAsRatesOff();
   integrator->SetNumberOfIntegrationSteps(50);
   integrator->Update();
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -40,7 +40,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   VectorType constantVelocity;
   constantVelocity.Fill(0.1);
 
-  TimeVaryingVelocityFieldType::Pointer constantVelocityField = TimeVaryingVelocityFieldType::New();
+  auto constantVelocityField = TimeVaryingVelocityFieldType::New();
 
   constantVelocityField->SetOrigin(origin);
   constantVelocityField->SetSpacing(spacing);
@@ -51,7 +51,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
 
   using IntegratorType =
     itk::TimeVaryingVelocityFieldIntegrationImageFilter<TimeVaryingVelocityFieldType, DisplacementFieldType>;
-  IntegratorType::Pointer integrator = IntegratorType::New();
+  auto integrator = IntegratorType::New();
   integrator->SetInput(constantVelocityField);
   integrator->SetLowerTimeBound(0.3);
   integrator->SetUpperTimeBound(0.75);
@@ -64,7 +64,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   index.Fill(0);
   VectorType displacement;
 
-  IntegratorType::Pointer inverseIntegrator = IntegratorType::New();
+  auto inverseIntegrator = IntegratorType::New();
   inverseIntegrator->SetInput(constantVelocityField);
   inverseIntegrator->SetLowerTimeBound(1.0);
   inverseIntegrator->SetUpperTimeBound(0.0);
@@ -115,7 +115,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
    */
   using ImportFilterType = itk::ImportImageFilter<VectorType, 4>;
 
-  ImportFilterType::Pointer importFilter = ImportFilterType::New();
+  auto importFilter = ImportFilterType::New();
 
   /* Size is made denser on the z and t coordinates, for which
    * the velocity field is rapidly changing.
@@ -178,6 +178,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
    * Thus, we need to switch off the default rescaling
    * to the normalized time span [0, 1] */
   integrator->TimeBoundsAsRatesOff();
+
   integrator->SetNumberOfIntegrationSteps(50);
   integrator->Update();
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -17,10 +17,13 @@
  *=========================================================================*/
 
 #include "itkTimeVaryingVelocityFieldIntegrationImageFilter.h"
+#include "itkImportImageFilter.h"
 
 int
 itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
 {
+  /* First test with homogeneous and constant velocity field
+   */
   using VectorType = itk::Vector<double, 3>;
   using DisplacementFieldType = itk::Image<VectorType, 3>;
   using TimeVaryingVelocityFieldType = itk::Image<VectorType, 4>;
@@ -34,25 +37,25 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   TimeVaryingVelocityFieldType::SizeType size;
   size.Fill(25);
 
-  VectorType displacement1;
-  displacement1.Fill(0.1);
+  VectorType constantVelocity;
+  constantVelocity.Fill(0.1);
 
-  auto timeVaryingVelocityField = TimeVaryingVelocityFieldType::New();
+  TimeVaryingVelocityFieldType::Pointer constantVelocityField = TimeVaryingVelocityFieldType::New();
 
-  timeVaryingVelocityField->SetOrigin(origin);
-  timeVaryingVelocityField->SetSpacing(spacing);
-  timeVaryingVelocityField->SetRegions(size);
-  timeVaryingVelocityField->Allocate();
-  timeVaryingVelocityField->FillBuffer(displacement1);
+  constantVelocityField->SetOrigin(origin);
+  constantVelocityField->SetSpacing(spacing);
+  constantVelocityField->SetRegions(size);
+  constantVelocityField->Allocate();
+  constantVelocityField->FillBuffer(constantVelocity);
 
 
   using IntegratorType =
     itk::TimeVaryingVelocityFieldIntegrationImageFilter<TimeVaryingVelocityFieldType, DisplacementFieldType>;
-  auto integrator = IntegratorType::New();
-  integrator->SetInput(timeVaryingVelocityField);
+  IntegratorType::Pointer integrator = IntegratorType::New();
+  integrator->SetInput(constantVelocityField);
   integrator->SetLowerTimeBound(0.3);
   integrator->SetUpperTimeBound(0.75);
-  integrator->SetNumberOfIntegrationSteps(10);
+  integrator->SetNumberOfIntegrationSteps(100);
   integrator->Update();
 
   integrator->Print(std::cout, 3);
@@ -61,11 +64,11 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   index.Fill(0);
   VectorType displacement;
 
-  auto inverseIntegrator = IntegratorType::New();
-  inverseIntegrator->SetInput(timeVaryingVelocityField);
+  IntegratorType::Pointer inverseIntegrator = IntegratorType::New();
+  inverseIntegrator->SetInput(constantVelocityField);
   inverseIntegrator->SetLowerTimeBound(1.0);
   inverseIntegrator->SetUpperTimeBound(0.0);
-  inverseIntegrator->SetNumberOfIntegrationSteps(10);
+  inverseIntegrator->SetNumberOfIntegrationSteps(100);
   inverseIntegrator->Update();
 
   // This integration should result in a constant image of value
@@ -98,6 +101,114 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
     std::cerr << "Failed to produce the correct forward integration." << std::endl;
     return EXIT_FAILURE;
   }
+
+
+  /* Second test with inhomogeneous and time-varying velocity field
+   */
+
+  /* Generation of the velocity field defined by
+   *    v(x, y, z, t) = z/(1+t) * ( -sin(z), cos(z), 1 )
+   * which can be analytically integrated giving the motion
+   * corresponding to the displacement field:
+   *    Displacement(x0, y0, z0, t) =
+   *      ( cos(z0*(1+t)) - 1, sin(z0*(1+t)), z0*(1+t) )
+   */
+  using ImportFilterType = itk::ImportImageFilter<VectorType, 4>;
+
+  ImportFilterType::Pointer importFilter = ImportFilterType::New();
+
+  /* Size is made denser on the z and t coordinates, for which
+   * the velocity field is rapidly changing.
+   * The velocity field is homogeneous in the x-y plane.*/
+  size[0] = 3;
+  size[1] = 3;
+  size[2] = 401;
+  size[3] = 41;
+  ImportFilterType::IndexType start;
+  start.Fill(0);
+
+  ImportFilterType::RegionType region;
+  region.SetIndex(start);
+  region.SetSize(size);
+
+  importFilter->SetRegion(region);
+
+  origin.Fill(0.);
+  importFilter->SetOrigin(origin);
+
+  double spaceTimeSpan[4] = { 20., 20., 20., 1. };
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    spacing[i] = spaceTimeSpan[i] / (size[i] - 1);
+  }
+  importFilter->SetSpacing(spacing);
+
+  const unsigned int numberOfPixels = size[0] * size[1] * size[2] * size[3];
+  auto *             localBuffer = new VectorType[numberOfPixels];
+
+  VectorType * it = localBuffer;
+  for (unsigned int t = 0; t < size[3]; ++t)
+  {
+    for (unsigned int z = 0; z < size[2]; ++z)
+    {
+      const double zz = static_cast<double>(z) * spacing[2];
+      const double kappa = zz / (1 + t * spacing[3]);
+      for (unsigned int y = 0; y < size[1]; ++y)
+      {
+        for (unsigned int x = 0; x < size[0]; ++x, ++it)
+        {
+          (*it)[0] = -kappa * std::sin(zz);
+          (*it)[1] = kappa * std::cos(zz);
+          (*it)[2] = kappa;
+        }
+      }
+    }
+  }
+
+  const bool importImageFilterWillOwnTheBuffer = true;
+  importFilter->SetImportPointer(localBuffer, numberOfPixels, importImageFilterWillOwnTheBuffer);
+
+  TimeVaryingVelocityFieldType::Pointer timeVaryingVelocityField = importFilter->GetOutput();
+
+  integrator->SetInput(timeVaryingVelocityField);
+  integrator->SetLowerTimeBound(0.2);
+  integrator->SetUpperTimeBound(0.8);
+  integrator->SetNumberOfIntegrationSteps(50);
+  integrator->Update();
+
+  integrator->Print(std::cout, 3);
+
+  index[0] = (size[0] - 1) / 2;  // Corresponding to x = 10.
+  index[1] = (size[1] - 1) / 2;  // Corresponding to y = 10.
+  index[2] = (size[2] - 1) / 10; // Corresponding to z = 2.
+
+  displacementField = integrator->GetOutput();
+  displacement = displacementField->GetPixel(index);
+  // The analytic result is displacement = ( cos(3) - cos(2), sin(3) - sin(2), 3 - 2 )
+  std::cout << "Estimated forward displacement vector: " << displacement << std::endl;
+  if (itk::Math::abs(displacement[0] + 0.5738) > 0.0002 || itk::Math::abs(displacement[1] + 0.7682) > 0.0001 ||
+      itk::Math::abs(displacement[2] - 1.0000) > 0.0001)
+  {
+    std::cerr << "Failed to produce the correct forward integration." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  /* The same integrator is used backwards in time. */
+  integrator->SetLowerTimeBound(1.0);
+  integrator->SetUpperTimeBound(0.0);
+  integrator->Update();
+
+  inverseField = integrator->GetOutput();
+  displacement = inverseField->GetPixel(index);
+  // The analytic result is displacement = ( cos(1) - cos(2), sin(1) - sin(2), 1 - 2 )
+  std::cout << "Estimated inverse displacement vector: " << displacement << std::endl;
+  if (itk::Math::abs(displacement[0] - 0.9564) > 0.0001 || itk::Math::abs(displacement[1] + 0.0678) > 0.0003 ||
+      itk::Math::abs(displacement[2] + 1.0000) > 0.0001)
+  {
+    std::cerr << "Failed to produce the correct inverse integration." << std::endl;
+    return EXIT_FAILURE;
+  }
+
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The aimed normalization of the time apparently messed up the Runge-Kutta 
implementation resulting in a wrong algorithm. The implementation has been corrected to remove this bug. 

The existing test (itkTimeVaryingVelocityFieldIntegrationImageFilterTest) only tested for the integration of a homogeneous and constant velocity field, where the error could not be detected.
I have extended the test adding the case of a non-trivial (inhomogeneous and time-variaying) velocity field. This test is not passed by the previous implementation.

Added boolean flag to control the interpretation of LowerTimeBound and UpperTimeBound as rates 
in the velocity field time span. If true, it is equivalent to consider that the velocity field is defined in the normalized time interval [0, 1], ignoring the input origin and spacing in the temporal dimension.

This normalization was the previous behaviour. Thus, the default is true for backwards compatibility.
