### PR TITLE
ENH: Use UTC timestamp in CONFIGURE_DATE.

### DIFF
--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -8,7 +8,7 @@ if( GIT_LOCAL_MODIFICATIONS MATCHES ".*files changed.*")
    set(GIT_LOCAL_MODIFICATIONS " (with uncommitted code modifications ${GIT_LOCAL_MODIFICATIONS} )")
 endif()
 
-string(TIMESTAMP CONFIGURE_DATE "%Y-%m-%d %H:%M")
+string(TIMESTAMP CONFIGURE_DATE "%Y-%m-%d %H:%M" UTC)
 
 ## MAKE_MAP_ENTRY is a macro to facilitate placing items in the itk::BuildInformation class
 ##                /--------------------------_---------------------------_-------------------------------------------------/


### PR DESCRIPTION
While cmake respects SOURCE_DATE_EPOCH, the timezone may still change
the embedded timestamp used.

https://reproducible-builds.org/docs/source-date-epoch/

Closes #3072. Forwarded by @tillea.