### PR TITLE
DOC: Fix `itk::BuildInformation` class documentation typo

### DIFF
--- a/Modules/Core/Common/include/itkBuildInformation.h
+++ b/Modules/Core/Common/include/itkBuildInformation.h
@@ -33,7 +33,7 @@ namespace itk
  * that describe this version of ITK.
  *
  * Values in in the map provide information about
- * the ITK (i.e. it's version, the build options,
+ * the ITK (i.e. its version, the build options,
  * configuration options, the home URL for the project,
  * and other static information) that can be gathered
  * at configuration time.


### PR DESCRIPTION
Fix `itk::BuildInformation` class documentation typo.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)