### PR TITLE
COMP: add C++11 override to various HDF5 methods that indeed override

### DIFF
--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5ArrayType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5ArrayType.h
@@ -37,7 +37,7 @@ class H5_DLLCPP ArrayType : public DataType {
 
     // Returns an ArrayType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const;
+    virtual DataType *decode() const H5_OVERRIDE;
 
     // Returns the number of dimensions of this array datatype.
     int getArrayNDims() const;
@@ -49,7 +49,7 @@ class H5_DLLCPP ArrayType : public DataType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("ArrayType");
     }
@@ -61,7 +61,7 @@ class H5_DLLCPP ArrayType : public DataType {
     ArrayType(const hid_t existing_id);
 
     // Noop destructor
-    virtual ~ArrayType();
+    virtual ~ArrayType() H5_OVERRIDE;
 
     // Default constructor
     ArrayType();

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5AtomType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5AtomType.h
@@ -58,7 +58,7 @@ class H5_DLLCPP AtomType : public DataType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("AtomType");
     }
@@ -68,7 +68,7 @@ class H5_DLLCPP AtomType : public DataType {
     AtomType(const AtomType &original);
 
     // Noop destructor
-    virtual ~AtomType();
+    virtual ~AtomType() H5_OVERRIDE;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   protected:

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5Attribute.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5Attribute.h
@@ -38,7 +38,7 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
     Attribute(const hid_t attr_id);
 
     // Closes this attribute.
-    virtual void close();
+    virtual void close() H5_OVERRIDE;
 
     // Gets the name of this attribute.
     ssize_t      getName(char *attr_name, size_t buf_size = 0) const;
@@ -50,13 +50,13 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
     ssize_t getName(size_t buf_size, H5std_string &attr_name) const;
 
     // Gets a copy of the dataspace for this attribute.
-    virtual DataSpace getSpace() const;
+    virtual DataSpace getSpace() const H5_OVERRIDE;
 
     // Returns the amount of storage size required for this attribute.
-    virtual hsize_t getStorageSize() const;
+    virtual hsize_t getStorageSize() const H5_OVERRIDE;
 
     // Returns the in memory size of this attribute's data.
-    virtual size_t getInMemDataSize() const;
+    virtual size_t getInMemDataSize() const H5_OVERRIDE;
 
     // Reads data from this attribute.
     void read(const DataType &mem_type, void *buf) const;
@@ -68,21 +68,21 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("Attribute");
     }
 
     // Gets the attribute id.
-    virtual hid_t getId() const;
+    virtual hid_t getId() const H5_OVERRIDE;
 
     // Destructor: properly terminates access to this attribute.
-    virtual ~Attribute();
+    virtual ~Attribute() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   protected:
     // Sets the attribute id.
-    virtual void p_setId(const hid_t new_id);
+    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   private:
@@ -92,7 +92,7 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
     // getTypeClass and various API functions getXxxType
     // defined in AbstractDs for generic datatype and specific
     // sub-types
-    virtual hid_t p_get_type() const;
+    virtual hid_t p_get_type() const H5_OVERRIDE;
 
     // Reads variable or fixed len strings from this attribute.
     void p_read_variable_len(const DataType &mem_type, H5std_string &strg) const;

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5CompType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5CompType.h
@@ -45,7 +45,7 @@ class H5_DLLCPP CompType : public DataType {
 
     // Returns a CompType object via DataType* by decoding the binary
     // object description of this type.
-    virtual DataType *decode() const;
+    virtual DataType *decode() const H5_OVERRIDE;
 
     // Returns the type class of the specified member of this compound
     // datatype.  It provides to the user a way of knowing what type
@@ -108,13 +108,13 @@ class H5_DLLCPP CompType : public DataType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("CompType");
     }
 
     // Noop destructor.
-    virtual ~CompType();
+    virtual ~CompType() H5_OVERRIDE;
 
   private:
     // Contains common code that is used by the member functions

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DaccProp.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DaccProp.h
@@ -38,7 +38,7 @@ class H5_DLLCPP DSetAccPropList : public LinkAccPropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("DSetAccPropList");
     }
@@ -51,7 +51,7 @@ class H5_DLLCPP DSetAccPropList : public LinkAccPropList {
     DSetAccPropList(const hid_t plist_id);
 
     // Noop destructor.
-    virtual ~DSetAccPropList();
+    virtual ~DSetAccPropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DataSet.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DataSet.h
@@ -28,7 +28,7 @@ namespace H5 {
 class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
   public:
     // Close this dataset.
-    virtual void close();
+    virtual void close() H5_OVERRIDE;
 
     // Extends the dataset with unlimited dimension.
     void extend(const hsize_t *size) const;
@@ -53,16 +53,16 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
     haddr_t getOffset() const;
 
     // Gets the dataspace of this dataset.
-    virtual DataSpace getSpace() const;
+    virtual DataSpace getSpace() const H5_OVERRIDE;
 
     // Determines whether space has been allocated for a dataset.
     void getSpaceStatus(H5D_space_status_t &status) const;
 
     // Returns the amount of storage size required for this dataset.
-    virtual hsize_t getStorageSize() const;
+    virtual hsize_t getStorageSize() const H5_OVERRIDE;
 
     // Returns the in memory size of this attribute's data.
-    virtual size_t getInMemDataSize() const;
+    virtual size_t getInMemDataSize() const H5_OVERRIDE;
 
     // Returns the number of bytes required to store VL data.
     hsize_t getVlenBufSize(const DataType &type, const DataSpace &space) const;
@@ -100,7 +100,7 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("DataSet");
     }
@@ -124,15 +124,15 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
     DataSet(const hid_t existing_id);
 
     // Gets the dataset id.
-    virtual hid_t getId() const;
+    virtual hid_t getId() const H5_OVERRIDE;
 
     // Destructor: properly terminates access to this dataset.
-    virtual ~DataSet();
+    virtual ~DataSet() H5_OVERRIDE;
 
   protected:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     // Sets the dataset id.
-    virtual void p_setId(const hid_t new_id);
+    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   private:
@@ -142,7 +142,7 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
     // getTypeClass and various API functions getXxxType
     // defined in AbstractDs for generic datatype and specific
     // sub-types
-    virtual hid_t p_get_type() const;
+    virtual hid_t p_get_type() const H5_OVERRIDE;
 
     // Reads variable or fixed len strings from this dataset.
     void p_read_fixed_len(const hid_t mem_type_id, const hid_t mem_space_id, const hid_t file_space_id,

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DataSpace.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DataSpace.h
@@ -127,7 +127,7 @@ class H5_DLLCPP DataSpace : public IdComponent {
     static void deleteConstants();
 
     // Destructor: properly terminates access to this dataspace.
-    virtual ~DataSpace();
+    virtual ~DataSpace() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DataType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DataType.h
@@ -47,7 +47,7 @@ class H5_DLLCPP DataType : public H5Object {
     //        PropList& plist = PropList::DEFAULT);
 
     // Closes this datatype.
-    virtual void close();
+    virtual void close() H5_OVERRIDE;
 
     // Copies an existing datatype to this datatype object.
     void copy(const DataType &like_type);
@@ -133,7 +133,7 @@ class H5_DLLCPP DataType : public H5Object {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("DataType");
     }
@@ -148,10 +148,10 @@ class H5_DLLCPP DataType : public H5Object {
     bool hasBinaryDesc() const;
 
     // Gets the datatype id.
-    virtual hid_t getId() const;
+    virtual hid_t getId() const H5_OVERRIDE;
 
     // Destructor: properly terminates access to this datatype.
-    virtual ~DataType();
+    virtual ~DataType() H5_OVERRIDE;
 
   protected:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -162,7 +162,7 @@ class H5_DLLCPP DataType : public H5Object {
     hid_t p_decode() const;
 
     // Sets the datatype id.
-    virtual void p_setId(const hid_t new_id);
+    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
 
     // Opens a datatype and returns the id.
     hid_t p_opentype(const H5Location &loc, const char *dtype_name) const;

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DcreatProp.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DcreatProp.h
@@ -128,7 +128,7 @@ class H5_DLLCPP DSetCreatPropList : public ObjCreatPropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("DSetCreatPropList");
     }
@@ -141,7 +141,7 @@ class H5_DLLCPP DSetCreatPropList : public ObjCreatPropList {
     DSetCreatPropList(const hid_t plist_id);
 
     // Noop destructor.
-    virtual ~DSetCreatPropList();
+    virtual ~DSetCreatPropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DxferProp.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DxferProp.h
@@ -100,7 +100,7 @@ class H5_DLLCPP DSetMemXferPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("DSetMemXferPropList");
     }
@@ -113,7 +113,7 @@ class H5_DLLCPP DSetMemXferPropList : public PropList {
     DSetMemXferPropList(const hid_t plist_id);
 
     // Noop destructor
-    virtual ~DSetMemXferPropList();
+    virtual ~DSetMemXferPropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5EnumType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5EnumType.h
@@ -41,7 +41,7 @@ class H5_DLLCPP EnumType : public DataType {
 
     // Returns an EnumType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const;
+    virtual DataType *decode() const H5_OVERRIDE;
 
     // Returns the number of members in this enumeration datatype.
     int getNmembers() const;
@@ -68,7 +68,7 @@ class H5_DLLCPP EnumType : public DataType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("EnumType");
     }
@@ -82,7 +82,7 @@ class H5_DLLCPP EnumType : public DataType {
     // Copy constructor: same as the original EnumType.
     EnumType(const EnumType &original);
 
-    virtual ~EnumType();
+    virtual ~EnumType() H5_OVERRIDE;
 
 }; // end of EnumType
 } // namespace H5

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5FaccProp.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5FaccProp.h
@@ -137,7 +137,7 @@ class H5_DLLCPP FileAccPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("FileAccPropList");
     }
@@ -150,7 +150,7 @@ class H5_DLLCPP FileAccPropList : public PropList {
     FileAccPropList(const hid_t plist_id);
 
     // Noop destructor
-    virtual ~FileAccPropList();
+    virtual ~FileAccPropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5FcreatProp.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5FcreatProp.h
@@ -78,7 +78,7 @@ class H5_DLLCPP FileCreatPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("FileCreatPropList");
     }
@@ -91,7 +91,7 @@ class H5_DLLCPP FileCreatPropList : public PropList {
     FileCreatPropList(const hid_t plist_id);
 
     // Noop destructor
-    virtual ~FileCreatPropList();
+    virtual ~FileCreatPropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5File.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5File.h
@@ -117,7 +117,7 @@ class H5_DLLCPP H5File : public Group {
     virtual hid_t getId() const H5_OVERRIDE;
 
     // H5File destructor.
-    virtual ~H5File();
+    virtual ~H5File() H5_OVERRIDE;
 
   protected:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5FloatType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5FloatType.h
@@ -36,7 +36,7 @@ class H5_DLLCPP FloatType : public AtomType {
 
     // Returns an FloatType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const;
+    virtual DataType *decode() const H5_OVERRIDE;
 
     // Retrieves the exponent bias of a floating-point type.
     size_t getEbias() const;
@@ -64,7 +64,7 @@ class H5_DLLCPP FloatType : public AtomType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("FloatType");
     }
@@ -79,7 +79,7 @@ class H5_DLLCPP FloatType : public AtomType {
     FloatType(const FloatType &original);
 
     // Noop destructor.
-    virtual ~FloatType();
+    virtual ~FloatType() H5_OVERRIDE;
 
 }; // end of FloatType
 } // namespace H5

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5IntType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5IntType.h
@@ -36,7 +36,7 @@ class H5_DLLCPP IntType : public AtomType {
 
     // Returns an IntType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const;
+    virtual DataType *decode() const H5_OVERRIDE;
 
     // Retrieves the sign type for an integer type
     H5T_sign_t getSign() const;
@@ -46,7 +46,7 @@ class H5_DLLCPP IntType : public AtomType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("IntType");
     }
@@ -61,7 +61,7 @@ class H5_DLLCPP IntType : public AtomType {
     IntType(const IntType &original);
 
     // Noop destructor.
-    virtual ~IntType();
+    virtual ~IntType() H5_OVERRIDE;
 
 }; // end of IntType
 } // namespace H5

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5LaccProp.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5LaccProp.h
@@ -32,7 +32,7 @@ class H5_DLLCPP LinkAccPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("LinkAccPropList");
     }
@@ -52,7 +52,7 @@ class H5_DLLCPP LinkAccPropList : public PropList {
     size_t getNumLinks() const;
 
     // Noop destructor
-    virtual ~LinkAccPropList();
+    virtual ~LinkAccPropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5LcreatProp.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5LcreatProp.h
@@ -32,7 +32,7 @@ class H5_DLLCPP LinkCreatPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("LinkCreatPropList");
     }
@@ -59,7 +59,7 @@ class H5_DLLCPP LinkCreatPropList : public PropList {
     H5T_cset_t getCharEncoding() const;
 
     // Noop destructor
-    virtual ~LinkCreatPropList();
+    virtual ~LinkCreatPropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5OcreatProp.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5OcreatProp.h
@@ -44,7 +44,7 @@ class H5_DLLCPP ObjCreatPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("ObjCreatPropList");
     }
@@ -57,7 +57,7 @@ class H5_DLLCPP ObjCreatPropList : public PropList {
     ObjCreatPropList(const hid_t plist_id);
 
     // Noop destructor
-    virtual ~ObjCreatPropList();
+    virtual ~ObjCreatPropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5PredType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5PredType.h
@@ -29,7 +29,7 @@ class H5_DLLCPP PredType : public AtomType {
   public:
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("PredType");
     }
@@ -42,7 +42,7 @@ class H5_DLLCPP PredType : public AtomType {
     PredType(const PredType &original);
 
     // Noop destructor
-    virtual ~PredType();
+    virtual ~PredType() H5_OVERRIDE;
 
     /*! \brief This dummy function do not inherit from DataType - it will
         throw a DataTypeIException if invoked.

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5PropList.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5PropList.h
@@ -38,7 +38,7 @@ class H5_DLLCPP PropList : public IdComponent {
     bool operator==(const PropList &rhs) const;
 
     // Close this property list.
-    virtual void close();
+    virtual void close() H5_OVERRIDE;
 
     // Close a property list class.
     void closeClass() const;
@@ -102,7 +102,7 @@ class H5_DLLCPP PropList : public IdComponent {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("PropList");
     }
@@ -114,10 +114,10 @@ class H5_DLLCPP PropList : public IdComponent {
     PropList(const PropList &original);
 
     // Gets the property list id.
-    virtual hid_t getId() const;
+    virtual hid_t getId() const H5_OVERRIDE;
 
     // Destructor: properly terminates access to this property list.
-    virtual ~PropList();
+    virtual ~PropList() H5_OVERRIDE;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -128,7 +128,7 @@ class H5_DLLCPP PropList : public IdComponent {
     hid_t id; // HDF5 property list id
 
     // Sets the property list id.
-    virtual void p_setId(const hid_t new_id);
+    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
 
   private:
     static PropList *DEFAULT_;

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5StrType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5StrType.h
@@ -42,7 +42,7 @@ class H5_DLLCPP StrType : public AtomType {
 
     // Returns an StrType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const;
+    virtual DataType *decode() const H5_OVERRIDE;
 
     // Retrieves the character set type of this string datatype.
     H5T_cset_t getCset() const;
@@ -58,7 +58,7 @@ class H5_DLLCPP StrType : public AtomType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("StrType");
     }
@@ -73,7 +73,7 @@ class H5_DLLCPP StrType : public AtomType {
     StrType(const StrType &original);
 
     // Noop destructor.
-    virtual ~StrType();
+    virtual ~StrType() H5_OVERRIDE;
 
 }; // end of StrType
 } // namespace H5

--- a/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5VarLenType.h
+++ b/Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5VarLenType.h
@@ -33,11 +33,11 @@ class H5_DLLCPP VarLenType : public DataType {
 
     // Returns an VarLenType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const;
+    virtual DataType *decode() const H5_OVERRIDE;
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const
+    fromClass() const H5_OVERRIDE
     {
         return ("VarLenType");
     }
@@ -53,7 +53,7 @@ class H5_DLLCPP VarLenType : public DataType {
     VarLenType(const H5Location &loc, const H5std_string &name);
 
     // Noop destructor
-    virtual ~VarLenType();
+    virtual ~VarLenType() H5_OVERRIDE;
 
     // Default constructor
     VarLenType();


### PR DESCRIPTION
This fixes numerous warnings about missing override keywords.

These are all already fixed in upstream HDF5 but were not fixed by our recent update to HDF5 1.12.1 because the fixes post-date that release (which is the current release).