### PR TITLE
STYLE: Code clean-up initializing local `ImageRegion` variables

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -210,10 +210,6 @@ template <typename TImage, typename TBoundaryCondition>
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::ConstNeighborhoodIterator()
 
 {
-  constexpr IndexType zeroIndex = { { 0 } };
-  SizeType            zeroSize;
-  zeroSize.Fill(0);
-
   m_Bound.Fill(0);
   m_Begin = nullptr;
   m_BeginIndex.Fill(0);
@@ -221,8 +217,6 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::ConstNeighborhoodIterator
   m_End = nullptr;
   m_EndIndex.Fill(0);
   m_Loop.Fill(0);
-  m_Region.SetIndex(zeroIndex);
-  m_Region.SetSize(zeroSize);
 
   m_WrapOffset.Fill(0);
 

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -129,17 +129,10 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::GetBoundingBoxAsImageRegion() co
 template <typename TImage>
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnlyIndex()
 {
-  constexpr IndexType zeroIndex = { { 0 } };
-
-  SizeType zeroSize;
-  zeroSize.Fill(0);
-
   m_Bound.Fill(0);
   m_BeginIndex.Fill(0);
   m_EndIndex.Fill(0);
   m_Loop.Fill(0);
-  m_Region.SetIndex(zeroIndex);
-  m_Region.SetSize(zeroSize);
 
   for (DimensionValueType i = 0; i < Dimension; ++i)
   {

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
@@ -73,11 +73,8 @@ ConstantBoundaryCondition<TInputImage, TOutputImage>::GetInputRequestedRegion(
 
   if (!cropped)
   {
-    constexpr IndexType index = { { 0 } };
-    SizeType            size;
-    size.Fill(0);
-    inputRequestedRegion.SetIndex(index);
-    inputRequestedRegion.SetSize(size);
+    inputRequestedRegion.SetIndex({ { 0 } });
+    inputRequestedRegion.SetSize({ { 0 } });
   }
 
   return inputRequestedRegion;

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -65,8 +65,7 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(co
     }
   }
 
-  constexpr itk::Index<NDimensions> zeroIndex = { { 0 } };
-  const RegionType                  region(zeroIndex, size);
+  const RegionType region(size);
   rval->SetLargestPossibleRegion(region);
   rval->SetBufferedRegion(region);
   rval->SetRequestedRegion(region);

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -197,12 +197,10 @@ template <typename TOutputImage>
 void
 RandomImageSource<TOutputImage>::GenerateOutputInformation()
 {
-  TOutputImage *      output;
-  constexpr IndexType index = { { 0 } };
-
+  TOutputImage * output;
   output = this->GetOutput(0);
 
-  const typename TOutputImage::RegionType largestPossibleRegion(index, this->m_Size);
+  const typename TOutputImage::RegionType largestPossibleRegion(this->m_Size);
   output->SetLargestPossibleRegion(largestPossibleRegion);
 
   output->SetSpacing(m_Spacing);

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -420,8 +420,7 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   // Extract the relevant part out of the image.
   // The input FFT image may be bigger than the desired output image
   // because specific sizes are required for the FFT calculation.
-  constexpr typename LocalOutputImageType::IndexType imageIndex = { { 0 } };
-  const typename LocalOutputImageType::RegionType    imageRegion(imageIndex, combinedImageSize);
+  const typename LocalOutputImageType::RegionType imageRegion(combinedImageSize);
   using ExtractType = itk::RegionOfInterestImageFilter<LocalOutputImageType, LocalOutputImageType>;
   auto extracter = ExtractType::New();
   extracter->SetInput(FFTFilter->GetOutput());

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -32,12 +32,8 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::FastMarchingImageFilter()
 {
   this->ProcessObject::SetNumberOfRequiredInputs(0);
 
-  OutputSizeType outputSize;
-  outputSize.Fill(16);
-  constexpr typename LevelSetImageType::IndexType outputIndex = { { 0 } };
-
-  m_OutputRegion.SetSize(outputSize);
-  m_OutputRegion.SetIndex(outputIndex);
+  m_OutputRegion.SetSize(OutputSizeType::Filled(16));
+  m_OutputRegion.SetIndex({ { 0 } });
 
   m_OutputOrigin.Fill(0.0);
   m_OutputSpacing.Fill(1.0);

--- a/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
@@ -78,9 +78,7 @@ RegionOfInterestImageFilter<TInputImage, TOutputImage>::GenerateOutputInformatio
   }
 
   // Set the output image size to the same value as the region of interest.
-  constexpr IndexType start = { { 0 } };
-
-  const RegionType region(start, m_RegionOfInterest.GetSize());
+  const RegionType region(m_RegionOfInterest.GetSize());
 
   // Copy Information without modification.
   outputPtr->CopyInformation(inputPtr);

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -244,8 +244,6 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   typename TOutputImage::SpacingType outputSpacing;
   typename TOutputImage::SizeType    outputSize;
 
-  constexpr typename TOutputImage::IndexType outputStartIndex = { { 0 } };
-
   for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {
     outputSpacing[i] = inputSpacing[i] * itk::Math::abs(m_Step[i]);
@@ -296,7 +294,7 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
   // Set region
 
-  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputStartIndex, outputSize);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputSize);
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 }

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -200,7 +200,6 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   // be large enough to accommodate left-over images.
   OutputSizeType outputSize;
   outputSize.Fill(1);
-  constexpr OutputIndexType outputIndex = { { 0 } };
 
   if (m_Layout[OutputImageDimension - 1] == 0)
   {
@@ -220,7 +219,6 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
   OutputSizeType tileSize;
   tileSize.Fill(1);
-  constexpr OutputIndexType tileIndex = { { 0 } };
 
   for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {
@@ -230,7 +228,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   // Determine the size of the output. Each "row" size is determined
   // and the maximum size for each "row" will be the size for that
   // dimension.
-  RegionType tileRegion(tileIndex, tileSize);
+  RegionType tileRegion(tileSize);
   m_TileImage->SetRegions(tileRegion);
   m_TileImage->Allocate();
 
@@ -347,7 +345,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     ++it;
   }
 
-  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputIndex, outputSize);
+  const typename TOutputImage::RegionType outputLargestPossibleRegion(outputSize);
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
 
   // Support VectorImages by setting number of components on output.

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -136,8 +136,7 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::GenerateOutputInformation()
 {
   ImagePointer outputPtr = this->GetOutput(0);
 
-  constexpr ImageIndexType index = { { 0 } };
-  const ImageRegionType    outputRegion(index, this->m_Size);
+  const ImageRegionType outputRegion(this->m_Size);
   outputPtr->SetLargestPossibleRegion(outputRegion);
   outputPtr->SetSpacing(this->m_Spacing);
   outputPtr->SetOrigin(this->m_Origin);

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -210,8 +210,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
     origin[i] = 0;
   }
 
-  constexpr typename OutputImageType::IndexType index = { { 0 } };
-  typename OutputImageType::RegionType          region;
+  typename OutputImageType::RegionType region;
 
   // If the size of the output has been explicitly specified, the filter
   // will set the output size to the explicit size, otherwise the size from the
@@ -237,7 +236,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
     itkExceptionMacro(<< "Currently, the user MUST specify an image size");
     // region.SetSize( size );
   }
-  region.SetIndex(index);
+  region.SetIndex({ { 0 } });
 
   OutputImage->SetLargestPossibleRegion(region); //
   OutputImage->SetBufferedRegion(region);        // set the region

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -238,9 +238,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
   output->SetMetaDataDictionary(thisDic);
   this->SetMetaDataDictionary(thisDic);
 
-  constexpr IndexType start = { { 0 } };
-
-  const ImageRegionType region(start, dimSize);
+  const ImageRegionType region(dimSize);
 
   // If a VectorImage, this requires us to set the
   // VectorLength before allocate

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -167,9 +167,8 @@ ImageSeriesReader<TOutputImage>::GenerateOutputInformation()
     // dimensions we are going to use
     this->m_NumberOfDimensionsInImage = ComputeMovingDimensionIndex(firstReader);
     dimSize[this->m_NumberOfDimensionsInImage] = static_cast<typename SizeType::SizeValueType>(numberOfFiles);
-    constexpr IndexType start = { { 0 } };
     largestRegion.SetSize(dimSize);
-    largestRegion.SetIndex(start);
+    largestRegion.SetIndex({ { 0 } });
 
     // Initialize the position to the origin returned by the reader
     unsigned int j;

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -33,11 +33,8 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::ImageToNeighborhoo
   m_Radius.Fill(0);
   m_NeighborIndexInternal.Fill(0);
 
-  constexpr NeighborhoodIndexType start = { { 0 } };
-  NeighborhoodSizeType            sz;
-  sz.Fill(0);
-  m_Region.SetIndex(start);
-  m_Region.SetSize(sz);
+  m_Region.SetIndex({ { 0 } });
+  m_Region.SetSize({ { 0 } });
   this->SetMeasurementVectorSize(1);
 }
 

--- a/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
@@ -79,8 +79,7 @@ public:
   void
   GenerateImages(const typename MovingImageType::SizeType & size)
   {
-    constexpr typename MovingImageType::IndexType index = { { 0 } };
-    const typename MovingImageType::RegionType    region(index, size);
+    const typename MovingImageType::RegionType region(size);
 
     m_MovingImage->SetLargestPossibleRegion(region);
     m_MovingImage->SetBufferedRegion(region);

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -235,19 +235,11 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
   }
 
   {
-    JointPDFRegionType jointPDFRegion;
-    {
-      // For the joint PDF define a region starting from {0,0}
-      // with size {m_NumberOfHistogramBins, this->m_NumberOfHistogramBins}.
-      // The dimension represents fixed image bin size
-      // and moving image bin size , respectively.
-      constexpr JointPDFIndexType jointPDFIndex = { { 0 } };
-      JointPDFSizeType            jointPDFSize;
-      jointPDFSize.Fill(m_NumberOfHistogramBins);
-
-      jointPDFRegion.SetIndex(jointPDFIndex);
-      jointPDFRegion.SetSize(jointPDFSize);
-    }
+    // For the joint PDF define a region starting from {0,0}
+    // with size {m_NumberOfHistogramBins, this->m_NumberOfHistogramBins}.
+    // The dimension represents fixed image bin size
+    // and moving image bin size , respectively.
+    const JointPDFRegionType jointPDFRegion(JointPDFSizeType::Filled(m_NumberOfHistogramBins));
 
     // By setting these values, the joint histogram physical locations will
     // correspond to intensity values.
@@ -283,23 +275,14 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
     // Not needed if this->m_UseExplicitPDFDerivatives
     this->m_PRatioArray.SetSize(0, 0);
     {
-      JointPDFDerivativesRegionType jointPDFDerivativesRegion;
-      {
-        // For the derivatives of the joint PDF define a region
-        // starting from {0,0,0} with size
-        // {m_NumberOfParameters,m_NumberOfHistogramBins,
-        // this->m_NumberOfHistogramBins}. The dimension represents
-        // transform parameters, fixed image parzen window index and
-        // moving image parzen window index, respectively.
-        constexpr JointPDFDerivativesIndexType jointPDFDerivativesIndex = { { 0 } };
-        JointPDFDerivativesSizeType            jointPDFDerivativesSize;
-        jointPDFDerivativesSize[0] = this->m_NumberOfParameters;
-        jointPDFDerivativesSize[1] = this->m_NumberOfHistogramBins;
-        jointPDFDerivativesSize[2] = this->m_NumberOfHistogramBins;
-
-        jointPDFDerivativesRegion.SetIndex(jointPDFDerivativesIndex);
-        jointPDFDerivativesRegion.SetSize(jointPDFDerivativesSize);
-      }
+      // For the derivatives of the joint PDF define a region
+      // starting from {0,0,0} with size
+      // {m_NumberOfParameters,m_NumberOfHistogramBins,
+      // this->m_NumberOfHistogramBins}. The dimension represents
+      // transform parameters, fixed image parzen window index and
+      // moving image parzen window index, respectively.
+      const JointPDFDerivativesRegionType jointPDFDerivativesRegion(JointPDFDerivativesSizeType{
+        { this->m_NumberOfParameters, this->m_NumberOfHistogramBins, this->m_NumberOfHistogramBins } });
 
       // Set the regions and allocate
       for (ThreadIdType workUnitID = 0; workUnitID < this->m_NumberOfWorkUnits; ++workUnitID)

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -147,13 +147,10 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
 
   // Allocate memory for the joint PDF.
 
-  // Instantiate a region, index, size
-  constexpr JointPDFIndexType jointPDFIndex = { { 0 } };
-  JointPDFSizeType            jointPDFSize;
+  // Instantiate a region
 
   // the jointPDF is of size NumberOfBins x NumberOfBins
-  jointPDFSize.Fill(m_NumberOfHistogramBins);
-  const JointPDFRegionType jointPDFRegion(jointPDFIndex, jointPDFSize);
+  const JointPDFRegionType jointPDFRegion(JointPDFSizeType::Filled(m_NumberOfHistogramBins));
 
   // Set the regions and allocate
   this->m_JointPDF->SetRegions(jointPDFRegion);
@@ -175,15 +172,12 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   this->m_FixedImageMarginalPDF = MarginalPDFType::New();
   this->m_MovingImageMarginalPDF = MarginalPDFType::New();
 
-  // Instantiate a region, index, size
+  // Instantiate a region
   using MarginalPDFRegionType = typename MarginalPDFType::RegionType;
   using MarginalPDFSizeType = typename MarginalPDFType::SizeType;
-  constexpr MarginalPDFIndexType marginalPDFIndex = { { 0 } };
-  MarginalPDFSizeType            marginalPDFSize;
 
   // the marginalPDF is of size NumberOfBins x NumberOfBins
-  marginalPDFSize.Fill(m_NumberOfHistogramBins);
-  const MarginalPDFRegionType marginalPDFRegion(marginalPDFIndex, marginalPDFSize);
+  const MarginalPDFRegionType marginalPDFRegion(MarginalPDFSizeType::Filled(m_NumberOfHistogramBins));
 
   // Set the regions and allocate
   this->m_FixedImageMarginalPDF->SetRegions(marginalPDFRegion);

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -83,11 +83,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
   // with size {m_NumberOfHistogramBins, this->m_NumberOfHistogramBins}.
   // The dimension represents fixed image bin size
   // and moving image bin size , respectively.
-  constexpr JointPDFIndexType jointPDFIndex = { { 0 } };
-  JointPDFSizeType            jointPDFSize;
-  jointPDFSize.Fill(this->m_MattesAssociate->m_NumberOfHistogramBins);
-
-  const JointPDFRegionType jointPDFRegion(jointPDFIndex, jointPDFSize);
+  const JointPDFRegionType jointPDFRegion(JointPDFSizeType::Filled(this->m_MattesAssociate->m_NumberOfHistogramBins));
 
   /*
    * Allocate memory for the joint PDF and joint PDF derivatives accumulator caches
@@ -169,24 +165,17 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
     this->m_MattesAssociate->m_JointPdfIndex1DArray.clear();
     this->m_MattesAssociate->m_LocalDerivativeByParzenBin.clear();
 
-    JointPDFDerivativesRegionType jointPDFDerivativesRegion;
-    {
-      // For the derivatives of the joint PDF define a region starting from
-      // {0,0,0}
-      // with size {m_NumberOfParameters,m_NumberOfHistogramBins,
-      // this->m_NumberOfHistogramBins}. The dimension represents transform
-      // parameters,
-      // fixed image parzen window index and moving image parzen window index,
-      // respectively.
-      constexpr JointPDFDerivativesIndexType jointPDFDerivativesIndex = { { 0 } };
-      JointPDFDerivativesSizeType            jointPDFDerivativesSize;
-      jointPDFDerivativesSize[0] = this->GetCachedNumberOfLocalParameters();
-      jointPDFDerivativesSize[1] = this->m_MattesAssociate->m_NumberOfHistogramBins;
-      jointPDFDerivativesSize[2] = this->m_MattesAssociate->m_NumberOfHistogramBins;
-
-      jointPDFDerivativesRegion.SetIndex(jointPDFDerivativesIndex);
-      jointPDFDerivativesRegion.SetSize(jointPDFDerivativesSize);
-    }
+    // For the derivatives of the joint PDF define a region starting from
+    // {0,0,0}
+    // with size {m_NumberOfParameters,m_NumberOfHistogramBins,
+    // this->m_NumberOfHistogramBins}. The dimension represents transform
+    // parameters,
+    // fixed image parzen window index and moving image parzen window index,
+    // respectively.
+    const JointPDFDerivativesRegionType jointPDFDerivativesRegion(
+      JointPDFDerivativesSizeType{ { this->GetCachedNumberOfLocalParameters(),
+                                     this->m_MattesAssociate->m_NumberOfHistogramBins,
+                                     this->m_MattesAssociate->m_NumberOfHistogramBins } });
 
     // Set the regions and allocate
     if (this->m_MattesAssociate->m_JointPDFDerivatives.IsNull() ||

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
@@ -137,9 +137,7 @@ ImageClassifierBase<TInputImage, TClassifiedImage>::Allocate()
 
   this->SetClassifiedImage(classifiedImage);
 
-  constexpr typename TClassifiedImage::IndexType classifiedImageIndex = { { 0 } };
-
-  const typename TClassifiedImage::RegionType classifiedImageRegion(classifiedImageIndex, inputImageSize);
+  const typename TClassifiedImage::RegionType classifiedImageRegion(inputImageSize);
 
   classifiedImage->SetLargestPossibleRegion(classifiedImageRegion);
   classifiedImage->SetBufferedRegion(classifiedImageRegion);

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -47,8 +47,7 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
   const TInputImage * input = this->GetInput();
 
   size = input->GetLargestPossibleRegion().GetSize();
-  constexpr IndexType index = { { 0 } };
-  const RegionType    region(index, size);
+  const RegionType region(size);
   output->SetLargestPossibleRegion(region);
   output->SetBufferedRegion(region);
   output->SetRequestedRegion(region);

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -174,11 +174,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::GetLabelledImage() -> Label
 
   LabelImagePointer labelImagePtr = LabelImageType::New();
 
-  typename LabelImageType::SizeType labelImageSize = this->GetInput()->GetBufferedRegion().GetSize();
-
-  constexpr LabelImageIndexType labelImageIndex = { { 0 } };
-
-  const typename LabelImageType::RegionType labelImageRegion(labelImageIndex, labelImageSize);
+  const typename LabelImageType::RegionType labelImageRegion(this->GetInput()->GetBufferedRegion().GetSize());
 
   labelImagePtr->SetLargestPossibleRegion(labelImageRegion);
   labelImagePtr->SetBufferedRegion(labelImageRegion);

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -364,9 +364,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::Allocate()
   }
 
   // Allocate the label image status
-  constexpr LabelStatusIndexType index = { { 0 } };
-
-  const LabelStatusRegionType region(index, inputImageSize);
+  const LabelStatusRegionType region(inputImageSize);
 
   m_LabelStatusImage = LabelStatusImageType::New();
   m_LabelStatusImage->SetLargestPossibleRegion(region);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -87,8 +87,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(const Inp
   this->Superclass::SetInput(input);
 
   this->SetSize(this->GetInput()->GetLargestPossibleRegion().GetSize());
-  constexpr IndexType index = { { 0 } };
-  const RegionType    region(index, this->GetSize());
+  const RegionType region(this->GetSize());
 
   m_WorkingImage = RGBHCVImage::New();
   m_WorkingImage->SetLargestPossibleRegion(region);

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -97,8 +97,7 @@ VideoFileReader<TOutputVideoStream>::UpdateOutputInformation()
       direction[j][i] = directionInI[j];
     }
   }
-  constexpr IndexType start = { { 0 } };
-  const RegionType    region(start, size);
+  const RegionType region(size);
 
   VideoStreamPointer output = this->GetOutput();
 


### PR DESCRIPTION
Made use of the fact that the default-constructor of `ImageRegion`
already properly zero-initializes its index and size. Preferred using
the `ImageRegion(const SizeType &)` constructor, rather than
`ImageRegion(const IndexType &, const SizeType &)`, when its index must
be zero-filled.

Follow-up to:
Pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3036
commit c46354736b0723ae4a7c66b03b6203c643754659
"STYLE: Declare local zero-filled `Index` variables `constexpr`"

Addresses a suggestion from Hans Johnson (@hjmjohnson) by passing `{ {0} }` directly
as index or size to `ImageRegion`.