### PR TITLE
BUG: Protect itk::OutputWindow cerr usage with a mutex

### DIFF
--- a/Modules/Core/Common/include/itkOutputWindow.h
+++ b/Modules/Core/Common/include/itkOutputWindow.h
@@ -28,6 +28,8 @@
 #ifndef itkOutputWindow_h
 #define itkOutputWindow_h
 
+#include <atomic>
+#include <mutex>
 #include "itkObject.h"
 
 namespace itk
@@ -132,7 +134,8 @@ protected:
 private:
   itkGetGlobalDeclarationMacro(OutputWindowGlobals, PimplGlobals);
 
-  bool                         m_PromptUser;
+  std::atomic<bool>            m_PromptUser;
+  std::mutex                   m_cerrMutex;
   static OutputWindowGlobals * m_PimplGlobals;
 };
 } // end namespace itk

--- a/Modules/Core/Common/src/itkOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkOutputWindow.cxx
@@ -94,6 +94,7 @@ OutputWindow::PrintSelf(std::ostream & os, Indent indent) const
 void
 OutputWindow::DisplayText(const char * txt)
 {
+  std::lock_guard<std::mutex> cerrLock(m_cerrMutex);
   std::cerr << txt;
   if (m_PromptUser)
   {


### PR DESCRIPTION
TSan otherwise complained when multiple threads use OutputWindow::DisplayText at the same time, such as in the itkSLICImageFilterTest3 test. This I don't really understand though, since C++11 cerr usage is supposed to be thread safe. But even if strictly thread-safe, output can get interleaved, and a mutex solves both that and the TSan complaint.
