### PR TITLE
BUG: warning in TIFFImageIO with component bit depth reduction

### DIFF
--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -506,14 +506,18 @@ TIFFImageIO::ReadImageInformation()
 
     if (!m_IsReadAsScalarPlusPalette)
     {
-      itkDebugMacro(<< "Using TIFFReadRGBAImage");
+      itkDebugMacro(<< "Using TIFFReadRGBAImageOriented");
+      if (m_InternalImage->m_BitsPerSample > 8)
+      {
+        itkWarningMacro("Falling back to suboptimal 8-bit RGBA reader. Data loss will occur with reduced bit depth.");
+      }
       this->SetNumberOfComponents(4);
       this->SetPixelType(IOPixelEnum::RGBA);
       m_ComponentType = IOComponentEnum::UCHAR;
     }
     else
     {
-      itkDebugMacro(<< "Using TIFFReadRGBImage");
+      itkDebugMacro(<< "Using TIFFReadRGBAImageOriented");
       itkWarningMacro(<< "Could not read this palette image as scalar+Palette because of its TIFF format");
       // can't read as scalar+palette so reset type to RGB
       m_IsReadAsScalarPlusPalette = false;


### PR DESCRIPTION
Add warning for the suboptimal case described in #2959.