### PR TITLE
Doxygen Generation Improvements

### DIFF
--- a/Documentation/Doxygen/DoxygenFooter.html
+++ b/Documentation/Doxygen/DoxygenFooter.html
@@ -21,7 +21,8 @@
   </small>
 </div>
 <address class="footer"><small>
-$generatedby &#160;<a href="http://www.doxygen.org/index.html">
+Generated on <span id="datetime">unknown</span> for $projectname by &#160;
+<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="$relpath^doxygen.png" alt="doxygen"/>
 </a> $doxygenversion
 </small></address>

--- a/Documentation/Doxygen/DoxygenHeader.html
+++ b/Documentation/Doxygen/DoxygenHeader.html
@@ -14,6 +14,7 @@
 $treeview
 $search
 $mathjax
+<script type="text/javascript" src="$relpath^build_text.js"></script>
 <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
 $extrastylesheet
 </head>

--- a/Utilities/Doxygen/CMakeLists.txt
+++ b/Utilities/Doxygen/CMakeLists.txt
@@ -140,11 +140,8 @@ if (ITK_BUILD_DOCUMENTATION)
   file(COPY workbox-cli-config.js serviceWorker.js.in
     DESTINATION ${ITK_BINARY_DIR}/Utilities/Doxygen/)
 
-  find_package( LATEX )
 
-  if( NOT LATEX_COMPILER )
-    message( "Warning: LaTeX not found. Formulas will not be generated in documentation." )
-  endif()
+  find_package( LATEX )
 
   # Custom command to generate a examples page which include all ITK examples
   add_custom_command( OUTPUT "${ITK_BINARY_DIR}/Documentation/Doxygen/Examples.dox"

--- a/Utilities/Doxygen/CMakeLists.txt
+++ b/Utilities/Doxygen/CMakeLists.txt
@@ -140,6 +140,16 @@ if (ITK_BUILD_DOCUMENTATION)
   file(COPY workbox-cli-config.js serviceWorker.js.in
     DESTINATION ${ITK_BINARY_DIR}/Utilities/Doxygen/)
 
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_LIST_DIR}/datetime.py"
+     RESULT_VARIABLE CMD_RESULT
+     OUTPUT_VARIABLE _DATETIME)
+
+   if (CMD_RESULT)
+     message(FATAL_ERROR "Datetime failed!")
+   endif()
+
+   configure_file(${CMAKE_CURRENT_LIST_DIR}/build_text.js.in
+     "${ITK_BINARY_DIR}/Utilities/Doxygen//html/build_text.js")
 
   find_package( LATEX )
 

--- a/Utilities/Doxygen/build_text.js.in
+++ b/Utilities/Doxygen/build_text.js.in
@@ -1,0 +1,3 @@
+$(function(){
+    document.getElementById("datetime").textContent = "@_DATETIME@"
+});

--- a/Utilities/Doxygen/datetime.py
+++ b/Utilities/Doxygen/datetime.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Writes the date and time in RFC 2822 format to stdout
+
+import  time
+import sys
+sys.stdout.write(time.strftime('%a, %d %b %Y %H:%M:%S +0000', time.gmtime()))

--- a/Utilities/Doxygen/doxygen.config.in
+++ b/Utilities/Doxygen/doxygen.config.in
@@ -1533,7 +1533,7 @@ FORMULA_TRANSPARENT    = YES
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:
@@ -1556,7 +1556,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://www.mathjax.org/mathjax
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example
@@ -2476,7 +2476,7 @@ DIRECTORY_GRAPH        = @ITK_DOXYGEN_DIAGRAMS@
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.


### PR DESCRIPTION
Three things are done in the PR:
 - Use SVG file format for class graphs
 - Use mathjax javascript to render math latex on the client side
 - Replace static datetime stamp in footer with value dynamically set via javascript

The following changes reduce the HTML from 2.7GB to 884MB a 67%  reduction in size. Additionally, without the daily file modifications of the time stamps few files are modified each night, improving client side cache and enabling committing to gh-pages with little daily churn.

Sample GH repo hosting Doxygen:
https://github.com/blowekamp/ITKDoxygen
https://blowekamp.github.io/ITKDoxygen/

SimpleITK has been using these Doxygen changes on GH pages:
https://simpleitk.org/doxygen/latest/html/index.html

Additionally, the ITKDoxygen repo provides a Dockerfile to reproduce the Doxygen so that issue can better be reproduced and changes to the Doxygen generation system can be contributed by the community.

