### PR TITLE
BUG: Synchronize the object factory across Python modules

### DIFF
--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -57,7 +57,7 @@ namespace itk
 
 // Forward reference because of private implementation
 class OverRideMap;
-struct ObjectFactoryBasePrivate;
+class ObjectFactoryBasePrivate;
 
 class ITKCommon_EXPORT ObjectFactoryBase : public Object
 {
@@ -237,6 +237,10 @@ public:
     (void)staticFactoryRegistration;
   }
 
+  /** Initialize the static members of ObjectFactoryBase.
+   *  RegisterInternal() and InitializeFactoryList() are called here. */
+  static void
+  Initialize();
 
 protected:
   void
@@ -277,11 +281,6 @@ private:
   /** Initialize the static list of Factories. */
   static void
   InitializeFactoryList();
-
-  /** Initialize the static members of ObjectFactoryBase.
-   *  RegisterInternal() and InitializeFactoryList() are called here. */
-  static void
-  Initialize();
 
   /** Register default factories which are not loaded at run time. */
   static void

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -31,6 +31,7 @@
 #  include "itkDynamicLoader.h"
 #endif
 #include "itkDirectory.h"
+#include "itkLightObject.h"
 #include "itkSingleton.h"
 #include "itkVersion.h"
 #include <cstring>
@@ -60,7 +61,7 @@ SynchronizeList(FactoryListType * output, FactoryListType * input, bool internal
       int curr = 0;
       for (auto & i : *output)
       {
-        if (i->GetNameOfClass() == factory->GetNameOfClass())
+        if (typeid(*i) == typeid(*factory))
         {
           pos = curr;
           break; // factory already in internal factories.
@@ -99,8 +100,9 @@ namespace itk
  *
  */
 
-struct ObjectFactoryBasePrivate
+class ObjectFactoryBasePrivate : public LightObject
 {
+public:
   ~ObjectFactoryBasePrivate()
   {
     itk::ObjectFactoryBase::UnRegisterAllFactories();
@@ -126,11 +128,12 @@ struct ObjectFactoryBasePrivate
 ObjectFactoryBasePrivate *
 ObjectFactoryBase::GetPimplGlobalsPointer()
 {
-  if (m_PimplGlobals == nullptr)
+  static auto                deleteLambda = []() { m_PimplGlobals->UnRegister(); };
+  ObjectFactoryBasePrivate * globalInstance =
+    Singleton<ObjectFactoryBasePrivate>("ObjectFactoryBase", SynchronizeObjectFactoryBase, deleteLambda);
+  if (globalInstance != m_PimplGlobals)
   {
-    static auto deleteLambda = []() { delete m_PimplGlobals; };
-    m_PimplGlobals =
-      Singleton<ObjectFactoryBasePrivate>("ObjectFactoryBase", SynchronizeObjectFactoryBase, deleteLambda);
+    SynchronizeObjectFactoryBase(globalInstance);
   }
   return m_PimplGlobals;
 }
@@ -867,15 +870,20 @@ ObjectFactoryBase::SynchronizeObjectFactoryBase(void * objectFactoryBasePrivate)
   // We keep track of the previoulsy registered factory in `previousObjectFactoryBasePrivate`
   // but assign the new pointer to `m_PimplGlobals` so factories can be
   // registered directly with the new pointer.
-  ObjectFactoryBasePrivate * previousObjectFactoryBasePrivate;
-  previousObjectFactoryBasePrivate = GetPimplGlobalsPointer();
-
+  ObjectFactoryBasePrivate * previousObjectFactoryBasePrivate = m_PimplGlobals;
   m_PimplGlobals = static_cast<ObjectFactoryBasePrivate *>(objectFactoryBasePrivate);
+
   if (m_PimplGlobals && previousObjectFactoryBasePrivate)
   {
     SynchronizeList(m_PimplGlobals->m_InternalFactories, previousObjectFactoryBasePrivate->m_InternalFactories, true);
     SynchronizeList(
       m_PimplGlobals->m_RegisteredFactories, previousObjectFactoryBasePrivate->m_RegisteredFactories, false);
+  }
+
+  if (m_PimplGlobals && previousObjectFactoryBasePrivate && previousObjectFactoryBasePrivate != m_PimplGlobals)
+  {
+    m_PimplGlobals->Register();
+    previousObjectFactoryBasePrivate->UnRegister();
   }
 }
 

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -670,7 +670,7 @@ ObjectFactoryBase::PrintSelf(std::ostream & os, Indent indent) const
   for (auto & i : *m_OverrideMap)
   {
     os << indent << "Class : " << i.first.c_str() << "\n";
-    os << indent << "Overriden with: " << i.second.m_OverrideWithName.c_str() << std::endl;
+    os << indent << "Overridden with: " << i.second.m_OverrideWithName.c_str() << std::endl;
     os << indent << "Enable flag: " << i.second.m_EnabledFlag << std::endl;
     os << indent << "Create object: " << i.second.m_CreateObject << std::endl;
     os << std::endl;

--- a/Modules/Filtering/Convolution/wrapping/test/CMakeLists.txt
+++ b/Modules/Filtering/Convolution/wrapping/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+list(FIND ITK_WRAP_IMAGE_DIMS 2 wrap_2_index)
+if(ITK_WRAP_PYTHON AND ITK_WRAP_float AND wrap_2_index GREATER -1)
+  itk_python_add_test(NAME PythonFFTConvolutionImageFilterTest
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/FFTConvolutionImageFilterTest.py
+            DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+            DATA{${ITK_DATA_ROOT}/Input/sobel_x.nii.gz}
+            ${ITK_TEST_OUTPUT_DIR}/PythonFFTConvolutionImageFilterTest.nrrd
+  )
+endif()

--- a/Modules/Filtering/Convolution/wrapping/test/FFTConvolutionImageFilterTest.py
+++ b/Modules/Filtering/Convolution/wrapping/test/FFTConvolutionImageFilterTest.py
@@ -1,0 +1,49 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+
+#
+#  Verify FFT-based convolution in Python.
+#
+#  This checks that necessary FFT factories have been registered by default
+#  and synchronized across modules so that they are available to filters in
+#  the FFTConvolution Python module.
+#
+#  See `itkObjectFactoryBase.h` and `itkSingletonIndex.h` for more information.
+#
+import itk
+from sys import argv
+import os
+
+itk.auto_progress(2)
+
+dim = 2
+PixelType = itk.F
+ImageType = itk.Image[PixelType, dim]
+ComplexImageType = itk.Image[itk.complex[PixelType], dim]
+
+input_image = itk.imread(argv[1], pixel_type=PixelType)
+kernel_image = itk.imread(argv[2], pixel_type=PixelType)
+
+assert type(input_image) == ImageType
+assert type(kernel_image) == ImageType
+
+# FFTConvolutionImageFilter will fail if FFT factories are not available in
+# ITKConvolution
+output_image = itk.fft_convolution_image_filter(input_image, kernel_image=kernel_image)
+
+itk.imwrite(output_image, argv[3])

--- a/Modules/Filtering/FFT/src/itkFFTWFFTImageFilterFactories.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWFFTImageFilterFactories.cxx
@@ -20,6 +20,7 @@
 #if defined(ITK_USE_FFTWF) || defined(ITK_USE_FFTWD)
 
 #  include "ITKFFTExport.h"
+
 #  include "itkFFTWComplexToComplex1DFFTImageFilter.h"
 #  include "itkFFTWComplexToComplexFFTImageFilter.h"
 #  include "itkFFTWForward1DFFTImageFilter.h"
@@ -37,93 +38,52 @@ namespace itk
 {
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
-
-static bool FFTWComplexToComplex1DFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            FFTWComplexToComplex1DFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     FFTWComplexToComplex1DFFTFactoryRegister__Private()
 {
-  if (!FFTWComplexToComplex1DFFTHasBeenRegistered)
-  {
-    FFTWComplexToComplex1DFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<FFTWComplexToComplex1DFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<FFTWComplexToComplex1DFFTImageFilter>>();
 }
 
-static bool FFTWComplexToComplexFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            FFTWComplexToComplexFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     FFTWComplexToComplexFFTFactoryRegister__Private()
 {
-  if (!FFTWComplexToComplexFFTHasBeenRegistered)
-  {
-    FFTWComplexToComplexFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<FFTWComplexToComplexFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<FFTWComplexToComplexFFTImageFilter>>();
 }
 
-static bool FFTWForward1DFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            FFTWForward1DFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     FFTWForward1DFFTFactoryRegister__Private()
 {
-  if (!FFTWForward1DFFTHasBeenRegistered)
-  {
-    FFTWForward1DFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<FFTWForward1DFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<FFTWForward1DFFTImageFilter>>();
 }
 
-static bool FFTWForwardFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            FFTWForwardFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     FFTWForwardFFTFactoryRegister__Private()
 {
-  if (!FFTWForwardFFTHasBeenRegistered)
-  {
-    FFTWForwardFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<FFTWForwardFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<FFTWForwardFFTImageFilter>>();
 }
 
-static bool FFTWHalfHermitianToRealInverseFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            FFTWHalfHermitianToRealInverseFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     FFTWHalfHermitianToRealInverseFFTFactoryRegister__Private()
 {
-  if (!FFTWHalfHermitianToRealInverseFFTHasBeenRegistered)
-  {
-    FFTWHalfHermitianToRealInverseFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<FFTWHalfHermitianToRealInverseFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<FFTWHalfHermitianToRealInverseFFTImageFilter>>();
 }
 
-static bool FFTWInverse1DFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            FFTWInverse1DFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     FFTWInverse1DFFTFactoryRegister__Private()
 {
-  if (!FFTWInverse1DFFTHasBeenRegistered)
-  {
-    FFTWInverse1DFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<FFTWInverse1DFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<FFTWInverse1DFFTImageFilter>>();
 }
 
-static bool FFTWInverseFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            FFTWInverseFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     FFTWInverseFFTFactoryRegister__Private()
 {
-  if (!FFTWInverseFFTHasBeenRegistered)
-  {
-    FFTWInverseFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<FFTWInverseFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<FFTWInverseFFTImageFilter>>();
 }
 
-static bool FFTWRealToHalfHermitianForwardFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            FFTWRealToHalfHermitianForwardFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     FFTWRealToHalfHermitianForwardFFTFactoryRegister__Private()
 {
-  if (!FFTWRealToHalfHermitianForwardFFTHasBeenRegistered)
-  {
-    FFTWRealToHalfHermitianForwardFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<FFTWRealToHalfHermitianForwardFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<FFTWRealToHalfHermitianForwardFFTImageFilter>>();
 }
 } // end namespace itk
 

--- a/Modules/Filtering/FFT/src/itkVnlFFTImageFilterFactories.cxx
+++ b/Modules/Filtering/FFT/src/itkVnlFFTImageFilterFactories.cxx
@@ -34,92 +34,51 @@ namespace itk
 {
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
-
-static bool VnlComplexToComplex1DFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            VnlComplexToComplex1DFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     VnlComplexToComplex1DFFTFactoryRegister__Private()
 {
-  if (!VnlComplexToComplex1DFFTHasBeenRegistered)
-  {
-    VnlComplexToComplex1DFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<VnlComplexToComplex1DFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<VnlComplexToComplex1DFFTImageFilter>>();
 }
 
-static bool VnlComplexToComplexFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            VnlComplexToComplexFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     VnlComplexToComplexFFTFactoryRegister__Private()
 {
-  if (!VnlComplexToComplexFFTHasBeenRegistered)
-  {
-    VnlComplexToComplexFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<VnlComplexToComplexFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<VnlComplexToComplexFFTImageFilter>>();
 }
 
-static bool VnlForward1DFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            VnlForward1DFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     VnlForward1DFFTFactoryRegister__Private()
 {
-  if (!VnlForward1DFFTHasBeenRegistered)
-  {
-    VnlForward1DFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<VnlForward1DFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<VnlForward1DFFTImageFilter>>();
 }
 
-static bool VnlForwardFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            VnlForwardFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     VnlForwardFFTFactoryRegister__Private()
 {
-  if (!VnlForwardFFTHasBeenRegistered)
-  {
-    VnlForwardFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<VnlForwardFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<VnlForwardFFTImageFilter>>();
 }
 
-static bool VnlHalfHermitianToRealInverseFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            VnlHalfHermitianToRealInverseFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     VnlHalfHermitianToRealInverseFFTFactoryRegister__Private()
 {
-  if (!VnlHalfHermitianToRealInverseFFTHasBeenRegistered)
-  {
-    VnlHalfHermitianToRealInverseFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<VnlHalfHermitianToRealInverseFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<VnlHalfHermitianToRealInverseFFTImageFilter>>();
 }
 
-static bool VnlInverse1DFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            VnlInverse1DFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     VnlInverse1DFFTFactoryRegister__Private()
 {
-  if (!VnlInverse1DFFTHasBeenRegistered)
-  {
-    VnlInverse1DFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<VnlInverse1DFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<VnlInverse1DFFTImageFilter>>();
 }
 
-static bool VnlInverseFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            VnlInverseFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     VnlInverseFFTFactoryRegister__Private()
 {
-  if (!VnlInverseFFTHasBeenRegistered)
-  {
-    VnlInverseFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<VnlInverseFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<VnlInverseFFTImageFilter>>();
 }
 
-static bool VnlRealToHalfHermitianForwardFFTHasBeenRegistered;
-void        ITKFFT_EXPORT
-            VnlRealToHalfHermitianForwardFFTFactoryRegister__Private()
+void ITKFFT_EXPORT
+     VnlRealToHalfHermitianForwardFFTFactoryRegister__Private()
 {
-  if (!VnlRealToHalfHermitianForwardFFTHasBeenRegistered)
-  {
-    VnlRealToHalfHermitianForwardFFTHasBeenRegistered = true;
-    FFTImageFilterFactory<VnlRealToHalfHermitianForwardFFTImageFilter>::RegisterOneFactory();
-  }
+  ObjectFactoryBase::RegisterInternalFactoryOnce<FFTImageFilterFactory<VnlRealToHalfHermitianForwardFFTImageFilter>>();
 }
 } // end namespace itk

--- a/Modules/Filtering/FFT/wrapping/test/CMakeLists.txt
+++ b/Modules/Filtering/FFT/wrapping/test/CMakeLists.txt
@@ -9,4 +9,8 @@ if(ITK_WRAP_PYTHON AND ITK_WRAP_float AND wrap_2_index GREATER -1)
       ${ITK_TEST_OUTPUT_DIR}/PythonFFTImageFilterRealTest.png
       ${ITK_TEST_OUTPUT_DIR}/PythonFFTImageFilterImaginaryTest.png
   )
+
+  itk_python_add_test(NAME PythonFFTObjectFactoryTest
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/FFTObjectFactoryTest.py
+  )
 endif()

--- a/Modules/Filtering/FFT/wrapping/test/FFTObjectFactoryTest.py
+++ b/Modules/Filtering/FFT/wrapping/test/FFTObjectFactoryTest.py
@@ -1,0 +1,52 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+
+#
+#  Verify FFT factories are registered and synchronized with ITKCommon
+#
+FFT_BASE_CLASSES = [
+    "ComplexToComplex1DFFTImageFilter",
+    "ComplexToComplexFFTImageFilter",
+    "Forward1DFFTImageFilter",
+    "ForwardFFTImageFilter",
+    "HalfHermitianToRealInverseFFTImageFilter",
+    "Inverse1DFFTImageFilter",
+    "InverseFFTImageFilter",
+    "RealToHalfHermitianForwardFFTImageFilter",
+]
+
+import itk
+
+itk.auto_progress(2)
+try:
+    itk.force_load()
+except ImportError as e:
+    pass
+
+# Verify ITKCommon factory list is not empty after loading all modules
+assert len(itk.ObjectFactoryBase.GetRegisteredFactories()) > 0
+
+# Verify that FFT factories are in the list
+overrides_found = list()
+for factory in itk.ObjectFactoryBase.GetRegisteredFactories():
+    for override_name in factory.GetClassOverrideNames():
+        for base_name in FFT_BASE_CLASSES:
+            if base_name not in overrides_found and base_name in override_name:
+                overrides_found.append(base_name)
+
+assert all([base_name in overrides_found for base_name in FFT_BASE_CLASSES])

--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -358,6 +358,7 @@ _ITKCommonPython_GetGlobalSingletonIndex_RETURN
 _ITKCommonPython_GetGlobalSingletonIndex
 _ITKCommonPython_GetGlobalSingletonIndex_PROTO
 {
+  itk::ObjectFactoryBase::Initialize();
   return itk::SingletonIndex::GetInstance();
 }
 
@@ -394,6 +395,7 @@ ${DO_NOT_WAIT_FOR_THREADS_DECLS}
 #endif
     }
   itk::SingletonIndex::SetInstance( _ITKCommonPython_GetGlobalSingletonIndex() );
+  itk::ObjectFactoryBase::Initialize();
   ${DO_NOT_WAIT_FOR_THREADS_CALLS}
 ")
     endif()

--- a/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
+++ b/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
@@ -19,6 +19,7 @@
 #define itkPyITKCommonCAPI_h
 
 #include "itkSingleton.h"
+#include "itkObjectFactoryBase.h"
 
 /* Header file for the _ITKCommonPython C API exposed via an PyCapsule.
  *


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

## Overview

Addresses #2909 to make the object factory behave as a singleton across Python modules.

## Background

The ITK object factory is used to provide alternate class implementations at runtime, such as adding support for new image/mesh/transform formats in `ImageRead()` and `ImageWrite()` or (more recently) swapping out backends for accelerated FFT computations. In theory "the object factory" should be treated as a global singleton within ITK, allowing any module or library to define class overrides that are then picked up at program execution by any other filter or class within ITK. In implementation "object factories" are defined and registered to a common `ObjectFactoryBase` object, which can then be accessed with `ObjectFactory<T>::Create()` to yield a subclass instance upcast to type `T`.

ITK Python wrappings introduce extra complexity into factory management where ITK is broken into individual modules such as ITKCommon, ITKFFT, ITKConvolution, etc. that are loaded on a lazy, as-needed basis. Along with this, Python modules maintain their own distinct versions of singleton objects with some behavioral differences across platforms, as we touched on with discussion in #2864. In practice both Windows and Linux were observed to initialize and maintain distinct, unsynchronized factory lists in their own individual modules.

This issue was previously confronted in [6770250](https://github.com/InsightSoftwareConsortium/ITK/commit/67702504e840a60bc968e2e09804879d9c6c5801), which added code for synchronizing global timestamps through `PyCapsule` objects in the Python C API, and then in [a66337e](https://github.com/InsightSoftwareConsortium/ITK/commit/a66337ec215c88f4900a2caf419b055483c42085), which extended synchronization so that all modules would point to a common map of singletons in the ITKCommon module (rather than a growing list of individual singleton references to synchronize). Unfortunately issues remained with object factory synchronization:
- Singleton synchronization executes after factory initialization, so each module initializes its own factory list before the singleton factory list is available;
- Object factory init caches a reference to the factory list, so each module continues to refer to its own individual list even though the common list is available;
- At exit each module attempts to destroy its referenced factory lists, so simply removing caching leads to memory management errors and segfaults.

## Changes

This modules introduces changes to appropriately synchronize object factory references across Python modules to behave as a singleton:
- `ObjectFactoryBase::Initialize()` is exposed and called immediately after `SingletonIndex` is synchronized. New functionality checks the cache against the global instance in ITKCommon and, if different, synchronizes the cache with the global instance before destroying the cache.
- The underlying factory list structure is made to inherit from `LightObject` to handle shared ownership among modules. In C++ projects the structure will have exactly one reference as a global singleton, while in Python the structure will have as many references as the number of modules with a synchronized object factory.
- Reverts [35df104](https://github.com/InsightSoftwareConsortium/ITK/commit/35df104b3eaf2fbd7c765d1e786db804bdf5fbbd) so that FFT factories are registered exactly once with C++ magic statics.

## Previous behavior

Object factory lists differ across modules. This can be verified by force loading all modules and then checking the list of factories in the ITKCommon module:
```py
> import itk
> itk.force_load()
> len(itk.ObjectFactoryBase.GetRegisteredFactories())
0
```

Unfortunately I'm not aware of a way to examine object factories in other modules from the console, as `itk.ObjectFactoryBase` always points to the object factory in ITKCommon. I've added more discussion in #2909 on debugging steps that can be used to trace through factories at load time.

## New behavior

Object factory lists are synchronized across modules.

```py
> import itk
> itk.force_load()
> len(itk.ObjectFactoryBase.GetRegisteredFactories())
38
```

`pdb` and `gdb` can be used to trace through and verify that each module references the same `SingletonIndex` and `ObjectFactoryBasePrivate` structures after load (see #2909).

## Other notes

- Closes #2909 .

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
