### PR TITLE
COMP: Fix spline order return type in getter macro

### DIFF
--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
@@ -110,7 +110,7 @@ public:
   void
   SetSplineOrder(unsigned int SplineOrder);
 
-  itkGetConstMacro(SplineOrder, int);
+  itkGetConstMacro(SplineOrder, unsigned int);
 
   /** Get the poles calculated for a given spline order. */
   itkGetConstMacro(SplinePoles, SplinePolesVectorType);

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -280,7 +280,7 @@ public:
   void
   SetSplineOrder(unsigned int SplineOrder);
 
-  itkGetConstMacro(SplineOrder, int);
+  itkGetConstMacro(SplineOrder, unsigned int);
 
   void
   SetNumberOfWorkUnits(ThreadIdType numThreads);

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
@@ -122,7 +122,7 @@ public:
   void
   SetSplineOrder(unsigned int SplineOrder);
 
-  itkGetConstMacro(SplineOrder, int);
+  itkGetConstMacro(SplineOrder, unsigned int);
 
   /** Set the input image.  This must be set by the user, after setting the
     spline order! */


### PR DESCRIPTION
Fix spline order return type in getter macro: use `unsigned int` to
match the type of the member variable.

Fixes:
```
In file included from
/home/vsts/work/1/s/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx:34:0:
/home/vsts/work/1/s/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx:
In function 'int test2DSpline()':
/home/vsts/work/1/s/Modules/Core/TestKernel/include/itkTestingMacros.h:220:44:
warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   CLANG_SUPPRESS_Wfloat_equal if (variable != command) CLANG_PRAGMA_POP \
/home/vsts/work/1/s/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx:341:5:
note: in expansion of macro 'ITK_TEST_SET_GET_VALUE'
     ITK_TEST_SET_GET_VALUE(splineOrder, interp->GetSplineOrder());
     ^~~~~~~~~~~~~~~~~~~~~~
```

raised for example in:
https://dev.azure.com/itkrobotlinux/ITK.Linux/_build/results?buildId=7551&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=f58be928-45a1-58e7-c1ad-04869565b3f4&l=6743

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)