### PR TITLE
BUG: Do not print non-self member variables in `PrintSelf`

### DIFF
--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -71,7 +71,6 @@ LBFGSBOptimizerv4 ::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 
   os << indent << "InitialPosition: " << m_InitialPosition << std::endl;
-  os << indent << "CurrentPosition: " << this->GetCurrentPosition() << std::endl;
 
   os << indent << "LowerBound: " << m_LowerBound << std::endl;
   os << indent << "UpperBound: " << m_UpperBound << std::endl;


### PR DESCRIPTION
Do not print non-self member variables in `PrintSelf`.

Fixes
```
  CurrentPosition: ITK test driver caught an ITK exception:

itk::ExceptionObject (0x55be11155e70)
Location: "unknown"
File: /home/vsts/work/1/s/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
Line: 201
Description: ITK ERROR: LBFGSBOptimizerv4(0x55be11150c00): m_Metric has not been assigned. Cannot get parameters.
```

raised in:
https://open.cdash.org/test/583682381

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)