### PR TITLE
ENH: Use `itkPrintSelfObjectMacro` to print objects that can be null

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -293,12 +293,8 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
   os << indent << "LowerTimeBound: " << this->m_LowerTimeBound << std::endl;
   os << indent << "UpperTimeBound: " << this->m_UpperTimeBound << std::endl;
   os << indent << "NumberOfIntegrationSteps: " << this->m_NumberOfIntegrationSteps << std::endl;
-
-  if (!this->m_InitialDiffeomorphism.IsNull())
-  {
-    os << indent << "InitialDiffeomorphism: " << this->m_InitialDiffeomorphism << std::endl;
-    os << indent << "DisplacementFieldInterpolator: " << this->m_DisplacementFieldInterpolator << std::endl;
-  }
+  itkPrintSelfObjectMacro(InitialDiffeomorphism);
+  itkPrintSelfObjectMacro(DisplacementFieldInterpolator);
 }
 
 } // end namespace itk

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -325,11 +325,7 @@ VideoFileReader<TOutputVideoStream>::PrintSelf(std::ostream & os, Indent indent)
   Superclass::PrintSelf(os, indent);
 
   os << indent << "FileName: " << this->m_FileName << std::endl;
-  if (m_VideoIO)
-  {
-    os << indent << "VideoIO:" << std::endl;
-    this->m_VideoIO->Print(os, indent.GetNextIndent());
-  }
+  itkPrintSelfObjectMacro(VideoIO);
 }
 
 } // end namespace itk


### PR DESCRIPTION
Use `itkPrintSelfObjectMacro` to print objects that can be null.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
