### PR TITLE
BUG: Initialize variables

### DIFF
--- a/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
@@ -154,9 +154,9 @@ protected:
 
   ParametersType m_CurrentIndex;
 
-  SizeValueType m_MaximumNumberOfIterations;
+  SizeValueType m_MaximumNumberOfIterations{ 1 };
 
-  MeasureType m_MaximumMetricValue;
+  MeasureType m_MaximumMetricValue{ itk::NumericTraits<MeasureType>::max() };
 
   MeasureType m_MinimumMetricValue;
 

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
@@ -135,7 +135,8 @@ itkMultiResolutionImageRegistrationMethodTest(int, char *[])
   registration->SetInitialTransformParameters(initialParameters);
   ITK_TEST_SET_GET_VALUE(initialParameters, registration->GetInitialTransformParameters());
 
-  ParametersType initialTransformParametersOfNextLevel(1);
+  typename ParametersType::ValueType initialTransformParametersOfNextLevelVal(0.0);
+  ParametersType                     initialTransformParametersOfNextLevel(1, initialTransformParametersOfNextLevelVal);
   registration->SetInitialTransformParametersOfNextLevel(initialTransformParametersOfNextLevel);
   ITK_TEST_SET_GET_VALUE(initialTransformParametersOfNextLevel,
                          registration->GetInitialTransformParametersOfNextLevel());


### PR DESCRIPTION
- BUG: Initialize `itk::ExhaustiveOptimizer` ivars 
- BUG: Initialize `itk::Array` variable values in test 

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)