### PR TITLE
STYLE: Disable MSVC settings for non-MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,16 +121,18 @@ endif()
 include(CTest)
 mark_as_advanced(CLEAR BUILD_TESTING)
 
-option(ITK_MSVC_STATIC_RUNTIME_LIBRARY "Link to MSVC's static CRT (/MT and /MTd).
+if(MSVC) #-- Configure MSVC_STATIC_RUNTIME only if using MSVC environment
+  option(ITK_MSVC_STATIC_RUNTIME_LIBRARY "Link to MSVC's static CRT (/MT and /MTd).
 OFF (default) means link to regular, dynamic CRT (/MD and /MDd)." OFF)
-mark_as_advanced(ITK_MSVC_STATIC_RUNTIME_LIBRARY)
-set(ITK_MSVC_STATIC_RUNTIME_LIBRARY_value ${ITK_MSVC_STATIC_RUNTIME_LIBRARY})
-if(ITK_MSVC_STATIC_RUNTIME_LIBRARY)
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-  message(STATUS "Using MSVC's static CRT (/MT and /MTd)")
-else()
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-  message(STATUS "Using MSVC's dynamic CRT (/MD and /MDd)")
+  mark_as_advanced(ITK_MSVC_STATIC_RUNTIME_LIBRARY)
+  set(ITK_MSVC_STATIC_RUNTIME_LIBRARY_value ${ITK_MSVC_STATIC_RUNTIME_LIBRARY})
+  if(ITK_MSVC_STATIC_RUNTIME_LIBRARY)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    message(STATUS "Using MSVC's static CRT (/MT and /MTd)")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    message(STATUS "Using MSVC's dynamic CRT (/MD and /MDd)")
+  endif()
 endif()
 
 include(ITKDownloadSetup)


### PR DESCRIPTION
Configure MSVC_STATIC_RUNTIME only if using MSVC environment

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
