### PR TITLE
ENH: Add RTTI to `itk::DisplacementFieldToBSplineImageFilter`

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
@@ -54,6 +54,9 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(DisplacementFieldToBSplineImageFilter, ImageToImageFilter);
+
   /** Extract dimension from input image. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkDisplacementFieldToBSplineImageFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
@@ -85,6 +86,10 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   numberOfControlPoints.Fill(4);
 
   auto bspliner = BSplineFilterType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(bspliner, DisplacementFieldToBSplineImageFilter, ImageToImageFilter);
+
+
   bspliner->SetDisplacementField(field);
   bspliner->SetConfidenceImage(confidenceImage);
   bspliner->SetPointSet(pointSet);


### PR DESCRIPTION
Add run-time type information to
`itk::DisplacementFieldToBSplineImageFilter`.

Exercise the basic object methods using the
`ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)