### PR TITLE
STYLE: Declare local `ImageRegion` variables `const`

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
@@ -358,9 +358,7 @@ VTKImageExport<TInputImage>::PropagateUpdateExtentCallback(int * extent)
     size[i] = (extent[i * 2 + 1] - extent[i * 2]) + 1;
   }
 
-  InputRegionType region;
-  region.SetSize(size);
-  region.SetIndex(index);
+  const InputRegionType region(index, size);
 
   InputImagePointer input = this->GetInput();
   if (!input)

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -193,9 +193,7 @@ VTKImageImport<TOutputImage>::GenerateOutputInformation()
       size[i] = (extent[i * 2 + 1] - extent[i * 2]) + 1;
     }
 
-    OutputRegionType region;
-    region.SetIndex(index);
-    region.SetSize(size);
+    const OutputRegionType region(index, size);
     output->SetLargestPossibleRegion(region);
   }
   if (m_SpacingCallback)
@@ -325,9 +323,7 @@ VTKImageImport<TOutputImage>::GenerateData()
       importSize *= size[i];
     }
 
-    OutputRegionType region;
-    region.SetIndex(index);
-    region.SetSize(size);
+    const OutputRegionType region(index, size);
     output->SetBufferedRegion(region);
 
     void * data = (m_BufferPointerCallback)(m_CallbackUserData);

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -201,10 +201,7 @@ auto
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetBoundingBoxAsImageRegion() const -> RegionType
 {
   const IndexValueType zero = NumericTraits<IndexValueType>::ZeroValue();
-  RegionType           ans;
-
-  ans.SetIndex(this->GetIndex(zero));
-  ans.SetSize(this->GetSize());
+  const RegionType     ans(this->GetIndex(zero), this->GetSize());
 
   return ans;
 }

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -121,9 +121,7 @@ auto
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::GetBoundingBoxAsImageRegion() const -> RegionType
 {
   const IndexValueType zero = NumericTraits<IndexValueType>::ZeroValue();
-  RegionType           ans;
-  ans.SetIndex(this->GetIndex(zero));
-  ans.SetSize(this->GetSize());
+  const RegionType     ans(this->GetIndex(zero), this->GetSize());
 
   return ans;
 }

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -265,11 +265,9 @@ Octree<TPixel, ColorTableSize, MappingFunctionType>::GetImage() -> ImageTypePoin
   sizes[1] = m_TrueDims[1];
   sizes[2] = m_TrueDims[2];
   imageSize.SetSize(sizes);
-  const typename ImageType::IndexType imageIndex = { { 0, 0, 0 } };
-  typename ImageType::RegionType      region;
-  region.SetSize(imageSize);
-  region.SetIndex(imageIndex);
-  auto img = ImageType::New();
+  const typename ImageType::IndexType  imageIndex = { { 0, 0, 0 } };
+  const typename ImageType::RegionType region(imageIndex, imageSize);
+  auto                                 img = ImageType::New();
   img->SetLargestPossibleRegion(region);
   img->SetBufferedRegion(region);
   img->SetRequestedRegion(region);

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -156,10 +156,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::GenerateData()
       itkExceptionMacro(<< "Must Set Image Size");
     }
 
-    typename OutputImageType::RegionType region;
-
-    region.SetSize(m_Size);
-    region.SetIndex(m_Index);
+    const typename OutputImageType::RegionType region(m_Index, m_Size);
 
     OutputImage->SetLargestPossibleRegion(region); //
     OutputImage->SetBufferedRegion(region);        // set the region

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -65,11 +65,9 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(co
     }
   }
 
-  RegionType region;
-  region.SetSize(size);
   itk::Index<NDimensions> zeroIndex;
   zeroIndex.Fill(0);
-  region.SetIndex(zeroIndex);
+  const RegionType region(zeroIndex, size);
   rval->SetLargestPossibleRegion(region);
   rval->SetBufferedRegion(region);
   rval->SetRequestedRegion(region);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -186,9 +186,7 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
       }
     }
 
-    RegionType region;
-    region.SetIndex(indMin);
-    region.SetSize(size);
+    const RegionType region(indMin, size);
 
     using IteratorType = ImageRegionConstIteratorWithIndex<ImageType>;
     IteratorType it = IteratorType(m_Image, region);

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -204,9 +204,7 @@ RandomImageSource<TOutputImage>::GenerateOutputInformation()
 
   output = this->GetOutput(0);
 
-  typename TOutputImage::RegionType largestPossibleRegion;
-  largestPossibleRegion.SetSize(this->m_Size);
-  largestPossibleRegion.SetIndex(index);
+  const typename TOutputImage::RegionType largestPossibleRegion(index, this->m_Size);
   output->SetLargestPossibleRegion(largestPossibleRegion);
 
   output->SetSpacing(m_Spacing);

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -265,12 +265,10 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);
 
   // For each dimension, copy the weight to the support region
-  RegionType supportRegion;
-  SizeType   supportSize;
+  SizeType supportSize;
   supportSize.Fill(SplineOrder + 1);
-  supportRegion.SetSize(supportSize);
-  supportRegion.SetIndex(supportIndex);
-  unsigned long counter = 0;
+  const RegionType supportRegion(supportIndex, supportSize);
+  unsigned long    counter = 0;
 
   using IteratorType = ImageRegionIterator<ImageType>;
 

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -498,10 +498,8 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Tra
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);
 
   // For each dimension, correlate coefficient with weights
-  RegionType         supportRegion;
   constexpr SizeType supportSize = WeightsFunctionType::SupportSize;
-  supportRegion.SetSize(supportSize);
-  supportRegion.SetIndex(supportIndex);
+  const RegionType   supportRegion(supportIndex, supportSize);
 
   outputPoint.Fill(NumericTraits<ScalarType>::ZeroValue());
 
@@ -557,10 +555,8 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Com
   // Zero all components of jacobian
   jacobian.SetSize(SpaceDimension, this->GetNumberOfParameters());
   jacobian.Fill(0.0);
-  RegionType supportRegion;
-  SizeType   supportSize;
+  SizeType supportSize;
   supportSize.Fill(SplineOrder + 1);
-  supportRegion.SetSize(supportSize);
 
   ContinuousIndexType index =
     this->m_CoefficientImages[0]
@@ -580,7 +576,7 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Com
   IndexType supportIndex;
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);
 
-  supportRegion.SetIndex(supportIndex);
+  const RegionType supportRegion(supportIndex, supportSize);
 
   IndexType startIndex = this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetIndex();
 

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -541,9 +541,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoin
     // For each dimension, correlate coefficient with weights
     SizeType supportSize;
     supportSize.Fill(SplineOrder + 1);
-    RegionType supportRegion;
-    supportRegion.SetSize(supportSize);
-    supportRegion.SetIndex(supportIndex);
+    const RegionType supportRegion(supportIndex, supportSize);
 
     outputPoint.Fill(NumericTraits<ScalarType>::ZeroValue());
 
@@ -608,10 +606,8 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::ComputeJacobi
   // Zero all components of jacobian
   jacobian.SetSize(SpaceDimension, this->GetNumberOfParameters());
   jacobian.Fill(0.0);
-  RegionType supportRegion;
-  SizeType   supportSize;
+  SizeType supportSize;
   supportSize.Fill(SplineOrder + 1);
-  supportRegion.SetSize(supportSize);
 
   ContinuousIndexType index =
     this->m_CoefficientImages[0]
@@ -631,7 +627,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::ComputeJacobi
   IndexType supportIndex;
   this->m_WeightsFunction->Evaluate(index, weights, supportIndex);
 
-  supportRegion.SetIndex(supportIndex);
+  const RegionType supportRegion(supportIndex, supportSize);
 
   IndexType startIndex = this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetIndex();
 

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -420,11 +420,9 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   // Extract the relevant part out of the image.
   // The input FFT image may be bigger than the desired output image
   // because specific sizes are required for the FFT calculation.
-  typename LocalOutputImageType::RegionType imageRegion;
-  typename LocalOutputImageType::IndexType  imageIndex;
+  typename LocalOutputImageType::IndexType imageIndex;
   imageIndex.Fill(0);
-  imageRegion.SetIndex(imageIndex);
-  imageRegion.SetSize(combinedImageSize);
+  const typename LocalOutputImageType::RegionType imageRegion(imageIndex, combinedImageSize);
   using ExtractType = itk::RegionOfInterestImageFilter<LocalOutputImageType, LocalOutputImageType>;
   auto extracter = ExtractType::New();
   extracter->SetInput(FFTFilter->GetOutput());
@@ -688,15 +686,13 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   OutputImagePointer     output = this->GetOutput();
 
   // Compute the size of the output image.
-  typename OutputImageType::RegionType region;
-  typename OutputImageType::SizeType   size;
+  typename OutputImageType::SizeType size;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     size[i] =
       fixedImage->GetLargestPossibleRegion().GetSize()[i] + movingImage->GetLargestPossibleRegion().GetSize()[i] - 1;
   }
-  region.SetSize(size);
-  region.SetIndex(fixedImage->GetLargestPossibleRegion().GetIndex());
+  const typename OutputImageType::RegionType region(fixedImage->GetLargestPossibleRegion().GetIndex(), size);
 
   output->SetLargestPossibleRegion(region);
 
@@ -730,15 +726,13 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   InputImageConstPointer movingImage = this->GetMovingImage();
 
   // Compute the size of the output image.
-  typename OutputImageType::RegionType region;
-  typename OutputImageType::SizeType   size;
+  typename OutputImageType::SizeType size;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     size[i] =
       fixedImage->GetLargestPossibleRegion().GetSize()[i] + movingImage->GetLargestPossibleRegion().GetSize()[i] - 1;
   }
-  region.SetSize(size);
-  region.SetIndex(fixedImage->GetLargestPossibleRegion().GetIndex());
+  const typename OutputImageType::RegionType region(fixedImage->GetLargestPossibleRegion().GetIndex(), size);
 
   auto * optr = dynamic_cast<OutputImageType *>(output);
   if (optr)

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -135,9 +135,7 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::PrepareKernelBas
     spacing[i] *= m_SubsamplingFactor;
   }
 
-  InputRegionType subsampledRegion;
-  subsampledRegion.SetSize(size);
-  subsampledRegion.SetIndex(region.GetIndex());
+  const InputRegionType subsampledRegion(region.GetIndex(), size);
 
   resampler->SetSize(size);
   resampler->SetOutputStartIndex(subsampledRegion.GetIndex());

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -127,9 +127,7 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Generate
   }
   else
   {
-    typename TOutputImage::RegionType outputLargestPossibleRegion;
-    outputLargestPossibleRegion.SetSize(m_Size);
-    outputLargestPossibleRegion.SetIndex(m_OutputStartIndex);
+    const typename TOutputImage::RegionType outputLargestPossibleRegion(m_OutputStartIndex, m_Size);
     output->SetLargestPossibleRegion(outputLargestPossibleRegion);
   }
 

--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.hxx
@@ -81,9 +81,8 @@ ComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::GenerateInputReques
   const typename InputImageType::IndexType & inputLargeIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
   inputRequestedRegionStartIndex[direction] = inputLargeIndex[direction];
 
-  typename InputImageType::RegionType inputRequestedRegion;
-  inputRequestedRegion.SetSize(inputRequestedRegionSize);
-  inputRequestedRegion.SetIndex(inputRequestedRegionStartIndex);
+  const typename InputImageType::RegionType inputRequestedRegion(inputRequestedRegionStartIndex,
+                                                                 inputRequestedRegionSize);
 
   inputPtr->SetRequestedRegion(inputRequestedRegion);
 }
@@ -109,9 +108,7 @@ ComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::EnlargeOutputReques
   enlargedSize[this->m_Direction] = outputLargeSize[this->m_Direction];
   enlargedIndex[this->m_Direction] = outputLargeIndex[this->m_Direction];
 
-  typename OutputImageType::RegionType enlargedRegion;
-  enlargedRegion.SetSize(enlargedSize);
-  enlargedRegion.SetIndex(enlargedIndex);
+  const typename OutputImageType::RegionType enlargedRegion(enlargedIndex, enlargedSize);
   outputPtr->SetRequestedRegion(enlargedRegion);
 }
 

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.hxx
@@ -73,9 +73,8 @@ Forward1DFFTImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
   const typename InputImageType::IndexType & inputLargeIndex = input->GetLargestPossibleRegion().GetIndex();
   inputRequestedRegionStartIndex[direction] = inputLargeIndex[direction];
 
-  typename InputImageType::RegionType inputRequestedRegion;
-  inputRequestedRegion.SetSize(inputRequestedRegionSize);
-  inputRequestedRegion.SetIndex(inputRequestedRegionStartIndex);
+  const typename InputImageType::RegionType inputRequestedRegion(inputRequestedRegionStartIndex,
+                                                                 inputRequestedRegionSize);
 
   input->SetRequestedRegion(inputRequestedRegion);
 }
@@ -101,9 +100,7 @@ Forward1DFFTImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion
   enlargedSize[this->m_Direction] = outputLargeSize[this->m_Direction];
   enlargedIndex[this->m_Direction] = outputLargeIndex[this->m_Direction];
 
-  typename OutputImageType::RegionType enlargedRegion;
-  enlargedRegion.SetSize(enlargedSize);
-  enlargedRegion.SetIndex(enlargedIndex);
+  const typename OutputImageType::RegionType enlargedRegion(enlargedIndex, enlargedSize);
   output->SetRequestedRegion(enlargedRegion);
 }
 

--- a/Modules/Filtering/FFT/include/itkFullToHalfHermitianImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFullToHalfHermitianImageFilter.hxx
@@ -61,9 +61,7 @@ FullToHalfHermitianImageFilter<TInputImage>::GenerateOutputInformation()
   }
   outputSize[0] = (inputSize[0] / 2) + 1;
 
-  typename OutputImageType::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename OutputImageType::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
   this->SetActualXDimensionIsOdd(inputSize[0] % 2 != 0);

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -91,9 +91,7 @@ HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::GenerateOut
     outputSize[i] = inputSize[i];
     outputStartIndex[i] = inputStartIndex[i];
   }
-  typename OutputImageType::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename OutputImageType::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
@@ -67,9 +67,7 @@ HalfToFullHermitianImageFilter<TInputImage>::GenerateOutputInformation()
     outputSize[0]++;
   }
 
-  typename OutputImageType::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename OutputImageType::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.hxx
@@ -79,10 +79,8 @@ Inverse1DFFTImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
   const typename InputImageType::IndexType & inputLargeIndex = input->GetLargestPossibleRegion().GetIndex();
   inputRequestedRegionStartIndex[direction] = inputLargeIndex[direction];
 
-  typename InputImageType::RegionType inputRequestedRegion;
-  inputRequestedRegion.SetSize(inputRequestedRegionSize);
-  inputRequestedRegion.SetIndex(inputRequestedRegionStartIndex);
-
+  const typename InputImageType::RegionType inputRequestedRegion(inputRequestedRegionStartIndex,
+                                                                 inputRequestedRegionSize);
   input->SetRequestedRegion(inputRequestedRegion);
 }
 
@@ -107,9 +105,7 @@ Inverse1DFFTImageFilter<TInputImage, TOutputImage>::EnlargeOutputRequestedRegion
   enlargedSize[this->m_Direction] = outputLargeSize[this->m_Direction];
   enlargedIndex[this->m_Direction] = outputLargeIndex[this->m_Direction];
 
-  typename OutputImageType::RegionType enlargedRegion;
-  enlargedRegion.SetSize(enlargedSize);
-  enlargedRegion.SetIndex(enlargedIndex);
+  const typename OutputImageType::RegionType enlargedRegion(enlargedIndex, enlargedSize);
   output->SetRequestedRegion(enlargedRegion);
 }
 

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -80,9 +80,7 @@ RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateOut
     outputStartIndex[i] = inputStartIndex[i];
   }
 
-  typename OutputImageType::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename OutputImageType::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
   this->SetActualXDimensionIsOdd(inputSize[0] % 2 != 0);

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
@@ -123,17 +123,15 @@ GPUNeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType
   /** Create GPU memory for operator coefficients */
   m_NeighborhoodGPUBuffer->Initialize();
 
-  typename NeighborhoodGPUBufferType::IndexType  index;
-  typename NeighborhoodGPUBufferType::SizeType   size;
-  typename NeighborhoodGPUBufferType::RegionType region;
+  typename NeighborhoodGPUBufferType::IndexType index;
+  typename NeighborhoodGPUBufferType::SizeType  size;
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     index[i] = 0;
     size[i] = (unsigned int)(p.GetSize(i));
   }
-  region.SetSize(size);
-  region.SetIndex(index);
+  const typename NeighborhoodGPUBufferType::RegionType region(index, size);
 
   m_NeighborhoodGPUBuffer->SetRegions(region);
   m_NeighborhoodGPUBuffer->Allocate();

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -62,15 +62,13 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GenerateOut
   }
 
   // Compute the size of the output image
-  typename InputImageType::RegionType region;
-  Size<2>                             size;
+  Size<2> size;
 
   size[0] = (SizeValueType)(
     std::sqrt(m_AngleResolution * m_AngleResolution +
               input->GetLargestPossibleRegion().GetSize()[0] * input->GetLargestPossibleRegion().GetSize()[0]));
   size[1] = (SizeValueType)m_AngleResolution;
-  region.SetSize(size);
-  region.SetIndex(input->GetLargestPossibleRegion().GetIndex());
+  const typename InputImageType::RegionType region(input->GetLargestPossibleRegion().GetIndex(), size);
 
   output->SetLargestPossibleRegion(region);
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
@@ -138,14 +138,12 @@ NullImageToImageFilterDriver<TInputImage, TOutputImage>::Execute()
   };
 
   // Set up input images
-  auto                              ip = TInputImage::New();
-  typename TOutputImage::IndexType  index;
-  typename TOutputImage::RegionType region;
+  auto                             ip = TInputImage::New();
+  typename TOutputImage::IndexType index;
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
     index[i] = 0;
-  region.SetSize(m_ImageSize);
-  region.SetIndex(index);
+  const typename TOutputImage::RegionType region(index, m_ImageSize);
 
   // Allocate the input
   ip->SetLargestPossibleRegion(region);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
@@ -89,9 +89,7 @@ BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::Generate
     inputRequestedRegionStartIndex[i] = outputRequestedRegionStartIndex[i] * (int)2;
   }
 
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion.SetSize(inputRequestedRegionSize);
-  inputRequestedRegion.SetIndex(inputRequestedRegionStartIndex);
+  const typename TInputImage::RegionType inputRequestedRegion(inputRequestedRegionStartIndex, inputRequestedRegionSize);
 
   inputPtr->SetRequestedRegion(inputRequestedRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
@@ -100,9 +100,7 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::GenerateIn
     inputRequestedRegionStartIndex[i] = outputRequestedRegionStartIndex[i] / (int)2;
   }
 
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion.SetSize(inputRequestedRegionSize);
-  inputRequestedRegion.SetIndex(inputRequestedRegionStartIndex);
+  const typename TInputImage::RegionType inputRequestedRegion(inputRequestedRegionStartIndex, inputRequestedRegionSize);
 
   inputPtr->SetRequestedRegion(inputRequestedRegion);
 }
@@ -148,9 +146,7 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::GenerateOu
 
   outputPtr->SetSpacing(outputSpacing);
 
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -249,9 +249,7 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
     inputSize[i] = outputRequestedRegionSize[i] * m_ShrinkFactors[i];
   }
 
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion.SetIndex(inputIndex0);
-  inputRequestedRegion.SetSize(inputSize);
+  const typename TInputImage::RegionType inputRequestedRegion(inputIndex0, inputSize);
 
   // actually if we need to crop an exceptions should be thrown!
   // inputRequestedRegion.Crop( inputPtr->GetLargestPossibleRegion() );
@@ -318,9 +316,7 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetOrigin(outputOrigin);
 
   // Set region
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
@@ -33,9 +33,8 @@ CropImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   }
 
   // Compute the new region size
-  OutputImageRegionType croppedRegion;
-  SizeType              sz;
-  OutputImageIndexType  idx;
+  SizeType             sz;
+  OutputImageIndexType idx;
 
   InputImageSizeType  input_sz = inputPtr->GetLargestPossibleRegion().GetSize();
   InputImageIndexType input_idx = inputPtr->GetLargestPossibleRegion().GetIndex();
@@ -48,8 +47,7 @@ CropImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     sz[i] = input_sz[i] - (m_UpperBoundaryCropSize[i] + m_LowerBoundaryCropSize[i]);
   }
 
-  croppedRegion.SetSize(sz);
-  croppedRegion.SetIndex(idx);
+  const OutputImageRegionType croppedRegion(idx, sz);
 
   // Set extraction region in the superclass
   this->SetExtractionRegion(croppedRegion);

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
@@ -254,9 +254,7 @@ ExpandImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetSpacing(outputSpacing);
   outputPtr->SetOrigin(outputOrigin);
 
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.hxx
@@ -164,9 +164,7 @@ InterpolateImagePointsFilter<TInputImage, TOutputImage, TCoordType, Interpolator
 
   outputPtr->SetSpacing(outputSpacing);
 
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -616,9 +616,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
     inputRequestedRegionSize[dimCtr] = maxIndex[dimCtr] - minIndex[dimCtr];
   }
 
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion.SetSize(inputRequestedRegionSize);
-  inputRequestedRegion.SetIndex(inputRequestedRegionStartIndex);
+  const typename TInputImage::RegionType inputRequestedRegion(inputRequestedRegionStartIndex, inputRequestedRegionSize);
 
   inputPtr->SetRequestedRegion(inputRequestedRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
@@ -115,9 +115,7 @@ PadImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     outputStartIndex[i] = inputStartIndex[i] - static_cast<OffsetValueType>(m_PadLowerBound[i]);
   }
 
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -165,9 +165,7 @@ PermuteAxesImageFilter<TImage>::GenerateOutputInformation()
   outputPtr->SetOrigin(outputOrigin);
   outputPtr->SetDirection(outputDirection);
 
-  typename TImage::RegionType outputRegion;
-  outputRegion.SetSize(outputSize);
-  outputRegion.SetIndex(outputStartIndex);
+  const typename TImage::RegionType outputRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputRegion);
 }
@@ -205,9 +203,7 @@ PermuteAxesImageFilter<TImage>::GenerateInputRequestedRegion()
     inputIndex[j] = outputIndex[m_InverseOrder[j]];
   }
 
-  typename TImage::RegionType inputRegion;
-  inputRegion.SetSize(inputSize);
-  inputRegion.SetIndex(inputIndex);
+  const typename TImage::RegionType inputRegion(inputIndex, inputSize);
 
   inputPtr->SetRequestedRegion(inputRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
@@ -78,12 +78,10 @@ RegionOfInterestImageFilter<TInputImage, TOutputImage>::GenerateOutputInformatio
   }
 
   // Set the output image size to the same value as the region of interest.
-  RegionType region;
-  IndexType  start;
+  IndexType start;
   start.Fill(0);
 
-  region.SetSize(m_RegionOfInterest.GetSize());
-  region.SetIndex(start);
+  const RegionType region(start, m_RegionOfInterest.GetSize());
 
   // Copy Information without modification.
   outputPtr->CopyInformation(inputPtr);

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -624,9 +624,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   }
   else
   {
-    typename TOutputImage::RegionType outputLargestPossibleRegion;
-    outputLargestPossibleRegion.SetSize(m_Size);
-    outputLargestPossibleRegion.SetIndex(m_OutputStartIndex);
+    const typename TOutputImage::RegionType outputLargestPossibleRegion(m_OutputStartIndex, m_Size);
     outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
   }
 

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -316,9 +316,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetOrigin(outputOrigin);
 
   // Set region
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -209,9 +209,7 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   }
 
 
-  typename TInputImage::RegionType inputRequestedRegion;
-  inputRequestedRegion.SetIndex(inputRequestedRegionIndex);
-  inputRequestedRegion.SetSize(inputRequestedRegionSize);
+  const typename TInputImage::RegionType inputRequestedRegion(inputRequestedRegionIndex, inputRequestedRegionSize);
 
   // test if input RR is completely inside input largest region
   if (inputRequestedRegion.GetNumberOfPixels() > 0 &&
@@ -298,9 +296,8 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetOrigin(outputOrigin);
 
   // Set region
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -349,10 +349,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     ++it;
   }
 
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputIndex);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputIndex, outputSize);
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 
   // Support VectorImages by setting number of components on output.

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -201,8 +201,6 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   using ProjectionImageRegionType = typename ProjectionImageType::RegionType;
   using ProjectionImageSizeType = typename ProjectionImageType::SizeType;
 
-  ProjectionImageRegionType projectionRegion;
-
   // Determine the projection image size by transforming the eight corners
   // of the 3D input image
 
@@ -308,8 +306,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   projectionSize[0] = (IndexValueType)(bounds[1] - bounds[0]) + pad;
   projectionSize[1] = (IndexValueType)(bounds[3] - bounds[2]) + pad;
 
-  projectionRegion.SetIndex(projectionStart);
-  projectionRegion.SetSize(projectionSize);
+  const ProjectionImageRegionType projectionRegion(projectionStart, projectionSize);
 
   auto projectionImagePtr = ProjectionImageType::New();
 

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
@@ -269,9 +269,7 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   outputPtr->SetSpacing(outputSpacing);
   outputPtr->SetOrigin(outputOrigin);
 
-  typename TOutputImage::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -38,7 +38,6 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 {
   itkDebugMacro("GenerateOutputInformation Start");
 
-  typename TOutputImage::RegionType    outputRegion;
   typename TInputImage::IndexType      inputIndex;
   typename TInputImage::SizeType       inputSize;
   typename TOutputImage::SizeType      outputSize;
@@ -84,8 +83,7 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     }
   }
 
-  outputRegion.SetSize(outputSize);
-  outputRegion.SetIndex(outputIndex);
+  const typename TOutputImage::RegionType outputRegion(outputIndex, outputSize);
   output->SetOrigin(outOrigin);
   output->SetSpacing(outSpacing);
   output->SetDirection(outDirection);
@@ -103,7 +101,6 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 
   if (this->GetInput())
   {
-    typename TInputImage::RegionType RequestedRegion;
     typename TInputImage::SizeType   inputSize;
     typename TInputImage::IndexType  inputIndex;
     typename TInputImage::SizeType   inputLargSize;
@@ -130,9 +127,8 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
       }
     }
 
-    RequestedRegion.SetSize(inputSize);
-    RequestedRegion.SetIndex(inputIndex);
-    InputImagePointer input = const_cast<TInputImage *>(this->GetInput());
+    const typename TInputImage::RegionType RequestedRegion(inputIndex, inputSize);
+    InputImagePointer                      input = const_cast<TInputImage *>(this->GetInput());
     input->SetRequestedRegion(RequestedRegion);
   }
 
@@ -166,9 +162,8 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
   outputIterType outputIter(outputImage, outputImage->GetBufferedRegion());
   using inputIterType = ImageRegionConstIterator<TInputImage>;
 
-  typename TInputImage::RegionType AccumulatedRegion;
-  typename TInputImage::SizeType   AccumulatedSize = inputImage->GetLargestPossibleRegion().GetSize();
-  typename TInputImage::IndexType  AccumulatedIndex = inputImage->GetLargestPossibleRegion().GetIndex();
+  typename TInputImage::SizeType  AccumulatedSize = inputImage->GetLargestPossibleRegion().GetSize();
+  typename TInputImage::IndexType AccumulatedIndex = inputImage->GetLargestPossibleRegion().GetIndex();
 
   typename TInputImage::SizeValueType  SizeAccumulateDimension = AccumulatedSize[m_AccumulateDimension];
   const auto                           sizeAccumulateDimensionDouble = static_cast<double>(SizeAccumulateDimension);
@@ -180,7 +175,6 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
       AccumulatedSize[i] = 1;
     }
   }
-  AccumulatedRegion.SetSize(AccumulatedSize);
   outputIter.GoToBegin();
   while (!outputIter.IsAtEnd())
   {
@@ -196,8 +190,8 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
         AccumulatedIndex[i] = IndexAccumulateDimension;
       }
     }
-    AccumulatedRegion.SetIndex(AccumulatedIndex);
-    inputIterType inputIter(inputImage, AccumulatedRegion);
+    const typename TInputImage::RegionType AccumulatedRegion(AccumulatedIndex, AccumulatedSize);
+    inputIterType                          inputIter(inputImage, AccumulatedRegion);
     inputIter.GoToBegin();
     AccumulateType Value = NumericTraits<AccumulateType>::ZeroValue();
     while (!inputIter.IsAtEnd())

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -434,9 +434,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetRegion(LabelPixelType l
       index[i] = bbox[2 * i];
       size[i] = bbox[2 * i + 1] - bbox[2 * i] + 1;
     }
-    RegionType region;
-    region.SetSize(size);
-    region.SetIndex(index);
+    const RegionType region(index, size);
 
     return region;
   }

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -45,7 +45,6 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateOutputIn
                       << " but input ImageDimension is " << TInputImage::ImageDimension);
   }
 
-  typename TOutputImage::RegionType    outputRegion;
   typename TInputImage::IndexType      inputIndex;
   typename TInputImage::SizeType       inputSize;
   typename TInputImage::DirectionType  inDirection;
@@ -115,8 +114,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateOutputIn
     outDirection.SetIdentity();
   }
 
-  outputRegion.SetSize(outputSize);
-  outputRegion.SetIndex(outputIndex);
+  const typename TOutputImage::RegionType outputRegion(outputIndex, outputSize);
   output->SetOrigin(outOrigin);
   output->SetSpacing(outSpacing);
   output->SetDirection(outDirection);
@@ -141,7 +139,6 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateInputReq
 
   if (this->GetInput())
   {
-    typename TInputImage::RegionType RequestedRegion;
     typename TInputImage::SizeType   inputSize;
     typename TInputImage::IndexType  inputIndex;
     typename TInputImage::SizeType   inputLargSize;
@@ -191,9 +188,8 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateInputReq
       inputIndex[m_ProjectionDimension] = inputLargIndex[m_ProjectionDimension];
     }
 
-    RequestedRegion.SetSize(inputSize);
-    RequestedRegion.SetIndex(inputIndex);
-    InputImagePointer input = const_cast<TInputImage *>(this->GetInput());
+    const typename TInputImage::RegionType RequestedRegion(inputIndex, inputSize);
+    InputImagePointer                      input = const_cast<TInputImage *>(this->GetInput());
     input->SetRequestedRegion(RequestedRegion);
   }
 

--- a/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.hxx
@@ -43,9 +43,8 @@ CropLabelMapFilter<TInputImage>::GenerateOutputInformation()
   }
 
   // Compute the new region size.
-  RegionType croppedRegion;
-  SizeType   size;
-  IndexType  index;
+  SizeType  size;
+  IndexType index;
 
   SizeType  inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
   IndexType inputIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
@@ -55,8 +54,7 @@ CropLabelMapFilter<TInputImage>::GenerateOutputInformation()
   index = inputIndex + m_LowerBoundaryCropSize;
   size = inputSize - (originalCropSize);
 
-  croppedRegion.SetSize(size);
-  croppedRegion.SetIndex(index);
+  const RegionType croppedRegion(index, size);
 
   // Set extraction region in the superclass.
   this->SetRegion(croppedRegion);

--- a/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.hxx
@@ -42,9 +42,8 @@ PadLabelMapFilter<TInputImage>::GenerateOutputInformation()
   }
 
   // Compute the new region size.
-  RegionType croppedRegion;
-  SizeType   size;
-  IndexType  index;
+  SizeType  size;
+  IndexType index;
 
   SizeType  inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
   IndexType inputIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
@@ -54,8 +53,7 @@ PadLabelMapFilter<TInputImage>::GenerateOutputInformation()
   index = inputIndex - m_LowerBoundaryPadSize;
   size = inputSize + (originalPadSize);
 
-  croppedRegion.SetSize(size);
-  croppedRegion.SetIndex(index);
+  const RegionType croppedRegion(index, size);
 
   // Set extraction region in the superclass.
   this->SetRegion(croppedRegion);

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -512,9 +512,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputePerimeter(LabelObjectType * lab
     lIdx[i] = boundingBox.GetIndex()[i + 1];
     lSize[i] = boundingBox.GetSize()[i + 1];
   }
-  typename LineImageType::RegionType lRegion;
-  lRegion.SetIndex(lIdx);
-  lRegion.SetSize(lSize);
+  const typename LineImageType::RegionType lRegion(lIdx, lSize);
   // enlarge the region a bit to avoid boundary problems
   typename LineImageType::RegionType elRegion(lRegion);
   lSize.Fill(1);

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -136,12 +136,10 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::GenerateOutputInformation()
 {
   ImagePointer outputPtr = this->GetOutput(0);
 
-  ImageRegionType outputRegion;
-  ImageIndexType  index;
+  ImageIndexType index;
 
   index.Fill(0);
-  outputRegion.SetSize(this->m_Size);
-  outputRegion.SetIndex(index);
+  const ImageRegionType outputRegion(index, this->m_Size);
   outputPtr->SetLargestPossibleRegion(outputRegion);
   outputPtr->SetSpacing(this->m_Spacing);
   outputPtr->SetOrigin(this->m_Origin);

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -241,9 +241,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
   IndexType start;
   start.Fill(0);
 
-  ImageRegionType region;
-  region.SetSize(dimSize);
-  region.SetIndex(start);
+  const ImageRegionType region(start, dimSize);
 
   // If a VectorImage, this requires us to set the
   // VectorLength before allocate

--- a/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
@@ -81,9 +81,7 @@ public:
   {
     typename MovingImageType::IndexType index;
     index.Fill(0);
-    typename MovingImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(index);
+    const typename MovingImageType::RegionType region(index, size);
 
     m_MovingImage->SetLargestPossibleRegion(region);
     m_MovingImage->SetBufferedRegion(region);

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -394,9 +394,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateOutputInfo
       outputOrigin[idim] = inputOrigin[idim] + outputOriginOffset[idim];
     }
 
-    typename OutputImageType::RegionType outputLargestPossibleRegion;
-    outputLargestPossibleRegion.SetSize(outputSize);
-    outputLargestPossibleRegion.SetIndex(outputStartIndex);
+    const typename OutputImageType::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
     outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
     outputPtr->SetOrigin(outputOrigin);
@@ -527,7 +525,6 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputReque
   unsigned int refLevel = m_NumberOfLevels - 1;
   SizeType     baseSize = this->GetOutput(refLevel)->GetRequestedRegion().GetSize();
   IndexType    baseIndex = this->GetOutput(refLevel)->GetRequestedRegion().GetIndex();
-  RegionType   baseRegion;
 
   unsigned int idim;
   for (idim = 0; idim < ImageDimension; ++idim)
@@ -536,8 +533,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateInputReque
     baseIndex[idim] *= static_cast<IndexValueType>(factor);
     baseSize[idim] *= static_cast<SizeValueType>(factor);
   }
-  baseRegion.SetIndex(baseIndex);
-  baseRegion.SetSize(baseSize);
+  const RegionType baseRegion(baseIndex, baseSize);
 
   // compute requirements for the smoothing part
   using OutputPixelType = typename TOutputImage::PixelType;

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -376,7 +376,6 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateI
   unsigned int refLevel = this->GetNumberOfLevels() - 1;
   SizeType     baseSize = this->GetOutput(refLevel)->GetRequestedRegion().GetSize();
   IndexType    baseIndex = this->GetOutput(refLevel)->GetRequestedRegion().GetIndex();
-  RegionType   baseRegion;
 
   unsigned int idim;
   for (idim = 0; idim < ImageDimension; ++idim)
@@ -385,8 +384,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateI
     baseIndex[idim] *= static_cast<IndexValueType>(factor);
     baseSize[idim] *= static_cast<SizeValueType>(factor);
   }
-  baseRegion.SetIndex(baseIndex);
-  baseRegion.SetSize(baseSize);
+  const RegionType baseRegion(baseIndex, baseSize);
 
   // compute requirements for the smoothing part
   using OutputPixelType = typename TOutputImage::PixelType;

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -595,11 +595,9 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDo
 
 
   // convert virtualPoint to a single point region
-  ImageRegionType singlePointRegion;
-  singlePointRegion.SetIndex(virtualIndex);
   typename ImageRegionType::SizeType singlePointSize;
   singlePointSize.Fill(1);
-  singlePointRegion.SetSize(singlePointSize);
+  const ImageRegionType singlePointRegion(virtualIndex, singlePointSize);
 
   // use scanning variables just for a single point region
   // iterate over the single point and initialize the scanning variables

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -148,15 +148,13 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   // Allocate memory for the joint PDF.
 
   // Instantiate a region, index, size
-  JointPDFRegionType jointPDFRegion;
-  JointPDFIndexType  jointPDFIndex;
-  JointPDFSizeType   jointPDFSize;
+  JointPDFIndexType jointPDFIndex;
+  JointPDFSizeType  jointPDFSize;
 
   // the jointPDF is of size NumberOfBins x NumberOfBins
   jointPDFSize.Fill(m_NumberOfHistogramBins);
   jointPDFIndex.Fill(0);
-  jointPDFRegion.SetIndex(jointPDFIndex);
-  jointPDFRegion.SetSize(jointPDFSize);
+  const JointPDFRegionType jointPDFRegion(jointPDFIndex, jointPDFSize);
 
   // Set the regions and allocate
   this->m_JointPDF->SetRegions(jointPDFRegion);
@@ -181,15 +179,13 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   // Instantiate a region, index, size
   using MarginalPDFRegionType = typename MarginalPDFType::RegionType;
   using MarginalPDFSizeType = typename MarginalPDFType::SizeType;
-  MarginalPDFRegionType marginalPDFRegion;
-  MarginalPDFIndexType  marginalPDFIndex;
-  MarginalPDFSizeType   marginalPDFSize;
+  MarginalPDFIndexType marginalPDFIndex;
+  MarginalPDFSizeType  marginalPDFSize;
 
   // the marginalPDF is of size NumberOfBins x NumberOfBins
   marginalPDFSize.Fill(m_NumberOfHistogramBins);
   marginalPDFIndex.Fill(0);
-  marginalPDFRegion.SetIndex(marginalPDFIndex);
-  marginalPDFRegion.SetSize(marginalPDFSize);
+  const MarginalPDFRegionType marginalPDFRegion(marginalPDFIndex, marginalPDFSize);
 
   // Set the regions and allocate
   this->m_FixedImageMarginalPDF->SetRegions(marginalPDFRegion);

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -79,7 +79,6 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
 
   this->m_MattesAssociate->m_JointPDFSum = 0;
 
-  JointPDFRegionType jointPDFRegion;
   // For the joint PDF define a region starting from {0,0}
   // with size {m_NumberOfHistogramBins, this->m_NumberOfHistogramBins}.
   // The dimension represents fixed image bin size
@@ -89,8 +88,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
   JointPDFSizeType jointPDFSize;
   jointPDFSize.Fill(this->m_MattesAssociate->m_NumberOfHistogramBins);
 
-  jointPDFRegion.SetIndex(jointPDFIndex);
-  jointPDFRegion.SetSize(jointPDFSize);
+  const JointPDFRegionType jointPDFRegion(jointPDFIndex, jointPDFSize);
 
   /*
    * Allocate memory for the joint PDF and joint PDF derivatives accumulator caches

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
@@ -140,10 +140,7 @@ ImageClassifierBase<TInputImage, TClassifiedImage>::Allocate()
   typename TClassifiedImage::IndexType classifiedImageIndex;
   classifiedImageIndex.Fill(0);
 
-  typename TClassifiedImage::RegionType classifiedImageRegion;
-
-  classifiedImageRegion.SetSize(inputImageSize);
-  classifiedImageRegion.SetIndex(classifiedImageIndex);
+  const typename TClassifiedImage::RegionType classifiedImageRegion(classifiedImageIndex, inputImageSize);
 
   classifiedImage->SetLargestPossibleRegion(classifiedImageRegion);
   classifiedImage->SetBufferedRegion(classifiedImageRegion);

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -43,15 +43,13 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
   SizeType  size;
 
   typename ListType::iterator iter;
-  RegionType                  region;
 
   TOutputImage *      output = this->GetOutput();
   const TInputImage * input = this->GetInput();
 
   size = input->GetLargestPossibleRegion().GetSize();
   index.Fill(0);
-  region.SetSize(size);
-  region.SetIndex(index);
+  const RegionType region(index, size);
   output->SetLargestPossibleRegion(region);
   output->SetBufferedRegion(region);
   output->SetRequestedRegion(region);

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -179,10 +179,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GetLabelledImage() -> Label
   LabelImageIndexType labelImageIndex;
   labelImageIndex.Fill(0);
 
-  typename LabelImageType::RegionType labelImageRegion;
-
-  labelImageRegion.SetSize(labelImageSize);
-  labelImageRegion.SetIndex(labelImageIndex);
+  const typename LabelImageType::RegionType labelImageRegion(labelImageIndex, labelImageSize);
 
   labelImagePtr->SetLargestPossibleRegion(labelImageRegion);
   labelImagePtr->SetBufferedRegion(labelImageRegion);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
@@ -37,11 +37,9 @@ LevelSetEvolutionComputeIterationThreader<LevelSetDenseImage<TImage>,
   typename LevelSetImageType::ConstPointer levelSetImage = levelSet->GetImage();
 
   // Identify the level-set region
-  OffsetType offset = levelSet->GetDomainOffset();
-  IndexType  index = imageSubRegion.GetIndex() - offset;
-  RegionType subRegion;
-  subRegion.SetSize(imageSubRegion.GetSize());
-  subRegion.SetIndex(index);
+  OffsetType       offset = levelSet->GetDomainOffset();
+  IndexType        index = imageSubRegion.GetIndex() - offset;
+  const RegionType subRegion(index, imageSubRegion.GetSize());
 
   ImageRegionConstIteratorWithIndex<LevelSetImageType> imageIt(levelSetImage, subRegion);
   imageIt.GoToBegin();

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -367,9 +367,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::Allocate()
   LabelStatusIndexType index;
   index.Fill(0);
 
-  LabelStatusRegionType region;
-  region.SetSize(inputImageSize);
-  region.SetIndex(index);
+  const LabelStatusRegionType region(index, inputImageSize);
 
   m_LabelStatusImage = LabelStatusImageType::New();
   m_LabelStatusImage->SetLargestPossibleRegion(region);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -89,9 +89,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(const Inp
   this->SetSize(this->GetInput()->GetLargestPossibleRegion().GetSize());
   IndexType index;
   index.Fill(0);
-  RegionType region;
-  region.SetSize(this->GetSize());
-  region.SetIndex(index);
+  const RegionType region(index, this->GetSize());
 
   m_WorkingImage = RGBHCVImage::New();
   m_WorkingImage->SetLargestPossibleRegion(region);

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -1292,9 +1292,7 @@ Segmenter<TInputImage>::UpdateOutputInformation()
     outputStartIndex[i] = inputStartIndex[i];
   }
 
-  typename OutputImageType::RegionType outputLargestPossibleRegion;
-  outputLargestPossibleRegion.SetSize(outputSize);
-  outputLargestPossibleRegion.SetIndex(outputStartIndex);
+  const typename OutputImageType::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -82,7 +82,6 @@ VideoFileReader<TOutputVideoStream>::UpdateOutputInformation()
   //
 
   // Set up largest possible spatial region
-  RegionType    region;
   SizeType      size;
   IndexType     start;
   PointType     origin;
@@ -100,8 +99,7 @@ VideoFileReader<TOutputVideoStream>::UpdateOutputInformation()
     }
   }
   start.Fill(0);
-  region.SetSize(size);
-  region.SetIndex(start);
+  const RegionType region(start, size);
 
   VideoStreamPointer output = this->GetOutput();
 


### PR DESCRIPTION
Replaced lines of code like the following:

    RegionType region;
    region.SetIndex(index);
    region.SetSize(size);

With:

    const RegionType region(index, size);

Following C++ Core Guidelines, August 19, 2021, "By default, make objects immutable"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rconst-immutable