### PR TITLE
STYLE: Use the `itkNameOfTestExecutableMacro` macro in tests

### DIFF
--- a/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
+++ b/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #include <ctime>
 #include <cstring>
+#include "itkTestingMacros.h"
 
 void
 itkCMakeInformationPrintFile(const char * name, std::ostream & os)
@@ -74,7 +75,7 @@ main(int argc, char * argv[])
 {
   if (argc != 2)
   {
-    std::cerr << "Usage: itkCMakeInformationTest <top-of-build-tree>\n";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <top-of-build-tree>\n";
     return EXIT_FAILURE;
   }
   std::string build_dir = argv[1];

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkCentralDifferenceImageFunction.h"
 #include "itkImageRegionIteratorWithIndex.h"
+#include "itkTestingMacros.h"
 
 template <unsigned int vecLength>
 int
@@ -125,7 +126,8 @@ itkCentralDifferenceImageFunctionOnVectorSpeedTest(int argc, char * argv[])
 {
   if (argc != 7)
   {
-    std::cerr << "usage: size reps doEAI doEACI doE vecLength" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " size reps doEAI doEACI doE vecLength"
+              << std::endl;
     return EXIT_FAILURE;
   }
   int vecLength = std::stoi(argv[6]);

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
@@ -18,13 +18,14 @@
 
 #include "itkCentralDifferenceImageFunction.h"
 #include "itkImageRegionIteratorWithIndex.h"
+#include "itkTestingMacros.h"
 
 int
 itkCentralDifferenceImageFunctionSpeedTest(int argc, char * argv[])
 {
   if (argc != 6)
   {
-    std::cerr << "usage: size reps doEAI doEACI doE" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " size reps doEAI doEACI doE" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
@@ -26,6 +26,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkRGBPixel.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -34,7 +35,7 @@ itkMaskFeaturePointSelectionFilterTest(int argc, char * argv[])
   if (argc < 2)
   {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << " itkMaskFeaturePointSelectionFilterTest inputImageFile outputImageFile [Mask File] ";
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImageFile outputImageFile [Mask File] ";
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTest.cxx
@@ -98,7 +98,7 @@ itkUnsharpMaskImageFilterTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Usage:\n itkUnsharpMaskImageFilterTest";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " float | uchar in.png out.nrrd [amount [sigma [threshold]]]" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkGradientRecursiveGaussianImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -24,7 +25,7 @@ itkGradientRecursiveGaussianFilterSpeedTest(int argc, char * argv[])
 {
   if (argc != 3)
   {
-    std::cerr << "usage: size reps" << std::endl;
+    std::cerr << "usage: " << itkNameOfTestExecutableMacro(argv) << " size reps" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/ImageGrid/test/itkMirrorPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkMirrorPadImageFilterTest.cxx
@@ -78,7 +78,7 @@ itkMirrorPadImageFilterTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Usage:\n itkMirrorPadImageFilterTest";
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " float | uchar in.png out.nrrd [decayFactor [lowerPad [upperPad]]]" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest.cxx
@@ -21,15 +21,15 @@
 
 #include "itkQuadEdgeMeshExtendedTraits.h"
 #include "itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cout << "*** GaussianCurvature ***" << std::endl;
-    std::cout << "This example requires at least one argument:" << std::endl;
-    std::cout << " 1- FileName" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMaximumCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMaximumCurvatureQuadEdgeMeshFilterTest.cxx
@@ -20,15 +20,15 @@
 
 #include "itkQuadEdgeMeshExtendedTraits.h"
 #include "itkDiscreteMaximumCurvatureQuadEdgeMeshFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkDiscreteMaximumCurvatureQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cout << "*** GaussianCurvature ***" << std::endl;
-    std::cout << "This example requires at least one argument:" << std::endl;
-    std::cout << " 1- FileName" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMeanCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMeanCurvatureQuadEdgeMeshFilterTest.cxx
@@ -20,15 +20,15 @@
 
 #include "itkQuadEdgeMeshExtendedTraits.h"
 #include "itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkDiscreteMeanCurvatureQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cout << "*** GaussianCurvature ***" << std::endl;
-    std::cout << "This example requires at least one argument:" << std::endl;
-    std::cout << " 1- FileName" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMinimumCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMinimumCurvatureQuadEdgeMeshFilterTest.cxx
@@ -20,15 +20,15 @@
 
 #include "itkQuadEdgeMeshExtendedTraits.h"
 #include "itkDiscreteMinimumCurvatureQuadEdgeMeshFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkDiscreteMinimumCurvatureQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cout << "*** GaussianCurvature ***" << std::endl;
-    std::cout << "This example requires at least one argument:" << std::endl;
-    std::cout << " 1- FileName" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/DCMTK/test/itkDCMTKMultiFrame4DTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKMultiFrame4DTest.cxx
@@ -29,8 +29,7 @@ itkDCMTKMultiFrame4DTest(int argc, char * argv[])
   if (argc != 3)
   {
     std::cerr << "Missing Parameters" << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " itkDCMTKMultiFram4DTest"
-              << " inputDicomFile" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputDicomFile" << std::endl;
     return EXIT_FAILURE;
   }
   using ImageType = itk::Image<unsigned short, 4>;

--- a/Modules/IO/ImageBase/test/itkImageFileReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderDimensionsTest.cxx
@@ -29,8 +29,8 @@ itkImageFileReaderDimensionsTest(int argc, char * argv[])
 
   if (argc < 4)
   {
-    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
-              << " itkIOTests itkImageFileReaderTest inputFileName outputDirectory outputExtension" << std::endl;
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName outputDirectory outputExtension"
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
@@ -26,8 +26,7 @@ itkMeshFileWriteReadTensorTest(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Usage: "
-              << "<OutputMesh2D.vtk> "
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << "<OutputMesh2D.vtk> "
               << "<OutputMesh3D.vtk> " << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
@@ -21,6 +21,7 @@
 #include "itkRandomImageSource.h"
 #include "itkMetaDataObject.h"
 #include "itkMetaImageIO.h"
+#include "itkTestingMacros.h"
 
 
 // Specific ImageIO test
@@ -150,7 +151,7 @@ itkMetaImageIOMetaDataTest(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "Usage: metadatatest outputimage" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " metadatatest outputimage" << std::endl;
     return 1;
   }
   // write out an image -- using a random image source, but

--- a/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
@@ -33,6 +33,7 @@
 #include "itkScalarToRGBColormapImageFilter.h"
 #include "itkTranslationTransform.h"
 #include "itkResampleImageFilter.h"
+#include "itkTestingMacros.h"
 
 
 int
@@ -41,7 +42,7 @@ itkBlockMatchingImageFilterTest(int argc, char * argv[])
   if (argc < 2)
   {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << " itkitkBlockMatchingImageFilterTest inputImageFile outputImageFile [Mask File]" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputImageFile outputImageFile [Mask File]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Video/IO/test/itkFileListVideoIOFactoryTest.cxx
+++ b/Modules/Video/IO/test/itkFileListVideoIOFactoryTest.cxx
@@ -20,6 +20,7 @@
 
 #include "itkVideoIOFactory.h"
 #include "itkFileListVideoIOFactory.h"
+#include "itkTestingMacros.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 // This tests all of the functionality of the FileListVideoIO
@@ -75,7 +76,8 @@ itkFileListVideoIOFactoryTest(int argc, char * argv[])
 {
   if (argc != 8)
   {
-    std::cerr << "Usage: [Video Input] [Video Output] [Webcam Number]" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " [Video Input] [Video Output] [Webcam Number]"
+              << std::endl;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Use the `itkNameOfTestExecutableMacro` macro to get the test name
instead of hard-coding the test name.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)