### PR TITLE
DOC: Remove mistake from `ImageRegion::IsInside(region)` documentation

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -283,10 +283,7 @@ public:
     return true;
   }
 
-  /** Test if a region (the argument) is completely inside of this region. If
-   * the region that is passed as argument to this method, has a size of value
-   * zero, then it will not be considered to be inside of the current region,
-   * even its starting index is inside. */
+  /** Test if a region (the argument) is completely inside of this region. */
   bool
   IsInside(const Self & region) const
   {

--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -285,23 +285,18 @@ public:
 
   /** Test if a region (the argument) is completely inside of this region. */
   bool
-  IsInside(const Self & region) const
+  IsInside(const Self & otherRegion) const
   {
-    IndexType beginCorner = region.GetIndex();
+    const auto otherIndex = otherRegion.m_Index;
+    const auto otherSize = otherRegion.m_Size;
 
-    if (!this->IsInside(beginCorner))
-    {
-      return false;
-    }
-    IndexType        endCorner;
-    const SizeType & size = region.GetSize();
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      endCorner[i] = beginCorner[i] + static_cast<OffsetValueType>(size[i]) - 1;
-    }
-    if (!this->IsInside(endCorner))
-    {
-      return false;
+      if (otherIndex[i] < m_Index[i] || otherIndex[i] + static_cast<IndexValueType>(otherSize[i]) >
+                                          m_Index[i] + static_cast<IndexValueType>(m_Size[i]))
+      {
+        return false;
+      }
     }
     return true;
   }

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -616,6 +616,7 @@ set(ITKCommonGTests
       itkImageBufferRangeGTest.cxx
       itkImageRegionRangeGTest.cxx
       itkImageIORegionGTest.cxx
+      itkImageRegionGTest.cxx
       itkIndexGTest.cxx
       itkIndexRangeGTest.cxx
       itkMatrixGTest.cxx

--- a/Modules/Core/Common/test/itkImageRegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionGTest.cxx
@@ -1,0 +1,90 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkImageRegion.h"
+#include "itkIndexRange.h"
+#include <gtest/gtest.h>
+#include <algorithm>   // For count.
+#include <type_traits> // For remove_const_t and remove_reference_t.
+
+
+// Tests when zero-sized regions are considered to be inside of a region.
+TEST(ImageRegion, ZeroSizedRegionIsInside)
+{
+  const auto check = [](const auto & region) {
+    using RegionType = std::remove_const_t<std::remove_reference_t<decltype(region)>>;
+    using SizeType = typename RegionType::SizeType;
+
+    auto paddedRegion = region;
+    paddedRegion.PadByRadius(1);
+
+    for (const auto & index : itk::ImageRegionIndexRange<RegionType::ImageDimension>(paddedRegion))
+    {
+      const RegionType zeroSizedRegion(index, SizeType{ { 0 } });
+
+      const auto offset = index - region.GetIndex();
+
+      if (std::count(offset.begin(), offset.end(), 0) == 0)
+      {
+        // In this case (the most common case) the one-sized region is considered inside this region if and only if its
+        // index is inside this region.
+        EXPECT_EQ(region.IsInside(zeroSizedRegion), region.IsInside(index));
+      }
+      else
+      {
+        // In this border case, at least one of the index values of the zero-sized region appears equal to the
+        // corresponding index value of this region. (Which means for 2D that the zero-sized region is on the left or
+        // upper border of this region.) For historical reasons (based on the original implementation of
+        // `itk::ImageRegion::IsInside` from 5 February 2002), the zero-sized region is then considered _outside_ of
+        // this region.
+        EXPECT_FALSE(region.IsInside(zeroSizedRegion));
+      }
+    }
+  };
+
+  // Check for a 2D and a 3D image region.
+  check(itk::ImageRegion<2>(itk::Size<2>::Filled(3)));
+  check(itk::ImageRegion<3>(itk::MakeIndex(-1, 0, 1), itk::MakeSize(2, 3, 4)));
+}
+
+
+// Tests that regions of size 1 are considered to be inside of a region, if and only if ("iff") their index is inside of
+// this region.
+TEST(ImageRegion, OneSizedRegionIsInsideIffItsIndexIsInside)
+{
+  const auto check = [](const auto & region) {
+    using RegionType = std::remove_const_t<std::remove_reference_t<decltype(region)>>;
+    using SizeType = typename RegionType::SizeType;
+
+    auto paddedRegion = region;
+    paddedRegion.PadByRadius(1);
+
+    for (const auto & index : itk::ImageRegionIndexRange<RegionType::ImageDimension>(paddedRegion))
+    {
+      const RegionType oneSizedRegion{ index, SizeType::Filled(1) };
+
+      // The one-sized region is inside this region if and only if its index is inside this region.
+      EXPECT_EQ(region.IsInside(oneSizedRegion), region.IsInside(index));
+    }
+  };
+
+  // Check for a 2D and a 3D image region.
+  check(itk::ImageRegion<2>(itk::Size<2>::Filled(3)));
+  check(itk::ImageRegion<3>(itk::MakeIndex(-1, 0, 1), itk::MakeSize(2, 3, 4)));
+}


### PR DESCRIPTION
Reverted commit a872710c63ab223e78f45de8d3e4bc435172867d
"STYLE: Documenting the behavior of the IsInside() method when the argument region has zero size in any of its dimensions" by Luis Ibanez (@luisibanez), 18 December 2009

Unlike the original documentation, `ImageRegion::IsInside(region)` may in some cases return true, even when the argument region has zero size!

Examples:

    using RegionType = ImageRegion<2>;
    using IndexType = RegionType::IndexType;
    using SizeType = RegionType::SizeType;

    const RegionType currentRegion1(IndexType::Filled(-1), SizeType::Filled(2));
    const RegionType zeroSizedRegion1{};

    EXPECT_TRUE(currentRegion1.IsInside(zeroSizedRegion1)); // OK: returns true!

    const RegionType currentRegion2(SizeType::Filled(2));
    const RegionType zeroSizedRegion2(IndexType::Filled(1), SizeType{ { 0 } });

    EXPECT_TRUE(currentRegion2.IsInside(zeroSizedRegion2)); // OK: returns true!

Simplified the implementation of `ImageRegion::IsInside(const Self &)`, assuming that it may return true for a zero-sized region as argument, when the index (start corner position) of this zero-sized region is inside the current region.