### PR TITLE
STYLE: Remove remaining `void` from empty function parameter lists

### DIFF
--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -47,8 +47,7 @@ class ITKCommon_EXPORT SingletonIndex
 public:
   /** Standard class types. */
   using Self = SingletonIndex;
-  using SingletonData =
-    std::map<std::string, std::tuple<void *, std::function<void(void *)>, std::function<void(void)>>>;
+  using SingletonData = std::map<std::string, std::tuple<void *, std::function<void(void *)>, std::function<void()>>>;
 
   // obtain a global registered in the singleton index under the
   // globalName, if unknown then nullptr will be returned.
@@ -69,7 +68,7 @@ public:
   SetGlobalInstance(const char *                globalName,
                     T *                         global,
                     std::function<void(void *)> func,
-                    std::function<void(void)>   deleteFunc)
+                    std::function<void()>       deleteFunc)
   {
     return this->SetGlobalInstancePrivate(globalName, global, func, deleteFunc);
   }
@@ -97,7 +96,7 @@ private:
   SetGlobalInstancePrivate(const char *                globalName,
                            void *                      global,
                            std::function<void(void *)> func,
-                           std::function<void(void)>   deleteFunc);
+                           std::function<void()>       deleteFunc);
 
   /** The static GlobalSingleton. This is initialized to nullptr as the first
    * stage of static initialization. It is then populated on the first call to
@@ -112,7 +111,7 @@ private:
 // A wrapper for a global variable registered in the singleton index.
 template <typename T>
 T *
-Singleton(const char * globalName, std::function<void(void *)> func, std::function<void(void)> deleteFunc)
+Singleton(const char * globalName, std::function<void(void *)> func, std::function<void()> deleteFunc)
 {
   static SingletonIndex * singletonIndex = SingletonIndex::GetInstance();
   Unused(singletonIndex);

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -102,7 +102,7 @@ bool
 SingletonIndex::SetGlobalInstancePrivate(const char *                globalName,
                                          void *                      global,
                                          std::function<void(void *)> func,
-                                         std::function<void(void)>   deleteFunc)
+                                         std::function<void()>       deleteFunc)
 {
   m_GlobalObjects.erase(globalName);
   m_GlobalObjects.insert(std::make_pair(globalName, std::make_tuple(global, func, deleteFunc)));

--- a/Modules/Core/Common/src/itkStreamingProcessObject.cxx
+++ b/Modules/Core/Common/src/itkStreamingProcessObject.cxx
@@ -206,7 +206,7 @@ StreamingProcessObject::ResetPipeline()
 }
 
 
-StreamingProcessObject::StreamingProcessObject(void) = default;
+StreamingProcessObject::StreamingProcessObject() = default;
 
 
 StreamingProcessObject::~StreamingProcessObject() = default;

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -60,7 +60,7 @@ public:
    * Default implementation is VnlFFT1D.
    */
   static Pointer
-  New(void);
+  New();
 
   /** Get the direction in which the filter is to be applied. */
   itkGetConstMacro(Direction, unsigned int);

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -94,7 +94,7 @@ SPSAOptimizer::GetValue(const ParametersType & parameters) const
 {
   /**
    * This method just calls the Superclass' implementation,
-   * but is necessary because GetValue(void) is also declared
+   * but is necessary because GetValue() is also declared
    * in this class.
    */
   return this->Superclass::GetValue(parameters);


### PR DESCRIPTION
Did check all itk*.cxx, itk*.h, and itk*.hxx source files.

Follow-up to:

"STYLE: removing void if used in place of empty parameter list"
by Dženan Zukić (@dzenanz), 11 September 2018
https://github.com/InsightSoftwareConsortium/ITK/commit/60807f4abcfd7c4d42ddf93796d6acf272aa442b

"STYLE: Remove redundant void argument lists"
by Hans Johnson (@hjmjohnson), 20 February 2020
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/1628
https://github.com/InsightSoftwareConsortium/ITK/commit/e6d859ecae955a4e2a44b9e60677093dc254a4ca