### PR TITLE
WIP: BUG: Fixed __init__.pyi generation and import issues for python stub files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,19 +636,6 @@ set(ITK_DIR "${ITK_BINARY_DIR}")
 
 if(ITK_WRAPPING)
   add_subdirectory(Wrapping)
-  if(ITK_WRAP_PYTHON)
-    # Generate __init__.pyi file with wrapped templates/interfaces
-    set(ITK_STUB_TEMPLATE_IMPORTS "$ENV{ITK_STUB_TEMPLATE_IMPORTS}")
-    list(SORT ITK_STUB_TEMPLATE_IMPORTS CASE INSENSITIVE)
-    list(JOIN ITK_STUB_TEMPLATE_IMPORTS "\n" ITK_STUB_TEMPLATE_IMPORTS)
-    configure_file(Wrapping/Generators/Python/itk/__init__.pyi.in Wrapping/Generators/Python/itk-stubs/__init__.pyi)
-
-    # Generate _proxies.pyi file with wrapped proxy classes and method
-    set(ITK_STUB_PROXY_IMPORTS "$ENV{ITK_STUB_PROXY_IMPORTS}")
-    list(SORT ITK_STUB_PROXY_IMPORTS CASE INSENSITIVE)
-    list(JOIN ITK_STUB_PROXY_IMPORTS "\n" ITK_STUB_PROXY_IMPORTS)
-    configure_file(Wrapping/Generators/Python/itk/_proxies.pyi.in Wrapping/Generators/Python/itk-stubs/_proxies.pyi)
-  endif()
 endif()
 
 if(BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,10 +637,17 @@ set(ITK_DIR "${ITK_BINARY_DIR}")
 if(ITK_WRAPPING)
   add_subdirectory(Wrapping)
   if(ITK_WRAP_PYTHON)
-    set(ITK_STUB_IMPORTS "$ENV{ITK_STUB_IMPORTS}")
-    list(SORT ITK_STUB_IMPORTS CASE INSENSITIVE)
-    list(JOIN ITK_STUB_IMPORTS "\n" ITK_STUB_IMPORTS)
+    # Generate __init__.pyi file with wrapped templates/interfaces
+    set(ITK_STUB_TEMPLATE_IMPORTS "$ENV{ITK_STUB_TEMPLATE_IMPORTS}")
+    list(SORT ITK_STUB_TEMPLATE_IMPORTS CASE INSENSITIVE)
+    list(JOIN ITK_STUB_TEMPLATE_IMPORTS "\n" ITK_STUB_TEMPLATE_IMPORTS)
     configure_file(Wrapping/Generators/Python/itk/__init__.pyi.in Wrapping/Generators/Python/itk-stubs/__init__.pyi)
+
+    # Generate _proxies.pyi file with wrapped proxy classes and method
+    set(ITK_STUB_PROXY_IMPORTS "$ENV{ITK_STUB_PROXY_IMPORTS}")
+    list(SORT ITK_STUB_PROXY_IMPORTS CASE INSENSITIVE)
+    list(JOIN ITK_STUB_PROXY_IMPORTS "\n" ITK_STUB_PROXY_IMPORTS)
+    configure_file(Wrapping/Generators/Python/itk/_proxies.pyi.in Wrapping/Generators/Python/itk-stubs/_proxies.pyi)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,6 +636,12 @@ set(ITK_DIR "${ITK_BINARY_DIR}")
 
 if(ITK_WRAPPING)
   add_subdirectory(Wrapping)
+  if(ITK_WRAP_PYTHON)
+    set(ITK_STUB_IMPORTS "$ENV{ITK_STUB_IMPORTS}")
+    list(SORT ITK_STUB_IMPORTS CASE INSENSITIVE)
+    list(JOIN ITK_STUB_IMPORTS "\n" ITK_STUB_IMPORTS)
+    configure_file(Wrapping/Generators/Python/itk/__init__.pyi.in Wrapping/Generators/Python/itk-stubs/__init__.pyi)
+  endif()
 endif()
 
 if(BUILD_EXAMPLES)

--- a/Wrapping/CMakeLists.txt
+++ b/Wrapping/CMakeLists.txt
@@ -116,3 +116,21 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/Modules" "${CMAKE_CURRENT_BINARY_D
 ###############################################################################
 
 itk_end_wrap_modules()
+
+
+###############################################################################
+# Generate Python typehints when wrapped
+###############################################################################
+if(ITK_WRAP_PYTHON)
+  # Generate __init__.pyi file with wrapped templates/interfaces
+  set(ITK_STUB_TEMPLATE_IMPORTS "$ENV{ITK_STUB_TEMPLATE_IMPORTS}")
+  list(SORT ITK_STUB_TEMPLATE_IMPORTS CASE INSENSITIVE)
+  list(JOIN ITK_STUB_TEMPLATE_IMPORTS "\n" ITK_STUB_TEMPLATE_IMPORTS)
+  configure_file(Generators/Python/itk/__init__.pyi.in Generators/Python/itk-stubs/__init__.pyi)
+
+  # Generate _proxies.pyi file with wrapped proxy classes and methods
+  set(ITK_STUB_PROXY_IMPORTS "$ENV{ITK_STUB_PROXY_IMPORTS}")
+  list(SORT ITK_STUB_PROXY_IMPORTS CASE INSENSITIVE)
+  list(JOIN ITK_STUB_PROXY_IMPORTS "\n" ITK_STUB_PROXY_IMPORTS)
+  configure_file(Generators/Python/itk/_proxies.pyi.in Generators/Python/itk-stubs/_proxies.pyi)
+endif()

--- a/Wrapping/Generators/Python/itk/__init__.pyi.in
+++ b/Wrapping/Generators/Python/itk/__init__.pyi.in
@@ -8,4 +8,4 @@ from .support.extras import *
 from .support.types import *
 
 # Begin stub imports
-${ITK_STUB_IMPORTS}
+${ITK_STUB_TEMPLATE_IMPORTS}

--- a/Wrapping/Generators/Python/itk/__init__.pyi.in
+++ b/Wrapping/Generators/Python/itk/__init__.pyi.in
@@ -1,0 +1,11 @@
+# Python Header Interface File
+# imports as they appear in __init__.py
+from typing import Union, Any
+from itkConfig import ITK_GLOBAL_VERSION_STRING as __version__
+
+# Must import using relative paths so that symbols are imported successfully
+from .support.extras import *
+from .support.types import *
+
+# Begin stub imports
+${ITK_STUB_IMPORTS}

--- a/Wrapping/Generators/Python/itk/_proxies.pyi.in
+++ b/Wrapping/Generators/Python/itk/_proxies.pyi.in
@@ -1,0 +1,5 @@
+# Python proxy import file
+# This file allows the wrapped classes (both templates and proxies)
+# to import proxy classes without exposing the Proxy classes to a user
+# This also allows the imports to be done in other files without knowing the classes file name
+${ITK_STUB_PROXY_IMPORTS}

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -333,8 +333,10 @@ macro(itk_end_wrap_module_swig_interface)
     list(APPEND typedef_in_files "${WRAPPER_LIBRARY_OUTPUT_DIR}/${module}SwigInterface.h.in")
     list(APPEND typedef_files "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${module}SwigInterface.h")
     if(${module_prefix}_WRAP_PYTHON)
-      list(APPEND ITK_STUB_PYI_FILES "${ITK_STUB_DIR}/${module}.pyi")
-      set(ENV{ITK_STUB_IMPORTS} "$ENV{ITK_STUB_IMPORTS}from .${module} import *;")
+      list(APPEND ITK_STUB_PYI_FILES "${ITK_STUB_DIR}/${module}Template.pyi")
+      list(APPEND ITK_STUB_PYI_FILES "${ITK_STUB_DIR}/${module}Proxy.pyi")
+      set(ENV{ITK_STUB_TEMPLATE_IMPORTS} "$ENV{ITK_STUB_TEMPLATE_IMPORTS}from .${module}Template import *;")
+      set(ENV{ITK_STUB_PROXY_IMPORTS} "$ENV{ITK_STUB_PROXY_IMPORTS}from .${module}Proxy import *;")
     endif()
 
 

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -269,6 +269,7 @@ set(ITK_WRAP_SWIGINTERFACE_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE INTERN
 
 set(WRAPPER_MASTER_INDEX_OUTPUT_DIR "${ITK_DIR}/Wrapping/Typedefs" CACHE INTERNAL "typedefs dir")
 set(IGENERATOR  "${CMAKE_CURRENT_SOURCE_DIR}/igenerator.py" CACHE INTERNAL "igenerator.py path" FORCE)
+set(ENV{ITK_STUB_IMPORTS})
 
 macro(itk_wrap_module_swig_interface library_name)
   # store the content of the mdx file
@@ -333,6 +334,7 @@ macro(itk_end_wrap_module_swig_interface)
     list(APPEND typedef_files "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${module}SwigInterface.h")
     if(${module_prefix}_WRAP_PYTHON)
       list(APPEND ITK_STUB_PYI_FILES "${ITK_STUB_DIR}/${module}.pyi")
+      set(ENV{ITK_STUB_IMPORTS} "$ENV{ITK_STUB_IMPORTS}from .${module} import *;")
     endif()
 
 

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -269,7 +269,6 @@ set(ITK_WRAP_SWIGINTERFACE_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE INTERN
 
 set(WRAPPER_MASTER_INDEX_OUTPUT_DIR "${ITK_DIR}/Wrapping/Typedefs" CACHE INTERNAL "typedefs dir")
 set(IGENERATOR  "${CMAKE_CURRENT_SOURCE_DIR}/igenerator.py" CACHE INTERNAL "igenerator.py path" FORCE)
-set(ENV{ITK_STUB_IMPORTS})
 
 macro(itk_wrap_module_swig_interface library_name)
   # store the content of the mdx file

--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -1752,45 +1752,6 @@ def write_class_pyi(
         pyiFile.write(interfaces_code)
 
 
-def write_common_init_interface_file(interface_dir_path: Path) -> None:
-    # This code may still be problematic due to possible parallel runs overwriting
-    # the file each time.  As long as the last write is successful, this code
-    # works.  Initial testing demonstrated that igenerator.py was never run
-    # in parallel, so that also makes this OK.
-    with open(interface_dir_path / "__init__.pyi", "w") as pyiIndexFile:
-        # This is a bit of a hack to re-write this file every time
-        # a new .pyi file is written.
-        # Keeping track of these generated files from CMake is
-        # very convoluted, and the cmake custom command dependencies
-        # caused circular dependencies.
-        #
-        # This __init__.pyi file needs a small preamble
-        # and then import all the auto-generated .pyi files
-        # statically.
-        preamble = """
-# Create/Clear .pyi file and add boilerplate import content
-# Python Header Interface File
-# imports as they appear in __init__.py
-from typing import Union, Any
-from itkConfig import ITK_GLOBAL_VERSION_STRING as __version__Ï
-
-## Must import using relative paths so that symbols are imported successfully
-from .support.extras import *
-from .support.types import *
-
-### All items below are written out statically during
-
-"""
-        pyiIndexFile.write(preamble)
-
-        # If we could keep track of the interface files in CMake, we could avoid
-        # rewriting the __init__.pyi file every time a new version is created.
-        for interface_file in Path(f"{interface_dir_path}").glob(f"i*.pyi"):
-            pyiIndexFile.write(
-                f"from .{interface_file.name.replace('.pyi', '')} import *\n"
-            )
-
-
 if __name__ == "__main__":
     argParser = ArgumentParser()
     argParser.add_argument(

--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -200,7 +200,7 @@ def generate_class_pyi_def(
         )
 
     outputPYIMethodFile.write(
-        f"class _{class_name}Proxy({itk_class.parent_class}):\n"  # if
+        f"class {class_name}Proxy({itk_class.parent_class}):\n"  # if
     )
 
     if itk_class.is_enum and len(itk_class.enums) > 0:
@@ -647,6 +647,7 @@ class SwigInputGenerator(object):
 
         # A dict of sets containing the .pyi python equivalent for all class methods and params
         self.classes = classes
+        self.python_parent_imports = []
         self.current_class = ""
 
         # a dict to let us use the alias name instead of the full c++ name. Without
@@ -1665,6 +1666,9 @@ if _version_info < (3, 7, 0):
                     if ":" in base:
                         continue
 
+                    if base not in self.python_parent_imports:
+                        self.python_parent_imports.append(base)
+
                     if self.classes[self.current_class].parent_class == "":
                         self.classes[self.current_class].parent_class = f"_{base}Proxy"
 
@@ -1729,10 +1733,10 @@ if _version_info < (3, 7, 0):
                 f.write(content)
 
 
-def init_submodule_pyi_file(pyiFile: Path, submodule_name: str) -> None:
+def init_submodule_pyi_template_file(pyiFile: Path, submodule_name: str) -> None:
     with open(pyiFile, "w") as pyiFile:
         pyiFile.write(
-            f"""# Interface and Interface methods for submodule: {submodule_name}
+            f"""# Interface for submodule: {submodule_name}
 from typing import Union, Any
 # additional imports
 from .support.template_class import itkTemplate as _itkTemplate
@@ -1741,13 +1745,34 @@ from .support.template_class import itkTemplate as _itkTemplate
         )
 
 
-def write_class_pyi(
-    pyiFile: Path, class_name: str, header_code: str, interfaces_code: str
+def init_submodule_pyi_proxy_file(pyiFile: Path, submodule_name: str, parent_imports) -> None:
+    with open(pyiFile, "w") as pyiFile:
+        pyiFile.write(
+            f"""# Interface methods for submodule: {submodule_name}
+from typing import Union, Any
+# additional imports
+from .support.template_class import itkTemplate as _itkTemplate
+{ f"from ._proxies import {', '.join(parent_imports)}" if len(parent_imports) > 0 else ""}
+
+\n"""
+        )
+
+
+def write_class_template_pyi(
+        pyiFile: Path, class_name: str, header_code: str
 ) -> None:
-    # Write interface files to the stub directory to support editor autocompletions
+    # Write interface files to the stub directory to support editor autocompletion
     with open(pyiFile, "a+") as pyiFile:
         pyiFile.write(f"# Interface for class: {class_name}\n")
+        pyiFile.write(f"from ._proxies import {class_name}Proxy as _{class_name}Proxy\n")
         pyiFile.write(header_code)
+
+
+def write_class_proxy_pyi(
+        pyiFile: Path, class_name: str, interfaces_code: str
+) -> None:
+    # Write interface files to the stub directory to support editor autocompletion
+    with open(pyiFile, "a+") as pyiFile:
         pyiFile.write(f"# Interface methods for class: {class_name}\n")
         pyiFile.write(interfaces_code)
 
@@ -1958,6 +1983,8 @@ if __name__ == "__main__":
             swig_input_generator.snakeCaseProcessObjectFunctions
         )
 
+        return swig_input_generator.python_parent_imports
+
     classes = {}
 
     ordered_submodule_list: List[str] = []
@@ -1971,11 +1998,15 @@ if __name__ == "__main__":
     del submoduleNames
 
     for submoduleName in ordered_submodule_list:
-        generate_swig_input(submoduleName, classes)
+        parents = generate_swig_input(submoduleName, classes)
+        parent_imports = [f"{p}Proxy as _{p}Proxy" for p in parents]
         if options.pyi_dir != "":
-          init_submodule_pyi_file(
-            Path(f"{options.pyi_dir}/{submoduleName}.pyi"), submoduleName
-          )
+            init_submodule_pyi_template_file(
+                Path(f"{options.pyi_dir}/{submoduleName}Template.pyi"), submoduleName
+            )
+            init_submodule_pyi_proxy_file(
+                Path(f"{options.pyi_dir}/{submoduleName}Proxy.pyi"), submoduleName, parent_imports
+            )
 
     if options.pyi_dir != "":
       for itk_class in classes.keys():
@@ -1985,13 +2016,16 @@ if __name__ == "__main__":
             outputPYIHeaderFile, outputPYIMethodFile, classes[itk_class]
         )
 
-        write_class_pyi(
-            Path(f"{options.pyi_dir}/{classes[itk_class].submodule_name}.pyi"),
+        write_class_template_pyi(
+            Path(f"{options.pyi_dir}/{classes[itk_class].submodule_name}Template.pyi"),
             itk_class,
             outputPYIHeaderFile.getvalue(),
+        )
+        write_class_proxy_pyi(
+            Path(f"{options.pyi_dir}/{classes[itk_class].submodule_name}Proxy.pyi"),
+            itk_class,
             outputPYIMethodFile.getvalue(),
         )
-
 
     snake_case_file = options.snake_case_file
     if len(snake_case_file) > 1:


### PR DESCRIPTION
There are a few problems remaining with the Python Stub interface (.pyi) file generation.

1. `__init__.pyi` generation
The function call that generated this file was removed in an earlier commit.
Instead of recreating the old behavior, the `__init__.pyi` file generation was
moved into CMake configuration files. The previous implementation was unreliable
in parallel builds and would often be missing a few imports. The new implementation
should work better in a parallel build environment.

2. Missing imports for dependent .pyi files. 
In the original implementation Python hints were contained in just two files. To resolve parallelization issues the .pyi files were split into many separate files that were generated in parallel and then imported into a main `__init__.pyi` file. Some of these files are dependent on each other and some form of importing needs to be added. The solution may not be as simple as adding import statements due to the following:
   - Classes pretended with `_` cannot be imported in the static context. While this could work in an actual program, the IDE will not produce the type hints due to the underscore. Removing the underscore will reveal several 'fake' classes to the user. 
   - The import names may not be known. While some classes such `Array` are contained in a file with their same name`itkArray.pyi` others, like `Object`, are in files with other names (`ITKCommonBase.pyi`). It may be difficult to learn the correct file name to import during the execution of `igenerator.py` without maintaining a list.  

The final solution resolved these issues by splitting the Template and Proxy classes into two separate files, allowing the leading underscores to be removed from the proxies (Which is necessary for * imports to work). The `_proxies.pyi` then imports all proxy files making all Proxy classes available to other Template and Proxy classes through the same interface: `from ._proxies import <class_name>Proxy as _<class_name>Proxy`. This method allows for the imports to function as desired while not requiring the file name of each class to be known and without exposing the proxy classes to the user. 

These issues were mentioned in #3128.