### PR TITLE
Fix BuildInformation GetValue, GetDescription `key` parameter type, extend its test

### DIFF
--- a/Modules/Core/Common/include/itkBuildInformation.h
+++ b/Modules/Core/Common/include/itkBuildInformation.h
@@ -90,9 +90,9 @@ public:
   static const MapType &
   GetMap();
   static const MapValueType
-  GetValue(const MapKeyType &&);
+  GetValue(const MapKeyType &);
   static const MapValueDescriptionType
-  GetDescription(const MapKeyType &&);
+  GetDescription(const MapKeyType &);
   static const std::vector<MapKeyType>
   GetAllKeys();
 

--- a/Modules/Core/Common/src/itkBuildInformation.cxx.in
+++ b/Modules/Core/Common/src/itkBuildInformation.cxx.in
@@ -78,7 +78,7 @@ BuildInformation::GetMap()
 }
 
 const BuildInformation::MapValueType
-BuildInformation::GetValue(const MapKeyType &&key)
+BuildInformation::GetValue(const MapKeyType & key)
 {
   const MapType &localMap = BuildInformation::GetInstance()->GetMap();
 
@@ -91,7 +91,7 @@ BuildInformation::GetValue(const MapKeyType &&key)
 }
 
 const BuildInformation::MapValueDescriptionType
-BuildInformation::GetDescription(const MapKeyType && key)
+BuildInformation::GetDescription(const MapKeyType & key)
 {
   const MapType &localMap = BuildInformation::GetInstance()->GetMap();
 

--- a/Modules/Core/Common/test/itkBuildInformationGTest.cxx
+++ b/Modules/Core/Common/test/itkBuildInformationGTest.cxx
@@ -49,10 +49,15 @@ TEST(ITKBuildInformation, InformationFeatures)
 
   for (auto mapEntry : localMap)
   {
+    const auto & key = mapEntry.first;
+
     std::cout << "--------------------------------------------------------------------" << std::endl
-              << "Key: " << mapEntry.first << std::endl
+              << "Key: " << key << std::endl
               << "\tValue: " << mapEntry.second.m_Value << std::endl
               << "\tDescription: " << mapEntry.second.m_Description << std::endl;
+
+    EXPECT_EQ(itk::BuildInformation::GetValue(key), mapEntry.second.m_Value);
+    EXPECT_EQ(itk::BuildInformation::GetDescription(key), mapEntry.second.m_Description);
   }
 
   EXPECT_EQ(itk::BuildInformation::GetValue("PROJECT_URL"), "http://www.itk.org");


### PR DESCRIPTION
Added a check that for each entry from the map retrieved by `GetMap()`,
both `GetValue(key)` and `GetDescription(key)` return the expected
string.