### PR TITLE
ENH: Improve `JPEG` module tests

### DIFF
--- a/Modules/IO/JPEG/include/itkJPEGImageIO.h
+++ b/Modules/IO/JPEG/include/itkJPEGImageIO.h
@@ -67,10 +67,12 @@ public:
   /**  */
   itkSetMacro(Progressive, bool);
   itkGetConstMacro(Progressive, bool);
+  itkBooleanMacro(Progressive);
 
   /** Convert to RGB if out_color_space is CMYK, default is true */
   itkSetMacro(CMYKtoRGB, bool);
   itkGetConstMacro(CMYKtoRGB, bool);
+  itkBooleanMacro(CMYKtoRGB);
 
   /*-------- This part of the interface deals with reading data. ------ */
 

--- a/Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
@@ -54,7 +54,8 @@ itkJPEGImageIOCMYKTest(int argc, char * argv[])
 
     itk::ImageFileReader<ImageType>::Pointer reader = itk::ImageFileReader<ImageType>::New();
 
-    io->SetCMYKtoRGB(false);
+    auto cmykToRGB = false;
+    ITK_TEST_SET_GET_BOOLEAN(io, CMYKtoRGB, cmykToRGB);
 
     reader->SetFileName(argv[1]);
 

--- a/Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
@@ -46,11 +46,7 @@ itkJPEGImageIOCMYKTest(int argc, char * argv[])
 
     ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
-    if (!(io->GetPixelType() == itk::CommonEnums::IOPixel::RGB))
-    {
-      std::cout << "Expected RGB. Test failed" << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TEST_EXPECT_TRUE(io->GetPixelType() == itk::CommonEnums::IOPixel::RGB);
   }
 
   {
@@ -66,11 +62,7 @@ itkJPEGImageIOCMYKTest(int argc, char * argv[])
 
     ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
-    if (!(io->GetPixelType() == itk::CommonEnums::IOPixel::VECTOR))
-    {
-      std::cout << "Expected VECTOR. Test failed" << std::endl;
-      return EXIT_FAILURE;
-    }
+    ITK_TEST_EXPECT_TRUE(io->GetPixelType() == itk::CommonEnums::IOPixel::VECTOR);
   }
 
   std::cout << "Test finished." << std::endl;

--- a/Modules/IO/JPEG/test/itkJPEGImageIODegenerateCasesTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIODegenerateCasesTest.cxx
@@ -39,6 +39,9 @@ itkJPEGImageIODegenerateCasesTest(int argc, char * argv[])
 
   itk::JPEGImageIO::Pointer io = itk::JPEGImageIO::New();
 
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(io, JPEGImageIO, ImageIOBase);
+
+
   auto progressive = true;
   ITK_TEST_SET_GET_BOOLEAN(io, Progressive, progressive);
 

--- a/Modules/IO/JPEG/test/itkJPEGImageIODegenerateCasesTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIODegenerateCasesTest.cxx
@@ -39,6 +39,9 @@ itkJPEGImageIODegenerateCasesTest(int argc, char * argv[])
 
   itk::JPEGImageIO::Pointer io = itk::JPEGImageIO::New();
 
+  auto progressive = true;
+  ITK_TEST_SET_GET_BOOLEAN(io, Progressive, progressive);
+
   itk::ImageFileReader<ImageType>::Pointer reader = itk::ImageFileReader<ImageType>::New();
 
   reader->SetFileName(argv[1]);

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest.cxx
@@ -30,30 +30,25 @@ itkJPEGImageIOTest(int argc, char * argv[])
 
   if (argc < 3)
   {
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input Output\n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputFilename outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 
   // ATTENTION THIS IS THE PIXEL TYPE FOR
   // THE RESULTING IMAGE
+  constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
 
-  using myImage = itk::Image<PixelType, 2>;
+  using myImage = itk::Image<PixelType, Dimension>;
 
   itk::ImageFileReader<myImage>::Pointer reader = itk::ImageFileReader<myImage>::New();
 
   reader->SetFileName(argv[1]);
 
-  try
-  {
-    reader->Update();
-  }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cerr << "exception in file reader " << std::endl;
-    std::cerr << e << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
 
   myImage::Pointer image = reader->GetOutput();
 
@@ -67,7 +62,9 @@ itkJPEGImageIOTest(int argc, char * argv[])
   writer = itk::ImageFileWriter<myImage>::New();
   writer->SetInput(reader->GetOutput());
   writer->SetFileName(argv[2]);
-  writer->Update();
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- STYLE: Improve the `JPEG` module tests' style
- ENH: Add boolean macros for `itk::JPEGImageIO` boolean ivars
- ENH: Exercise basic object methods for `itk::JPEGImageIO`

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)