### PR TITLE
COMP: Fix variable type and syntax errors

### DIFF
--- a/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
@@ -66,11 +66,11 @@ itkTestingComparisonImageFilterTest(int argc, char * argv[])
 
 
   // setup the filter
-  auto differenceThreshold = std::stoi(argv[4]);
+  auto differenceThreshold = static_cast<typename FilterType::OutputPixelType>(std::stoi(argv[4]));
   filter->SetDifferenceThreshold(differenceThreshold);
   TEST_SET_GET_VALUE(differenceThreshold, filter->GetDifferenceThreshold());
 
-  auto toleranceRadius = std::stoi(argv[5]);
+  int toleranceRadius = std::stoi(argv[5]);
   filter->SetToleranceRadius(toleranceRadius);
   TEST_SET_GET_VALUE(toleranceRadius, filter->GetToleranceRadius());
 

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
@@ -228,7 +228,7 @@ TestMattesMetricWithAffineTransform(TInterpolator * const interpolator, const bo
   // set the number of histogram bins
   itk::SizeValueType numberOfHistogramBins = 50;
   metric->SetNumberOfHistogramBins(numberOfHistogramBins);
-  ITK_TEST_SET_GET_VALUE(numberOfHistogramBins, metric->GetNumberOfHistogramBins())
+  ITK_TEST_SET_GET_VALUE(numberOfHistogramBins, metric->GetNumberOfHistogramBins());
 
   // this test doesn't pass when using gradient image filters,
   // presumably because of different deriviative scaling created


### PR DESCRIPTION
Fix expected variable type and syntax errors in `ITK_TEST_SET_GET_VALUE`
calls.

Fixes:
```
/Users/builder/externalModules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx:71:21: error:
called object type 'const char [55]' is not a function or function pointer
  TEST_SET_GET_VALUE(differenceThreshold, filter->GetDifferenceThreshold());
  ~~~~~~~~~~~~~~~~~~^
/Users/builder/externalModules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx:75:21:
error: called object type 'const char [55]' is not a function or function pointer
  TEST_SET_GET_VALUE(toleranceRadius, filter->GetToleranceRadius());
  ~~~~~~~~~~~~~~~~~~^
2 errors generated.
```

and
```
/Users/builder/externalModules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx:223:84:
error: expected ';' after static_assert
  ITK_TEST_SET_GET_VALUE(numberOfHistogramBins, metric->GetNumberOfHistogramBins())
                                                                                   ^
                                                                                   ;
```

Raised for example in:
https://open.cdash.org/viewBuildError.php?buildid=7679319

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)