### PR TITLE
WIP: Linux support for vector_container_from_array

### DIFF
--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -469,7 +469,10 @@ def vector_container_from_array(arr: ArrayLike, ttype=None) -> "itkt.VectorConta
         arr = np.asarray(arr)
 
     # Return VectorContainer with 64-bit index type
-    IndexType = itk.ULL
+    if os.name == 'nt':
+        IndexType = itk.ULL
+    else:
+        IndexType = itk.UL
 
     # Find container type
     if ttype is not None:


### PR DESCRIPTION
Currently, **itk.vector_container_from_array** does not work in Ubuntu due to the absence of itk.ULL key in 
the list of PyVectorContainer wrapping. It throws the error message
**"No suitable template parameter can be found"**

The correct key would be itk.UL.

Also, the test is not performed in Linux for itkPyVectorContainerTest
where we give the message "Insufficient wrapping to perform itkPyVectorContainerTest" and just skip the test.
Also refer https://github.com/InsightSoftwareConsortium/ITK/pull/2970.

Are there any issues with the approach in this PR that I am not aware of?

Opening for getting comments as we need this support for mesh serialization.



<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->


Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
