### PR TITLE
STYLE: Use `auto` for variables initialized by `New()` in Examples

### DIFF
--- a/Examples/DataRepresentation/Image/Image1.cxx
+++ b/Examples/DataRepresentation/Image/Image1.cxx
@@ -62,7 +62,7 @@ main(int, char *[])
   // Software Guide : EndLatex
   //
   // Software Guide : BeginCodeSnippet
-  ImageType::Pointer image = ImageType::New();
+  auto image = ImageType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Image/Image2.cxx
+++ b/Examples/DataRepresentation/Image/Image2.cxx
@@ -81,7 +81,7 @@ main(int, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/DataRepresentation/Image/Image3.cxx
+++ b/Examples/DataRepresentation/Image/Image3.cxx
@@ -40,7 +40,7 @@ main(int, char *[])
   using ImageType = itk::Image<unsigned short, 3>;
 
   // Then the image object can be created
-  ImageType::Pointer image = ImageType::New();
+  auto image = ImageType::New();
 
   // The image region should be initialized
   const ImageType::SizeType size = {

--- a/Examples/DataRepresentation/Image/Image4.cxx
+++ b/Examples/DataRepresentation/Image/Image4.cxx
@@ -79,7 +79,7 @@ main(int, char *[])
 {
   constexpr unsigned int Dimension = 3;
   using ImageType = itk::Image<unsigned short, Dimension>;
-  ImageType::Pointer image = ImageType::New();
+  auto image = ImageType::New();
 
   const ImageType::SizeType size = {
     { 200, 200, 200 }

--- a/Examples/DataRepresentation/Image/Image5.cxx
+++ b/Examples/DataRepresentation/Image/Image5.cxx
@@ -94,7 +94,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
   //
   // Software Guide : BeginCodeSnippet
-  ImportFilterType::Pointer importFilter = ImportFilterType::New();
+  auto importFilter = ImportFilterType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -241,7 +241,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[1]);
   writer->SetInput(importFilter->GetOutput());

--- a/Examples/DataRepresentation/Image/ImageAdaptor1.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor1.cxx
@@ -111,7 +111,7 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<InputPixelType, Dimension>;
 
   using ImageAdaptorType = itk::ImageAdaptor<ImageType, CastPixelAccessor>;
-  ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
+  auto adaptor = ImageAdaptorType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -124,7 +124,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Image/ImageAdaptor2.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor2.cxx
@@ -110,7 +110,7 @@ main(int argc, char * argv[])
   using ImageAdaptorType =
     itk::ImageAdaptor<ImageType, RedChannelPixelAccessor>;
 
-  ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
+  auto adaptor = ImageAdaptorType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -124,7 +124,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   // Software Guide : EndCodeSnippet
 
   reader->SetFileName(argv[1]);
@@ -152,9 +152,9 @@ main(int argc, char * argv[])
   using RescalerType =
     itk::RescaleIntensityImageFilter<ImageAdaptorType, OutputImageType>;
 
-  RescalerType::Pointer rescaler = RescalerType::New();
+  auto rescaler = RescalerType::New();
   using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Image/ImageAdaptor3.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor3.cxx
@@ -139,7 +139,7 @@ main(int argc, char * argv[])
     itk::GradientRecursiveGaussianImageFilter<InputImageType,
                                               VectorImageType>;
 
-  GradientFilterType::Pointer gradient = GradientFilterType::New();
+  auto gradient = GradientFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -155,7 +155,7 @@ main(int argc, char * argv[])
   using ImageAdaptorType =
     itk::ImageAdaptor<VectorImageType, itk::VectorPixelAccessor>;
 
-  ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
+  auto adaptor = ImageAdaptorType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -186,7 +186,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<InputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   gradient->SetInput(reader->GetOutput());
 
   reader->SetFileName(argv[1]);
@@ -211,9 +211,9 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<unsigned char, Dimension>;
   using RescalerType =
     itk::RescaleIntensityImageFilter<ImageAdaptorType, OutputImageType>;
-  RescalerType::Pointer rescaler = RescalerType::New();
+  auto rescaler = RescalerType::New();
   using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[2]);
 

--- a/Examples/DataRepresentation/Image/ImageAdaptor4.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor4.cxx
@@ -146,7 +146,7 @@ main(int argc, char * argv[])
   using ImageAdaptorType =
     itk::ImageAdaptor<ImageType, itk::ThresholdingPixelAccessor>;
 
-  ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
+  auto adaptor = ImageAdaptorType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -176,7 +176,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   reader->Update();
 
@@ -187,9 +187,9 @@ main(int argc, char * argv[])
   using RescalerType =
     itk::RescaleIntensityImageFilter<ImageAdaptorType, ImageType>;
 
-  RescalerType::Pointer rescaler = RescalerType::New();
+  auto rescaler = RescalerType::New();
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
 
   writer->SetFileName(argv[2]);

--- a/Examples/DataRepresentation/Image/RGBImage.cxx
+++ b/Examples/DataRepresentation/Image/RGBImage.cxx
@@ -83,8 +83,8 @@ main(int, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   // Software Guide : EndCodeSnippet
 
-  ReaderType::Pointer reader = ReaderType::New();
-  const char * const  filename = argv[1];
+  auto               reader = ReaderType::New();
+  const char * const filename = argv[1];
   reader->SetFileName(filename);
   reader->Update();
 

--- a/Examples/DataRepresentation/Image/VectorImage.cxx
+++ b/Examples/DataRepresentation/Image/VectorImage.cxx
@@ -68,7 +68,7 @@ main(int, char *[])
   // Software Guide : EndCodeSnippet
 
   // Then the image object can be created
-  ImageType::Pointer image = ImageType::New();
+  auto image = ImageType::New();
 
   // The image region should be initialized
   const ImageType::IndexType start = {

--- a/Examples/DataRepresentation/Mesh/ImageToPointSet.cxx
+++ b/Examples/DataRepresentation/Mesh/ImageToPointSet.cxx
@@ -51,7 +51,7 @@ main(int argc, char * argv[])
   using PointSetType = itk::PointSet<PixelType, Dimension>;
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   const char * inputFilename = argv[1];
   reader->SetFileName(inputFilename);
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  PointSetType::Pointer pointSet = PointSetType::New();
+  auto pointSet = PointSetType::New();
 
 
   using IteratorType = itk::ImageRegionConstIterator<ImageType>;

--- a/Examples/DataRepresentation/Mesh/Mesh1.cxx
+++ b/Examples/DataRepresentation/Mesh/Mesh1.cxx
@@ -101,7 +101,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Mesh/Mesh2.cxx
+++ b/Examples/DataRepresentation/Mesh/Mesh2.cxx
@@ -142,7 +142,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
   MeshType::PointType p0;
   MeshType::PointType p1;

--- a/Examples/DataRepresentation/Mesh/Mesh3.cxx
+++ b/Examples/DataRepresentation/Mesh/Mesh3.cxx
@@ -97,7 +97,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
   using PointType = MeshType::PointType;
   PointType point;

--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
@@ -106,7 +106,7 @@ public:
 int
 main(int, char *[])
 {
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
 
   // Creating the points and inserting them in the mesh
@@ -269,8 +269,7 @@ main(int, char *[])
 
 
   // Software Guide : BeginCodeSnippet
-  TriangleVisitorInterfaceType::Pointer triangleVisitor =
-    TriangleVisitorInterfaceType::New();
+  auto triangleVisitor = TriangleVisitorInterfaceType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -286,7 +285,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using CellMultiVisitorType = CellType::MultiVisitor;
-  CellMultiVisitorType::Pointer multiVisitor = CellMultiVisitorType::New();
+  auto multiVisitor = CellMultiVisitorType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
@@ -219,7 +219,7 @@ public:
 int
 main(int, char *[])
 {
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
   // Creating the points and inserting them in the mesh
   //
@@ -397,17 +397,13 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  VertexVisitorInterfaceType::Pointer vertexVisitor =
-    VertexVisitorInterfaceType::New();
+  auto vertexVisitor = VertexVisitorInterfaceType::New();
 
-  LineVisitorInterfaceType::Pointer lineVisitor =
-    LineVisitorInterfaceType::New();
+  auto lineVisitor = LineVisitorInterfaceType::New();
 
-  TriangleVisitorInterfaceType::Pointer triangleVisitor =
-    TriangleVisitorInterfaceType::New();
+  auto triangleVisitor = TriangleVisitorInterfaceType::New();
 
-  TetrahedronVisitorInterfaceType::Pointer tetrahedronVisitor =
-    TetrahedronVisitorInterfaceType::New();
+  auto tetrahedronVisitor = TetrahedronVisitorInterfaceType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -451,7 +447,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using CellMultiVisitorType = CellType::MultiVisitor;
-  CellMultiVisitorType::Pointer multiVisitor = CellMultiVisitorType::New();
+  auto multiVisitor = CellMultiVisitorType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Mesh/MeshCellsIteration.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellsIteration.cxx
@@ -50,7 +50,7 @@ main(int, char *[])
   using TriangleType = itk::TriangleCell<CellType>;
   using TetrahedronType = itk::TetrahedronCell<CellType>;
 
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
 
   // Creating the points and inserting them in the mesh

--- a/Examples/DataRepresentation/Mesh/MeshKComplex.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshKComplex.cxx
@@ -119,7 +119,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
   MeshType::PointType point0;
   MeshType::PointType point1;

--- a/Examples/DataRepresentation/Mesh/MeshPolyLine.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshPolyLine.cxx
@@ -104,7 +104,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
   MeshType::PointType point0;
   MeshType::PointType point1;

--- a/Examples/DataRepresentation/Mesh/MeshTraits.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshTraits.cxx
@@ -155,7 +155,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MeshType::Pointer mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
   using PointType = MeshType::PointType;
   PointType point;

--- a/Examples/DataRepresentation/Mesh/PointSet1.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSet1.cxx
@@ -85,7 +85,7 @@ main(int, char *[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  PointSetType::Pointer pointsSet = PointSetType::New();
+  auto pointsSet = PointSetType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Mesh/PointSet2.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSet2.cxx
@@ -74,7 +74,7 @@ main(int, char *[])
 
 
   // Software Guide : BeginCodeSnippet
-  PointsContainer::Pointer points = PointsContainer::New();
+  auto points = PointsContainer::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -117,7 +117,7 @@ main(int, char *[])
   points->InsertElement(pointId++, p1);
   // Software Guide : EndCodeSnippet
 
-  PointSetType::Pointer pointSet = PointSetType::New();
+  auto pointSet = PointSetType::New();
 
   //  Software Guide : BeginLatex
   //

--- a/Examples/DataRepresentation/Mesh/PointSet3.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSet3.cxx
@@ -51,7 +51,7 @@ main(int, char *[])
 
 
   // A point set is instantiated here
-  PointSetType::Pointer pointSet = PointSetType::New();
+  auto pointSet = PointSetType::New();
 
 
   //  Software Guide : BeginLatex
@@ -137,7 +137,7 @@ main(int, char *[])
 
 
   // Software Guide : BeginCodeSnippet
-  PointDataContainer::Pointer pointData = PointDataContainer::New();
+  auto pointData = PointDataContainer::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Mesh/PointSetWithCovariantVectors.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSetWithCovariantVectors.cxx
@@ -83,7 +83,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using PointSetType = itk::PointSet<PixelType, Dimension>;
-  PointSetType::Pointer pointSet = PointSetType::New();
+  auto pointSet = PointSetType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Mesh/PointSetWithVectors.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSetWithVectors.cxx
@@ -79,7 +79,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using PointSetType = itk::PointSet<PixelType, Dimension>;
-  PointSetType::Pointer pointSet = PointSetType::New();
+  auto pointSet = PointSetType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Mesh/RGBPointSet.cxx
+++ b/Examples/DataRepresentation/Mesh/RGBPointSet.cxx
@@ -59,7 +59,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using PointSetType = itk::PointSet<PixelType, 3>;
-  PointSetType::Pointer pointSet = PointSetType::New();
+  auto pointSet = PointSetType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/DataRepresentation/Path/PolyLineParametricPath1.cxx
+++ b/Examples/DataRepresentation/Path/PolyLineParametricPath1.cxx
@@ -68,7 +68,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -85,7 +85,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   ImageType::ConstPointer image = reader->GetOutput();
-  PathType::Pointer       path = PathType::New();
+  auto                    path = PathType::New();
   path->Initialize();
 
   using ContinuousIndexType = PathType::ContinuousIndexType;

--- a/Examples/Filtering/AntiAliasBinaryImageFilter.cxx
+++ b/Examples/Filtering/AntiAliasBinaryImageFilter.cxx
@@ -127,15 +127,15 @@ main(int argc, char * argv[])
 
   // Setting the IO
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
-  CastToRealFilterType::Pointer toReal = CastToRealFilterType::New();
-  RescaleFilter::Pointer        rescale = RescaleFilter::New();
+  auto toReal = CastToRealFilterType::New();
+  auto rescale = RescaleFilter::New();
 
   // Setting the ITK pipeline filter
 
   // Software Guide : BeginCodeSnippet
-  AntiAliasFilterType::Pointer antiAliasFilter = AntiAliasFilterType::New();
+  auto antiAliasFilter = AntiAliasFilterType::New();
 
   reader->SetFileName(inputFilename);
 
@@ -150,7 +150,7 @@ main(int argc, char * argv[])
   antiAliasFilter->SetNumberOfIterations(numberOfIterations);
   antiAliasFilter->SetNumberOfLayers(2);
 
-  RealWriterType::Pointer realWriter = RealWriterType::New();
+  auto realWriter = RealWriterType::New();
   realWriter->SetInput(antiAliasFilter->GetOutput());
   realWriter->SetFileName(outputFilename1);
 
@@ -166,7 +166,7 @@ main(int argc, char * argv[])
   }
 
 
-  WriterType::Pointer rescaledWriter = WriterType::New();
+  auto rescaledWriter = WriterType::New();
   rescale->SetInput(antiAliasFilter->GetOutput());
   rescaledWriter->SetInput(rescale->GetOutput());
   rescaledWriter->SetFileName(outputFilename2);

--- a/Examples/Filtering/BilateralImageFilter.cxx
+++ b/Examples/Filtering/BilateralImageFilter.cxx
@@ -146,11 +146,11 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType =
     itk::BilateralImageFilter<InputImageType, OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -225,12 +225,12 @@ main(int argc, char * argv[])
   using WriteImageType = itk::Image<WritePixelType, 2>;
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
   // Software Guide : BeginCodeSnippet

--- a/Examples/Filtering/BinaryMedianImageFilter.cxx
+++ b/Examples/Filtering/BinaryMedianImageFilter.cxx
@@ -93,8 +93,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -114,7 +114,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::BinaryMedianImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/BinaryMinMaxCurvatureFlowImageFilter.cxx
+++ b/Examples/Filtering/BinaryMinMaxCurvatureFlowImageFilter.cxx
@@ -125,11 +125,11 @@ main(int argc, char * argv[])
     itk::BinaryMinMaxCurvatureFlowImageFilter<InputImageType,
                                               OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -205,7 +205,7 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
@@ -213,7 +213,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[2]);
 

--- a/Examples/Filtering/BinaryThresholdImageFilter.cxx
+++ b/Examples/Filtering/BinaryThresholdImageFilter.cxx
@@ -147,11 +147,11 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  FilterType::Pointer filter = FilterType::New();
+  auto reader = ReaderType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   reader->SetFileName(argv[1]);
 

--- a/Examples/Filtering/BinomialBlurImageFilter.cxx
+++ b/Examples/Filtering/BinomialBlurImageFilter.cxx
@@ -98,11 +98,11 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType =
     itk::BinomialBlurImageFilter<InputImageType, OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   const unsigned int repetitions = std::stoi(argv[3]);
 
@@ -135,12 +135,12 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[2]);
   rescaler->SetInput(filter->GetOutput());

--- a/Examples/Filtering/CannyEdgeDetectionImageFilter.cxx
+++ b/Examples/Filtering/CannyEdgeDetectionImageFilter.cxx
@@ -131,11 +131,11 @@ main(int argc, char * argv[])
 
   // Setting the IO
 
-  ReaderType::Pointer           reader = ReaderType::New();
-  CastToRealFilterType::Pointer toReal = CastToRealFilterType::New();
-  CannyFilterType::Pointer      cannyFilter = CannyFilterType::New();
-  RescaleFilterType::Pointer    rescale = RescaleFilterType::New();
-  WriterType::Pointer           writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto toReal = CastToRealFilterType::New();
+  auto cannyFilter = CannyFilterType::New();
+  auto rescale = RescaleFilterType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(inputFilename);
   writer->SetFileName(outputFilename);

--- a/Examples/Filtering/CastingImageFilters.cxx
+++ b/Examples/Filtering/CastingImageFilters.cxx
@@ -153,7 +153,7 @@ main(int argc, char * argv[])
     itk::NormalizeImageFilter<InputImageType, OutputImageType>;
   // Software Guide : EndCodeSnippet
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
 
   //  Software Guide : BeginLatex
@@ -174,10 +174,10 @@ main(int argc, char * argv[])
 
 
   // Software Guide : BeginCodeSnippet
-  CastFilterType::Pointer       castFilter = CastFilterType::New();
-  RescaleFilterType::Pointer    rescaleFilter = RescaleFilterType::New();
-  ShiftScaleFilterType::Pointer shiftFilter = ShiftScaleFilterType::New();
-  NormalizeFilterType::Pointer  normalizeFilter = NormalizeFilterType::New();
+  auto castFilter = CastFilterType::New();
+  auto rescaleFilter = RescaleFilterType::New();
+  auto shiftFilter = ShiftScaleFilterType::New();
+  auto normalizeFilter = NormalizeFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/CompositeFilterExample.cxx
+++ b/Examples/Filtering/CompositeFilterExample.cxx
@@ -208,7 +208,7 @@ template <typename TImage>
 void
 CompositeExampleImageFilter<TImage>::GenerateData()
 {
-  typename ImageType::Pointer input = ImageType::New();
+  auto input = ImageType::New();
   input->Graft(const_cast<ImageType *>(this->GetInput()));
   m_GradientFilter->SetInput(input);
 
@@ -271,16 +271,16 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<short, 2>;
 
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
   using FilterType = itk::CompositeExampleImageFilter<ImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   filter->SetInput(reader->GetOutput());
   filter->SetThreshold(20);
 
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
 

--- a/Examples/Filtering/CurvatureAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/CurvatureAnisotropicDiffusionImageFilter.cxx
@@ -129,11 +129,11 @@ main(int argc, char * argv[])
     itk::CurvatureAnisotropicDiffusionImageFilter<InputImageType,
                                                   OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
   //  Software Guide : BeginLatex
@@ -207,13 +207,13 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   rescaler->SetInput(filter->GetOutput());
   writer->SetInput(rescaler->GetOutput());

--- a/Examples/Filtering/CurvatureFlowImageFilter.cxx
+++ b/Examples/Filtering/CurvatureFlowImageFilter.cxx
@@ -126,7 +126,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -141,7 +141,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -212,13 +212,13 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
   // Software Guide : BeginCodeSnippet

--- a/Examples/Filtering/DanielssonDistanceMapImageFilter.cxx
+++ b/Examples/Filtering/DanielssonDistanceMapImageFilter.cxx
@@ -102,22 +102,22 @@ main(int argc, char * argv[])
 
   using LabelerType =
     itk::ConnectedComponentImageFilter<InputImageType, InputImageType>;
-  LabelerType::Pointer labeler = LabelerType::New();
+  auto labeler = LabelerType::New();
 
   // Software Guide : BeginCodeSnippet
   using FilterType = itk::DanielssonDistanceMapImageFilter<InputImageType,
                                                            OutputImageType,
                                                            VoronoiImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
   using RescalerType =
     itk::RescaleIntensityImageFilter<OutputImageType, OutputImageType>;
-  RescalerType::Pointer scaler = RescalerType::New();
+  auto scaler = RescalerType::New();
 
   using VoronoiRescalerType =
     itk::RescaleIntensityImageFilter<VoronoiImageType, VoronoiImageType>;
-  VoronoiRescalerType::Pointer voronoiScaler = VoronoiRescalerType::New();
+  auto voronoiScaler = VoronoiRescalerType::New();
 
   //
   // Reader and Writer types are instantiated.
@@ -126,9 +126,9 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
   using VoronoiWriterType = itk::ImageFileWriter<VoronoiImageType>;
 
-  ReaderType::Pointer        reader = ReaderType::New();
-  WriterType::Pointer        writer = WriterType::New();
-  VoronoiWriterType::Pointer voronoiWriter = VoronoiWriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
+  auto voronoiWriter = VoronoiWriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -226,7 +226,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterOffsetType = itk::ImageFileWriter<OffsetImageType>;
-  WriterOffsetType::Pointer offsetWriter = WriterOffsetType::New();
+  auto offsetWriter = WriterOffsetType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/DerivativeImageFilter.cxx
+++ b/Examples/Filtering/DerivativeImageFilter.cxx
@@ -90,8 +90,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -111,7 +111,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::DerivativeImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -178,9 +178,8 @@ main(int argc, char * argv[])
 
   using NormalizedWriterType = itk::ImageFileWriter<WriteImageType>;
 
-  NormalizeFilterType::Pointer  normalizer = NormalizeFilterType::New();
-  NormalizedWriterType::Pointer normalizedWriter =
-    NormalizedWriterType::New();
+  auto normalizer = NormalizeFilterType::New();
+  auto normalizedWriter = NormalizedWriterType::New();
 
   normalizer->SetInput(filter->GetOutput());
   normalizedWriter->SetInput(normalizer->GetOutput());

--- a/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
@@ -216,7 +216,7 @@ main(int argc, char * argv[])
   //
   for (unsigned int i = 0; i < numberOfImages; ++i)
   {
-    GradientImageType::Pointer image = GradientImageType::New();
+    auto image = GradientImageType::New();
     image->CopyInformation(img);
     image->SetBufferedRegion(img->GetBufferedRegion());
     image->SetRequestedRegion(img->GetRequestedRegion());
@@ -244,7 +244,7 @@ main(int argc, char * argv[])
     using GradientWriterType = itk::ImageFileWriter<GradientImageType>;
     for (unsigned int i = 0; i < numberOfImages; ++i)
     {
-      GradientWriterType::Pointer gradientWriter = GradientWriterType::New();
+      auto gradientWriter = GradientWriterType::New();
       gradientWriter->SetInput(imageContainer[i]);
       char filename[100];
       if (DiffusionVectors->ElementAt(i).two_norm() <=
@@ -266,7 +266,7 @@ main(int argc, char * argv[])
 
 
   // -------------------------------------------------------------------------
-  TensorReconstructionImageFilterType::Pointer tensorReconstructionFilter =
+  auto tensorReconstructionFilter =
     TensorReconstructionImageFilterType::New();
 
   // The reference and the gradient images are conveniently provided as
@@ -305,7 +305,7 @@ main(int argc, char * argv[])
   //
   using TensorWriterType = itk::ImageFileWriter<
     TensorReconstructionImageFilterType::OutputImageType>;
-  TensorWriterType::Pointer tensorWriter = TensorWriterType::New();
+  auto tensorWriter = TensorWriterType::New();
   tensorWriter->SetFileName(argv[3]);
   tensorWriter->SetInput(tensorReconstructionFilter->GetOutput());
   tensorWriter->Update();
@@ -324,14 +324,14 @@ main(int argc, char * argv[])
     TensorReconstructionImageFilterType::OutputImageType,
     FAImageType>;
 
-  FAFilterType::Pointer fractionalAnisotropyFilter = FAFilterType::New();
+  auto fractionalAnisotropyFilter = FAFilterType::New();
   fractionalAnisotropyFilter->SetInput(
     tensorReconstructionFilter->GetOutput());
 
   // Write the FA image
   //
   using FAWriterType = itk::ImageFileWriter<FAFilterType::OutputImageType>;
-  FAWriterType::Pointer faWriter = FAWriterType::New();
+  auto faWriter = FAWriterType::New();
   faWriter->SetInput(fractionalAnisotropyFilter->GetOutput());
   faWriter->SetFileName(argv[4]);
   faWriter->Update();
@@ -346,11 +346,11 @@ main(int argc, char * argv[])
     TensorReconstructionImageFilterType::OutputImageType,
     RAImageType>;
 
-  RAFilterType::Pointer relativeAnisotropyFilter = RAFilterType::New();
+  auto relativeAnisotropyFilter = RAFilterType::New();
   relativeAnisotropyFilter->SetInput(tensorReconstructionFilter->GetOutput());
 
   using RAWriterType = itk::ImageFileWriter<RAFilterType::OutputImageType>;
-  RAWriterType::Pointer raWriter = RAWriterType::New();
+  auto raWriter = RAWriterType::New();
   raWriter->SetInput(relativeAnisotropyFilter->GetOutput());
   raWriter->SetFileName(argv[5]);
   raWriter->Update();

--- a/Examples/Filtering/DigitallyReconstructedRadiograph1.cxx
+++ b/Examples/Filtering/DigitallyReconstructedRadiograph1.cxx
@@ -329,7 +329,7 @@ main(int argc, char * argv[])
   {
 
     using ReaderType = itk::ImageFileReader<InputImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
+    auto reader = ReaderType::New();
     reader->SetFileName(input_name);
 
 
@@ -436,7 +436,7 @@ main(int argc, char * argv[])
 #ifdef WRITE_CUBE_IMAGE_TO_FILE
     const char * filename = "cube.gipl";
     using WriterType = itk::ImageFileWriter<InputImageType>;
-    WriterType::Pointer writer = WriterType::New();
+    auto writer = WriterType::New();
 
     writer->SetFileName(filename);
     writer->SetInput(image);
@@ -501,7 +501,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType = itk::ResampleImageFilter<InputImageType, InputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   filter->SetInput(image);
   filter->SetDefaultPixelValue(0);
@@ -518,7 +518,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::CenteredEuler3DTransform<double>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   transform->SetComputeZYX(true);
 
@@ -581,7 +581,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using InterpolatorType =
     itk::RayCastInterpolateImageFunction<InputImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
   interpolator->SetTransform(transform);
   // Software Guide : EndCodeSnippet
 
@@ -716,13 +716,13 @@ main(int argc, char * argv[])
     // Software Guide : BeginCodeSnippet
     using RescaleFilterType =
       itk::RescaleIntensityImageFilter<InputImageType, OutputImageType>;
-    RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+    auto rescaler = RescaleFilterType::New();
     rescaler->SetOutputMinimum(0);
     rescaler->SetOutputMaximum(255);
     rescaler->SetInput(filter->GetOutput());
 
     using WriterType = itk::ImageFileWriter<OutputImageType>;
-    WriterType::Pointer writer = WriterType::New();
+    auto writer = WriterType::New();
 
     writer->SetFileName(output_name);
     writer->SetInput(rescaler->GetOutput());

--- a/Examples/Filtering/DiscreteGaussianImageFilter.cxx
+++ b/Examples/Filtering/DiscreteGaussianImageFilter.cxx
@@ -122,11 +122,11 @@ main(int argc, char * argv[])
   using FilterType =
     itk::DiscreteGaussianImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -194,13 +194,13 @@ main(int argc, char * argv[])
   using WriteImageType = itk::Image<WritePixelType, 2>;
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
   // Software Guide : BeginCodeSnippet

--- a/Examples/Filtering/FFTDirectInverse.cxx
+++ b/Examples/Filtering/FFTDirectInverse.cxx
@@ -66,8 +66,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<IOImageType>;
   using WriterType = itk::ImageFileWriter<IOImageType>;
 
-  ReaderType::Pointer inputreader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto inputreader = ReaderType::New();
+  auto writer = WriterType::New();
 
   inputreader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -75,7 +75,7 @@ main(int argc, char * argv[])
   // Handle padding of the image with resampling
   using ResamplerType = itk::ResampleImageFilter<IOImageType, WorkImageType>;
 
-  ResamplerType::Pointer inputresampler = ResamplerType::New();
+  auto inputresampler = ResamplerType::New();
   inputresampler->SetDefaultPixelValue(0);
 
   // Read the image and get its size
@@ -107,7 +107,7 @@ main(int argc, char * argv[])
 
   // Forward FFT filter
   using FFTFilterType = itk::VnlForwardFFTImageFilter<WorkImageType>;
-  FFTFilterType::Pointer fftinput = FFTFilterType::New();
+  auto fftinput = FFTFilterType::New();
   fftinput->SetInput(inputresampler->GetOutput());
 
   // This is the output type from the FFT filters
@@ -115,14 +115,14 @@ main(int argc, char * argv[])
 
   // Do the inverse transform = forward transform / num voxels
   using invFFTFilterType = itk::VnlInverseFFTImageFilter<ComplexImageType>;
-  invFFTFilterType::Pointer fftoutput = invFFTFilterType::New();
+  auto fftoutput = invFFTFilterType::New();
   fftoutput->SetInput(
     fftinput->GetOutput()); // try to recover the input image
 
   // undo the padding
   using ResampleOutType =
     itk::ResampleImageFilter<WorkImageType, IOImageType>;
-  ResampleOutType::Pointer outputResampler = ResampleOutType::New();
+  auto outputResampler = ResampleOutType::New();
   outputResampler->SetDefaultPixelValue(0);
   outputResampler->SetSize(inputsize);
   outputResampler->SetInput(fftoutput->GetOutput());

--- a/Examples/Filtering/FFTDirectInverse2.cxx
+++ b/Examples/Filtering/FFTDirectInverse2.cxx
@@ -78,8 +78,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer inputreader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto inputreader = ReaderType::New();
+  auto writer = WriterType::New();
 
   inputreader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -90,7 +90,7 @@ main(int argc, char * argv[])
   // Forward FFT filter
   using FFTFilterType = itk::FFTWForwardFFTImageFilter<InputImageType>;
 
-  FFTFilterType::Pointer fftinput = FFTFilterType::New();
+  auto fftinput = FFTFilterType::New();
   fftinput->SetInput(inputreader->GetOutput());
   fftinput->Update();
 
@@ -100,7 +100,7 @@ main(int argc, char * argv[])
   // Do the inverse transform = forward transform + flip all axes
   using invFFTFilterType = itk::FFTWInverseFFTImageFilter<ComplexImageType>;
 
-  invFFTFilterType::Pointer fftoutput = invFFTFilterType::New();
+  auto fftoutput = invFFTFilterType::New();
   fftoutput->SetInput(
     fftinput->GetOutput()); // try to recover the input image
   fftoutput->Update();
@@ -109,7 +109,7 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<WorkImageType, OutputImageType>;
 
-  RescaleFilterType::Pointer intensityrescaler = RescaleFilterType::New();
+  auto intensityrescaler = RescaleFilterType::New();
 
   std::cout << fftoutput->GetOutput()->GetLargestPossibleRegion().GetSize()
             << std::endl;

--- a/Examples/Filtering/FFTImageFilter.cxx
+++ b/Examples/Filtering/FFTImageFilter.cxx
@@ -104,7 +104,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FFTFilterType = itk::VnlForwardFFTImageFilter<ImageType>;
 
-  FFTFilterType::Pointer fftFilter = FFTFilterType::New();
+  auto fftFilter = FFTFilterType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -115,7 +115,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
   fftFilter->SetInput(reader->GetOutput());
@@ -157,7 +157,7 @@ main(int argc, char * argv[])
 
   using ComplexWriterType = itk::ImageFileWriter<ComplexImageType>;
 
-  ComplexWriterType::Pointer complexWriter = ComplexWriterType::New();
+  auto complexWriter = ComplexWriterType::New();
   complexWriter->SetFileName(argv[4]);
 
   complexWriter->SetInput(fftFilter->GetOutput());
@@ -205,7 +205,7 @@ main(int argc, char * argv[])
   using RealFilterType =
     itk::ComplexToRealImageFilter<ComplexImageType, ImageType>;
 
-  RealFilterType::Pointer realFilter = RealFilterType::New();
+  auto realFilter = RealFilterType::New();
 
   realFilter->SetInput(fftFilter->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -231,7 +231,7 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<ImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer intensityRescaler = RescaleFilterType::New();
+  auto intensityRescaler = RescaleFilterType::New();
 
   intensityRescaler->SetInput(realFilter->GetOutput());
 
@@ -241,7 +241,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[2]);
 
@@ -275,7 +275,7 @@ main(int argc, char * argv[])
   using ImaginaryFilterType =
     itk::ComplexToImaginaryImageFilter<ComplexImageType, ImageType>;
 
-  ImaginaryFilterType::Pointer imaginaryFilter = ImaginaryFilterType::New();
+  auto imaginaryFilter = ImaginaryFilterType::New();
 
   imaginaryFilter->SetInput(fftFilter->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -317,7 +317,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ComplexReaderType = itk::ImageFileReader<ComplexImageType>;
 
-  ComplexReaderType::Pointer complexReader = ComplexReaderType::New();
+  auto complexReader = ComplexReaderType::New();
 
   complexReader->SetFileName(argv[4]);
   complexReader->Update();

--- a/Examples/Filtering/FFTImageFilterFourierDomainFiltering.cxx
+++ b/Examples/Filtering/FFTImageFilterFourierDomainFiltering.cxx
@@ -107,8 +107,8 @@ main(int argc, char * argv[])
   using InputReaderType = itk::ImageFileReader<InputImageType>;
   using MaskReaderType = itk::ImageFileReader<MaskImageType>;
 
-  InputReaderType::Pointer inputReader = InputReaderType::New();
-  MaskReaderType::Pointer  maskReader = MaskReaderType::New();
+  auto inputReader = InputReaderType::New();
+  auto maskReader = MaskReaderType::New();
 
   inputReader->SetFileName(argv[1]);
   maskReader->SetFileName(argv[2]);
@@ -126,7 +126,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FFTFilterType = itk::VnlForwardFFTImageFilter<InputImageType>;
 
-  FFTFilterType::Pointer fftFilter = FFTFilterType::New();
+  auto fftFilter = FFTFilterType::New();
 
   fftFilter->SetInput(inputReader->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -148,7 +148,7 @@ main(int argc, char * argv[])
   using MaskFilterType =
     itk::MaskImageFilter<SpectralImageType, MaskImageType, SpectralImageType>;
 
-  MaskFilterType::Pointer maskFilter = MaskFilterType::New();
+  auto maskFilter = MaskFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -175,7 +175,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using SpectralWriterType = itk::ImageFileWriter<SpectralImageType>;
-  SpectralWriterType::Pointer spectralWriter = SpectralWriterType::New();
+  auto spectralWriter = SpectralWriterType::New();
   spectralWriter->SetFileName("filteredSpectrum.mhd");
   spectralWriter->SetInput(maskFilter->GetOutput());
   spectralWriter->Update();
@@ -194,7 +194,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using IFFTFilterType = itk::VnlInverseFFTImageFilter<SpectralImageType>;
 
-  IFFTFilterType::Pointer fftInverseFilter = IFFTFilterType::New();
+  auto fftInverseFilter = IFFTFilterType::New();
 
   fftInverseFilter->SetInput(maskFilter->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -232,7 +232,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<InputImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[3]);
   writer->SetInput(fftInverseFilter->GetOutput());
   // Software Guide : EndCodeSnippet

--- a/Examples/Filtering/FlipImageFilter.cxx
+++ b/Examples/Filtering/FlipImageFilter.cxx
@@ -90,8 +90,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -110,7 +110,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType = itk::FlipImageFilter<ImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/GaussianBlurImageFunction.cxx
+++ b/Examples/Filtering/GaussianBlurImageFunction.cxx
@@ -39,7 +39,7 @@ main(int argc, char * argv[])
   using IteratorType = itk::ImageRegionIterator<ImageType>;
   using ConstIteratorType = itk::ImageRegionConstIterator<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   reader->Update();
 
@@ -49,7 +49,7 @@ main(int argc, char * argv[])
 
   ConstIteratorType it(inputImage, region);
 
-  ImageType::Pointer output = ImageType::New();
+  auto output = ImageType::New();
 
   output->SetRegions(region);
   output->SetOrigin(inputImage->GetOrigin());
@@ -59,7 +59,7 @@ main(int argc, char * argv[])
   IteratorType out(output, region);
 
   using GFunctionType = itk::GaussianBlurImageFunction<ImageType>;
-  GFunctionType::Pointer gaussianFunction = GFunctionType::New();
+  auto gaussianFunction = GFunctionType::New();
   gaussianFunction->SetInputImage(inputImage);
 
   GFunctionType::ErrorArrayType setError;
@@ -79,7 +79,7 @@ main(int argc, char * argv[])
   }
 
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(output);
   writer->Update();

--- a/Examples/Filtering/GradientAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/GradientAnisotropicDiffusionImageFilter.cxx
@@ -111,11 +111,11 @@ main(int argc, char * argv[])
   using FilterType =
     itk::GradientAnisotropicDiffusionImageFilter<InputImageType,
                                                  OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -183,13 +183,13 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
 

--- a/Examples/Filtering/GradientMagnitudeImageFilter.cxx
+++ b/Examples/Filtering/GradientMagnitudeImageFilter.cxx
@@ -123,7 +123,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -138,7 +138,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -182,13 +182,13 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
   // Software Guide : BeginCodeSnippet

--- a/Examples/Filtering/GradientMagnitudeRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/GradientMagnitudeRecursiveGaussianImageFilter.cxx
@@ -133,7 +133,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -148,7 +148,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -210,14 +210,14 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[2]);
 

--- a/Examples/Filtering/GradientRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/GradientRecursiveGaussianImageFilter.cxx
@@ -103,7 +103,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -176,7 +176,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[2]);
 

--- a/Examples/Filtering/GradientVectorFlowImageFilter.cxx
+++ b/Examples/Filtering/GradientVectorFlowImageFilter.cxx
@@ -112,7 +112,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -127,7 +127,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -189,7 +189,7 @@ main(int argc, char * argv[])
   //
   //  Software Guide : EndLatex
   using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
   // Software Guide : BeginCodeSnippet

--- a/Examples/Filtering/GrayscaleFunctionDilateImageFilter.cxx
+++ b/Examples/Filtering/GrayscaleFunctionDilateImageFilter.cxx
@@ -40,8 +40,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -52,7 +52,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::GrayscaleFunctionDilateImageFilter<ImageType, ImageType, KernelType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   KernelType           ball;
   KernelType::SizeType ballSize;

--- a/Examples/Filtering/LaplacianImageFilter.cxx
+++ b/Examples/Filtering/LaplacianImageFilter.cxx
@@ -62,17 +62,17 @@ main(int argc, char * argv[])
     itk::ZeroCrossingImageFilter<RealImageType, RealImageType>;
 
   // Setting the IO
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
-  CastToRealFilterType::Pointer toReal = CastToRealFilterType::New();
-  CastToCharFilterType::Pointer toChar = CastToCharFilterType::New();
-  RescaleFilter::Pointer        rescale = RescaleFilter::New();
+  auto toReal = CastToRealFilterType::New();
+  auto toChar = CastToCharFilterType::New();
+  auto rescale = RescaleFilter::New();
 
   // Setting the ITK pipeline filter
 
-  LaplacianFilter::Pointer    lapFilter = LaplacianFilter::New();
-  ZeroCrossingFilter::Pointer zeroFilter = ZeroCrossingFilter::New();
+  auto lapFilter = LaplacianFilter::New();
+  auto zeroFilter = ZeroCrossingFilter::New();
 
   reader->SetFileName(inputFilename);
   writer->SetFileName(outputFilename);

--- a/Examples/Filtering/LaplacianRecursiveGaussianImageFilter1.cxx
+++ b/Examples/Filtering/LaplacianRecursiveGaussianImageFilter1.cxx
@@ -114,7 +114,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -136,11 +136,11 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filterX1 = FilterType::New();
-  FilterType::Pointer filterY1 = FilterType::New();
+  auto filterX1 = FilterType::New();
+  auto filterY1 = FilterType::New();
 
-  FilterType::Pointer filterX2 = FilterType::New();
-  FilterType::Pointer filterY2 = FilterType::New();
+  auto filterX2 = FilterType::New();
+  auto filterY2 = FilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -288,7 +288,7 @@ main(int argc, char * argv[])
   using AddFilterType =
     itk::AddImageFilter<OutputImageType, OutputImageType, OutputImageType>;
 
-  AddFilterType::Pointer addFilter = AddFilterType::New();
+  auto addFilter = AddFilterType::New();
 
   addFilter->SetInput1(filterY1->GetOutput());
   addFilter->SetInput2(filterX2->GetOutput());
@@ -330,7 +330,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetInput(addFilter->GetOutput());
 
@@ -365,12 +365,12 @@ main(int argc, char * argv[])
     using RescaleFilterType =
       itk::RescaleIntensityImageFilter<OutputImageType, CharImageType>;
 
-    RescaleFilterType::Pointer rescale = RescaleFilterType::New();
+    auto rescale = RescaleFilterType::New();
     rescale->SetInput(addFilter->GetOutput());
     rescale->SetOutputMinimum(0);
     rescale->SetOutputMaximum(255);
     using CharWriterType = itk::ImageFileWriter<CharImageType>;
-    CharWriterType::Pointer charWriter = CharWriterType::New();
+    auto charWriter = CharWriterType::New();
     charWriter->SetFileName(argv[4]);
     charWriter->SetInput(rescale->GetOutput());
     charWriter->Update();

--- a/Examples/Filtering/LaplacianRecursiveGaussianImageFilter2.cxx
+++ b/Examples/Filtering/LaplacianRecursiveGaussianImageFilter2.cxx
@@ -110,7 +110,7 @@ main(int argc, char * argv[])
                                                OutputImageType>;
   // Software Guide : EndCodeSnippet
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
   //  Software Guide : BeginLatex
@@ -125,7 +125,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer laplacian = FilterType::New();
+  auto laplacian = FilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -199,7 +199,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(laplacian->GetOutput());
   writer->SetFileName(argv[2]);
   writer->Update();
@@ -213,12 +213,12 @@ main(int argc, char * argv[])
 
     using RescaleFilterType =
       itk::RescaleIntensityImageFilter<OutputImageType, CharImageType>;
-    RescaleFilterType::Pointer rescale = RescaleFilterType::New();
+    auto rescale = RescaleFilterType::New();
     rescale->SetInput(laplacian->GetOutput());
     rescale->SetOutputMinimum(0);
     rescale->SetOutputMaximum(255);
     using CharWriterType = itk::ImageFileWriter<CharImageType>;
-    CharWriterType::Pointer charWriter = CharWriterType::New();
+    auto charWriter = CharWriterType::New();
     charWriter->SetFileName(argv[4]);
     charWriter->SetInput(rescale->GetOutput());
     charWriter->Update();

--- a/Examples/Filtering/LaplacianSharpeningImageFilter.cxx
+++ b/Examples/Filtering/LaplacianSharpeningImageFilter.cxx
@@ -50,14 +50,13 @@ main(int argc, char * argv[])
 
 
   // Setting the IO
-  ReaderType::Pointer    reader = ReaderType::New();
-  WriterType::Pointer    writer = WriterType::New();
-  RescaleFilter::Pointer rescale = RescaleFilter::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
+  auto rescale = RescaleFilter::New();
 
   // Setting the ITK pipeline filter
 
-  LaplacianSharpeningFilter::Pointer lapFilter =
-    LaplacianSharpeningFilter::New();
+  auto lapFilter = LaplacianSharpeningFilter::New();
 
   reader->SetFileName(inputFilename);
   writer->SetFileName(outputFilename);

--- a/Examples/Filtering/MathematicalMorphologyBinaryFilters.cxx
+++ b/Examples/Filtering/MathematicalMorphologyBinaryFilters.cxx
@@ -134,11 +134,11 @@ main(int argc, char * argv[])
 
 
   // Creation of Reader and Writer filters
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writerDilation = WriterType::New();
-  WriterType::Pointer writerErosion = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writerDilation = WriterType::New();
+  auto writerErosion = WriterType::New();
 
-  ThresholdFilterType::Pointer thresholder = ThresholdFilterType::New();
+  auto thresholder = ThresholdFilterType::New();
 
   //  Software Guide : BeginLatex
   //
@@ -153,8 +153,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ErodeFilterType::Pointer  binaryErode = ErodeFilterType::New();
-  DilateFilterType::Pointer binaryDilate = DilateFilterType::New();
+  auto binaryErode = ErodeFilterType::New();
+  auto binaryDilate = DilateFilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex

--- a/Examples/Filtering/MathematicalMorphologyGrayscaleFilters.cxx
+++ b/Examples/Filtering/MathematicalMorphologyGrayscaleFilters.cxx
@@ -129,9 +129,9 @@ main(int argc, char * argv[])
 
 
   // Creation of Reader and Writer filters
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writerDilation = WriterType::New();
-  WriterType::Pointer writerErosion = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writerDilation = WriterType::New();
+  auto writerErosion = WriterType::New();
 
 
   //  Software Guide : BeginLatex
@@ -147,8 +147,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ErodeFilterType::Pointer  grayscaleErode = ErodeFilterType::New();
-  DilateFilterType::Pointer grayscaleDilate = DilateFilterType::New();
+  auto grayscaleErode = ErodeFilterType::New();
+  auto grayscaleDilate = DilateFilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex

--- a/Examples/Filtering/MeanImageFilter.cxx
+++ b/Examples/Filtering/MeanImageFilter.cxx
@@ -108,8 +108,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -128,7 +128,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType = itk::MeanImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/MedianImageFilter.cxx
+++ b/Examples/Filtering/MedianImageFilter.cxx
@@ -108,8 +108,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -128,7 +128,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType = itk::MedianImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/MinMaxCurvatureFlowImageFilter.cxx
+++ b/Examples/Filtering/MinMaxCurvatureFlowImageFilter.cxx
@@ -142,11 +142,11 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType =
     itk::MinMaxCurvatureFlowImageFilter<InputImageType, OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -221,12 +221,12 @@ main(int argc, char * argv[])
   using WriteImageType = itk::Image<WritePixelType, 2>;
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
   // Software Guide : BeginCodeSnippet

--- a/Examples/Filtering/MorphologicalImageEnhancement.cxx
+++ b/Examples/Filtering/MorphologicalImageEnhancement.cxx
@@ -99,9 +99,9 @@ main(int argc, char * argv[])
   structuringElement.CreateStructuringElement();
 
   // Setup the input and output files
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
   // reading input image
@@ -118,31 +118,30 @@ main(int argc, char * argv[])
   }
 
   // Create the opening closing filters
-  OpeningFilterType::Pointer opening = OpeningFilterType::New();
-  ClosingFilterType::Pointer closing = ClosingFilterType::New();
+  auto opening = OpeningFilterType::New();
+  auto closing = ClosingFilterType::New();
   // Setup the opening and closing methods
   opening->SetKernel(structuringElement);
   closing->SetKernel(structuringElement);
   // Setup minnimum and maximum of rescale filter
-  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  auto rescaleFilter = RescaleFilterType::New();
   rescaleFilter->SetOutputMinimum(0);
   rescaleFilter->SetOutputMaximum(255);
   // creation of the pipeline. The enhancement operation is given by:
   // Original Image + Top Hat Image - Bottom Hat Image
   opening->SetInput(reader->GetOutput());
   closing->SetInput(reader->GetOutput());
-  SubtractionFilterType::Pointer topHat = SubtractionFilterType::New();
+  auto topHat = SubtractionFilterType::New();
   topHat->SetInput1(reader->GetOutput());
   topHat->SetInput2(opening->GetOutput());
-  SubtractionFilterType::Pointer bottomHat = SubtractionFilterType::New();
+  auto bottomHat = SubtractionFilterType::New();
   bottomHat->SetInput1(closing->GetOutput());
   bottomHat->SetInput2(reader->GetOutput());
-  AdditionFilterType::Pointer internalAddition = AdditionFilterType::New();
+  auto internalAddition = AdditionFilterType::New();
   internalAddition->SetInput1(reader->GetOutput());
   internalAddition->SetInput2(topHat->GetOutput());
 
-  SubtractionFilterType::Pointer imageEnhancement =
-    SubtractionFilterType::New();
+  auto imageEnhancement = SubtractionFilterType::New();
   imageEnhancement->SetInput1(internalAddition->GetOutput());
   imageEnhancement->SetInput2(bottomHat->GetOutput());
   rescaleFilter->SetInput(imageEnhancement->GetOutput());

--- a/Examples/Filtering/OtsuMultipleThresholdImageFilter.cxx
+++ b/Examples/Filtering/OtsuMultipleThresholdImageFilter.cxx
@@ -107,12 +107,12 @@ main(int argc, char * argv[])
     scalarImageToHistogramGenerator =
       ScalarImageToHistogramGeneratorType::New();
 
-  CalculatorType::Pointer calculator = CalculatorType::New();
-  FilterType::Pointer     filter = FilterType::New();
+  auto calculator = CalculatorType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   // Software Guide : BeginLatex
   //

--- a/Examples/Filtering/OtsuThresholdImageFilter.cxx
+++ b/Examples/Filtering/OtsuThresholdImageFilter.cxx
@@ -123,11 +123,11 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  FilterType::Pointer filter = FilterType::New();
+  auto reader = ReaderType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   reader->SetFileName(argv[1]);
 

--- a/Examples/Filtering/RGBCurvatureAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/RGBCurvatureAnisotropicDiffusionImageFilter.cxx
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::VectorCurvatureAnisotropicDiffusionImageFilter<InputImageType,
                                                         InputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -131,7 +131,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<InputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   filter->SetInput(reader->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -179,7 +179,7 @@ main(int argc, char * argv[])
   using WritePixelType = itk::RGBPixel<unsigned char>;
   using WriteImageType = itk::Image<WritePixelType, 2>;
   using CasterType = itk::CastImageFilter<InputImageType, WriteImageType>;
-  CasterType::Pointer caster = CasterType::New();
+  auto caster = CasterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -191,7 +191,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   caster->SetInput(filter->GetOutput());
   writer->SetInput(caster->GetOutput());
   writer->SetFileName(argv[2]);

--- a/Examples/Filtering/RGBGradientAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/RGBGradientAnisotropicDiffusionImageFilter.cxx
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::VectorGradientAnisotropicDiffusionImageFilter<InputImageType,
                                                        InputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -131,7 +131,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<InputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   filter->SetInput(reader->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -179,7 +179,7 @@ main(int argc, char * argv[])
   using WritePixelType = itk::RGBPixel<unsigned char>;
   using WriteImageType = itk::Image<WritePixelType, 2>;
   using CasterType = itk::CastImageFilter<InputImageType, WriteImageType>;
-  CasterType::Pointer caster = CasterType::New();
+  auto caster = CasterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -193,7 +193,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   caster->SetInput(filter->GetOutput());
   writer->SetInput(caster->GetOutput());
   writer->SetFileName(argv[2]);

--- a/Examples/Filtering/RGBToGrayscale.cxx
+++ b/Examples/Filtering/RGBToGrayscale.cxx
@@ -66,7 +66,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<InputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -74,14 +74,14 @@ main(int argc, char * argv[])
   using FilterType =
     itk::RGBToLuminanceImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   filter->SetInput(reader->GetOutput());
 
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetInput(filter->GetOutput());
 

--- a/Examples/Filtering/ResampleImageFilter.cxx
+++ b/Examples/Filtering/ResampleImageFilter.cxx
@@ -130,8 +130,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -151,7 +151,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType =
     itk::ResampleImageFilter<InputImageType, OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -182,7 +182,7 @@ main(int argc, char * argv[])
 
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   filter->SetTransform(transform);
   // Software Guide : EndCodeSnippet
 
@@ -213,7 +213,7 @@ main(int argc, char * argv[])
 
 
   // Software Guide : BeginCodeSnippet
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
   filter->SetInterpolator(interpolator);
   // Software Guide : EndCodeSnippet
 

--- a/Examples/Filtering/ResampleImageFilter2.cxx
+++ b/Examples/Filtering/ResampleImageFilter2.cxx
@@ -86,8 +86,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -96,13 +96,13 @@ main(int argc, char * argv[])
   using FilterType =
     itk::ResampleImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   using TransformType = itk::AffineTransform<double, Dimension>;
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   using InterpolatorType =
     itk::NearestNeighborInterpolateImageFunction<InputImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
   filter->SetInterpolator(interpolator);
 
 

--- a/Examples/Filtering/ResampleImageFilter3.cxx
+++ b/Examples/Filtering/ResampleImageFilter3.cxx
@@ -111,21 +111,21 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
 
   using FilterType =
     itk::ResampleImageFilter<InputImageType, OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   using TransformType = itk::AffineTransform<double, Dimension>;
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   using InterpolatorType =
     itk::NearestNeighborInterpolateImageFunction<InputImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
   filter->SetInterpolator(interpolator);
 
 

--- a/Examples/Filtering/ResampleImageFilter4.cxx
+++ b/Examples/Filtering/ResampleImageFilter4.cxx
@@ -70,8 +70,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -81,7 +81,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::ResampleImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
   //  Software Guide : BeginLatex
@@ -98,13 +98,13 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::AffineTransform<double, Dimension>;
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
 
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<InputImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   filter->SetInterpolator(interpolator);
 

--- a/Examples/Filtering/ResampleImageFilter5.cxx
+++ b/Examples/Filtering/ResampleImageFilter5.cxx
@@ -68,8 +68,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -80,7 +80,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::ResampleImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
   //  Software Guide : BeginLatex
@@ -108,13 +108,13 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
 
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<InputImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   filter->SetInterpolator(interpolator);
 

--- a/Examples/Filtering/ResampleImageFilter6.cxx
+++ b/Examples/Filtering/ResampleImageFilter6.cxx
@@ -44,8 +44,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -53,17 +53,17 @@ main(int argc, char * argv[])
 
   using FilterType = itk::ResampleImageFilter<ImageType, ImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<ImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   filter->SetInterpolator(interpolator);
 
 
   using TransformType = itk::IdentityTransform<double, Dimension>;
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   filter->SetTransform(transform);
 

--- a/Examples/Filtering/ResampleImageFilter7.cxx
+++ b/Examples/Filtering/ResampleImageFilter7.cxx
@@ -66,8 +66,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -86,11 +86,11 @@ main(int argc, char * argv[])
   using FilterType =
     itk::ResampleImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   using TransformType = itk::AffineTransform<double, Dimension>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   filter->SetTransform(transform);
   // Software Guide : EndCodeSnippet
@@ -106,7 +106,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using InterpolatorType =
     itk::BSplineInterpolateImageFunction<InputImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   filter->SetInterpolator(interpolator);
 

--- a/Examples/Filtering/ResampleImageFilter8.cxx
+++ b/Examples/Filtering/ResampleImageFilter8.cxx
@@ -73,8 +73,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -93,11 +93,11 @@ main(int argc, char * argv[])
   using FilterType =
     itk::ResampleImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   using TransformType = itk::AffineTransform<double, Dimension>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   filter->SetTransform(transform);
   // Software Guide : EndCodeSnippet
@@ -143,7 +143,7 @@ main(int argc, char * argv[])
                                               BoundaryConditionType,
                                               double>;
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   filter->SetInterpolator(interpolator);
 

--- a/Examples/Filtering/ResampleImageFilter9.cxx
+++ b/Examples/Filtering/ResampleImageFilter9.cxx
@@ -63,10 +63,9 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writerNearest =
-    WriterType::New(); // writer for nearest neighbor
-  WriterType::Pointer writerLinear = WriterType::New(); // writer for linear
+  auto reader = ReaderType::New();
+  auto writerNearest = WriterType::New(); // writer for nearest neighbor
+  auto writerLinear = WriterType::New();  // writer for linear
 
   reader->SetFileName(argv[1]);
   writerNearest->SetFileName(argv[2]);
@@ -74,25 +73,23 @@ main(int argc, char * argv[])
 
   using FilterType = itk::ResampleImageFilter<ImageType, ImageType>;
 
-  FilterType::Pointer nearestFilter = FilterType::New();
-  FilterType::Pointer linearFilter = FilterType::New();
+  auto nearestFilter = FilterType::New();
+  auto linearFilter = FilterType::New();
 
   // Interpolators
   using NearestInterpolatorType =
     itk::NearestNeighborInterpolateImageFunction<ImageType, double>;
-  NearestInterpolatorType::Pointer interpolatorNearest =
-    NearestInterpolatorType::New();
+  auto interpolatorNearest = NearestInterpolatorType::New();
 
   using LinearInterpolatorType =
     itk::LinearInterpolateImageFunction<ImageType, double>;
-  LinearInterpolatorType::Pointer interpolatorLinear =
-    LinearInterpolatorType::New();
+  auto interpolatorLinear = LinearInterpolatorType::New();
 
   nearestFilter->SetInterpolator(interpolatorNearest);
   linearFilter->SetInterpolator(interpolatorLinear);
 
   using TransformType = itk::IdentityTransform<double, Dimension>;
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   nearestFilter->SetTransform(transform);
   linearFilter->SetTransform(transform);

--- a/Examples/Filtering/ResampleOrientedImageFilter.cxx
+++ b/Examples/Filtering/ResampleOrientedImageFilter.cxx
@@ -43,8 +43,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -52,7 +52,7 @@ main(int argc, char * argv[])
 
   using FilterType =
     itk::ResampleImageFilter<InputImageType, OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   filter->SetDefaultPixelValue(0);
 

--- a/Examples/Filtering/ResampleVolumesToBeIsotropic.cxx
+++ b/Examples/Filtering/ResampleVolumesToBeIsotropic.cxx
@@ -193,7 +193,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<InputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -210,8 +210,7 @@ main(int argc, char * argv[])
   using IntensityFilterType =
     itk::IntensityWindowingImageFilter<InputImageType, InternalImageType>;
 
-  IntensityFilterType::Pointer intensityWindowing =
-    IntensityFilterType::New();
+  auto intensityWindowing = IntensityFilterType::New();
 
   intensityWindowing->SetWindowMinimum(std::stoi(argv[3]));
   intensityWindowing->SetWindowMaximum(std::stoi(argv[4]));
@@ -248,8 +247,8 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  GaussianFilterType::Pointer smootherX = GaussianFilterType::New();
-  GaussianFilterType::Pointer smootherY = GaussianFilterType::New();
+  auto smootherX = GaussianFilterType::New();
+  auto smootherY = GaussianFilterType::New();
 
   smootherX->SetInput(intensityWindowing->GetOutput());
   smootherY->SetInput(smootherX->GetOutput());
@@ -332,7 +331,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<InternalImageType, OutputImageType>;
 
-  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  auto resampler = ResampleFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -346,7 +345,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::IdentityTransform<double, Dimension>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   transform->SetIdentity();
 
   resampler->SetTransform(transform);
@@ -364,7 +363,7 @@ main(int argc, char * argv[])
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<InternalImageType, double>;
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   resampler->SetInterpolator(interpolator);
   // Software Guide : EndCodeSnippet
@@ -477,7 +476,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[2]);
   writer->SetInput(resampler->GetOutput());

--- a/Examples/Filtering/ScaleSpaceGenerator2D.cxx
+++ b/Examples/Filtering/ScaleSpaceGenerator2D.cxx
@@ -58,10 +58,10 @@ main(int argc, char * argv[])
                                                OutputImageType>;
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
-  FilterType::Pointer laplacian = FilterType::New();
+  auto laplacian = FilterType::New();
 
   laplacian->SetNormalizeAcrossScale(true);
 
@@ -70,7 +70,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetInput(laplacian->GetOutput());
 

--- a/Examples/Filtering/SecondDerivativeRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/SecondDerivativeRecursiveGaussianImageFilter.cxx
@@ -96,10 +96,10 @@ main(int argc, char * argv[])
 
   using FilterType = itk::RecursiveGaussianImageFilter<ImageType, ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
-  DuplicatorType::Pointer duplicator = DuplicatorType::New();
+  auto duplicator = DuplicatorType::New();
   // Software Guide : EndCodeSnippet
 
   reader->SetFileName(argv[1]);
@@ -130,9 +130,9 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  FilterType::Pointer ga = FilterType::New();
-  FilterType::Pointer gb = FilterType::New();
-  FilterType::Pointer gc = FilterType::New();
+  auto ga = FilterType::New();
+  auto gb = FilterType::New();
+  auto gc = FilterType::New();
 
   ga->SetDirection(0);
   gb->SetDirection(1);

--- a/Examples/Filtering/SigmoidImageFilter.cxx
+++ b/Examples/Filtering/SigmoidImageFilter.cxx
@@ -110,8 +110,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -131,7 +131,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using SigmoidFilterType =
     itk::SigmoidImageFilter<InputImageType, OutputImageType>;
-  SigmoidFilterType::Pointer sigmoidFilter = SigmoidFilterType::New();
+  auto sigmoidFilter = SigmoidFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/SignedDanielssonDistanceMapImageFilter.cxx
+++ b/Examples/Filtering/SignedDanielssonDistanceMapImageFilter.cxx
@@ -90,14 +90,14 @@ main(int argc, char * argv[])
                                                 OutputImageType,
                                                 VoronoiImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
   using RescalerType =
     itk::RescaleIntensityImageFilter<OutputImageType, OutputImageType>;
 
-  RescalerType::Pointer scaler = RescalerType::New();
+  auto scaler = RescalerType::New();
 
   // Software Guide : BeginLatex
   //
@@ -113,8 +113,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
   using VoronoiWriterType = itk::ImageFileWriter<VoronoiImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -149,7 +149,7 @@ main(int argc, char * argv[])
   //
   //  \index{itk::Danielsson\-Distance\-Map\-Image\-Filter!GetVoronoiMap()}
   //
-  VoronoiWriterType::Pointer voronoiWriter = VoronoiWriterType::New();
+  auto voronoiWriter = VoronoiWriterType::New();
   voronoiWriter->SetFileName(voronoiMapFileName);
   voronoiWriter->SetInput(filter->GetVoronoiMap());
 
@@ -175,7 +175,7 @@ main(int argc, char * argv[])
   //  and creating an object of this class in the following lines.
 
   using WriterOffsetType = itk::ImageFileWriter<OffsetImageType>;
-  WriterOffsetType::Pointer offsetWriter = WriterOffsetType::New();
+  auto offsetWriter = WriterOffsetType::New();
   offsetWriter->SetInput(filter->GetVectorDistanceMap());
   offsetWriter->SetFileName(argv[4]);
 

--- a/Examples/Filtering/SmoothingRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/SmoothingRecursiveGaussianImageFilter.cxx
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -137,8 +137,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filterX = FilterType::New();
-  FilterType::Pointer filterY = FilterType::New();
+  auto filterX = FilterType::New();
+  auto filterY = FilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -278,12 +278,12 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
 
   rescaler->SetInput(filterY->GetOutput());

--- a/Examples/Filtering/SmoothingRecursiveGaussianImageFilter2.cxx
+++ b/Examples/Filtering/SmoothingRecursiveGaussianImageFilter2.cxx
@@ -104,7 +104,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -120,7 +120,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -189,12 +189,12 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   rescaler->SetInput(filter->GetOutput());
   writer->SetInput(rescaler->GetOutput());

--- a/Examples/Filtering/SpatialObjectToImage1.cxx
+++ b/Examples/Filtering/SpatialObjectToImage1.cxx
@@ -130,8 +130,7 @@ main(int argc, char * argv[])
   using SpatialObjectToImageFilterType =
     itk::SpatialObjectToImageFilter<GroupType, ImageType>;
 
-  SpatialObjectToImageFilterType::Pointer imageFilter =
-    SpatialObjectToImageFilterType::New();
+  auto imageFilter = SpatialObjectToImageFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -170,9 +169,9 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  EllipseType::Pointer ellipse = EllipseType::New();
-  TubeType::Pointer    tube1 = TubeType::New();
-  TubeType::Pointer    tube2 = TubeType::New();
+  auto ellipse = EllipseType::New();
+  auto tube1 = TubeType::New();
+  auto tube2 = TubeType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -235,9 +234,9 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using TransformType = GroupType::TransformType;
 
-  TransformType::Pointer transform1 = TransformType::New();
-  TransformType::Pointer transform2 = TransformType::New();
-  TransformType::Pointer transform3 = TransformType::New();
+  auto transform1 = TransformType::New();
+  auto transform2 = TransformType::New();
+  auto transform3 = TransformType::New();
 
   transform1->SetIdentity();
   transform2->SetIdentity();
@@ -284,7 +283,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  GroupType::Pointer group = GroupType::New();
+  auto group = GroupType::New();
   group->AddChild(ellipse);
   group->AddChild(tube1);
   group->AddChild(tube2);
@@ -339,7 +338,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[1]);
   writer->SetInput(imageFilter->GetOutput());

--- a/Examples/Filtering/SpatialObjectToImage2.cxx
+++ b/Examples/Filtering/SpatialObjectToImage2.cxx
@@ -127,8 +127,7 @@ main(int argc, char * argv[])
   using SpatialObjectToImageFilterType =
     itk::SpatialObjectToImageFilter<GroupType, ImageType>;
 
-  SpatialObjectToImageFilterType::Pointer imageFilter =
-    SpatialObjectToImageFilterType::New();
+  auto imageFilter = SpatialObjectToImageFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -167,9 +166,9 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MetaBallType::Pointer metaBall1 = MetaBallType::New();
-  MetaBallType::Pointer metaBall2 = MetaBallType::New();
-  MetaBallType::Pointer metaBall3 = MetaBallType::New();
+  auto metaBall1 = MetaBallType::New();
+  auto metaBall2 = MetaBallType::New();
+  auto metaBall3 = MetaBallType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -202,9 +201,9 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using TransformType = GroupType::TransformType;
 
-  TransformType::Pointer transform1 = TransformType::New();
-  TransformType::Pointer transform2 = TransformType::New();
-  TransformType::Pointer transform3 = TransformType::New();
+  auto transform1 = TransformType::New();
+  auto transform2 = TransformType::New();
+  auto transform3 = TransformType::New();
 
   transform1->SetIdentity();
   transform2->SetIdentity();
@@ -250,7 +249,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  GroupType::Pointer group = GroupType::New();
+  auto group = GroupType::New();
   group->AddChild(metaBall1);
   group->AddChild(metaBall2);
   group->AddChild(metaBall3);
@@ -292,7 +291,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[1]);
   writer->SetInput(imageFilter->GetOutput());

--- a/Examples/Filtering/SpatialObjectToImage3.cxx
+++ b/Examples/Filtering/SpatialObjectToImage3.cxx
@@ -92,8 +92,7 @@ main(int argc, char * argv[])
   using SpatialObjectToImageFilterType =
     itk::SpatialObjectToImageFilter<PolygonType, ImageType>;
 
-  SpatialObjectToImageFilterType::Pointer imageFilter =
-    SpatialObjectToImageFilterType::New();
+  auto imageFilter = SpatialObjectToImageFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -131,7 +130,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  PolygonType::Pointer polygon = PolygonType::New();
+  auto polygon = PolygonType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -198,7 +197,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[1]);
   writer->SetInput(imageFilter->GetOutput());

--- a/Examples/Filtering/SubsampleVolume.cxx
+++ b/Examples/Filtering/SubsampleVolume.cxx
@@ -89,7 +89,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<InputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -133,7 +133,7 @@ main(int argc, char * argv[])
   using CastFilterType =
     itk::CastImageFilter<InputImageType, InternalImageType>;
 
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto caster = CastFilterType::New();
 
   caster->SetInput(inputImage);
   // Software Guide : EndCodeSnippet
@@ -152,9 +152,9 @@ main(int argc, char * argv[])
   using GaussianFilterType =
     itk::RecursiveGaussianImageFilter<InternalImageType, InternalImageType>;
 
-  GaussianFilterType::Pointer smootherX = GaussianFilterType::New();
-  GaussianFilterType::Pointer smootherY = GaussianFilterType::New();
-  GaussianFilterType::Pointer smootherZ = GaussianFilterType::New();
+  auto smootherX = GaussianFilterType::New();
+  auto smootherY = GaussianFilterType::New();
+  auto smootherZ = GaussianFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -223,7 +223,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<InternalImageType, OutputImageType>;
 
-  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  auto resampler = ResampleFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -238,7 +238,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::IdentityTransform<double, Dimension>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   transform->SetIdentity();
   resampler->SetTransform(transform);
   // Software Guide : EndCodeSnippet
@@ -257,7 +257,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<InternalImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
   resampler->SetInterpolator(interpolator);
   // Software Guide : EndCodeSnippet
 
@@ -343,7 +343,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetInput(resampler->GetOutput());
 

--- a/Examples/Filtering/SurfaceExtraction.cxx
+++ b/Examples/Filtering/SurfaceExtraction.cxx
@@ -99,7 +99,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   // Software Guide : EndCodeSnippet
 
@@ -144,7 +144,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using MeshSourceType = itk::BinaryMask3DMeshSource<ImageType, MeshType>;
 
-  MeshSourceType::Pointer meshSource = MeshSourceType::New();
+  auto meshSource = MeshSourceType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/ThresholdImageFilter.cxx
+++ b/Examples/Filtering/ThresholdImageFilter.cxx
@@ -182,11 +182,11 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  FilterType::Pointer filter = FilterType::New();
+  auto reader = ReaderType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   reader->SetFileName(argv[1]);
 

--- a/Examples/Filtering/VectorCurvatureAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/VectorCurvatureAnisotropicDiffusionImageFilter.cxx
@@ -89,7 +89,7 @@ main(int argc, char * argv[])
 
 
   using ReaderType = itk::ImageFileReader<InputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -109,7 +109,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::VectorCurvatureAnisotropicDiffusionImageFilter<VectorImageType,
                                                         VectorImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -117,7 +117,7 @@ main(int argc, char * argv[])
     itk::GradientRecursiveGaussianImageFilter<InputImageType,
                                               VectorImageType>;
 
-  GradientFilterType::Pointer gradient = GradientFilterType::New();
+  auto gradient = GradientFilterType::New();
 
 
   //  Software Guide : BeginLatex
@@ -182,7 +182,7 @@ main(int argc, char * argv[])
   using ComponentFilterType =
     itk::VectorIndexSelectionCastImageFilter<VectorImageType,
                                              OutputImageType>;
-  ComponentFilterType::Pointer component = ComponentFilterType::New();
+  auto component = ComponentFilterType::New();
 
   // Select the component to extract.
   component->SetIndex(0);
@@ -191,12 +191,12 @@ main(int argc, char * argv[])
   using WriteImageType = itk::Image<WritePixelType, 2>;
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   rescaler->SetInput(component->GetOutput());
   writer->SetInput(rescaler->GetOutput());
 

--- a/Examples/Filtering/VectorGradientAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/VectorGradientAnisotropicDiffusionImageFilter.cxx
@@ -88,7 +88,7 @@ main(int argc, char * argv[])
 
 
   using ReaderType = itk::ImageFileReader<InputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
 
@@ -108,14 +108,14 @@ main(int argc, char * argv[])
   using FilterType =
     itk::VectorGradientAnisotropicDiffusionImageFilter<VectorImageType,
                                                        VectorImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
   using GradientFilterType =
     itk::GradientRecursiveGaussianImageFilter<InputImageType,
                                               VectorImageType>;
-  GradientFilterType::Pointer gradient = GradientFilterType::New();
+  auto gradient = GradientFilterType::New();
 
 
   //  Software Guide : BeginLatex
@@ -180,7 +180,7 @@ main(int argc, char * argv[])
   using ComponentFilterType =
     itk::VectorIndexSelectionCastImageFilter<VectorImageType,
                                              OutputImageType>;
-  ComponentFilterType::Pointer component = ComponentFilterType::New();
+  auto component = ComponentFilterType::New();
 
   // Select the component to extract.
   component->SetIndex(0);
@@ -189,12 +189,12 @@ main(int argc, char * argv[])
   using WriteImageType = itk::Image<WritePixelType, 2>;
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<WriteImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   rescaler->SetInput(component->GetOutput());
   writer->SetInput(rescaler->GetOutput());
 

--- a/Examples/Filtering/VectorIndexSelection.cxx
+++ b/Examples/Filtering/VectorIndexSelection.cxx
@@ -60,7 +60,7 @@ main(int argc, char * argv[])
 
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   filter->SetIndex(std::stoi(argv[3]));
   // Software Guide : EndCodeSnippet
 
@@ -77,8 +77,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   filter->SetInput(reader->GetOutput());
   writer->SetInput(filter->GetOutput());

--- a/Examples/Filtering/VesselnessMeasureImageFilter.cxx
+++ b/Examples/Filtering/VesselnessMeasureImageFilter.cxx
@@ -49,12 +49,11 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  HessianFilterType::Pointer hessianFilter = HessianFilterType::New();
-  VesselnessMeasureFilterType::Pointer vesselnessFilter =
-    VesselnessMeasureFilterType::New();
+  auto hessianFilter = HessianFilterType::New();
+  auto vesselnessFilter = VesselnessMeasureFilterType::New();
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   hessianFilter->SetInput(reader->GetOutput());

--- a/Examples/Filtering/VotingBinaryHoleFillingImageFilter.cxx
+++ b/Examples/Filtering/VotingBinaryHoleFillingImageFilter.cxx
@@ -95,8 +95,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -116,7 +116,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::VotingBinaryHoleFillingImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/VotingBinaryIterativeHoleFillingImageFilter.cxx
+++ b/Examples/Filtering/VotingBinaryIterativeHoleFillingImageFilter.cxx
@@ -98,8 +98,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -119,7 +119,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::VotingBinaryIterativeHoleFillingImageFilter<ImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Filtering/WarpImageFilter1.cxx
+++ b/Examples/Filtering/WarpImageFilter1.cxx
@@ -86,14 +86,14 @@ main(int argc, char * argv[])
   using FieldReaderType = itk::ImageFileReader<DisplacementFieldType>;
   // Software Guide : EndCodeSnippet
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[3]);
 
   // Software Guide : BeginCodeSnippet
-  FieldReaderType::Pointer fieldReader = FieldReaderType::New();
+  auto fieldReader = FieldReaderType::New();
   fieldReader->SetFileName(argv[2]);
   fieldReader->Update();
 
@@ -112,7 +112,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::WarpImageFilter<ImageType, ImageType, DisplacementFieldType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -129,7 +129,7 @@ main(int argc, char * argv[])
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<ImageType, double>;
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   filter->SetInterpolator(interpolator);
   // Software Guide : EndCodeSnippet

--- a/Examples/Filtering/ZeroCrossingBasedEdgeDetectionImageFilter.cxx
+++ b/Examples/Filtering/ZeroCrossingBasedEdgeDetectionImageFilter.cxx
@@ -81,10 +81,10 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<OutputImageType, CharImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -92,7 +92,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::ZeroCrossingBasedEdgeDetectionImageFilter<InputImageType,
                                                    OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
   //  Software Guide : BeginLatex

--- a/Examples/IO/ComplexImageReadWrite.cxx
+++ b/Examples/IO/ComplexImageReadWrite.cxx
@@ -84,8 +84,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/CovariantVectorImageExtractComponent.cxx
+++ b/Examples/IO/CovariantVectorImageExtractComponent.cxx
@@ -112,7 +112,7 @@ main(int argc, char ** argv)
     itk::VectorIndexSelectionCastImageFilter<InputImageType,
                                              ComponentImageType>;
 
-  FilterType::Pointer componentExtractor = FilterType::New();
+  auto componentExtractor = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -159,7 +159,7 @@ main(int argc, char ** argv)
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<ComponentImageType, OutputImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   //  Software Guide : EndCodeSnippet
 
 
@@ -195,8 +195,8 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -264,7 +264,7 @@ main(int argc, char ** argv)
   // file
   //
   using ComponentWriterType = itk::ImageFileWriter<ComponentImageType>;
-  ComponentWriterType::Pointer componentWriter = ComponentWriterType::New();
+  auto componentWriter = ComponentWriterType::New();
   componentWriter->SetInput(componentExtractor->GetOutput());
   componentWriter->SetFileName(argv[2]);
   componentWriter->Update();

--- a/Examples/IO/CovariantVectorImageRead.cxx
+++ b/Examples/IO/CovariantVectorImageRead.cxx
@@ -120,7 +120,7 @@ main(int argc, char ** argv)
   using FilterType =
     itk::VectorMagnitudeImageFilter<InputImageType, MagnitudeImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -138,7 +138,7 @@ main(int argc, char ** argv)
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<MagnitudeImageType, OutputImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
   //  Software Guide : EndCodeSnippet
 
 
@@ -174,8 +174,8 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/CovariantVectorImageWrite.cxx
+++ b/Examples/IO/CovariantVectorImageWrite.cxx
@@ -118,7 +118,7 @@ main(int argc, char ** argv)
     itk::GradientRecursiveGaussianImageFilter<InputImageType,
                                               OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -149,8 +149,8 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/DicomImageReadChangeHeaderWrite.cxx
+++ b/Examples/IO/DicomImageReadChangeHeaderWrite.cxx
@@ -92,7 +92,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<InputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   // Software Guide : EndCodeSnippet
 
@@ -106,7 +106,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ImageIOType = itk::GDCMImageIO;
-  ImageIOType::Pointer gdcmImageIO = ImageIOType::New();
+  auto gdcmImageIO = ImageIOType::New();
   reader->SetImageIO(gdcmImageIO);
   // Software Guide : EndCodeSnippet
 
@@ -184,7 +184,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using Writer1Type = itk::ImageFileWriter<InputImageType>;
 
-  Writer1Type::Pointer writer1 = Writer1Type::New();
+  auto writer1 = Writer1Type::New();
 
   writer1->SetInput(reader->GetOutput());
   writer1->SetFileName(argv[2]);

--- a/Examples/IO/DicomImageReadPrintTags.cxx
+++ b/Examples/IO/DicomImageReadPrintTags.cxx
@@ -100,7 +100,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -112,7 +112,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ImageIOType = itk::GDCMImageIO;
-  ImageIOType::Pointer dicomIO = ImageIOType::New();
+  auto dicomIO = ImageIOType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/IO/DicomImageReadWrite.cxx
+++ b/Examples/IO/DicomImageReadWrite.cxx
@@ -79,7 +79,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<InputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   // Software Guide : EndCodeSnippet
 
@@ -94,7 +94,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ImageIOType = itk::GDCMImageIO;
 
-  ImageIOType::Pointer gdcmImageIO = ImageIOType::New();
+  auto gdcmImageIO = ImageIOType::New();
 
   reader->SetImageIO(gdcmImageIO);
   // Software Guide : EndCodeSnippet
@@ -142,7 +142,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using Writer1Type = itk::ImageFileWriter<InputImageType>;
 
-  Writer1Type::Pointer writer1 = Writer1Type::New();
+  auto writer1 = Writer1Type::New();
 
   writer1->SetFileName(argv[2]);
   writer1->SetInput(reader->GetOutput());
@@ -200,7 +200,7 @@ main(int argc, char * argv[])
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<InputImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
@@ -219,7 +219,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using Writer2Type = itk::ImageFileWriter<WriteImageType>;
 
-  Writer2Type::Pointer writer2 = Writer2Type::New();
+  auto writer2 = Writer2Type::New();
 
   writer2->SetFileName(argv[3]);
 
@@ -257,7 +257,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using Writer3Type = itk::ImageFileWriter<WriteImageType>;
 
-  Writer3Type::Pointer writer3 = Writer3Type::New();
+  auto writer3 = Writer3Type::New();
 
   writer3->SetFileName(argv[4]);
   writer3->SetInput(rescaler->GetOutput());

--- a/Examples/IO/DicomPrintPatientInformation.cxx
+++ b/Examples/IO/DicomPrintPatientInformation.cxx
@@ -56,7 +56,7 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<PixelType, Dimension>;
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   itk::GDCMImageIO::Pointer dicomIO = itk::GDCMImageIO::New();
 

--- a/Examples/IO/DicomSeriesReadGaussianImageWrite.cxx
+++ b/Examples/IO/DicomSeriesReadGaussianImageWrite.cxx
@@ -42,17 +42,17 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<PixelType, Dimension>;
 
   using ReaderType = itk::ImageSeriesReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
 
   using ImageIOType = itk::GDCMImageIO;
-  ImageIOType::Pointer dicomIO = ImageIOType::New();
+  auto dicomIO = ImageIOType::New();
 
   reader->SetImageIO(dicomIO);
 
 
   using NamesGeneratorType = itk::GDCMSeriesFileNames;
-  NamesGeneratorType::Pointer nameGenerator = NamesGeneratorType::New();
+  auto nameGenerator = NamesGeneratorType::New();
 
   nameGenerator->SetUseSeriesDetails(true);
   nameGenerator->AddSeriesRestriction("0008|0021");
@@ -122,7 +122,7 @@ main(int argc, char * argv[])
     using FilterType =
       itk::SmoothingRecursiveGaussianImageFilter<ImageType, ImageType>;
 
-    FilterType::Pointer filter = FilterType::New();
+    auto filter = FilterType::New();
 
     filter->SetInput(reader->GetOutput());
 
@@ -130,7 +130,7 @@ main(int argc, char * argv[])
     filter->SetSigma(sigma);
 
     using WriterType = itk::ImageFileWriter<ImageType>;
-    WriterType::Pointer writer = WriterType::New();
+    auto writer = WriterType::New();
 
     writer->SetFileName(argv[2]);
 

--- a/Examples/IO/DicomSeriesReadImageWrite.cxx
+++ b/Examples/IO/DicomSeriesReadImageWrite.cxx
@@ -119,7 +119,7 @@ main(int argc, char * argv[])
     }
     std::cout << std::endl << std::endl;
 
-    ReaderType::Pointer reader = ReaderType::New();
+    auto reader = ReaderType::New();
     reader->SetFileNames(fileNames);
     reader->SetImageIO(dicomIO);
 
@@ -134,7 +134,7 @@ main(int argc, char * argv[])
     }
 
     using WriterType = itk::ImageFileWriter<ImageType>;
-    WriterType::Pointer writer = WriterType::New();
+    auto writer = WriterType::New();
 
     std::cout << "Writing the image as " << std::endl << std::endl;
     std::cout << argv[2] << std::endl << std::endl;

--- a/Examples/IO/DicomSeriesReadImageWrite2.cxx
+++ b/Examples/IO/DicomSeriesReadImageWrite2.cxx
@@ -91,7 +91,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageSeriesReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -103,7 +103,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ImageIOType = itk::GDCMImageIO;
-  ImageIOType::Pointer dicomIO = ImageIOType::New();
+  auto dicomIO = ImageIOType::New();
 
   reader->SetImageIO(dicomIO);
   // Software Guide : EndCodeSnippet
@@ -154,7 +154,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using NamesGeneratorType = itk::GDCMSeriesFileNames;
-  NamesGeneratorType::Pointer nameGenerator = NamesGeneratorType::New();
+  auto nameGenerator = NamesGeneratorType::New();
 
   nameGenerator->SetUseSeriesDetails(true);
   nameGenerator->AddSeriesRestriction("0008|0021");
@@ -298,7 +298,7 @@ main(int argc, char * argv[])
 
     // Software Guide : BeginCodeSnippet
     using WriterType = itk::ImageFileWriter<ImageType>;
-    WriterType::Pointer writer = WriterType::New();
+    auto writer = WriterType::New();
 
     writer->SetFileName(argv[2]);
 

--- a/Examples/IO/DicomSeriesReadPrintTags.cxx
+++ b/Examples/IO/DicomSeriesReadPrintTags.cxx
@@ -73,7 +73,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageSeriesReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -85,7 +85,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ImageIOType = itk::GDCMImageIO;
 
-  ImageIOType::Pointer dicomIO = ImageIOType::New();
+  auto dicomIO = ImageIOType::New();
 
   reader->SetImageIO(dicomIO);
   // Software Guide : EndCodeSnippet
@@ -103,7 +103,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using NamesGeneratorType = itk::GDCMSeriesFileNames;
 
-  NamesGeneratorType::Pointer nameGenerator = NamesGeneratorType::New();
+  auto nameGenerator = NamesGeneratorType::New();
 
   nameGenerator->SetInputDirectory(argv[1]);
   // Software Guide : EndCodeSnippet

--- a/Examples/IO/DicomSeriesReadSeriesWrite.cxx
+++ b/Examples/IO/DicomSeriesReadSeriesWrite.cxx
@@ -120,8 +120,8 @@ main(int argc, char * argv[])
   using ImageIOType = itk::GDCMImageIO;
   using NamesGeneratorType = itk::GDCMSeriesFileNames;
 
-  ImageIOType::Pointer        gdcmIO = ImageIOType::New();
-  NamesGeneratorType::Pointer namesGenerator = NamesGeneratorType::New();
+  auto gdcmIO = ImageIOType::New();
+  auto namesGenerator = NamesGeneratorType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -160,7 +160,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetImageIO(gdcmIO);
   reader->SetFileNames(filenames);
@@ -249,7 +249,7 @@ main(int argc, char * argv[])
   //  the writer filter.  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  SeriesWriterType::Pointer seriesWriter = SeriesWriterType::New();
+  auto seriesWriter = SeriesWriterType::New();
 
   seriesWriter->SetInput(reader->GetOutput());
   seriesWriter->SetImageIO(gdcmIO);

--- a/Examples/IO/IOPlugin.cxx
+++ b/Examples/IO/IOPlugin.cxx
@@ -104,8 +104,8 @@ main(int argc, char * argv[])
 
     using ReaderType = itk::ImageFileReader<ImageNDType>;
     using WriterType = itk::ImageFileWriter<ImageNDType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    WriterType::Pointer writer = WriterType::New();
+    auto reader = ReaderType::New();
+    auto writer = WriterType::New();
 
     try
     {

--- a/Examples/IO/ImageReadCastWrite.cxx
+++ b/Examples/IO/ImageReadCastWrite.cxx
@@ -124,7 +124,7 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   filter->SetOutputMinimum(0);
   filter->SetOutputMaximum(255);
   // Software Guide : EndCodeSnippet
@@ -142,8 +142,8 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   filter->SetInput(reader->GetOutput());
   writer->SetInput(filter->GetOutput());

--- a/Examples/IO/ImageReadDicomSeriesWrite.cxx
+++ b/Examples/IO/ImageReadDicomSeriesWrite.cxx
@@ -62,7 +62,7 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<PixelType, Dimension>;
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -80,7 +80,7 @@ main(int argc, char * argv[])
   using ImageIOType = itk::GDCMImageIO;
   using NamesGeneratorType = itk::NumericSeriesFileNames;
 
-  ImageIOType::Pointer gdcmIO = ImageIOType::New();
+  auto gdcmIO = ImageIOType::New();
 
   const char * outputDirectory = argv[2];
 
@@ -94,7 +94,7 @@ main(int argc, char * argv[])
 
   using SeriesWriterType = itk::ImageSeriesWriter<ImageType, Image2DType>;
 
-  NamesGeneratorType::Pointer namesGenerator = NamesGeneratorType::New();
+  auto namesGenerator = NamesGeneratorType::New();
 
   itk::MetaDataDictionary & dict = gdcmIO->GetMetaDataDictionary();
   std::string               tagkey, value;
@@ -109,7 +109,7 @@ main(int argc, char * argv[])
   itk::EncapsulateMetaData<std::string>(dict, tagkey, value);
 
 
-  SeriesWriterType::Pointer seriesWriter = SeriesWriterType::New();
+  auto seriesWriter = SeriesWriterType::New();
 
   seriesWriter->SetInput(reader->GetOutput());
   seriesWriter->SetImageIO(gdcmIO);

--- a/Examples/IO/ImageReadExportVTK.cxx
+++ b/Examples/IO/ImageReadExportVTK.cxx
@@ -111,9 +111,9 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer  reader = ReaderType::New();
-  WriterType::Pointer  writer = WriterType::New();
-  ImageIOType::Pointer vtkIO = ImageIOType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
+  auto vtkIO = ImageIOType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/ImageReadExtractFilterInsertWrite.cxx
+++ b/Examples/IO/ImageReadExtractFilterInsertWrite.cxx
@@ -115,8 +115,8 @@ main(int argc, char ** argv)
   //
   //  Software Guide : EndLatex
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -145,7 +145,7 @@ main(int argc, char ** argv)
   // Software Guide : BeginCodeSnippet
   using ExtractFilterType =
     itk::ExtractImageFilter<InputImageType, MiddleImageType>;
-  ExtractFilterType::Pointer extractFilter = ExtractFilterType::New();
+  auto extractFilter = ExtractFilterType::New();
   extractFilter->SetDirectionCollapseToSubmatrix();
   // Software Guide : EndCodeSnippet
 
@@ -229,12 +229,12 @@ main(int argc, char ** argv)
   // Software Guide : BeginCodeSnippet
   using PasteFilterType =
     itk::PasteImageFilter<MiddleImageType, OutputImageType>;
-  PasteFilterType::Pointer pasteFilter = PasteFilterType::New();
+  auto pasteFilter = PasteFilterType::New();
   // Software Guide : EndCodeSnippet
   // Software Guide : BeginCodeSnippet
   using MedianFilterType =
     itk::MedianImageFilter<MiddleImageType, MiddleImageType>;
-  MedianFilterType::Pointer medianFilter = MedianFilterType::New();
+  auto medianFilter = MedianFilterType::New();
   // Software Guide : EndCodeSnippet
   //  Software Guide : BeginLatex
   //

--- a/Examples/IO/ImageReadExtractWrite.cxx
+++ b/Examples/IO/ImageReadExtractWrite.cxx
@@ -117,8 +117,8 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -150,7 +150,7 @@ main(int argc, char ** argv)
 
   // Software Guide : BeginCodeSnippet
   using FilterType = itk::ExtractImageFilter<InputImageType, OutputImageType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   filter->InPlaceOn();
   filter->SetDirectionCollapseToSubmatrix();
   // Software Guide : EndCodeSnippet

--- a/Examples/IO/ImageReadImageSeriesWrite.cxx
+++ b/Examples/IO/ImageReadImageSeriesWrite.cxx
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   // Software Guide : EndCodeSnippet
 
@@ -85,7 +85,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageSeriesWriter<ImageType, Image2DType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetInput(reader->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -101,7 +101,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using NameGeneratorType = itk::NumericSeriesFileNames;
 
-  NameGeneratorType::Pointer nameGenerator = NameGeneratorType::New();
+  auto nameGenerator = NameGeneratorType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex

--- a/Examples/IO/ImageReadRegionOfInterestWrite.cxx
+++ b/Examples/IO/ImageReadRegionOfInterestWrite.cxx
@@ -105,7 +105,7 @@ main(int argc, char ** argv)
   using FilterType =
     itk::RegionOfInterestImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -177,8 +177,8 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/ImageReadWrite.cxx
+++ b/Examples/IO/ImageReadWrite.cxx
@@ -126,8 +126,8 @@ main(int argc, char ** argv)
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/ImageSeriesReadWrite.cxx
+++ b/Examples/IO/ImageSeriesReadWrite.cxx
@@ -89,8 +89,8 @@ main(int argc, char ** argv)
   using ReaderType = itk::ImageSeriesReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -110,7 +110,7 @@ main(int argc, char ** argv)
   // Software Guide : BeginCodeSnippet
   using NameGeneratorType = itk::NumericSeriesFileNames;
 
-  NameGeneratorType::Pointer nameGenerator = NameGeneratorType::New();
+  auto nameGenerator = NameGeneratorType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/ImageSeriesReadWrite2.cxx
+++ b/Examples/IO/ImageSeriesReadWrite2.cxx
@@ -119,8 +119,8 @@ main(int argc, char ** argv)
   using ReaderType = itk::ImageSeriesReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -142,7 +142,7 @@ main(int argc, char ** argv)
   // Software Guide : BeginCodeSnippet
   using NameGeneratorType = itk::RegularExpressionSeriesFileNames;
 
-  NameGeneratorType::Pointer nameGenerator = NameGeneratorType::New();
+  auto nameGenerator = NameGeneratorType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/RGBImageReadWrite.cxx
+++ b/Examples/IO/RGBImageReadWrite.cxx
@@ -80,8 +80,8 @@ main(int argc, char ** argv)
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/RGBImageSeriesReadWrite.cxx
+++ b/Examples/IO/RGBImageSeriesReadWrite.cxx
@@ -86,8 +86,8 @@ main(int argc, char ** argv)
   using SeriesReaderType = itk::ImageSeriesReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  SeriesReaderType::Pointer seriesReader = SeriesReaderType::New();
-  WriterType::Pointer       writer = WriterType::New();
+  auto seriesReader = SeriesReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -107,7 +107,7 @@ main(int argc, char ** argv)
   // Software Guide : BeginCodeSnippet
   using NameGeneratorType = itk::NumericSeriesFileNames;
 
-  NameGeneratorType::Pointer nameGenerator = NameGeneratorType::New();
+  auto nameGenerator = NameGeneratorType::New();
 
   nameGenerator->SetStartIndex(first);
   nameGenerator->SetEndIndex(last);
@@ -188,7 +188,7 @@ main(int argc, char ** argv)
 
   using SeriesWriterType = itk::ImageSeriesWriter<ImageType, Image2DType>;
 
-  SeriesWriterType::Pointer seriesWriter = SeriesWriterType::New();
+  auto seriesWriter = SeriesWriterType::New();
 
   seriesWriter->SetInput(seriesReader->GetOutput());
   // Software Guide : EndCodeSnippet

--- a/Examples/IO/TransformReadWrite.cxx
+++ b/Examples/IO/TransformReadWrite.cxx
@@ -52,10 +52,10 @@ main(int argc, char * argv[])
 
   using CompositeTransformType =
     itk::CompositeTransform<ScalarType, Dimension>;
-  CompositeTransformType::Pointer composite = CompositeTransformType::New();
+  auto composite = CompositeTransformType::New();
 
   using AffineTransformType = itk::AffineTransform<ScalarType, Dimension>;
-  AffineTransformType::Pointer        affine = AffineTransformType::New();
+  auto                                affine = AffineTransformType::New();
   AffineTransformType::InputPointType cor;
   cor.Fill(12);
   affine->SetCenter(cor);
@@ -74,7 +74,7 @@ main(int argc, char * argv[])
   itk::TransformFactory<BSplineTransformType>::RegisterTransform();
   itk::TransformFactory<BSplineTransformFType>::RegisterTransform();
 
-  BSplineTransformType::Pointer bspline = BSplineTransformType::New();
+  auto bspline = BSplineTransformType::New();
 
   BSplineTransformType::OriginType origin;
   origin.Fill(100);
@@ -100,7 +100,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
   // Software Guide : BeginCodeSnippet
   using TransformWriterType = itk::TransformFileWriterTemplate<ScalarType>;
-  TransformWriterType::Pointer writer = TransformWriterType::New();
+  auto writer = TransformWriterType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -148,7 +148,7 @@ main(int argc, char * argv[])
 
   using TransformReaderType =
     itk::TransformFileReaderTemplate<ReadScalarType>;
-  TransformReaderType::Pointer reader = TransformReaderType::New();
+  auto reader = TransformReaderType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/IO/VectorImageReadWrite.cxx
+++ b/Examples/IO/VectorImageReadWrite.cxx
@@ -90,8 +90,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/IO/VisibleHumanPasteWrite.cxx
+++ b/Examples/IO/VisibleHumanPasteWrite.cxx
@@ -56,7 +56,7 @@ main(int argc, char * argv[])
   //  we begin by creating a reader for the file just written that is
   //  capable of streaming
   using ImageReaderType = itk::ImageFileReader<RGB2DImageType>;
-  ImageReaderType::Pointer reader = ImageReaderType::New();
+  auto reader = ImageReaderType::New();
   reader->SetFileName(inputImageFile);
 
   // The pipeline is continued through a gradient magnitude filter,
@@ -65,8 +65,7 @@ main(int argc, char * argv[])
   // and blue channels.
   using GradientMagnitudeImageFilter =
     itk::VectorGradientMagnitudeImageFilter<RGB2DImageType>;
-  GradientMagnitudeImageFilter::Pointer grad =
-    GradientMagnitudeImageFilter::New();
+  auto grad = GradientMagnitudeImageFilter::New();
   grad->SetInput(reader->GetOutput());
 
   grad->UseImageSpacingOn();
@@ -76,7 +75,7 @@ main(int argc, char * argv[])
 
   using ComposeRGBFilterType =
     itk::ComposeImageFilter<GradientMagnitudeOutputImageType, RGB2DImageType>;
-  ComposeRGBFilterType::Pointer composeRGB = ComposeRGBFilterType::New();
+  auto composeRGB = ComposeRGBFilterType::New();
   composeRGB->SetInput1(grad->GetOutput());
   composeRGB->SetInput2(grad->GetOutput());
   composeRGB->SetInput3(grad->GetOutput());
@@ -107,11 +106,11 @@ main(int argc, char * argv[])
   // regions
   using ToVectorImageAdaptorType =
     itk::RGBToVectorImageAdaptor<RGB2DImageType>;
-  ToVectorImageAdaptorType::Pointer adaptor = ToVectorImageAdaptorType::New();
+  auto adaptor = ToVectorImageAdaptorType::New();
   adaptor->SetImage(composeRGB->GetOutput());
 
   using ImageWriterType = itk::ImageFileWriter<ToVectorImageAdaptorType>;
-  ImageWriterType::Pointer writer = ImageWriterType::New();
+  auto writer = ImageWriterType::New();
   writer->SetFileName(outputImageFile);
   writer->SetNumberOfStreamDivisions(10);
   writer->SetIORegion(halfIO);

--- a/Examples/IO/VisibleHumanStreamReadWrite.cxx
+++ b/Examples/IO/VisibleHumanStreamReadWrite.cxx
@@ -66,7 +66,7 @@ main(int argc, char * argv[])
 
   // genderate the names of the decompressed Visible Male images
   using NameGeneratorType = itk::NumericSeriesFileNames;
-  NameGeneratorType::Pointer nameGenerator = NameGeneratorType::New();
+  auto nameGenerator = NameGeneratorType::New();
   nameGenerator->SetSeriesFormat(visibleHumanPath + "a_vm%04d.raw");
   nameGenerator->SetStartIndex(1001);
   nameGenerator->SetEndIndex(2878);
@@ -74,7 +74,7 @@ main(int argc, char * argv[])
 
   // create a ImageIO for the red channel
   using ImageIOType = itk::RawImageIO<PixelType, 2>;
-  ImageIOType::Pointer rimageio = ImageIOType::New();
+  auto rimageio = ImageIOType::New();
   rimageio->SetDimensions(0, 2048);
   rimageio->SetDimensions(1, 1216);
   rimageio->SetSpacing(0, .33);
@@ -83,7 +83,7 @@ main(int argc, char * argv[])
 
 
   // create a ImageIO for the green channel
-  ImageIOType::Pointer gimageio = ImageIOType::New();
+  auto gimageio = ImageIOType::New();
   gimageio->SetDimensions(0, 2048);
   gimageio->SetDimensions(1, 1216);
   gimageio->SetSpacing(0, .33);
@@ -92,7 +92,7 @@ main(int argc, char * argv[])
 
 
   // create a ImageIO for the blue channel
-  ImageIOType::Pointer bimageio = ImageIOType::New();
+  auto bimageio = ImageIOType::New();
   bimageio->SetDimensions(0, 2048);
   bimageio->SetDimensions(1, 1216);
   bimageio->SetSpacing(0, .33);
@@ -100,22 +100,22 @@ main(int argc, char * argv[])
   bimageio->SetHeaderSize(bimageio->GetImageSizeInPixels() * 2);
 
   using SeriesReaderType = itk::ImageSeriesReader<ImageType>;
-  SeriesReaderType::Pointer rreader = SeriesReaderType::New();
+  auto rreader = SeriesReaderType::New();
   rreader->SetFileNames(nameGenerator->GetFileNames());
   rreader->SetImageIO(rimageio);
   // the z-spacing will default to be correctly 1mm
 
-  SeriesReaderType::Pointer greader = SeriesReaderType::New();
+  auto greader = SeriesReaderType::New();
   greader->SetFileNames(nameGenerator->GetFileNames());
   greader->SetImageIO(gimageio);
 
-  SeriesReaderType::Pointer breader = SeriesReaderType::New();
+  auto breader = SeriesReaderType::New();
   breader->SetFileNames(nameGenerator->GetFileNames());
   breader->SetImageIO(bimageio);
 
   using ComposeRGBFilterType =
     itk::ComposeImageFilter<ImageType, RGB3DImageType>;
-  ComposeRGBFilterType::Pointer composeRGB = ComposeRGBFilterType::New();
+  auto composeRGB = ComposeRGBFilterType::New();
   composeRGB->SetInput1(rreader->GetOutput());
   composeRGB->SetInput2(greader->GetOutput());
   composeRGB->SetInput3(breader->GetOutput());
@@ -123,7 +123,7 @@ main(int argc, char * argv[])
   // this filter is needed if square pixels are needed
   //   const int xyShrinkFactor = 3;
   //   using ShrinkImageFilterType = itk::ShrinkImageFilter<  RGB3DImageType,
-  //   RGB3DImageType >; ShrinkImageFilterType::Pointer shrinker =
+  //   RGB3DImageType >; auto shrinker =
   //   ShrinkImageFilterType::New(); shrinker->SetInput(
   //   composeRGB->GetOutput() ); shrinker->SetShrinkFactors(  xyShrinkFactor
   //   ); shrinker->SetShrinkFactor( 2, 1 );
@@ -144,7 +144,7 @@ main(int argc, char * argv[])
   // create a 2D coronal slice from the volume
   using ExtractFilterType =
     itk::ExtractImageFilter<RGB3DImageType, RGB2DImageType>;
-  ExtractFilterType::Pointer extract = ExtractFilterType::New();
+  auto extract = ExtractFilterType::New();
   // Note on direction cosines: Because our plane is in the xz-plane,
   // the default submatrix would be invalid, so we must use the identity
   extract->SetDirectionCollapseToIdentity();
@@ -154,7 +154,7 @@ main(int argc, char * argv[])
 
 
   using ImageWriterType = itk::ImageFileWriter<RGB2DImageType>;
-  ImageWriterType::Pointer writer = ImageWriterType::New();
+  auto writer = ImageWriterType::New();
   writer->SetFileName(outputImageFile);
 
   // this line is a request for the number of regions

--- a/Examples/IO/XML/ParticleSwarmOptimizerReadWrite.cxx
+++ b/Examples/IO/XML/ParticleSwarmOptimizerReadWrite.cxx
@@ -58,14 +58,12 @@ main(int argc, char * argv[])
     {
       itk::ParticleSwarmOptimizer::Pointer optimizer;
       // read the optimizer from an XML file
-      itk::ParticleSwarmOptimizerDOMReader::Pointer reader =
-        itk::ParticleSwarmOptimizerDOMReader::New();
+      auto reader = itk::ParticleSwarmOptimizerDOMReader::New();
       reader->SetFileName(argv[1]);
       reader->Update();
       optimizer = reader->GetOutput();
       // write a DOM object to an XML file
-      itk::ParticleSwarmOptimizerDOMWriter::Pointer writer =
-        itk::ParticleSwarmOptimizerDOMWriter::New();
+      auto writer = itk::ParticleSwarmOptimizerDOMWriter::New();
       writer->SetInput(optimizer);
       writer->SetFileName(argv[2]);
       writer->Update();
@@ -73,18 +71,15 @@ main(int argc, char * argv[])
 
     // use SAX reader/writer
     {
-      itk::ParticleSwarmOptimizer::Pointer optimizer =
-        itk::ParticleSwarmOptimizer::New();
+      auto optimizer = itk::ParticleSwarmOptimizer::New();
       // read the optimizer from an XML file
-      itk::ParticleSwarmOptimizerSAXReader::Pointer reader =
-        itk::ParticleSwarmOptimizerSAXReader::New();
+      auto reader = itk::ParticleSwarmOptimizerSAXReader::New();
       reader->SetOutputObject(
         optimizer);                 // method defined in itk::XMLReader<T>
       reader->SetFilename(argv[1]); // method defined in itk::XMLReaderBase
       reader->ReadFile();
       // write a DOM object to an XML file
-      itk::ParticleSwarmOptimizerSAXWriter::Pointer writer =
-        itk::ParticleSwarmOptimizerSAXWriter::New();
+      auto writer = itk::ParticleSwarmOptimizerSAXWriter::New();
       writer->SetObject(optimizer); // method defined in itk::XMLWriterBase
       writer->SetFilename(argv[3]); // method defined in itk::XMLWriterBase
       writer->WriteFile();

--- a/Examples/Installation/HelloWorld.cxx
+++ b/Examples/Installation/HelloWorld.cxx
@@ -32,7 +32,7 @@ main()
 {
   using ImageType = itk::Image<unsigned short, 3>;
 
-  ImageType::Pointer image = ImageType::New();
+  auto image = ImageType::New();
 
   std::cout << "ITK Hello World !" << std::endl;
 

--- a/Examples/Iterators/ImageLinearIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageLinearIteratorWithIndex.cxx
@@ -142,7 +142,7 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<ImageType>;
 
   ImageType::ConstPointer inputImage;
-  ReaderType::Pointer     reader = ReaderType::New();
+  auto                    reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -164,7 +164,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ImageType::Pointer outputImage = ImageType::New();
+  auto outputImage = ImageType::New();
   outputImage->SetRegions(inputImage->GetRequestedRegion());
   outputImage->CopyInformation(inputImage);
   outputImage->Allocate();
@@ -209,7 +209,7 @@ main(int argc, char * argv[])
   }
   // Software Guide : EndCodeSnippet
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
   try

--- a/Examples/Iterators/ImageLinearIteratorWithIndex2.cxx
+++ b/Examples/Iterators/ImageLinearIteratorWithIndex2.cxx
@@ -65,7 +65,7 @@ main(int argc, char * argv[])
   using Writer3DType = itk::ImageFileWriter<Image3DType>;
   // Software Guide : EndCodeSnippet
 
-  Reader4DType::Pointer reader4D = Reader4DType::New();
+  auto reader4D = Reader4DType::New();
   reader4D->SetFileName(argv[1]);
 
   try
@@ -88,7 +88,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  Image3DType::Pointer image3D = Image3DType::New();
+  auto image3D = Image3DType::New();
   using Index3DType = Image3DType::IndexType;
   using Size3DType = Image3DType::SizeType;
   using Region3DType = Image3DType::RegionType;
@@ -199,7 +199,7 @@ main(int argc, char * argv[])
   //
   // Software Guide : EndLatex
 
-  Writer3DType::Pointer writer3D = Writer3DType::New();
+  auto writer3D = Writer3DType::New();
   writer3D->SetFileName(argv[2]);
   writer3D->SetInput(image3D);
 

--- a/Examples/Iterators/ImageRandomConstIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageRandomConstIteratorWithIndex.cxx
@@ -74,7 +74,7 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
 
   ImageType::ConstPointer inputImage;
-  ReaderType::Pointer     reader = ReaderType::New();
+  auto                    reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {

--- a/Examples/Iterators/ImageRegionIterator.cxx
+++ b/Examples/Iterators/ImageRegionIterator.cxx
@@ -130,7 +130,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -168,7 +168,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ImageType::Pointer outputImage = ImageType::New();
+  auto outputImage = ImageType::New();
   outputImage->SetRegions(outputRegion);
   const ImageType::SpacingType & spacing = reader->GetOutput()->GetSpacing();
   const ImageType::PointType & inputOrigin = reader->GetOutput()->GetOrigin();
@@ -225,7 +225,7 @@ main(int argc, char * argv[])
   //
   // Software Guide : EndLatex
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
 

--- a/Examples/Iterators/ImageRegionIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageRegionIteratorWithIndex.cxx
@@ -86,7 +86,7 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<ImageType>;
 
   ImageType::ConstPointer inputImage;
-  ReaderType::Pointer     reader = ReaderType::New();
+  auto                    reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -110,7 +110,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ImageType::Pointer outputImage = ImageType::New();
+  auto outputImage = ImageType::New();
   outputImage->SetRegions(inputImage->GetRequestedRegion());
   outputImage->CopyInformation(inputImage);
   outputImage->Allocate();
@@ -149,7 +149,7 @@ main(int argc, char * argv[])
   }
   // Software Guide : EndCodeSnippet
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
   try

--- a/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
@@ -149,7 +149,7 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<ImageType2D>;
 
   ImageType3D::ConstPointer inputImage;
-  ReaderType::Pointer       reader = ReaderType::New();
+  auto                      reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -215,7 +215,7 @@ main(int argc, char * argv[])
   region.SetSize(size);
   region.SetIndex(index);
 
-  ImageType2D::Pointer outputImage = ImageType2D::New();
+  auto outputImage = ImageType2D::New();
 
   outputImage->SetRegions(region);
   outputImage->Allocate();
@@ -286,7 +286,7 @@ main(int argc, char * argv[])
   }
   // Software Guide : EndCodeSnippet
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
   try

--- a/Examples/Iterators/NeighborhoodIterators1.cxx
+++ b/Examples/Iterators/NeighborhoodIterators1.cxx
@@ -94,7 +94,7 @@ main(int argc, char ** argv)
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -131,7 +131,7 @@ main(int argc, char ** argv)
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ImageType::Pointer output = ImageType::New();
+  auto output = ImageType::New();
   output->SetRegions(reader->GetOutput()->GetRequestedRegion());
   output->Allocate();
 
@@ -208,13 +208,13 @@ main(int argc, char ** argv)
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<ImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
   rescaler->SetInput(output);
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(rescaler->GetOutput());
   try

--- a/Examples/Iterators/NeighborhoodIterators2.cxx
+++ b/Examples/Iterators/NeighborhoodIterators2.cxx
@@ -73,7 +73,7 @@ main(int argc, char ** argv)
   using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator<ImageType>;
   using IteratorType = itk::ImageRegionIterator<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -86,7 +86,7 @@ main(int argc, char ** argv)
     return EXIT_FAILURE;
   }
 
-  ImageType::Pointer output = ImageType::New();
+  auto output = ImageType::New();
   output->SetRegions(reader->GetOutput()->GetRequestedRegion());
   output->Allocate();
 
@@ -164,13 +164,13 @@ main(int argc, char ** argv)
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<ImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
   rescaler->SetInput(output);
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(rescaler->GetOutput());
   try

--- a/Examples/Iterators/NeighborhoodIterators3.cxx
+++ b/Examples/Iterators/NeighborhoodIterators3.cxx
@@ -77,7 +77,7 @@ main(int argc, char ** argv)
   using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator<ImageType>;
   using IteratorType = itk::ImageRegionIterator<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -90,7 +90,7 @@ main(int argc, char ** argv)
     return EXIT_FAILURE;
   }
 
-  ImageType::Pointer output = ImageType::New();
+  auto output = ImageType::New();
   output->SetRegions(reader->GetOutput()->GetRequestedRegion());
   output->Allocate();
 
@@ -203,13 +203,13 @@ main(int argc, char ** argv)
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<ImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
   rescaler->SetInput(output);
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(rescaler->GetOutput());
   try

--- a/Examples/Iterators/NeighborhoodIterators4.cxx
+++ b/Examples/Iterators/NeighborhoodIterators4.cxx
@@ -83,7 +83,7 @@ main(int argc, char ** argv)
   using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator<ImageType>;
   using IteratorType = itk::ImageRegionIterator<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -96,7 +96,7 @@ main(int argc, char ** argv)
     return EXIT_FAILURE;
   }
 
-  ImageType::Pointer output = ImageType::New();
+  auto output = ImageType::New();
   output->SetRegions(reader->GetOutput()->GetRequestedRegion());
   output->Allocate();
 
@@ -209,13 +209,13 @@ main(int argc, char ** argv)
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<ImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
   rescaler->SetInput(output);
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(rescaler->GetOutput());
   try

--- a/Examples/Iterators/NeighborhoodIterators5.cxx
+++ b/Examples/Iterators/NeighborhoodIterators5.cxx
@@ -75,7 +75,7 @@ main(int argc, char ** argv)
   using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator<ImageType>;
   using IteratorType = itk::ImageRegionIterator<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -88,7 +88,7 @@ main(int argc, char ** argv)
     return EXIT_FAILURE;
   }
 
-  ImageType::Pointer output = ImageType::New();
+  auto output = ImageType::New();
   output->SetRegions(reader->GetOutput()->GetRequestedRegion());
   output->Allocate();
 
@@ -192,13 +192,13 @@ main(int argc, char ** argv)
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<ImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
   rescaler->SetInput(output);
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(rescaler->GetOutput());
   try

--- a/Examples/Iterators/NeighborhoodIterators6.cxx
+++ b/Examples/Iterators/NeighborhoodIterators6.cxx
@@ -67,13 +67,12 @@ main(int argc, char ** argv)
   using FastMarchingFilterType =
     itk::FastMarchingImageFilter<ImageType, ImageType>;
 
-  FastMarchingFilterType::Pointer fastMarching =
-    FastMarchingFilterType::New();
+  auto fastMarching = FastMarchingFilterType::New();
 
   using NodeContainer = FastMarchingFilterType::NodeContainer;
   using NodeType = FastMarchingFilterType::NodeType;
 
-  NodeContainer::Pointer seeds = NodeContainer::New();
+  auto seeds = NodeContainer::New();
 
   ImageType::IndexType seedPosition;
 
@@ -215,13 +214,13 @@ main(int argc, char ** argv)
   using RescaleFilterType =
     itk::RescaleIntensityImageFilter<ImageType, WriteImageType>;
 
-  RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
+  auto rescaler = RescaleFilterType::New();
 
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
   rescaler->SetInput(input);
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[1]);
   writer->SetInput(rescaler->GetOutput());
   try

--- a/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
@@ -77,7 +77,7 @@ main(int argc, char ** argv)
   // Software Guide : EndCodeSnippet
 
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
   try
@@ -91,7 +91,7 @@ main(int argc, char ** argv)
     return EXIT_FAILURE;
   }
 
-  ImageType::Pointer output = ImageType::New();
+  auto output = ImageType::New();
   output->SetRegions(reader->GetOutput()->GetRequestedRegion());
   output->Allocate();
 
@@ -233,7 +233,7 @@ main(int argc, char ** argv)
 
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(output);
   try

--- a/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
@@ -49,7 +49,7 @@ main(int argc, char ** argv)
     itk::ConstShapedNeighborhoodIterator<ImageType>;
   using IteratorType = itk::ImageRegionIterator<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
   unsigned int element_radius = std::stoi(argv[3]);
@@ -65,7 +65,7 @@ main(int argc, char ** argv)
     return EXIT_FAILURE;
   }
 
-  ImageType::Pointer output = ImageType::New();
+  auto output = ImageType::New();
   output->SetRegions(reader->GetOutput()->GetRequestedRegion());
   output->Allocate();
 
@@ -171,7 +171,7 @@ main(int argc, char ** argv)
 
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(output);
   try

--- a/Examples/Numerics/FourierDescriptors1.cxx
+++ b/Examples/Numerics/FourierDescriptors1.cxx
@@ -105,7 +105,7 @@ main(int argc, char * argv[])
 
   using PointsContainer = itk::VectorContainer<unsigned int, PointType>;
 
-  PointsContainer::Pointer points = PointsContainer::New();
+  auto points = PointsContainer::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex

--- a/Examples/RegistrationITKv4/BSplineWarping1.cxx
+++ b/Examples/RegistrationITKv4/BSplineWarping1.cxx
@@ -108,7 +108,7 @@ main(int argc, char * argv[])
   using MovingWriterType = itk::ImageFileWriter<MovingImageType>;
   // Software Guide : EndCodeSnippet
 
-  FixedReaderType::Pointer fixedReader = FixedReaderType::New();
+  auto fixedReader = FixedReaderType::New();
   fixedReader->SetFileName(argv[2]);
 
   try
@@ -123,8 +123,8 @@ main(int argc, char * argv[])
   }
 
 
-  MovingReaderType::Pointer movingReader = MovingReaderType::New();
-  MovingWriterType::Pointer movingWriter = MovingWriterType::New();
+  auto movingReader = MovingReaderType::New();
+  auto movingWriter = MovingWriterType::New();
 
   movingReader->SetFileName(argv[3]);
   movingWriter->SetFileName(argv[4]);
@@ -136,12 +136,12 @@ main(int argc, char * argv[])
   using FilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  FilterType::Pointer resampler = FilterType::New();
+  auto resampler = FilterType::New();
 
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<MovingImageType, double>;
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   resampler->SetInterpolator(interpolator);
 
@@ -194,7 +194,7 @@ main(int argc, char * argv[])
   using TransformType =
     itk::BSplineTransform<CoordinateRepType, SpaceDimension, SplineOrder>;
 
-  TransformType::Pointer bsplineTransform = TransformType::New();
+  auto bsplineTransform = TransformType::New();
   //  Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -281,7 +281,7 @@ main(int argc, char * argv[])
   bsplineTransform->SetParameters(parameters);
   //  Software Guide : EndCodeSnippet
 
-  CommandProgressUpdate::Pointer observer = CommandProgressUpdate::New();
+  auto observer = CommandProgressUpdate::New();
 
   resampler->AddObserver(itk::ProgressEvent(), observer);
 
@@ -312,7 +312,7 @@ main(int argc, char * argv[])
   using VectorType = itk::Vector<float, ImageDimension>;
   using DisplacementFieldType = itk::Image<VectorType, ImageDimension>;
 
-  DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+  auto field = DisplacementFieldType::New();
   field->SetRegions(fixedRegion);
   field->SetOrigin(fixedOrigin);
   field->SetSpacing(fixedSpacing);
@@ -341,7 +341,7 @@ main(int argc, char * argv[])
   }
 
   using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-  FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+  auto fieldWriter = FieldWriterType::New();
 
   fieldWriter->SetInput(field);
 
@@ -366,8 +366,7 @@ main(int argc, char * argv[])
     try
     {
       using TransformWriterType = itk::TransformFileWriter;
-      TransformWriterType::Pointer transformWriter =
-        TransformWriterType::New();
+      auto transformWriter = TransformWriterType::New();
       transformWriter->AddTransform(bsplineTransform);
       transformWriter->SetFileName(argv[6]);
       transformWriter->Update();

--- a/Examples/RegistrationITKv4/BSplineWarping2.cxx
+++ b/Examples/RegistrationITKv4/BSplineWarping2.cxx
@@ -106,7 +106,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  FixedReaderType::Pointer fixedReader = FixedReaderType::New();
+  auto fixedReader = FixedReaderType::New();
   fixedReader->SetFileName(argv[2]);
 
   try
@@ -128,8 +128,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  MovingReaderType::Pointer movingReader = MovingReaderType::New();
-  MovingWriterType::Pointer movingWriter = MovingWriterType::New();
+  auto movingReader = MovingReaderType::New();
+  auto movingWriter = MovingWriterType::New();
 
   movingReader->SetFileName(argv[3]);
   movingWriter->SetFileName(argv[4]);
@@ -141,12 +141,12 @@ main(int argc, char * argv[])
   using FilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  FilterType::Pointer resampler = FilterType::New();
+  auto resampler = FilterType::New();
 
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<MovingImageType, double>;
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   resampler->SetInterpolator(interpolator);
 
@@ -198,7 +198,7 @@ main(int argc, char * argv[])
   using TransformType =
     itk::BSplineTransform<CoordinateRepType, SpaceDimension, SplineOrder>;
 
-  TransformType::Pointer bsplineTransform = TransformType::New();
+  auto bsplineTransform = TransformType::New();
   //  Software Guide : EndCodeSnippet
 
 
@@ -280,7 +280,7 @@ main(int argc, char * argv[])
   bsplineTransform->SetParameters(parameters);
   //  Software Guide : EndCodeSnippet
 
-  CommandProgressUpdate::Pointer observer = CommandProgressUpdate::New();
+  auto observer = CommandProgressUpdate::New();
 
   resampler->AddObserver(itk::ProgressEvent(), observer);
 
@@ -312,7 +312,7 @@ main(int argc, char * argv[])
   using VectorType = itk::Vector<float, ImageDimension>;
   using DisplacementFieldType = itk::Image<VectorType, ImageDimension>;
 
-  DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+  auto field = DisplacementFieldType::New();
   field->SetRegions(fixedRegion);
   field->SetOrigin(fixedOrigin);
   field->SetSpacing(fixedSpacing);
@@ -341,7 +341,7 @@ main(int argc, char * argv[])
   }
 
   using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-  FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+  auto fieldWriter = FieldWriterType::New();
 
   fieldWriter->SetInput(field);
 
@@ -366,8 +366,7 @@ main(int argc, char * argv[])
     try
     {
       using TransformWriterType = itk::TransformFileWriter;
-      TransformWriterType::Pointer transformWriter =
-        TransformWriterType::New();
+      auto transformWriter = TransformWriterType::New();
       transformWriter->AddTransform(bsplineTransform);
       transformWriter->SetFileName(argv[6]);
       transformWriter->Update();

--- a/Examples/RegistrationITKv4/ChangeInformationImageFilter.cxx
+++ b/Examples/RegistrationITKv4/ChangeInformationImageFilter.cxx
@@ -80,8 +80,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -100,7 +100,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using FilterType = itk::ChangeInformationImageFilter<ImageType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
   //

--- a/Examples/RegistrationITKv4/DeformableRegistration1.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration1.cxx
@@ -120,7 +120,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  RegistrationType::Pointer registrationFilter = RegistrationType::New();
+  auto registrationFilter = RegistrationType::New();
   registrationFilter->SetMaxLevel(1);
   registrationFilter->SetUseNormalizedGradient(true);
   registrationFilter->ChooseMetric(0);
@@ -146,9 +146,9 @@ main(int argc, char * argv[])
   // Read the image files
   using FileSourceType = itk::ImageFileReader<DiskImageType>;
 
-  FileSourceType::Pointer movingfilter = FileSourceType::New();
+  auto movingfilter = FileSourceType::New();
   movingfilter->SetFileName(movingImageName);
-  FileSourceType::Pointer fixedfilter = FileSourceType::New();
+  auto fixedfilter = FileSourceType::New();
   fixedfilter->SetFileName(fixedImageName);
   std::cout << " reading moving " << movingImageName << std::endl;
   std::cout << " reading fixed " << fixedImageName << std::endl;
@@ -180,8 +180,8 @@ main(int argc, char * argv[])
   // Rescale the image intensities so that they fall between 0 and 255
   using FilterType =
     itk::RescaleIntensityImageFilter<DiskImageType, ImageType>;
-  FilterType::Pointer movingrescalefilter = FilterType::New();
-  FilterType::Pointer fixedrescalefilter = FilterType::New();
+  auto movingrescalefilter = FilterType::New();
+  auto fixedrescalefilter = FilterType::New();
 
   movingrescalefilter->SetInput(movingfilter->GetOutput());
   fixedrescalefilter->SetInput(fixedfilter->GetOutput());
@@ -200,7 +200,7 @@ main(int argc, char * argv[])
   // Histogram match the images
   using HEFilterType =
     itk::HistogramMatchingImageFilter<ImageType, ImageType>;
-  HEFilterType::Pointer IntensityEqualizeFilter = HEFilterType::New();
+  auto IntensityEqualizeFilter = HEFilterType::New();
 
   IntensityEqualizeFilter->SetReferenceImage(fixedrescalefilter->GetOutput());
   IntensityEqualizeFilter->SetInput(movingrescalefilter->GetOutput());
@@ -273,7 +273,7 @@ main(int argc, char * argv[])
   m->SetDensityHeatProduct(1.0); // Density-Heat capacity product
 
   // Create the element type
-  ElementType::Pointer e1 = ElementType::New();
+  auto e1 = ElementType::New();
   e1->SetMaterial(m);
   registrationFilter->SetElement(e1);
   registrationFilter->SetMaterial(m);
@@ -325,7 +325,7 @@ main(int argc, char * argv[])
 
   //  Software Guide : BeginCodeSnippet
   using DispWriterType = itk::ImageFileWriter<RegistrationType::FieldType>;
-  DispWriterType::Pointer dispWriter = DispWriterType::New();
+  auto dispWriter = DispWriterType::New();
   dispWriter->SetInput(registrationFilter->GetDisplacementField());
   dispWriter->SetFileName("displacement.mha");
   try

--- a/Examples/RegistrationITKv4/DeformableRegistration10.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration10.cxx
@@ -103,10 +103,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -118,17 +116,15 @@ main(int argc, char * argv[])
   using MovingImageCasterType =
     itk::CastImageFilter<MovingImageType, InternalImageType>;
 
-  FixedImageCasterType::Pointer fixedImageCaster =
-    FixedImageCasterType::New();
-  MovingImageCasterType::Pointer movingImageCaster =
-    MovingImageCasterType::New();
+  auto fixedImageCaster = FixedImageCasterType::New();
+  auto movingImageCaster = MovingImageCasterType::New();
 
   fixedImageCaster->SetInput(fixedImageReader->GetOutput());
   movingImageCaster->SetInput(movingImageReader->GetOutput());
 
   using MatchingFilterType =
     itk::HistogramMatchingImageFilter<InternalImageType, InternalImageType>;
-  MatchingFilterType::Pointer matcher = MatchingFilterType::New();
+  auto matcher = MatchingFilterType::New();
 
   matcher->SetInput(movingImageCaster->GetOutput());
   matcher->SetReferenceImage(fixedImageCaster->GetOutput());
@@ -147,19 +143,18 @@ main(int argc, char * argv[])
       InternalImageType,
       DisplacementFieldType>>;
 
-  RegistrationFilterType::Pointer filter = RegistrationFilterType::New();
+  auto filter = RegistrationFilterType::New();
   filter->SetTimeStep(1);
   filter->SetConstraintWeight(0.1);
 
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   filter->AddObserver(itk::IterationEvent(), observer);
 
   using MultiResRegistrationFilterType =
     itk::MultiResolutionPDEDeformableRegistration<InternalImageType,
                                                   InternalImageType,
                                                   DisplacementFieldType>;
-  MultiResRegistrationFilterType::Pointer multires =
-    MultiResRegistrationFilterType::New();
+  auto multires = MultiResRegistrationFilterType::New();
   multires->SetRegistrationFilter(filter);
   multires->SetNumberOfLevels(3);
   multires->SetFixedImage(fixedImageCaster->GetOutput());
@@ -180,9 +175,9 @@ main(int argc, char * argv[])
                                               InternalPixelType>;
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<MovingImageType, InternalPixelType>;
-  WarperType::Pointer       warper = WarperType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  FixedImageType::Pointer   fixedImage = fixedImageReader->GetOutput();
+  auto                    warper = WarperType::New();
+  auto                    interpolator = InterpolatorType::New();
+  FixedImageType::Pointer fixedImage = fixedImageReader->GetOutput();
 
   warper->SetInput(movingImageReader->GetOutput());
   warper->SetInterpolator(interpolator);
@@ -198,8 +193,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<MovingImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -212,7 +207,7 @@ main(int argc, char * argv[])
 
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
 
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
     fieldWriter->SetFileName(argv[4]);
     fieldWriter->SetInput(multires->GetOutput());
 

--- a/Examples/RegistrationITKv4/DeformableRegistration11.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration11.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   }
 
   // Setup registration parameters
-  RegistrationType::Pointer registrationFilter = RegistrationType::New();
+  auto registrationFilter = RegistrationType::New();
   registrationFilter->SetMaxLevel(1);
   registrationFilter->SetUseNormalizedGradient(true);
   registrationFilter->ChooseMetric(0);
@@ -82,9 +82,9 @@ main(int argc, char * argv[])
 
   // Read the image files
   using FileSourceType = itk::ImageFileReader<FileImageType>;
-  FileSourceType::Pointer movingfilter = FileSourceType::New();
+  auto movingfilter = FileSourceType::New();
   movingfilter->SetFileName(movingImageName);
-  FileSourceType::Pointer fixedfilter = FileSourceType::New();
+  auto fixedfilter = FileSourceType::New();
   fixedfilter->SetFileName(fixedImageName);
 
   std::cout << " reading moving ";
@@ -119,8 +119,8 @@ main(int argc, char * argv[])
   using FilterType =
     itk::RescaleIntensityImageFilter<FileImageType, ImageType>;
 
-  FilterType::Pointer movingrescalefilter = FilterType::New();
-  FilterType::Pointer fixedrescalefilter = FilterType::New();
+  auto movingrescalefilter = FilterType::New();
+  auto fixedrescalefilter = FilterType::New();
 
   movingrescalefilter->SetInput(movingfilter->GetOutput());
   fixedrescalefilter->SetInput(fixedfilter->GetOutput());
@@ -139,7 +139,7 @@ main(int argc, char * argv[])
   // Histogram match the images
   using HEFilterType =
     itk::HistogramMatchingImageFilter<ImageType, ImageType>;
-  HEFilterType::Pointer IntensityEqualizeFilter = HEFilterType::New();
+  auto IntensityEqualizeFilter = HEFilterType::New();
 
   IntensityEqualizeFilter->SetReferenceImage(fixedrescalefilter->GetOutput());
   IntensityEqualizeFilter->SetInput(movingrescalefilter->GetOutput());
@@ -180,7 +180,7 @@ main(int argc, char * argv[])
   m->SetDensityHeatProduct(1.0); // Density-Heat capacity product
 
   // Create the element type
-  ElementType::Pointer e1 = ElementType::New();
+  auto e1 = ElementType::New();
   e1->SetMaterial(m);
   registrationFilter->SetElement(e1);
   registrationFilter->SetMaterial(m);
@@ -203,7 +203,7 @@ main(int argc, char * argv[])
 
   // output the displacement field
   using DispWriterType = itk::ImageFileWriter<RegistrationType::FieldType>;
-  DispWriterType::Pointer dispWriter = DispWriterType::New();
+  auto dispWriter = DispWriterType::New();
   dispWriter->SetInput(registrationFilter->GetDisplacementField());
   dispWriter->SetFileName("displacement.mha");
   try

--- a/Examples/RegistrationITKv4/DeformableRegistration12.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration12.cxx
@@ -146,16 +146,14 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
   fixedImageReader->SetFileName(argv[1]);
   fixedImageReader->Update();
   FixedImageType::ConstPointer fixedImage = fixedImageReader->GetOutput();
   FixedImageType::RegionType   fixedRegion = fixedImage->GetBufferedRegion();
 
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
   movingImageReader->SetFileName(argv[2]);
   movingImageReader->Update();
   MovingImageType::ConstPointer movingImage = movingImageReader->GetOutput();
@@ -171,7 +169,7 @@ main(int argc, char * argv[])
 
   using RegistrationType =
     itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>;
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto registration = RegistrationType::New();
 
   //  Software Guide : BeginLatex
   //
@@ -180,7 +178,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
   //
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
   unsigned int numberOfGridNodesInOneDimension = 7;
@@ -227,14 +225,14 @@ main(int argc, char * argv[])
   using MetricType =
     itk::MattesMutualInformationImageToImageMetricv4<FixedImageType,
                                                      MovingImageType>;
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   metric->SetNumberOfHistogramBins(32);
   metric->SetUseMovingImageGradientFilter(false);
   metric->SetUseFixedImageGradientFilter(false);
   metric->SetUseSampledPointSet(false);
 
   using OptimizerType = itk::LBFGSBOptimizerv4;
-  OptimizerType::Pointer optimizer = OptimizerType::New();
+  auto optimizer = OptimizerType::New();
 
   // Software Guide : BeginCodeSnippet
   const unsigned int numParameters = transform->GetNumberOfParameters();
@@ -259,7 +257,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   // One level registration is performed using the shrink factor 1 and
@@ -332,7 +330,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -358,8 +356,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -385,9 +383,9 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
 
@@ -438,7 +436,7 @@ main(int argc, char * argv[])
     using VectorType = itk::Vector<float, ImageDimension>;
     using DisplacementFieldType = itk::Image<VectorType, ImageDimension>;
 
-    DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+    auto field = DisplacementFieldType::New();
     field->SetRegions(fixedRegion);
     field->SetOrigin(fixedImage->GetOrigin());
     field->SetSpacing(fixedImage->GetSpacing());
@@ -467,7 +465,7 @@ main(int argc, char * argv[])
     }
 
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
 
     fieldWriter->SetInput(field);
 

--- a/Examples/RegistrationITKv4/DeformableRegistration13.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration13.cxx
@@ -163,10 +163,10 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethod<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
 
   registration->SetMetric(metric);
@@ -174,16 +174,14 @@ main(int argc, char * argv[])
   registration->SetInterpolator(interpolator);
 
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   registration->SetTransform(transform);
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -252,7 +250,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   metric->SetNumberOfHistogramBins(50);
@@ -323,7 +321,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -349,8 +347,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -376,9 +374,9 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
 
@@ -429,7 +427,7 @@ main(int argc, char * argv[])
     using VectorType = itk::Vector<float, ImageDimension>;
     using DisplacementFieldType = itk::Image<VectorType, ImageDimension>;
 
-    DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+    auto field = DisplacementFieldType::New();
     field->SetRegions(fixedRegion);
     field->SetOrigin(fixedImage->GetOrigin());
     field->SetSpacing(fixedImage->GetSpacing());
@@ -458,7 +456,7 @@ main(int argc, char * argv[])
     }
 
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
 
     fieldWriter->SetInput(field);
 

--- a/Examples/RegistrationITKv4/DeformableRegistration14.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration14.cxx
@@ -140,25 +140,23 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethod<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetMetric(metric);
   registration->SetOptimizer(optimizer);
   registration->SetInterpolator(interpolator);
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   registration->SetTransform(transform);
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -246,7 +244,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   metric->SetNumberOfHistogramBins(50);
@@ -315,7 +313,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -340,8 +338,8 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -364,9 +362,9 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
   // Compute the difference image between the
@@ -415,7 +413,7 @@ main(int argc, char * argv[])
     using VectorType = itk::Vector<float, ImageDimension>;
     using DisplacementFieldType = itk::Image<VectorType, ImageDimension>;
 
-    DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+    auto field = DisplacementFieldType::New();
     field->SetRegions(fixedRegion);
     field->SetOrigin(fixedImage->GetOrigin());
     field->SetSpacing(fixedImage->GetSpacing());
@@ -444,7 +442,7 @@ main(int argc, char * argv[])
     }
 
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
 
     fieldWriter->SetInput(field);
 

--- a/Examples/RegistrationITKv4/DeformableRegistration15.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration15.cxx
@@ -164,10 +164,10 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethod<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
 
   registration->SetMetric(metric);
@@ -177,18 +177,15 @@ main(int argc, char * argv[])
   // Auxiliary identity transform.
   using IdentityTransformType =
     itk::IdentityTransform<double, SpaceDimension>;
-  IdentityTransformType::Pointer identityTransform =
-    IdentityTransformType::New();
+  auto identityTransform = IdentityTransformType::New();
 
 
   //   Read the Fixed and Moving images.
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -247,10 +244,9 @@ main(int argc, char * argv[])
 
 
   //  Initialize a rigid transform by using Image Intensity Moments
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
 
-  RigidTransformType::Pointer rigidTransform = RigidTransformType::New();
+  auto rigidTransform = RigidTransformType::New();
 
   initializer->SetTransform(rigidTransform);
   initializer->SetFixedImage(fixedImageReader->GetOutput());
@@ -308,7 +304,7 @@ main(int argc, char * argv[])
   metric->SetNumberOfSpatialSamples(10000L);
 
   // Create the Command observer and register it with the optimizer.
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -342,7 +338,7 @@ main(int argc, char * argv[])
 
 
   //  Perform Affine Registration
-  AffineTransformType::Pointer affineTransform = AffineTransformType::New();
+  auto affineTransform = AffineTransformType::New();
 
   affineTransform->SetCenter(rigidTransform->GetCenter());
   affineTransform->SetTranslation(rigidTransform->GetTranslation());
@@ -411,8 +407,7 @@ main(int argc, char * argv[])
 
 
   //  Perform Deformable Registration
-  DeformableTransformType::Pointer bsplineTransformCoarse =
-    DeformableTransformType::New();
+  auto bsplineTransformCoarse = DeformableTransformType::New();
 
   unsigned int numberOfGridNodesInOneDimensionCoarse = 5;
 
@@ -455,8 +450,7 @@ main(int argc, char * argv[])
 
   using CompositeTransformType =
     itk::CompositeTransform<double, SpaceDimension>;
-  typename CompositeTransformType::Pointer compositeTransform =
-    CompositeTransformType::New();
+  auto compositeTransform = CompositeTransformType::New();
   compositeTransform->AddTransform(affineTransform);
   compositeTransform->AddTransform(bsplineTransformCoarse);
   compositeTransform->SetOnlyMostRecentTransformToOptimizeOn();
@@ -544,8 +538,7 @@ main(int argc, char * argv[])
   //
   //  Software Guide : EndLatex
 
-  DeformableTransformType::Pointer bsplineTransformFine =
-    DeformableTransformType::New();
+  auto bsplineTransformFine = DeformableTransformType::New();
 
   unsigned int numberOfGridNodesInOneDimensionFine = 20;
 
@@ -580,11 +573,11 @@ main(int argc, char * argv[])
     using ParametersImageType = DeformableTransformType::ImageType;
     using ResamplerType =
       itk::ResampleImageFilter<ParametersImageType, ParametersImageType>;
-    ResamplerType::Pointer upsampler = ResamplerType::New();
+    auto upsampler = ResamplerType::New();
 
     using FunctionType =
       itk::BSplineResampleImageFunction<ParametersImageType, double>;
-    FunctionType::Pointer function = FunctionType::New();
+    auto function = FunctionType::New();
 
     upsampler->SetInput(bsplineTransformCoarse->GetCoefficientImages()[k]);
     upsampler->SetInterpolator(function);
@@ -600,7 +593,7 @@ main(int argc, char * argv[])
     using DecompositionType =
       itk::BSplineDecompositionImageFilter<ParametersImageType,
                                            ParametersImageType>;
-    DecompositionType::Pointer decomposition = DecompositionType::New();
+    auto decomposition = DecompositionType::New();
 
     decomposition->SetSplineOrder(SplineOrder);
     decomposition->SetInput(upsampler->GetOutput());
@@ -694,7 +687,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(bsplineTransformFine);
   resample->SetInput(movingImageReader->GetOutput());
@@ -720,8 +713,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -751,16 +744,15 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
   using SqrtFilterType =
     itk::SqrtImageFilter<OutputImageType, OutputImageType>;
-  SqrtFilterType::Pointer sqrtFilter = SqrtFilterType::New();
+  auto sqrtFilter = SqrtFilterType::New();
   sqrtFilter->SetInput(difference->GetOutput());
 
   using DifferenceImageWriterType = itk::ImageFileWriter<OutputImageType>;
 
-  DifferenceImageWriterType::Pointer writer2 =
-    DifferenceImageWriterType::New();
+  auto writer2 = DifferenceImageWriterType::New();
   writer2->SetInput(sqrtFilter->GetOutput());
 
 
@@ -821,7 +813,7 @@ main(int argc, char * argv[])
     using VectorType = itk::Vector<float, ImageDimension>;
     using DisplacementFieldType = itk::Image<VectorType, ImageDimension>;
 
-    DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+    auto field = DisplacementFieldType::New();
     field->SetRegions(fixedRegion);
     field->SetOrigin(fixedImage->GetOrigin());
     field->SetSpacing(fixedImage->GetSpacing());
@@ -850,7 +842,7 @@ main(int argc, char * argv[])
     }
 
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
 
     fieldWriter->SetInput(field);
 
@@ -877,7 +869,7 @@ main(int argc, char * argv[])
   {
     std::cout << "Writing transform parameter file ...";
     using TransformWriterType = itk::TransformFileWriter;
-    TransformWriterType::Pointer transformWriter = TransformWriterType::New();
+    auto transformWriter = TransformWriterType::New();
     transformWriter->AddTransform(bsplineTransformFine);
     transformWriter->SetFileName(argv[6]);
     transformWriter->Update();

--- a/Examples/RegistrationITKv4/DeformableRegistration16.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration16.cxx
@@ -218,18 +218,18 @@ main(int argc, char * argv[])
 
   // setup input file readers
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer targetReader = ReaderType::New();
+  auto targetReader = ReaderType::New();
   targetReader->SetFileName(argv[1]);
   targetReader->Update();
 
-  ReaderType::Pointer sourceReader = ReaderType::New();
+  auto sourceReader = ReaderType::New();
   sourceReader->SetFileName(argv[2]);
   sourceReader->Update();
 
 
   // cast target and source to float
-  ImageCasterType::Pointer targetImageCaster = ImageCasterType::New();
-  ImageCasterType::Pointer sourceImageCaster = ImageCasterType::New();
+  auto targetImageCaster = ImageCasterType::New();
+  auto sourceImageCaster = ImageCasterType::New();
   targetImageCaster->SetInput(targetReader->GetOutput());
   sourceImageCaster->SetInput(sourceReader->GetOutput());
 
@@ -237,7 +237,7 @@ main(int argc, char * argv[])
   using MatchingFilterType =
     itk::HistogramMatchingImageFilter<InternalImageType, InternalImageType>;
 
-  MatchingFilterType::Pointer matcher = MatchingFilterType::New();
+  auto matcher = MatchingFilterType::New();
 
   matcher->SetInput(sourceImageCaster->GetOutput());
   matcher->SetReferenceImage(targetImageCaster->GetOutput());
@@ -255,14 +255,14 @@ main(int argc, char * argv[])
                                   InternalImageType,
                                   DisplacementFieldType>;
 
-  RegistrationFilterType::Pointer filter = RegistrationFilterType::New();
+  auto filter = RegistrationFilterType::New();
 
   filter->SetStandardDeviations(1.0);
 
   //
   // Create the Command observer and register it with the registration filter.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   filter->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -272,8 +272,7 @@ main(int argc, char * argv[])
                                                   InternalImageType,
                                                   DisplacementFieldType>;
 
-  MultiResRegistrationFilterType::Pointer multires =
-    MultiResRegistrationFilterType::New();
+  auto multires = MultiResRegistrationFilterType::New();
 
   multires->SetRegistrationFilter(filter);
   multires->SetNumberOfLevels(4);
@@ -285,8 +284,7 @@ main(int argc, char * argv[])
   //
   // Create the Command observer and register it with the registration filter.
   //
-  CommandResolutionLevelUpdate::Pointer levelobserver =
-    CommandResolutionLevelUpdate::New();
+  auto levelobserver = CommandResolutionLevelUpdate::New();
   multires->AddObserver(itk::IterationEvent(), levelobserver);
 
   // apply the registration filter
@@ -314,9 +312,9 @@ main(int argc, char * argv[])
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<ImageType, InterpolatorPrecisionType>;
 
-  WarperType::Pointer warper = WarperType::New();
+  auto warper = WarperType::New();
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   ImageType::Pointer targetImage = targetReader->GetOutput();
   warper->SetInput(sourceReader->GetOutput());
@@ -327,7 +325,7 @@ main(int argc, char * argv[])
   warper->SetTransform(displacementTransform);
 
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[3]);
   writer->SetInput(warper->GetOutput());
 
@@ -343,7 +341,7 @@ main(int argc, char * argv[])
 
   // write the deformation field
   using DeformationWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-  DeformationWriterType::Pointer defwriter = DeformationWriterType::New();
+  auto defwriter = DeformationWriterType::New();
   defwriter->SetFileName(argv[4]);
   defwriter->SetInput(multires->GetOutput());
 

--- a/Examples/RegistrationITKv4/DeformableRegistration17.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration17.cxx
@@ -220,17 +220,17 @@ main(int argc, char * argv[])
 
   // setup input file readers
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer targetReader = ReaderType::New();
+  auto targetReader = ReaderType::New();
   targetReader->SetFileName(argv[1]);
   targetReader->Update();
 
-  ReaderType::Pointer sourceReader = ReaderType::New();
+  auto sourceReader = ReaderType::New();
   sourceReader->SetFileName(argv[2]);
   sourceReader->Update();
 
   // cast target and source to float
-  ImageCasterType::Pointer targetImageCaster = ImageCasterType::New();
-  ImageCasterType::Pointer sourceImageCaster = ImageCasterType::New();
+  auto targetImageCaster = ImageCasterType::New();
+  auto sourceImageCaster = ImageCasterType::New();
   targetImageCaster->SetInput(targetReader->GetOutput());
   sourceImageCaster->SetInput(sourceReader->GetOutput());
 
@@ -238,7 +238,7 @@ main(int argc, char * argv[])
   using MatchingFilterType =
     itk::HistogramMatchingImageFilter<InternalImageType, InternalImageType>;
 
-  MatchingFilterType::Pointer matcher = MatchingFilterType::New();
+  auto matcher = MatchingFilterType::New();
 
   matcher->SetInput(sourceImageCaster->GetOutput());
   matcher->SetReferenceImage(targetImageCaster->GetOutput());
@@ -256,14 +256,14 @@ main(int argc, char * argv[])
                                                  InternalImageType,
                                                  DisplacementFieldType>;
 
-  RegistrationFilterType::Pointer filter = RegistrationFilterType::New();
+  auto filter = RegistrationFilterType::New();
 
   filter->SetStandardDeviations(1.0);
 
   //
   // Create the Command observer and register it with the registration filter.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   filter->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -273,8 +273,7 @@ main(int argc, char * argv[])
                                                   InternalImageType,
                                                   DisplacementFieldType>;
 
-  MultiResRegistrationFilterType::Pointer multires =
-    MultiResRegistrationFilterType::New();
+  auto multires = MultiResRegistrationFilterType::New();
 
   multires->SetRegistrationFilter(filter);
   multires->SetNumberOfLevels(4);
@@ -286,8 +285,7 @@ main(int argc, char * argv[])
   //
   // Create the Command observer and register it with the registration filter.
   //
-  CommandResolutionLevelUpdate::Pointer levelobserver =
-    CommandResolutionLevelUpdate::New();
+  auto levelobserver = CommandResolutionLevelUpdate::New();
   multires->AddObserver(itk::IterationEvent(), levelobserver);
 
   // apply the registration filter
@@ -315,9 +313,9 @@ main(int argc, char * argv[])
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<ImageType, InterpolatorPrecisionType>;
 
-  WarperType::Pointer warper = WarperType::New();
+  auto warper = WarperType::New();
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   ImageType::Pointer targetImage = targetReader->GetOutput();
   warper->SetInput(sourceReader->GetOutput());
@@ -328,7 +326,7 @@ main(int argc, char * argv[])
   warper->SetTransform(displacementTransform);
 
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[3]);
   writer->SetInput(warper->GetOutput());
 
@@ -345,7 +343,7 @@ main(int argc, char * argv[])
 
   // write the deformation field
   using DeformationWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-  DeformationWriterType::Pointer defwriter = DeformationWriterType::New();
+  auto defwriter = DeformationWriterType::New();
   defwriter->SetFileName(argv[4]);
   defwriter->SetInput(multires->GetOutput());
 

--- a/Examples/RegistrationITKv4/DeformableRegistration2.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration2.cxx
@@ -119,10 +119,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -145,10 +143,8 @@ main(int argc, char * argv[])
   using MovingImageCasterType =
     itk::CastImageFilter<MovingImageType, InternalImageType>;
 
-  FixedImageCasterType::Pointer fixedImageCaster =
-    FixedImageCasterType::New();
-  MovingImageCasterType::Pointer movingImageCaster =
-    MovingImageCasterType::New();
+  auto fixedImageCaster = FixedImageCasterType::New();
+  auto movingImageCaster = MovingImageCasterType::New();
 
   fixedImageCaster->SetInput(fixedImageReader->GetOutput());
   movingImageCaster->SetInput(movingImageReader->GetOutput());
@@ -175,7 +171,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using MatchingFilterType =
     itk::HistogramMatchingImageFilter<InternalImageType, InternalImageType>;
-  MatchingFilterType::Pointer matcher = MatchingFilterType::New();
+  auto matcher = MatchingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -243,13 +239,13 @@ main(int argc, char * argv[])
     itk::DemonsRegistrationFilter<InternalImageType,
                                   InternalImageType,
                                   DisplacementFieldType>;
-  RegistrationFilterType::Pointer filter = RegistrationFilterType::New();
+  auto filter = RegistrationFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
   // Create the Command observer and register it with the registration filter.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   filter->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -323,7 +319,7 @@ main(int argc, char * argv[])
                                               OutputImageType,
                                               InterpolatorPrecisionType,
                                               float>;
-  WarperType::Pointer warper = WarperType::New();
+  auto warper = WarperType::New();
 
   warper->SetInput(movingImageReader->GetOutput());
   warper->UseReferenceImageOn();
@@ -356,7 +352,7 @@ main(int argc, char * argv[])
   // Write warped image out to file
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[3]);
   writer->SetInput(warper->GetOutput());
@@ -401,7 +397,7 @@ main(int argc, char * argv[])
 
     // Software Guide : BeginCodeSnippet
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
     fieldWriter->SetFileName(argv[4]);
     fieldWriter->SetInput(filter->GetOutput());
 
@@ -437,10 +433,9 @@ main(int argc, char * argv[])
 
     using VectorImage3DWriterType = itk::ImageFileWriter<VectorImage3DType>;
 
-    VectorImage3DWriterType::Pointer writer3D =
-      VectorImage3DWriterType::New();
+    auto writer3D = VectorImage3DWriterType::New();
 
-    VectorImage3DType::Pointer vectorImage3D = VectorImage3DType::New();
+    auto vectorImage3D = VectorImage3DType::New();
 
     VectorImage3DType::RegionType region3D;
     VectorImage3DType::IndexType  index3D;

--- a/Examples/RegistrationITKv4/DeformableRegistration3.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration3.cxx
@@ -118,10 +118,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -144,10 +142,8 @@ main(int argc, char * argv[])
   using MovingImageCasterType =
     itk::CastImageFilter<MovingImageType, InternalImageType>;
 
-  FixedImageCasterType::Pointer fixedImageCaster =
-    FixedImageCasterType::New();
-  MovingImageCasterType::Pointer movingImageCaster =
-    MovingImageCasterType::New();
+  auto fixedImageCaster = FixedImageCasterType::New();
+  auto movingImageCaster = MovingImageCasterType::New();
 
   fixedImageCaster->SetInput(fixedImageReader->GetOutput());
   movingImageCaster->SetInput(movingImageReader->GetOutput());
@@ -174,7 +170,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using MatchingFilterType =
     itk::HistogramMatchingImageFilter<InternalImageType, InternalImageType>;
-  MatchingFilterType::Pointer matcher = MatchingFilterType::New();
+  auto matcher = MatchingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -242,12 +238,12 @@ main(int argc, char * argv[])
     itk::SymmetricForcesDemonsRegistrationFilter<InternalImageType,
                                                  InternalImageType,
                                                  DisplacementFieldType>;
-  RegistrationFilterType::Pointer filter = RegistrationFilterType::New();
+  auto filter = RegistrationFilterType::New();
   // Software Guide : EndCodeSnippet
 
   // Create the Command observer and register it with the registration filter.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   filter->AddObserver(itk::IterationEvent(), observer);
 
   // Software Guide : BeginLatex
@@ -320,9 +316,9 @@ main(int argc, char * argv[])
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<MovingImageType,
                                         InterpolatorPrecisionType>;
-  WarperType::Pointer       warper = WarperType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  FixedImageType::Pointer   fixedImage = fixedImageReader->GetOutput();
+  auto                    warper = WarperType::New();
+  auto                    interpolator = InterpolatorType::New();
+  FixedImageType::Pointer fixedImage = fixedImageReader->GetOutput();
 
   warper->SetInput(movingImageReader->GetOutput());
   warper->SetInterpolator(interpolator);
@@ -359,8 +355,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<MovingImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -408,7 +404,7 @@ main(int argc, char * argv[])
     // Software Guide : BeginCodeSnippet
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
 
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
     fieldWriter->SetFileName(argv[4]);
     fieldWriter->SetInput(filter->GetOutput());
 

--- a/Examples/RegistrationITKv4/DeformableRegistration4.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration4.cxx
@@ -127,9 +127,9 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
 
   registration->SetMetric(metric);
@@ -138,10 +138,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -157,7 +155,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -175,7 +173,7 @@ main(int argc, char * argv[])
   using InitializerType =
     itk::BSplineTransformInitializer<TransformType, FixedImageType>;
 
-  InitializerType::Pointer transformInitializer = InitializerType::New();
+  auto transformInitializer = InitializerType::New();
 
   unsigned int numberOfGridNodesInOneDimension = 8;
 
@@ -236,7 +234,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ScalesEstimatorType =
     itk::RegistrationParameterScalesFromPhysicalShift<MetricType>;
-  ScalesEstimatorType::Pointer scalesEstimator = ScalesEstimatorType::New();
+  auto scalesEstimator = ScalesEstimatorType::New();
   scalesEstimator->SetMetric(metric);
   scalesEstimator->SetTransformForward(true);
   scalesEstimator->SetSmallParameterVariation(1.0);
@@ -333,7 +331,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -354,8 +352,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -381,9 +379,9 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
 
@@ -437,8 +435,7 @@ main(int argc, char * argv[])
                                             CoordinateRepType>;
 
   /** Create an setup displacement field generator. */
-  DisplacementFieldGeneratorType::Pointer dispfieldGenerator =
-    DisplacementFieldGeneratorType::New();
+  auto dispfieldGenerator = DisplacementFieldGeneratorType::New();
   dispfieldGenerator->UseReferenceImageOn();
   dispfieldGenerator->SetReferenceImage(fixedImage);
   dispfieldGenerator->SetTransform(transform);
@@ -454,7 +451,7 @@ main(int argc, char * argv[])
   }
 
   using FieldWriterType = itk::ImageFileWriter<DisplacementFieldImageType>;
-  FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+  auto fieldWriter = FieldWriterType::New();
 
   fieldWriter->SetInput(dispfieldGenerator->GetOutput());
 

--- a/Examples/RegistrationITKv4/DeformableRegistration5.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration5.cxx
@@ -113,10 +113,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -139,10 +137,8 @@ main(int argc, char * argv[])
   using MovingImageCasterType =
     itk::CastImageFilter<MovingImageType, InternalImageType>;
 
-  FixedImageCasterType::Pointer fixedImageCaster =
-    FixedImageCasterType::New();
-  MovingImageCasterType::Pointer movingImageCaster =
-    MovingImageCasterType::New();
+  auto fixedImageCaster = FixedImageCasterType::New();
+  auto movingImageCaster = MovingImageCasterType::New();
 
   fixedImageCaster->SetInput(fixedImageReader->GetOutput());
   movingImageCaster->SetInput(movingImageReader->GetOutput());
@@ -170,7 +166,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using MatchingFilterType =
     itk::HistogramMatchingImageFilter<InternalImageType, InternalImageType>;
-  MatchingFilterType::Pointer matcher = MatchingFilterType::New();
+  auto matcher = MatchingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -239,12 +235,12 @@ main(int argc, char * argv[])
     itk::LevelSetMotionRegistrationFilter<InternalImageType,
                                           InternalImageType,
                                           DisplacementFieldType>;
-  RegistrationFilterType::Pointer filter = RegistrationFilterType::New();
+  auto filter = RegistrationFilterType::New();
   // Software Guide : EndCodeSnippet
 
   // Create the Command observer and register it with the registration filter.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   filter->AddObserver(itk::IterationEvent(), observer);
 
   // Software Guide : BeginLatex
@@ -318,9 +314,9 @@ main(int argc, char * argv[])
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<MovingImageType,
                                         InterpolatorPrecisionType>;
-  WarperType::Pointer       warper = WarperType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  FixedImageType::Pointer   fixedImage = fixedImageReader->GetOutput();
+  auto                    warper = WarperType::New();
+  auto                    interpolator = InterpolatorType::New();
+  FixedImageType::Pointer fixedImage = fixedImageReader->GetOutput();
 
   warper->SetInput(movingImageReader->GetOutput());
   warper->SetInterpolator(interpolator);
@@ -356,8 +352,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<MovingImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -403,7 +399,7 @@ main(int argc, char * argv[])
 
     // Software Guide : BeginCodeSnippet
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
     fieldWriter->SetFileName(argv[4]);
     fieldWriter->SetInput(filter->GetOutput());
 
@@ -439,10 +435,9 @@ main(int argc, char * argv[])
 
     using VectorImage3DWriterType = itk::ImageFileWriter<VectorImage3DType>;
 
-    VectorImage3DWriterType::Pointer writer3D =
-      VectorImage3DWriterType::New();
+    auto writer3D = VectorImage3DWriterType::New();
 
-    VectorImage3DType::Pointer vectorImage3D = VectorImage3DType::New();
+    auto vectorImage3D = VectorImage3DType::New();
 
     VectorImage3DType::RegionType region3D;
     VectorImage3DType::IndexType  index3D;

--- a/Examples/RegistrationITKv4/DeformableRegistration6.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration6.cxx
@@ -178,9 +178,9 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
 
   registration->SetMetric(metric);
@@ -189,10 +189,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -214,14 +212,14 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer outputBSplineTransform = TransformType::New();
+  auto outputBSplineTransform = TransformType::New();
 
   // Initialize the fixed parameters of transform (grid size, etc).
   //
   using InitializerType =
     itk::BSplineTransformInitializer<TransformType, FixedImageType>;
 
-  InitializerType::Pointer transformInitializer = InitializerType::New();
+  auto transformInitializer = InitializerType::New();
 
   unsigned int numberOfGridNodesInOneDimension = 8;
 
@@ -299,7 +297,7 @@ main(int argc, char * argv[])
   {
     using ShrinkFilterType =
       itk::ShrinkImageFilter<FixedImageType, FixedImageType>;
-    ShrinkFilterType::Pointer shrinkFilter = ShrinkFilterType::New();
+    auto shrinkFilter = ShrinkFilterType::New();
     shrinkFilter->SetShrinkFactors(shrinkFactorsPerLevel[level]);
     shrinkFilter->SetInput(fixedImage);
     shrinkFilter->Update();
@@ -315,7 +313,7 @@ main(int argc, char * argv[])
 
     using BSplineAdaptorType =
       itk::BSplineTransformParametersAdaptor<TransformType>;
-    BSplineAdaptorType::Pointer bsplineAdaptor = BSplineAdaptorType::New();
+    auto bsplineAdaptor = BSplineAdaptorType::New();
     bsplineAdaptor->SetTransform(outputBSplineTransform);
     bsplineAdaptor->SetRequiredTransformDomainMeshSize(requiredMeshSize);
     bsplineAdaptor->SetRequiredTransformDomainOrigin(
@@ -334,7 +332,7 @@ main(int argc, char * argv[])
   // Scale estimator
   using ScalesEstimatorType =
     itk::RegistrationParameterScalesFromPhysicalShift<MetricType>;
-  ScalesEstimatorType::Pointer scalesEstimator = ScalesEstimatorType::New();
+  auto scalesEstimator = ScalesEstimatorType::New();
   scalesEstimator->SetMetric(metric);
   scalesEstimator->SetTransformForward(true);
   scalesEstimator->SetSmallParameterVariation(1.0);
@@ -347,7 +345,7 @@ main(int argc, char * argv[])
   optimizer->SetMaximumLineSearchEvaluations(10);
 
   // Connect an observer
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   std::cout << "Starting Registration " << std::endl;
@@ -371,7 +369,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(outputBSplineTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -392,8 +390,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -419,9 +417,9 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
 
@@ -475,8 +473,7 @@ main(int argc, char * argv[])
                                             CoordinateRepType>;
 
   /** Create an setup displacement field generator. */
-  DisplacementFieldGeneratorType::Pointer dispfieldGenerator =
-    DisplacementFieldGeneratorType::New();
+  auto dispfieldGenerator = DisplacementFieldGeneratorType::New();
   dispfieldGenerator->UseReferenceImageOn();
   dispfieldGenerator->SetReferenceImage(fixedImage);
   dispfieldGenerator->SetTransform(outputBSplineTransform);
@@ -492,7 +489,7 @@ main(int argc, char * argv[])
   }
 
   using FieldWriterType = itk::ImageFileWriter<DisplacementFieldImageType>;
-  FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+  auto fieldWriter = FieldWriterType::New();
 
   fieldWriter->SetInput(dispfieldGenerator->GetOutput());
 

--- a/Examples/RegistrationITKv4/DeformableRegistration7.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration7.cxx
@@ -167,9 +167,9 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
 
   registration->SetMetric(metric);
@@ -179,10 +179,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -205,14 +203,14 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer outputBSplineTransform = TransformType::New();
+  auto outputBSplineTransform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
   // Initialize the transform
   using InitializerType =
     itk::BSplineTransformInitializer<TransformType, FixedImageType>;
 
-  InitializerType::Pointer transformInitializer = InitializerType::New();
+  auto transformInitializer = InitializerType::New();
 
   unsigned int numberOfGridNodesInOneDimension = 8;
 
@@ -289,7 +287,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   std::cout << "Starting Registration " << std::endl;
@@ -319,7 +317,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(outputBSplineTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -340,8 +338,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -367,9 +365,9 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
 
@@ -423,8 +421,7 @@ main(int argc, char * argv[])
                                             CoordinateRepType>;
 
   /** Create an setup displacement field generator. */
-  DisplacementFieldGeneratorType::Pointer dispfieldGenerator =
-    DisplacementFieldGeneratorType::New();
+  auto dispfieldGenerator = DisplacementFieldGeneratorType::New();
   dispfieldGenerator->UseReferenceImageOn();
   dispfieldGenerator->SetReferenceImage(fixedImage);
   dispfieldGenerator->SetTransform(outputBSplineTransform);
@@ -440,7 +437,7 @@ main(int argc, char * argv[])
   }
 
   using FieldWriterType = itk::ImageFileWriter<DisplacementFieldImageType>;
-  FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+  auto fieldWriter = FieldWriterType::New();
 
   fieldWriter->SetInput(dispfieldGenerator->GetOutput());
 

--- a/Examples/RegistrationITKv4/DeformableRegistration8.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration8.cxx
@@ -156,9 +156,9 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
 
   registration->SetMetric(metric);
@@ -167,10 +167,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -193,7 +191,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
   // Initialize the transform
@@ -207,7 +205,7 @@ main(int argc, char * argv[])
   using InitializerType =
     itk::BSplineTransformInitializer<TransformType, FixedImageType>;
 
-  InitializerType::Pointer transformInitializer = InitializerType::New();
+  auto transformInitializer = InitializerType::New();
 
   TransformType::MeshSizeType meshSize;
   meshSize.Fill(numberOfGridNodesInOneDimension - SplineOrder);
@@ -255,7 +253,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   //  A single level registration process is run using
@@ -326,7 +324,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -352,8 +350,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -379,9 +377,9 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
 
@@ -437,8 +435,7 @@ main(int argc, char * argv[])
                                               CoordinateRepType>;
 
     /** Create an setup displacement field generator. */
-    DisplacementFieldGeneratorType::Pointer dispfieldGenerator =
-      DisplacementFieldGeneratorType::New();
+    auto dispfieldGenerator = DisplacementFieldGeneratorType::New();
     dispfieldGenerator->UseReferenceImageOn();
     dispfieldGenerator->SetReferenceImage(fixedImage);
     dispfieldGenerator->SetTransform(transform);
@@ -454,7 +451,7 @@ main(int argc, char * argv[])
     }
 
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldImageType>;
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
 
     fieldWriter->SetInput(dispfieldGenerator->GetOutput());
 

--- a/Examples/RegistrationITKv4/DeformableRegistration9.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration9.cxx
@@ -105,10 +105,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -120,17 +118,15 @@ main(int argc, char * argv[])
   using MovingImageCasterType =
     itk::CastImageFilter<MovingImageType, InternalImageType>;
 
-  FixedImageCasterType::Pointer fixedImageCaster =
-    FixedImageCasterType::New();
-  MovingImageCasterType::Pointer movingImageCaster =
-    MovingImageCasterType::New();
+  auto fixedImageCaster = FixedImageCasterType::New();
+  auto movingImageCaster = MovingImageCasterType::New();
 
   fixedImageCaster->SetInput(fixedImageReader->GetOutput());
   movingImageCaster->SetInput(movingImageReader->GetOutput());
 
   using MatchingFilterType =
     itk::HistogramMatchingImageFilter<InternalImageType, InternalImageType>;
-  MatchingFilterType::Pointer matcher = MatchingFilterType::New();
+  auto matcher = MatchingFilterType::New();
 
   matcher->SetInput(movingImageCaster->GetOutput());
   matcher->SetReferenceImage(fixedImageCaster->GetOutput());
@@ -149,9 +145,9 @@ main(int argc, char * argv[])
       InternalImageType,
       DisplacementFieldType>>;
 
-  RegistrationFilterType::Pointer filter = RegistrationFilterType::New();
+  auto filter = RegistrationFilterType::New();
 
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   filter->AddObserver(itk::IterationEvent(), observer);
 
   filter->SetFixedImage(fixedImageCaster->GetOutput());
@@ -170,9 +166,9 @@ main(int argc, char * argv[])
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<MovingImageType,
                                         InterpolatorPrecisionType>;
-  WarperType::Pointer       warper = WarperType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  FixedImageType::Pointer   fixedImage = fixedImageReader->GetOutput();
+  auto                    warper = WarperType::New();
+  auto                    interpolator = InterpolatorType::New();
+  FixedImageType::Pointer fixedImage = fixedImageReader->GetOutput();
 
   warper->SetInput(movingImageReader->GetOutput());
   warper->SetInterpolator(interpolator);
@@ -193,8 +189,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<MovingImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -207,7 +203,7 @@ main(int argc, char * argv[])
 
     using FieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
 
-    FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+    auto fieldWriter = FieldWriterType::New();
     fieldWriter->SetFileName(argv[4]);
     fieldWriter->SetInput(filter->GetOutput());
 

--- a/Examples/RegistrationITKv4/DisplacementFieldInitialization.cxx
+++ b/Examples/RegistrationITKv4/DisplacementFieldInitialization.cxx
@@ -72,7 +72,7 @@ main(int argc, char * argv[])
   using FixedReaderType = itk::ImageFileReader<FixedImageType>;
 
 
-  FixedReaderType::Pointer fixedReader = FixedReaderType::New();
+  auto fixedReader = FixedReaderType::New();
 
   fixedReader->SetFileName(argv[2]);
 
@@ -93,7 +93,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::LandmarkDisplacementFieldSource<DisplacementFieldType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   filter->SetOutputSpacing(fixedImage->GetSpacing());
   filter->SetOutputOrigin(fixedImage->GetOrigin());
@@ -105,10 +105,8 @@ main(int argc, char * argv[])
   using LandmarkContainerType = FilterType::LandmarkContainer;
   using LandmarkPointType = FilterType::LandmarkPointType;
 
-  LandmarkContainerType::Pointer sourceLandmarks =
-    LandmarkContainerType::New();
-  LandmarkContainerType::Pointer targetLandmarks =
-    LandmarkContainerType::New();
+  auto          sourceLandmarks = LandmarkContainerType::New();
+  auto          targetLandmarks = LandmarkContainerType::New();
   std::ifstream pointsFile;
   pointsFile.open(argv[1]);
 
@@ -145,7 +143,7 @@ main(int argc, char * argv[])
   // Write an image for regression testing
   using WriterType = itk::ImageFileWriter<DisplacementFieldType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[3]);
   filter->Print(std::cout);

--- a/Examples/RegistrationITKv4/ImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration1.cxx
@@ -200,9 +200,9 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -256,10 +256,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FixedLinearInterpolatorType::Pointer fixedInterpolator =
-    FixedLinearInterpolatorType::New();
-  MovingLinearInterpolatorType::Pointer movingInterpolator =
-    MovingLinearInterpolatorType::New();
+  auto fixedInterpolator = FixedLinearInterpolatorType::New();
+  auto movingInterpolator = MovingLinearInterpolatorType::New();
 
   metric->SetFixedInterpolator(fixedInterpolator);
   metric->SetMovingInterpolator(movingInterpolator);
@@ -267,10 +265,8 @@ main(int argc, char * argv[])
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -309,7 +305,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer movingInitialTransform = TransformType::New();
+  auto movingInitialTransform = TransformType::New();
 
   TransformType::ParametersType initialParameters(
     movingInitialTransform->GetNumberOfParameters());
@@ -369,7 +365,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer identityTransform = TransformType::New();
+  auto identityTransform = TransformType::New();
   identityTransform->SetIdentity();
 
   registration->SetFixedInitialTransform(identityTransform);
@@ -455,7 +451,7 @@ main(int argc, char * argv[])
   {
     using ScalesEstimatorType =
       itk::RegistrationParameterScalesFromPhysicalShift<MetricType>;
-    ScalesEstimatorType::Pointer scalesEstimator = ScalesEstimatorType::New();
+    auto scalesEstimator = ScalesEstimatorType::New();
     scalesEstimator->SetMetric(metric);
     scalesEstimator->SetTransformForward(true);
     optimizer->SetScalesEstimator(scalesEstimator);
@@ -480,7 +476,7 @@ main(int argc, char * argv[])
 
 
   // Connect an observer
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   //  Software Guide : BeginLatex
@@ -664,8 +660,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using CompositeTransformType = itk::CompositeTransform<double, Dimension>;
-  CompositeTransformType::Pointer outputCompositeTransform =
-    CompositeTransformType::New();
+  auto outputCompositeTransform = CompositeTransformType::New();
   outputCompositeTransform->AddTransform(movingInitialTransform);
   outputCompositeTransform->AddTransform(
     registration->GetModifiableTransform());
@@ -698,7 +693,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  auto resampler = ResampleFilterType::New();
   resampler->SetInput(movingImageReader->GetOutput());
   // Software Guide : EndCodeSnippet
 
@@ -786,8 +781,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -834,7 +829,7 @@ main(int argc, char * argv[])
   using DifferenceFilterType =
     itk::SubtractImageFilter<FixedImageType, FixedImageType, FixedImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
   difference->SetInput1(fixedImageReader->GetOutput());
   difference->SetInput2(resampler->GetOutput());
@@ -870,7 +865,7 @@ main(int argc, char * argv[])
   using RescalerType =
     itk::RescaleIntensityImageFilter<FixedImageType, OutputImageType>;
 
-  RescalerType::Pointer intensityRescaler = RescalerType::New();
+  auto intensityRescaler = RescalerType::New();
 
   intensityRescaler->SetInput(difference->GetOutput());
   intensityRescaler->SetOutputMinimum(0);
@@ -887,7 +882,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(intensityRescaler->GetOutput());
   // Software Guide : EndCodeSnippet
 

--- a/Examples/RegistrationITKv4/ImageRegistration10.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration10.cxx
@@ -184,11 +184,11 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MetricType::Pointer       metric = MetricType::New();
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -223,10 +223,8 @@ main(int argc, char * argv[])
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -362,7 +360,7 @@ main(int argc, char * argv[])
   //
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   //  Software Guide : BeginLatex
@@ -482,7 +480,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
   //  Software Guide : EndCodeSnippet
@@ -495,7 +493,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
   //  Software Guide : EndCodeSnippet
@@ -547,8 +545,8 @@ main(int argc, char * argv[])
   // SoftwareGuide : EndLatex
 
   // SoftwareGuide : BeginCodeSnippet
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
   // SoftwareGuide : EndCodeSnippet
 
   writer->SetFileName(argv[3]);
@@ -581,14 +579,14 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
   difference->SetInput1(fixedImageReader->GetOutput());
   difference->SetInput2(resample->GetOutput());
   // SoftwareGuide : EndCodeSnippet
 
   //  Its output can be passed to another writer.
   //
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
   if (argc > 4)

--- a/Examples/RegistrationITKv4/ImageRegistration11.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration11.cxx
@@ -139,10 +139,10 @@ main(int argc, char * argv[])
                                                      MovingImageType>;
   // Software Guide : EndCodeSnippet
 
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  MetricType::Pointer       metric = MetricType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto metric = MetricType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetMetric(metric);
@@ -187,10 +187,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -228,7 +226,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using GeneratorType = itk::Statistics::NormalVariateGenerator;
 
-  GeneratorType::Pointer generator = GeneratorType::New();
+  auto generator = GeneratorType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -276,7 +274,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -333,7 +331,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -353,8 +351,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<FixedImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 

--- a/Examples/RegistrationITKv4/ImageRegistration12.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration12.cxx
@@ -121,23 +121,21 @@ main(int argc, char * argv[])
   using RegistrationType = itk::
     ImageRegistrationMethodv4<FixedImageType, MovingImageType, TransformType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetMetric(metric);
   registration->SetOptimizer(optimizer);
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   registration->SetInitialTransform(transform);
   registration->InPlaceOn();
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -150,8 +148,7 @@ main(int argc, char * argv[])
     itk::CenteredTransformInitializer<TransformType,
                                       FixedImageType,
                                       MovingImageType>;
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
 
   initializer->SetTransform(transform);
   initializer->SetFixedImage(fixedImageReader->GetOutput());
@@ -179,7 +176,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   //  Software Guide : BeginLatex
@@ -206,7 +203,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MaskType::Pointer spatialObjectMask = MaskType::New();
+  auto spatialObjectMask = MaskType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -230,7 +227,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MaskReaderType::Pointer maskReader = MaskReaderType::New();
+  auto maskReader = MaskReaderType::New();
 
   maskReader->SetFileName(argv[3]);
   // Software Guide : EndCodeSnippet
@@ -387,12 +384,12 @@ main(int argc, char * argv[])
 
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -414,8 +411,8 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[4]);
 
@@ -428,9 +425,9 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
   // Compute the difference image between the

--- a/Examples/RegistrationITKv4/ImageRegistration13.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration13.cxx
@@ -124,10 +124,10 @@ main(int argc, char * argv[])
                                                      MovingImageType>;
   // Software Guide : EndCodeSnippet
 
-  TransformType::Pointer    transform = TransformType::New();
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetMetric(metric);
@@ -151,10 +151,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -189,8 +187,7 @@ main(int argc, char * argv[])
     itk::CenteredTransformInitializer<TransformType,
                                       FixedImageType,
                                       MovingImageType>;
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
   initializer->SetTransform(transform);
 
   initializer->SetFixedImage(fixedImageReader->GetOutput());
@@ -248,7 +245,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -301,7 +298,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -323,8 +320,8 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 

--- a/Examples/RegistrationITKv4/ImageRegistration14.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration14.cxx
@@ -126,17 +126,17 @@ main(int argc, char * argv[])
       FixedImageType,
       MovingImageType>;
 
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetTransform(transform);
   registration->SetInterpolator(interpolator);
 
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   registration->SetMetric(metric);
 
 
@@ -167,10 +167,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -187,8 +185,7 @@ main(int argc, char * argv[])
     itk::CenteredTransformInitializer<TransformType,
                                       FixedImageType,
                                       MovingImageType>;
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
   initializer->SetTransform(transform);
   initializer->SetFixedImage(fixedImageReader->GetOutput());
   initializer->SetMovingImage(movingImageReader->GetOutput());
@@ -230,7 +227,7 @@ main(int argc, char * argv[])
   optimizer->SetScales(optimizerScales);
 
   using GeneratorType = itk::Statistics::NormalVariateGenerator;
-  GeneratorType::Pointer generator = GeneratorType::New();
+  auto generator = GeneratorType::New();
   generator->Initialize(12345);
   optimizer->MaximizeOn();
   optimizer->SetNormalVariateGenerator(generator);
@@ -253,7 +250,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
   try
   {
@@ -298,11 +295,11 @@ main(int argc, char * argv[])
 
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
   resample->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
@@ -314,7 +311,7 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<PixelType, Dimension>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[3]);
   writer->SetInput(resample->GetOutput());
   writer->Update();

--- a/Examples/RegistrationITKv4/ImageRegistration15.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration15.cxx
@@ -124,17 +124,17 @@ main(int argc, char * argv[])
       FixedImageType,
       MovingImageType>;
 
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetTransform(transform);
   registration->SetInterpolator(interpolator);
 
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   registration->SetMetric(metric);
 
 
@@ -164,10 +164,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -209,7 +207,7 @@ main(int argc, char * argv[])
   optimizer->SetScales(optimizerScales);
 
   using GeneratorType = itk::Statistics::NormalVariateGenerator;
-  GeneratorType::Pointer generator = GeneratorType::New();
+  auto generator = GeneratorType::New();
   generator->Initialize(12345);
 
   optimizer->MaximizeOn();
@@ -232,7 +230,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
   try
   {
@@ -264,11 +262,11 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -281,7 +279,7 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<PixelType, Dimension>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[3]);
   writer->SetInput(resample->GetOutput());
   writer->Update();

--- a/Examples/RegistrationITKv4/ImageRegistration16.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration16.cxx
@@ -116,17 +116,17 @@ main(int argc, char * argv[])
                                                    MovingImageType>;
 
 
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetTransform(transform);
   registration->SetInterpolator(interpolator);
 
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   registration->SetMetric(metric);
 
 
@@ -172,10 +172,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -264,7 +262,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -302,12 +300,12 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -324,7 +322,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[3]);
 

--- a/Examples/RegistrationITKv4/ImageRegistration17.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration17.cxx
@@ -114,17 +114,17 @@ main(int argc, char * argv[])
                                                       MovingImageType>;
 
 
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetTransform(transform);
   registration->SetInterpolator(interpolator);
 
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   registration->SetMetric(metric);
 
 
@@ -152,10 +152,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -257,7 +255,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -295,12 +293,12 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -317,7 +315,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[3]);
 

--- a/Examples/RegistrationITKv4/ImageRegistration18.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration18.cxx
@@ -110,16 +110,16 @@ main(int argc, char * argv[])
     itk::GradientDifferenceImageToImageMetric<FixedImageType,
                                               MovingImageType>;
 
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetTransform(transform);
   registration->SetInterpolator(interpolator);
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
 
   metric->SetDerivativeDelta(0.5);
 
@@ -128,10 +128,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -173,7 +171,7 @@ main(int argc, char * argv[])
   optimizer->MaximizeOn();
 
 
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   try
@@ -215,12 +213,12 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -246,8 +244,8 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);

--- a/Examples/RegistrationITKv4/ImageRegistration19.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration19.cxx
@@ -128,11 +128,11 @@ main(int argc, char * argv[])
   //  \code{New()} method and is assigned to its respective
   //  \doxygen{SmartPointer}.
   //
-  MetricType::Pointer       metric = MetricType::New();
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   metric->MeasureMatchesOff();
 
@@ -153,10 +153,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -198,8 +196,7 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       MovingImageType>;
 
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
 
   initializer->SetTransform(transform);
   initializer->SetFixedImage(fixedImageReader->GetOutput());
@@ -282,8 +279,7 @@ main(int argc, char * argv[])
   //
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate19::Pointer observer =
-    CommandIterationUpdate19::New();
+  auto observer = CommandIterationUpdate19::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -375,7 +371,7 @@ main(int argc, char * argv[])
   //
   //  \index{itk::ImageRegistrationMethod!Resampling image}
   //
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
@@ -385,7 +381,7 @@ main(int argc, char * argv[])
   //  Then a resampling filter is created and the corresponding transform and
   //  moving image connected as inputs.
   //
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
 
@@ -419,8 +415,8 @@ main(int argc, char * argv[])
   //  The filters are created by invoking their \code{New()}
   //  method.
   //
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -445,13 +441,13 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       OutputImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
   difference->SetInput1(fixedImageReader->GetOutput());
   difference->SetInput2(resample->GetOutput());
 
   //  Its output can be passed to another writer.
   //
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(difference->GetOutput());
 
   if (argc > 4)

--- a/Examples/RegistrationITKv4/ImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration2.cxx
@@ -203,10 +203,10 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetTransform(transform);
@@ -221,7 +221,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   registration->SetMetric(metric);
   // Software Guide : EndCodeSnippet
 
@@ -252,10 +252,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -275,11 +273,9 @@ main(int argc, char * argv[])
   using MovingNormalizeFilterType =
     itk::NormalizeImageFilter<MovingImageType, InternalImageType>;
 
-  FixedNormalizeFilterType::Pointer fixedNormalizer =
-    FixedNormalizeFilterType::New();
+  auto fixedNormalizer = FixedNormalizeFilterType::New();
 
-  MovingNormalizeFilterType::Pointer movingNormalizer =
-    MovingNormalizeFilterType::New();
+  auto movingNormalizer = MovingNormalizeFilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -294,8 +290,8 @@ main(int argc, char * argv[])
   using GaussianFilterType =
     itk::DiscreteGaussianImageFilter<InternalImageType, InternalImageType>;
 
-  GaussianFilterType::Pointer fixedSmoother = GaussianFilterType::New();
-  GaussianFilterType::Pointer movingSmoother = GaussianFilterType::New();
+  auto fixedSmoother = GaussianFilterType::New();
+  auto movingSmoother = GaussianFilterType::New();
 
   fixedSmoother->SetVariance(2.0);
   movingSmoother->SetVariance(2.0);
@@ -428,7 +424,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -504,12 +500,12 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -533,8 +529,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -549,7 +545,7 @@ main(int argc, char * argv[])
   //
   using CheckerBoardFilterType = itk::CheckerBoardImageFilter<FixedImageType>;
 
-  CheckerBoardFilterType::Pointer checker = CheckerBoardFilterType::New();
+  auto checker = CheckerBoardFilterType::New();
 
   checker->SetInput1(fixedImage);
   checker->SetInput2(resample->GetOutput());
@@ -558,7 +554,7 @@ main(int argc, char * argv[])
   writer->SetInput(caster->GetOutput());
 
   // Before registration
-  TransformType::Pointer identityTransform = TransformType::New();
+  auto identityTransform = TransformType::New();
   identityTransform->SetIdentity();
   resample->SetTransform(identityTransform);
 

--- a/Examples/RegistrationITKv4/ImageRegistration20.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration20.cxx
@@ -153,10 +153,10 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethod<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetMetric(metric);
   registration->SetOptimizer(optimizer);
@@ -175,17 +175,15 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   registration->SetTransform(transform);
   // Software Guide : EndCodeSnippet
 
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
 
@@ -213,8 +211,7 @@ main(int argc, char * argv[])
     itk::CenteredTransformInitializer<TransformType,
                                       FixedImageType,
                                       MovingImageType>;
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
   initializer->SetTransform(transform);
   initializer->SetFixedImage(fixedImageReader->GetOutput());
   initializer->SetMovingImage(movingImageReader->GetOutput());
@@ -311,7 +308,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   //  Software Guide : BeginLatex
@@ -377,12 +374,12 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  auto resampler = ResampleFilterType::New();
 
   resampler->SetTransform(finalTransform);
   resampler->SetInput(movingImageReader->GetOutput());
@@ -405,8 +402,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -420,17 +417,17 @@ main(int argc, char * argv[])
   using DifferenceFilterType =
     itk::SubtractImageFilter<FixedImageType, FixedImageType, FixedImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
   difference->SetInput1(fixedImageReader->GetOutput());
   difference->SetInput2(resampler->GetOutput());
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
 
   using RescalerType =
     itk::RescaleIntensityImageFilter<FixedImageType, OutputImageType>;
 
-  RescalerType::Pointer intensityRescaler = RescalerType::New();
+  auto intensityRescaler = RescalerType::New();
 
   intensityRescaler->SetInput(difference->GetOutput());
   intensityRescaler->SetOutputMinimum(0);
@@ -449,7 +446,7 @@ main(int argc, char * argv[])
 
 
   using IdentityTransformType = itk::IdentityTransform<double, Dimension>;
-  IdentityTransformType::Pointer identity = IdentityTransformType::New();
+  auto identity = IdentityTransformType::New();
 
   // Compute the difference image between the
   // fixed and moving image before registration.

--- a/Examples/RegistrationITKv4/ImageRegistration3.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration3.cxx
@@ -296,22 +296,20 @@ main(int argc, char * argv[])
   using MetricType =
     itk::MeanSquaresImageToImageMetricv4<FixedImageType, MovingImageType>;
 
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
 
   registration->SetMetric(metric);
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -352,7 +350,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -485,7 +483,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(registration->GetTransform());
   resample->SetInput(movingImageReader->GetOutput());
@@ -511,8 +509,8 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);

--- a/Examples/RegistrationITKv4/ImageRegistration4.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration4.cxx
@@ -136,8 +136,8 @@ main(int argc, char * argv[])
                                                      MovingImageType>;
   // Software Guide : EndCodeSnippet
 
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
 
@@ -150,7 +150,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   registration->SetMetric(metric);
   // Software Guide : EndCodeSnippet
 
@@ -197,10 +197,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -269,7 +267,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   // One level registration process without shrinking and smoothing.
@@ -450,7 +448,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(registration->GetTransform());
   resample->SetInput(movingImageReader->GetOutput());
@@ -480,8 +478,8 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -515,7 +513,7 @@ main(int argc, char * argv[])
   //
   using CheckerBoardFilterType = itk::CheckerBoardImageFilter<FixedImageType>;
 
-  CheckerBoardFilterType::Pointer checker = CheckerBoardFilterType::New();
+  auto checker = CheckerBoardFilterType::New();
 
   checker->SetInput1(fixedImage);
   checker->SetInput2(resample->GetOutput());
@@ -526,7 +524,7 @@ main(int argc, char * argv[])
   resample->SetDefaultPixelValue(0);
 
   // Before registration
-  TransformType::Pointer identityTransform = TransformType::New();
+  auto identityTransform = TransformType::New();
   identityTransform->SetIdentity();
   resample->SetTransform(identityTransform);
 

--- a/Examples/RegistrationITKv4/ImageRegistration5.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration5.cxx
@@ -156,9 +156,9 @@ main(int argc, char * argv[])
   using RegistrationType = itk::
     ImageRegistrationMethodv4<FixedImageType, MovingImageType, TransformType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetMetric(metric);
   registration->SetOptimizer(optimizer);
@@ -245,17 +245,15 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer initialTransform = TransformType::New();
+  auto initialTransform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -443,7 +441,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   // One level registration process without shrinking and smoothing.
@@ -597,7 +595,7 @@ main(int argc, char * argv[])
   // TransformType::ConstPointer finalTransform =
   // registration->GetTransform();
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(registration->GetTransform());
   resample->SetInput(movingImageReader->GetOutput());
@@ -614,8 +612,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<FixedImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -639,12 +637,12 @@ main(int argc, char * argv[])
   using DifferenceFilterType = itk::
     SubtractImageFilter<FixedImageType, FixedImageType, DifferenceImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
   using RescalerType =
     itk::RescaleIntensityImageFilter<DifferenceImageType, OutputImageType>;
 
-  RescalerType::Pointer intensityRescaler = RescalerType::New();
+  auto intensityRescaler = RescalerType::New();
 
   intensityRescaler->SetOutputMinimum(0);
   intensityRescaler->SetOutputMaximum(255);
@@ -656,7 +654,7 @@ main(int argc, char * argv[])
 
   intensityRescaler->SetInput(difference->GetOutput());
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
 
   writer2->SetInput(intensityRescaler->GetOutput());
 
@@ -673,7 +671,7 @@ main(int argc, char * argv[])
 
     // Compute the difference image between the
     // fixed and resampled moving image after registration.
-    TransformType::Pointer identityTransform = TransformType::New();
+    auto identityTransform = TransformType::New();
     identityTransform->SetIdentity();
     resample->SetTransform(identityTransform);
     if (argc > 5)

--- a/Examples/RegistrationITKv4/ImageRegistration6.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration6.cxx
@@ -176,9 +176,9 @@ main(int argc, char * argv[])
   using RegistrationType =
     itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
 
   registration->SetMetric(metric);
@@ -197,15 +197,13 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -238,8 +236,7 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       MovingImageType>;
 
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -334,7 +331,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   // One level registration process without shrinking and smoothing.
@@ -575,7 +572,7 @@ main(int argc, char * argv[])
 
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -598,8 +595,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -617,7 +614,7 @@ main(int argc, char * argv[])
   using DifferenceFilterType = itk::
     SubtractImageFilter<FixedImageType, FixedImageType, DifferenceImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
   using OutputPixelType = unsigned char;
 
@@ -626,7 +623,7 @@ main(int argc, char * argv[])
   using RescalerType =
     itk::RescaleIntensityImageFilter<DifferenceImageType, OutputImageType>;
 
-  RescalerType::Pointer intensityRescaler = RescalerType::New();
+  auto intensityRescaler = RescalerType::New();
 
   intensityRescaler->SetOutputMinimum(0);
   intensityRescaler->SetOutputMaximum(255);
@@ -640,7 +637,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
 
   writer2->SetInput(intensityRescaler->GetOutput());
 
@@ -657,7 +654,7 @@ main(int argc, char * argv[])
 
     // Compute the difference image between the
     // fixed and resampled moving image after registration.
-    TransformType::Pointer identityTransform = TransformType::New();
+    auto identityTransform = TransformType::New();
     identityTransform->SetIdentity();
     resample->SetTransform(identityTransform);
     if (argc > 4)

--- a/Examples/RegistrationITKv4/ImageRegistration7.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration7.cxx
@@ -169,9 +169,9 @@ main(int argc, char * argv[])
   using RegistrationType = itk::
     ImageRegistrationMethodv4<FixedImageType, MovingImageType, TransformType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetMetric(metric);
   registration->SetOptimizer(optimizer);
@@ -187,17 +187,15 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -223,8 +221,7 @@ main(int argc, char * argv[])
                                       FixedImageType,
                                       MovingImageType>;
 
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
 
   initializer->SetTransform(transform);
 
@@ -336,7 +333,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   // One level registration process without shrinking and smoothing.
@@ -488,7 +485,7 @@ main(int argc, char * argv[])
 
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
-  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  auto resampler = ResampleFilterType::New();
 
   resampler->SetTransform(transform);
   resampler->SetInput(movingImageReader->GetOutput());
@@ -511,8 +508,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -526,13 +523,13 @@ main(int argc, char * argv[])
   using DifferenceFilterType =
     itk::SubtractImageFilter<FixedImageType, FixedImageType, FixedImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
 
   using RescalerType =
     itk::RescaleIntensityImageFilter<FixedImageType, OutputImageType>;
 
-  RescalerType::Pointer intensityRescaler = RescalerType::New();
+  auto intensityRescaler = RescalerType::New();
 
   intensityRescaler->SetInput(difference->GetOutput());
   intensityRescaler->SetOutputMinimum(0);
@@ -543,7 +540,7 @@ main(int argc, char * argv[])
 
   resampler->SetDefaultPixelValue(1);
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(intensityRescaler->GetOutput());
 
 
@@ -557,7 +554,7 @@ main(int argc, char * argv[])
 
 
   using IdentityTransformType = itk::IdentityTransform<double, Dimension>;
-  IdentityTransformType::Pointer identity = IdentityTransformType::New();
+  auto identity = IdentityTransformType::New();
 
   // Compute the difference image between the
   // fixed and moving image before registration.

--- a/Examples/RegistrationITKv4/ImageRegistration8.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration8.cxx
@@ -173,9 +173,9 @@ main(int argc, char * argv[])
   using RegistrationType = itk::
     ImageRegistrationMethodv4<FixedImageType, MovingImageType, TransformType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetMetric(metric);
   registration->SetOptimizer(optimizer);
@@ -191,15 +191,13 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer initialTransform = TransformType::New();
+  auto initialTransform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -231,8 +229,7 @@ main(int argc, char * argv[])
     itk::CenteredTransformInitializer<TransformType,
                                       FixedImageType,
                                       MovingImageType>;
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -333,7 +330,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   // One level registration process without shrinking and smoothing.
@@ -447,7 +444,7 @@ main(int argc, char * argv[])
   //
   //  Software Guide : EndLatex
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetFixedParameters(
     registration->GetOutput()->Get()->GetFixedParameters());
@@ -560,7 +557,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  auto resampler = ResampleFilterType::New();
 
   resampler->SetTransform(finalTransform);
   resampler->SetInput(movingImageReader->GetOutput());
@@ -579,8 +576,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<FixedImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -590,11 +587,11 @@ main(int argc, char * argv[])
 
   using DifferenceFilterType =
     itk::SubtractImageFilter<FixedImageType, FixedImageType, FixedImageType>;
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
   using RescalerType =
     itk::RescaleIntensityImageFilter<FixedImageType, OutputImageType>;
-  RescalerType::Pointer intensityRescaler = RescalerType::New();
+  auto intensityRescaler = RescalerType::New();
 
   intensityRescaler->SetInput(difference->GetOutput());
   intensityRescaler->SetOutputMinimum(0);
@@ -605,7 +602,7 @@ main(int argc, char * argv[])
 
   resampler->SetDefaultPixelValue(1);
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
   writer2->SetInput(intensityRescaler->GetOutput());
 
   // Compute the difference image between the
@@ -617,7 +614,7 @@ main(int argc, char * argv[])
   }
 
   using IdentityTransformType = itk::IdentityTransform<double, Dimension>;
-  IdentityTransformType::Pointer identity = IdentityTransformType::New();
+  auto identity = IdentityTransformType::New();
   // Compute the difference image between the
   // fixed and moving image before registration.
   if (argc > 4)
@@ -635,7 +632,7 @@ main(int argc, char * argv[])
   using OutputSliceType = itk::Image<OutputPixelType, 2>;
   using ExtractFilterType =
     itk::ExtractImageFilter<OutputImageType, OutputSliceType>;
-  ExtractFilterType::Pointer extractor = ExtractFilterType::New();
+  auto extractor = ExtractFilterType::New();
   extractor->SetDirectionCollapseToSubmatrix();
   extractor->InPlaceOn();
 
@@ -652,7 +649,7 @@ main(int argc, char * argv[])
   desiredRegion.SetIndex(start);
   extractor->SetExtractionRegion(desiredRegion);
   using SliceWriterType = itk::ImageFileWriter<OutputSliceType>;
-  SliceWriterType::Pointer sliceWriter = SliceWriterType::New();
+  auto sliceWriter = SliceWriterType::New();
   sliceWriter->SetInput(extractor->GetOutput());
   if (argc > 6)
   {

--- a/Examples/RegistrationITKv4/ImageRegistration9.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration9.cxx
@@ -174,9 +174,9 @@ main(int argc, char * argv[])
   using RegistrationType = itk::
     ImageRegistrationMethodv4<FixedImageType, MovingImageType, TransformType>;
 
-  MetricType::Pointer       metric = MetricType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetMetric(metric);
   registration->SetOptimizer(optimizer);
@@ -194,16 +194,14 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
 
@@ -227,8 +225,7 @@ main(int argc, char * argv[])
     itk::CenteredTransformInitializer<TransformType,
                                       FixedImageType,
                                       MovingImageType>;
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
   initializer->SetTransform(transform);
   initializer->SetFixedImage(fixedImageReader->GetOutput());
   initializer->SetMovingImage(movingImageReader->GetOutput());
@@ -322,7 +319,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -521,7 +518,7 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  auto resampler = ResampleFilterType::New();
 
   resampler->SetTransform(transform);
   resampler->SetInput(movingImageReader->GetOutput());
@@ -544,8 +541,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -559,17 +556,17 @@ main(int argc, char * argv[])
   using DifferenceFilterType =
     itk::SubtractImageFilter<FixedImageType, FixedImageType, FixedImageType>;
 
-  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  auto difference = DifferenceFilterType::New();
 
   difference->SetInput1(fixedImageReader->GetOutput());
   difference->SetInput2(resampler->GetOutput());
 
-  WriterType::Pointer writer2 = WriterType::New();
+  auto writer2 = WriterType::New();
 
   using RescalerType =
     itk::RescaleIntensityImageFilter<FixedImageType, OutputImageType>;
 
-  RescalerType::Pointer intensityRescaler = RescalerType::New();
+  auto intensityRescaler = RescalerType::New();
 
   intensityRescaler->SetInput(difference->GetOutput());
   intensityRescaler->SetOutputMinimum(0);
@@ -588,7 +585,7 @@ main(int argc, char * argv[])
 
 
   using IdentityTransformType = itk::IdentityTransform<double, Dimension>;
-  IdentityTransformType::Pointer identity = IdentityTransformType::New();
+  auto identity = IdentityTransformType::New();
 
   // Compute the difference image between the
   // fixed and moving image before registration.

--- a/Examples/RegistrationITKv4/ImageRegistrationHistogramPlotter.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistrationHistogramPlotter.cxx
@@ -330,14 +330,13 @@ public:
                                    RescaledOutputImageType,
                                    RescaleDynamicRangeFunctorType>;
 
-    RescaleDynamicRangeFilterType::Pointer rescaler =
-      RescaleDynamicRangeFilterType::New();
+    auto rescaler = RescaleDynamicRangeFilterType::New();
 
     rescaler->SetInput(m_Filter->GetOutput());
 
     using RescaledWriterType = itk::ImageFileWriter<RescaledOutputImageType>;
 
-    RescaledWriterType::Pointer rescaledWriter = RescaledWriterType::New();
+    auto rescaledWriter = RescaledWriterType::New();
 
     rescaledWriter->SetInput(rescaler->GetOutput());
 
@@ -509,11 +508,11 @@ main(int argc, char * argv[])
   //
   // Software Guide : EndLatex
 
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
-  MetricType::Pointer       metric = MetricType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
+  auto metric = MetricType::New();
 
 
   registration->SetOptimizer(optimizer);
@@ -550,7 +549,7 @@ main(int argc, char * argv[])
   scales.Fill(1.0);
   metric->SetDerivativeStepLengthScales(scales);
 
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
 
   // Set the metric for the joint histogram writer
   observer->m_JointHistogramWriter.SetMetric(metric);
@@ -560,10 +559,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -575,16 +572,14 @@ main(int argc, char * argv[])
   using MovingNormalizeFilterType =
     itk::NormalizeImageFilter<MovingImageType, InternalImageType>;
 
-  FixedNormalizeFilterType::Pointer fixedNormalizer =
-    FixedNormalizeFilterType::New();
+  auto fixedNormalizer = FixedNormalizeFilterType::New();
 
-  MovingNormalizeFilterType::Pointer movingNormalizer =
-    MovingNormalizeFilterType::New();
+  auto movingNormalizer = MovingNormalizeFilterType::New();
   using GaussianFilterType =
     itk::DiscreteGaussianImageFilter<InternalImageType, InternalImageType>;
 
-  GaussianFilterType::Pointer fixedSmoother = GaussianFilterType::New();
-  GaussianFilterType::Pointer movingSmoother = GaussianFilterType::New();
+  auto fixedSmoother = GaussianFilterType::New();
+  auto movingSmoother = GaussianFilterType::New();
 
   fixedSmoother->SetVariance(2.0);
   movingSmoother->SetVariance(2.0);
@@ -684,12 +679,12 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -713,8 +708,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);

--- a/Examples/RegistrationITKv4/IterativeClosestPoint1.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint1.cxx
@@ -107,15 +107,15 @@ main(int argc, char * argv[])
 
   using PointSetType = itk::PointSet<float, Dimension>;
 
-  PointSetType::Pointer fixedPointSet = PointSetType::New();
-  PointSetType::Pointer movingPointSet = PointSetType::New();
+  auto fixedPointSet = PointSetType::New();
+  auto movingPointSet = PointSetType::New();
 
   using PointType = PointSetType::PointType;
 
   using PointsContainer = PointSetType::PointsContainer;
 
-  PointsContainer::Pointer fixedPointContainer = PointsContainer::New();
-  PointsContainer::Pointer movingPointContainer = PointsContainer::New();
+  auto fixedPointContainer = PointsContainer::New();
+  auto movingPointContainer = PointsContainer::New();
 
   PointType fixedPoint;
   PointType movingPoint;
@@ -175,7 +175,7 @@ main(int argc, char * argv[])
   using MetricType =
     itk::EuclideanDistancePointMetric<PointSetType, PointSetType>;
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -188,20 +188,20 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::TranslationTransform<double, Dimension>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
 
   // Optimizer Type
   using OptimizerType = itk::LevenbergMarquardtOptimizer;
 
-  OptimizerType::Pointer optimizer = OptimizerType::New();
+  auto optimizer = OptimizerType::New();
   optimizer->SetUseCostFunctionGradient(false);
 
   // Registration Method
   using RegistrationType =
     itk::PointSetToPointSetRegistrationMethod<PointSetType, PointSetType>;
 
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto registration = RegistrationType::New();
 
   // Scale the translation components of the Transform in the Optimizer
   OptimizerType::ScalesType scales(transform->GetNumberOfParameters());
@@ -257,7 +257,7 @@ main(int argc, char * argv[])
   registration->SetMovingPointSet(movingPointSet);
 
   // Connect an observer
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
   // Software Guide : EndCodeSnippet
 

--- a/Examples/RegistrationITKv4/IterativeClosestPoint2.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint2.cxx
@@ -104,15 +104,15 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using PointSetType = itk::PointSet<float, Dimension>;
 
-  PointSetType::Pointer fixedPointSet = PointSetType::New();
-  PointSetType::Pointer movingPointSet = PointSetType::New();
+  auto fixedPointSet = PointSetType::New();
+  auto movingPointSet = PointSetType::New();
 
   using PointType = PointSetType::PointType;
 
   using PointsContainer = PointSetType::PointsContainer;
 
-  PointsContainer::Pointer fixedPointContainer = PointsContainer::New();
-  PointsContainer::Pointer movingPointContainer = PointsContainer::New();
+  auto fixedPointContainer = PointsContainer::New();
+  auto movingPointContainer = PointsContainer::New();
 
   PointType fixedPoint;
   PointType movingPoint;
@@ -174,7 +174,7 @@ main(int argc, char * argv[])
   using MetricType =
     itk::EuclideanDistancePointMetric<PointSetType, PointSetType>;
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -186,13 +186,13 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::Euler3DTransform<double>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
 
   // Optimizer Type
   using OptimizerType = itk::LevenbergMarquardtOptimizer;
 
-  OptimizerType::Pointer optimizer = OptimizerType::New();
+  auto optimizer = OptimizerType::New();
   optimizer->SetUseCostFunctionGradient(false);
 
   // Registration Method
@@ -200,7 +200,7 @@ main(int argc, char * argv[])
     itk::PointSetToPointSetRegistrationMethod<PointSetType, PointSetType>;
 
 
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto registration = RegistrationType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -273,7 +273,7 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
   //
   // Connect an observer
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   try

--- a/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
@@ -70,15 +70,15 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using PointSetType = itk::PointSet<float, Dimension>;
 
-  PointSetType::Pointer fixedPointSet = PointSetType::New();
-  PointSetType::Pointer movingPointSet = PointSetType::New();
+  auto fixedPointSet = PointSetType::New();
+  auto movingPointSet = PointSetType::New();
 
   using PointType = PointSetType::PointType;
 
   using PointsContainer = PointSetType::PointsContainer;
 
-  PointsContainer::Pointer fixedPointContainer = PointsContainer::New();
-  PointsContainer::Pointer movingPointContainer = PointsContainer::New();
+  auto fixedPointContainer = PointsContainer::New();
+  auto movingPointContainer = PointsContainer::New();
 
   PointType fixedPoint;
   PointType movingPoint;
@@ -138,7 +138,7 @@ main(int argc, char * argv[])
   using MetricType =
     itk::EuclideanDistancePointMetric<PointSetType, PointSetType>;
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
 
   //-----------------------------------------------------------
   // Set up a Transform
@@ -146,19 +146,19 @@ main(int argc, char * argv[])
 
   using TransformType = itk::TranslationTransform<double, Dimension>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   // Optimizer Type
   using OptimizerType = itk::LevenbergMarquardtOptimizer;
 
-  OptimizerType::Pointer optimizer = OptimizerType::New();
+  auto optimizer = OptimizerType::New();
   optimizer->SetUseCostFunctionGradient(false);
 
   // Registration Method
   using RegistrationType =
     itk::PointSetToPointSetRegistrationMethod<PointSetType, PointSetType>;
 
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto registration = RegistrationType::New();
 
   // Scale the translation components of the Transform in the Optimizer
   OptimizerType::ScalesType scales(transform->GetNumberOfParameters());
@@ -213,8 +213,7 @@ main(int argc, char * argv[])
   using PointsToImageFilterType =
     itk::PointSetToImageFilter<PointSetType, BinaryImageType>;
 
-  PointsToImageFilterType::Pointer pointsToImageFilter =
-    PointsToImageFilterType::New();
+  auto pointsToImageFilter = PointsToImageFilterType::New();
 
   pointsToImageFilter->SetInput(fixedPointSet);
 
@@ -242,7 +241,7 @@ main(int argc, char * argv[])
   using DistanceFilterType =
     itk::DanielssonDistanceMapImageFilter<BinaryImageType, DistanceImageType>;
 
-  DistanceFilterType::Pointer distanceFilter = DistanceFilterType::New();
+  auto distanceFilter = DistanceFilterType::New();
   distanceFilter->SetInput(binaryImage);
   distanceFilter->Update();
   metric->SetDistanceMap(distanceFilter->GetOutput());

--- a/Examples/RegistrationITKv4/LandmarkWarping2.cxx
+++ b/Examples/RegistrationITKv4/LandmarkWarping2.cxx
@@ -70,7 +70,7 @@ main(int argc, char * argv[])
   using MovingWriterType = itk::ImageFileWriter<MovingImageType>;
 
 
-  FixedReaderType::Pointer fixedReader = FixedReaderType::New();
+  auto fixedReader = FixedReaderType::New();
   fixedReader->SetFileName(argv[2]);
 
   try
@@ -85,8 +85,8 @@ main(int argc, char * argv[])
   }
 
 
-  MovingReaderType::Pointer movingReader = MovingReaderType::New();
-  MovingWriterType::Pointer movingWriter = MovingWriterType::New();
+  auto movingReader = MovingReaderType::New();
+  auto movingWriter = MovingWriterType::New();
 
   movingReader->SetFileName(argv[3]);
   movingWriter->SetFileName(argv[4]);
@@ -107,7 +107,7 @@ main(int argc, char * argv[])
   using DisplacementSourceType =
     itk::LandmarkDisplacementFieldSource<DisplacementFieldType>;
 
-  DisplacementSourceType::Pointer deformer = DisplacementSourceType::New();
+  auto deformer = DisplacementSourceType::New();
 
   deformer->SetOutputSpacing(fixedImage->GetSpacing());
   deformer->SetOutputOrigin(fixedImage->GetOrigin());
@@ -128,10 +128,8 @@ main(int argc, char * argv[])
   using LandmarkContainerType = DisplacementSourceType::LandmarkContainer;
   using LandmarkPointType = DisplacementSourceType::LandmarkPointType;
 
-  LandmarkContainerType::Pointer sourceLandmarks =
-    LandmarkContainerType::New();
-  LandmarkContainerType::Pointer targetLandmarks =
-    LandmarkContainerType::New();
+  auto sourceLandmarks = LandmarkContainerType::New();
+  auto targetLandmarks = LandmarkContainerType::New();
 
   LandmarkPointType sourcePoint;
   LandmarkPointType targetPoint;
@@ -199,13 +197,13 @@ main(int argc, char * argv[])
                                               MovingImageType,
                                               InterpolatorPrecisionType,
                                               TransformPrecisionType>;
-  FilterType::Pointer warper = FilterType::New();
+  auto warper = FilterType::New();
 
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<MovingImageType,
                                         InterpolatorPrecisionType>;
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
   warper->SetInterpolator(interpolator);
 

--- a/Examples/RegistrationITKv4/MeanSquaresImageMetric1.cxx
+++ b/Examples/RegistrationITKv4/MeanSquaresImageMetric1.cxx
@@ -77,8 +77,8 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer fixedReader = ReaderType::New();
-  ReaderType::Pointer movingReader = ReaderType::New();
+  auto fixedReader = ReaderType::New();
+  auto movingReader = ReaderType::New();
 
   fixedReader->SetFileName(argv[1]);
   movingReader->SetFileName(argv[2]);
@@ -106,7 +106,7 @@ main(int argc, char * argv[])
   using MetricType =
     itk::MeanSquaresImageToImageMetricv4<ImageType, ImageType>;
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -120,13 +120,13 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::TranslationTransform<double, Dimension>;
 
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
 
   using InterpolatorType =
     itk::NearestNeighborInterpolateImageFunction<ImageType, double>;
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
@@ -424,9 +424,9 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  EllipseType::Pointer ellipse1 = EllipseType::New();
-  EllipseType::Pointer ellipse2 = EllipseType::New();
-  EllipseType::Pointer ellipse3 = EllipseType::New();
+  auto ellipse1 = EllipseType::New();
+  auto ellipse2 = EllipseType::New();
+  auto ellipse3 = EllipseType::New();
   //  Software Guide : EndCodeSnippet
 
 
@@ -509,7 +509,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  GroupType::Pointer group = GroupType::New();
+  auto group = GroupType::New();
   group->AddChild(ellipse1);
   group->AddChild(ellipse2);
   group->AddChild(ellipse3);
@@ -546,8 +546,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   //  Software Guide : BeginCodeSnippet
-  SpatialObjectToImageFilterType::Pointer imageFilter =
-    SpatialObjectToImageFilterType::New();
+  auto imageFilter = SpatialObjectToImageFilterType::New();
   //  Software Guide : EndCodeSnippet
 
 
@@ -609,7 +608,7 @@ main(int argc, char * argv[])
   //  Software Guide : BeginCodeSnippet
   using GaussianFilterType =
     itk::DiscreteGaussianImageFilter<ImageType, ImageType>;
-  GaussianFilterType::Pointer gaussianFilter = GaussianFilterType::New();
+  auto gaussianFilter = GaussianFilterType::New();
   //  Software Guide : EndCodeSnippet
 
 
@@ -658,7 +657,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using RegistrationType =
     itk::ImageToSpatialObjectRegistrationMethod<ImageType, GroupType>;
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto registration = RegistrationType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -674,7 +673,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using MetricType = SimpleImageToSpatialObjectMetric<ImageType, GroupType>;
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -688,7 +687,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<ImageType, double>;
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -702,7 +701,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using OptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
-  OptimizerType::Pointer optimizer = OptimizerType::New();
+  auto optimizer = OptimizerType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -716,7 +715,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::Euler2DTransform<>;
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -734,8 +733,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  itk::Statistics::NormalVariateGenerator::Pointer generator =
-    itk::Statistics::NormalVariateGenerator::New();
+  auto generator = itk::Statistics::NormalVariateGenerator::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -802,7 +800,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using IterationCallbackType = IterationCallback<OptimizerType>;
-  IterationCallbackType::Pointer callback = IterationCallbackType::New();
+  auto callback = IterationCallbackType::New();
   callback->SetOptimizer(optimizer);
   // Software Guide : EndCodeSnippet
 

--- a/Examples/RegistrationITKv4/ModelToImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/ModelToImageRegistration2.cxx
@@ -285,7 +285,7 @@ main(int argc, char * argv[])
   if (argc > 4)
   {
     using MaskWriterType = itk::ImageFileWriter<MaskImageType>;
-    MaskWriterType::Pointer maskWriter = MaskWriterType::New();
+    auto maskWriter = MaskWriterType::New();
     maskWriter->SetInput(rasterizationFilter->GetOutput());
     maskWriter->SetFileName(argv[4]);
     maskWriter->Update();

--- a/Examples/RegistrationITKv4/MultiResImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration1.cxx
@@ -369,10 +369,10 @@ main(int argc, const char * argv[])
   //  All the components are instantiated using their \code{New()} method
   //  and connected to the registration object as in previous example.
   //
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  MetricType::Pointer       metric = MetricType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto metric = MetricType::New();
+  auto registration = RegistrationType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetMetric(metric);
@@ -380,10 +380,8 @@ main(int argc, const char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(fixedImageFile);
   movingImageReader->SetFileName(movingImageFile);
@@ -428,7 +426,7 @@ main(int argc, const char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
 
@@ -478,7 +476,7 @@ main(int argc, const char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using CommandType = RegistrationInterfaceCommand<RegistrationType>;
-  CommandType::Pointer command = CommandType::New();
+  auto command = CommandType::New();
 
   registration->AddObserver(itk::MultiResolutionIterationEvent(), command);
   // Software Guide : EndCodeSnippet
@@ -567,7 +565,7 @@ main(int argc, const char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(transform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -592,8 +590,8 @@ main(int argc, const char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(outImagefile);
@@ -608,7 +606,7 @@ main(int argc, const char * argv[])
   //
   using CheckerBoardFilterType = itk::CheckerBoardImageFilter<FixedImageType>;
 
-  CheckerBoardFilterType::Pointer checker = CheckerBoardFilterType::New();
+  auto checker = CheckerBoardFilterType::New();
 
   checker->SetInput1(fixedImage);
   checker->SetInput2(resample->GetOutput());
@@ -619,7 +617,7 @@ main(int argc, const char * argv[])
   resample->SetDefaultPixelValue(0);
 
   // Before registration
-  TransformType::Pointer identityTransform = TransformType::New();
+  auto identityTransform = TransformType::New();
   identityTransform->SetIdentity();
   resample->SetTransform(identityTransform);
 

--- a/Examples/RegistrationITKv4/MultiResImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration2.cxx
@@ -219,10 +219,10 @@ main(int argc, char * argv[])
     itk::MultiResolutionImageRegistrationMethod<InternalImageType,
                                                 InternalImageType>;
 
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
-  MetricType::Pointer       metric = MetricType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
+  auto metric = MetricType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetInterpolator(interpolator);
@@ -240,17 +240,15 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
   registration->SetTransform(transform);
   // Software Guide : EndCodeSnippet
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -259,8 +257,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<FixedImageType, InternalImageType>;
   using MovingCastFilterType =
     itk::CastImageFilter<MovingImageType, InternalImageType>;
-  FixedCastFilterType::Pointer  fixedCaster = FixedCastFilterType::New();
-  MovingCastFilterType::Pointer movingCaster = MovingCastFilterType::New();
+  auto fixedCaster = FixedCastFilterType::New();
+  auto movingCaster = MovingCastFilterType::New();
 
   fixedCaster->SetInput(fixedImageReader->GetOutput());
   movingCaster->SetInput(movingImageReader->GetOutput());
@@ -289,8 +287,7 @@ main(int argc, char * argv[])
     itk::CenteredTransformInitializer<TransformType,
                                       FixedImageType,
                                       MovingImageType>;
-  TransformInitializerType::Pointer initializer =
-    TransformInitializerType::New();
+  auto initializer = TransformInitializerType::New();
   initializer->SetTransform(transform);
   initializer->SetFixedImage(fixedImageReader->GetOutput());
   initializer->SetMovingImage(movingImageReader->GetOutput());
@@ -437,13 +434,13 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   // Create the Command interface observer and register it with the optimizer.
   //
   using CommandType = RegistrationInterfaceCommand<RegistrationType>;
-  CommandType::Pointer command = CommandType::New();
+  auto command = CommandType::New();
   registration->AddObserver(itk::IterationEvent(), command);
   registration->SetNumberOfLevels(3);
 
@@ -528,12 +525,12 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -558,8 +555,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<FixedImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -610,7 +607,7 @@ main(int argc, char * argv[])
   //
   using CheckerBoardFilterType = itk::CheckerBoardImageFilter<FixedImageType>;
 
-  CheckerBoardFilterType::Pointer checker = CheckerBoardFilterType::New();
+  auto checker = CheckerBoardFilterType::New();
 
   checker->SetInput1(fixedImage);
   checker->SetInput2(resample->GetOutput());
@@ -622,7 +619,7 @@ main(int argc, char * argv[])
 
   // Write out checkerboard outputs
   // Before registration
-  TransformType::Pointer identityTransform = TransformType::New();
+  auto identityTransform = TransformType::New();
   identityTransform->SetIdentity();
   resample->SetTransform(identityTransform);
 

--- a/Examples/RegistrationITKv4/MultiResImageRegistration3.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration3.cxx
@@ -181,16 +181,14 @@ main(int argc, char * argv[])
   //  All the components are instantiated using their \code{New()} method
   //  and connected to the registration object as in previous example.
   //
-  TransformType::Pointer    transform = TransformType::New();
-  OptimizerType::Pointer    optimizer = OptimizerType::New();
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
-  RegistrationType::Pointer registration = RegistrationType::New();
-  MetricType::Pointer       metric = MetricType::New();
+  auto transform = TransformType::New();
+  auto optimizer = OptimizerType::New();
+  auto interpolator = InterpolatorType::New();
+  auto registration = RegistrationType::New();
+  auto metric = MetricType::New();
 
-  FixedImagePyramidType::Pointer fixedImagePyramid =
-    FixedImagePyramidType::New();
-  MovingImagePyramidType::Pointer movingImagePyramid =
-    MovingImagePyramidType::New();
+  auto fixedImagePyramid = FixedImagePyramidType::New();
+  auto movingImagePyramid = MovingImagePyramidType::New();
 
   registration->SetOptimizer(optimizer);
   registration->SetTransform(transform);
@@ -203,10 +201,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -217,8 +213,8 @@ main(int argc, char * argv[])
   using MovingCastFilterType =
     itk::CastImageFilter<MovingImageType, InternalImageType>;
 
-  FixedCastFilterType::Pointer  fixedCaster = FixedCastFilterType::New();
-  MovingCastFilterType::Pointer movingCaster = MovingCastFilterType::New();
+  auto fixedCaster = FixedCastFilterType::New();
+  auto movingCaster = MovingCastFilterType::New();
 
   fixedCaster->SetInput(fixedImageReader->GetOutput());
   movingCaster->SetInput(movingImageReader->GetOutput());
@@ -278,11 +274,11 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  auto observer = CommandIterationUpdate::New();
   optimizer->AddObserver(itk::IterationEvent(), observer);
 
   using CommandType = RegistrationInterfaceCommand<RegistrationType>;
-  CommandType::Pointer command = CommandType::New();
+  auto command = CommandType::New();
   registration->AddObserver(itk::IterationEvent(), command);
 
 
@@ -325,12 +321,12 @@ main(int argc, char * argv[])
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
-  TransformType::Pointer finalTransform = TransformType::New();
+  auto finalTransform = TransformType::New();
 
   finalTransform->SetParameters(finalParameters);
   finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(finalTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -360,8 +356,8 @@ main(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
 
   writer->SetFileName(argv[3]);
@@ -376,7 +372,7 @@ main(int argc, char * argv[])
   //
   using CheckerBoardFilterType = itk::CheckerBoardImageFilter<FixedImageType>;
 
-  CheckerBoardFilterType::Pointer checker = CheckerBoardFilterType::New();
+  auto checker = CheckerBoardFilterType::New();
 
   checker->SetInput1(fixedImage);
   checker->SetInput2(resample->GetOutput());
@@ -387,7 +383,7 @@ main(int argc, char * argv[])
   resample->SetDefaultPixelValue(0);
 
   // Before registration
-  TransformType::Pointer identityTransform = TransformType::New();
+  auto identityTransform = TransformType::New();
   identityTransform->SetIdentity();
   resample->SetTransform(identityTransform);
 

--- a/Examples/RegistrationITKv4/MultiStageImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/MultiStageImageRegistration1.cxx
@@ -251,9 +251,9 @@ main(int argc, char * argv[])
   //
   //  Software Guide : EndLatex
 
-  TOptimizerType::Pointer    transOptimizer = TOptimizerType::New();
-  MetricType::Pointer        transMetric = MetricType::New();
-  TRegistrationType::Pointer transRegistration = TRegistrationType::New();
+  auto transOptimizer = TOptimizerType::New();
+  auto transMetric = MetricType::New();
+  auto transRegistration = TRegistrationType::New();
 
   transRegistration->SetOptimizer(transOptimizer);
   transRegistration->SetMetric(transMetric);
@@ -272,7 +272,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TTransformType::Pointer movingInitTx = TTransformType::New();
+  auto movingInitTx = TTransformType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -310,18 +310,15 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using CompositeTransformType = itk::CompositeTransform<double, Dimension>;
-  CompositeTransformType::Pointer compositeTransform =
-    CompositeTransformType::New();
+  auto compositeTransform = CompositeTransformType::New();
   compositeTransform->AddTransform(movingInitTx);
   // Software Guide : EndCodeSnippet
 
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -380,7 +377,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer1 = CommandIterationUpdate::New();
+  auto observer1 = CommandIterationUpdate::New();
   transOptimizer->AddObserver(itk::IterationEvent(), observer1);
 
   // Create the Registration interface observer and register it with the
@@ -388,7 +385,7 @@ main(int argc, char * argv[])
   //
   using TranslationCommandType =
     RegistrationInterfaceCommand<TRegistrationType>;
-  TranslationCommandType::Pointer command1 = TranslationCommandType::New();
+  auto command1 = TranslationCommandType::New();
   transRegistration->AddObserver(itk::MultiResolutionIterationEvent(),
                                  command1);
 
@@ -462,9 +459,9 @@ main(int argc, char * argv[])
   //
   // Software Guide : EndLatex
 
-  AOptimizerType::Pointer    affineOptimizer = AOptimizerType::New();
-  MetricType::Pointer        affineMetric = MetricType::New();
-  ARegistrationType::Pointer affineRegistration = ARegistrationType::New();
+  auto affineOptimizer = AOptimizerType::New();
+  auto affineMetric = MetricType::New();
+  auto affineRegistration = ARegistrationType::New();
 
   affineRegistration->SetOptimizer(affineOptimizer);
   affineRegistration->SetMetric(affineMetric);
@@ -520,7 +517,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ATransformType::Pointer affineTx = ATransformType::New();
+  auto affineTx = ATransformType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -663,7 +660,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ScalesEstimatorType =
     itk::RegistrationParameterScalesFromPhysicalShift<MetricType>;
-  ScalesEstimatorType::Pointer scalesEstimator = ScalesEstimatorType::New();
+  auto scalesEstimator = ScalesEstimatorType::New();
   scalesEstimator->SetMetric(affineMetric);
   scalesEstimator->SetTransformForward(true);
 
@@ -704,7 +701,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer2 = CommandIterationUpdate::New();
+  auto observer2 = CommandIterationUpdate::New();
   affineOptimizer->AddObserver(itk::IterationEvent(), observer2);
 
   //  Software Guide : BeginLatex
@@ -736,7 +733,7 @@ main(int argc, char * argv[])
   // Create the Registration interface observer and register it with the
   // registration object.
   using AffineCommandType = RegistrationInterfaceCommand<ARegistrationType>;
-  AffineCommandType::Pointer command2 = AffineCommandType::New();
+  auto command2 = AffineCommandType::New();
   affineRegistration->AddObserver(itk::MultiResolutionIterationEvent(),
                                   command2);
 
@@ -881,7 +878,7 @@ main(int argc, char * argv[])
 
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(compositeTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -904,8 +901,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<FixedImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -936,7 +933,7 @@ main(int argc, char * argv[])
   // Generate checkerboards before and after registration
   using CheckerBoardFilterType = itk::CheckerBoardImageFilter<FixedImageType>;
 
-  CheckerBoardFilterType::Pointer checker = CheckerBoardFilterType::New();
+  auto checker = CheckerBoardFilterType::New();
 
   checker->SetInput1(fixedImage);
   checker->SetInput2(resample->GetOutput());

--- a/Examples/RegistrationITKv4/MultiStageImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/MultiStageImageRegistration2.cxx
@@ -223,9 +223,9 @@ main(int argc, char * argv[])
   //  All the components are instantiated using their \code{New()} method
   //  and connected to the registration object as in previous example.
   //
-  TOptimizerType::Pointer    transOptimizer = TOptimizerType::New();
-  MetricType::Pointer        transMetric = MetricType::New();
-  TRegistrationType::Pointer transRegistration = TRegistrationType::New();
+  auto transOptimizer = TOptimizerType::New();
+  auto transMetric = MetricType::New();
+  auto transRegistration = TRegistrationType::New();
 
   transRegistration->SetOptimizer(transOptimizer);
   transRegistration->SetMetric(transMetric);
@@ -242,7 +242,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  TTransformType::Pointer translationTx = TTransformType::New();
+  auto translationTx = TTransformType::New();
 
   transRegistration->SetInitialTransform(translationTx);
   transRegistration->InPlaceOn();
@@ -257,10 +257,8 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer fixedImageReader =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  auto fixedImageReader = FixedImageReaderType::New();
+  auto movingImageReader = MovingImageReaderType::New();
 
   fixedImageReader->SetFileName(argv[1]);
   movingImageReader->SetFileName(argv[2]);
@@ -311,14 +309,14 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer1 = CommandIterationUpdate::New();
+  auto observer1 = CommandIterationUpdate::New();
   transOptimizer->AddObserver(itk::IterationEvent(), observer1);
 
   // Create the Command interface observer and register it with the optimizer.
   //
   using TranslationCommandType =
     RegistrationInterfaceCommand<TRegistrationType>;
-  TranslationCommandType::Pointer command1 = TranslationCommandType::New();
+  auto command1 = TranslationCommandType::New();
   transRegistration->AddObserver(itk::MultiResolutionIterationEvent(),
                                  command1);
 
@@ -355,9 +353,9 @@ main(int argc, char * argv[])
   //
   //  Software Guide : EndLatex
 
-  AOptimizerType::Pointer    affineOptimizer = AOptimizerType::New();
-  MetricType::Pointer        affineMetric = MetricType::New();
-  ARegistrationType::Pointer affineRegistration = ARegistrationType::New();
+  auto affineOptimizer = AOptimizerType::New();
+  auto affineMetric = MetricType::New();
+  auto affineRegistration = ARegistrationType::New();
 
   affineRegistration->SetOptimizer(affineOptimizer);
   affineRegistration->SetMetric(affineMetric);
@@ -377,8 +375,7 @@ main(int argc, char * argv[])
   using FixedImageCalculatorType =
     itk::ImageMomentsCalculator<FixedImageType>;
 
-  FixedImageCalculatorType::Pointer fixedCalculator =
-    FixedImageCalculatorType::New();
+  auto fixedCalculator = FixedImageCalculatorType::New();
   fixedCalculator->SetImage(fixedImage);
   fixedCalculator->Compute();
 
@@ -394,7 +391,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ATransformType::Pointer affineTx = ATransformType::New();
+  auto affineTx = ATransformType::New();
 
   const unsigned int numberOfFixedParameters =
     affineTx->GetFixedParameters().Size();
@@ -435,7 +432,7 @@ main(int argc, char * argv[])
 
   using ScalesEstimatorType =
     itk::RegistrationParameterScalesFromPhysicalShift<MetricType>;
-  ScalesEstimatorType::Pointer scalesEstimator = ScalesEstimatorType::New();
+  auto scalesEstimator = ScalesEstimatorType::New();
   scalesEstimator->SetMetric(affineMetric);
   scalesEstimator->SetTransformForward(true);
 
@@ -451,7 +448,7 @@ main(int argc, char * argv[])
 
   // Create the Command observer and register it with the optimizer.
   //
-  CommandIterationUpdate::Pointer observer2 = CommandIterationUpdate::New();
+  auto observer2 = CommandIterationUpdate::New();
   affineOptimizer->AddObserver(itk::IterationEvent(), observer2);
 
   //  Software Guide : BeginLatex
@@ -480,7 +477,7 @@ main(int argc, char * argv[])
   // Create the Command interface observer and register it with the optimizer.
   //
   using AffineCommandType = RegistrationInterfaceCommand<ARegistrationType>;
-  AffineCommandType::Pointer command2 = AffineCommandType::New();
+  auto command2 = AffineCommandType::New();
   affineRegistration->AddObserver(itk::MultiResolutionIterationEvent(),
                                   command2);
 
@@ -523,8 +520,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using CompositeTransformType = itk::CompositeTransform<double, Dimension>;
-  CompositeTransformType::Pointer compositeTransform =
-    CompositeTransformType::New();
+  auto compositeTransform = CompositeTransformType::New();
   compositeTransform->AddTransform(translationTx);
   compositeTransform->AddTransform(affineTx);
   // Software Guide : EndCodeSnippet
@@ -598,7 +594,7 @@ main(int argc, char * argv[])
 
   using ResampleFilterType =
     itk::ResampleImageFilter<MovingImageType, FixedImageType>;
-  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  auto resample = ResampleFilterType::New();
 
   resample->SetTransform(compositeTransform);
   resample->SetInput(movingImageReader->GetOutput());
@@ -621,8 +617,8 @@ main(int argc, char * argv[])
     itk::CastImageFilter<FixedImageType, OutputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer     writer = WriterType::New();
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto writer = WriterType::New();
+  auto caster = CastFilterType::New();
 
   writer->SetFileName(argv[3]);
 
@@ -655,7 +651,7 @@ main(int argc, char * argv[])
   //
   using CheckerBoardFilterType = itk::CheckerBoardImageFilter<FixedImageType>;
 
-  CheckerBoardFilterType::Pointer checker = CheckerBoardFilterType::New();
+  auto checker = CheckerBoardFilterType::New();
 
   checker->SetInput1(fixedImage);
   checker->SetInput2(resample->GetOutput());

--- a/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
+++ b/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
@@ -74,7 +74,7 @@ main(int argc, char * argv[])
   using InterpolatorType =
     itk::LinearInterpolateImageFunction<InputImageType, double>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[2]);
 
   try
@@ -100,10 +100,10 @@ main(int argc, char * argv[])
   // Define container for landmarks
 
   // Software Guide : BeginCodeSnippet
-  PointSetType::Pointer sourceLandMarks = PointSetType::New();
-  PointSetType::Pointer targetLandMarks = PointSetType::New();
-  PointType             p1;
-  PointType             p2;
+  auto      sourceLandMarks = PointSetType::New();
+  auto      targetLandMarks = PointSetType::New();
+  PointType p1;
+  PointType p2;
   PointSetType::PointsContainer::Pointer sourceLandMarkContainer =
     sourceLandMarks->GetPoints();
   PointSetType::PointsContainer::Pointer targetLandMarkContainer =
@@ -127,7 +127,7 @@ main(int argc, char * argv[])
   infile.close();
 
   // Software Guide : BeginCodeSnippet
-  TransformType::Pointer tps = TransformType::New();
+  auto tps = TransformType::New();
   tps->SetSourceLandmarks(sourceLandMarks);
   tps->SetTargetLandmarks(targetLandMarks);
   tps->ComputeWMatrix();
@@ -142,8 +142,8 @@ main(int argc, char * argv[])
 
   // Set the resampler params
   InputImageType::ConstPointer inputImage = reader->GetOutput();
-  ResamplerType::Pointer       resampler = ResamplerType::New();
-  InterpolatorType::Pointer    interpolator = InterpolatorType::New();
+  auto                         resampler = ResamplerType::New();
+  auto                         interpolator = InterpolatorType::New();
   resampler->SetInterpolator(interpolator);
   InputImageType::SpacingType   spacing = inputImage->GetSpacing();
   InputImageType::PointType     origin = inputImage->GetOrigin();
@@ -163,8 +163,7 @@ main(int argc, char * argv[])
   resampler->SetInput(reader->GetOutput());
 
   // Set and write deformed image
-  DeformedImageWriterType::Pointer deformedImageWriter =
-    DeformedImageWriterType::New();
+  auto deformedImageWriter = DeformedImageWriterType::New();
   deformedImageWriter->SetInput(resampler->GetOutput());
   deformedImageWriter->SetFileName(argv[3]);
 
@@ -189,7 +188,7 @@ main(int argc, char * argv[])
 
   // Compute the deformation field
 
-  DisplacementFieldType::Pointer field = DisplacementFieldType::New();
+  auto field = DisplacementFieldType::New();
   field->SetRegions(region);
   field->SetOrigin(origin);
   field->SetSpacing(spacing);
@@ -217,7 +216,7 @@ main(int argc, char * argv[])
   }
 
   // Write computed deformation field
-  FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
+  auto fieldWriter = FieldWriterType::New();
   fieldWriter->SetFileName(argv[4]);
   fieldWriter->SetInput(field);
   try

--- a/Examples/Segmentation/CannySegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/CannySegmentationLevelSetImageFilter.cxx
@@ -126,7 +126,7 @@ main(int argc, char * argv[])
   using ThresholdingFilterType =
     itk::BinaryThresholdImageFilter<InternalImageType, OutputImageType>;
 
-  ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
+  auto thresholder = ThresholdingFilterType::New();
 
   thresholder->SetUpperThreshold(10.0);
   thresholder->SetLowerThreshold(0.0);
@@ -137,9 +137,9 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader1 = ReaderType::New();
-  ReaderType::Pointer reader2 = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader1 = ReaderType::New();
+  auto reader2 = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader1->SetFileName(argv[1]);
   reader2->SetFileName(argv[2]);
@@ -157,7 +157,7 @@ main(int argc, char * argv[])
   using DiffusionFilterType =
     itk::GradientAnisotropicDiffusionImageFilter<InternalImageType,
                                                  InternalImageType>;
-  DiffusionFilterType::Pointer diffusion = DiffusionFilterType::New();
+  auto diffusion = DiffusionFilterType::New();
   diffusion->SetNumberOfIterations(5);
   diffusion->SetTimeStep(0.125);
   diffusion->SetConductanceParameter(1.0);
@@ -174,8 +174,7 @@ main(int argc, char * argv[])
   using CannySegmentationLevelSetImageFilterType =
     itk::CannySegmentationLevelSetImageFilter<InternalImageType,
                                               InternalImageType>;
-  CannySegmentationLevelSetImageFilterType::Pointer cannySegmentation =
-    CannySegmentationLevelSetImageFilterType::New();
+  auto cannySegmentation = CannySegmentationLevelSetImageFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -359,7 +358,7 @@ main(int argc, char * argv[])
     using SpeedImageType =
       CannySegmentationLevelSetImageFilterType::SpeedImageType;
     using SpeedWriterType = itk::ImageFileWriter<SpeedImageType>;
-    SpeedWriterType::Pointer speedWriter = SpeedWriterType::New();
+    auto speedWriter = SpeedWriterType::New();
 
     speedWriter->SetInput(cannySegmentation->GetSpeedImage());
     //  Software Guide : EndCodeSnippet

--- a/Examples/Segmentation/ConfidenceConnected.cxx
+++ b/Examples/Segmentation/ConfidenceConnected.cxx
@@ -132,7 +132,7 @@ main(int argc, char * argv[])
 
   using CastingFilterType =
     itk::CastImageFilter<InternalImageType, OutputImageType>;
-  CastingFilterType::Pointer caster = CastingFilterType::New();
+  auto caster = CastingFilterType::New();
 
 
   // We instantiate reader and writer types
@@ -140,8 +140,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -168,8 +168,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  CurvatureFlowImageFilterType::Pointer smoothing =
-    CurvatureFlowImageFilterType::New();
+  auto smoothing = CurvatureFlowImageFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -193,8 +192,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ConnectedFilterType::Pointer confidenceConnected =
-    ConnectedFilterType::New();
+  auto confidenceConnected = ConnectedFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Segmentation/ConfidenceConnected3D.cxx
+++ b/Examples/Segmentation/ConfidenceConnected3D.cxx
@@ -58,27 +58,25 @@ main(int argc, char * argv[])
 
   using CastingFilterType =
     itk::CastImageFilter<InternalImageType, OutputImageType>;
-  CastingFilterType::Pointer caster = CastingFilterType::New();
+  auto caster = CastingFilterType::New();
 
 
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
 
   using CurvatureFlowImageFilterType =
     itk::CurvatureFlowImageFilter<InternalImageType, InternalImageType>;
-  CurvatureFlowImageFilterType::Pointer smoothing =
-    CurvatureFlowImageFilterType::New();
+  auto smoothing = CurvatureFlowImageFilterType::New();
 
   using ConnectedFilterType =
     itk::ConfidenceConnectedImageFilter<InternalImageType, InternalImageType>;
-  ConnectedFilterType::Pointer confidenceConnected =
-    ConnectedFilterType::New();
+  auto confidenceConnected = ConnectedFilterType::New();
 
   smoothing->SetInput(reader->GetOutput());
   confidenceConnected->SetInput(smoothing->GetOutput());

--- a/Examples/Segmentation/ConnectedThresholdImageFilter.cxx
+++ b/Examples/Segmentation/ConnectedThresholdImageFilter.cxx
@@ -126,15 +126,15 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
   using CastingFilterType =
     itk::CastImageFilter<InternalImageType, OutputImageType>;
-  CastingFilterType::Pointer caster = CastingFilterType::New();
+  auto caster = CastingFilterType::New();
 
   // We instantiate reader and writer types
   //
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -162,8 +162,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  CurvatureFlowImageFilterType::Pointer smoothing =
-    CurvatureFlowImageFilterType::New();
+  auto smoothing = CurvatureFlowImageFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -187,8 +186,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ConnectedFilterType::Pointer connectedThreshold =
-    ConnectedFilterType::New();
+  auto connectedThreshold = ConnectedFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Segmentation/CurvesLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/CurvesLevelSetImageFilter.cxx
@@ -132,7 +132,7 @@ main(int argc, char * argv[])
   using ThresholdingFilterType =
     itk::BinaryThresholdImageFilter<InternalImageType, OutputImageType>;
 
-  ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
+  auto thresholder = ThresholdingFilterType::New();
 
   thresholder->SetLowerThreshold(-1000.0);
   thresholder->SetUpperThreshold(0.0);
@@ -146,8 +146,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -167,7 +167,7 @@ main(int argc, char * argv[])
     itk::CurvatureAnisotropicDiffusionImageFilter<InternalImageType,
                                                   InternalImageType>;
 
-  SmoothingFilterType::Pointer smoothing = SmoothingFilterType::New();
+  auto smoothing = SmoothingFilterType::New();
 
 
   //  The types of the
@@ -182,9 +182,9 @@ main(int argc, char * argv[])
   using SigmoidFilterType =
     itk::SigmoidImageFilter<InternalImageType, InternalImageType>;
 
-  GradientFilterType::Pointer gradientMagnitude = GradientFilterType::New();
+  auto gradientMagnitude = GradientFilterType::New();
 
-  SigmoidFilterType::Pointer sigmoid = SigmoidFilterType::New();
+  auto sigmoid = SigmoidFilterType::New();
 
 
   //  The minimum and maximum values of the SigmoidImageFilter output
@@ -210,8 +210,7 @@ main(int argc, char * argv[])
   //  Next we construct one filter of this class using the \code{New()}
   //  method.
   //
-  FastMarchingFilterType::Pointer fastMarching =
-    FastMarchingFilterType::New();
+  auto fastMarching = FastMarchingFilterType::New();
 
   //  Software Guide : BeginLatex
   //
@@ -224,7 +223,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using CurvesFilterType =
     itk::CurvesLevelSetImageFilter<InternalImageType, InternalImageType>;
-  CurvesFilterType::Pointer geodesicActiveContour = CurvesFilterType::New();
+  auto geodesicActiveContour = CurvesFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -339,7 +338,7 @@ main(int argc, char * argv[])
   using NodeContainer = FastMarchingFilterType::NodeContainer;
   using NodeType = FastMarchingFilterType::NodeType;
 
-  NodeContainer::Pointer seeds = NodeContainer::New();
+  auto seeds = NodeContainer::New();
 
   InternalImageType::IndexType seedPosition;
 
@@ -396,15 +395,15 @@ main(int argc, char * argv[])
   //  relevant.  Observing intermediate output is helpful in the process of
   //  fine tuning the parameters of filters in the pipeline.
   //
-  CastFilterType::Pointer caster1 = CastFilterType::New();
-  CastFilterType::Pointer caster2 = CastFilterType::New();
-  CastFilterType::Pointer caster3 = CastFilterType::New();
-  CastFilterType::Pointer caster4 = CastFilterType::New();
+  auto caster1 = CastFilterType::New();
+  auto caster2 = CastFilterType::New();
+  auto caster3 = CastFilterType::New();
+  auto caster4 = CastFilterType::New();
 
-  WriterType::Pointer writer1 = WriterType::New();
-  WriterType::Pointer writer2 = WriterType::New();
-  WriterType::Pointer writer3 = WriterType::New();
-  WriterType::Pointer writer4 = WriterType::New();
+  auto writer1 = WriterType::New();
+  auto writer2 = WriterType::New();
+  auto writer3 = WriterType::New();
+  auto writer4 = WriterType::New();
 
   caster1->SetInput(smoothing->GetOutput());
   writer1->SetInput(caster1->GetOutput());
@@ -489,17 +488,17 @@ main(int argc, char * argv[])
   //
   using InternalWriterType = itk::ImageFileWriter<InternalImageType>;
 
-  InternalWriterType::Pointer mapWriter = InternalWriterType::New();
+  auto mapWriter = InternalWriterType::New();
   mapWriter->SetInput(fastMarching->GetOutput());
   mapWriter->SetFileName("CurvesImageFilterOutput4.mha");
   mapWriter->Update();
 
-  InternalWriterType::Pointer speedWriter = InternalWriterType::New();
+  auto speedWriter = InternalWriterType::New();
   speedWriter->SetInput(sigmoid->GetOutput());
   speedWriter->SetFileName("CurvesImageFilterOutput3.mha");
   speedWriter->Update();
 
-  InternalWriterType::Pointer gradientWriter = InternalWriterType::New();
+  auto gradientWriter = InternalWriterType::New();
   gradientWriter->SetInput(gradientMagnitude->GetOutput());
   gradientWriter->SetFileName("CurvesImageFilterOutput2.mha");
   gradientWriter->Update();

--- a/Examples/Segmentation/FastMarchingImageFilter.cxx
+++ b/Examples/Segmentation/FastMarchingImageFilter.cxx
@@ -240,7 +240,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ThresholdingFilterType =
     itk::BinaryThresholdImageFilter<InternalImageType, OutputImageType>;
-  ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
+  auto thresholder = ThresholdingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -277,8 +277,8 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -312,7 +312,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  SmoothingFilterType::Pointer smoothing = SmoothingFilterType::New();
+  auto smoothing = SmoothingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -342,8 +342,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  GradientFilterType::Pointer gradientMagnitude = GradientFilterType::New();
-  SigmoidFilterType::Pointer  sigmoid = SigmoidFilterType::New();
+  auto gradientMagnitude = GradientFilterType::New();
+  auto sigmoid = SigmoidFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -385,8 +385,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FastMarchingFilterType::Pointer fastMarching =
-    FastMarchingFilterType::New();
+  auto fastMarching = FastMarchingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -518,7 +517,7 @@ main(int argc, char * argv[])
   //  Software Guide : BeginCodeSnippet
   using NodeContainer = FastMarchingFilterType::NodeContainer;
   using NodeType = FastMarchingFilterType::NodeType;
-  NodeContainer::Pointer seeds = NodeContainer::New();
+  auto seeds = NodeContainer::New();
   //  Software Guide : EndCodeSnippet
 
 
@@ -583,8 +582,8 @@ main(int argc, char * argv[])
   //
   try
   {
-    CastFilterType::Pointer caster1 = CastFilterType::New();
-    WriterType::Pointer     writer1 = WriterType::New();
+    auto caster1 = CastFilterType::New();
+    auto writer1 = WriterType::New();
     caster1->SetInput(smoothing->GetOutput());
     writer1->SetInput(caster1->GetOutput());
     writer1->SetFileName(argv[10]);
@@ -601,8 +600,8 @@ main(int argc, char * argv[])
 
   try
   {
-    CastFilterType::Pointer caster2 = CastFilterType::New();
-    WriterType::Pointer     writer2 = WriterType::New();
+    auto caster2 = CastFilterType::New();
+    auto writer2 = WriterType::New();
     caster2->SetInput(gradientMagnitude->GetOutput());
     writer2->SetInput(caster2->GetOutput());
     writer2->SetFileName(argv[11]);
@@ -619,8 +618,8 @@ main(int argc, char * argv[])
 
   try
   {
-    CastFilterType::Pointer caster3 = CastFilterType::New();
-    WriterType::Pointer     writer3 = WriterType::New();
+    auto caster3 = CastFilterType::New();
+    auto writer3 = WriterType::New();
     caster3->SetInput(sigmoid->GetOutput());
     writer3->SetInput(caster3->GetOutput());
     writer3->SetFileName(argv[12]);
@@ -696,8 +695,8 @@ main(int argc, char * argv[])
 
   try
   {
-    CastFilterType::Pointer caster4 = CastFilterType::New();
-    WriterType::Pointer     writer4 = WriterType::New();
+    auto caster4 = CastFilterType::New();
+    auto writer4 = WriterType::New();
     caster4->SetInput(fastMarching->GetOutput());
     writer4->SetInput(caster4->GetOutput());
     writer4->SetFileName("FastMarchingFilterOutput4.png");
@@ -721,17 +720,17 @@ main(int argc, char * argv[])
   //
   using InternalWriterType = itk::ImageFileWriter<InternalImageType>;
 
-  InternalWriterType::Pointer mapWriter = InternalWriterType::New();
+  auto mapWriter = InternalWriterType::New();
   mapWriter->SetInput(fastMarching->GetOutput());
   mapWriter->SetFileName("FastMarchingFilterOutput4.mha");
   mapWriter->Update();
 
-  InternalWriterType::Pointer speedWriter = InternalWriterType::New();
+  auto speedWriter = InternalWriterType::New();
   speedWriter->SetInput(sigmoid->GetOutput());
   speedWriter->SetFileName("FastMarchingFilterOutput3.mha");
   speedWriter->Update();
 
-  InternalWriterType::Pointer gradientWriter = InternalWriterType::New();
+  auto gradientWriter = InternalWriterType::New();
   gradientWriter->SetInput(gradientMagnitude->GetOutput());
   gradientWriter->SetFileName("FastMarchingFilterOutput2.mha");
   gradientWriter->Update();

--- a/Examples/Segmentation/GeodesicActiveContourImageFilter.cxx
+++ b/Examples/Segmentation/GeodesicActiveContourImageFilter.cxx
@@ -155,7 +155,7 @@ main(int argc, char * argv[])
   using ThresholdingFilterType =
     itk::BinaryThresholdImageFilter<InternalImageType, OutputImageType>;
 
-  ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
+  auto thresholder = ThresholdingFilterType::New();
 
   thresholder->SetLowerThreshold(-1000.0);
   thresholder->SetUpperThreshold(0.0);
@@ -169,8 +169,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -190,7 +190,7 @@ main(int argc, char * argv[])
     itk::CurvatureAnisotropicDiffusionImageFilter<InternalImageType,
                                                   InternalImageType>;
 
-  SmoothingFilterType::Pointer smoothing = SmoothingFilterType::New();
+  auto smoothing = SmoothingFilterType::New();
 
 
   //  The types of the
@@ -204,9 +204,9 @@ main(int argc, char * argv[])
   using SigmoidFilterType =
     itk::SigmoidImageFilter<InternalImageType, InternalImageType>;
 
-  GradientFilterType::Pointer gradientMagnitude = GradientFilterType::New();
+  auto gradientMagnitude = GradientFilterType::New();
 
-  SigmoidFilterType::Pointer sigmoid = SigmoidFilterType::New();
+  auto sigmoid = SigmoidFilterType::New();
 
 
   //  The minimum and maximum values of the SigmoidImageFilter output
@@ -232,8 +232,7 @@ main(int argc, char * argv[])
   //  Next we construct one filter of this class using the \code{New()}
   //  method.
   //
-  FastMarchingFilterType::Pointer fastMarching =
-    FastMarchingFilterType::New();
+  auto fastMarching = FastMarchingFilterType::New();
 
   //  Software Guide : BeginLatex
   //
@@ -247,8 +246,7 @@ main(int argc, char * argv[])
   using GeodesicActiveContourFilterType =
     itk::GeodesicActiveContourLevelSetImageFilter<InternalImageType,
                                                   InternalImageType>;
-  GeodesicActiveContourFilterType::Pointer geodesicActiveContour =
-    GeodesicActiveContourFilterType::New();
+  auto geodesicActiveContour = GeodesicActiveContourFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -363,7 +361,7 @@ main(int argc, char * argv[])
   using NodeContainer = FastMarchingFilterType::NodeContainer;
   using NodeType = FastMarchingFilterType::NodeType;
 
-  NodeContainer::Pointer seeds = NodeContainer::New();
+  auto seeds = NodeContainer::New();
 
   InternalImageType::IndexType seedPosition;
 
@@ -420,15 +418,15 @@ main(int argc, char * argv[])
   //  relevant.  Observing intermediate output is helpful in the process of
   //  fine tuning the parameters of filters in the pipeline.
   //
-  CastFilterType::Pointer caster1 = CastFilterType::New();
-  CastFilterType::Pointer caster2 = CastFilterType::New();
-  CastFilterType::Pointer caster3 = CastFilterType::New();
-  CastFilterType::Pointer caster4 = CastFilterType::New();
+  auto caster1 = CastFilterType::New();
+  auto caster2 = CastFilterType::New();
+  auto caster3 = CastFilterType::New();
+  auto caster4 = CastFilterType::New();
 
-  WriterType::Pointer writer1 = WriterType::New();
-  WriterType::Pointer writer2 = WriterType::New();
-  WriterType::Pointer writer3 = WriterType::New();
-  WriterType::Pointer writer4 = WriterType::New();
+  auto writer1 = WriterType::New();
+  auto writer2 = WriterType::New();
+  auto writer3 = WriterType::New();
+  auto writer4 = WriterType::New();
 
   caster1->SetInput(smoothing->GetOutput());
   writer1->SetInput(caster1->GetOutput());
@@ -513,17 +511,17 @@ main(int argc, char * argv[])
   //
   using InternalWriterType = itk::ImageFileWriter<InternalImageType>;
 
-  InternalWriterType::Pointer mapWriter = InternalWriterType::New();
+  auto mapWriter = InternalWriterType::New();
   mapWriter->SetInput(fastMarching->GetOutput());
   mapWriter->SetFileName("GeodesicActiveContourImageFilterOutput4.mha");
   mapWriter->Update();
 
-  InternalWriterType::Pointer speedWriter = InternalWriterType::New();
+  auto speedWriter = InternalWriterType::New();
   speedWriter->SetInput(sigmoid->GetOutput());
   speedWriter->SetFileName("GeodesicActiveContourImageFilterOutput3.mha");
   speedWriter->Update();
 
-  InternalWriterType::Pointer gradientWriter = InternalWriterType::New();
+  auto gradientWriter = InternalWriterType::New();
   gradientWriter->SetInput(gradientMagnitude->GetOutput());
   gradientWriter->SetFileName("GeodesicActiveContourImageFilterOutput2.mha");
   gradientWriter->Update();

--- a/Examples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx
@@ -236,7 +236,7 @@ main(int argc, char * argv[])
   using ThresholdingFilterType =
     itk::BinaryThresholdImageFilter<InternalImageType, OutputImageType>;
 
-  ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
+  auto thresholder = ThresholdingFilterType::New();
 
   thresholder->SetLowerThreshold(-1000.0);
   thresholder->SetUpperThreshold(0.0);
@@ -250,8 +250,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -271,7 +271,7 @@ main(int argc, char * argv[])
     itk::CurvatureAnisotropicDiffusionImageFilter<InternalImageType,
                                                   InternalImageType>;
 
-  SmoothingFilterType::Pointer smoothing = SmoothingFilterType::New();
+  auto smoothing = SmoothingFilterType::New();
 
 
   //  The types of the
@@ -282,7 +282,7 @@ main(int argc, char * argv[])
     itk::GradientMagnitudeRecursiveGaussianImageFilter<InternalImageType,
                                                        InternalImageType>;
 
-  GradientFilterType::Pointer gradientMagnitude = GradientFilterType::New();
+  auto gradientMagnitude = GradientFilterType::New();
 
 
   //  We declare now the type of the FastMarchingImageFilter that
@@ -296,8 +296,7 @@ main(int argc, char * argv[])
   //  Next we construct one filter of this class using the \code{New()}
   //  method.
   //
-  FastMarchingFilterType::Pointer fastMarching =
-    FastMarchingFilterType::New();
+  auto fastMarching = FastMarchingFilterType::New();
 
   //  Software Guide : BeginLatex
   //
@@ -312,8 +311,7 @@ main(int argc, char * argv[])
     itk::GeodesicActiveContourShapePriorLevelSetImageFilter<
       InternalImageType,
       InternalImageType>;
-  GeodesicActiveContourFilterType::Pointer geodesicActiveContour =
-    GeodesicActiveContourFilterType::New();
+  auto geodesicActiveContour = GeodesicActiveContourFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -331,7 +329,7 @@ main(int argc, char * argv[])
   using CenterFilterType =
     itk::ChangeInformationImageFilter<InternalImageType>;
 
-  CenterFilterType::Pointer center = CenterFilterType::New();
+  auto center = CenterFilterType::New();
   center->CenterImageOn();
   // Software Guide : EndCodeSnippet
 
@@ -346,7 +344,7 @@ main(int argc, char * argv[])
   using ReciprocalFilterType =
     itk::BoundedReciprocalImageFilter<InternalImageType, InternalImageType>;
 
-  ReciprocalFilterType::Pointer reciprocal = ReciprocalFilterType::New();
+  auto reciprocal = ReciprocalFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -469,7 +467,7 @@ main(int argc, char * argv[])
   using NodeContainer = FastMarchingFilterType::NodeContainer;
   using NodeType = FastMarchingFilterType::NodeType;
 
-  NodeContainer::Pointer seeds = NodeContainer::New();
+  auto seeds = NodeContainer::New();
 
   InternalImageType::IndexType seedPosition;
 
@@ -536,15 +534,15 @@ main(int argc, char * argv[])
   //  relevant.  Observing intermediate output is helpful in the process of
   //  fine tuning the parameters of filters in the pipeline.
   //
-  CastFilterType::Pointer caster1 = CastFilterType::New();
-  CastFilterType::Pointer caster2 = CastFilterType::New();
-  CastFilterType::Pointer caster3 = CastFilterType::New();
-  CastFilterType::Pointer caster4 = CastFilterType::New();
+  auto caster1 = CastFilterType::New();
+  auto caster2 = CastFilterType::New();
+  auto caster3 = CastFilterType::New();
+  auto caster4 = CastFilterType::New();
 
-  WriterType::Pointer writer1 = WriterType::New();
-  WriterType::Pointer writer2 = WriterType::New();
-  WriterType::Pointer writer3 = WriterType::New();
-  WriterType::Pointer writer4 = WriterType::New();
+  auto writer1 = WriterType::New();
+  auto writer2 = WriterType::New();
+  auto writer3 = WriterType::New();
+  auto writer4 = WriterType::New();
 
   caster1->SetInput(smoothing->GetOutput());
   writer1->SetInput(caster1->GetOutput());
@@ -622,7 +620,7 @@ main(int argc, char * argv[])
   using ShapeFunctionType =
     itk::PCAShapeSignedDistanceFunction<double, Dimension, InternalImageType>;
 
-  ShapeFunctionType::Pointer shape = ShapeFunctionType::New();
+  auto shape = ShapeFunctionType::New();
 
   shape->SetNumberOfPrincipalComponents(numberOfPCAModes);
   // Software Guide : EndCodeSnippet
@@ -640,14 +638,13 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ReaderType::Pointer meanShapeReader = ReaderType::New();
+  auto meanShapeReader = ReaderType::New();
   meanShapeReader->SetFileName(argv[13]);
   meanShapeReader->Update();
 
   std::vector<InternalImageType::Pointer> shapeModeImages(numberOfPCAModes);
 
-  itk::NumericSeriesFileNames::Pointer fileNamesCreator =
-    itk::NumericSeriesFileNames::New();
+  auto fileNamesCreator = itk::NumericSeriesFileNames::New();
 
   fileNamesCreator->SetStartIndex(0);
   fileNamesCreator->SetEndIndex(numberOfPCAModes - 1);
@@ -657,7 +654,7 @@ main(int argc, char * argv[])
 
   for (unsigned int k = 0; k < numberOfPCAModes; ++k)
   {
-    ReaderType::Pointer shapeModeReader = ReaderType::New();
+    auto shapeModeReader = ReaderType::New();
     shapeModeReader->SetFileName(shapeModeFileNames[k].c_str());
     shapeModeReader->Update();
     shapeModeImages[k] = shapeModeReader->GetOutput();
@@ -699,7 +696,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using TransformType = itk::Euler2DTransform<double>;
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
   shape->SetTransform(transform);
   // Software Guide : EndCodeSnippet
@@ -720,7 +717,7 @@ main(int argc, char * argv[])
   using CostFunctionType =
     itk::ShapePriorMAPCostFunction<InternalImageType, InternalPixelType>;
 
-  CostFunctionType::Pointer costFunction = CostFunctionType::New();
+  auto costFunction = CostFunctionType::New();
 
   CostFunctionType::WeightsType weights;
   weights[0] = 1.0;  // weight for contour fit term
@@ -784,7 +781,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using OptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
-  OptimizerType::Pointer optimizer = OptimizerType::New();
+  auto optimizer = OptimizerType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -802,7 +799,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using GeneratorType = itk::Statistics::NormalVariateGenerator;
-  GeneratorType::Pointer generator = GeneratorType::New();
+  auto generator = GeneratorType::New();
 
   generator->Initialize(20020702);
 
@@ -891,7 +888,7 @@ main(int argc, char * argv[])
   geodesicActiveContour->SetInitialParameters(parameters);
 
   using CommandType = CommandIterationUpdate<GeodesicActiveContourFilterType>;
-  CommandType::Pointer observer = CommandType::New();
+  auto observer = CommandType::New();
   geodesicActiveContour->AddObserver(itk::IterationEvent(), observer);
   // Software Guide : EndCodeSnippet
 
@@ -942,19 +939,19 @@ main(int argc, char * argv[])
   //
   using InternalWriterType = itk::ImageFileWriter<InternalImageType>;
 
-  InternalWriterType::Pointer mapWriter = InternalWriterType::New();
+  auto mapWriter = InternalWriterType::New();
   mapWriter->SetInput(fastMarching->GetOutput());
   mapWriter->SetFileName(
     "GeodesicActiveContourShapePriorImageFilterOutput4.mha");
   mapWriter->Update();
 
-  InternalWriterType::Pointer speedWriter = InternalWriterType::New();
+  auto speedWriter = InternalWriterType::New();
   speedWriter->SetInput(reciprocal->GetOutput());
   speedWriter->SetFileName(
     "GeodesicActiveContourShapePriorImageFilterOutput3.mha");
   speedWriter->Update();
 
-  InternalWriterType::Pointer gradientWriter = InternalWriterType::New();
+  auto gradientWriter = InternalWriterType::New();
   gradientWriter->SetInput(gradientMagnitude->GetOutput());
   gradientWriter->SetFileName(
     "GeodesicActiveContourShapePriorImageFilterOutput2.mha");
@@ -966,7 +963,7 @@ main(int argc, char * argv[])
                                              InternalImageType,
                                              InternalImageType>;
 
-  EvaluatorFilterType::Pointer evaluator = EvaluatorFilterType::New();
+  auto evaluator = EvaluatorFilterType::New();
   evaluator->SetInput(geodesicActiveContour->GetOutput());
   evaluator->SetFunction(shape);
   shape->SetParameters(geodesicActiveContour->GetInitialParameters());

--- a/Examples/Segmentation/GibbsPriorImageFilter1.cxx
+++ b/Examples/Segmentation/GibbsPriorImageFilter1.cxx
@@ -98,9 +98,9 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ClassImageType>;
   using WriterType = itk::ImageFileWriter<ClassImageType>;
 
-  ReaderType::Pointer inputimagereader = ReaderType::New();
-  ReaderType::Pointer trainingimagereader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto inputimagereader = ReaderType::New();
+  auto trainingimagereader = ReaderType::New();
+  auto writer = WriterType::New();
 
   inputimagereader->SetFileName(argv[1]);
   trainingimagereader->SetFileName(argv[2]);
@@ -109,7 +109,7 @@ main(int argc, char * argv[])
 
   // We convert the input into vector images
   //
-  VecImageType::Pointer vecImage = VecImageType::New();
+  auto vecImage = VecImageType::New();
   using VecImagePixelType = VecImageType::PixelType;
   VecImageType::SizeType vecImgSize = { { 181, 217, 1 } };
 
@@ -178,8 +178,7 @@ main(int argc, char * argv[])
                                      MembershipFunctionType,
                                      ClassImageType>;
 
-  ImageGaussianModelEstimatorType::Pointer applyEstimateModel =
-    ImageGaussianModelEstimatorType::New();
+  auto applyEstimateModel = ImageGaussianModelEstimatorType::New();
 
   applyEstimateModel->SetNumberOfModels(NUM_CLASSES);
   applyEstimateModel->SetInputImage(vecImage);
@@ -204,7 +203,7 @@ main(int argc, char * argv[])
   using DecisionRuleBasePointer = itk::Statistics::DecisionRule::Pointer;
 
   using DecisionRuleType = itk::Statistics::MinimumDecisionRule;
-  DecisionRuleType::Pointer myDecisionRule = DecisionRuleType::New();
+  auto myDecisionRule = DecisionRuleType::New();
 
   std::cout << " site 3 " << std::endl;
 
@@ -251,8 +250,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using GibbsPriorFilterType =
     itk::RGBGibbsPriorFilter<VecImageType, ClassImageType>;
-  GibbsPriorFilterType::Pointer applyGibbsImageFilter =
-    GibbsPriorFilterType::New();
+  auto applyGibbsImageFilter = GibbsPriorFilterType::New();
   // Software Guide : EndCodeSnippet
 
   // Set the MRF labeller parameters

--- a/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
@@ -89,7 +89,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   try
   {
@@ -120,8 +120,7 @@ main(int argc, char * argv[])
     itk::HoughTransform2DCirclesImageFilter<PixelType,
                                             AccumulatorPixelType,
                                             RadiusPixelType>;
-  HoughTransformFilterType::Pointer houghFilter =
-    HoughTransformFilterType::New();
+  auto houghFilter = HoughTransformFilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -198,7 +197,7 @@ main(int argc, char * argv[])
   using OutputPixelType = unsigned char;
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  OutputImageType::Pointer localOutputImage = OutputImageType::New();
+  auto localOutputImage = OutputImageType::New();
 
   OutputImageType::RegionType region;
   region.SetSize(localImage->GetLargestPossibleRegion().GetSize());
@@ -266,7 +265,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<ImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName(argv[2]);
   writer->SetInput(localOutputImage);

--- a/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
@@ -83,7 +83,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
   try
@@ -111,14 +111,14 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using CastingFilterType =
     itk::CastImageFilter<ImageType, AccumulatorImageType>;
-  CastingFilterType::Pointer caster = CastingFilterType::New();
+  auto caster = CastingFilterType::New();
 
   std::cout << "Applying gradient magnitude filter" << std::endl;
 
   using GradientFilterType =
     itk::GradientMagnitudeImageFilter<AccumulatorImageType,
                                       AccumulatorImageType>;
-  GradientFilterType::Pointer gradFilter = GradientFilterType::New();
+  auto gradFilter = GradientFilterType::New();
 
   caster->SetInput(localImage);
   gradFilter->SetInput(caster->GetOutput());
@@ -137,7 +137,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   std::cout << "Thresholding" << std::endl;
   using ThresholdFilterType = itk::ThresholdImageFilter<AccumulatorImageType>;
-  ThresholdFilterType::Pointer threshFilter = ThresholdFilterType::New();
+  auto threshFilter = ThresholdFilterType::New();
 
   threshFilter->SetInput(gradFilter->GetOutput());
   threshFilter->SetOutsideValue(0);
@@ -159,8 +159,7 @@ main(int argc, char * argv[])
     itk::HoughTransform2DLinesImageFilter<AccumulatorPixelType,
                                           AccumulatorPixelType>;
 
-  HoughTransformFilterType::Pointer houghFilter =
-    HoughTransformFilterType::New();
+  auto houghFilter = HoughTransformFilterType::New();
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -217,7 +216,7 @@ main(int argc, char * argv[])
   using OutputPixelType = unsigned char;
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  OutputImageType::Pointer localOutputImage = OutputImageType::New();
+  auto localOutputImage = OutputImageType::New();
 
   OutputImageType::RegionType region(localImage->GetLargestPossibleRegion());
   localOutputImage->SetRegions(region);
@@ -305,7 +304,7 @@ main(int argc, char * argv[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(argv[2]);
   writer->SetInput(localOutputImage);
 

--- a/Examples/Segmentation/IsolatedConnectedImageFilter.cxx
+++ b/Examples/Segmentation/IsolatedConnectedImageFilter.cxx
@@ -90,7 +90,7 @@ main(int argc, char * argv[])
   using CastingFilterType =
     itk::CastImageFilter<InternalImageType, OutputImageType>;
 
-  CastingFilterType::Pointer caster = CastingFilterType::New();
+  auto caster = CastingFilterType::New();
 
 
   // We instantiate reader and writer types
@@ -98,8 +98,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -107,8 +107,7 @@ main(int argc, char * argv[])
 
   using CurvatureFlowImageFilterType =
     itk::CurvatureFlowImageFilter<InternalImageType, InternalImageType>;
-  CurvatureFlowImageFilterType::Pointer smoothing =
-    CurvatureFlowImageFilterType::New();
+  auto smoothing = CurvatureFlowImageFilterType::New();
 
 
   //  Software Guide : BeginLatex
@@ -131,7 +130,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ConnectedFilterType::Pointer isolatedConnected = ConnectedFilterType::New();
+  auto isolatedConnected = ConnectedFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Segmentation/LaplacianSegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/LaplacianSegmentationLevelSetImageFilter.cxx
@@ -117,7 +117,7 @@ main(int argc, char * argv[])
   using ThresholdingFilterType =
     itk::BinaryThresholdImageFilter<InternalImageType, OutputImageType>;
 
-  ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
+  auto thresholder = ThresholdingFilterType::New();
 
   thresholder->SetUpperThreshold(10.0);
   thresholder->SetLowerThreshold(0.0);
@@ -128,9 +128,9 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader1 = ReaderType::New();
-  ReaderType::Pointer reader2 = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader1 = ReaderType::New();
+  auto reader2 = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader1->SetFileName(argv[1]);
   reader2->SetFileName(argv[2]);
@@ -149,7 +149,7 @@ main(int argc, char * argv[])
   using DiffusionFilterType =
     itk::GradientAnisotropicDiffusionImageFilter<InternalImageType,
                                                  InternalImageType>;
-  DiffusionFilterType::Pointer diffusion = DiffusionFilterType::New();
+  auto diffusion = DiffusionFilterType::New();
   diffusion->SetNumberOfIterations(std::stoi(argv[4]));
   diffusion->SetTimeStep(0.125);
   diffusion->SetConductanceParameter(std::stod(argv[5]));

--- a/Examples/Segmentation/NeighborhoodConnectedImageFilter.cxx
+++ b/Examples/Segmentation/NeighborhoodConnectedImageFilter.cxx
@@ -96,7 +96,7 @@ main(int argc, char * argv[])
 
   using CastingFilterType =
     itk::CastImageFilter<InternalImageType, OutputImageType>;
-  CastingFilterType::Pointer caster = CastingFilterType::New();
+  auto caster = CastingFilterType::New();
 
 
   // We instantiate reader and writer types
@@ -104,8 +104,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -132,8 +132,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  CurvatureFlowImageFilterType::Pointer smoothing =
-    CurvatureFlowImageFilterType::New();
+  auto smoothing = CurvatureFlowImageFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -157,8 +156,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ConnectedFilterType::Pointer neighborhoodConnected =
-    ConnectedFilterType::New();
+  auto neighborhoodConnected = ConnectedFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Segmentation/RelabelComponentImageFilter.cxx
+++ b/Examples/Segmentation/RelabelComponentImageFilter.cxx
@@ -75,8 +75,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -96,7 +96,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::RelabelComponentImageFilter<InputImageType, OutputImageType>;
 
-  FilterType::Pointer relabeler = FilterType::New();
+  auto relabeler = FilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Segmentation/ShapeDetectionLevelSetFilter.cxx
+++ b/Examples/Segmentation/ShapeDetectionLevelSetFilter.cxx
@@ -222,7 +222,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ThresholdingFilterType =
     itk::BinaryThresholdImageFilter<InternalImageType, OutputImageType>;
-  ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
+  auto thresholder = ThresholdingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -250,8 +250,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(inputImageFile);
   writer->SetFileName(outputImageFile);
@@ -285,7 +285,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  SmoothingFilterType::Pointer smoothing = SmoothingFilterType::New();
+  auto smoothing = SmoothingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -315,8 +315,8 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  GradientFilterType::Pointer gradientMagnitude = GradientFilterType::New();
-  SigmoidFilterType::Pointer  sigmoid = SigmoidFilterType::New();
+  auto gradientMagnitude = GradientFilterType::New();
+  auto sigmoid = SigmoidFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -360,8 +360,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  FastMarchingFilterType::Pointer fastMarching =
-    FastMarchingFilterType::New();
+  auto fastMarching = FastMarchingFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -377,8 +376,7 @@ main(int argc, char * argv[])
   using ShapeDetectionFilterType =
     itk::ShapeDetectionLevelSetImageFilter<InternalImageType,
                                            InternalImageType>;
-  ShapeDetectionFilterType::Pointer shapeDetection =
-    ShapeDetectionFilterType::New();
+  auto shapeDetection = ShapeDetectionFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -483,7 +481,7 @@ main(int argc, char * argv[])
   //  Software Guide : BeginCodeSnippet
   using NodeContainer = FastMarchingFilterType::NodeContainer;
   using NodeType = FastMarchingFilterType::NodeType;
-  NodeContainer::Pointer seeds = NodeContainer::New();
+  auto seeds = NodeContainer::New();
   //  Software Guide : EndCodeSnippet
 
 
@@ -569,15 +567,15 @@ main(int argc, char * argv[])
   //  be relevant.  Observing intermediate output is helpful in the process
   //  of fine tuning the parameters of filters in the pipeline.
   //
-  CastFilterType::Pointer caster1 = CastFilterType::New();
-  CastFilterType::Pointer caster2 = CastFilterType::New();
-  CastFilterType::Pointer caster3 = CastFilterType::New();
-  CastFilterType::Pointer caster4 = CastFilterType::New();
+  auto caster1 = CastFilterType::New();
+  auto caster2 = CastFilterType::New();
+  auto caster3 = CastFilterType::New();
+  auto caster4 = CastFilterType::New();
 
-  WriterType::Pointer writer1 = WriterType::New();
-  WriterType::Pointer writer2 = WriterType::New();
-  WriterType::Pointer writer3 = WriterType::New();
-  WriterType::Pointer writer4 = WriterType::New();
+  auto writer1 = WriterType::New();
+  auto writer2 = WriterType::New();
+  auto writer3 = WriterType::New();
+  auto writer4 = WriterType::New();
 
   const std::string outputImageFilePrefix =
     itksys::SystemTools::GetFilenameWithoutExtension(outputImageFile);
@@ -725,17 +723,17 @@ main(int argc, char * argv[])
   //
   using InternalWriterType = itk::ImageFileWriter<InternalImageType>;
 
-  InternalWriterType::Pointer mapWriter = InternalWriterType::New();
+  auto mapWriter = InternalWriterType::New();
   mapWriter->SetInput(fastMarching->GetOutput());
   mapWriter->SetFileName("ShapeDetectionLevelSetFilterOutput4.mha");
   mapWriter->Update();
 
-  InternalWriterType::Pointer speedWriter = InternalWriterType::New();
+  auto speedWriter = InternalWriterType::New();
   speedWriter->SetInput(sigmoid->GetOutput());
   speedWriter->SetFileName("ShapeDetectionLevelSetFilterOutput3.mha");
   speedWriter->Update();
 
-  InternalWriterType::Pointer gradientWriter = InternalWriterType::New();
+  auto gradientWriter = InternalWriterType::New();
   gradientWriter->SetInput(gradientMagnitude->GetOutput());
   gradientWriter->SetFileName("ShapeDetectionLevelSetFilterOutput2.mha");
   gradientWriter->Update();

--- a/Examples/Segmentation/ThresholdSegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/ThresholdSegmentationLevelSetImageFilter.cxx
@@ -138,7 +138,7 @@ main(int argc, char * argv[])
   using ThresholdingFilterType =
     itk::BinaryThresholdImageFilter<InternalImageType, OutputImageType>;
 
-  ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
+  auto thresholder = ThresholdingFilterType::New();
 
   thresholder->SetLowerThreshold(-1000.0);
   thresholder->SetUpperThreshold(0.0);
@@ -149,8 +149,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -163,8 +163,7 @@ main(int argc, char * argv[])
   using FastMarchingFilterType =
     itk::FastMarchingImageFilter<InternalImageType, InternalImageType>;
 
-  FastMarchingFilterType::Pointer fastMarching =
-    FastMarchingFilterType::New();
+  auto fastMarching = FastMarchingFilterType::New();
 
   //  Software Guide : BeginLatex
   //
@@ -273,7 +272,7 @@ main(int argc, char * argv[])
   using NodeContainer = FastMarchingFilterType::NodeContainer;
   using NodeType = FastMarchingFilterType::NodeType;
 
-  NodeContainer::Pointer seeds = NodeContainer::New();
+  auto seeds = NodeContainer::New();
 
   InternalImageType::IndexType seedPosition;
 
@@ -375,12 +374,12 @@ main(int argc, char * argv[])
   //
   using InternalWriterType = itk::ImageFileWriter<InternalImageType>;
 
-  InternalWriterType::Pointer mapWriter = InternalWriterType::New();
+  auto mapWriter = InternalWriterType::New();
   mapWriter->SetInput(fastMarching->GetOutput());
   mapWriter->SetFileName("fastMarchingImage.mha");
   mapWriter->Update();
 
-  InternalWriterType::Pointer speedWriter = InternalWriterType::New();
+  auto speedWriter = InternalWriterType::New();
   speedWriter->SetInput(thresholdSegmentation->GetSpeedImage());
   speedWriter->SetFileName("speedTermImage.mha");
   speedWriter->Update();

--- a/Examples/Segmentation/VectorConfidenceConnected.cxx
+++ b/Examples/Segmentation/VectorConfidenceConnected.cxx
@@ -96,8 +96,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InputImageType>;
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -123,8 +123,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ConnectedFilterType::Pointer confidenceConnected =
-    ConnectedFilterType::New();
+  auto confidenceConnected = ConnectedFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Segmentation/WatershedSegmentation1.cxx
+++ b/Examples/Segmentation/WatershedSegmentation1.cxx
@@ -117,10 +117,10 @@ main(int argc, char * argv[])
 
   using FileWriterType = itk::ImageFileWriter<RGBImageType>;
 
-  FileReaderType::Pointer reader = FileReaderType::New();
+  auto reader = FileReaderType::New();
   reader->SetFileName(argv[1]);
 
-  CastFilterType::Pointer caster = CastFilterType::New();
+  auto caster = CastFilterType::New();
 
   // Software Guide : BeginLatex
   //
@@ -137,7 +137,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  DiffusionFilterType::Pointer diffusion = DiffusionFilterType::New();
+  auto diffusion = DiffusionFilterType::New();
   diffusion->SetNumberOfIterations(std::stoi(argv[4]));
   diffusion->SetConductanceParameter(std::stod(argv[3]));
   diffusion->SetTimeStep(0.125);
@@ -152,8 +152,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  GradientMagnitudeFilterType::Pointer gradient =
-    GradientMagnitudeFilterType::New();
+  auto gradient = GradientMagnitudeFilterType::New();
   gradient->SetUsePrincipleComponents(std::stoi(argv[7]));
   // Software Guide : EndCodeSnippet
 
@@ -168,7 +167,7 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  WatershedFilterType::Pointer watershed = WatershedFilterType::New();
+  auto watershed = WatershedFilterType::New();
   watershed->SetLevel(std::stod(argv[6]));
   watershed->SetThreshold(std::stod(argv[5]));
   // Software Guide : EndCodeSnippet
@@ -196,11 +195,11 @@ main(int argc, char * argv[])
     itk::UnaryFunctorImageFilter<LabeledImageType,
                                  RGBImageType,
                                  ColormapFunctorType>;
-  ColormapFilterType::Pointer colormapper = ColormapFilterType::New();
+  auto colormapper = ColormapFilterType::New();
   // Software Guide : EndCodeSnippet
 
 
-  FileWriterType::Pointer writer = FileWriterType::New();
+  auto writer = FileWriterType::New();
   writer->SetFileName(argv[2]);
 
   // Software Guide : BeginLatex

--- a/Examples/Segmentation/WatershedSegmentation2.cxx
+++ b/Examples/Segmentation/WatershedSegmentation2.cxx
@@ -61,8 +61,8 @@ main(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<InternalImageType>;
   using WriterType = itk::ImageFileWriter<RGBImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   reader->SetFileName(argv[1]);
   writer->SetFileName(argv[2]);
@@ -75,8 +75,7 @@ main(int argc, char * argv[])
     itk::GradientMagnitudeRecursiveGaussianImageFilter<InternalImageType,
                                                        InternalImageType>;
 
-  GradientMagnitudeFilterType::Pointer gradienMagnitudeFilter =
-    GradientMagnitudeFilterType::New();
+  auto gradienMagnitudeFilter = GradientMagnitudeFilterType::New();
 
   gradienMagnitudeFilter->SetInput(reader->GetOutput());
   gradienMagnitudeFilter->SetSigma(1.0);
@@ -88,7 +87,7 @@ main(int argc, char * argv[])
 
   using WatershedFilterType = itk::WatershedImageFilter<InternalImageType>;
 
-  WatershedFilterType::Pointer watershedFilter = WatershedFilterType::New();
+  auto watershedFilter = WatershedFilterType::New();
 
   watershedFilter->SetInput(gradienMagnitudeFilter->GetOutput());
 
@@ -111,7 +110,7 @@ main(int argc, char * argv[])
                                  RGBImageType,
                                  ColormapFunctorType>;
 
-  ColormapFilterType::Pointer colorMapFilter = ColormapFilterType::New();
+  auto colorMapFilter = ColormapFilterType::New();
 
   colorMapFilter->SetInput(watershedFilter->GetOutput());
 

--- a/Examples/SpatialObjects/ArrowSpatialObject.cxx
+++ b/Examples/SpatialObjects/ArrowSpatialObject.cxx
@@ -41,7 +41,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using ArrowType = itk::ArrowSpatialObject<3>;
-  ArrowType::Pointer myArrow = ArrowType::New();
+  auto myArrow = ArrowType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/BoundingBoxFromImageMaskSpatialObject.cxx
+++ b/Examples/SpatialObjects/BoundingBoxFromImageMaskSpatialObject.cxx
@@ -53,7 +53,7 @@ main(int argc, char * argv[])
   using ImageType = ImageMaskSpatialObject::ImageType;
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  ImageMaskSpatialObject::Pointer maskSO = ImageMaskSpatialObject::New();
+  auto maskSO = ImageMaskSpatialObject::New();
 
   maskSO->SetImage(reader->GetOutput());
   maskSO->Update();

--- a/Examples/SpatialObjects/DTITubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/DTITubeSpatialObject.cxx
@@ -55,7 +55,7 @@ main(int, char *[])
   using DTITubePointType = DTITubeType::DTITubePointType;
   using PointType = DTITubeType::PointType;
 
-  DTITubeType::Pointer dtiTube = DTITubeType::New();
+  auto dtiTube = DTITubeType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/EllipseSpatialObject.cxx
+++ b/Examples/SpatialObjects/EllipseSpatialObject.cxx
@@ -44,7 +44,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using EllipseType = itk::EllipseSpatialObject<3>;
-  EllipseType::Pointer myEllipse = EllipseType::New();
+  auto myEllipse = EllipseType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/GaussianSpatialObject.cxx
+++ b/Examples/SpatialObjects/GaussianSpatialObject.cxx
@@ -43,7 +43,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using GaussianType = itk::GaussianSpatialObject<3>;
-  GaussianType::Pointer myGaussian = GaussianType::New();
+  auto myGaussian = GaussianType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/GroupSpatialObject.cxx
+++ b/Examples/SpatialObjects/GroupSpatialObject.cxx
@@ -46,7 +46,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using GroupType = itk::GroupSpatialObject<3>;
-  GroupType::Pointer myGroup = GroupType::New();
+  auto myGroup = GroupType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -58,7 +58,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using EllipseType = itk::EllipseSpatialObject<3>;
-  EllipseType::Pointer myEllipse = EllipseType::New();
+  auto myEllipse = EllipseType::New();
   myEllipse->SetRadiusInObjectSpace(2);
 
   myGroup->AddChild(myEllipse);

--- a/Examples/SpatialObjects/ImageMaskSpatialObject.cxx
+++ b/Examples/SpatialObjects/ImageMaskSpatialObject.cxx
@@ -67,7 +67,7 @@ main(int, char *[])
   using ImageType = ImageMaskSpatialObject::ImageType;
   using Iterator = itk::ImageRegionIterator<ImageType>;
 
-  ImageType::Pointer    image = ImageType::New();
+  auto                  image = ImageType::New();
   ImageType::SizeType   size = { { 50, 50, 50 } };
   ImageType::IndexType  index = { { 0, 0, 0 } };
   ImageType::RegionType region;
@@ -101,7 +101,7 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ImageMaskSpatialObject::Pointer maskSO = ImageMaskSpatialObject::New();
+  auto maskSO = ImageMaskSpatialObject::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/ImageSpatialObject.cxx
+++ b/Examples/SpatialObjects/ImageSpatialObject.cxx
@@ -43,7 +43,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using Image = itk::Image<short, 2>;
-  Image::Pointer    image = Image::New();
+  auto              image = Image::New();
   Image::SizeType   size = { { 10, 10 } };
   Image::RegionType region;
   region.SetSize(size);
@@ -77,7 +77,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using ImageSpatialObject = itk::ImageSpatialObject<2, short>;
-  ImageSpatialObject::Pointer imageSO = ImageSpatialObject::New();
+  auto imageSO = ImageSpatialObject::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/MeshSpatialObject.cxx
+++ b/Examples/SpatialObjects/MeshSpatialObject.cxx
@@ -61,7 +61,7 @@ main(int, char *[])
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginCodeSnippet
-  MeshType::Pointer myMesh = MeshType::New();
+  auto myMesh = MeshType::New();
 
   MeshType::CoordRepType testPointCoords[4][3] = {
     { 0, 0, 0 }, { 9, 0, 0 }, { 9, 9, 0 }, { 0, 0, 9 }
@@ -96,8 +96,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using MeshSpatialObjectType = itk::MeshSpatialObject<MeshType>;
-  MeshSpatialObjectType::Pointer myMeshSpatialObject =
-    MeshSpatialObjectType::New();
+  auto myMeshSpatialObject = MeshSpatialObjectType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -152,7 +151,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::SpatialObjectWriter<3, float, MeshTrait>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -177,7 +176,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::SpatialObjectReader<3, float, MeshTrait>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -205,8 +204,7 @@ main(int, char *[])
   using GroupType = itk::GroupSpatialObject<3>;
   using SpatialObjectToImageFilterType =
     itk::SpatialObjectToImageFilter<GroupType, ImageType>;
-  SpatialObjectToImageFilterType::Pointer imageFilter =
-    SpatialObjectToImageFilterType::New();
+  auto imageFilter = SpatialObjectToImageFilterType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/ReadWriteSpatialObject.cxx
+++ b/Examples/SpatialObjects/ReadWriteSpatialObject.cxx
@@ -53,7 +53,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::SpatialObjectWriter<3>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -64,7 +64,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using EllipseType = itk::EllipseSpatialObject<3>;
-  EllipseType::Pointer ellipse = EllipseType::New();
+  auto ellipse = EllipseType::New();
   ellipse->SetRadiusInObjectSpace(3);
   // Software Guide : EndCodeSnippet
   // Software Guide : BeginLatex
@@ -93,7 +93,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::SpatialObjectReader<3>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/SceneSpatialObject.cxx
+++ b/Examples/SpatialObjects/SceneSpatialObject.cxx
@@ -47,7 +47,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using GroupSpatialObjectType = itk::GroupSpatialObject<3>;
-  GroupSpatialObjectType::Pointer scene = GroupSpatialObjectType::New();
+  auto scene = GroupSpatialObjectType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -58,10 +58,10 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using EllipseType = itk::EllipseSpatialObject<3>;
-  EllipseType::Pointer ellipse1 = EllipseType::New();
+  auto ellipse1 = EllipseType::New();
   ellipse1->SetRadiusInObjectSpace(1);
   ellipse1->SetId(1);
-  EllipseType::Pointer ellipse2 = EllipseType::New();
+  auto ellipse2 = EllipseType::New();
   ellipse2->SetId(2);
   ellipse2->SetRadiusInObjectSpace(2);
   // Software Guide : EndCodeSnippet

--- a/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
+++ b/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
@@ -43,10 +43,10 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   using SpatialObjectType = itk::SpatialObject<3>;
 
-  SpatialObjectType::Pointer object1 = SpatialObjectType::New();
+  auto object1 = SpatialObjectType::New();
   object1->GetProperty().SetName("First Object");
 
-  SpatialObjectType::Pointer object2 = SpatialObjectType::New();
+  auto object2 = SpatialObjectType::New();
   object2->GetProperty().SetName("Second Object");
   // Software Guide : EndCodeSnippet
 

--- a/Examples/SpatialObjects/SpatialObjectToImageStatisticsCalculator.cxx
+++ b/Examples/SpatialObjects/SpatialObjectToImageStatisticsCalculator.cxx
@@ -46,8 +46,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   using ImageType = itk::Image<unsigned char, 2>;
   using RandomImageSourceType = itk::RandomImageSource<ImageType>;
-  RandomImageSourceType::Pointer randomImageSource =
-    RandomImageSourceType::New();
+  auto                     randomImageSource = RandomImageSourceType::New();
   ImageType::SizeValueType size[2];
   size[0] = 10;
   size[1] = 10;
@@ -65,7 +64,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using EllipseType = itk::EllipseSpatialObject<2>;
-  EllipseType::Pointer ellipse = EllipseType::New();
+  auto ellipse = EllipseType::New();
   ellipse->SetRadiusInObjectSpace(2);
   EllipseType::PointType offset;
   offset.Fill(5);
@@ -83,7 +82,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   using CalculatorType =
     itk::SpatialObjectToImageStatisticsCalculator<ImageType, EllipseType>;
-  CalculatorType::Pointer calculator = CalculatorType::New();
+  auto calculator = CalculatorType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/SpatialObjects/SpatialObjectTransforms.cxx
+++ b/Examples/SpatialObjects/SpatialObjectTransforms.cxx
@@ -104,10 +104,10 @@ main(int, char *[])
   using SpatialObjectType = itk::SpatialObject<2>;
   using TransformType = SpatialObjectType::TransformType;
 
-  SpatialObjectType::Pointer object1 = SpatialObjectType::New();
+  auto object1 = SpatialObjectType::New();
   object1->GetProperty().SetName("First Object");
 
-  SpatialObjectType::Pointer object2 = SpatialObjectType::New();
+  auto object2 = SpatialObjectType::New();
   object2->GetProperty().SetName("Second Object");
   object1->AddChild(object2);
   // Software Guide : EndCodeSnippet

--- a/Examples/SpatialObjects/VesselTubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/VesselTubeSpatialObject.cxx
@@ -54,7 +54,7 @@ main(int, char *[])
 
   using PointType = VesselTubeType::PointType;
 
-  VesselTubeType::Pointer vesselTube = VesselTubeType::New();
+  auto vesselTube = VesselTubeType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Statistics/BayesianClassifier.cxx
+++ b/Examples/Statistics/BayesianClassifier.cxx
@@ -77,7 +77,7 @@ main(int argc, char * argv[])
   using InputImageType = itk::VectorImage<InputPixelType, Dimension>;
   using ReaderType = itk::ImageFileReader<InputImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(membershipImageFileName);
 
   using LabelType = unsigned char;
@@ -91,7 +91,7 @@ main(int argc, char * argv[])
                                        PosteriorType,
                                        PriorType>;
 
-  ClassifierFilterType::Pointer filter = ClassifierFilterType::New();
+  auto filter = ClassifierFilterType::New();
 
 
   filter->SetInput(reader->GetOutput());
@@ -104,7 +104,7 @@ main(int argc, char * argv[])
     using SmoothingFilterType = itk::GradientAnisotropicDiffusionImageFilter<
       ExtractedComponentImageType,
       ExtractedComponentImageType>;
-    SmoothingFilterType::Pointer smoother = SmoothingFilterType::New();
+    auto smoother = SmoothingFilterType::New();
     smoother->SetNumberOfIterations(1);
     smoother->SetTimeStep(0.125);
     smoother->SetConductanceParameter(3);
@@ -125,14 +125,14 @@ main(int argc, char * argv[])
   using RescalerType =
     itk::RescaleIntensityImageFilter<ClassifierOutputImageType,
                                      OutputImageType>;
-  RescalerType::Pointer rescaler = RescalerType::New();
+  auto rescaler = RescalerType::New();
   rescaler->SetInput(filter->GetOutput());
   rescaler->SetOutputMinimum(0);
   rescaler->SetOutputMaximum(255);
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetFileName(labelMapImageFileName);
 
   //

--- a/Examples/Statistics/BayesianClassifierInitializer.cxx
+++ b/Examples/Statistics/BayesianClassifierInitializer.cxx
@@ -83,11 +83,10 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<unsigned char, Dimension>;
   using BayesianInitializerType =
     itk::BayesianClassifierInitializationImageFilter<ImageType>;
-  BayesianInitializerType::Pointer bayesianInitializer =
-    BayesianInitializerType::New();
+  auto bayesianInitializer = BayesianInitializerType::New();
 
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);
 
   try
@@ -108,7 +107,7 @@ main(int argc, char * argv[])
 
   using WriterType =
     itk::ImageFileWriter<BayesianInitializerType::OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
   writer->SetInput(bayesianInitializer->GetOutput());
   writer->SetFileName(argv[2]);
 
@@ -139,8 +138,7 @@ main(int argc, char * argv[])
     using MembershipImageType = BayesianInitializerType::OutputImageType;
     using ExtractedComponentImageType =
       itk::Image<MembershipImageType::InternalPixelType, Dimension>;
-    ExtractedComponentImageType::Pointer extractedComponentImage =
-      ExtractedComponentImageType::New();
+    auto extractedComponentImage = ExtractedComponentImageType::New();
     extractedComponentImage->CopyInformation(
       bayesianInitializer->GetOutput());
     extractedComponentImage->SetBufferedRegion(
@@ -173,14 +171,13 @@ main(int argc, char * argv[])
     using RescalerType =
       itk::RescaleIntensityImageFilter<ExtractedComponentImageType,
                                        OutputImageType>;
-    RescalerType::Pointer rescaler = RescalerType::New();
+    auto rescaler = RescalerType::New();
     rescaler->SetInput(extractedComponentImage);
     rescaler->SetOutputMinimum(0);
     rescaler->SetOutputMaximum(255);
     using ExtractedComponentWriterType =
       itk::ImageFileWriter<OutputImageType>;
-    ExtractedComponentWriterType::Pointer rescaledImageWriter =
-      ExtractedComponentWriterType::New();
+    auto rescaledImageWriter = ExtractedComponentWriterType::New();
     rescaledImageWriter->SetInput(rescaler->GetOutput());
     rescaledImageWriter->SetFileName(argv[5]);
     rescaledImageWriter->Update();

--- a/Examples/Statistics/BayesianPluginClassifier.cxx
+++ b/Examples/Statistics/BayesianPluginClassifier.cxx
@@ -120,7 +120,7 @@ main(int, char *[])
   constexpr unsigned int measurementVectorLength = 1;
   using MeasurementVectorType = itk::Vector<double, measurementVectorLength>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   // length of measurement vectors in the sample.
   sample->SetMeasurementVectorSize(measurementVectorLength);
 
@@ -154,7 +154,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
-  NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();
+  auto normalGenerator = NormalGeneratorType::New();
 
   normalGenerator->Initialize(101);
 
@@ -253,7 +253,7 @@ main(int, char *[])
   using MembershipFunctionType =
     itk::Statistics::GaussianMembershipFunction<MeasurementVectorType>;
   using DecisionRuleType = itk::Statistics::MaximumRatioDecisionRule;
-  DecisionRuleType::Pointer decisionRule = DecisionRuleType::New();
+  auto decisionRule = DecisionRuleType::New();
 
   DecisionRuleType::PriorProbabilityVectorType aPrioris;
   aPrioris.push_back((double)classSamples[0]->GetTotalFrequency() /
@@ -263,7 +263,7 @@ main(int, char *[])
   decisionRule->SetPriorProbabilities(aPrioris);
 
   using ClassifierType = itk::Statistics::SampleClassifierFilter<SampleType>;
-  ClassifierType::Pointer classifier = ClassifierType::New();
+  auto classifier = ClassifierType::New();
 
   classifier->SetDecisionRule(decisionRule);
   classifier->SetInput(sample);
@@ -273,8 +273,7 @@ main(int, char *[])
     ClassifierType::ClassLabelVectorObjectType;
   using ClassLabelVectorType = ClassifierType::ClassLabelVectorType;
 
-  ClassLabelVectorObjectType::Pointer classLabelVectorObject =
-    ClassLabelVectorObjectType::New();
+  auto classLabelVectorObject = ClassLabelVectorObjectType::New();
   ClassLabelVectorType classLabelVector = classLabelVectorObject->Get();
 
   ClassifierType::ClassLabelType class1 = 100;
@@ -315,15 +314,14 @@ main(int, char *[])
   using MembershipFunctionVectorType =
     ClassifierType::MembershipFunctionVectorType;
 
-  MembershipFunctionVectorObjectType::Pointer membershipFunctionVectorObject =
+  auto membershipFunctionVectorObject =
     MembershipFunctionVectorObjectType::New();
   MembershipFunctionVectorType membershipFunctionVector =
     membershipFunctionVectorObject->Get();
 
   for (unsigned int i = 0; i < 2; ++i)
   {
-    MembershipFunctionType::Pointer membershipFunction =
-      MembershipFunctionType::New();
+    auto membershipFunction = MembershipFunctionType::New();
     membershipFunction->SetMean(covarianceEstimators[i]->GetMean());
     membershipFunction->SetCovariance(
       covarianceEstimators[i]->GetCovarianceMatrix());

--- a/Examples/Statistics/EuclideanDistanceMetric.cxx
+++ b/Examples/Statistics/EuclideanDistanceMetric.cxx
@@ -72,7 +72,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   using DistanceMetricType =
     itk::Statistics::EuclideanDistanceMetric<MeasurementVectorType>;
-  DistanceMetricType::Pointer distanceMetric = DistanceMetricType::New();
+  auto distanceMetric = DistanceMetricType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Statistics/ExpectationMaximizationMixtureModelEstimator.cxx
+++ b/Examples/Statistics/ExpectationMaximizationMixtureModelEstimator.cxx
@@ -125,7 +125,7 @@ main()
   unsigned int numberOfClasses = 2;
   using MeasurementVectorType = itk::Vector<double, 1>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   sample->SetMeasurementVectorSize(1); // length of measurement vectors
                                        // in the sample.
   // Software Guide : EndCodeSnippet
@@ -151,7 +151,7 @@ main()
 
   // Software Guide : BeginCodeSnippet
   using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
-  NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();
+  auto normalGenerator = NormalGeneratorType::New();
 
   normalGenerator->Initialize(101);
 
@@ -218,7 +218,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using EstimatorType =
     itk::Statistics::ExpectationMaximizationMixtureModelEstimator<SampleType>;
-  EstimatorType::Pointer estimator = EstimatorType::New();
+  auto estimator = EstimatorType::New();
 
   estimator->SetSample(sample);
   estimator->SetMaximumIteration(200);

--- a/Examples/Statistics/GaussianMembershipFunction.cxx
+++ b/Examples/Statistics/GaussianMembershipFunction.cxx
@@ -58,7 +58,7 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   using DensityFunctionType =
     itk::Statistics::GaussianMembershipFunction<MeasurementVectorType>;
-  DensityFunctionType::Pointer densityFunction = DensityFunctionType::New();
+  auto densityFunction = DensityFunctionType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Statistics/Histogram.cxx
+++ b/Examples/Statistics/Histogram.cxx
@@ -72,7 +72,7 @@ main()
   using HistogramType =
     itk::Statistics::Histogram<MeasurementType, FrequencyContainerType>;
 
-  HistogramType::Pointer histogram = HistogramType::New();
+  auto histogram = HistogramType::New();
   histogram->SetMeasurementVectorSize(numberOfComponents);
   // Software Guide : EndCodeSnippet
 

--- a/Examples/Statistics/ImageEntropy1.cxx
+++ b/Examples/Statistics/ImageEntropy1.cxx
@@ -86,7 +86,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -113,8 +113,7 @@ main(int argc, char * argv[])
   using HistogramGeneratorType =
     itk::Statistics::ScalarImageToHistogramGenerator<ImageType>;
 
-  HistogramGeneratorType::Pointer histogramGenerator =
-    HistogramGeneratorType::New();
+  auto histogramGenerator = HistogramGeneratorType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/ImageHistogram1.cxx
+++ b/Examples/Statistics/ImageHistogram1.cxx
@@ -92,7 +92,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
   // Software Guide : EndCodeSnippet
@@ -113,7 +113,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using AdaptorType = itk::Statistics::ImageToListSampleAdaptor<ImageType>;
 
-  AdaptorType::Pointer adaptor = AdaptorType::New();
+  auto adaptor = AdaptorType::New();
 
   adaptor->SetImage(reader->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -160,7 +160,7 @@ main(int argc, char * argv[])
   using FilterType =
     itk::Statistics::SampleToHistogramFilter<AdaptorType, HistogramType>;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Statistics/ImageHistogram2.cxx
+++ b/Examples/Statistics/ImageHistogram2.cxx
@@ -77,7 +77,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -107,8 +107,7 @@ main(int argc, char * argv[])
   using HistogramGeneratorType =
     itk::Statistics::ScalarImageToHistogramGenerator<ImageType>;
 
-  HistogramGeneratorType::Pointer histogramGenerator =
-    HistogramGeneratorType::New();
+  auto histogramGenerator = HistogramGeneratorType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/ImageHistogram3.cxx
+++ b/Examples/Statistics/ImageHistogram3.cxx
@@ -83,7 +83,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<RGBImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -112,7 +112,7 @@ main(int argc, char * argv[])
   using HistogramFilterType =
     itk::Statistics::ImageToHistogramFilter<RGBImageType>;
 
-  HistogramFilterType::Pointer histogramFilter = HistogramFilterType::New();
+  auto histogramFilter = HistogramFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/ImageHistogram4.cxx
+++ b/Examples/Statistics/ImageHistogram4.cxx
@@ -92,7 +92,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<RGBImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -122,7 +122,7 @@ main(int argc, char * argv[])
   using HistogramFilterType =
     itk::Statistics::ImageToHistogramFilter<RGBImageType>;
 
-  HistogramFilterType::Pointer histogramFilter = HistogramFilterType::New();
+  auto histogramFilter = HistogramFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/ImageMutualInformation1.cxx
+++ b/Examples/Statistics/ImageMutualInformation1.cxx
@@ -122,8 +122,8 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader1 = ReaderType::New();
-  ReaderType::Pointer reader2 = ReaderType::New();
+  auto reader1 = ReaderType::New();
+  auto reader2 = ReaderType::New();
 
   reader1->SetFileName(argv[1]);
   reader2->SetFileName(argv[2]);
@@ -140,7 +140,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using JoinFilterType = itk::JoinImageFilter<ImageType, ImageType>;
 
-  JoinFilterType::Pointer joinFilter = JoinFilterType::New();
+  auto joinFilter = JoinFilterType::New();
 
   joinFilter->SetInput1(reader1->GetOutput());
   joinFilter->SetInput2(reader2->GetOutput());
@@ -185,7 +185,7 @@ main(int argc, char * argv[])
   using HistogramFilterType =
     itk::Statistics::ImageToHistogramFilter<VectorImageType>;
 
-  HistogramFilterType::Pointer histogramFilter = HistogramFilterType::New();
+  auto histogramFilter = HistogramFilterType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/ImageToListSampleAdaptor.cxx
+++ b/Examples/Statistics/ImageToListSampleAdaptor.cxx
@@ -117,7 +117,7 @@ main()
   using CasterType =
     itk::ComposeImageFilter<FloatImage2DType, ArrayImageType>;
 
-  CasterType::Pointer caster = CasterType::New();
+  auto caster = CasterType::New();
   caster->SetInput(random->GetOutput());
   caster->Update();
   // Software Guide : EndCodeSnippet
@@ -134,7 +134,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using SampleType =
     itk::Statistics::ImageToListSampleAdaptor<ArrayImageType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Statistics/KdTree.cxx
+++ b/Examples/Statistics/KdTree.cxx
@@ -51,7 +51,7 @@ main()
   using MeasurementVectorType = itk::Vector<float, 2>;
 
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   sample->SetMeasurementVectorSize(2);
 
   MeasurementVectorType mv;
@@ -89,7 +89,7 @@ main()
 
   // Software Guide : BeginCodeSnippet
   using TreeGeneratorType = itk::Statistics::KdTreeGenerator<SampleType>;
-  TreeGeneratorType::Pointer treeGenerator = TreeGeneratorType::New();
+  auto treeGenerator = TreeGeneratorType::New();
 
   treeGenerator->SetSample(sample);
   treeGenerator->SetBucketSize(16);
@@ -98,8 +98,7 @@ main()
   using CentroidTreeGeneratorType =
     itk::Statistics::WeightedCentroidKdTreeGenerator<SampleType>;
 
-  CentroidTreeGeneratorType::Pointer centroidTreeGenerator =
-    CentroidTreeGeneratorType::New();
+  auto centroidTreeGenerator = CentroidTreeGeneratorType::New();
 
   centroidTreeGenerator->SetSample(sample);
   centroidTreeGenerator->SetBucketSize(16);
@@ -194,7 +193,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using DistanceMetricType =
     itk::Statistics::EuclideanDistanceMetric<MeasurementVectorType>;
-  DistanceMetricType::Pointer distanceMetric = DistanceMetricType::New();
+  auto distanceMetric = DistanceMetricType::New();
 
   DistanceMetricType::OriginType origin(2);
   for (unsigned int i = 0; i < sample->GetMeasurementVectorSize(); ++i)

--- a/Examples/Statistics/KdTreeBasedKMeansClustering.cxx
+++ b/Examples/Statistics/KdTreeBasedKMeansClustering.cxx
@@ -144,7 +144,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MeasurementVectorType = itk::Vector<double, 1>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   sample->SetMeasurementVectorSize(1);
   // Software Guide : EndCodeSnippet
 
@@ -178,7 +178,7 @@ main()
 
   // Software Guide : BeginCodeSnippet
   using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
-  NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();
+  auto normalGenerator = NormalGeneratorType::New();
 
   normalGenerator->Initialize(101);
 
@@ -212,7 +212,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using TreeGeneratorType =
     itk::Statistics::WeightedCentroidKdTreeGenerator<SampleType>;
-  TreeGeneratorType::Pointer treeGenerator = TreeGeneratorType::New();
+  auto treeGenerator = TreeGeneratorType::New();
 
   treeGenerator->SetSample(sample);
   treeGenerator->SetBucketSize(16);
@@ -250,7 +250,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using TreeType = TreeGeneratorType::KdTreeType;
   using EstimatorType = itk::Statistics::KdTreeBasedKmeansEstimator<TreeType>;
-  EstimatorType::Pointer estimator = EstimatorType::New();
+  auto estimator = EstimatorType::New();
 
   EstimatorType::ParametersType initialMeans(2);
   initialMeans[0] = 0.0;
@@ -306,10 +306,10 @@ main()
     itk::Statistics::DistanceToCentroidMembershipFunction<
       MeasurementVectorType>;
   using DecisionRuleType = itk::Statistics::MinimumDecisionRule;
-  DecisionRuleType::Pointer decisionRule = DecisionRuleType::New();
+  auto decisionRule = DecisionRuleType::New();
 
   using ClassifierType = itk::Statistics::SampleClassifierFilter<SampleType>;
-  ClassifierType::Pointer classifier = ClassifierType::New();
+  auto classifier = ClassifierType::New();
 
   classifier->SetDecisionRule(decisionRule);
   classifier->SetInput(sample);
@@ -320,8 +320,7 @@ main()
   using ClassLabelVectorType = ClassifierType::ClassLabelVectorType;
   using ClassLabelType = ClassifierType::ClassLabelType;
 
-  ClassLabelVectorObjectType::Pointer classLabelsObject =
-    ClassLabelVectorObjectType::New();
+  auto classLabelsObject = ClassLabelVectorObjectType::New();
   ClassLabelVectorType & classLabelsVector = classLabelsObject->Get();
 
   ClassLabelType class1 = 200;
@@ -355,7 +354,7 @@ main()
   using MembershipFunctionVectorType =
     ClassifierType::MembershipFunctionVectorType;
 
-  MembershipFunctionVectorObjectType::Pointer membershipFunctionVectorObject =
+  auto membershipFunctionVectorObject =
     MembershipFunctionVectorObjectType::New();
   MembershipFunctionVectorType & membershipFunctionVector =
     membershipFunctionVectorObject->Get();
@@ -363,8 +362,7 @@ main()
   int index = 0;
   for (unsigned int i = 0; i < 2; ++i)
   {
-    MembershipFunctionType::Pointer membershipFunction =
-      MembershipFunctionType::New();
+    auto membershipFunction = MembershipFunctionType::New();
     MembershipFunctionType::CentroidType centroid(
       sample->GetMeasurementVectorSize());
     for (unsigned int j = 0; j < sample->GetMeasurementVectorSize(); ++j)

--- a/Examples/Statistics/ListSample.cxx
+++ b/Examples/Statistics/ListSample.cxx
@@ -64,7 +64,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MeasurementVectorType = itk::Vector<float, 3>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Statistics/MaximumDecisionRule.cxx
+++ b/Examples/Statistics/MaximumDecisionRule.cxx
@@ -49,7 +49,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using DecisionRuleType = itk::Statistics::MaximumDecisionRule;
-  DecisionRuleType::Pointer decisionRule = DecisionRuleType::New();
+  auto decisionRule = DecisionRuleType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/MaximumRatioDecisionRule.cxx
+++ b/Examples/Statistics/MaximumRatioDecisionRule.cxx
@@ -62,7 +62,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using DecisionRuleType = itk::Statistics::MaximumRatioDecisionRule;
-  DecisionRuleType::Pointer decisionRule = DecisionRuleType::New();
+  auto decisionRule = DecisionRuleType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/MembershipSample.cxx
+++ b/Examples/Statistics/MembershipSample.cxx
@@ -59,7 +59,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MeasurementVectorType = itk::Vector<float, 3>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer   sample = SampleType::New();
+  auto                  sample = SampleType::New();
   MeasurementVectorType mv;
 
   mv[0] = 1.0;
@@ -102,8 +102,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MembershipSampleType = itk::Statistics::MembershipSample<SampleType>;
 
-  MembershipSampleType::Pointer membershipSample =
-    MembershipSampleType::New();
+  auto membershipSample = MembershipSampleType::New();
 
   membershipSample->SetSample(sample);
   membershipSample->SetNumberOfClasses(2);

--- a/Examples/Statistics/MembershipSampleGenerator.cxx
+++ b/Examples/Statistics/MembershipSampleGenerator.cxx
@@ -63,7 +63,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MeasurementVectorType = itk::Vector<float, 3>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer   sample = SampleType::New();
+  auto                  sample = SampleType::New();
   MeasurementVectorType mv;
 
   mv[0] = 1.0;
@@ -110,8 +110,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MembershipSampleType = itk::Statistics::MembershipSample<SampleType>;
 
-  MembershipSampleType::Pointer membershipSample =
-    MembershipSampleType::New();
+  auto membershipSample = MembershipSampleType::New();
 
   membershipSample->SetSample(sample);
   membershipSample->SetNumberOfClasses(2);

--- a/Examples/Statistics/MinimumDecisionRule.cxx
+++ b/Examples/Statistics/MinimumDecisionRule.cxx
@@ -47,7 +47,7 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
   using DecisionRuleType = itk::Statistics::MinimumDecisionRule;
-  DecisionRuleType::Pointer decisionRule = DecisionRuleType::New();
+  auto decisionRule = DecisionRuleType::New();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/NeighborhoodSampler.cxx
+++ b/Examples/Statistics/NeighborhoodSampler.cxx
@@ -67,7 +67,7 @@ main()
   using MeasurementVectorType =
     itk::Vector<MeasurementType, MeasurementVectorLength>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   sample->SetMeasurementVectorSize(MeasurementVectorLength);
 
   MeasurementVectorType mv;
@@ -99,7 +99,7 @@ main()
 
   // Software Guide : BeginCodeSnippet
   using SamplerType = itk::Statistics::NeighborhoodSampler<SampleType>;
-  SamplerType::Pointer sampler = SamplerType::New();
+  auto sampler = SamplerType::New();
 
   sampler->SetInputSample(sample);
   SamplerType::CenterType center(MeasurementVectorLength);

--- a/Examples/Statistics/NormalVariateGenerator.cxx
+++ b/Examples/Statistics/NormalVariateGenerator.cxx
@@ -50,7 +50,7 @@ main()
 
   // Software Guide : BeginCodeSnippet
   using GeneratorType = itk::Statistics::NormalVariateGenerator;
-  GeneratorType::Pointer generator = GeneratorType::New();
+  auto generator = GeneratorType::New();
   generator->Initialize((int)2003);
 
   for (unsigned int i = 0; i < 50; ++i)

--- a/Examples/Statistics/PointSetToAdaptor.cxx
+++ b/Examples/Statistics/PointSetToAdaptor.cxx
@@ -99,7 +99,7 @@ main()
   using CasterType = itk::ScalarToArrayCastPointSetFilter<FloatPointSet2DType,
                                                           ArrayPointSetType>;
 
-  CasterType::Pointer caster = CasterType::New();
+  auto caster = CasterType::New();
   caster->SetInput(random->GetOutput());
   caster->Update();
   // Software Guide : EndCodeSnippet
@@ -116,7 +116,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using SampleType =
     itk::Statistics::PointSetToListSampleAdaptor<ArrayPointSetType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Statistics/PointSetToListSampleAdaptor.cxx
+++ b/Examples/Statistics/PointSetToListSampleAdaptor.cxx
@@ -68,7 +68,7 @@ main()
 
   // Software Guide : BeginCodeSnippet
   using PointSetType = itk::PointSet<short>;
-  PointSetType::Pointer pointSet = PointSetType::New();
+  auto pointSet = PointSetType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -123,7 +123,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using SampleType =
     itk::Statistics::PointSetToListSampleAdaptor<PointSetType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex

--- a/Examples/Statistics/SampleSorting.cxx
+++ b/Examples/Statistics/SampleSorting.cxx
@@ -140,7 +140,7 @@ main()
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
 
   MeasurementVectorType mv;
   for (unsigned int i = 5; i > 0; --i)
@@ -163,7 +163,7 @@ main()
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  SubsampleType::Pointer subsample = SubsampleType::New();
+  auto subsample = SubsampleType::New();
   subsample->SetSample(sample);
   initializeSubsample(subsample, sample);
   printSubsample(subsample, "Unsorted");

--- a/Examples/Statistics/SampleStatistics.cxx
+++ b/Examples/Statistics/SampleStatistics.cxx
@@ -69,7 +69,7 @@ main()
   constexpr unsigned int MeasurementVectorLength = 3;
   using MeasurementVectorType = itk::Vector<float, MeasurementVectorLength>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   sample->SetMeasurementVectorSize(MeasurementVectorLength);
   MeasurementVectorType mv;
   mv[0] = 1.0;
@@ -114,7 +114,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MeanAlgorithmType = itk::Statistics::MeanSampleFilter<SampleType>;
 
-  MeanAlgorithmType::Pointer meanAlgorithm = MeanAlgorithmType::New();
+  auto meanAlgorithm = MeanAlgorithmType::New();
 
   meanAlgorithm->SetInput(sample);
   meanAlgorithm->Update();
@@ -134,8 +134,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using CovarianceAlgorithmType =
     itk::Statistics::CovarianceSampleFilter<SampleType>;
-  CovarianceAlgorithmType::Pointer covarianceAlgorithm =
-    CovarianceAlgorithmType::New();
+  auto covarianceAlgorithm = CovarianceAlgorithmType::New();
 
   covarianceAlgorithm->SetInput(sample);
   covarianceAlgorithm->Update();

--- a/Examples/Statistics/SampleToHistogramFilter.cxx
+++ b/Examples/Statistics/SampleToHistogramFilter.cxx
@@ -72,7 +72,7 @@ main()
     itk::Vector<MeasurementType, MeasurementVectorLength>;
 
   using ListSampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  ListSampleType::Pointer listSample = ListSampleType::New();
+  auto listSample = ListSampleType::New();
   listSample->SetMeasurementVectorSize(MeasurementVectorLength);
 
   MeasurementVectorType mv;
@@ -129,7 +129,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using FilterType =
     itk::Statistics::SampleToHistogramFilter<ListSampleType, HistogramType>;
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   filter->SetInput(listSample);
   filter->SetHistogramSize(size);

--- a/Examples/Statistics/ScalarImageKmeansClassifier.cxx
+++ b/Examples/Statistics/ScalarImageKmeansClassifier.cxx
@@ -74,7 +74,7 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<PixelType, Dimension>;
 
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(inputImageFileName);
   // Software Guide : EndCodeSnippet
 
@@ -90,7 +90,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using KMeansFilterType = itk::ScalarImageKmeansImageFilter<ImageType>;
 
-  KMeansFilterType::Pointer kmeansFilter = KMeansFilterType::New();
+  auto kmeansFilter = KMeansFilterType::New();
 
   kmeansFilter->SetInput(reader->GetOutput());
 
@@ -173,7 +173,7 @@ main(int argc, char * argv[])
 
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetInput(kmeansFilter->GetOutput());
 

--- a/Examples/Statistics/ScalarImageKmeansModelEstimator.cxx
+++ b/Examples/Statistics/ScalarImageKmeansModelEstimator.cxx
@@ -65,7 +65,7 @@ main(int argc, char * argv[])
 
   using ReaderType = itk::ImageFileReader<ImageType>;
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
 
   reader->SetFileName(argv[1]);
 
@@ -87,14 +87,14 @@ main(int argc, char * argv[])
   // Create a List from the scalar image
   using AdaptorType = itk::Statistics::ImageToListSampleAdaptor<ImageType>;
 
-  AdaptorType::Pointer adaptor = AdaptorType::New();
+  auto adaptor = AdaptorType::New();
 
   adaptor->SetImage(reader->GetOutput());
 
   // Create the K-d tree structure
   using TreeGeneratorType =
     itk::Statistics::WeightedCentroidKdTreeGenerator<AdaptorType>;
-  TreeGeneratorType::Pointer treeGenerator = TreeGeneratorType::New();
+  auto treeGenerator = TreeGeneratorType::New();
 
   treeGenerator->SetSample(adaptor);
   treeGenerator->SetBucketSize(16);
@@ -104,7 +104,7 @@ main(int argc, char * argv[])
   using TreeType = TreeGeneratorType::KdTreeType;
   using EstimatorType = itk::Statistics::KdTreeBasedKmeansEstimator<TreeType>;
 
-  EstimatorType::Pointer estimator = EstimatorType::New();
+  auto estimator = EstimatorType::New();
 
   constexpr unsigned int numberOfClasses = 3;
 

--- a/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
+++ b/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
@@ -120,7 +120,7 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<PixelType, Dimension>;
 
   using ReaderType = itk::ImageFileReader<ImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName(inputImageFileName);
   // Software Guide : EndCodeSnippet
 
@@ -140,7 +140,7 @@ main(int argc, char * argv[])
   using LabelImageType = itk::Image<LabelPixelType, Dimension>;
 
   using LabelReaderType = itk::ImageFileReader<LabelImageType>;
-  LabelReaderType::Pointer labelReader = LabelReaderType::New();
+  auto labelReader = LabelReaderType::New();
   labelReader->SetFileName(inputLabelImageFileName);
   // Software Guide : EndCodeSnippet
 
@@ -165,8 +165,7 @@ main(int argc, char * argv[])
   using ScalarToArrayFilterType =
     itk::ComposeImageFilter<ImageType, ArrayImageType>;
 
-  ScalarToArrayFilterType::Pointer scalarToArrayFilter =
-    ScalarToArrayFilterType::New();
+  auto scalarToArrayFilter = ScalarToArrayFilterType::New();
   scalarToArrayFilter->SetInput(reader->GetOutput());
   // Software Guide : EndCodeSnippet
 
@@ -183,7 +182,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using MRFFilterType = itk::MRFImageFilter<ArrayImageType, LabelImageType>;
 
-  MRFFilterType::Pointer mrfFilter = MRFFilterType::New();
+  auto mrfFilter = MRFFilterType::New();
 
   mrfFilter->SetInput(scalarToArrayFilter->GetOutput());
   // Software Guide : EndCodeSnippet
@@ -236,8 +235,7 @@ main(int argc, char * argv[])
   using SupervisedClassifierType =
     itk::ImageClassifierBase<ArrayImageType, LabelImageType>;
 
-  SupervisedClassifierType::Pointer classifier =
-    SupervisedClassifierType::New();
+  auto classifier = SupervisedClassifierType::New();
   // Software Guide : EndCodeSnippet
 
 
@@ -255,7 +253,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using DecisionRuleType = itk::Statistics::MinimumDecisionRule;
 
-  DecisionRuleType::Pointer classifierDecisionRule = DecisionRuleType::New();
+  auto classifierDecisionRule = DecisionRuleType::New();
 
   classifier->SetDecisionRule(classifierDecisionRule);
   // Software Guide : EndCodeSnippet
@@ -421,7 +419,7 @@ main(int argc, char * argv[])
     itk::RescaleIntensityImageFilter<OutputImageType,
                                      RescaledOutputImageType>;
 
-  RescalerType::Pointer intensityRescaler = RescalerType::New();
+  auto intensityRescaler = RescalerType::New();
   intensityRescaler->SetOutputMinimum(0);
   intensityRescaler->SetOutputMaximum(255);
   intensityRescaler->SetInput(mrfFilter->GetOutput());
@@ -429,7 +427,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetInput(intensityRescaler->GetOutput());
 

--- a/Examples/Statistics/SelectiveSubsampleGenerator.cxx
+++ b/Examples/Statistics/SelectiveSubsampleGenerator.cxx
@@ -63,7 +63,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MeasurementVectorType = itk::Vector<float, 3>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer   sample = SampleType::New();
+  auto                  sample = SampleType::New();
   MeasurementVectorType mv;
   mv[0] = 1.0;
   mv[1] = 2.0;
@@ -110,8 +110,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MembershipSampleType = itk::Statistics::MembershipSample<SampleType>;
 
-  MembershipSampleType::Pointer membershipSample =
-    MembershipSampleType::New();
+  auto membershipSample = MembershipSampleType::New();
 
   membershipSample->SetSample(sample);
   membershipSample->SetNumberOfClasses(2);

--- a/Examples/Statistics/Subsample.cxx
+++ b/Examples/Statistics/Subsample.cxx
@@ -72,7 +72,7 @@ main()
   // Software Guide : BeginCodeSnippet
   using MeasurementVectorType = itk::Vector<float, 3>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer   sample = SampleType::New();
+  auto                  sample = SampleType::New();
   MeasurementVectorType mv;
   mv[0] = 1.0;
   mv[1] = 2.0;
@@ -123,7 +123,7 @@ main()
 
   // Software Guide : BeginCodeSnippet
   using SubsampleType = itk::Statistics::Subsample<SampleType>;
-  SubsampleType::Pointer subsample = SubsampleType::New();
+  auto subsample = SubsampleType::New();
   subsample->SetSample(sample);
 
   subsample->AddInstance(0UL);

--- a/Examples/Statistics/WeightedSampleStatistics.cxx
+++ b/Examples/Statistics/WeightedSampleStatistics.cxx
@@ -108,7 +108,7 @@ main()
 
   // Software Guide : BeginCodeSnippet
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-  SampleType::Pointer sample = SampleType::New();
+  auto sample = SampleType::New();
   sample->SetMeasurementVectorSize(3);
   MeasurementVectorType mv;
   mv[0] = 1.0;
@@ -161,8 +161,7 @@ main()
   weightArray[2] = 0.01;
   weightArray[4] = 0.01;
 
-  WeightedMeanAlgorithmType::Pointer weightedMeanAlgorithm =
-    WeightedMeanAlgorithmType::New();
+  auto weightedMeanAlgorithm = WeightedMeanAlgorithmType::New();
 
   weightedMeanAlgorithm->SetInput(sample);
   weightedMeanAlgorithm->SetWeights(weightArray);
@@ -174,8 +173,7 @@ main()
   using WeightedCovarianceAlgorithmType =
     itk::Statistics::WeightedCovarianceSampleFilter<SampleType>;
 
-  WeightedCovarianceAlgorithmType::Pointer weightedCovarianceAlgorithm =
-    WeightedCovarianceAlgorithmType::New();
+  auto weightedCovarianceAlgorithm = WeightedCovarianceAlgorithmType::New();
 
   weightedCovarianceAlgorithm->SetInput(sample);
   weightedCovarianceAlgorithm->SetWeights(weightArray);
@@ -198,8 +196,7 @@ main()
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  ExampleWeightFunction::Pointer weightFunction =
-    ExampleWeightFunction::New();
+  auto weightFunction = ExampleWeightFunction::New();
 
   weightedMeanAlgorithm->SetWeightingFunction(weightFunction);
   weightedMeanAlgorithm->Update();


### PR DESCRIPTION
Replace initializations of the form `T::Pointer var = T::New()`
(sometimes starting with `typename`) with `auto var = T::New()` in `Examples` to
reduce code redundancy

In accordance with C++ Core Guidelines, August 19, 2021:
"ES.11: Use `auto` to avoid redundant repetition of type names"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-auto

Following PR https://github.com/InsightSoftwareConsortium/ITK/pull/2826
and commit 828453d1bf61c487310d2d8c9570093e08798a40.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
