### PR TITLE
STYLE: Use the `itkNameOfTestExecutableMacro` macro in tests

### DIFF
--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBorderQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBorderQuadEdgeMeshFilterTest.cxx
@@ -19,6 +19,7 @@
 #include "itkMeshFileWriter.h"
 
 #include "itkBorderQuadEdgeMeshFilter.h"
+#include "itkTestingMacros.h"
 
 int
 itkBorderQuadEdgeMeshFilterTest(int argc, char * argv[])
@@ -26,16 +27,11 @@ itkBorderQuadEdgeMeshFilterTest(int argc, char * argv[])
   // ** ERROR MESSAGE AND HELP ** //
   if (argc < 5)
   {
-    std::cout << "Requires 4 arguments: " << std::endl;
-    std::cout << "1-Input file name " << std::endl;
-    std::cout << "2-Border Type" << std::endl;
-    std::cout << "   * 0: SQUARE" << std::endl;
-    std::cout << "   * 1: DISK" << std::endl;
-    std::cout << "3-Border Pick" << std::endl;
-    std::cout << "   * 0: LONGEST" << std::endl;
-    std::cout << "   * 1: LARGEST" << std::endl;
-    std::cout << "4-Output file name " << std::endl;
-
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputFilename borderType (0: SQUARE; 1: DISK)" << std::endl;
+    std::cerr << " borderPick (0: LONGEST; 1: LARGEST)" << std::endl;
+    std::cerr << " outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBorderQuadEdgeMeshFilterTest2.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBorderQuadEdgeMeshFilterTest2.cxx
@@ -30,11 +30,9 @@ itkBorderQuadEdgeMeshFilterTest2(int argc, char * argv[])
   // ** ERROR MESSAGE AND HELP ** //
   if (argc != 2)
   {
-    std::cout << "Requires 1 arguments: " << std::endl;
-    std::cout << "- Border Pick" << std::endl;
-    std::cout << "   * 0: LONGEST" << std::endl;
-    std::cout << "   * 1: LARGEST" << std::endl;
-
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " borderPick (0: LONGEST; 1: LARGEST)" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
@@ -21,17 +21,18 @@
 
 
 #include "itkCleanQuadEdgeMeshFilter.h"
+#include "itkTestingMacros.h"
+
 
 int
 itkCleanQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   // ** ERROR MESSAGE AND HELP ** //
-  if (argc < 3)
+  if (argc != 4)
   {
-    std::cout << "Requires 3 argument: " << std::endl;
-    std::cout << "1-Input file name " << std::endl;
-    std::cout << "2-Relative Tolerance " << std::endl;
-    std::cout << "3-Output file name " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputFilename relativeTolerance outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDelaunayConformingQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDelaunayConformingQuadEdgeMeshFilterTest.cxx
@@ -102,9 +102,9 @@ itkDelaunayConformingQuadEdgeMeshFilterTest(int argc, char * argv[])
   // ** ERROR MESSAGE AND HELP ** //
   if (argc < 3)
   {
-    std::cout << "Requires 2 arguments: " << std::endl;
-    std::cout << "1-Input file name " << std::endl;
-    std::cout << "2-Output file name " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputFilename outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
@@ -22,6 +22,7 @@
 #include "itkQuadEdgeMeshParamMatrixCoefficients.h"
 #include "itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraints.h"
 #include "VNLSparseLUSolverTraits.h"
+#include "itkTestingMacros.h"
 
 int
 itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char * argv[])
@@ -29,10 +30,9 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
   // ** ERROR MESSAGE AND HELP ** //
   if (argc != 4)
   {
-    std::cout << "Requires 3 argument: " << std::endl;
-    std::cout << "1-Input file name " << std::endl;
-    std::cout << "2-Output file name " << std::endl;
-    std::cout << "3-Use Mixed Area" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName outputFileName useMixedArea"
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
@@ -22,6 +22,7 @@
 #include "itkQuadEdgeMeshParamMatrixCoefficients.h"
 #include "itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.h"
 #include "VNLSparseLUSolverTraits.h"
+#include "itkTestingMacros.h"
 
 int
 itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest(int argc, char * argv[])
@@ -29,10 +30,9 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest(int argc, char 
   // ** ERROR MESSAGE AND HELP ** //
   if (argc != 4)
   {
-    std::cout << "Requires 3 argument: " << std::endl;
-    std::cout << "1-Input file name " << std::endl;
-    std::cout << "2-Output file name " << std::endl;
-    std::cout << "3-Use Mixed Area" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " inputFileName outputFileName useMixedArea"
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkQuadricDecimationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkQuadricDecimationQuadEdgeMeshFilterTest.cxx
@@ -28,12 +28,11 @@ int
 itkQuadricDecimationQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   // ** ERROR MESSAGE AND HELP ** //
-  if (argc < 3)
+  if (argc != 4)
   {
-    std::cout << "Requires 3 argument: " << std::endl;
-    std::cout << "1-Input file name " << std::endl;
-    std::cout << "2-Number of Faces " << std::endl;
-    std::cout << "3-Output file name " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputFilename numberOfFaces outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSmoothingQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSmoothingQuadEdgeMeshFilterTest.cxx
@@ -26,14 +26,12 @@ int
 itkSmoothingQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   // ** ERROR MESSAGE AND HELP ** //
-  if (argc < 4)
+  if (argc != 6)
   {
-    std::cout << "Requires 3 argument: " << std::endl;
-    std::cout << "1-Input file name " << std::endl;
-    std::cout << "2-Number Of Iterations " << std::endl;
-    std::cout << "3-Relaxation Factor" << std::endl;
-    std::cout << "4-Use Delaunay Conforming filter" << std::endl;
-    std::cout << "5-Output file name " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputFilename numberOfIterations relaxationFactor useDelaunayConformingFilter outputFilename"
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest.cxx
@@ -28,12 +28,11 @@ int
 itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   // ** ERROR MESSAGE AND HELP ** //
-  if (argc < 3)
+  if (argc != 4)
   {
-    std::cout << "Requires 3 argument: " << std::endl;
-    std::cout << "1-Input file name " << std::endl;
-    std::cout << "2-Number of Faces " << std::endl;
-    std::cout << "3-Output file name " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputFilename numberOfFaces outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest2.cxx
+++ b/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest2.cxx
@@ -20,26 +20,17 @@
 #include "itkDiscreteGaussianImageFilter.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
 
 template <typename TIMAGE>
 int
-itkDiscreteGaussianImageFilterTestA(int argc, char * argv[])
+itkDiscreteGaussianImageFilterTestA(const char * inputFilename, float sigma, const char * outputFilename)
 {
-  if (argc < 6)
-  {
-    std::cerr << "Missing Arguments" << std::endl;
-    return EXIT_FAILURE;
-  }
-
   using ImageType = TIMAGE;
-
-  const char * input_file_name = argv[3];
-  float        sigma = std::stod(argv[4]);
-  const char * output_file_name = argv[5];
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
-  reader->SetFileName(input_file_name);
+  reader->SetFileName(inputFilename);
 
   using FilterType = itk::DiscreteGaussianImageFilter<ImageType, ImageType>;
 
@@ -51,7 +42,7 @@ itkDiscreteGaussianImageFilterTestA(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<ImageType>;
 
   auto writer = WriterType::New();
-  writer->SetFileName(output_file_name);
+  writer->SetFileName(outputFilename);
   writer->SetInput(filter->GetOutput());
   writer->UseCompressionOn();
   writer->Update();
@@ -62,18 +53,12 @@ itkDiscreteGaussianImageFilterTestA(int argc, char * argv[])
 int
 itkDiscreteGaussianImageFilterTest2(int argc, char * argv[])
 {
-
-  if (argc < 3)
+  if (argc != 6)
   {
-    std::cerr << "Test DiscreteGaussianImageFilter working on both vector type and scalar type images on one 2D RGB "
-                 "image and 2D scalar image."
-              << std::endl
-              << "DiscreteGaussianImageFilterTest #image_dim #vector_dim #image_file_name #sigma #output_file_name"
-              << std::endl
-              << "e.g. test on a vector image: " << std::endl
-              << "DiscreteGaussianImageFilterTest 2 3 ShapesRGB.mha 4.5 ShapesRGB_Smoothed.mha" << std::endl
-              << "test on a scalar image: " << std::endl
-              << "DiscreteGaussianImageFilterTest 2 3 Shapes.mha 4.5 Shapes_Smoothed.mha" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv)
+              << " imageDimension vectorDimension inputFilename sigma outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -100,10 +85,10 @@ itkDiscreteGaussianImageFilterTest2(int argc, char * argv[])
   switch (vec_dim)
   {
     case 1:
-      itkDiscreteGaussianImageFilterTestA<ScalarImageType>(argc, argv);
+      itkDiscreteGaussianImageFilterTestA<ScalarImageType>(argv[3], std::stod(argv[4]), argv[5]);
       break;
     case 3:
-      itkDiscreteGaussianImageFilterTestA<VectorImageType>(argc, argv);
+      itkDiscreteGaussianImageFilterTestA<VectorImageType>(argv[3], std::stod(argv[4]), argv[5]);
       break;
   }
 

--- a/Modules/IO/XML/test/itkDOMTest2.cxx
+++ b/Modules/IO/XML/test/itkDOMTest2.cxx
@@ -30,13 +30,14 @@ It also demonstrates
 
 #include <iostream>
 #include "itkMacro.h"
+#include "itkTestingMacros.h"
 
 int
 itkDOMTest2(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "arguments expected: input.xml output.xml" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " input.xml output.xml" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/XML/test/itkDOMTest3.cxx
+++ b/Modules/IO/XML/test/itkDOMTest3.cxx
@@ -29,13 +29,14 @@ so it is important to supply the correct input during the testing process.
 
 #include <iostream>
 #include "itkMacro.h"
+#include "itkTestingMacros.h"
 
 int
 itkDOMTest3(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "arguments expected: test.xml" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " test.xml" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/XML/test/itkDOMTest4.cxx
+++ b/Modules/IO/XML/test/itkDOMTest4.cxx
@@ -26,13 +26,15 @@ because it is used here to verify the correctness of the query output.
 
 #include <iostream>
 #include "itkMacro.h"
+#include "itkTestingMacros.h"
 
 int
 itkDOMTest4(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "arguments expected: <test>.xml <QueryString> <GroundTruthPathString>" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <test>.xml <QueryString> <GroundTruthPathString>"
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/XML/test/itkDOMTest5.cxx
+++ b/Modules/IO/XML/test/itkDOMTest5.cxx
@@ -26,13 +26,14 @@ especially the change of working directory for reading/writing external files in
 
 #include <iostream>
 #include "itkMacro.h"
+#include "itkTestingMacros.h"
 
 int
 itkDOMTest5(int argc, char * argv[])
 {
   if (argc < 2)
   {
-    std::cerr << "arguments expected: <output>.DOMTestObject.xml" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <output>.DOMTestObject.xml" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/XML/test/itkDOMTest8.cxx
+++ b/Modules/IO/XML/test/itkDOMTest8.cxx
@@ -25,13 +25,14 @@ This program tests operations of itk::FileTools.
 #include <iostream>
 #include <string>
 #include "itkMacro.h"
+#include "itkTestingMacros.h"
 
 int
 itkDOMTest8(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "arguments expected: <OutputFolder> <OutputFile>" << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <OutputFolder> <OutputFile>" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToMalcolmSparseLevelSetAdaptorTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToMalcolmSparseLevelSetAdaptorTest.cxx
@@ -19,13 +19,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int
 itkBinaryImageToMalcolmSparseLevelSetAdaptorTest(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename outputFilename [debugPrint]" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToShiSparseLevelSetAdaptorTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToShiSparseLevelSetAdaptorTest.cxx
@@ -19,13 +19,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int
 itkBinaryImageToShiSparseLevelSetAdaptorTest(int argc, char * argv[])
 {
   if (argc < 3)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToWhitakerSparseLevelSetAdaptorTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToWhitakerSparseLevelSetAdaptorTest.cxx
@@ -19,13 +19,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
+#include "itkTestingMacros.h"
 
 int
 itkBinaryImageToWhitakerSparseLevelSetAdaptorTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename outputFilename statusFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseAdvectionImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseAdvectionImage2DTest.cxx
@@ -26,13 +26,18 @@
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 #include "itkLevelSetEvolution.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
 int
 itkSingleLevelSetDenseAdvectionImage2DTest(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv)
+              << " inputFilename seedPosition0 seedPosition1 initialDistance outputFilename derivativeSigma"
+              << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseImage2DTest.cxx
@@ -26,13 +26,17 @@
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 #include "itkLevelSetEvolution.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
 int
 itkSingleLevelSetDenseImage2DTest(int argc, char * argv[])
 {
   if (argc < 6)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv)
+              << " inputFilename seedPosition0 seedPosition1 initialDistance outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetMalcolmImage2DTest.cxx
@@ -26,13 +26,16 @@
 #include "itkLevelSetEvolution.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
 int
 itkSingleLevelSetMalcolmImage2DTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename numberOfIterations outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetShiImage2DTest.cxx
@@ -26,13 +26,16 @@
 #include "itkLevelSetEvolution.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
 int
 itkSingleLevelSetShiImage2DTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename numberOfIterations outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DTest.cxx
@@ -26,13 +26,16 @@
 #include "itkLevelSetEvolution.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
 int
 itkSingleLevelSetWhitakerImage2DTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename numberOfIterations outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetDenseImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetDenseImage2DTest.cxx
@@ -25,13 +25,17 @@
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
 #include "itkLevelSetEvolution.h"
+#include "itkTestingMacros.h"
 
 int
 itkTwoLevelSetDenseImage2DTest(int argc, char * argv[])
 {
-  if (argc < 6)
+  if (argc != 6)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv)
+              << " inputFilename seedPosition0 seedPosition1 initialDistance outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
@@ -26,13 +26,16 @@
 #include "itkLevelSetEvolution.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
 int
 itkTwoLevelSetMalcolmImage2DTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename numberOfIterations outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
@@ -26,13 +26,16 @@
 #include "itkLevelSetEvolution.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
 int
 itkTwoLevelSetShiImage2DTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename numberOfIterations outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
@@ -26,13 +26,16 @@
 #include "itkLevelSetEvolution.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h"
+#include "itkTestingMacros.h"
 
 int
 itkTwoLevelSetWhitakerImage2DTest(int argc, char * argv[])
 {
   if (argc < 4)
   {
-    std::cerr << "Missing Arguments" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFilename numberOfIterations outputFilename" << std::endl;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Use the `itkNameOfTestExecutableMacro` macro to get the test name
instead of hard-coding the test name.

Avoid directly passing the test's main method `argc` and `argv`
parameters to helper methods: provide only the required parameters.

Fix the argument count check where necessary, and prefer using exact
checks when no optional argument exists.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)