### PR TITLE
STYLE: Use the superclass name in itkTypeMacro

### DIFF
--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
@@ -57,7 +57,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiGradientOptimizerv4Template, Superclass);
+  itkTypeMacro(MultiGradientOptimizerv4Template, GradientDescentOptimizerv4Template);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "itkMultiGradientOptimizerv4.h"
+#include "itkTestingMacros.h"
 
 /**
  *  \class MultiGradientOptimizerv4TestMetric
@@ -328,6 +329,9 @@ itkMultiGradientOptimizerv4Test(int, char *[])
 
   // Declaration of a itkOptimizer
   auto itkOptimizer = OptimizerType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(itkOptimizer, MultiGradientOptimizerv4Template, GradientDescentOptimizerv4Template);
+
 
   // Declaration of the Metric
   auto                   metric = MultiGradientOptimizerv4TestMetric::New();


### PR DESCRIPTION
Use the superclass name instead of the `Superclass` alias in
`itkTypeMacro`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)