### PR TITLE
BUG: Initialize `itk::ExhaustiveOptimizer::m_MinimumMetricValue`

### DIFF
--- a/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
@@ -158,7 +158,7 @@ protected:
 
   MeasureType m_MaximumMetricValue{ itk::NumericTraits<MeasureType>::max() };
 
-  MeasureType m_MinimumMetricValue;
+  MeasureType m_MinimumMetricValue{ itk::NumericTraits<MeasureType>::Zero };
 
   ParametersType m_MinimumMetricValuePosition;
 


### PR DESCRIPTION
Provide an initial value to the
`itk::ExhaustiveOptimizer::m_MinimumMetricValue` ivar.

Fixes:
```
UMC ==18288== Conditional jump or move depends on uninitialised value(s)
==18288==    at 0x663E1F8:
__printf_fp_l (printf_fp.c:387)
==18288==    by 0x6659639:
__vfprintf_internal (vfprintf-internal.c:1687)
==18288==    by 0x666E119:
__vsnprintf_internal (vsnprintf.c:114)
==18288==    by 0x64D4C3F:
??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==18288==    by 0x6506245:
std::ostreambuf_iterator > std::num_put > >::
_M_insert_float(std::ostreambuf_iterator >, std::ios_base&, char, char, double) const
(in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==18288==    by 0x6514972:
std::ostream& std::ostream::_M_insert(double) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==18288==    by 0x489F46D:
itk::ExhaustiveOptimizer::PrintSelf(std::ostream&, itk::Indent) const (itkExhaustiveOptimizer.cxx:229)
==18288==    by 0x53B4B19:
itk::LightObject::Print(std::ostream&, itk::Indent) const (itkLightObject.cxx:125)
==18288==    by 0x16536A:
itkExhaustiveOptimizerTest(int, char**) (itkExhaustiveOptimizerTest.cxx:158)
==18288==    by 0x12F2E7:
main (ITKOptimizersTestDriver.cxx:222)
```

Uncovered by the dynamic analysis in:
https://open.cdash.org/viewDynamicAnalysisFile.php?id=9074678

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)