### PR TITLE
STYLE: Remove old FFT 1D implementation includes

### DIFF
--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
@@ -118,15 +118,7 @@ private:
 } // namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#  ifndef itkVnlComplexToComplex1DFFTImageFilter_h
-#    ifndef itkVnlComplexToComplex1DFFTImageFilter_hxx
-#      ifndef itkFFTWComplexToComplex1DFFTImageFilter_h
-#        ifndef itkFFTWComplexToComplex1DFFTImageFilter_hxx
-#          include "itkComplexToComplex1DFFTImageFilter.hxx"
-#        endif
-#      endif
-#    endif
-#  endif
+#  include "itkComplexToComplex1DFFTImageFilter.hxx"
 #endif
 
 #ifdef ITK_FFT_FACTORY_REGISTER_MANAGER

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
@@ -101,15 +101,7 @@ private:
 } // namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#  ifndef itkVnlForward1DFFTImageFilter_h
-#    ifndef itkVnlForward1DFFTImageFilter_hxx
-#      ifndef itkFFTWForward1DFFTImageFilter_h
-#        ifndef itkFFTWForward1DFFTImageFilter_hxx
-#          include "itkForward1DFFTImageFilter.hxx"
-#        endif
-#      endif
-#    endif
-#  endif
+#  include "itkForward1DFFTImageFilter.hxx"
 #endif
 
 #ifdef ITK_FFT_FACTORY_REGISTER_MANAGER

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -96,15 +96,7 @@ private:
 } // namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#  ifndef itkVnlInverse1DFFTImageFilter_h
-#    ifndef itkVnlInverse1DFFTImageFilter_hxx
-#      ifndef itkFFTWInverse1DFFTImageFilter_h
-#        ifndef itkFFTWInverse1DFFTImageFilter_hxx
-#          include "itkInverse1DFFTImageFilter.hxx"
-#        endif
-#      endif
-#    endif
-#  endif
+#  include "itkInverse1DFFTImageFilter.hxx"
 #endif
 
 #ifdef ITK_FFT_FACTORY_REGISTER_MANAGER


### PR DESCRIPTION
These are no longer required since we use the factory mechanism.
