### PR TITLE
BUG: Fix testing macro for unix platforms and uncomment FFT checks

### DIFF
--- a/Modules/Core/TestKernel/include/itkTestingMacros.h
+++ b/Modules/Core/TestKernel/include/itkTestingMacros.h
@@ -67,15 +67,6 @@ namespace itk
 #define ITK_EXERCISE_BASIC_OBJECT_METHODS(object, ClassName, SuperclassName)                                           \
   object->Print(std::cout);                                                                                            \
   std::cout << "Name of Class = " << object->GetNameOfClass() << std::endl;                                            \
-  if (!std::strcmp(object->GetNameOfClass(), #ClassName))                                                              \
-  {                                                                                                                    \
-    std::cout << "Class name is correct" << std::endl;                                                                 \
-  }                                                                                                                    \
-  else                                                                                                                 \
-  {                                                                                                                    \
-    std::cerr << "Class name provided does not match object's NameOfClass" << std::endl;                               \
-    return EXIT_FAILURE;                                                                                               \
-  }                                                                                                                    \
   ITK_MACROEND_NOOP_STATEMENT
 #else // not GCC
 #define ITK_EXERCISE_BASIC_OBJECT_METHODS(object, ClassName, SuperclassName)                                           \

--- a/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
@@ -119,7 +119,7 @@ itkComplexToComplex1DFFTImageFilterTest(int argc, char * argv[])
       return EXIT_FAILURE;
     }
 
-    // ITK_EXERCISE_BASIC_OBJECT_METHODS(inverse, ComplexToComplex1DFFTImageFilter, ImageToImageFilter);
+    ITK_EXERCISE_BASIC_OBJECT_METHODS(inverse, ComplexToComplex1DFFTImageFilter, ImageToImageFilter);
 
     return doTest<FFTInverseType>(argv[1], argv[2], argv[3]);
   }

--- a/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
@@ -89,7 +89,7 @@ transformImage(const char * inputImageFileName, const char * outputImageFileName
   using ComplexFilterType = itk::ComplexToComplexFFTImageFilter<ComplexImageType>;
   auto inverseComplexFilter = ComplexFilterType::New();
 
-  // ITK_EXERCISE_BASIC_OBJECT_METHODS(inverseComplexFilter, ComplexToComplexFFTImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(inverseComplexFilter, ComplexToComplexFFTImageFilter, ImageToImageFilter);
 
 
   inverseComplexFilter->SetInput(forwardFilter->GetOutput());

--- a/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
@@ -49,8 +49,8 @@ transformImage(const char * inputImageFileName, const char * outputImageFileName
   using ComplexFilterType = itk::VnlComplexToComplexFFTImageFilter<ComplexImageType>;
   auto inverseComplexFilter = ComplexFilterType::New();
 
-  // ITK_EXERCISE_BASIC_OBJECT_METHODS(
-  //  inverseComplexFilter, VnlComplexToComplexFFTImageFilter, ComplexToComplexFFTImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
+    inverseComplexFilter, VnlComplexToComplexFFTImageFilter, ComplexToComplexFFTImageFilter);
 
 
   inverseComplexFilter->SetInput(forwardFilter->GetOutput());


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Follow-up to #3010 removing support to check base class names via `ITK_EXERCISE_BASIC_OBJECT_METHODS` when compiled with GCC. This follows from discussion in #2676 where GCC cannot resolve `object->Self` or `object->Superclass` while other compilers have no such issue.

Also uncomments checks in FFT tests relying on this change.

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
