### PR TITLE
COMP: Disable Eigen3 warning Wused-but-marked-unused

### DIFF
--- a/Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt
@@ -758,6 +758,12 @@ if(ITK_USE_EIGEN_MPL2_ONLY)
   target_compile_definitions (eigen_internal INTERFACE "EIGEN_MPL2_ONLY")
 endif()
 
+# Hack to disable warning. To remove when/if fixed upstream.
+# See issue: https://gitlab.com/libeigen/eigen/-/issues/2416
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 17 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(eigen_internal INTERFACE "-Wno-used-but-marked-unused")
+endif()
+
 # BUILD: go one directory before to localize the headers:
 #   #include <itkeigen/Eigen/x>
 # INSTALL: headers require pre-prend itkeigen/Eigen/X.


### PR DESCRIPTION
Triggered using clang with std>=17
The warning is correct, in Eigen/x/arch/SSE the functions are used.
However in other archs the functions might be unused.
This patch hacks CMake to ignore it while waiting for resolution upstream.
Reported here: https://gitlab.com/libeigen/eigen/-/issues/2416

Another option to explore suggested by @seanm:
If we assume that ITK would only use the SSE arch we could remove the unused attribute.