### PR TITLE
BUG: Fix superclass name in itkTypeMacro

### DIFF
--- a/Modules/Core/Common/include/itkLogger.h
+++ b/Modules/Core/Common/include/itkLogger.h
@@ -44,7 +44,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(Logger, Object);
+  itkTypeMacro(Logger, LoggerBase);
 
   /** New macro for creation of through a Smart Pointer */
   itkNewMacro(Self);

--- a/Modules/IO/TransformBase/include/itkTransformFileReader.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileReader.h
@@ -41,6 +41,7 @@ public:
 
   /** SmartPointer type alias support */
   using Self = TransformFileReaderTemplate;
+  using Superclass = LightProcessObject;
   using Pointer = SmartPointer<Self>;
   using TransformType = TransformBaseTemplate<TParametersValueType>;
 
@@ -57,7 +58,6 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  using Superclass = Object;
   itkTypeMacro(TransformFileReaderTemplate, LightProcessObject);
 
   /** Set the filename  */


### PR DESCRIPTION
Fix superclass name in `itkTypeMacro`.

Fixes:
```
Name of Class = Logger
Name of Superclass = LoggerBase
Class name is correct
Superclass name provided does not match object's Superclass::NameOfClass
```

and
```
Name of Class = TransformFileReaderTemplate
Name of Superclass = Object
Class name is correct
Superclass name provided does not match object's Superclass::NameOfClass
```

raised for example in:
https://dev.azure.com/itkrobotwindow/ITK.Windows/_build/results?buildId=7533&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=77aad734-2057-5694-9ae2-ee1f5f26eae8&l=45617
and
https://dev.azure.com/itkrobotwindow/ITK.Windows/_build/results?buildId=7533&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=77aad734-2057-5694-9ae2-ee1f5f26eae8&l=120728

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)