### PR TITLE
STYLE: Clean-up default-constructed local `inputRegion` variables

### DIFF
--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -159,7 +159,6 @@ ImageSink<TInputImage>::GenerateNthInputRequestedRegion(unsigned int inputReques
         continue;
       }
       // copy the requested region of the first input to the others
-      InputImageRegionType inputRegion;
       input->SetRequestedRegion(m_CurrentInputRegion);
     }
   }

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -651,7 +651,6 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   // is bigger than our input.
 
   // Cast away the constness so we can set the requested region.
-  InputRegionType   inputRegion;
   InputImagePointer inputPtr;
   inputPtr = const_cast<InputImageType *>(this->GetFixedImage());
   inputPtr->SetRequestedRegion(this->GetFixedImage()->GetLargestPossibleRegion());

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -281,8 +281,7 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateInputReq
   InputImagePointer inputPtr = const_cast<InputImageType *>(this->GetInput());
 
   // Request the entire input image
-  InputImageRegionType inputRegion;
-  inputRegion = inputPtr->GetLargestPossibleRegion();
+  const InputImageRegionType inputRegion = inputPtr->GetLargestPossibleRegion();
   inputPtr->SetRequestedRegion(inputRegion);
 }
 

--- a/Modules/Video/Core/include/itkVideoToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkVideoToVideoFilter.hxx
@@ -189,9 +189,7 @@ VideoToVideoFilter<TInputVideoStream, TOutputVideoStream>::GenerateInputRequeste
   OutputFrameSpatialRegionType outputRegion = this->GetOutput()->GetFrameRequestedSpatialRegion(outputStart);
 
   // Convert to input spatial region (TODO: handle dificult cases)
-  InputFrameSpatialRegionType inputRegion;
-  inputRegion.SetSize(outputRegion.GetSize());
-  inputRegion.SetIndex(outputRegion.GetIndex());
+  const InputFrameSpatialRegionType inputRegion = outputRegion;
 
   // Create input spatial regions for each frame of each input
   for (unsigned int i = 0; i < this->GetNumberOfInputs(); ++i)

--- a/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
@@ -114,10 +114,7 @@ FrameAverageVideoFilter<TInputVideoStream, TOutputVideoStream>::ThreadedGenerate
   std::vector<IterType> inputIters;
   for (SizeValueType i = inputStart; i < inputStart + numFrames; ++i)
   {
-    OutputFrameSpatialRegionType inputRegion;
-    inputRegion.SetSize(outputRegionForThread.GetSize());
-    inputRegion.SetIndex(outputRegionForThread.GetIndex());
-    inputIters.push_back(IterType(input->GetFrame(i), inputRegion));
+    inputIters.push_back(IterType(input->GetFrame(i), outputRegionForThread));
   }
 
   // Get the output frame and its iterator

--- a/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
@@ -114,11 +114,8 @@ FrameDifferenceVideoFilter<TInputVideoStream, TOutputVideoStream>::ThreadedGener
 
   // Get iterators for the input frames
   using ConstIterType = ImageRegionConstIterator<InputFrameType>;
-  OutputFrameSpatialRegionType inputRegion;
-  inputRegion.SetSize(outputRegionForThread.GetSize());
-  inputRegion.SetIndex(outputRegionForThread.GetIndex());
-  ConstIterType I0Iter(input->GetFrame(inputStart), inputRegion);
-  ConstIterType I1Iter(input->GetFrame(inputStart + numFrames - 1), inputRegion);
+  ConstIterType I0Iter(input->GetFrame(inputStart), outputRegionForThread);
+  ConstIterType I1Iter(input->GetFrame(inputStart + numFrames - 1), outputRegionForThread);
 
   // Get the output frame and its iterator
   OutputFrameType *                         outFrame = output->GetFrame(outputFrameNumber);


### PR DESCRIPTION
Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3021
commit ac3156140b29e64467f87725f9a0bb0a12602d15
"STYLE: Declare local `ImageRegion` variables `const`"