### PR TITLE
STYLE: Default (`= default`) special member functions of `Neighborhood`

### DIFF
--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -96,28 +96,20 @@ public:
   using NeighborIndexType = SizeValueType;
 
   /** Default constructor. */
-  Neighborhood()
-  {
-    m_Radius.Fill(0);
-    m_Size.Fill(0);
-    for (DimensionValueType i = 0; i < VDimension; ++i)
-    {
-      m_StrideTable[i] = 0;
-    }
-  }
+  Neighborhood() = default;
 
   /** Default destructor. */
   virtual ~Neighborhood() = default;
 
   /** Copy constructor. */
-  Neighborhood(const Self & other);
+  Neighborhood(const Self &) = default;
 
   /** Move-constructor. */
   Neighborhood(Self &&) = default;
 
   /** Assignment operator. */
   Self &
-  operator=(const Self & other);
+  operator=(const Self &) = default;
 
   /** Move-assignment. */
   Self &
@@ -314,18 +306,18 @@ protected:
 private:
   /** Number of neighbors to include (symmetrically) along each axis.
    * A neighborhood will always have odd-length axes (m_Radius[n]*2+1). */
-  SizeType m_Radius;
+  SizeType m_Radius{ { 0 } };
 
   /** Actual length of each dimension, calculated from m_Radius.
    * A neighborhood will always have odd-length axes (m_Radius[n]*2+1). */
-  SizeType m_Size;
+  SizeType m_Size{ { 0 } };
 
   /** The buffer in which data is stored. */
   AllocatorType m_DataBuffer;
 
   /** A lookup table for keeping track of stride lengths in a neighborhood
       i.e. the memory offsets between pixels along each dimensional axis */
-  OffsetValueType m_StrideTable[VDimension];
+  OffsetValueType m_StrideTable[VDimension]{ 0 };
 
   /** */
   std::vector<OffsetType> m_OffsetTable;

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -98,31 +98,6 @@ Neighborhood<TPixel, VDimension, TContainer>::SetRadius(const SizeType & r)
 }
 
 template <typename TPixel, unsigned int VDimension, typename TContainer>
-Neighborhood<TPixel, VDimension, TContainer>::Neighborhood(const Self & other)
-  : m_Radius(other.m_Radius)
-  , m_Size(other.m_Size)
-  , m_DataBuffer(other.m_DataBuffer)
-  , m_OffsetTable(other.m_OffsetTable)
-{
-  std::copy_n(other.m_StrideTable, VDimension, m_StrideTable);
-}
-
-template <typename TPixel, unsigned int VDimension, typename TContainer>
-Neighborhood<TPixel, VDimension, TContainer> &
-Neighborhood<TPixel, VDimension, TContainer>::operator=(const Self & other)
-{
-  if (this != &other)
-  {
-    m_Radius = other.m_Radius;
-    m_Size = other.m_Size;
-    m_DataBuffer = other.m_DataBuffer;
-    std::copy(other.m_StrideTable, other.m_StrideTable + VDimension, m_StrideTable);
-    m_OffsetTable = other.m_OffsetTable;
-  }
-  return *this;
-}
-
-template <typename TPixel, unsigned int VDimension, typename TContainer>
 std::slice
 Neighborhood<TPixel, VDimension, TContainer>::GetSlice(unsigned int d) const
 {


### PR DESCRIPTION
Added in-class default member initializers, in accordance with C++ Core
Guidelines, January 3, 2022: "Prefer in-class initializers to member
initializers in constructors for constant initializers"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-in-class-initializer

Defaulted its default constructor, copy-constructor, and copy-assignment
operator.

No longer optimized self-assignment (`neighborhoodX = neighborhoodX`).
Note that this commit still supports self-assignment correctly. It just
does not have optimized code anymore for this very specific use case. In
accordance with C++ Core Guidelines, January 3, 2022: "Make copy
assignment safe for self-assignment"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c62-make-copy-assignment-safe-for-self-assignment