### PR TITLE
BUG: Provide consistent shape on Fortran-order np.ndarray views

### DIFF
--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -413,7 +413,17 @@ str = str
 
                 if(self.GetNumberOfComponentsPerPixel() > 1):
                     result = [self.GetNumberOfComponentsPerPixel(), ] + result
-                result.reverse()
+                # ITK is C-order. The shape needs to be reversed unless we are a view on
+                # a NumPy array that is Fortran-order.
+                reverse = True
+                base = self
+                while hasattr(base, 'base'):
+                    if hasattr(base, 'flags'):
+                        reverse = not base.flags.f_contiguous
+                        break
+                    base = base.base
+                if reverse:
+                    result.reverse()
                 return tuple(result)
 
             @property

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -328,6 +328,9 @@ assert np.any(arr != itk.array_from_image(image))
 image = itk.GetImageViewFromArray(arr)
 image.FillBuffer(2)
 assert np.all(arr == itk.array_from_image(image))
+arr_fortran = arr.copy(order="F")
+image = itk.GetImageViewFromArray(arr_fortran)
+assert np.array_equal(arr_fortran.shape, image.shape)
 image = itk.image_from_array(arr, is_vector=True)
 assert image.GetImageDimension() == 2
 image = itk.GetImageViewFromArray(arr, is_vector=True)
@@ -337,6 +340,7 @@ assert arr.shape[0] == 2
 assert arr.shape[1] == 3
 assert arr[1, 1] == 5
 image = itk.image_from_array(arr)
+assert np.array_equal(arr.shape, image.shape)
 arrKeepAxes = itk.array_from_image(image, keep_axes=True)
 assert arrKeepAxes.shape[0] == 3
 assert arrKeepAxes.shape[1] == 2


### PR DESCRIPTION
The itk.Image shape should be consistent for Fortran-order np.ndarray views.

Check the .base attr recursively and its .f_contiguous flag status.

This only applies to GetImageViewFromArray -- GetImageFromArray creates
a copy that is C-order.
