### PR TITLE
COMP: fixed -Wset-but-unused warning building in Release

### DIFF
--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -384,6 +384,7 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   m_Visited.clear();
 
   // Report some statistics
+#ifndef NDEBUG
   if (this->GetDebug())
   {
     SizeValueType count = 0;
@@ -394,6 +395,7 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     itkDebugMacro(<< "Total #of cells accounted for: " << count);
     itkDebugMacro(<< "Extracted " << output->GetNumberOfCells() << " cells");
   }
+#endif
 
   // This prevents unnecessary re-executions of the pipeline.
   output->SetBufferedRegion(output->GetRequestedRegion());


### PR DESCRIPTION
The `count` variable was set but unused when the itkDebugMacro does nothing.  So wrapped the whole thing based on NDEBUG.
