### PR TITLE
ENH: Use `itkPrintSelfObjectMacro` to print objects that can be null

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
@@ -265,14 +265,7 @@ GradientVectorFlowImageFilter<TInputImage, TOutputImage, TInternalPixel>::PrintS
   os << indent << "NoiseLevel: " << m_NoiseLevel << std::endl;
   os << indent << "IterationNum: " << m_IterationNum << std::endl;
   os << indent << "TimeStep: " << m_TimeStep << std::endl;
-  if (m_LaplacianFilter)
-  {
-    os << indent << "LaplacianFilter: " << m_LaplacianFilter << std::endl;
-  }
-  else
-  {
-    os << indent << "LaplacianFilter: (None)" << std::endl;
-  }
+  itkPrintSelfObjectMacro(LaplacianFilter);
 }
 } // namespace itk
 

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -46,16 +46,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  if (m_MeshIO)
-  {
-    os << indent << "MeshIO: \n";
-    m_MeshIO->Print(os, indent.GetNextIndent());
-  }
-  else
-  {
-    os << indent << "MeshIO: (null)"
-       << "\n";
-  }
+  itkPrintSelfObjectMacro(MeshIO);
 
   os << indent << "UserSpecifiedMeshIO flag: " << m_UserSpecifiedMeshIO << "\n";
   os << indent << "FileName: " << m_FileName << "\n";


### PR DESCRIPTION
Use `itkPrintSelfObjectMacro` to print objects that can be null.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)