### PR TITLE
STYLE: Replace `NumericTraits<double>::ZeroValue()` and `NumericTraits<double>::OneValue()` calls by `0.0` and `1.0`, respectively

### DIFF
--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -444,7 +444,7 @@ Versor<T>::Set(const VectorType & axis)
     throw exception;
   }
 
-  const ValueType cosangle2 = std::sqrt(NumericTraits<double>::OneValue() - sinangle2 * sinangle2);
+  const ValueType cosangle2 = std::sqrt(1.0 - sinangle2 * sinangle2);
 
   m_X = axis[0];
   m_Y = axis[1];

--- a/Modules/Core/Common/test/itkBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkBoundaryConditionTest.cxx
@@ -170,7 +170,7 @@ itkBoundaryConditionTest(int, char *[])
   SmartIteratorType it2d(sz2, image2D, image2D->GetRequestedRegion());
 
   itk::ConstantBoundaryCondition<ImageType2D> cbc;
-  cbc.SetConstant(itk::NumericTraits<float>::ZeroValue());
+  cbc.SetConstant(0.0f);
   it2d.OverrideBoundaryCondition(&cbc);
 
   SmartIteratorType::NeighborhoodType tempN;

--- a/Modules/Core/Common/test/itkBoundingBoxTest.cxx
+++ b/Modules/Core/Common/test/itkBoundingBoxTest.cxx
@@ -62,7 +62,7 @@ itkBoundingBoxTest(int, char *[])
   }
 
 
-  if (itk::Math::NotExactlyEquals(myBox->GetDiagonalLength2(), itk::NumericTraits<double>::ZeroValue()))
+  if (itk::Math::NotExactlyEquals(myBox->GetDiagonalLength2(), 0.0))
   {
     return EXIT_FAILURE;
   }

--- a/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
@@ -74,7 +74,7 @@ public:
       itk::CompensatedSummation<double> compensatedSum;
       for (DomainType::IndexValueType i = subdomain[0]; i <= subdomain[1]; ++i)
       {
-        double value = itk::NumericTraits<double>::OneValue() / 7;
+        double value = 1.0 / 7;
         this->m_PerThreadCompensatedSum[threadId].AddElement(value);
       }
     }

--- a/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
@@ -82,7 +82,7 @@ public:
     void
     AfterThreadedExecution() override
     {
-      this->m_Associate->m_UncompensatedSumOfThreads = itk::NumericTraits<double>::ZeroValue();
+      this->m_Associate->m_UncompensatedSumOfThreads = 0.0;
       this->m_Associate->m_CompensatedSumOfThreads.ResetToZero();
 
       for (itk::ThreadIdType i = 0, numWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed(); i < numWorkUnitsUsed; ++i)

--- a/Modules/Core/Common/test/itkMathTest.cxx
+++ b/Modules/Core/Common/test/itkMathTest.cxx
@@ -622,8 +622,7 @@ main(int, char *[])
     }
 
     // Test comparison values of different types
-    if (itk::Math::NotExactlyEquals(itk::NumericTraits<float>::OneValue(), 1.0) ||
-        itk::Math::NotExactlyEquals(1.0, static_cast<float>(1)))
+    if (itk::Math::NotExactlyEquals(1.0f, 1.0) || itk::Math::NotExactlyEquals(1.0, 1.0f))
     {
       std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkMathTest.cxx
+++ b/Modules/Core/Common/test/itkMathTest.cxx
@@ -622,8 +622,8 @@ main(int, char *[])
     }
 
     // Test comparison values of different types
-    if (itk::Math::NotExactlyEquals(itk::NumericTraits<float>::OneValue(), itk::NumericTraits<double>::OneValue()) ||
-        itk::Math::NotExactlyEquals(itk::NumericTraits<double>::OneValue(), static_cast<float>(1)))
+    if (itk::Math::NotExactlyEquals(itk::NumericTraits<float>::OneValue(), 1.0) ||
+        itk::Math::NotExactlyEquals(1.0, static_cast<float>(1)))
     {
       std::cout << __FILE__ << " " << __LINE__ << " " << f << " == " << d << std::endl;
       testPassStatus = EXIT_FAILURE;
@@ -633,8 +633,8 @@ main(int, char *[])
     FloatRepresentationD oneExact;
     FloatRepresentationD oneAlmost;
 
-    oneExact.asFloat = itk::NumericTraits<double>::OneValue();
-    oneAlmost.asFloat = itk::NumericTraits<double>::OneValue();
+    oneExact.asFloat = 1.0;
+    oneAlmost.asFloat = 1.0;
     oneAlmost.asInt += 1;
 
     // Very close values should be AlmostEqual

--- a/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
@@ -23,7 +23,7 @@ namespace itk
 {
 template <typename TInputImage, typename TCoordRep>
 MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordRep>::MahalanobisDistanceThresholdImageFunction()
-  : m_Threshold(NumericTraits<double>::ZeroValue())
+  : m_Threshold(0.0)
   , m_MahalanobisDistanceMembershipFunction(MahalanobisDistanceFunctionType::New())
 {}
 

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -437,7 +437,7 @@ RayCastHelper<TInputImage, TCoordRep>::CalcPlanesAndCorners()
     m_BoundingPlane[j][2] = C / std::sqrt(A * A + B * B + C * C);
     m_BoundingPlane[j][3] = D / std::sqrt(A * A + B * B + C * C);
 
-    if (itk::Math::AlmostEquals((A * A + B * B + C * C), itk::NumericTraits<double>::ZeroValue()))
+    if (itk::Math::AlmostEquals((A * A + B * B + C * C), 0.0))
     {
       itk::ExceptionObject err(__FILE__, __LINE__);
       err.SetLocation(ITK_LOCATION);

--- a/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest2.cxx
+++ b/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest2.cxx
@@ -72,7 +72,7 @@ itkRegularSphereMeshSourceTest2(int, char *[])
   while (it != end)
   {
     const MeshType::PointType p = it->Value();
-    double                    d = itk::NumericTraits<double>::ZeroValue();
+    double                    d = 0.0;
     for (unsigned int dim = 0; dim < Dimension; ++dim)
     {
       d += (center[dim] - p[dim]) * (center[dim] - p[dim]) / (scale[dim] * scale[dim]);

--- a/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
@@ -203,7 +203,7 @@ CenteredSimilarity2DTransform<TParametersValueType>::GetInverse(Self * inverse) 
     return false;
   }
   inverse->SetCenter(this->GetCenter()); // inverse have the same center
-  inverse->SetScale(NumericTraits<double>::OneValue() / this->GetScale());
+  inverse->SetScale(1.0 / this->GetScale());
   inverse->SetAngle(-this->GetAngle());
   inverse->SetTranslation(-(this->GetInverseMatrix() * this->GetTranslation()));
   return true;

--- a/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.hxx
@@ -75,7 +75,7 @@ Rigid3DPerspectiveTransform<TParametersValueType>::SetParameters(const Parameter
   axis[1] = parameters[1];
   norm += parameters[2] * parameters[2];
   axis[2] = parameters[2];
-  if (norm > NumericTraits<double>::ZeroValue())
+  if (norm > 0.0)
   {
     norm = std::sqrt(norm);
   }

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
@@ -178,7 +178,7 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::ComputeMatrix()
     {
       if (Math::NotAlmostEquals(m_MatrixScale[i],
                                 NumericTraits<typename NumericTraits<InputVectorType>::ValueType>::ZeroValue()) &&
-          Math::NotAlmostEquals(m_Scale[i], NumericTraits<double>::ZeroValue()))
+          Math::NotAlmostEquals(m_Scale[i], 0.0))
       {
         imat.put(i, i, m_Scale[i] / m_MatrixScale[i] * this->GetMatrix()[i][i]);
         m_MatrixScale[i] = m_Scale[i];

--- a/Modules/Core/Transform/include/itkScaleTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleTransform.hxx
@@ -174,7 +174,7 @@ ScaleTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) co
   inverse->SetFixedParameters(this->GetFixedParameters());
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
-    inverse->m_Scale[i] = NumericTraits<double>::OneValue() / m_Scale[i];
+    inverse->m_Scale[i] = 1.0 / m_Scale[i];
   }
 
   return true;

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
@@ -247,7 +247,7 @@ Similarity2DTransform<TParametersValueType>::GetInverse(Self * inverse) const
     return false;
   }
   inverse->SetCenter(this->GetCenter()); // inverse have the same center
-  inverse->SetScale(NumericTraits<double>::OneValue() / this->GetScale());
+  inverse->SetScale(1.0 / this->GetScale());
   inverse->SetAngle(-this->GetAngle());
   inverse->SetTranslation(-(this->GetInverseMatrix() * this->GetTranslation()));
 

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.hxx
@@ -26,7 +26,7 @@ template <typename TInputImage>
 LabelShapeOpeningImageFilter<TInputImage>::LabelShapeOpeningImageFilter()
 {
   m_BackgroundValue = NumericTraits<OutputImagePixelType>::NonpositiveMin();
-  m_Lambda = NumericTraits<double>::ZeroValue();
+  m_Lambda = 0.0;
   m_ReverseOrdering = false;
   m_Attribute = LabelObjectType::NUMBER_OF_PIXELS;
 }

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.hxx
@@ -26,7 +26,7 @@ template <typename TInputImage, typename TFeatureImage>
 LabelStatisticsOpeningImageFilter<TInputImage, TFeatureImage>::LabelStatisticsOpeningImageFilter()
 {
   m_BackgroundValue = NumericTraits<OutputImagePixelType>::NonpositiveMin();
-  m_Lambda = NumericTraits<double>::ZeroValue();
+  m_Lambda = 0.0;
   m_ReverseOrdering = false;
   m_Attribute = LabelObjectType::MEAN;
   this->SetNumberOfRequiredInputs(2);

--- a/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.hxx
@@ -25,7 +25,7 @@ namespace itk
 template <typename TImage>
 ShapeOpeningLabelMapFilter<TImage>::ShapeOpeningLabelMapFilter()
 {
-  m_Lambda = NumericTraits<double>::ZeroValue();
+  m_Lambda = 0.0;
   m_ReverseOrdering = false;
   m_Attribute = LabelObjectType::NUMBER_OF_PIXELS;
 

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -282,7 +282,7 @@ HDF5ReadWriteTest(const char * fileName)
   }
 
   itk::Array<double> metaDataDoubleArray2;
-  metaDataDoubleArray2.Fill(itk::NumericTraits<double>::ZeroValue());
+  metaDataDoubleArray2.Fill(0.0);
   if (!itk::ExposeMetaData<itk::Array<double>>(metaDict2, "TestDoubleArray", metaDataDoubleArray2) ||
       metaDataDoubleArray2 != metaDataDoubleArray)
   {

--- a/Modules/IO/ImageBase/test/itkImageFileReaderPositiveSpacingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderPositiveSpacingTest.cxx
@@ -112,7 +112,7 @@ itkImageFileReaderPositiveSpacingTest(int argc, char * argv[])
     ImageNDType::IndexType baselineIndex;
     for (unsigned int ii = 0; ii < ImageNDType::ImageDimension; ++ii)
     {
-      double sum = itk::NumericTraits<double>::ZeroValue();
+      double sum = 0.0;
       for (unsigned int jj = 0; jj < ImageNDType::ImageDimension; ++jj)
       {
         sum += physicalPointToIndex[ii][jj] * (point[jj] - ioOrigin[jj]);

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -433,7 +433,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
   // Check MetaData
   itk::MetaDataDictionary & metaDict2(im2->GetMetaDataDictionary());
 
-  double metaDataDouble = itk::NumericTraits<double>::ZeroValue();
+  double metaDataDouble = 0.0;
   if (!itk::ExposeMetaData<double>(metaDict2, "acquisition:TestDouble", metaDataDouble) || metaDataDouble != 1.23)
   {
     std::cerr << "Failure reading metaData "
@@ -681,7 +681,7 @@ MINCReadWriteTestVector(const char * fileName,
   // Check MetaData
   itk::MetaDataDictionary & metaDict2(im2->GetMetaDataDictionary());
 
-  double metaDataDouble = itk::NumericTraits<double>::ZeroValue();
+  double metaDataDouble = 0.0;
   if (!itk::ExposeMetaData<double>(metaDict2, "acquisition:TestDouble", metaDataDouble) || metaDataDouble != 1.23)
   {
     std::cerr << "Failure reading metaData "

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -441,7 +441,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
     success = EXIT_FAILURE;
   }
 
-  float metaDataFloat = itk::NumericTraits<float>::ZeroValue();
+  float metaDataFloat = 0.0f;
   if (!itk::ExposeMetaData<float>(metaDict2, "acquisition:TestFloat", metaDataFloat) || metaDataFloat != 1.2f)
   {
     std::cerr << "Failure reading metaData "

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -313,7 +313,7 @@ FreeSurferAsciiMeshIO ::WritePoints(void * buffer)
     }
     case IOComponentEnum::DOUBLE:
     {
-      WritePoints(static_cast<double *>(buffer), outputFile, itk::NumericTraits<double>::ZeroValue());
+      WritePoints(static_cast<double *>(buffer), outputFile, 0.0);
 
       break;
     }

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -307,7 +307,7 @@ FreeSurferAsciiMeshIO ::WritePoints(void * buffer)
     }
     case IOComponentEnum::FLOAT:
     {
-      WritePoints(static_cast<float *>(buffer), outputFile, itk::NumericTraits<float>::ZeroValue());
+      WritePoints(static_cast<float *>(buffer), outputFile, 0.0f);
 
       break;
     }

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
@@ -44,7 +44,7 @@ MultipleValuedVnlCostFunctionAdaptor::SetScales(const ScalesType & scales)
       itkGenericExceptionMacro("ERROR: Scales must have value greater than epsilon! Scale[" << i
                                                                                             << "] = " << scales[i]);
     }
-    m_InverseScales[i] = NumericTraits<double>::OneValue() / scales[i];
+    m_InverseScales[i] = 1.0 / scales[i];
   }
   m_ScalesInitialized = true;
 }

--- a/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
@@ -45,7 +45,7 @@ Optimizer::SetScales(const ScalesType & scales)
     {
       itkExceptionMacro("ERROR: Scales must have value greater than epsilon! Scale[" << i << "] = " << m_Scales[i]);
     }
-    m_InverseScales[i] = NumericTraits<double>::OneValue() / m_Scales[i];
+    m_InverseScales[i] = 1.0 / m_Scales[i];
   }
   m_ScalesInitialized = true;
   this->Modified();

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
@@ -46,7 +46,7 @@ SingleValuedVnlCostFunctionAdaptor::SetScales(const ScalesType & scales)
       itkGenericExceptionMacro("ERROR: Scales must have value greater than epsilon! Scale[" << i
                                                                                             << "] = " << scales[i]);
     }
-    m_InverseScales[i] = NumericTraits<double>::OneValue() / scales[i];
+    m_InverseScales[i] = 1.0 / scales[i];
   }
   m_ScalesInitialized = true;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
@@ -235,7 +235,7 @@ itkGradientDescentOptimizerv4Test(int, char *[])
   itkOptimizer->SetNumberOfIterations(numberOfIterations);
   ITK_TEST_SET_GET_VALUE(numberOfIterations, itkOptimizer->GetNumberOfIterations());
 
-  double maximumStepSizeInPhysicalUnits = itk::NumericTraits<double>::ZeroValue();
+  double maximumStepSizeInPhysicalUnits = 0.0;
   itkOptimizer->SetMaximumStepSizeInPhysicalUnits(maximumStepSizeInPhysicalUnits);
   ITK_TEST_SET_GET_VALUE(maximumStepSizeInPhysicalUnits, itkOptimizer->GetMaximumStepSizeInPhysicalUnits());
 

--- a/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.hxx
@@ -37,7 +37,7 @@ EuclideanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x) cons
                                   measurementVectorSize,
                                   "EuclideanDistanceMetric::Evaluate Origin and input vector have different lengths");
 
-  double sumOfSquares = NumericTraits<double>::ZeroValue();
+  double sumOfSquares = 0.0;
 
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
@@ -63,7 +63,7 @@ EuclideanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x1, con
                       << NumericTraits<MeasurementVectorType>::GetLength(x2) << ")");
   }
 
-  double sumOfSquares = NumericTraits<double>::ZeroValue();
+  double sumOfSquares = 0.0;
 
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {

--- a/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
@@ -38,7 +38,7 @@ EuclideanSquareDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x
     measurementVectorSize,
     "EuclideanSquareDistanceMetric::Evaluate Origin and input vector have different lengths");
 
-  double temp, distance = NumericTraits<double>::ZeroValue();
+  double temp, distance = 0.0;
 
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
@@ -61,7 +61,7 @@ EuclideanSquareDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x
     itkExceptionMacro(<< "EuclideanSquareDistanceMetric:: The two measurement vectors have unequal size");
   }
 
-  double temp, distance = NumericTraits<double>::ZeroValue();
+  double temp, distance = 0.0;
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
     temp = x1[i] - x2[i];

--- a/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
@@ -65,9 +65,9 @@ GaussianMixtureModelComponent<TSample>::SetSample(const TSample * sample)
   NumericTraits<MeasurementVectorType>::SetLength(m_Mean, measurementVectorLength);
   m_Covariance.SetSize(measurementVectorLength, measurementVectorLength);
 
-  m_Mean.Fill(NumericTraits<double>::ZeroValue());
+  m_Mean.Fill(0.0);
 
-  m_Covariance.Fill(NumericTraits<double>::ZeroValue());
+  m_Covariance.Fill(0.0);
 
   typename NativeMembershipFunctionType::MeanVectorType mean;
 

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -626,13 +626,13 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
   {
     n = size - 1;
     InstanceIdentifier m = NumericTraits<InstanceIdentifier>::ZeroValue();
-    p_n = NumericTraits<double>::OneValue();
+    p_n = 1.0;
     do
     {
       f_n = this->GetFrequency(n, dimension);
       cumulated += f_n;
       p_n_prev = p_n;
-      p_n = NumericTraits<double>::OneValue() - cumulated / totalFrequency;
+      p_n = 1.0 - cumulated / totalFrequency;
       n--;
       m++;
     } while (m < size && p_n > p);

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -605,7 +605,7 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
   if (p < 0.5)
   {
     n = 0;
-    p_n = NumericTraits<double>::ZeroValue();
+    p_n = 0.0;
     do
     {
       f_n = this->GetFrequency(n, dimension);

--- a/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
@@ -37,7 +37,7 @@ ManhattanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x) cons
                                   measurementVectorSize,
                                   "ManhattanDistanceMetric::Evaluate Origin and input vector have different lengths");
 
-  double temp, distance = NumericTraits<double>::ZeroValue();
+  double temp, distance = 0.0;
 
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
@@ -58,7 +58,7 @@ ManhattanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x1, con
     itkExceptionMacro(<< "ManhattanDistanceMetric:: The two measurement vectors have unequal size");
   }
 
-  double temp, distance = NumericTraits<double>::ZeroValue();
+  double temp, distance = 0.0;
   for (unsigned int i = 0; i < measurementVectorSize; ++i)
   {
     temp = itk::Math::abs(x1[i] - x2[i]);

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -131,7 +131,7 @@ ChiSquareDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
 {
   if (p <= 0.0)
   {
-    return itk::NumericTraits<double>::ZeroValue();
+    return 0.0;
   }
   else if (p >= 1.0)
   {

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.hxx
@@ -57,7 +57,7 @@ CurvesLevelSetFunction<TImageType, TFeatureImageType>::CalculateAdvectionImage()
 
   typename VectorImageType::Pointer gradientImage;
 
-  if (Math::NotAlmostEquals(m_DerivativeSigma, NumericTraits<float>::ZeroValue()))
+  if (Math::NotAlmostEquals(m_DerivativeSigma, 0.0f))
   {
     using DerivativeFilterType = GradientRecursiveGaussianImageFilter<FeatureImageType, VectorImageType>;
 

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.hxx
@@ -46,7 +46,7 @@ GeodesicActiveContourLevelSetFunction<TImageType, TFeatureImageType>::CalculateA
 
   typename VectorImageType::Pointer gradientImage;
 
-  if (Math::NotAlmostEquals(m_DerivativeSigma, NumericTraits<float>::ZeroValue()))
+  if (Math::NotAlmostEquals(m_DerivativeSigma, 0.0f))
   {
     using DerivativeFilterType = GradientRecursiveGaussianImageFilter<FeatureImageType, VectorImageType>;
 

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.hxx
@@ -44,7 +44,7 @@ GeodesicActiveContourShapePriorLevelSetFunction<TImageType, TFeatureImageType>::
 
   typename VectorImageType::Pointer gradientImage;
 
-  if (Math::NotExactlyEquals(m_DerivativeSigma, NumericTraits<double>::ZeroValue()))
+  if (Math::NotExactlyEquals(m_DerivativeSigma, 0.0))
   {
     // Compute the gradient of the feature image
     using DerivativeFilterType = GradientRecursiveGaussianImageFilter<FeatureImageType, VectorImageType>;


### PR DESCRIPTION
Aims to improve code readability (assuming that most programmers know that the type of the floating point literals `0.0` and `1.0` is `double`, according to the C++ Standard).