### PR TITLE
STYLE: Use `Transform` default-constructor instead of `Transform(0)`

### DIFF
--- a/Modules/Core/Transform/include/itkIdentityTransform.h
+++ b/Modules/Core/Transform/include/itkIdentityTransform.h
@@ -240,10 +240,7 @@ public:
   {}
 
 protected:
-  IdentityTransform()
-    : Transform<TParametersValueType, NDimensions, NDimensions>(0)
-  {}
-
+  IdentityTransform() = default;
   ~IdentityTransform() override = default;
 };
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -108,9 +108,7 @@ public:
   }
 
 protected:
-  ProjectTransform()
-    : Transform<double, 3, 2>(0)
-  {}
+  ProjectTransform() = default;
   ~ProjectTransform() override = default;
 
 }; // class ProjectTransform

--- a/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
@@ -286,7 +286,6 @@ public:
 
 protected:
   MINCTransformAdapter()
-    : Transform<TParametersValueType, NInputDimensions, NOutputDimensions>(0)
   {
     if (NInputDimensions != 3 || NOutputDimensions != 3)
       itkExceptionMacro(<< "Sorry, only 3D to 3d minc xfm transform is currently implemented");


### PR DESCRIPTION
Adjusted the default-constructor of `IdentityTransform`,
`MINCTransformAdapter`, and `ProjectTransform` to use the
default-constructor of `Transform`, instead of its
`Transform(NumberOfParametersType)` constructor, as in each of these
cases, both `Parameters` and `FixedParameters` should just be empty.

Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2983
commit 20249ece000a22347dd363df4cdeb6fccdedaae4
"ENH: Make Parameters empty, do not warn in Transform default-constructor"