### PR TITLE
COMP: Initialized derivs array to zero.

### DIFF
--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -349,7 +349,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordRepType *            x,
   double                  tcol[Self::PointDimension3D];
   double                  d;
   PointType               pt;
-  CoordRepType            derivs[CellDimension3D * Self::NumberOfPoints];
+  CoordRepType            derivs[CellDimension3D * Self::NumberOfPoints]{ 0 };
   InterpolationWeightType weights[Self::NumberOfPoints];
 
   //  set initial position for Newton's method


### PR DESCRIPTION
This resolves the following uninitialized compiler warning for the HexahedronCell:

```
/localscratch/Users/kjweimer/ITK/Modules/Core/Common/include/itkHexahedronCell.hxx:385:34: warning: ‘derivs[16]’ is used uninitialized in this function [-Wuninitialized]
  385 |         tcol[j] += pt[j] * derivs[i + 2 * Self::NumberOfPoints];
      |                                  ^ 
``` 