### PR TITLE
ENH: Add getter macro to ivar

### DIFF
--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.h
@@ -105,6 +105,7 @@ public:
 
   /** Get/Set the Training Fixed Image.  */
   itkSetConstObjectMacro(TrainingFixedImage, FixedImageType);
+  itkGetConstObjectMacro(TrainingFixedImage, FixedImageType);
 
   /** Get/Set the Training Moving Image.  */
   itkSetConstObjectMacro(TrainingMovingImage, MovingImageType);

--- a/Modules/Registration/Common/test/itkCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkCompareHistogramImageToImageMetricTest.cxx
@@ -141,6 +141,7 @@ itkCompareHistogramImageToImageMetricTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(transform, metric->GetTrainingTransform());
 
   metric->SetTrainingFixedImage(fixedImage);
+  ITK_TEST_SET_GET_VALUE(fixedImage, metric->GetTrainingFixedImage());
 
   metric->SetTrainingFixedImageRegion(fixedImage->GetBufferedRegion());
   ITK_TEST_SET_GET_VALUE(fixedImage->GetBufferedRegion(), metric->GetTrainingFixedImageRegion());


### PR DESCRIPTION
Add getter macro to `itk::CompareHistogramImageToImageMetric` class
ivar.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)