### PR TITLE
BUG: Guarantee array contains enough elements for access in loop

### DIFF
--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.hxx
@@ -47,9 +47,9 @@ ThresholdLabelerImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateDa
 {
   auto size = static_cast<unsigned int>(m_Thresholds.size());
 
-  for (unsigned int i = 0; i < size - 1; ++i)
+  for (unsigned int i = 1; i < size; ++i)
   {
-    if (m_Thresholds[i] > m_Thresholds[i + 1])
+    if (m_Thresholds[i - 1] > m_Thresholds[i])
     {
       itkExceptionMacro(<< "Thresholds must be sorted.");
     }


### PR DESCRIPTION
Guarantee array contains enough elements for access in loop.
Specifically, the array must contain at least two elements so that the
sorting can take place.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)