### PR TITLE
ENH: Add boolean macros to `itk::SpatialObjectWriter` boolean ivars

### DIFF
--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
@@ -79,6 +79,7 @@ public:
 
   itkSetMacro(BinaryPoints, bool);
   itkGetConstMacro(BinaryPoints, bool);
+  itkBooleanMacro(BinaryPoints);
 
   void
   SetTransformPrecision(unsigned int precision);
@@ -89,6 +90,7 @@ public:
   /** Set/Get if the images should be written in a different file */
   itkSetMacro(WriteImagesInSeparateFile, bool);
   itkGetConstMacro(WriteImagesInSeparateFile, bool);
+  itkBooleanMacro(WriteImagesInSeparateFile);
 
   /** Add a converter for a new MetaObject/SpatialObject type */
   void

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -20,7 +20,7 @@
 #include "itkSpatialObjectReader.h"
 
 #include "itkMath.h"
-#include "itkMath.h"
+#include "itkTestingMacros.h"
 
 int
 itkReadWriteSpatialObjectTest(int argc, char * argv[])
@@ -386,31 +386,24 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
   std::cout << "Testing Writing SceneSpatialObject: " << std::endl;
 
   auto writer = WriterType::New();
-  try
+
+  auto binaryPoints = false;
+
+  if ((argc > 3) && (!strcmp(argv[2], "binary")))
   {
-    writer->SetInput(tubeN1);
-    writer->SetFileName(argv[1]);
-    writer->SetBinaryPoints(false);
-    if (writer->GetBinaryPoints())
-    {
-      std::cout << "[FAILURE]" << std::endl;
-      return EXIT_FAILURE;
-    }
-    if ((argc > 3) && (!strcmp(argv[2], "binary")))
-    {
-      writer->SetBinaryPoints(true);
-    }
-    writer->Update();
+    binaryPoints = true;
   }
-  catch (const itk::ExceptionObject & e)
-  {
-    std::cout << e << std::endl;
-  }
-  catch (...)
-  {
-    std::cout << "[EXCEPTION FAILURE]" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  ITK_TEST_SET_GET_BOOLEAN(writer, BinaryPoints, binaryPoints);
+
+  auto writeImagesInSeparateFile = false;
+  ITK_TEST_SET_GET_BOOLEAN(writer, WriteImagesInSeparateFile, writeImagesInSeparateFile);
+
+  writer->SetInput(tubeN1);
+  writer->SetFileName(argv[1]);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   std::cout << "[PASSED]" << std::endl;
 


### PR DESCRIPTION
Add boolean macros to `itk::SpatialObjectWriter` boolean ivars.

Exercise the boolean macros and the boolean ivar Set/Get methods.

Take advantage of the commit to simplify and improve the style and
readability around such testing: use the `ITK_TRY_EXPECT_NO_EXCEPTION`
macro to avoid boilerplate code when updating a filter that can trigger
exceptions, and take out the rest of the statements of the `try/catch`
block.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)