### PR TITLE
ENH: Increase coverage for miscellaneous classes

### DIFF
--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -124,7 +124,17 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
   ITK_TEST_SET_GET_VALUE(threshold, interp->GetThreshold());
 
   /* Evaluate the function */
-  double    integral;
+  double integral;
+
+
+  // Evaluate the ray casting function at the same point as the focal point:
+  //   - Allows to increase coverage.
+  //   - Makes the ray be invalid.
+  //   - Sets the traversal direction to TraversalDirectionEnum::UNDEFINED_DIRECTION
+  //   - The integral should equal to 0.
+  integral = interp->Evaluate(focus);
+  ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(integral, 0.0));
+
   PointType query;
   query[0] = 15.;
   query[1] = 15.;

--- a/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest.cxx
@@ -84,8 +84,11 @@ itkImageToHistogramFilterTest(int, char *[])
   itk::SimpleFilterWatcher watcher(filter, "filter");
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, ImageToHistogramFilter, ImageSink);
-  // Exercise the method NameOfClass();
-  std::cout << filter->GetNameOfClass() << std::endl;
+
+
+  unsigned int numberOfStreamDivisions = 1;
+  filter->SetNumberOfStreamDivisions(numberOfStreamDivisions);
+  ITK_TEST_SET_GET_VALUE(numberOfStreamDivisions, filter->GetNumberOfStreamDivisions());
 
   // Testing the settings of the BinMaximum and BinMinimum methods.
   HistogramMeasurementVectorType histogramBinMinimum1(MeasurementVectorSize);


### PR DESCRIPTION
Increase coverage for miscellaneous classes:
- Exercise the basic object methods using the
  `ITK_EXERCISE_BASIC_OBJECT_METHODS` macro.
- Test the Set/Get methods using the `ITK_TEST_SET_GET_VALUE` macro.
- Use other testing macros to check the expected value of a number of
  ivars and method return values.
- Test exceptions using the `ITK_TRY_EXPECT_EXCEPTION` macro.
- Remove explicit calls to the `Print` method and rely on the basic
  method exercising macro call.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)