### PR TITLE
COMP: Fix testing macro call and array initialization errors

### DIFF
--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -39,7 +39,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
   {
     auto transform = TransformType::New();
 
-    typename TransformType::InputVectorType vector{ { 1.0, 4.0, 9.0 } };
+    typename TransformType::InputVectorType vector = itk::MakeVector(1.0, 4.0, 9.0);
     ITK_TRY_EXPECT_EXCEPTION(transform->TransformVector(vector));
 
     typename TransformType::InputVnlVectorType vnlVector;
@@ -50,7 +50,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     covVector.Fill(1.0);
     ITK_TRY_EXPECT_EXCEPTION(transform->TransformCovariantVector(covVector));
 
-    typename TransformType::InputPointType       point{ { 1.0, 1.0, 1.0 } };
+    typename TransformType::InputPointType       point{ 1.0 };
     typename TransformType::JacobianPositionType jacobianPosition;
     ITK_TRY_EXPECT_EXCEPTION(transform->ComputeJacobianWithRespectToPosition(point, jacobianPosition));
   }
@@ -59,7 +59,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
   {
     auto transform = TransformType::New();
 
-    EXERCISE_BASIC_OBJECT_METHODS(transform, Rigid3DPerspectiveTransform, Transform);
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(transform, Rigid3DPerspectiveTransform, Transform);
 
 
     typename TransformType::OffsetType fixedOffset;

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -152,8 +152,9 @@ itkFastMarchingTest(int argc, char * argv[])
 
   auto outputRegionIndexValue =
     static_cast<typename FloatFMType::LevelSetImageType::IndexType::IndexValueType>(std::stoi(argv[5]));
-  typename FloatFMType::LevelSetImageType::IndexType outputRegionIndex{ outputRegionIndexValue };
-  typename FloatFMType::OutputRegionType             outputRegion;
+  typename FloatFMType::LevelSetImageType::IndexType outputRegionIndex;
+  outputRegionIndex.Fill(outputRegionIndexValue);
+  typename FloatFMType::OutputRegionType outputRegion;
   outputRegion.SetSize(size);
   outputRegion.SetIndex(outputRegionIndex);
   marcher->SetOutputRegion(outputRegion);


### PR DESCRIPTION
Fix call to basic object method exercise macro and array initialization
compilation errors.

Fixes:
```
[CTest: warning matched]
/Users/builder/external/ITK-AppleClang-dbg-Universal/Modules/ThirdPartysrc/vxl/vcl/vcl_compiler.h:2:9:
warning: macro name is a reserved identifier [-Wreserved-id-macro]
        ^
/Users/builder/externalModules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx:62:46:
error: use of undeclared identifier 'Rigid3DPerspectiveTransform'
    EXERCISE_BASIC_OBJECT_METHODS(transform, Rigid3DPerspectiveTransform, Transform);
                                             ^
/Users/builder/externalModules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx:62:75:
error: use of undeclared identifier 'Transform'
    EXERCISE_BASIC_OBJECT_METHODS(transform, Rigid3DPerspectiveTransform, Transform);
                                                                          ^
[CTest: warning matched] 1 warning and 2 errors generated.
```

and
```
[CTest: warning matched]
/Users/builder/externalModules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx:42:55:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
    typename TransformType::InputVectorType vector{ { 1.0, 4.0, 9.0 } };
                                                      ^~~~~~~~~~~~~
                                                      {            }
[CTest: warning matched]
/Users/builder/externalModules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx:53:59:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
    typename TransformType::InputPointType       point{ { 1.0, 1.0, 1.0 } };
                                                          ^~~~~~~~~~~~~
                                                          {            }
[CTest: warning suppressed] 2 warnings generated.
```

and
```
[CTest: warning matched]
/Users/builder/externalModules/Filtering/FastMarching/test/itkFastMarchingTest.cxx:155:73:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
  typename FloatFMType::LevelSetImageType::IndexType outputRegionIndex{ outputRegionIndexValue };
                                                                        ^~~~~~~~~~~~~~~~~~~~~~
                                                                        {                     }
[CTest: warning suppressed] 1 warning generated.
```

reported for example in:
https://open.cdash.org/viewBuildError.php?buildid=7652795
and
https://open.cdash.org/viewBuildError.php?type=1&buildid=7652659

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)