### PR TITLE
BUG: Fix for incorrect number of cells in ConnectedRegionsMeshFilter output

### DIFF
--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -287,8 +287,8 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   CellsContainerConstIterator    cell;
   CellDataContainerConstIterator cellData;
   bool                           CellDataPresent = (nullptr != inCellData && !inCellData->empty());
-  InputMeshCellPointer           cellCopy; // need an autopointer to duplicate
-                                           // a cell
+  InputMeshCellPointer           cellCopy; // need an autopointer to duplicate a cell
+  int                            inserted_count = 0;
 
   if (m_ExtractionMode == PointSeededRegions || m_ExtractionMode == CellSeededRegions ||
       m_ExtractionMode == ClosestPointRegion || m_ExtractionMode == AllRegions)
@@ -302,7 +302,8 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
       if (m_Visited[cellId] >= 0)
       {
         cell->Value()->MakeCopy(cellCopy);
-        outCells->InsertElement(cellId, cellCopy.GetPointer());
+        outCells->InsertElement(inserted_count, cellCopy.GetPointer());
+        ++inserted_count;
         cellCopy.ReleaseOwnership(); // Pass cell ownership to output mesh
         if (CellDataPresent)
         {
@@ -340,8 +341,9 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
         if (inReg)
         {
           cell->Value()->MakeCopy(cellCopy);
-          outCells->InsertElement(cellId, cellCopy.GetPointer());
+          outCells->InsertElement(inserted_count, cellCopy.GetPointer());
           cellCopy.ReleaseOwnership(); // Pass cell ownership to output mesh
+          ++inserted_count;
           if (CellDataPresent)
           {
             outCellData->InsertElement(cellId, cellData->Value());
@@ -358,13 +360,15 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     {
       cellData = inCellData->Begin();
     }
+
     for (cell = inCells->Begin(); cell != inCells->End(); ++cell, ++cellId)
     {
       if (m_Visited[cellId] == static_cast<OffsetValueType>(largestRegionId))
       {
         cell->Value()->MakeCopy(cellCopy);
-        outCells->InsertElement(cellId, cellCopy.GetPointer());
+        outCells->InsertElement(inserted_count, cellCopy.GetPointer());
         cellCopy.ReleaseOwnership(); // Pass cell ownership to output mesh
+        ++inserted_count;
         if (CellDataPresent)
         {
           outCellData->InsertElement(cellId, cellData->Value());

--- a/Modules/Core/Mesh/itk-module.cmake
+++ b/Modules/Core/Mesh/itk-module.cmake
@@ -17,6 +17,7 @@ itk_module(ITKMesh
     ITKIOMesh
     ITKMetaIO
     ITKTransform
+    ITKThresholding
   DESCRIPTION
     "${DOCUMENTATION}"
 )

--- a/Modules/Core/Mesh/test/CMakeLists.txt
+++ b/Modules/Core/Mesh/test/CMakeLists.txt
@@ -26,6 +26,7 @@ itkMeshTest.cxx
 itkBinaryMask3DMeshSourceTest.cxx
 itkDynamicMeshTest.cxx
 itkExtractMeshConnectedRegionsTest.cxx
+itkConnectedRegionsMeshFilterTest2.cxx
 itkMeshFstreamTest.cxx
 itkMeshSourceGraftOutputTest.cxx
 itkMeshSpatialObjectIOTest.cxx
@@ -163,6 +164,9 @@ itk_add_test(NAME itkDynamicMeshTest
       COMMAND ITKMeshTestDriver itkDynamicMeshTest)
 itk_add_test(NAME itkExtractMeshConnectedRegionsTest
       COMMAND ITKMeshTestDriver itkExtractMeshConnectedRegionsTest)
+itk_add_test(NAME itkConnectedRegionsMeshFilterTest2
+      COMMAND ITKMeshTestDriver itkConnectedRegionsMeshFilterTest2
+              DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha} 15 2154)
 itk_add_test(NAME itkMeshFstreamTest
       COMMAND ITKMeshTestDriver itkMeshFstreamTest
               ${ITK_TEST_OUTPUT_DIR}/testMeshFstream.txt)

--- a/Modules/Core/Mesh/test/CMakeLists.txt
+++ b/Modules/Core/Mesh/test/CMakeLists.txt
@@ -25,7 +25,7 @@ itkWarpMeshFilterTest.cxx
 itkMeshTest.cxx
 itkBinaryMask3DMeshSourceTest.cxx
 itkDynamicMeshTest.cxx
-itkExtractMeshConnectedRegionsTest.cxx
+itkConnectedRegionsMeshFilterTest1.cxx
 itkConnectedRegionsMeshFilterTest2.cxx
 itkMeshFstreamTest.cxx
 itkMeshSourceGraftOutputTest.cxx
@@ -162,8 +162,8 @@ itk_add_test(NAME itkWarpMeshFilterTest
       COMMAND ITKMeshTestDriver itkWarpMeshFilterTest)
 itk_add_test(NAME itkDynamicMeshTest
       COMMAND ITKMeshTestDriver itkDynamicMeshTest)
-itk_add_test(NAME itkExtractMeshConnectedRegionsTest
-      COMMAND ITKMeshTestDriver itkExtractMeshConnectedRegionsTest)
+itk_add_test(NAME itkConnectedRegionsMeshFilterTest1
+      COMMAND ITKMeshTestDriver itkConnectedRegionsMeshFilterTest1)
 itk_add_test(NAME itkConnectedRegionsMeshFilterTest2
       COMMAND ITKMeshTestDriver itkConnectedRegionsMeshFilterTest2
               DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha} 15 2154)

--- a/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest1.cxx
+++ b/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest1.cxx
@@ -26,7 +26,7 @@
  * Test the mesh connectivity class.
  */
 int
-itkExtractMeshConnectedRegionsTest(int, char *[])
+itkConnectedRegionsMeshFilterTest1(int, char *[])
 {
 
   /**

--- a/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest2.cxx
+++ b/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest2.cxx
@@ -1,0 +1,113 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkImageFileReader.h"
+#include "itkConnectedRegionsMeshFilter.h"
+#include "itkTestingMacros.h"
+#include "itkBinaryThresholdImageFilter.h"
+#include "itkBinaryMask3DMeshSource.h"
+#include "itkMeshFileReader.h"
+#include <iostream>
+#include <string>
+
+int
+itkConnectedRegionsMeshFilterTest2(int argc, char * argv[])
+{
+
+  if (argc < 4)
+  {
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
+              << " Input NumberOfConnectedComponents NumberOfCellsInLargestComponent" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Check if input file is a mesh file or image file by checking presence of .vtk
+  std::string fileName(argv[1]);
+  std::size_t found = fileName.find(".vtk");
+  bool        imageSource = true;
+
+  if (found != std::string::npos)
+  {
+    imageSource = false;
+  }
+
+  const unsigned int Dimension = 3;
+  using MeshType = itk::Mesh<float, Dimension>;
+  MeshType::Pointer mesh;
+
+  if (imageSource)
+  {
+    // Read 3D Image to create test mesh
+    using PixelType = unsigned char;
+    using ImageType = itk::Image<PixelType, Dimension>;
+
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    auto reader = ReaderType::New();
+    reader->SetFileName(fileName);
+    ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+    auto inputImage = reader->GetOutput();
+
+    // Threshold the 3D image to get binary mask for mesh generation
+    using ThresholdFilterType = itk::BinaryThresholdImageFilter<ImageType, ImageType>;
+    auto thresholdFilter = ThresholdFilterType::New();
+    thresholdFilter->SetInput(inputImage);
+    thresholdFilter->SetLowerThreshold(0);
+    thresholdFilter->SetUpperThreshold(200);
+    thresholdFilter->SetOutsideValue(1);
+    thresholdFilter->SetInsideValue(0);
+    ITK_TRY_EXPECT_NO_EXCEPTION(thresholdFilter->Update());
+
+    auto outputImage = thresholdFilter->GetOutput();
+
+    // Get mesh from binary image
+    using MeshSourceType = itk::BinaryMask3DMeshSource<ImageType, MeshType>;
+
+    auto meshSource = MeshSourceType::New();
+    meshSource->SetInput(outputImage);
+    meshSource->SetObjectValue(1);
+    ITK_TRY_EXPECT_NO_EXCEPTION(meshSource->Update());
+    mesh = meshSource->GetOutput();
+  }
+  else
+  {
+    // Read the test mesh using MeshFileReader
+    using ReaderType = itk::MeshFileReader<MeshType>;
+    ReaderType::Pointer polyDataReader = ReaderType::New();
+    polyDataReader->SetFileName(fileName);
+    ITK_TRY_EXPECT_NO_EXCEPTION(polyDataReader->Update());
+    mesh = polyDataReader->GetOutput();
+  }
+
+  unsigned int numberOfConnectedComponents = std::stoi(argv[2]);
+  unsigned int numberOfCellsInLargestComponent = std::stoi(argv[3]);
+
+  // Check number of connected components in the mesh
+  using ConnectFilterType = itk::ConnectedRegionsMeshFilter<MeshType, MeshType>;
+  auto connectivityFilter = ConnectFilterType::New();
+  connectivityFilter->SetInput(mesh);
+  connectivityFilter->SetExtractionModeToAllRegions();
+  ITK_TRY_EXPECT_NO_EXCEPTION(connectivityFilter->Update());
+  ITK_TEST_EXPECT_TRUE(connectivityFilter->GetNumberOfExtractedRegions() == numberOfConnectedComponents);
+
+  // Check the number of cells in the largest connected component
+  connectivityFilter->SetExtractionModeToLargestRegion();
+  ITK_TRY_EXPECT_NO_EXCEPTION(connectivityFilter->Update());
+  ITK_TEST_EXPECT_TRUE(connectivityFilter->GetOutput()->GetNumberOfCells() == numberOfCellsInLargestComponent);
+
+  return EXIT_SUCCESS;
+}

--- a/Modules/Core/Mesh/wrapping/test/CMakeLists.txt
+++ b/Modules/Core/Mesh/wrapping/test/CMakeLists.txt
@@ -27,4 +27,5 @@ if(ITK_WRAP_PYTHON)
    EXPRESSION "instance = itk.SphereMeshSource.New()")
 
   itk_python_add_test(NAME itkMeshArrayPixelTypePythonTest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkMeshArrayPixelTypeTest.py)
+  itk_python_add_test(NAME itkConnectedRegionsMeshFilterPythonTest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkConnectedRegionsMeshFilterTest.py DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha} 15 2154)
 endif()

--- a/Modules/Core/Mesh/wrapping/test/itkConnectedRegionsMeshFilterTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkConnectedRegionsMeshFilterTest.py
@@ -1,0 +1,58 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+import itk
+import sys
+
+filename = sys.argv[1]
+numberOfConnectedComponents = int(sys.argv[2])
+numberOfCellsInLargestComponent = int(sys.argv[3])
+
+input_image = itk.imread(filename, itk.UC)
+
+# Threshold the 3D image to get binary mask for mesh generation
+threshold_filter = itk.BinaryThresholdImageFilter.IUC3IUC3.New()
+threshold_filter.SetInput(input_image)
+threshold_filter.SetLowerThreshold(0)
+threshold_filter.SetUpperThreshold(200)
+threshold_filter.SetOutsideValue(1)
+threshold_filter.SetInsideValue(0)
+threshold_filter.Update()
+
+output_image = threshold_filter.GetOutput()
+
+# Get mesh from binary image
+mesh_source = itk.BinaryMask3DMeshSource.IUC3MF3.New()
+mesh_source.SetInput(output_image)
+mesh_source.SetObjectValue(1)
+mesh_source.Update()
+mesh = mesh_source.GetOutput()
+
+# Check number of Connected Components in the mesh
+connectivity_filter = itk.ConnectedRegionsMeshFilter.MF3MF3.New()
+connectivity_filter.SetInput(mesh)
+connectivity_filter.SetExtractionModeToAllRegions()
+connectivity_filter.Update()
+
+assert connectivity_filter.GetNumberOfExtractedRegions() == numberOfConnectedComponents
+
+# Check the number of cells in the largest connected component
+connectivity_filter.SetExtractionModeToLargestRegion()
+connectivity_filter.Update()
+largest_component = connectivity_filter.GetOutput()
+
+assert largest_component.GetNumberOfCells() == numberOfCellsInLargestComponent


### PR DESCRIPTION
Fix for correct number of cells in the output mesh. A counter while inserting cell
is used. Earlier the same cell id as in original mesh is used and due to that while counting total number of cells it was
giving wrong result.

Also added a test in Python for testing number of connected components and count of cells in the
largest connected component. Serves the purpose of demonstrating the usage of ConnectedRegionsMeshFilter as well.


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [X] Added test (or behavior not changed)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
