### PR TITLE
DOC: warning for calling GetImageViewFromArray on non-contiguous array

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -72,6 +72,10 @@
         inverts the indexing scheme, the Image representation will be the
         same for an array and its transpose. If flipping is desired, see
         *np.reshape*.
+
+        By default, a warning is issued if this function is called on a non-contiguous
+        array, since a copy is performed and care must be taken to keep a reference
+        to the copied array. This warning can be suppressed with need_contiguous=False
         """
 
         assert ndarr.ndim in (1, 2, 3, 4, 5), \

--- a/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
+++ b/Modules/Bridge/NumPy/wrapping/PyBuffer.i.in
@@ -57,7 +57,7 @@
 
     GetArrayFromImage = staticmethod(GetArrayFromImage)
 
-    def GetImageViewFromArray(ndarr, is_vector=False):
+    def GetImageViewFromArray(ndarr, is_vector=False, need_contiguous=True):
         """Get an ITK Image view of a NumPy array.
 
         If is_vector is True, then a 3D array will be treated as a 2D vector image,
@@ -78,6 +78,13 @@
             "Only arrays of 1, 2, 3, 4 or 5 dimensions are supported."
         if not ndarr.flags['C_CONTIGUOUS'] and not ndarr.flags['F_CONTIGUOUS']:
             ndarr = np.ascontiguousarray(ndarr)
+            if need_contiguous:
+                import warnings
+                msg = """Because the input array was not contiguous, the returned
+                image is not a view of the array passed to this function. Instead,
+                it is a view of the member "base" of the returned image! If that
+                member is ever garbage collected, this view becomes invalid."""
+                warnings.warn(msg)
 
         if is_vector:
             if ndarr.flags['C_CONTIGUOUS']:
@@ -115,7 +122,7 @@
         """
 
         # Create a temporary image view of the array
-        imageView = itkPyBuffer@PyBufferTypes@.GetImageViewFromArray(ndarr, is_vector)
+        imageView = itkPyBuffer@PyBufferTypes@.GetImageViewFromArray(ndarr, is_vector, need_contiguous=False)
 
         # Duplicate the image to let it manage its own memory buffer
         import itk


### PR DESCRIPTION
There's a bit of a foot-gun in GetImageViewFromArray, where if you pass it a non-contiguous array, it makes a contiguous copy of that array and returns an image view of that copy. The copy is then stored in the .base member of the returned image, to keep it from being garbage collected. This behavior is used by GetImageFromArray, which should be able to get images from non-contiguous arrays. 

However, the .base member can be lost if the returned image is passed to, for example, a SetTransform method in itk, and then no longer referenced from python. This can cause surprise segfaults.

This pull request adds a warning to GetImageViewFromArray that is displayed when it is not actually returning a view, which can be suppressed with a keyword argument. 

Another possibility would be to move the handling of non-contiguous arrays to GetImageFromArray, and throw an error if a non-contiguous array is passed to GetImageViewFromArray. That would be a cleaner solution, but a breaking change.
