### PR TITLE
DOC: Fix possessive "its" usage

### DIFF
--- a/CMake/ITKModuleRemote.cmake
+++ b/CMake/ITKModuleRemote.cmake
@@ -178,7 +178,7 @@ function(itk_fetch_module _name _description)
   if(NOT DEFINED Module_${_name} )
     option(Module_${_name} "(Remote-${MODULE_COMPLIANCE_LEVEL}) ${_description}" OFF)
   else()
-    # If Module_${_name} is set manually, put it's value in the CACHE
+    # If Module_${_name} is set manually, put its value in the CACHE
     option(Module_${_name} "(Remote-${MODULE_COMPLIANCE_LEVEL}) ${_description}" ${Module_${_name}})
   endif()
 

--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -318,7 +318,7 @@ point-based SpatialObjects, it is the inherent space in which the Point coordina
 extracted from an Image, the parameters/coordinates of the SpatialObject are the space as the physical space of the source Image.   Any
 children of a SpatialObject are defined within the ObjectSpace of that parent SpatialObject.
 
-* ObjectToParent transform is the transform applied to move a SpatialObject within it's parent object's ObjectSpace.   An ObjectToParent
+* ObjectToParent transform is the transform applied to move a SpatialObject within its parent object's ObjectSpace.   An ObjectToParent
 transform is an invertible affine transform.  It is used to, for example, align a SpatialObject with a parent image (e.g., if an object
 is extracted from one ImageSpatialObject but then aligned to and made a child of another ImageSpatialObject as is needed for atlas-based
 image segmentation or for image-to-image registration).    If an object does not have a parent, then its ObjectToParent transform

--- a/Documentation/ReleaseNotes/3.12.md
+++ b/Documentation/ReleaseNotes/3.12.md
@@ -1165,10 +1165,10 @@ Changes in this Release
         STYLE: according to kwstyle.
 
     Code/Common/itkImageBase
-        BUG: 8490: ImageBase::Initialized method modifies it's MTime requiring pipelines to re-executed. Added InitializeBufferedRegion method which does not call Modify as a protected method
+        BUG: 8490: ImageBase::Initialized method modifies its MTime requiring pipelines to re-executed. Added InitializeBufferedRegion method which does not call Modify as a protected method
 
     Code/Common/itkImageBase
-        BUG: 8490: ImageBase::Initialized method modifies it's MTime requiring pipelines to re-executed. Added InitializeBufferedRegion method which does not call Modify as a protected method
+        BUG: 8490: ImageBase::Initialized method modifies its MTime requiring pipelines to re-executed. Added InitializeBufferedRegion method which does not call Modify as a protected method
 
     Code/Common/itkImageRandomNonRepeatingConstIteratorWithIndex
         STYLE: according to kwstyle.

--- a/Documentation/ReleaseNotes/3.18.md
+++ b/Documentation/ReleaseNotes/3.18.md
@@ -421,11 +421,11 @@ Changes in this Release
         STYLE: Removing unnecessary semicolon after the closing bracket of the destructor method.
 
     Code/Common/itkImageBase
-        BUG: 10008 added check to determin if the requested region was zero, if so then the filter is not called to be updated since no data is being requested. This enables streaming of JoinSeriesImageFilter with out having all of it's inputs being updated.
+        BUG: 10008 added check to determin if the requested region was zero, if so then the filter is not called to be updated since no data is being requested. This enables streaming of JoinSeriesImageFilter with out having all of its inputs being updated.
 
     Code/Common/itkImageBase
         BUG: Failure on my part to correctly apply: !(A || B) => !A && !B to disable warnings int UpdateOutputData
-        BUG: 10008 added check to determin if the requested region was zero, if so then the filter is not called to be updated since no data is being requested. This enables streaming of JoinSeriesImageFilter with out having all of it's inputs being updated.
+        BUG: 10008 added check to determin if the requested region was zero, if so then the filter is not called to be updated since no data is being requested. This enables streaming of JoinSeriesImageFilter with out having all of its inputs being updated.
 
     Code/Common/itkImageFunction
         ENH: Changed some signed long to a cleaner IndexValueType + replaced some hand constructed floor by itk::Math::Floor

--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -408,7 +408,7 @@ public:
    * a derived class is assumed to call its source's
    * ProcessObject::UpdateOutputInformation() which determines modified
    * times, LargestPossibleRegions, and any extra meta data like spacing,
-   * origin, etc. Default implementation simply call's it's source's
+   * origin, etc. Default implementation simply calls its source's
    * UpdateOutputInformation(). */
   virtual void
   UpdateOutputInformation();

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -127,7 +127,7 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateGaussianCoef
     if (coeff[i] < sum.GetSum() * NumericTraits<double>::epsilon())
     {
       // if the coeff is less then this value then the value of cap
-      // will not change, and it's will not contribute to the operator
+      // will not change, and it will not contribute to the operator
       itkWarningMacro("Kernel failed to accumulate to approximately one with current remainder "
                       << cap - sum.GetSum() << " and current coefficient " << coeff[i] << ".");
 

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -820,7 +820,7 @@ protected:
   DirectionType m_IndexToPhysicalPoint{ DirectionType::GetIdentity() };
   DirectionType m_PhysicalPointToIndex{ DirectionType::GetIdentity() };
 
-  /** Restores the buffered region to it's default state
+  /** Restores the buffered region to its default state
    *  This method does not call Modify because Initialization is
    *  called by ReleaseData and can not modify the MTime
    * \sa  ReleaseData, Initialize, SetBufferedRegion */

--- a/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
+++ b/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
@@ -107,7 +107,7 @@ ResourceProbesCollectorBase<TProbe>::Report(const char *   name,
   auto pos = this->m_Probes.find(tid);
   if (pos == this->m_Probes.end())
   {
-    os << "The probe \"" << name << "\" does not exist. It's report is not available" << std::endl;
+    os << "The probe \"" << name << "\" does not exist. Its report is not available" << std::endl;
     return;
   }
 
@@ -162,7 +162,7 @@ ResourceProbesCollectorBase<TProbe>::ExpandedReport(const char *   name,
   auto pos = this->m_Probes.find(tid);
   if (pos == this->m_Probes.end())
   {
-    os << "The probe \"" << name << "\" does not exist. It's report is not available" << std::endl;
+    os << "The probe \"" << name << "\" does not exist. Its report is not available" << std::endl;
     return;
   }
 

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -83,7 +83,7 @@ TBBMultiThreader::SingleMethodExecute()
   //   value onto active head of the FIFO stack for 'max_allowed_parallelism'
   //   type, and destruction of the "global_control" object pops
   //   the 'max_allowed_parallelism' type and returns the active value
-  //   to it's original state.
+  //   to its original state.
   tbb::global_control l_SingleMethodExecute_tbb_global_context(
     tbb::global_control::max_allowed_parallelism,
     std::min<int>(tbb_utility::get_default_num_threads(), m_MaximumNumberOfThreads));

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
@@ -45,7 +45,7 @@ namespace itk
  * and QEDual of \ref QuadEdgeMesh identical and would prevent any algorithm
  * requiring to distinguish those types (e.g. by relying on a
  * dynamic_cast<QEType*>) to be effective.  This justifies the existence of
- * last dummy template parameter and it's default value.
+ * last dummy template parameter and its default value.
  *
  * \author Alexandre Gouaillard, Leonardo Florez-Valencia, Eric Boix
  *

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
@@ -220,7 +220,7 @@ GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::GetNextBo
   // Definition: an edge is said to be a boundary edge when it is adjacent to
   // noface i.e. when at least one of the faces edge->GetLeft() or
   // edge->GetRight() is unset.  Definition: an point is said to be a boundary
-  // point when at least one of the edges of it's Onext() ring is a boundary
+  // point when at least one of the edges of its Onext() ring is a boundary
   // edge.
   //
   // Assume "this" edge belongs to a triangulation (i.e. it belongs to a QEMesh
@@ -446,7 +446,7 @@ GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::ReorderOn
   // b4.Onext() to be b1. In other terms, when considering the
   // additional information that b4.Onext() is b1, and before
   // building the triangle [P, A, B], we need to reorder
-  // the Onext() ring of P from it's current state
+  // the Onext() ring of P from its current state
   //    b1, b2, b3, b4, b5, b6, b1...
   // to an order coherent with the [P, A, B] request, i.e.
   //     b1, b2, b5, b6, b3, b4, b1...

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
@@ -216,7 +216,7 @@ public:
    * \warning This class only handles of the connectivity and is not aware
    *    of the geometry that lies at the \ref GeometricalQuadEdge level.
    *    It is strongly discouraged to use this method. Instead you should
-   *    use itk::QuadEdgeMesh::Splice it's geometry aware version.
+   *    use itk::QuadEdgeMesh::Splice its geometry aware version.
    *
    */
   // TODO fix this ref

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBoundaryEdgesMeshFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBoundaryEdgesMeshFunction.hxx
@@ -50,7 +50,7 @@ QuadEdgeMeshBoundaryEdgesMeshFunction<TMesh>::Evaluate(const InputType & mesh) c
   while (!boundaryList.empty())
   {
     // Pop the first edge of list and make sure it has no face
-    // on it's left [because we want to follow the boundary with
+    // on its left [because we want to follow the boundary with
     // GeometricalQuadEdge::Lnext()]:
     auto       b = boundaryList.begin();
     QEPrimal * bdryEdge = *b;
@@ -66,7 +66,7 @@ QuadEdgeMeshBoundaryEdgesMeshFunction<TMesh>::Evaluate(const InputType & mesh) c
       return ((OutputType) nullptr);
     }
 
-    // Store this edge as representative of it's Lnext() ring i.e.
+    // Store this edge as representative of its Lnext() ring i.e.
     // representative of the boundary:
     ResultList->push_back(bdryEdge);
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.hxx
@@ -77,7 +77,7 @@ QuadEdgeMeshEulerOperatorSplitFacetFunction<TMesh, TQEType>::Evaluate(QEType * h
   VertexRefType orgPid = h->GetDestination();
   VertexRefType destPid = g->GetDestination();
 
-  // Create an new isolated edge and set it's geometry:
+  // Create an new isolated edge and set its geometry:
   auto *   newEdge = new EdgeCellType;
   QEType * newEdgeGeom = newEdge->GetQEGeom();
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.h
@@ -24,7 +24,7 @@ namespace itk
 {
 /**
  * \class QuadEdgeMeshZipMeshFunction
- * \brief Fuse the incoming edge and it's Onext() follower (like a zipper does).
+ * \brief Fuse the incoming edge and its Onext() follower (like a zipper does).
  *
  * \ingroup QEMeshModifierFunctions
  * \ingroup ITKQuadEdgeMesh

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.hxx
@@ -111,7 +111,7 @@ QuadEdgeMeshZipMeshFunction<TMesh, TQEType>::Evaluate(QEType * e) -> OutputType
     }
   }
 
-  // Delete the Edge e and it's right face:
+  // Delete the Edge e and its right face:
   if (wasFacePresent)
   {
     this->m_Mesh->DeleteFace(e->GetRight());

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorFlipTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorFlipTest.cxx
@@ -115,7 +115,7 @@ itkQuadEdgeMeshEulerOperatorFlipTest(int, char *[])
     return EXIT_FAILURE;
   }
   std::cout << ".OK" << std::endl;
-  // Checking invariance (i.e. FlipEdge is it's own inverse):
+  // Checking invariance (i.e. FlipEdge is its own inverse):
   std::cout << "     "
             << "Check FlipEdge(FlipEdge()) invariance (possible for triangles).";
   if (!flipEdge->Evaluate(tempFlippedEdge))

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
@@ -485,8 +485,8 @@ itkQuadEdgeMeshEulerOperatorJoinVertexTest(int argc, char * argv[])
     }
    std::cout << "OK" << std::endl;
   // Just to make sure, we now consider a boundary edge with the surface
-  // on it's left (as opposed to the previous one which had the surface
-  // on it's right) i.e. we consider [2, 3]:
+  // on its left (as opposed to the previous one which had the surface
+  // on its right) i.e. we consider [2, 3]:
   //
   //   20 --------- 21 --------- 22 --------- 23 --------- 24
   //    |        __/ |        __/ |        __/ |        __/ |
@@ -538,7 +538,7 @@ itkQuadEdgeMeshEulerOperatorJoinVertexTest(int argc, char * argv[])
     }
    std::cout << "OK" << std::endl;
   // Now try with a wire edge (a pathological edge which has no face
-  // neither on it's left nor on it's right).
+  // neither on its left nor on its right).
   // Create this situation by manually deleting two faces sharing the
   // same edge which will thus become a wire edge.
   //

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -112,7 +112,7 @@ bool
 PipelineMonitorImageFilter<TImageType>::VerifyInputFilterBufferedRequestedRegions()
 {
   // we expect that the input filter's output image's buffered
-  // region is going to match it's requested region
+  // region is going to match its requested region
   bool         ret = true;
   unsigned int i;
   for (i = 0; i < m_UpdatedBufferedRegions.size(); ++i)
@@ -132,7 +132,7 @@ bool
 PipelineMonitorImageFilter<TImageType>::VerifyInputFilterMatchedRequestedRegions()
 {
   // we expect that the input filter's output image's buffered
-  // region is going to match it's requested region, which is going
+  // region is going to match its requested region, which is going
   // to match the requested region at the end of propagation
   //
   bool   ret = true;
@@ -158,7 +158,7 @@ PipelineMonitorImageFilter<TImageType>::VerifyInputFilterRequestedLargestRegion(
 {
   if (m_InputRequestedRegions.back() != m_UpdatedOutputLargestPossibleRegion)
   {
-    itkWarningMacro(<< "The input filter didn't set it's output request to the largest region");
+    itkWarningMacro(<< "The input filter didn't set its output request to the largest region");
     return false;
   }
   return true;

--- a/Modules/Core/Transform/include/itkIdentityTransform.h
+++ b/Modules/Core/Transform/include/itkIdentityTransform.h
@@ -189,7 +189,7 @@ public:
   }
   using Superclass::ComputeJacobianWithRespectToPosition;
 
-  /* Always returns true if not null, as an identity is it's own inverse */
+  /* Always returns true if not null, as an identity is its own inverse */
   bool
   GetInverse(Self * inverseTransform) const
   {

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -330,7 +330,7 @@ public:
   /** Set the transformation parameters and update internal transformation.
    * SetParameters gives the transform the option to set it's
    * parameters by keeping a reference to the parameters, or by
-   * copying.  To force the transform to copy it's parameters call
+   * copying.  To force the transform to copy its parameters call
    * SetParametersByValue.
    * \sa SetParametersByValue
    */

--- a/Modules/Core/Transform/test/itkBSplineTransformInitializerTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformInitializerTest2.cxx
@@ -37,7 +37,7 @@
 // constructs a second control point grid from a permuted version of the
 // given image (using the itkPermuteAxesImageFilter class) the second control
 // point grid will be oriented completely different from the first image
-// even though the image and it's permuted counterpart are situated in physical
+// even though the image and its permuted counterpart are situated in physical
 // domain precisely the same way.
 
 int

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
@@ -420,7 +420,7 @@ public:
 
   /** Set/Get the coordinate tolerance.
    *  This tolerance is used when comparing the space defined
-   *  by deformation fields and it's inverse to ensure they occupy the
+   *  by deformation fields and its inverse to ensure they occupy the
    *  same physical space.
    *
    * \sa ImageToImageFilterCommon::SetGlobalDefaultCoordinateTolerance
@@ -430,7 +430,7 @@ public:
 
   /** Set/Get the direction tolerance.
    *  This tolerance is used to when comparing the orientation of the
-   *  deformation fields and it's inverse to ensure they occupy the
+   *  deformation fields and its inverse to ensure they occupy the
    *  same physical space.
    *
    * \sa ImageToImageFilterCommon::SetGlobalDefaultDirectionTolerance

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -156,7 +156,7 @@ public:
    *
    * The combination of the OBB origin, OBB size and OBB direction (
    * principal axes ) defines a coordinate system suitable to use
-   * resample the OBB onto it's own image.
+   * resample the OBB onto its own image.
    */
   static constexpr AttributeType ORIENTED_BOUNDING_BOX_SIZE = 120;
 

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -571,7 +571,7 @@ GE5ImageIO::ModifyImageInformation()
     delete hdr2;
   }
   else
-  // If there is only one slice, the use it's origin
+  // If there is only one slice, the use its origin
   {
     this->SetOrigin(0, -m_ImageHeader->tlhcR);
     this->SetOrigin(1, -m_ImageHeader->tlhcA);

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1430,7 +1430,7 @@ NiftiImageIO ::WriteImageInformation()
   { // NOTE: LegacyMode is only valid for header extensions .hdr and .img
     if (this->GetUseLegacyModeForTwoFileWriting() == false)
     {
-      // This filter needs to write nifti files in it's default mode
+      // This filter needs to write nifti files in its default mode
       // , not default to legacy analyze files.
       this->m_NiftiImage->nifti_type = NIFTI_FTYPE_NIFTI1_2;
     }

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -183,7 +183,7 @@ oneTest(const std::string goodname, const std::string badname, const bool UseCom
   using AffineTransformTypeNotRegistered = typename itk::AffineTransform<TParametersValueType, 10>;
   auto affine = AffineTransformType::New();
 
-  // Set it's parameters
+  // Set its parameters
   {
     typename AffineTransformType::ParametersType p = affine->GetParameters();
     for (unsigned int i = 0; i < p.GetSize(); ++i)
@@ -252,7 +252,7 @@ oneTest(const std::string goodname, const std::string badname, const bool UseCom
   std::cout << "Creating bad writer" << std::endl;
   auto Bogus = AffineTransformTypeNotRegistered::New();
 
-  // Set it's parameters
+  // Set its parameters
   {
     typename AffineTransformType::ParametersType p = Bogus->GetParameters();
     for (unsigned int i = 0; i < p.GetSize(); ++i)

--- a/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
@@ -39,7 +39,7 @@ oneTest(const std::string & outputDirectory, const char * goodname, const char *
 
   itk::ObjectFactoryBase::RegisterFactory(itk::TxtTransformIOFactory::New());
 
-  // Set it's parameters
+  // Set its parameters
   {
     typename AffineTransformType::ParametersType p = affine->GetParameters();
     for (i = 0; i < p.GetSize(); ++i)
@@ -118,7 +118,7 @@ oneTest(const std::string & outputDirectory, const char * goodname, const char *
   std::cout << "Creating bad writer" << std::endl;
   auto Bogus = AffineTransformTypeNotRegistered::New();
 
-  // Set it's parameters
+  // Set its parameters
   {
     typename AffineTransformType::ParametersType p = Bogus->GetParameters();
     for (i = 0; i < p.GetSize(); ++i)

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -65,12 +65,12 @@ check_linear(const char * linear_transform)
 
   itk::ObjectFactoryBase::RegisterFactory(itk::MINCTransformIOFactory::New());
 
-  // Set it's parameters
+  // Set its parameters
   AffineTransformType::OutputVectorType rot_axis;
   rot_axis[0] = 0.0;
   rot_axis[1] = 1.0;
   rot_axis[2] = 0.0;
-  // Set it's parameters
+  // Set its parameters
   affine->Rotate3D(rot_axis, itk::Math::pi / 6);
 
   AffineTransformType::OutputVectorType offset;
@@ -482,12 +482,12 @@ check_composite(const char * transform_file)
 
   itk::ObjectFactoryBase::RegisterFactory(itk::MINCTransformIOFactory::New());
 
-  // Set it's parameters
+  // Set its parameters
   AffineTransformType::OutputVectorType rot_axis;
   rot_axis[0] = 0.0;
   rot_axis[1] = 1.0;
   rot_axis[2] = 0.0;
-  // Set it's parameters
+  // Set its parameters
   affine1->Rotate3D(rot_axis, itk::Math::pi / 6);
 
   AffineTransformType::OutputVectorType offset;

--- a/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
@@ -67,7 +67,7 @@ compare_linear(const char * linear_transform)
   rot_axis[0] = 1.0;
   rot_axis[1] = 1.0;
   rot_axis[2] = 0.0;
-  // Set it's parameters
+  // Set its parameters
   affine->Rotate3D(rot_axis, itk::Math::pi / 12);
 
   AffineTransformType::OutputVectorType offset;

--- a/Modules/IO/TransformMatlab/test/itkIOTransformMatlabTest.cxx
+++ b/Modules/IO/TransformMatlab/test/itkIOTransformMatlabTest.cxx
@@ -41,7 +41,7 @@ oneTest(const char * goodname, const char * badname)
   itk::ObjectFactoryBase::RegisterFactory(itk::MatlabTransformIOFactory::New());
 
 
-  // Set it's parameters
+  // Set its parameters
   {
     typename AffineTransformType::ParametersType p = affine->GetParameters();
     for (i = 0; i < p.GetSize(); ++i)
@@ -109,7 +109,7 @@ oneTest(const char * goodname, const char * badname)
   std::cout << "\n\nCreating bad writer" << std::endl;
   auto Bogus = AffineTransformTypeNotRegistered::New();
 
-  // Set it's parameters
+  // Set its parameters
   {
     typename AffineTransformType::ParametersType p = Bogus->GetParameters();
     for (i = 0; i < p.GetSize(); ++i)

--- a/Modules/IO/XML/include/itkXMLFile.h
+++ b/Modules/IO/XML/include/itkXMLFile.h
@@ -90,7 +90,7 @@ protected:
 /**
  *\class XMLReader
  * \brief template base class for an XMLReader
- * It's purpose really is just to define the simple interface for
+ * Its purpose really is just to define the simple interface for
  * extracting the object resulting from reading the XML File.
  * Since it doesn't define any of the pure virtual methods in XMLReaderBase,
  * It can't be instantiated by itself

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
@@ -35,7 +35,7 @@ namespace itk
  * constrained iterative k-means method.
  *
  * The original algorithm was designed to cluster on the joint
- * domain of the images index space and it's CIELAB color space. This
+ * domain of the images index space and its CIELAB color space. This
  * implementation works with images of arbitrary dimension
  * as well as scalar, single channel, images and most multi-component image
  * types including ITK's arbitrary length VectorImage.

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -195,7 +195,7 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
               {
                 if (inputImage->GetPixel(NeighborIndex) <= SeedValue)
                 {
-                  // Found a match, check it's class
+                  // Found a match, check its class
                   OutputImagePixelType NeighborClass = outputImage->GetPixel(NeighborIndex);
                   // We've never seen this pixel before, so add it to the open
                   // list

--- a/Modules/Video/Core/include/itkVideoToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkVideoToVideoFilter.hxx
@@ -194,7 +194,7 @@ VideoToVideoFilter<TInputVideoStream, TOutputVideoStream>::GenerateInputRequeste
   // Create input spatial regions for each frame of each input
   for (unsigned int i = 0; i < this->GetNumberOfInputs(); ++i)
   {
-    // Get the input and it's requeted temporal region
+    // Get the input and its requeted temporal region
     auto * input = dynamic_cast<InputVideoStreamType *>(this->ProcessObject::GetInput(i));
     if (!input)
     {

--- a/Utilities/ITKv5Preparation/replaceClassWithTypename.py
+++ b/Utilities/ITKv5Preparation/replaceClassWithTypename.py
@@ -54,7 +54,7 @@ early c++ compilers did not have a "typename" keyword, and "class" was
 repurposed for declaring template parameters. It was later discovered that this
 lead to ambiguity in some valid code constructs, and the "typename" key word
 was added. It is sometimes stated [2] that "typename" is marginally more
-expressive in it's intent and ITK should consistently use "typename" instead of
+expressive in its intent and ITK should consistently use "typename" instead of
 "class".
 
 [1] http://www.vtk.org/Wiki/ITK/Coding_Style_Guide

--- a/Wrapping/Generators/Python/itk/support/base.py
+++ b/Wrapping/Generators/Python/itk/support/base.py
@@ -62,7 +62,7 @@ def itk_load_swig_module(name: str, namespace=None):
     # find the module's name in sys.modules, or create a new module so named
     this_module = sys.modules.setdefault(swig_module_name, create_itk_module(name))
 
-    # if this library and it's template_feature instantiations have already been loaded
+    # if this library and its template_feature instantiations have already been loaded
     # into sys.modules, bail out after loading the defined symbols into
     # 'namespace'
     if hasattr(this_module, "__templates_loaded"):


### PR DESCRIPTION
This closes #2997. I have reviewed and updated ITK files (not third-party sources) to update the correct usage of the possessive "Its". Note that I have not checked the inverse if any "its" usage should really be the contraction "it's", but this forgetting of an apostrophe for the contraction is seemingly not a common mistake.

Possessive "Its"
Correct: "Its class does something"

Contraction "It's" means "It is"
Correct: "It's correct to assume that something"
