### PR TITLE
STYLE: Declare local zero-filled `Index` variables `constexpr`

### DIFF
--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -53,12 +53,12 @@ BresenhamLine<VDimension>::BuildLine(LType Direction, IdentifierType length) -> 
 
   OffsetArray result(length);
 
-  IndexType m_CurrentImageIndex, StartIndex, LastIndex;
+  IndexType m_CurrentImageIndex, LastIndex;
 
   Direction.Normalize();
   // we are going to start at 0
   m_CurrentImageIndex.Fill(0);
-  StartIndex.Fill(0);
+  constexpr IndexType StartIndex = { { 0 } };
   for (unsigned i = 0; i < VDimension; ++i)
   {
     LastIndex[i] = (IndexValueType)(length * Direction[i]);

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -210,9 +210,8 @@ template <typename TImage, typename TBoundaryCondition>
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::ConstNeighborhoodIterator()
 
 {
-  IndexType zeroIndex;
-  zeroIndex.Fill(0);
-  SizeType zeroSize;
+  constexpr IndexType zeroIndex = { { 0 } };
+  SizeType            zeroSize;
   zeroSize.Fill(0);
 
   m_Bound.Fill(0);

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -129,8 +129,7 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::GetBoundingBoxAsImageRegion() co
 template <typename TImage>
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnlyIndex()
 {
-  IndexType zeroIndex;
-  zeroIndex.Fill(0);
+  constexpr IndexType zeroIndex = { { 0 } };
 
   SizeType zeroSize;
   zeroSize.Fill(0);

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
@@ -73,9 +73,8 @@ ConstantBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
 
   if (!cropped)
   {
-    IndexType index;
-    index.Fill(0);
-    SizeType size;
+    constexpr IndexType index = { { 0 } };
+    SizeType            size;
     size.Fill(0);
     inputRequestedRegion.SetIndex(index);
     inputRequestedRegion.SetSize(size);

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -513,10 +513,9 @@ private:
                       VariableLengthVector<RealTypeScalarRealType> & tempZeros) const
   {
     // Variable length vector version to get the size of the pixel correct.
-    typename TInputImage::IndexType idx;
-    idx.Fill(0);
-    const typename TInputImage::PixelType & tempPixel = inputImagePtr->GetPixel(idx);
-    const unsigned int                      sizeOfVarLengthVector = tempPixel.GetSize();
+    constexpr typename TInputImage::IndexType idx = { { 0 } };
+    const typename TInputImage::PixelType &   tempPixel = inputImagePtr->GetPixel(idx);
+    const unsigned int                        sizeOfVarLengthVector = tempPixel.GetSize();
     tempZeros.SetSize(sizeOfVarLengthVector);
     tempZeros.Fill(NumericTraits<RealTypeScalarRealType>::ZeroValue());
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -65,9 +65,8 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(co
     }
   }
 
-  itk::Index<NDimensions> zeroIndex;
-  zeroIndex.Fill(0);
-  const RegionType region(zeroIndex, size);
+  constexpr itk::Index<NDimensions> zeroIndex = { { 0 } };
+  const RegionType                  region(zeroIndex, size);
   rval->SetLargestPossibleRegion(region);
   rval->SetBufferedRegion(region);
   rval->SetRequestedRegion(region);

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -197,10 +197,8 @@ template <typename TOutputImage>
 void
 RandomImageSource<TOutputImage>::GenerateOutputInformation()
 {
-  TOutputImage * output;
-  IndexType      index;
-
-  index.Fill(0);
+  TOutputImage *      output;
+  constexpr IndexType index = { { 0 } };
 
   output = this->GetOutput(0);
 

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -420,9 +420,8 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   // Extract the relevant part out of the image.
   // The input FFT image may be bigger than the desired output image
   // because specific sizes are required for the FFT calculation.
-  typename LocalOutputImageType::IndexType imageIndex;
-  imageIndex.Fill(0);
-  const typename LocalOutputImageType::RegionType imageRegion(imageIndex, combinedImageSize);
+  constexpr typename LocalOutputImageType::IndexType imageIndex = { { 0 } };
+  const typename LocalOutputImageType::RegionType    imageRegion(imageIndex, combinedImageSize);
   using ExtractType = itk::RegionOfInterestImageFilter<LocalOutputImageType, LocalOutputImageType>;
   auto extracter = ExtractType::New();
   extracter->SetInput(FFTFilter->GetOutput());
@@ -579,8 +578,7 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   calculator->SetImage(inputImage);
   calculator->ComputeMaximum();
 
-  typename LocalInputImageType::IndexType index;
-  index.Fill(0);
+  constexpr typename LocalInputImageType::IndexType index = { { 0 } };
 
   double precisionTolerance = 0.0F;
   if (typeid(inputImage->GetPixel(index)) == typeid(double))

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -34,8 +34,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::FastMarchingImageFilter()
 
   OutputSizeType outputSize;
   outputSize.Fill(16);
-  typename LevelSetImageType::IndexType outputIndex;
-  outputIndex.Fill(0);
+  constexpr typename LevelSetImageType::IndexType outputIndex = { { 0 } };
 
   m_OutputRegion.SetSize(outputSize);
   m_OutputRegion.SetIndex(outputIndex);

--- a/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
@@ -78,8 +78,7 @@ RegionOfInterestImageFilter<TInputImage, TOutputImage>::GenerateOutputInformatio
   }
 
   // Set the output image size to the same value as the region of interest.
-  IndexType start;
-  start.Fill(0);
+  constexpr IndexType start = { { 0 } };
 
   const RegionType region(start, m_RegionOfInterest.GetSize());
 

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -244,8 +244,7 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   typename TOutputImage::SpacingType outputSpacing;
   typename TOutputImage::SizeType    outputSize;
 
-  typename TOutputImage::IndexType outputStartIndex;
-  outputStartIndex.Fill(0);
+  constexpr typename TOutputImage::IndexType outputStartIndex = { { 0 } };
 
   for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -200,8 +200,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   // be large enough to accommodate left-over images.
   OutputSizeType outputSize;
   outputSize.Fill(1);
-  OutputIndexType outputIndex;
-  outputIndex.Fill(0);
+  constexpr OutputIndexType outputIndex = { { 0 } };
 
   if (m_Layout[OutputImageDimension - 1] == 0)
   {
@@ -221,8 +220,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
   OutputSizeType tileSize;
   tileSize.Fill(1);
-  OutputIndexType tileIndex;
-  tileIndex.Fill(0);
+  constexpr OutputIndexType tileIndex = { { 0 } };
 
   for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -136,10 +136,8 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::GenerateOutputInformation()
 {
   ImagePointer outputPtr = this->GetOutput(0);
 
-  ImageIndexType index;
-
-  index.Fill(0);
-  const ImageRegionType outputRegion(index, this->m_Size);
+  constexpr ImageIndexType index = { { 0 } };
+  const ImageRegionType    outputRegion(index, this->m_Size);
   outputPtr->SetLargestPossibleRegion(outputRegion);
   outputPtr->SetSpacing(this->m_Spacing);
   outputPtr->SetOrigin(this->m_Origin);

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -210,9 +210,8 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
     origin[i] = 0;
   }
 
-  typename OutputImageType::IndexType index;
-  index.Fill(0);
-  typename OutputImageType::RegionType region;
+  constexpr typename OutputImageType::IndexType index = { { 0 } };
+  typename OutputImageType::RegionType          region;
 
   // If the size of the output has been explicitly specified, the filter
   // will set the output size to the explicit size, otherwise the size from the

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -238,8 +238,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
   output->SetMetaDataDictionary(thisDic);
   this->SetMetaDataDictionary(thisDic);
 
-  IndexType start;
-  start.Fill(0);
+  constexpr IndexType start = { { 0 } };
 
   const ImageRegionType region(start, dimSize);
 

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -167,8 +167,7 @@ ImageSeriesReader<TOutputImage>::GenerateOutputInformation()
     // dimensions we are going to use
     this->m_NumberOfDimensionsInImage = ComputeMovingDimensionIndex(firstReader);
     dimSize[this->m_NumberOfDimensionsInImage] = static_cast<typename SizeType::SizeValueType>(numberOfFiles);
-    IndexType start;
-    start.Fill(0);
+    constexpr IndexType start = { { 0 } };
     largestRegion.SetSize(dimSize);
     largestRegion.SetIndex(start);
 

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -33,9 +33,8 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::ImageToNeighborhoo
   m_Radius.Fill(0);
   m_NeighborIndexInternal.Fill(0);
 
-  NeighborhoodIndexType start;
-  NeighborhoodSizeType  sz;
-  start.Fill(0);
+  constexpr NeighborhoodIndexType start = { { 0 } };
+  NeighborhoodSizeType            sz;
   sz.Fill(0);
   m_Region.SetIndex(start);
   m_Region.SetSize(sz);

--- a/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
@@ -79,9 +79,8 @@ public:
   void
   GenerateImages(const typename MovingImageType::SizeType & size)
   {
-    typename MovingImageType::IndexType index;
-    index.Fill(0);
-    const typename MovingImageType::RegionType region(index, size);
+    constexpr typename MovingImageType::IndexType index = { { 0 } };
+    const typename MovingImageType::RegionType    region(index, size);
 
     m_MovingImage->SetLargestPossibleRegion(region);
     m_MovingImage->SetBufferedRegion(region);

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -241,9 +241,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
       // with size {m_NumberOfHistogramBins, this->m_NumberOfHistogramBins}.
       // The dimension represents fixed image bin size
       // and moving image bin size , respectively.
-      JointPDFIndexType jointPDFIndex;
-      jointPDFIndex.Fill(0);
-      JointPDFSizeType jointPDFSize;
+      constexpr JointPDFIndexType jointPDFIndex = { { 0 } };
+      JointPDFSizeType            jointPDFSize;
       jointPDFSize.Fill(m_NumberOfHistogramBins);
 
       jointPDFRegion.SetIndex(jointPDFIndex);
@@ -292,9 +291,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
         // this->m_NumberOfHistogramBins}. The dimension represents
         // transform parameters, fixed image parzen window index and
         // moving image parzen window index, respectively.
-        JointPDFDerivativesIndexType jointPDFDerivativesIndex;
-        jointPDFDerivativesIndex.Fill(0);
-        JointPDFDerivativesSizeType jointPDFDerivativesSize;
+        constexpr JointPDFDerivativesIndexType jointPDFDerivativesIndex = { { 0 } };
+        JointPDFDerivativesSizeType            jointPDFDerivativesSize;
         jointPDFDerivativesSize[0] = this->m_NumberOfParameters;
         jointPDFDerivativesSize[1] = this->m_NumberOfHistogramBins;
         jointPDFDerivativesSize[2] = this->m_NumberOfHistogramBins;

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -148,12 +148,11 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   // Allocate memory for the joint PDF.
 
   // Instantiate a region, index, size
-  JointPDFIndexType jointPDFIndex;
-  JointPDFSizeType  jointPDFSize;
+  constexpr JointPDFIndexType jointPDFIndex = { { 0 } };
+  JointPDFSizeType            jointPDFSize;
 
   // the jointPDF is of size NumberOfBins x NumberOfBins
   jointPDFSize.Fill(m_NumberOfHistogramBins);
-  jointPDFIndex.Fill(0);
   const JointPDFRegionType jointPDFRegion(jointPDFIndex, jointPDFSize);
 
   // Set the regions and allocate
@@ -179,12 +178,11 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   // Instantiate a region, index, size
   using MarginalPDFRegionType = typename MarginalPDFType::RegionType;
   using MarginalPDFSizeType = typename MarginalPDFType::SizeType;
-  MarginalPDFIndexType marginalPDFIndex;
-  MarginalPDFSizeType  marginalPDFSize;
+  constexpr MarginalPDFIndexType marginalPDFIndex = { { 0 } };
+  MarginalPDFSizeType            marginalPDFSize;
 
   // the marginalPDF is of size NumberOfBins x NumberOfBins
   marginalPDFSize.Fill(m_NumberOfHistogramBins);
-  marginalPDFIndex.Fill(0);
   const MarginalPDFRegionType marginalPDFRegion(marginalPDFIndex, marginalPDFSize);
 
   // Set the regions and allocate

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -83,9 +83,8 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
   // with size {m_NumberOfHistogramBins, this->m_NumberOfHistogramBins}.
   // The dimension represents fixed image bin size
   // and moving image bin size , respectively.
-  JointPDFIndexType jointPDFIndex;
-  jointPDFIndex.Fill(0);
-  JointPDFSizeType jointPDFSize;
+  constexpr JointPDFIndexType jointPDFIndex = { { 0 } };
+  JointPDFSizeType            jointPDFSize;
   jointPDFSize.Fill(this->m_MattesAssociate->m_NumberOfHistogramBins);
 
   const JointPDFRegionType jointPDFRegion(jointPDFIndex, jointPDFSize);
@@ -179,9 +178,8 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
       // parameters,
       // fixed image parzen window index and moving image parzen window index,
       // respectively.
-      JointPDFDerivativesIndexType jointPDFDerivativesIndex;
-      jointPDFDerivativesIndex.Fill(0);
-      JointPDFDerivativesSizeType jointPDFDerivativesSize;
+      constexpr JointPDFDerivativesIndexType jointPDFDerivativesIndex = { { 0 } };
+      JointPDFDerivativesSizeType            jointPDFDerivativesSize;
       jointPDFDerivativesSize[0] = this->GetCachedNumberOfLocalParameters();
       jointPDFDerivativesSize[1] = this->m_MattesAssociate->m_NumberOfHistogramBins;
       jointPDFDerivativesSize[2] = this->m_MattesAssociate->m_NumberOfHistogramBins;

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
@@ -137,8 +137,7 @@ ImageClassifierBase<TInputImage, TClassifiedImage>::Allocate()
 
   this->SetClassifiedImage(classifiedImage);
 
-  typename TClassifiedImage::IndexType classifiedImageIndex;
-  classifiedImageIndex.Fill(0);
+  constexpr typename TClassifiedImage::IndexType classifiedImageIndex = { { 0 } };
 
   const typename TClassifiedImage::RegionType classifiedImageRegion(classifiedImageIndex, inputImageSize);
 

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -39,7 +39,6 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
   auto *    equivalenceTable = new LabelType[NumericTraits<LabelType>::max()];
   LabelType label = 0;
   LabelType maxLabel = 0;
-  IndexType index;
   SizeType  size;
 
   typename ListType::iterator iter;
@@ -48,8 +47,8 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
   const TInputImage * input = this->GetInput();
 
   size = input->GetLargestPossibleRegion().GetSize();
-  index.Fill(0);
-  const RegionType region(index, size);
+  constexpr IndexType index = { { 0 } };
+  const RegionType    region(index, size);
   output->SetLargestPossibleRegion(region);
   output->SetBufferedRegion(region);
   output->SetRequestedRegion(region);

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -176,8 +176,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GetLabelledImage() -> Label
 
   typename LabelImageType::SizeType labelImageSize = this->GetInput()->GetBufferedRegion().GetSize();
 
-  LabelImageIndexType labelImageIndex;
-  labelImageIndex.Fill(0);
+  constexpr LabelImageIndexType labelImageIndex = { { 0 } };
 
   const typename LabelImageType::RegionType labelImageRegion(labelImageIndex, labelImageSize);
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -364,8 +364,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::Allocate()
   }
 
   // Allocate the label image status
-  LabelStatusIndexType index;
-  index.Fill(0);
+  constexpr LabelStatusIndexType index = { { 0 } };
 
   const LabelStatusRegionType region(index, inputImageSize);
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -87,9 +87,8 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(const Inp
   this->Superclass::SetInput(input);
 
   this->SetSize(this->GetInput()->GetLargestPossibleRegion().GetSize());
-  IndexType index;
-  index.Fill(0);
-  const RegionType region(index, this->GetSize());
+  constexpr IndexType index = { { 0 } };
+  const RegionType    region(index, this->GetSize());
 
   m_WorkingImage = RGBHCVImage::New();
   m_WorkingImage->SetLargestPossibleRegion(region);

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -83,7 +83,6 @@ VideoFileReader<TOutputVideoStream>::UpdateOutputInformation()
 
   // Set up largest possible spatial region
   SizeType      size;
-  IndexType     start;
   PointType     origin;
   SpacingType   spacing;
   DirectionType direction;
@@ -98,8 +97,8 @@ VideoFileReader<TOutputVideoStream>::UpdateOutputInformation()
       direction[j][i] = directionInI[j];
     }
   }
-  start.Fill(0);
-  const RegionType region(start, size);
+  constexpr IndexType start = { { 0 } };
+  const RegionType    region(start, size);
 
   VideoStreamPointer output = this->GetOutput();
 


### PR DESCRIPTION
Replaced lines of code which look like the following:

    IndexType index;
    index.Fill(0);

With:

    constexpr IndexType index = { { 0 } };

In accordance with C++ Core Guidelines, January 3, 2022:

"By default, make objects immutable"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rconst-immutable

"Declare an object `const` or `constexpr` unless you want to modify its
value later on"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-const