### PR TITLE
STYLE: Change `constexpr static` to `static constexpr`.

### DIFF
--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -474,18 +474,18 @@ public:
 
 #if !defined(ITK_LEGACY_REMOVE)
   /** Expose old names for backwards compatibility*/
-  constexpr static CommonEnums::CellGeometry VERTEX_CELL = CommonEnums::CellGeometry::VERTEX_CELL;
-  constexpr static CommonEnums::CellGeometry LINE_CELL = CommonEnums::CellGeometry::LINE_CELL;
-  constexpr static CommonEnums::CellGeometry TRIANGLE_CELL = CommonEnums::CellGeometry::TRIANGLE_CELL;
-  constexpr static CommonEnums::CellGeometry QUADRILATERAL_CELL = CommonEnums::CellGeometry::QUADRILATERAL_CELL;
-  constexpr static CommonEnums::CellGeometry POLYGON_CELL = CommonEnums::CellGeometry::POLYGON_CELL;
-  constexpr static CommonEnums::CellGeometry TETRAHEDRON_CELL = CommonEnums::CellGeometry::TETRAHEDRON_CELL;
-  constexpr static CommonEnums::CellGeometry HEXAHEDRON_CELL = CommonEnums::CellGeometry::HEXAHEDRON_CELL;
-  constexpr static CommonEnums::CellGeometry QUADRATIC_EDGE_CELL = CommonEnums::CellGeometry::QUADRATIC_EDGE_CELL;
-  constexpr static CommonEnums::CellGeometry QUADRATIC_TRIANGLE_CELL =
+  static constexpr CommonEnums::CellGeometry VERTEX_CELL = CommonEnums::CellGeometry::VERTEX_CELL;
+  static constexpr CommonEnums::CellGeometry LINE_CELL = CommonEnums::CellGeometry::LINE_CELL;
+  static constexpr CommonEnums::CellGeometry TRIANGLE_CELL = CommonEnums::CellGeometry::TRIANGLE_CELL;
+  static constexpr CommonEnums::CellGeometry QUADRILATERAL_CELL = CommonEnums::CellGeometry::QUADRILATERAL_CELL;
+  static constexpr CommonEnums::CellGeometry POLYGON_CELL = CommonEnums::CellGeometry::POLYGON_CELL;
+  static constexpr CommonEnums::CellGeometry TETRAHEDRON_CELL = CommonEnums::CellGeometry::TETRAHEDRON_CELL;
+  static constexpr CommonEnums::CellGeometry HEXAHEDRON_CELL = CommonEnums::CellGeometry::HEXAHEDRON_CELL;
+  static constexpr CommonEnums::CellGeometry QUADRATIC_EDGE_CELL = CommonEnums::CellGeometry::QUADRATIC_EDGE_CELL;
+  static constexpr CommonEnums::CellGeometry QUADRATIC_TRIANGLE_CELL =
     CommonEnums::CellGeometry::QUADRATIC_TRIANGLE_CELL;
-  constexpr static CommonEnums::CellGeometry LAST_ITK_CELL = CommonEnums::CellGeometry::LAST_ITK_CELL;
-  constexpr static CommonEnums::CellGeometry MAX_ITK_CELLS = CommonEnums::CellGeometry::MAX_ITK_CELLS;
+  static constexpr CommonEnums::CellGeometry LAST_ITK_CELL = CommonEnums::CellGeometry::LAST_ITK_CELL;
+  static constexpr CommonEnums::CellGeometry MAX_ITK_CELLS = CommonEnums::CellGeometry::MAX_ITK_CELLS;
 #endif
 
 protected:

--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -82,13 +82,13 @@ private:
   // iterator::operator*() returns a reference to the internally stored pixel,
   // otherwise iterator::operator*() returns a proxy, which internally uses the
   // AccessorFunctor of the image to access the pixel indirectly.
-  constexpr static bool SupportsDirectPixelAccess =
+  static constexpr bool SupportsDirectPixelAccess =
     std::is_same<PixelType, InternalPixelType>::value &&
     std::is_same<typename TImage::AccessorType, DefaultPixelAccessor<PixelType>>::value &&
     std::is_same<AccessorFunctorType, DefaultPixelAccessorFunctor<std::remove_const_t<TImage>>>::value;
 
   // Tells whether or not this range is using a pointer as iterator.
-  constexpr static bool UsingPointerAsIterator = SupportsDirectPixelAccess;
+  static constexpr bool UsingPointerAsIterator = SupportsDirectPixelAccess;
 
   struct EmptyAccessorFunctor
   {};

--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -78,7 +78,7 @@ template <unsigned VDimension, bool VBeginAtZero>
 class IndexRange final
 {
 public:
-  constexpr static unsigned Dimension = VDimension;
+  static constexpr unsigned Dimension = VDimension;
   using SizeType = Size<VDimension>;
   using IndexType = Index<VDimension>;
 

--- a/Modules/Core/Common/test/ClientTestLibraryA.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryA.cxx
@@ -30,8 +30,8 @@ dynamic_castDownCast(const char * type, const char * instanceSource, itk::Object
 {
   using DerivedType = TDerived;
 
-  constexpr static int passed = 0;
-  constexpr static int failed = 1;
+  static constexpr int passed = 0;
+  static constexpr int failed = 1;
 
   DerivedType const * derived = dynamic_cast<DerivedType const *>(base);
   if (derived != nullptr)

--- a/Modules/Core/Common/test/ClientTestLibraryB.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryB.cxx
@@ -30,8 +30,8 @@ dynamic_castDownCast(const char * type, const char * instanceSource, itk::Object
 {
   using DerivedType = TDerived;
 
-  constexpr static int passed = 0;
-  constexpr static int failed = 1;
+  static constexpr int passed = 0;
+  static constexpr int failed = 1;
 
   DerivedType const * derived = dynamic_cast<DerivedType const *>(base);
   if (derived != nullptr)

--- a/Modules/Core/Common/test/ClientTestLibraryC.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryC.cxx
@@ -30,8 +30,8 @@ dynamic_castDownCast(const char * type, const char * instanceSource, itk::Object
 {
   using DerivedType = TDerived;
 
-  constexpr static int passed = 0;
-  constexpr static int failed = 1;
+  static constexpr int passed = 0;
+  static constexpr int failed = 1;
 
   DerivedType const * derived = dynamic_cast<DerivedType const *>(base);
   if (derived != nullptr)

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
@@ -81,7 +81,7 @@ itkFlatStructuringElementTest2(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  constexpr static unsigned int Dimension = 2;
+  static constexpr unsigned int Dimension = 2;
 
   // Read test image as unsigned char
   using ImageUCType = itk::Image<unsigned char, Dimension>;

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
@@ -170,7 +170,7 @@ public:
   using Rigid2DTransformType = Rigid2DTransform<ParametersValueType>;
   using AffineTransformType = AffineTransform<ParametersValueType, FixedImageType::ImageDimension>;
 
-  constexpr static unsigned int SplineOrder = 3;
+  static constexpr unsigned int SplineOrder = 3;
   using BSplineTransformType = BSplineTransform<ParametersValueType, FixedImageType::ImageDimension, SplineOrder>;
 
   /** Initialize the transform from the landmarks */


### PR DESCRIPTION
This pull request changes the 23 instances of `constexpr static` to be like the 2322 instances of `static constexpr`.
```bash
cd ITK
fgrep -Rl 'constexpr static' *
  | egrep '\.(c|h|cc)(xx|pp|)$'
  | fgrep -v ThirdParty
  | xargs sed -i -r \
    -e 's/([^A-Za-z0-9_])constexpr static([^A-Za-z0-9_])/\1static constexpr\2/g'
```
## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
