### PR TITLE
COMP: Fix missing initialization braces warning

### DIFF
--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -166,7 +166,7 @@ itkDisplacementFieldJacobianDeterminantFilterTest(int, char *[])
     filter->Print(std::cout);
 
     // Run the test again with specified weights
-    typename FilterType::WeightsType weights{ { 1.0, 2.0, 3.0 } };
+    typename FilterType::WeightsType weights{ { { 1.0, 2.0, 3.0 } } };
     filter->SetDerivativeWeights(weights);
     ITK_TEST_SET_GET_VALUE(weights, filter->GetDerivativeWeights());
 


### PR DESCRIPTION
Fix missing initialization braces warning.

Fixes:
```

[CTest: warning matched]
/Users/builder/externalModules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx:169:49:
warning: suggest braces around initialization of subobject [-Wmissing-braces]
    typename FilterType::WeightsType weights{ { 1.0, 2.0, 3.0 } };
                                                ^~~~~~~~~~~~~
                                                {            }
```

Raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=7679172

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)