### PR TITLE
Fixes ITK factory registration CMake

### DIFF
--- a/CMake/ITKFactoryRegistration.cmake
+++ b/CMake/ITKFactoryRegistration.cmake
@@ -204,7 +204,7 @@ macro(itk_generate_factory_registration)
     set(_factory_list ${variadic_args})
   endif()
 
-  foreach(_factory_name ${ITK_FACTORY_LIST})
+  foreach(_factory_name ${_factory_list})
     string(TOUPPER ${_factory_name} factory_uc)
     string(TOLOWER ${_factory_name} factory_lc)
     set(LIST_OF_${factory_uc}_FORMATS "")
@@ -227,8 +227,9 @@ macro(itk_generate_factory_registration)
     if(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER)
       # pass generation this factory registration
     elseif(_factory_name MATCHES "IO" AND ITK_NO_IO_FACTORY_REGISTER_MANAGER)
-      message(WARNING "ITK_NO_IO_FACTORY_REGISTER_MANAGER CMake variable
-      is deprecated.  Use ITK_NO_${_factory_name}_FACTORY_REGISTER_MANAGER")
+      message(WARNING
+        "ITK_NO_IO_FACTORY_REGISTER_MANAGER CMake variable is "
+        "deprecated. Use ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER")
     else()
       _itk_configure_FactoryRegisterManager("${_factory_name}" "${LIST_OF_${factory_uc}_FORMATS}")
     endif()

--- a/CMake/ITKModuleMacros.cmake
+++ b/CMake/ITKModuleMacros.cmake
@@ -9,6 +9,7 @@ include(${_ITKModuleMacros_DIR}/ITKModuleKWStyleTest.cmake)
 include(${_ITKModuleMacros_DIR}/ITKModuleClangFormat.cmake)
 include(${_ITKModuleMacros_DIR}/CppcheckTargets.cmake)
 include(${_ITKModuleMacros_DIR}/ITKModuleCPPCheckTest.cmake)
+include(${_ITKModuleMacros_DIR}/ITKFactoryRegistration.cmake)
 
 # With Apple's (GGC <=4.2 and LLVM-GCC <=4.2) or (Clang < 3.2)
 # visibility of template  don't work. Set the option to off and hide it.

--- a/CMake/UseITK.cmake
+++ b/CMake/UseITK.cmake
@@ -51,8 +51,9 @@ foreach(_factory_name ${ITK_FACTORY_LIST})
   if (_factory_name MATCHES "IO" AND
       ITK_NO_IO_FACTORY_REGISTER_MANAGER)
     if( "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.4")
-      message(WARNING "ITK_NO_IO_FACTORY_REGISTER_MANAGER CMake
-      variable is deprecated. Use ITK_NO_${_factory_uc}_FACTORY_REGISTER_MANAGER")
+      message(WARNING
+        "ITK_NO_IO_FACTORY_REGISTER_MANAGER CMake variable is "
+        "deprecated. Use ITK_NO_${_factory_uc}_FACTORY_REGISTER_MANAGER")
     endif()
     continue()
   endif()


### PR DESCRIPTION
Addresses the following build error:

CMake Error at CMake/UseITK.cmake:43 (itk_generate_factory_registration):
  Unknown CMake command "itk_generate_factory_registration".

This error occurs with the following configuration:

  cmake -DBUILD_EXAMPLES=ON -DModule_Montage:BOOL=ON ~/src/ITK 