### PR TITLE
STYLE: ConstNeighborhoodIterator in-class default member initializers

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -581,26 +581,26 @@ protected:
 
   /** The starting index for iteration within the itk::Image region
    * on which this ConstNeighborhoodIterator is defined. */
-  IndexType m_BeginIndex;
+  IndexType m_BeginIndex{ { 0 } };
 
   /** An array of upper looping boundaries used during iteration. */
-  IndexType m_Bound;
+  IndexType m_Bound{ { 0 } };
 
   /** A pointer to the first pixel in the iteration region. */
-  const InternalPixelType * m_Begin;
+  const InternalPixelType * m_Begin{ nullptr };
 
   /** The image on which iteration is defined. */
   typename ImageType::ConstWeakPointer m_ConstImage;
 
   /** A pointer to one past the last pixel in the iteration region. */
-  const InternalPixelType * m_End;
+  const InternalPixelType * m_End{ nullptr };
 
   /** The end index for iteration within the itk::Image region
    * on which this ConstNeighborhoodIterator is defined. */
-  IndexType m_EndIndex;
+  IndexType m_EndIndex{ { 0 } };
 
   /** Array of loop counters used during iteration. */
-  IndexType m_Loop;
+  IndexType m_Loop{ { 0 } };
 
   /** The region over which iteration is defined. */
   RegionType m_Region;
@@ -610,7 +610,7 @@ protected:
    *  An offset for each dimension is necessary to shift pointers when wrapping
    *  around region edges because region memory is not necessarily contiguous
    *  within the buffer. */
-  OffsetType m_WrapOffset;
+  OffsetType m_WrapOffset{ { 0 } };
 
   /** Pointer to the actual boundary condition that will be used.
    * By default this points to m_BoundaryCondition, but
@@ -619,8 +619,8 @@ protected:
   ImageBoundaryConditionPointerType m_BoundaryCondition;
 
   /** Denotes which of the iterators dimensional sides spill outside
-   * region of interest boundaries. */
-  mutable bool m_InBounds[Dimension];
+   * region of interest boundaries. By default `false` for each dimension. */
+  mutable bool m_InBounds[Dimension]{ false };
 
   /** Denotes if iterator is entirely within bounds */
   mutable bool m_IsInBounds{ false };

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -208,25 +208,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetBoundingBoxAsImageRegi
 
 template <typename TImage, typename TBoundaryCondition>
 ConstNeighborhoodIterator<TImage, TBoundaryCondition>::ConstNeighborhoodIterator()
-
 {
-  m_Bound.Fill(0);
-  m_Begin = nullptr;
-  m_BeginIndex.Fill(0);
-
-  m_End = nullptr;
-  m_EndIndex.Fill(0);
-  m_Loop.Fill(0);
-
-  m_WrapOffset.Fill(0);
-
-  for (DimensionValueType i = 0; i < Dimension; ++i)
-  {
-    m_InBounds[i] = false;
-  }
-
-  this->ResetBoundaryCondition();
-
   m_BoundaryCondition = &m_InternalBoundaryCondition;
 }
 

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -89,7 +89,7 @@ public:
   using NeighborIndexType = typename NeighborhoodType::NeighborIndexType;
 
   /** Default constructor */
-  ConstNeighborhoodIteratorWithOnlyIndex();
+  ConstNeighborhoodIteratorWithOnlyIndex() = default;
 
   /** Virtual destructor */
   ~ConstNeighborhoodIteratorWithOnlyIndex() override = default;
@@ -369,35 +369,35 @@ protected:
 
   /** The starting index for iteration within the itk::Image region
    * on which this ConstNeighborhoodIteratorWithOnlyIndex is defined. */
-  IndexType m_BeginIndex;
+  IndexType m_BeginIndex{ { 0 } };
 
   /** An array of upper looping boundaries used during iteration. */
-  IndexType m_Bound;
+  IndexType m_Bound{ { 0 } };
 
   /** The image on which iteration is defined. */
   typename ImageType::ConstPointer m_ConstImage;
 
   /** The end index for iteration within the itk::Image region
    * on which this ConstNeighborhoodIteratorWithOnlyIndex is defined. */
-  IndexType m_EndIndex;
+  IndexType m_EndIndex{ { 0 } };
 
   /** Array of loop counters used during iteration. */
-  IndexType m_Loop;
+  IndexType m_Loop{ { 0 } };
 
   /** The region over which iteration is defined. */
   RegionType m_Region;
 
   /** Denotes which of the iterators dimensional sides spill outside
-   * region of interest boundaries. */
-  mutable bool m_InBounds[Dimension];
+   * region of interest boundaries. By default `false` for each dimension. */
+  mutable bool m_InBounds[Dimension]{ false };
 
   /** Denotes if iterator is entirely within bounds */
-  mutable bool m_IsInBounds;
+  mutable bool m_IsInBounds{ false };
 
   /** Is the m_InBounds and m_IsInBounds variables up to date? Set to
    * false whenever the iterator is repositioned.  Set to true within
    * InBounds(). */
-  mutable bool m_IsInBoundsValid;
+  mutable bool m_IsInBoundsValid{ false };
 
   /** Lower threshold of in-bounds loop counter values. */
   IndexType m_InnerBoundsLow;
@@ -406,7 +406,7 @@ protected:
   IndexType m_InnerBoundsHigh;
 
   /** Does the specified region need to worry about boundary conditions? */
-  bool m_NeedToUseBoundaryCondition;
+  bool m_NeedToUseBoundaryCondition{ false };
 };
 
 template <typename TImage>

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -126,23 +126,6 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::GetBoundingBoxAsImageRegion() co
   return ans;
 }
 
-template <typename TImage>
-ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnlyIndex()
-{
-  m_Bound.Fill(0);
-  m_BeginIndex.Fill(0);
-  m_EndIndex.Fill(0);
-  m_Loop.Fill(0);
-
-  for (DimensionValueType i = 0; i < Dimension; ++i)
-  {
-    m_InBounds[i] = false;
-  }
-
-  m_IsInBounds = false;
-  m_IsInBoundsValid = false;
-  m_NeedToUseBoundaryCondition = false;
-}
 
 template <typename TImage>
 ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnlyIndex(const Self & orig)
@@ -173,10 +156,6 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ConstNeighborhoodIteratorWithOnl
                                                                                        const RegionType & region)
 {
   this->Initialize(radius, ptr, region);
-  for (unsigned int i = 0; i < Dimension; ++i)
-  {
-    m_InBounds[i] = false;
-  }
 }
 
 template <typename TImage>


### PR DESCRIPTION
Added in-class default member initializers to data members of
`ConstNeighborhoodIterator` and `ConstNeighborhoodIteratorWithOnlyIndex`.

Removed the apparently redundant `ResetBoundaryCondition()` call from
the default-constructor of `ConstNeighborhoodIterator`.

Defaulted (`= default`) the default-constructor of
`ConstNeighborhoodIteratorWithOnlyIndex`.

In accordance with C++ Core Guidelines, January 3, 2022: "Prefer
in-class initializers to member initializers in constructors for
constant initializers"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-in-class-initializer

Related Clang-Tidy check:
https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default-member-init.html