### PR TITLE
STYLE: OpenJPEG: removed outdated comment

### DIFF
--- a/Modules/ThirdParty/OpenJPEG/itk-module.cmake
+++ b/Modules/ThirdParty/OpenJPEG/itk-module.cmake
@@ -5,9 +5,6 @@ has been developed in order to promote the use of JPEG 2000, the new still-image
 compression standard from the Joint Photographic Experts Group (JPEG).")
 
 itk_module(ITKOpenJPEG
-  # Since GDCM is the only Module that depends on ITKOpenJPEG
-  # EXCLUDE_FROM_DEFAULT to prevent building if not required. If
-  # ITKGDCM is build, it will automatically enable this module.
   EXCLUDE_FROM_DEFAULT
   DESCRIPTION
     "${DOCUMENTATION}"


### PR DESCRIPTION
ITKGDCM build doesn't depend on and doesn't automatically enable _ThirdParty/OpenJPEG_ module.