### PR TITLE
ENH: Ignore RuntimeErrors when import `from distributed.protocol`

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.init
@@ -16,7 +16,7 @@ class NDArrayITKBase(np.ndarray):
 try:
     from distributed.protocol import dask_serialize, dask_deserialize
     from typing import Dict, List, Tuple
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 else:
     @dask_serialize.register(NDArrayITKBase)

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -62,7 +62,7 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         try:
             import dask
             from distributed.protocol.serialize import dask_dumps, dask_loads
-        except ImportError:
+        except (ImportError, RuntimeError):
             pass
         else:
             header, frames = dask_dumps(ndarray_itk_base)


### PR DESCRIPTION
This is to address an image loading issue from the MONAI tutorial:
https://github.com/Project-MONAI/tutorials/issues/494

In addition to the potential `ImportError`, `from distributed.protocol import
dask_serialize, dask_deserialize` may raise a RuntimeError due to the
system availability. This commit tries to catch the exception. The test
case is also updated accordingly.

relevant logs:
<details>

```
/home/jenkins/agent/workspace/Monai-notebooks/MONAI/monai/data/image_reader.py in _get_array_data(self, img)
    327         """
--> 328         np_img = itk.array_view_from_image(img, keep_axes=False)
    329         if img.GetNumberOfComponentsPerPixel() == 1:  # handling spatial images

/opt/conda/lib/python3.8/site-packages/itk/support/extras.py in GetArrayViewFromImage(image_or_filter, keep_axes, update, ttype)
    323     """Get an array view with the content of the image buffer"""
--> 324     return _GetArrayFromImage(
    325         image_or_filter, "GetArrayViewFromImage", keep_axes, update, ttype

/opt/conda/lib/python3.8/site-packages/itk/support/extras.py in _GetArrayFromImage(image_or_filter, function_name, keep_axes, update, ttype)
    293         ImageType = img.__class__
--> 294     keys = [k for k in itk.PyBuffer.keys() if k[0] == ImageType]
    295     if len(keys) == 0:

/opt/conda/lib/python3.8/site-packages/itk/support/lazy.py in __getattribute__(self, attr)
    131                     namespace = {}
--> 132                     base.itk_load_swig_module(module, namespace)
    133                     self.loaded_lazy_modules.add(module)

/opt/conda/lib/python3.8/site-packages/itk/support/base.py in itk_load_swig_module(name, namespace)
    109     loader = LibraryLoader()
--> 110     l_module = loader.load(swig_module_name)
    111 

/opt/conda/lib/python3.8/site-packages/itk/support/base.py in load(self, name)
    258             l_spec = importlib.util.find_spec(name)
--> 259             l_spec.loader.exec_module(l_module)  # pytype: disable=attribute-error
    260             return l_module

/opt/conda/lib/python3.8/importlib/_bootstrap_external.py in exec_module(self, module)

/opt/conda/lib/python3.8/importlib/_bootstrap.py in _call_with_frames_removed(f, *args, **kwds)

/opt/conda/lib/python3.8/site-packages/itk/support/../ITKBridgeNumPyPython.py in <module>
     70 import itk.ITKCommonPython
---> 71 from itk.itkPyBufferPython import *
     72 from itk.itkPyVectorContainerPython import *

/opt/conda/lib/python3.8/site-packages/itk/itkPyBufferPython.py in <module>
    117 try:
--> 118     from distributed.protocol import dask_serialize, dask_deserialize
    119     from typing import Dict, List, Tuple

/opt/conda/lib/python3.8/site-packages/distributed/__init__.py in <module>
      7 from ._version import get_versions
----> 8 from .actor import Actor, ActorFuture
      9 from .client import (

/opt/conda/lib/python3.8/site-packages/distributed/actor.py in <module>
      4 
----> 5 from .client import Future
      6 from .protocol import to_serialize

/opt/conda/lib/python3.8/site-packages/distributed/client.py in <module>
     52 from . import versions as version_module
---> 53 from .batched import BatchedSend
     54 from .cfexecutor import ClientExecutor

/opt/conda/lib/python3.8/site-packages/distributed/batched.py in <module>
      9 
---> 10 from .core import CommClosedError
     11 

/opt/conda/lib/python3.8/site-packages/distributed/core.py in <module>
     23 from . import profile, protocol
---> 24 from .comm import (
     25     CommClosedError,

/opt/conda/lib/python3.8/site-packages/distributed/comm/__init__.py in <module>
     24 
---> 25 _register_transports()

/opt/conda/lib/python3.8/site-packages/distributed/comm/__init__.py in _register_transports()
     16 def _register_transports():
---> 17     from . import inproc, tcp, ws
     18 

/opt/conda/lib/python3.8/site-packages/distributed/comm/tcp.py in <module>
    379 
--> 380 class BaseTCPConnector(Connector, RequireEncryptionMixin):
    381     _executor = ThreadPoolExecutor(2, thread_name_prefix="TCP-Executor")

/opt/conda/lib/python3.8/site-packages/distributed/comm/tcp.py in BaseTCPConnector()
    381     _executor = ThreadPoolExecutor(2, thread_name_prefix="TCP-Executor")
--> 382     _resolver = netutil.ExecutorResolver(close_executor=False, executor=_executor)
    383     client = TCPClient(resolver=_resolver)

/opt/conda/lib/python3.8/site-packages/tornado/util.py in __new__(cls, *args, **kwargs)
    287         # here too.
--> 288         instance.initialize(*args, **init_kwargs)
    289         return instance

/opt/conda/lib/python3.8/site-packages/tornado/netutil.py in initialize(self, executor, close_executor)
    426     ) -> None:
--> 427         self.io_loop = IOLoop.current()
    428         if executor is not None:

/opt/conda/lib/python3.8/site-packages/tornado/ioloop.py in current(instance)
    262         try:
--> 263             loop = asyncio.get_event_loop()
    264         except (RuntimeError, AssertionError):

/opt/conda/lib/python3.8/asyncio/events.py in get_event_loop(self)
    638         if self._local._loop is None:
--> 639             raise RuntimeError('There is no current event loop in thread %r.'
    640                                % threading.current_thread().name)

RuntimeError: There is no current event loop in thread 'Thread-9'.
```

</details>



<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
