### PR TITLE
STYLE: Use recursive FFT registration for N to 1

### DIFF
--- a/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
+++ b/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
@@ -93,46 +93,34 @@ protected:
    * with distinct specialization.
    * Requires TFFTImageFilter to have the template signature <InputImageType, OutputImageType>.
    */
-  template <typename InputPixelType, typename OutputPixelType, size_t ImageDimension>
+  template <typename InputPixelType, typename OutputPixelType, unsigned int D, unsigned int... ImageDimensions>
   void
-  OverrideFFTImageFilterType()
+  OverrideFFTImageFilterType(const std::integer_sequence<unsigned int, D, ImageDimensions...> &)
   {
-    using InputImageType = Image<InputPixelType, ImageDimension>;
-    using OutputImageType = Image<OutputPixelType, ImageDimension>;
+    using InputImageType = Image<InputPixelType, D>;
+    using OutputImageType = Image<OutputPixelType, D>;
     this->RegisterOverride(typeid(typename TFFTImageFilter<InputImageType, OutputImageType>::Superclass).name(),
                            typeid(TFFTImageFilter<InputImageType, OutputImageType>).name(),
                            "FFT Image Filter Override",
                            true,
                            CreateObjectFunction<TFFTImageFilter<InputImageType, OutputImageType>>::New());
+    OverrideFFTImageFilterType<InputPixelType, OutputPixelType>(
+      std::integer_sequence<unsigned int, ImageDimensions...>{});
   }
+  template <typename InputPixelType, typename OutputPixelType>
+  void
+  OverrideFFTImageFilterType(const std::integer_sequence<unsigned int> &)
+  {}
 
   FFTImageFilterFactory()
   {
     OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<float>,
-                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<float>,
-                               1>();
-    OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<float>,
-                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<float>,
-                               2>();
-    OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<float>,
-                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<float>,
-                               3>();
-    OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<float>,
-                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<float>,
-                               4>();
+                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<float>>(
+      std::integer_sequence<unsigned int, 4, 3, 2, 1>{});
 
     OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<double>,
-                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>,
-                               1>();
-    OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<double>,
-                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>,
-                               2>();
-    OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<double>,
-                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>,
-                               3>();
-    OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<double>,
-                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>,
-                               4>();
+                               typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>>(
+      std::integer_sequence<unsigned int, 4, 3, 2, 1>{});
   }
 };
 


### PR DESCRIPTION
Instead of manually listing the FFT filter dimensions to regisiter,
use a recursive function templated over an integer. This in the future
can easily enable the maximum FFT dimension to be registered as some
type of configuration parameter.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
