### PR TITLE
ENH: Add default FFT object factories to TestKernel initialization

### DIFF
--- a/CMake/ITKModuleTest.cmake
+++ b/CMake/ITKModuleTest.cmake
@@ -56,7 +56,7 @@ EM_ASM(
   set(CMAKE_TESTDRIVER_AFTER_TESTMAIN "#include \"itkTestDriverAfterTest.inc\"${emscripten_after}")
   create_test_sourcelist(Tests ${KIT}TestDriver.cxx
     ${KitTests}
-    EXTRA_INCLUDE itkTestDriverIncludeRequiredIOFactories.h
+    EXTRA_INCLUDE itkTestDriverIncludeRequiredFactories.h
     FUNCTION  ProcessArgumentsAndRegisterRequiredFactories
     )
   add_executable(${KIT}TestDriver ${KIT}TestDriver.cxx ${Tests} ${ADDITIONAL_SRC})

--- a/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredFactories.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredFactories.h
@@ -15,12 +15,26 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+#ifndef itkTestDriverIncludeRequiredFactories_h
+#define itkTestDriverIncludeRequiredFactories_h
 
-// Legacy file for backwards compatibility
 
-#ifndef itkTestDriverIncludeRequiredIOFactories_h
-#define itkTestDriverIncludeRequiredIOFactories_h
+#include "itkTestDriverInclude.h"
 
-#include "itkTestDriverIncludeRequiredFactories.h"
+#ifdef __EMSCRIPTEN__
+#  include <emscripten.h>
+#endif
+
+void
+RegisterRequiredFactories();
+
+void
+RegisterRequiredIOFactories();
+
+void
+RegisterRequiredFFTFactories();
+
+void
+ProcessArgumentsAndRegisterRequiredFactories(int * ac, ArgumentStringType * av);
 
 #endif

--- a/Modules/Core/TestKernel/itk-module.cmake
+++ b/Modules/Core/TestKernel/itk-module.cmake
@@ -24,6 +24,7 @@ itk_module(ITKTestKernel
     ITKIOMeshGifti
     ITKIOMeshOBJ
     ITKIOMeshOFF
+    ITKFFT
   COMPILE_DEPENDS
     ITKKWSys
     ITKDoubleConversion

--- a/Modules/Core/TestKernel/src/CMakeLists.txt
+++ b/Modules/Core/TestKernel/src/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT DO_NOT_INSTALL_ITK_TEST_DRIVER) # used only by vcpkg
 endif()
 
 set(ITKTestKernel_SRCS
-  itkTestDriverIncludeRequiredIOFactories.cxx
+  itkTestDriverIncludeRequiredFactories.cxx
   itkTestDriverInclude.cxx
   itkTestingExtractSliceImageFilter.cxx
   itkTestingHashImageFilter.cxx)

--- a/Modules/Core/TestKernel/src/itkTestDriver.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriver.cxx
@@ -26,7 +26,7 @@
  *
  *=========================================================================*/
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 
 
 /* Select the environment variable holding the shared library runtime

--- a/Modules/Core/TestKernel/src/itkTestDriverIncludeRequiredFactories.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverIncludeRequiredFactories.cxx
@@ -16,7 +16,7 @@
  *
  *=========================================================================*/
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 
 // ImageIO
 #include "itkGDCMImageIOFactory.h"
@@ -41,12 +41,31 @@
 #include "itkOFFMeshIOFactory.h"
 #include "itkVTKPolyDataMeshIOFactory.h"
 
+// FFT
+#include "itkFFTImageFilterFactory.h"
+#include "itkVnlComplexToComplex1DFFTImageFilter.h"
+#include "itkVnlComplexToComplexFFTImageFilter.h"
+#include "itkVnlForward1DFFTImageFilter.h"
+#include "itkVnlForwardFFTImageFilter.h"
+#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
+#include "itkVnlInverse1DFFTImageFilter.h"
+#include "itkVnlInverseFFTImageFilter.h"
+#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
+
 #ifdef __EMSCRIPTEN__
 #  include <emscripten.h>
 #endif
 
 void
 RegisterRequiredFactories()
+{
+  RegisterRequiredIOFactories();
+
+  RegisterRequiredFFTFactories();
+}
+
+void
+RegisterRequiredIOFactories()
 {
   // ImageIO
   itk::ObjectFactoryBase::RegisterFactory(itk::MetaImageIOFactory::New());
@@ -68,6 +87,21 @@ RegisterRequiredFactories()
   itk::ObjectFactoryBase::RegisterFactory(itk::OBJMeshIOFactory::New());
   itk::ObjectFactoryBase::RegisterFactory(itk::OFFMeshIOFactory::New());
   itk::ObjectFactoryBase::RegisterFactory(itk::VTKPolyDataMeshIOFactory::New());
+}
+
+void
+RegisterRequiredFFTFactories()
+{
+  itk::ObjectFactoryBase::RegisterFactory(itk::FFTImageFilterFactory<itk::VnlComplexToComplex1DFFTImageFilter>::New());
+  itk::ObjectFactoryBase::RegisterFactory(itk::FFTImageFilterFactory<itk::VnlComplexToComplexFFTImageFilter>::New());
+  itk::ObjectFactoryBase::RegisterFactory(itk::FFTImageFilterFactory<itk::VnlForward1DFFTImageFilter>::New());
+  itk::ObjectFactoryBase::RegisterFactory(itk::FFTImageFilterFactory<itk::VnlForwardFFTImageFilter>::New());
+  itk::ObjectFactoryBase::RegisterFactory(
+    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>::New());
+  itk::ObjectFactoryBase::RegisterFactory(itk::FFTImageFilterFactory<itk::VnlInverse1DFFTImageFilter>::New());
+  itk::ObjectFactoryBase::RegisterFactory(itk::FFTImageFilterFactory<itk::VnlInverseFFTImageFilter>::New());
+  itk::ObjectFactoryBase::RegisterFactory(
+    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>::New());
 }
 
 void

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
@@ -67,19 +67,6 @@ itkFFTConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
   }
   deltaFunctionImage->SetPixel(middleIndex, 1);
 
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
-
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;
   auto convolver = ConvolutionFilterType::New();
 

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
@@ -66,19 +66,6 @@ itkFFTConvolutionImageFilterTest(int argc, char * argv[])
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader2->Update());
 
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
-
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;
   auto convoluter = ConvolutionFilterType::New();
 

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTestInt.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTestInt.cxx
@@ -58,19 +58,6 @@ itkFFTConvolutionImageFilterTestInt(int argc, char * argv[])
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader2->Update());
 
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
-
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;
   auto convolver = ConvolutionFilterType::New();
 

--- a/Modules/Filtering/Convolution/test/itkFFTNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTNormalizedCorrelationImageFilterTest.cxx
@@ -70,23 +70,6 @@ itkFFTNormalizedCorrelationImageFilterTest(int argc, char * argv[])
   auto movingImageReader = ReaderType::New();
   movingImageReader->SetFileName(movingImageFileName);
 
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWInverseFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlInverseFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
-
   auto filter = FilterType::New();
   filter->SetFixedImage(fixedImageReader->GetOutput());
   filter->SetMovingImage(movingImageReader->GetOutput());

--- a/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
@@ -23,18 +23,6 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlForwardFFTImageFilter.h"
-#include "itkVnlInverseFFTImageFilter.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWForwardFFTImageFilter.h"
-#  include "itkFFTWInverseFFTImageFilter.h"
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#  include "itkFFTWHalfHermitianToRealInverseFFTImageFilter.h"
-#endif
-
 int
 itkMaskedFFTNormalizedCorrelationImageFilterTest(int argc, char * argv[])
 {
@@ -74,23 +62,6 @@ itkMaskedFFTNormalizedCorrelationImageFilterTest(int argc, char * argv[])
 
   auto movingImageReader = ReaderType::New();
   movingImageReader->SetFileName(movingImageFileName);
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWInverseFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlInverseFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
 
   auto filter = FilterType::New();
   filter->SetFixedImage(fixedImageReader->GetOutput());

--- a/Modules/Filtering/Deconvolution/test/itkInverseDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkInverseDeconvolutionImageFilterTest.cxx
@@ -22,14 +22,6 @@
 #include "itkImageFileWriter.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#  include "itkFFTWHalfHermitianToRealInverseFFTImageFilter.h"
-#endif
-
 int
 itkInverseDeconvolutionImageFilterTest(int argc, char * argv[])
 {
@@ -57,19 +49,6 @@ itkInverseDeconvolutionImageFilterTest(int argc, char * argv[])
 
   itk::ConstantBoundaryCondition<ImageType> cbc;
   cbc.SetConstant(0.0);
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
 
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;
   auto convolutionFilter = ConvolutionFilterType::New();

--- a/Modules/Filtering/Deconvolution/test/itkLandweberDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkLandweberDeconvolutionImageFilterTest.cxx
@@ -26,14 +26,6 @@
 #include "itkMath.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#  include "itkFFTWHalfHermitianToRealInverseFFTImageFilter.h"
-#endif
-
 int
 itkLandweberDeconvolutionImageFilterTest(int argc, char * argv[])
 {
@@ -57,19 +49,6 @@ itkLandweberDeconvolutionImageFilterTest(int argc, char * argv[])
   auto kernelReader = ReaderType::New();
   kernelReader->SetFileName(argv[2]);
   kernelReader->Update();
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
 
   // Generate a convolution of the input image with the kernel image
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;

--- a/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
@@ -23,14 +23,6 @@
 #include "itkParametricBlindLeastSquaresDeconvolutionImageFilter.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#  include "itkFFTWHalfHermitianToRealInverseFFTImageFilter.h"
-#endif
-
 // Define a version of the GaussianImageSource that has only the sigma
 // parameters
 namespace itk
@@ -164,20 +156,6 @@ itkParametricBlindLeastSquaresDeconvolutionImageFilterTest(int argc, char * argv
   mean[0] = 0.5 * (size[0] - 1) * spacing[0];
   mean[1] = 0.5 * (size[1] - 1) * spacing[1];
   kernelSource->SetMean(mean);
-
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
 
   // Generate a convolution of the input image with a kernel computed
   // from a parametric image source. We'll try to recover those

--- a/Modules/Filtering/Deconvolution/test/itkProjectedIterativeDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkProjectedIterativeDeconvolutionImageFilterTest.cxx
@@ -21,32 +21,11 @@
 #include "itkProjectedIterativeDeconvolutionImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#  include "itkFFTWHalfHermitianToRealInverseFFTImageFilter.h"
-#endif
-
 int
 itkProjectedIterativeDeconvolutionImageFilterTest(int, char *[])
 {
   // Declare the image type
   using ImageType = itk::Image<float, 2>;
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
 
   // Declare the base deconvolution filter choice
   using BaseDeconvolutionFilterType = itk::LandweberDeconvolutionImageFilter<ImageType>;

--- a/Modules/Filtering/Deconvolution/test/itkProjectedLandweberDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkProjectedLandweberDeconvolutionImageFilterTest.cxx
@@ -22,14 +22,6 @@
 #include "itkDeconvolutionIterationCommand.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#  include "itkFFTWHalfHermitianToRealInverseFFTImageFilter.h"
-#endif
-
 int
 itkProjectedLandweberDeconvolutionImageFilterTest(int argc, char * argv[])
 {
@@ -53,19 +45,6 @@ itkProjectedLandweberDeconvolutionImageFilterTest(int argc, char * argv[])
   auto kernelReader = ReaderType::New();
   kernelReader->SetFileName(argv[2]);
   kernelReader->Update();
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
 
   // Generate a convolution of the input image with the kernel image
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;

--- a/Modules/Filtering/Deconvolution/test/itkRichardsonLucyDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkRichardsonLucyDeconvolutionImageFilterTest.cxx
@@ -24,14 +24,6 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#  include "itkFFTWHalfHermitianToRealInverseFFTImageFilter.h"
-#endif
-
 int
 itkRichardsonLucyDeconvolutionImageFilterTest(int argc, char * argv[])
 {
@@ -55,19 +47,6 @@ itkRichardsonLucyDeconvolutionImageFilterTest(int argc, char * argv[])
   auto kernelReader = ReaderType::New();
   kernelReader->SetFileName(argv[2]);
   kernelReader->Update();
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
 
   // Generate a convolution of the input image with the kernel image
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;

--- a/Modules/Filtering/Deconvolution/test/itkTikhonovDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkTikhonovDeconvolutionImageFilterTest.cxx
@@ -23,14 +23,6 @@
 #include "itkImageFileWriter.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#  include "itkFFTWHalfHermitianToRealInverseFFTImageFilter.h"
-#endif
-
 int
 itkTikhonovDeconvolutionImageFilterTest(int argc, char * argv[])
 {
@@ -58,19 +50,6 @@ itkTikhonovDeconvolutionImageFilterTest(int argc, char * argv[])
 
   itk::ConstantBoundaryCondition<ImageType> cbc;
   cbc.SetConstant(0.0);
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
 
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;
   auto convolutionFilter = ConvolutionFilterType::New();

--- a/Modules/Filtering/Deconvolution/test/itkWienerDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkWienerDeconvolutionImageFilterTest.cxx
@@ -58,19 +58,6 @@ itkWienerDeconvolutionImageFilterTest(int argc, char * argv[])
   itk::ConstantBoundaryCondition<ImageType> cbc;
   cbc.SetConstant(0.0);
 
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK FFT tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWHalfHermitianToRealInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-#endif
-
   using ConvolutionFilterType = itk::FFTConvolutionImageFilter<ImageType>;
   auto convolutionFilter = ConvolutionFilterType::New();
   convolutionFilter->SetInput(reader1->GetOutput());

--- a/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
+++ b/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
@@ -117,6 +117,9 @@ protected:
     OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<float>,
                                typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<float>,
                                3>();
+    OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<float>,
+                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<float>,
+                               4>();
 
     OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<double>,
                                typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>,
@@ -127,6 +130,9 @@ protected:
     OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<double>,
                                typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>,
                                3>();
+    OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<double>,
+                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>,
+                               4>();
   }
 };
 

--- a/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
+++ b/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
@@ -19,6 +19,7 @@
 #ifndef itkFFTImageFilterFactory_h
 #define itkFFTImageFilterFactory_h
 
+#include "itkImage.h"
 #include "itkObjectFactoryBase.h"
 #include "itkVersion.h"
 

--- a/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
@@ -29,7 +29,6 @@
 #if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
 #  include "itkFFTWComplexToComplex1DFFTImageFilter.h"
 #endif
-#include "itkFFTImageFilterFactory.h"
 
 #include "itkTestingMacros.h"
 
@@ -99,15 +98,6 @@ itkComplexToComplex1DFFTImageFilterTest(int argc, char * argv[])
 
   if (backend == 0)
   {
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-    itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-      itk::FFTImageFilterFactory<itk::FFTWComplexToComplex1DFFTImageFilter>>();
-#  else
-    itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-      itk::FFTImageFilterFactory<itk::VnlComplexToComplex1DFFTImageFilter>>();
-#  endif
-#endif
     using FFTInverseType = itk::ComplexToComplex1DFFTImageFilter<ComplexImageType, ComplexImageType>;
     auto inverse = FFTInverseType::New();
     if (inverse == nullptr)

--- a/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
@@ -39,34 +39,6 @@
 #include "itkInverseFFTImageFilter.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlComplexToComplexFFTImageFilter.h"
-#include "itkVnlForwardFFTImageFilter.h"
-#include "itkVnlInverseFFTImageFilter.h"
-
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWComplexToComplexFFTImageFilter.h"
-#  include "itkFFTWForwardFFTImageFilter.h"
-#  include "itkFFTWInverseFFTImageFilter.h"
-#endif
-
-void
-registerFactories()
-{
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWComplexToComplexFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWInverseFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlComplexToComplexFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlInverseFFTImageFilter>>();
-#endif
-}
-
 template <typename TPixel, unsigned int VDimension>
 int
 transformImage(const char * inputImageFileName, const char * outputImageFileName)
@@ -141,8 +113,6 @@ itkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
   imageIO->SetFileName(inputImageFileName);
   imageIO->ReadImageInformation();
   const unsigned int dimension = imageIO->GetNumberOfDimensions();
-
-  registerFactories();
 
   if (pixelTypeString.compare("float") == 0)
   {

--- a/Modules/Filtering/FFT/test/itkFFTPadImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTPadImageFilterTest.cxx
@@ -66,14 +66,6 @@ itkFFTPadImageFilterTest(int argc, char * argv[])
   itk::ConstantBoundaryCondition<ImageType>        zeroCond;
   itk::PeriodicBoundaryCondition<ImageType>        wrapCond;
 
-  // FFTPadImageFilter requires backend for ForwardFFTImageFilter to get prime factor
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWForwardFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlForwardFFTImageFilter>>();
-#endif
-
   // Create the filters
   auto fftpad = FFTPadType::New();
   fftpad->SetInput(reader->GetOutput());

--- a/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
@@ -57,7 +57,7 @@ transformImage(const char * inputImageFileName, const char * outputImageFileName
   auto reader = ReaderType::New();
   reader->SetFileName(inputImageFileName);
 
-  using ForwardFilterType = itk::ForwardFFTImageFilter<RealImageType, ComplexImageType>;
+  using ForwardFilterType = itk::FFTWForwardFFTImageFilter<RealImageType, ComplexImageType>;
   auto forwardFilter = ForwardFilterType::New();
   forwardFilter->SetInput(reader->GetOutput());
 
@@ -72,7 +72,7 @@ transformImage(const char * inputImageFileName, const char * outputImageFileName
   // This tests the CanUseDestructiveAlgorithm state with the FFTW version.
   forwardComplexFilter->ReleaseDataFlagOn();
 
-  using InverseFilterType = itk::InverseFFTImageFilter<ComplexImageType, RealImageType>;
+  using InverseFilterType = itk::FFTWInverseFFTImageFilter<ComplexImageType, RealImageType>;
   auto inverseFilter = InverseFilterType::New();
   inverseFilter->SetInput(forwardComplexFilter->GetOutput());
 
@@ -111,11 +111,6 @@ itkFFTWComplexToComplexFFTImageFilterTest(int argc, char * argv[])
   imageIO->SetFileName(inputImageFileName);
   imageIO->ReadImageInformation();
   const unsigned int dimension = imageIO->GetNumberOfDimensions();
-
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWComplexToComplexFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWInverseFFTImageFilter>>();
 
   if (pixelTypeString.compare("float") == 0)
   {

--- a/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
@@ -29,7 +29,6 @@
 #if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
 #  include "itkFFTWForward1DFFTImageFilter.h"
 #endif
-#include "itkFFTImageFilterFactory.h"
 #include "itkTestingMacros.h"
 
 template <typename FFTType>
@@ -100,13 +99,6 @@ itkForward1DFFTImageFilterTest(int argc, char * argv[])
   if (backend == 0)
   {
     using FFTForwardType = itk::Forward1DFFTImageFilter<ImageType, ComplexImageType>;
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-    itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWForward1DFFTImageFilter>>();
-#  endif
-    itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlForward1DFFTImageFilter>>();
-#endif
 
     // Instantiate a filter to exercise basic object methods
     auto fft = FFTForwardType::New();

--- a/Modules/Filtering/FFT/test/itkFullToHalfHermitianImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFullToHalfHermitianImageFilterTest.cxx
@@ -25,12 +25,6 @@
 #include "itkRealToHalfHermitianForwardFFTImageFilter.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#endif
-
 int
 itkFullToHalfHermitianImageFilterTest(int argc, char * argv[])
 {
@@ -66,15 +60,6 @@ itkFullToHalfHermitianImageFilterTest(int argc, char * argv[])
   indexShift[1] = 5;
   changer->SetOutputOffset(indexShift);
   changer->SetInput(source->GetOutput());
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-#endif
 
   // Compute frequency image, yielding the non-redundant half of the
   // full complex image.

--- a/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
@@ -24,12 +24,6 @@
 #include "itkRealToHalfHermitianForwardFFTImageFilter.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-#if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-#  include "itkFFTWRealToHalfHermitianForwardFFTImageFilter.h"
-#endif
-
 int
 itkHalfToFullHermitianImageFilterTest(int argc, char * argv[])
 {
@@ -65,15 +59,6 @@ itkHalfToFullHermitianImageFilterTest(int argc, char * argv[])
   indexShift[1] = 5;
   changer->SetOutputOffset(indexShift);
   changer->SetInput(source->GetOutput());
-
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::FFTWRealToHalfHermitianForwardFFTImageFilter>>();
-#  endif
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-#endif
 
   // Compute frequency image, yielding the non-redundant half of the
   // full complex image.

--- a/Modules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx
@@ -96,13 +96,6 @@ itkInverse1DFFTImageFilterTest(int argc, char * argv[])
   {
     using FFTInverseType = itk::Inverse1DFFTImageFilter<ComplexImageType, ImageType>;
 
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER // Manual factory registration is required for ITK tests
-#  if defined(ITK_USE_FFTWD) || defined(ITK_USE_FFTWF)
-    itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::FFTWInverse1DFFTImageFilter>>();
-#  endif
-    itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlInverse1DFFTImageFilter>>();
-#endif
-
     // Instantiate a filter to exercise basic object methods
     auto fft = FFTInverseType::New();
     ITK_EXERCISE_BASIC_OBJECT_METHODS(fft, Inverse1DFFTImageFilter, ImageToImageFilter);

--- a/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
@@ -42,7 +42,7 @@ transformImage(const char * inputImageFileName, const char * outputImageFileName
   auto reader = ReaderType::New();
   reader->SetFileName(inputImageFileName);
 
-  using ForwardFilterType = itk::ForwardFFTImageFilter<RealImageType, ComplexImageType>;
+  using ForwardFilterType = itk::VnlForwardFFTImageFilter<RealImageType, ComplexImageType>;
   auto forwardFilter = ForwardFilterType::New();
   forwardFilter->SetInput(reader->GetOutput());
 
@@ -55,7 +55,7 @@ transformImage(const char * inputImageFileName, const char * outputImageFileName
   forwardComplexFilter->SetInput(inverseComplexFilter->GetOutput());
   forwardComplexFilter->SetTransformDirection(ComplexFilterType::TransformDirectionEnum::FORWARD);
 
-  using InverseFilterType = itk::InverseFFTImageFilter<ComplexImageType, RealImageType>;
+  using InverseFilterType = itk::VnlInverseFFTImageFilter<ComplexImageType, RealImageType>;
   auto inverseFilter = InverseFilterType::New();
   inverseFilter->SetInput(forwardComplexFilter->GetOutput());
 
@@ -89,11 +89,6 @@ itkVnlComplexToComplexFFTImageFilterTest(int argc, char * argv[])
   imageIO->SetFileName(inputImageFileName);
   imageIO->ReadImageInformation();
   const unsigned int dimension = imageIO->GetNumberOfDimensions();
-
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlComplexToComplexFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlInverseFFTImageFilter>>();
 
   if (pixelTypeString.compare("float") == 0)
   {

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
@@ -34,6 +34,25 @@
 #include "itkTestingComparisonImageFilter.h"
 #include "itkTestingMacros.h"
 
+#include "itkTestDriverIncludeRequiredFactories.h"
+
+namespace
+{
+class FrequencyIterators : public ::testing::Test
+{
+public:
+  FrequencyIterators() = default;
+  ~FrequencyIterators() override = default;
+
+protected:
+  void
+  SetUp() override
+  {
+    RegisterRequiredFactories();
+  }
+};
+} // namespace
+
 template <typename TOutputImageType>
 static typename TOutputImageType::Pointer
 CreateImage(unsigned int size)
@@ -195,7 +214,7 @@ compareAllTypesOfIterators(typename TImageType::Pointer image, double difference
   EXPECT_TRUE(fullAndHermitian);
 }
 
-TEST(FrequencyIterators, Even3D)
+TEST_F(FrequencyIterators, Even3D)
 {
   constexpr unsigned int ImageDimension = 3;
   using PixelType = float;
@@ -205,7 +224,7 @@ TEST(FrequencyIterators, Even3D)
   compareAllTypesOfIterators<ImageType>(image, differenceHermitianThreshold);
 }
 
-TEST(FrequencyIterators, Even2D)
+TEST_F(FrequencyIterators, Even2D)
 {
   constexpr unsigned int ImageDimension = 2;
   using PixelType = float;
@@ -215,7 +234,7 @@ TEST(FrequencyIterators, Even2D)
   compareAllTypesOfIterators<ImageType>(image, differenceHermitianThreshold);
 }
 
-TEST(FrequencyIterators, Odd3D)
+TEST_F(FrequencyIterators, Odd3D)
 {
   constexpr unsigned int ImageDimension = 3;
   using PixelType = float;
@@ -225,7 +244,7 @@ TEST(FrequencyIterators, Odd3D)
   compareAllTypesOfIterators<ImageType>(image, differenceHermitianThreshold);
 }
 
-TEST(FrequencyIterators, Odd2D)
+TEST_F(FrequencyIterators, Odd2D)
 {
   constexpr unsigned int ImageDimension = 2;
   using PixelType = float;

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
@@ -34,32 +34,6 @@
 #include "itkTestingComparisonImageFilter.h"
 #include "itkTestingMacros.h"
 
-#include "itkObjectFactoryBase.h"
-#include "itkFFTImageFilterFactory.h"
-#include "itkVnlComplexToComplexFFTImageFilter.h"
-#include "itkVnlHalfHermitianToRealInverseFFTImageFilter.h"
-#include "itkVnlForwardFFTImageFilter.h"
-#include "itkVnlInverseFFTImageFilter.h"
-#include "itkVnlRealToHalfHermitianForwardFFTImageFilter.h"
-
-// Tests do not include `UseITK.cmake` in their build process
-// and must manually register factories for FFT backends.
-// For brevity we rely on Vnl backends here
-void
-registerFactories()
-{
-#ifndef ITK_FFT_FACTORY_REGISTER_MANAGER
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlComplexToComplexFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlForwardFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlHalfHermitianToRealInverseFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<itk::FFTImageFilterFactory<itk::VnlInverseFFTImageFilter>>();
-  itk::ObjectFactoryBase::RegisterInternalFactoryOnce<
-    itk::FFTImageFilterFactory<itk::VnlRealToHalfHermitianForwardFFTImageFilter>>();
-#endif
-}
-
 template <typename TOutputImageType>
 static typename TOutputImageType::Pointer
 CreateImage(unsigned int size)
@@ -109,8 +83,6 @@ template <typename ImageType, typename ForwardFFTType, typename InverseFFTType, 
 typename ImageType::Pointer
 applyBandFilter(typename ImageType::Pointer image, bool shift = false)
 {
-  registerFactories();
-
   auto forwardFFT = ForwardFFTType::New();
   forwardFFT->SetInput(image);
   forwardFFT->Update();
@@ -157,8 +129,6 @@ template <typename ImageType>
 typename ImageType::Pointer
 applyBandFilterHermitian(typename ImageType::Pointer image)
 {
-  registerFactories();
-
   using ForwardFFTType = itk::RealToHalfHermitianForwardFFTImageFilter<ImageType>;
   using ComplexImageType = typename ForwardFFTType::OutputImageType;
   using InverseFFTType = itk::HalfHermitianToRealInverseFFTImageFilter<ComplexImageType, ImageType>;
@@ -191,8 +161,6 @@ template <typename TImageType>
 void
 compareAllTypesOfIterators(typename TImageType::Pointer image, double differenceHermitianThreshold = 0.0001)
 {
-  registerFactories();
-
   using ImageType = TImageType;
   // Full Forward FFT
   using ForwardFFTFilterType = itk::ForwardFFTImageFilter<ImageType>;

--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
@@ -21,7 +21,7 @@
 #include "itkPasteImageFilter.h"
 #include "itkVectorImage.h"
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 #include "itkTestingHashImageFilter.h"
 
 namespace

--- a/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
@@ -22,7 +22,7 @@
 #include "itkVectorImage.h"
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 #include "itkTestingHashImageFilter.h"
 
 

--- a/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
+++ b/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
@@ -21,7 +21,7 @@
 
 #include "itkGTest.h"
 #include "itksys/SystemTools.hxx"
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 
 #define STRING(s) #s
 

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration10.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration10.cxx
@@ -79,7 +79,7 @@ public:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration12.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration12.cxx
@@ -104,7 +104,7 @@ public:
   }
 };
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration4.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration4.cxx
@@ -70,7 +70,7 @@
 // NOTE: the LBFGSOptimizer does not invoke events
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration6.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration6.cxx
@@ -61,7 +61,7 @@
 // NOTE: the LBFGSOptimizer does not invoke events
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration7.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration7.cxx
@@ -108,7 +108,7 @@ public:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration8.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration8.cxx
@@ -105,7 +105,7 @@ public:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformationFieldJacobian.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformationFieldJacobian.cxx
@@ -22,7 +22,7 @@
 // itkDeformationFieldJacobianDeterminantFilter.h -> itkDisplacementFieldJacobianDeterminantFilter.h
 #include "itkDisplacementFieldJacobianDeterminantFilter.h"
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration1.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration1.cxx
@@ -93,7 +93,7 @@ public:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration11.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration11.cxx
@@ -95,7 +95,7 @@ private:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration12.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration12.cxx
@@ -87,7 +87,7 @@ public:
   }
 };
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration13.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration13.cxx
@@ -80,7 +80,7 @@ public:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration14.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration14.cxx
@@ -88,7 +88,7 @@ private:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration3.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration3.cxx
@@ -219,7 +219,7 @@ public:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration4.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration4.cxx
@@ -102,7 +102,7 @@ public:
   }
 };
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration5.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration5.cxx
@@ -104,7 +104,7 @@ public:
   }
 };
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration6.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration6.cxx
@@ -127,7 +127,7 @@ public:
   }
 };
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration7.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration7.cxx
@@ -115,7 +115,7 @@ public:
   }
 };
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration8.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration8.cxx
@@ -119,7 +119,7 @@ public:
   }
 };
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration9.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration9.cxx
@@ -113,7 +113,7 @@ public:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/MeanSquaresImageMetric1.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/MeanSquaresImageMetric1.cxx
@@ -44,7 +44,7 @@
 #include "itkNearestNeighborInterpolateImageFunction.h"
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, char * argv[])
 {

--- a/Modules/Registration/Common/test/RegistrationITKv3/MultiResImageRegistration1.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/MultiResImageRegistration1.cxx
@@ -243,7 +243,7 @@ public:
 };
 
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 int
 main(int argc, const char * argv[])
 {

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
@@ -23,7 +23,7 @@
 
 #include "itkCommand.h"
 
-#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
 #include "itkTestingHashImageFilter.h"
 
 namespace


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Addresses remote module test failures in #2950 by adding FFT factories to the list of default factories to be registered with ITKTestKernel.

`itkTestDriverIncludeRequiredIOFactories.h` and similar strings are renamed to `itkTestDriverIncludeRequiredFactories.h` to reflect that FFT factories and any other future backends managed with the object factory should be default registered here. Manual FFT factory registrations previously required for testing are removed.

ITKMontage tests pass when these changes are applied.

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
