### PR TITLE
BUG: region.IsInside(zeroSizedRegion) should always return false

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -273,23 +273,19 @@ public:
    * zero, then it will not be considered to be inside of the current region,
    * even its starting index is inside. */
   bool
-  IsInside(const Self & region) const
+  IsInside(const Self & otherRegion) const
   {
-    IndexType beginCorner = region.GetIndex();
+    const auto otherIndex = otherRegion.m_Index;
+    const auto otherSize = otherRegion.m_Size;
 
-    if (!this->IsInside(beginCorner))
-    {
-      return false;
-    }
-    IndexType        endCorner;
-    const SizeType & size = region.GetSize();
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      endCorner[i] = beginCorner[i] + static_cast<OffsetValueType>(size[i]) - 1;
-    }
-    if (!this->IsInside(endCorner))
-    {
-      return false;
+      if (otherIndex[i] < m_Index[i] || otherSize[i] == 0 ||
+          otherIndex[i] + static_cast<IndexValueType>(otherSize[i]) >
+            m_Index[i] + static_cast<IndexValueType>(m_Size[i]))
+      {
+        return false;
+      }
     }
     return true;
   }

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -616,6 +616,7 @@ set(ITKCommonGTests
       itkImageBufferRangeGTest.cxx
       itkImageRegionRangeGTest.cxx
       itkImageIORegionGTest.cxx
+      itkImageRegionGTest.cxx
       itkIndexGTest.cxx
       itkIndexRangeGTest.cxx
       itkMatrixGTest.cxx

--- a/Modules/Core/Common/test/itkImageRegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionGTest.cxx
@@ -1,0 +1,67 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkImageRegion.h"
+#include "itkIndexRange.h"
+#include <gtest/gtest.h>
+#include <type_traits> // For remove_const_t and remove_reference_t.
+
+
+// Tests that a zero-sized region is not considered to be inside of another region.
+TEST(ImageRegion, ZeroSizedRegionIsNotInside)
+{
+  using RegionType = itk::ImageRegion<2>;
+  using IndexType = RegionType::IndexType;
+  using SizeType = RegionType::SizeType;
+
+  const RegionType region(SizeType::Filled(2));
+
+  for (const auto indexValue : { -1, 0, 1 })
+  {
+    const RegionType zeroSizedRegion{ IndexType::Filled(indexValue), SizeType{ { 0 } } };
+
+    EXPECT_FALSE(region.IsInside(zeroSizedRegion));
+  }
+}
+
+
+// Tests that regions of size 1 are considered to be inside of a region, if and only if ("iff") their index is inside of
+// this region.
+TEST(ImageRegion, OneSizedRegionIsInsideIffItsIndexIsInside)
+{
+  const auto check = [](const auto & region) {
+    using RegionType = std::remove_const_t<std::remove_reference_t<decltype(region)>>;
+    using SizeType = typename RegionType::SizeType;
+
+    auto paddedRegion = region;
+    paddedRegion.PadByRadius(1);
+
+    for (const auto & index : itk::ImageRegionIndexRange<RegionType::ImageDimension>(paddedRegion))
+    {
+      const RegionType oneSizedRegion{ index, SizeType::Filled(1) };
+
+      // The one-sized region is inside this region if and only if its index is inside this region.
+      EXPECT_EQ(region.IsInside(oneSizedRegion), region.IsInside(index));
+    }
+  };
+
+  // Check for a 2D and a 3D image region.
+  check(itk::ImageRegion<2>(itk::Size<2>::Filled(3)));
+  check(itk::ImageRegion<3>(itk::MakeIndex(-1, 0, 1), itk::MakeSize(2, 3, 4)));
+}


### PR DESCRIPTION
As documented by commit a872710c63ab223e78f45de8d3e4bc435172867d "STYLE: Documenting the behavior of the IsInside() method when the argument region has zero size in any of its dimensions", by Luis Ibanez (@luisibanez), 18 December 2009:

> Test if a region (the argument) is completely inside of this region. If the region that is passed as argument to this method, has a size of value zero, then it will not be considered to be inside of the current region, even its starting index is inside.

Included GoogleTest unit tests for both zero-sized and one-sized regions as argument.

---
This pull request competes with pull request #3108 "DOC: Remove mistake from `ImageRegion::IsInside(region)` documentation" I think there is a choice to be made! There is a disagreement between the code and the documentation. So now, should the code follow the documentation (this pull request, #3110), or should the documentation follow the code (pull request #3108)?