### PR TITLE
BUG: TIFF IO: exception if orientation is not supported

### DIFF
--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -488,6 +488,12 @@ TIFFImageIO::ReadImageInformation()
 
   if (!m_InternalImage->CanRead())
   {
+    if (!(m_InternalImage->m_Orientation == ORIENTATION_TOPLEFT ||
+          m_InternalImage->m_Orientation == ORIENTATION_BOTLEFT))
+    {
+      itkExceptionMacro(<< "Only ORIENTATION_TOPLEFT and ORIENTATION_BOTLEFT are supported");
+    }
+
     //  exception if compression is not supported
     if (TIFFIsCODECConfigured(this->m_InternalImage->m_Compression) != 1)
     {


### PR DESCRIPTION
Throw exception to avoid wrong interpretation of a image (`RGBA unsigned char` instead `SCALAR 16-bits`).

_Please note that is quick and minimal fix for the problem!_

S. https://github.com/InsightSoftwareConsortium/ITK/issues/2959

CC @blowekamp 

**Edit**:
In [ReadGenericImage](https://github.com/InsightSoftwareConsortium/ITK/blob/6682f865b39fc0fa16e6483536e31ace8780f875/Modules/IO/TIFF/src/itkTIFFImageIO.cxx#L1368) is similar block, not reached on _ReadImageInformation_ and _Read_ with test images (s. issue).