### PR TITLE
DOC: Add comment for `SetNumberOfWorkUnits` to correct documentation.

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
@@ -131,6 +131,7 @@ public:
   itkGetConstMacro(NormalizeAcrossScale, bool);
   itkBooleanMacro(NormalizeAcrossScale);
 
+  /** Set the number of work units to create. */
   void
   SetNumberOfWorkUnits(ThreadIdType nb) override;
 


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

The missing comment of `SetNumberOfWorkUnits` function made Doxygen match a wired comment for it.

See: https://itk.org/Doxygen/html/classitk_1_1SmoothingRecursiveGaussianImageFilter.html#a09bfdb8fa9278129bcf017a20554a1c7

![doc](https://user-images.githubusercontent.com/30524126/147850862-58628edf-4721-4468-ae7c-bc89710d7ffd.png)

And it seems like that this problem also occurs with other classes with uncommented `SetNumberOfWorkUnits` function.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

<!-- **Thanks for contributing to ITK!** -->
