### PR TITLE
BUG: Fix class names in `itkTypeMacro`

### DIFF
--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
@@ -127,7 +127,7 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   itkNewMacro(Self);
-  itkTypeMacro(WatershedBoundary, DataObject);
+  itkTypeMacro(Boundary, DataObject);
 
   /** The following averts an internal compiler error on microsoft compilers */
   using FacePointer = typename face_t::Pointer;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
@@ -71,7 +71,7 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   itkNewMacro(Self);
-  itkTypeMacro(WatershedBoundaryResolver, ProcessObject);
+  itkTypeMacro(BoundaryResolver, ProcessObject);
 
   /** Expose the image dimension at run time. */
   static constexpr unsigned int ImageDimension = TDimension;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.h
@@ -70,7 +70,7 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   itkNewMacro(Self);
-  itkTypeMacro(WatershedEquivalenceRelabeler, ProcessObject);
+  itkTypeMacro(EquivalenceRelabeler, ProcessObject);
 
   /** Set/Get the image to relabel.   */
   void

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.h
@@ -73,7 +73,7 @@ public:
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
-  itkTypeMacro(WatershedRelabeler, ProcessObject);
+  itkTypeMacro(Relabeler, ProcessObject);
 
   /** Expose the ImageDimension template parameter at run time */
   static constexpr unsigned int ImageDimension = TImageDimension;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
@@ -56,7 +56,7 @@ public:
   using ScalarType = TScalar;
 
   itkNewMacro(Self);
-  itkTypeMacro(WatershedSegmentTable, DataObject);
+  itkTypeMacro(SegmentTable, DataObject);
 
   /** The value type for lists of adjacencies contained in each table
       entry */

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.h
@@ -54,7 +54,7 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   itkNewMacro(Self);
-  itkTypeMacro(WatershedSegmentTree, DataObject);
+  itkTypeMacro(SegmentTree, DataObject);
   using ScalarType = TScalar;
 
   /** Elements of the list (nodes of the tree).  A record of a merge

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
@@ -49,7 +49,7 @@ namespace watershed
  * \par Outputs
  * The output of this filter is a list of binary merges of segments at
  * increasing saliency.  This is the data structure
- * itk::watershed::WatershedSegmentTree referred to as a "merge tree" in the
+ * itk::watershed::SegmentTree referred to as a "merge tree" in the
  * itk::WatershedImageFilter documentation.
  *
  * \par Parameters
@@ -86,7 +86,7 @@ public:
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
-  itkTypeMacro(WatershedSegmentTreeGenerator, ProcessObject);
+  itkTypeMacro(SegmentTreeGenerator, ProcessObject);
 
   /** Convenient type definitions */
   using ScalarType = TScalar;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.h
@@ -111,7 +111,7 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   itkNewMacro(Self);
-  itkTypeMacro(WatershedSegmenter, ProcessObject);
+  itkTypeMacro(Segmenter, ProcessObject);
 
   /** Typedefs necessary on microsoft VC++ to avoid internal compiler errors */
   using InputImageTypePointer = typename InputImageType::Pointer;


### PR DESCRIPTION
Fix `Watersheds` module classes class names in `itkTypeMacro`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)