### PR TITLE
STYLE: Remove private `ImageScanlineConstIterator` member `Increment()`

### DIFF
--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.h
@@ -226,11 +226,8 @@ public:
    * \sa operator++
    * \sa IsAtEndOfLine
    */
-  inline void
-  NextLine()
-  {
-    this->Increment();
-  };
+  void
+  NextLine();
 
   /** Increment (prefix) along the scanline the iterator's index.
    *
@@ -262,12 +259,6 @@ public:
 protected:
   OffsetValueType m_SpanBeginOffset; // one pixel the beginning of the scanline
   OffsetValueType m_SpanEndOffset;   // one pixel past the end of the scanline
-
-private:
-  /* Move to the beginning of the next scanline
-   */
-  void
-  Increment();
 };
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.hxx
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.hxx
@@ -24,7 +24,7 @@ namespace itk
 
 template <typename TImage>
 void
-ImageScanlineConstIterator<TImage>::Increment()
+ImageScanlineConstIterator<TImage>::NextLine()
 {
   // increment to the next scanline
 


### PR DESCRIPTION
`ImageScanlineConstIterator::Increment()` was only called once, by
`ImageScanlineConstIterator::NextLine()`.