### PR TITLE
COMP: Use and move ITK_DISALLOW_COPY_AND_MOVE calls to public section

### DIFF
--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
@@ -54,6 +54,8 @@ template <typename TScalar, unsigned int TDimension>
 class ITK_TEMPLATE_EXPORT Boundary : public DataObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(Boundary);
+
   /** The dimensionality of this boundary.  For example, if the boundary
    * of a set of planes, it has dimensionality 2.  If the boundary is
    * a set of lines, it has dimensionality 1.  Dimensionality is one less
@@ -257,10 +259,7 @@ public:
 protected:
   Boundary();
   ~Boundary() override = default;
-  Boundary(const Self &) {}
-  void
-  operator=(const Self &)
-  {}
+
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
@@ -65,6 +65,8 @@ template <typename TPixelType, unsigned int TDimension>
 class ITK_TEMPLATE_EXPORT BoundaryResolver : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(BoundaryResolver);
+
   /** Set up smart pointer and object factory definitions.   */
   using Self = BoundaryResolver;
   using Superclass = ProcessObject;
@@ -146,10 +148,7 @@ protected:
   }
 
   ~BoundaryResolver() override = default;
-  BoundaryResolver(const Self &) {}
-  void
-  operator=(const Self &)
-  {}
+
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.h
@@ -54,6 +54,8 @@ template <typename TScalar, unsigned int TImageDimension>
 class ITK_TEMPLATE_EXPORT EquivalenceRelabeler : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(EquivalenceRelabeler);
+
   /** Expose templated image dimension parameter at run time */
   static constexpr unsigned int ImageDimension = TImageDimension;
 
@@ -129,10 +131,7 @@ protected:
   }
 
   ~EquivalenceRelabeler() override = default;
-  EquivalenceRelabeler(const Self &) {}
-  void
-  operator=(const Self &)
-  {}
+
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.h
@@ -48,6 +48,8 @@ template <typename TScalar>
 class ITK_TEMPLATE_EXPORT SegmentTree : public DataObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(SegmentTree);
+
   /** Define itk Smart Pointers for this object */
   using Self = SegmentTree;
   using Superclass = DataObject;
@@ -212,10 +214,7 @@ public:
 protected:
   SegmentTree() = default;
   ~SegmentTree() override = default;
-  SegmentTree(const Self &) {}
-  void
-  operator=(const Self &)
-  {}
+
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
@@ -78,6 +78,8 @@ template <typename TScalar>
 class ITK_TEMPLATE_EXPORT SegmentTreeGenerator : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(SegmentTreeGenerator);
+
   /**  Standard itk smart pointer declarations    */
   using Self = SegmentTreeGenerator;
   using Superclass = ProcessObject;
@@ -200,10 +202,7 @@ public:
 protected:
   SegmentTreeGenerator();
   ~SegmentTreeGenerator() override = default;
-  SegmentTreeGenerator(const Self &) {}
-  void
-  operator=(const Self &)
-  {}
+
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_MOVE` macro in the `Watersheds` module to
enhance consistency across the toolkit when disallowing the copy
constructor and the assign operator.

Move the `ITK_DISALLOW_COPY_AND_MOVE` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

Following the changes:
https://github.com/InsightSoftwareConsortium/ITK/commit/b0f183b04fd78062afafea26636b4dc597651b88
https://github.com/InsightSoftwareConsortium/ITK/commit/10429ae6b86c8d1f1578fe32c25180425f14a95d
https://github.com/InsightSoftwareConsortium/ITK/commit/7d177ca0c77aedb38cc8cf5561b785317617c315

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)