### PR TITLE
ENH: Add RTTI to `itk::InvertDisplacementFieldImageFilter`

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
@@ -51,6 +51,9 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(InvertDisplacementFieldImageFilter, ImageToImageFilter);
+
   /** Extract dimension from input image. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 

--- a/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkInvertDisplacementFieldImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
+#include "itkTestingMacros.h"
 
 int
 itkInvertDisplacementFieldImageFilterTest(int, char *[])
@@ -85,6 +86,10 @@ itkInvertDisplacementFieldImageFilterTest(int, char *[])
 
   using InverterType = itk::InvertDisplacementFieldImageFilter<DisplacementFieldType>;
   auto inverter = InverterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(inverter, InvertDisplacementFieldImageFilter, ImageToImageFilter);
+
+
   inverter->SetInput(field);
   inverter->SetMaximumNumberOfIterations(numberOfIterations);
   inverter->SetMeanErrorToleranceThreshold(meanTolerance);


### PR DESCRIPTION
Add run-time type information to `itk::InvertDisplacementFieldImageFilter`.

Exercise the basic object methods using the
`ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)