### PR TITLE
STYLE: Use strongly typed enum class ostream overload in `PrintSelf`

### DIFF
--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
@@ -64,22 +64,7 @@ ObjectToObjectMetricBaseTemplate<TInternalComputationValueType>::PrintSelf(std::
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Value: " << m_Value << std::endl;
-  os << indent << "GradientSourceEnum: ";
-  switch (m_GradientSource)
-  {
-    case GradientSourceEnum::GRADIENT_SOURCE_FIXED:
-      os << "GRADIENT_SOURCE_FIXED";
-      break;
-    case GradientSourceEnum::GRADIENT_SOURCE_MOVING:
-      os << "GRADIENT_SOURCE_MOVING";
-      break;
-    case GradientSourceEnum::GRADIENT_SOURCE_BOTH:
-      os << "GRADIENT_SOURCE_BOTH";
-      break;
-    default:
-      itkExceptionMacro(<< "Unknown GradientSource.");
-  }
-  os << std::endl;
+  os << indent << "GradientSourceEnum: " << m_GradientSource << std::endl;
 }
 
 } // namespace itk


### PR DESCRIPTION
Rely on strongly typed enum class ostream operator overload for member
variable value printing purposes.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)