### PR TITLE
ENH: Add `itkFactoryOnlyNewMacro` to selectively catch factory instantiation failures

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -343,6 +343,29 @@ namespace itk
   }                                                                       \
   ITK_MACROEND_NOOP_STATEMENT
 
+/** Define an object creation method throwing an exception if the object
+ * is not created through the object factory, for use in base classes that
+ * do not fully implement a backend. */
+#define itkFactoryOnlyNewMacro(x)  \
+  itkSimpleFactoryOnlyNewMacro(x); \
+  itkCreateAnotherMacro(x);        \
+  itkCloneMacro(x);                \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkSimpleFactoryOnlyNewMacro(x)                                                                 \
+  static auto New()->Pointer                                                                            \
+  {                                                                                                     \
+    Pointer smartPtr = itk::ObjectFactory<x>::Create();                                                 \
+    if (smartPtr == nullptr)                                                                            \
+    {                                                                                                   \
+      itkSpecializedMessageExceptionMacro(ExceptionObject,                                              \
+                                          "Object factory failed to instantiate " << typeid(x).name()); \
+    }                                                                                                   \
+    smartPtr->UnRegister();                                                                             \
+    return smartPtr;                                                                                    \
+  }                                                                                                     \
+  ITK_MACROEND_NOOP_STATEMENT
+
 /** Define two object creation methods.  The first method, New(),
  * creates an object from a class but does not defer to a factory.
  * The second method, CreateAnother(), creates an object from an

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -153,6 +153,7 @@ itkNeighborhoodTest.cxx
 itkVersorTest.cxx
 itkObjectFactoryTest2.cxx
 itkObjectFactoryTest3.cxx
+itkObjectFactoryOnlyNewTest.cxx
 itkMinimumMaximumImageCalculatorTest.cxx
 itkSliceIteratorTest.cxx
 itkImageRegionExclusionIteratorWithIndexTest.cxx
@@ -462,6 +463,7 @@ set_tests_properties(itkObjectFactoryTest2 PROPERTIES RUN_SERIAL 1)
 endif()
 
 itk_add_test(NAME itkObjectFactoryTest3 COMMAND ITKCommon2TestDriver itkObjectFactoryTest3)
+itk_add_test(NAME itkObjectFactoryOnlyNewTest COMMAND ITKCommon2TestDriver itkObjectFactoryOnlyNewTest)
 itk_add_test(NAME itkPeriodicBoundaryConditionTest COMMAND ITKCommon2TestDriver itkPeriodicBoundaryConditionTest)
 itk_add_test(NAME itkPhasedArray3DSpecialCoordinatesImageTest COMMAND ITKCommon1TestDriver itkPhasedArray3DSpecialCoordinatesImageTest)
 itk_add_test(NAME itkPriorityQueueTest COMMAND ITKCommon1TestDriver itkPriorityQueueTest)

--- a/Modules/Core/Common/test/itkObjectFactoryOnlyNewTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryOnlyNewTest.cxx
@@ -1,0 +1,202 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Test for interface class constructor override with
+// implementation class constructor through object factory methods
+
+#include "itkVersion.h"
+#include "itkImage.h"
+#include "itkTestingMacros.h"
+#include <list>
+
+// Define an interface class with no backend
+template <typename TPixel, unsigned int VImageDimension = 2>
+class TestImageInterfaceClass : public itk::Image<TPixel, VImageDimension>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(TestImageInterfaceClass);
+
+  /** Standard class type aliases.   */
+  using Self = TestImageInterfaceClass;
+  using Superclass = itk::Image<TPixel, VImageDimension>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
+
+  /** Method for creation through the object factory.*/
+  itkFactoryOnlyNewMacro(TestImageInterfaceClass);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(TestImageInterfaceClass, Image);
+
+  // Methods from itkObject
+  ~TestImageInterfaceClass() override = default;
+  TestImageInterfaceClass() = default;
+};
+
+// Define an implementation subclass
+template <typename TPixel, unsigned int VImageDimension = 2>
+class TestImageImplementationClass : public TestImageInterfaceClass<TPixel, VImageDimension>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(TestImageImplementationClass);
+
+  /** Standard class type aliases.   */
+  using Self = TestImageImplementationClass;
+  using Superclass = TestImageImplementationClass<TPixel, VImageDimension>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
+
+  /** Method for creation through the object factory. */
+  itkFactorylessNewMacro(TestImageImplementationClass);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(TestImageImplementationClass, TestImage);
+
+  // Methods from itkObject
+  ~TestImageImplementationClass() override = default;
+  TestImageImplementationClass() = default;
+};
+
+// Define factory to register implementation override for interface
+class TestFactory : public itk::ObjectFactoryBase
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(TestFactory);
+
+  using Self = TestFactory;
+  using Superclass = itk::ObjectFactoryBase;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
+
+  /** Class methods used to interface with the registered factories. */
+  const char *
+  GetITKSourceVersion() const override
+  {
+    return ITK_SOURCE_VERSION;
+  }
+  const char *
+  GetDescription() const override
+  {
+    return "A Test Factory";
+  }
+
+  /** Method for class instantiation. */
+  itkFactorylessNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(TestFactory, itk::ObjectFactoryBase);
+
+  /** Register one factory of this type  */
+  static void
+  RegisterOneFactory()
+  {
+    auto factory = TestFactory::New();
+    itk::ObjectFactoryBase::RegisterFactory(factory);
+  }
+
+private:
+  TestFactory()
+  {
+    this->RegisterOverride(typeid(TestImageInterfaceClass<short, 2>).name(),
+                           typeid(TestImageImplementationClass<short, 2>).name(),
+                           "Test image factory override",
+                           true,
+                           itk::CreateObjectFunction<TestImageImplementationClass<short, 2>>::New());
+  }
+};
+
+using myPointer = itk::Image<short, 2>::Pointer;
+bool
+TestNewImage(myPointer v, const char * expectedClassName)
+{
+  std::cout << "v->GetNameOfClass(): " << v->GetNameOfClass();
+  std::cout << ", expectedClassName: " << expectedClassName << std::endl;
+  if (strcmp(v->GetNameOfClass(), expectedClassName) != 0)
+  {
+    std::cout << "Test Failed" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+
+int
+itkObjectFactoryOnlyNewTest(int, char *[])
+{
+  // Verify that interface class cannot be instantiated
+  // if no implementation factory is registered
+  using PixelType = short;
+  const size_t Dimension = 2;
+  using TestImageInterfaceType = TestImageInterfaceClass<PixelType, Dimension>;
+  ITK_TRY_EXPECT_EXCEPTION(TestImageInterfaceType::New());
+
+  // Register implementation override
+  auto factory = TestFactory::New();
+  itk::ObjectFactoryBase::RegisterFactory(factory);
+
+  // Log all registered factories
+  std::list<itk::ObjectFactoryBase *> factories = itk::ObjectFactoryBase::GetRegisteredFactories();
+  std::cout << "----- Registered factories -----" << std::endl;
+  for (auto & oneFactory : factories)
+  {
+    std::cout << "  Factory version: " << oneFactory->GetITKSourceVersion() << std::endl
+              << "  Factory description: " << oneFactory->GetDescription() << std::endl;
+
+    std::list<std::string>                 overrides = oneFactory->GetClassOverrideNames();
+    std::list<std::string>                 names = oneFactory->GetClassOverrideWithNames();
+    std::list<std::string>                 descriptions = oneFactory->GetClassOverrideDescriptions();
+    std::list<bool>                        enableflags = oneFactory->GetEnableFlags();
+    std::list<std::string>::const_iterator n = names.begin();
+    std::list<std::string>::const_iterator d = descriptions.begin();
+    std::list<bool>::const_iterator        e = enableflags.begin();
+    for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
+    {
+      std::cout << "    Override " << *o << " with " << *n << std::endl
+                << "      described as \"" << *d << "\"" << std::endl
+                << "      enabled " << *e << std::endl;
+    }
+  }
+  std::cout << "----- -----" << std::endl;
+
+  TestImageInterfaceType::Pointer v;
+  ITK_TRY_EXPECT_NO_EXCEPTION(v = TestImageInterfaceType::New());
+  factory->Print(std::cout);
+  if (!TestNewImage(v, "TestImageImplementationClass"))
+  {
+    return EXIT_FAILURE;
+  }
+
+  // disable interface class creation through the factory
+  factory->Disable(typeid(TestImageInterfaceType).name());
+  ITK_TRY_EXPECT_EXCEPTION(v = TestImageInterfaceType::New());
+
+  // re-enable interface class creation through the factory
+  using TestImageImplementationType = TestImageImplementationClass<PixelType, Dimension>;
+  factory->SetEnableFlag(true, typeid(TestImageInterfaceType).name(), typeid(TestImageImplementationType).name());
+  ITK_TRY_EXPECT_NO_EXCEPTION(v = TestImageInterfaceType::New());
+  if (!TestNewImage(v, "TestImageImplementationClass"))
+  {
+    return EXIT_FAILURE;
+  }
+
+  // remove factory and verify interface class cannot be created
+  itk::ObjectFactoryBase::UnRegisterFactory(factory);
+  ITK_TRY_EXPECT_EXCEPTION(v = TestImageInterfaceType::New());
+
+  return EXIT_SUCCESS;
+}

--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
@@ -22,8 +22,7 @@
 
 #include "itkImage.h"
 #include "itkImageToImageFilter.h"
-
-#include "itkFFTImageFilterFactory.h"
+#include "itkMacro.h"
 
 namespace itk
 {
@@ -66,8 +65,7 @@ public:
    *
    * Default implementation is VnlFFT1D.
    */
-  static Pointer
-  New();
+  itkFactoryOnlyNewMacro(Self);
 
   /** Transform direction. */
   using TransformDirectionType = enum { DIRECT = 1, INVERSE };

--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.hxx
@@ -24,23 +24,6 @@
 
 namespace itk
 {
-
-template <typename TInputImage, typename TOutputImage>
-typename ComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::Pointer
-ComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::New()
-{
-  Pointer smartPtr = ObjectFactory<Self>::Create();
-
-  if (smartPtr.IsNotNull())
-  {
-    // Decrement ITK SmartPointer produced from object factory
-    smartPtr->UnRegister();
-  }
-
-  return smartPtr;
-}
-
-
 template <typename TInputImage, typename TOutputImage>
 ComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ComplexToComplex1DFFTImageFilter()
   : m_Direction(0)

--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
@@ -19,6 +19,7 @@
 #define itkComplexToComplexFFTImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "itkMacro.h"
 #include "ITKFFTExport.h"
 #include <complex>
 
@@ -97,10 +98,9 @@ public:
   /** Customized object creation methods that support configuration-based
    * selection of FFT implementation.
    *
-   * Default implementation is FFTW.
+   * Default implementation is VnlFFT.
    */
-  static Pointer
-  New();
+  itkFactoryOnlyNewMacro(Self);
 
   using TransformDirectionEnum = ComplexToComplexFFTImageFilterEnums::TransformDirection;
 #if !defined(ITK_LEGACY_REMOVE)

--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.hxx
@@ -37,22 +37,6 @@ namespace itk
 {
 
 template <typename TInputImage, typename TOutputImage>
-auto
-ComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
-{
-  Pointer smartPtr = ObjectFactory<Self>::Create();
-
-  if (smartPtr.IsNotNull())
-  {
-    // Correct extra reference count from ObjectFactory<Self>::Create()
-    smartPtr->UnRegister();
-  }
-
-  return smartPtr;
-}
-
-
-template <typename TInputImage, typename TOutputImage>
 void
 ComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
@@ -21,6 +21,7 @@
 #include <complex>
 
 #include "itkImageToImageFilter.h"
+#include "itkMacro.h"
 
 namespace itk
 {
@@ -65,8 +66,7 @@ public:
    *
    * Default implementation is VnlFFT1D.
    */
-  static Pointer
-  New();
+  itkFactoryOnlyNewMacro(Self);
 
   /** Get the direction in which the filter is to be applied. */
   itkGetConstMacro(Direction, unsigned int);

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.hxx
@@ -24,22 +24,6 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
-class VnlForward1DFFTImageFilter;
-
-template <typename TInputImage, typename TOutputImage>
-typename Forward1DFFTImageFilter<TInputImage, TOutputImage>::Pointer
-Forward1DFFTImageFilter<TInputImage, TOutputImage>::New()
-{
-  Pointer smartPtr = ObjectFactory<Self>::Create();
-  if (smartPtr.IsNotNull())
-  {
-    smartPtr->UnRegister();
-  }
-  return smartPtr;
-}
-
-
-template <typename TInputImage, typename TOutputImage>
 Forward1DFFTImageFilter<TInputImage, TOutputImage>::Forward1DFFTImageFilter()
   : m_Direction(0)
 {}

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
@@ -19,6 +19,7 @@
 #define itkForwardFFTImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "itkMacro.h"
 
 namespace itk
 {
@@ -88,8 +89,7 @@ public:
    * selection of FFT implementation.
    *
    * Default implementation is VnlFFT. */
-  static Pointer
-  New();
+  itkFactoryOnlyNewMacro(Self);
 
   /* Return the preferred greatest prime factor supported for the input image
    * size. Defaults to 2 as many implementations work only for sizes that are

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
@@ -22,22 +22,6 @@
 
 namespace itk
 {
-
-template <typename TInputImage, typename TOutputImage>
-auto
-ForwardFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
-{
-  Pointer smartPtr = itk::ObjectFactory<Self>::Create();
-
-  if (smartPtr.IsNotNull())
-  {
-    // Correct extra reference count from itk::ObjectFactory<Self>::Create()
-    smartPtr->UnRegister();
-  }
-
-  return smartPtr;
-}
-
 template <typename TInputImage, typename TOutputImage>
 void
 ForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
@@ -19,6 +19,7 @@
 #define itkHalfHermitianToRealInverseFFTImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "itkMacro.h"
 #include "itkSimpleDataObjectDecorator.h"
 
 namespace itk
@@ -80,8 +81,7 @@ public:
    * selection of FFT implementation.
    *
    * Default implementation is VnlFFT. */
-  static Pointer
-  New();
+  itkFactoryOnlyNewMacro(Self);
 
   /** Was the original truncated dimension size odd? */
   itkSetGetDecoratedInputMacro(ActualXDimensionIsOdd, bool);

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -21,22 +21,6 @@
 
 namespace itk
 {
-
-template <typename TInputImage, typename TOutputImage>
-auto
-HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
-{
-  Pointer smartPtr = itk::ObjectFactory<Self>::Create();
-
-  if (smartPtr.IsNotNull())
-  {
-    // Correct extra reference count from itk::ObjectFactory<Self>::Create()
-    smartPtr->UnRegister();
-  }
-
-  return smartPtr;
-}
-
 template <typename TInputImage, typename TOutputImage>
 HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::HalfHermitianToRealInverseFFTImageFilter()
 {

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -21,6 +21,7 @@
 #include <complex>
 
 #include "itkImageToImageFilter.h"
+#include "itkMacro.h"
 
 namespace itk
 {
@@ -59,8 +60,7 @@ public:
    *
    * Default implementation is VnlFFT1D.
    */
-  static Pointer
-  New();
+  itkFactoryOnlyNewMacro(Self);
 
   /** Get the direction in which the filter is to be applied. */
   itkGetConstMacro(Direction, unsigned int);

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.hxx
@@ -24,22 +24,6 @@
 
 namespace itk
 {
-
-template <typename TInputImage, typename TOutputImage>
-typename Inverse1DFFTImageFilter<TInputImage, TOutputImage>::Pointer
-Inverse1DFFTImageFilter<TInputImage, TOutputImage>::New()
-{
-  Pointer smartPtr = ObjectFactory<Self>::Create();
-
-  if (smartPtr.IsNotNull())
-  {
-    smartPtr->UnRegister();
-  }
-
-  return smartPtr;
-}
-
-
 template <typename TInputImage, typename TOutputImage>
 Inverse1DFFTImageFilter<TInputImage, TOutputImage>::Inverse1DFFTImageFilter()
   : m_Direction(0)

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
@@ -19,6 +19,7 @@
 #define itkInverseFFTImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "itkMacro.h"
 
 namespace itk
 {
@@ -73,8 +74,7 @@ public:
    * selection of FFT implementation.
    *
    * Default implementation is VnlFFT. */
-  static Pointer
-  New();
+  itkFactoryOnlyNewMacro(Self);
 
   /* Return the preferred greatest prime factor supported for the input image
    * size. Defaults to 2 as many implementations work only for sizes that are

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
@@ -22,22 +22,6 @@
 
 namespace itk
 {
-
-template <typename TInputImage, typename TOutputImage>
-auto
-InverseFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
-{
-  Pointer smartPtr = itk::ObjectFactory<Self>::Create();
-
-  if (smartPtr.IsNotNull())
-  {
-    // Correct extra reference count from itk::ObjectFactory<Self>::Create()
-    smartPtr->UnRegister();
-  }
-
-  return smartPtr;
-}
-
 template <typename TInputImage, typename TOutputImage>
 void
 InverseFFTImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.h
@@ -19,6 +19,7 @@
 #define itkRealToHalfHermitianForwardFFTImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "itkMacro.h"
 #include "itkSimpleDataObjectDecorator.h"
 
 namespace itk
@@ -81,8 +82,7 @@ public:
    * selection of FFT implementation.
    *
    * Default implementation is VnlFFT. */
-  static Pointer
-  New();
+  itkFactoryOnlyNewMacro(Self);
 
   /* Return the preferred greatest prime factor supported for the input image
    * size. Defaults to 2 as many implementations work only for sizes that are

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -21,22 +21,6 @@
 
 namespace itk
 {
-
-template <typename TInputImage, typename TOutputImage>
-auto
-RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::New() -> Pointer
-{
-  Pointer smartPtr = itk::ObjectFactory<Self>::Create();
-
-  if (smartPtr.IsNotNull())
-  {
-    // Correct extra reference count from itk::ObjectFactory<Self>::Create()
-    smartPtr->UnRegister();
-  }
-
-  return smartPtr;
-}
-
 template <typename TInputImage, typename TOutputImage>
 RealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::RealToHalfHermitianForwardFFTImageFilter()
 {


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

Adds `itkFactoryOnlyNewMacro` as an alternative to `itkNewMacro` and `itkFactorylessNewMacro` for defining the `New()` method for constructing object smart pointers.

The ITK object factory can be used for overriding class constructors and implicitly returning specialized constructs. [`itkNewMacro(Self)`](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Core/Common/include/itkMacro.h#L310) is commonly used to define a `New()` method for instantiating objects by first checking for factory methods and then relying on simple instantiation with the `new` keyword if (when) no factory is found. This is suitable for most classes which define their own concrete implementation; however, FFT filters specifically are structured such that the base class does not fully define a backend and should not be instructed on its own.

As discussed in #3050, the current method of returning `nullptr` if no suitable FFT factory is found is not common practice in ITK and results in segfaults when we try to query methods on the returned instance. ITK attempts to register factories for Vnl FFT implementations by default, so the absence of a factory indicates a failure condition. Rather than requiring changing methods to explicitly check for `nullptr` it is more reasonable to throw an exception to signify that expected factories are absent.

With these changes, attempting to instantiate an FFT filter for which no factory is available returns an ITK error such as follows:
```py
>>> itk.ComplexToComplex1DFFTImageFilter.values()[-1].New()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\repos\ITK-build-unstable\Wrapping\Generators\Python\itk\itkComplexToComplex1DFFTImageFilterPython.py", line 330, in New
    obj = itkComplexToComplex1DFFTImageFilterICF3.__New_orig__()
RuntimeError: C:\repos\ITK\Modules\Filtering\FFT\include\itkComplexToComplex1DFFTImageFilter.h:68:
ITK ERROR: Object factory failed to instantiate
```

Note that `itkFactoryOnlyNewMacro` also adds `CreateAnother` and `Clone` methods to base FFT classes, which were missing.

Closes #3050.

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
