### PR TITLE
ENH: Expose FFT filter dimension traits

### DIFF
--- a/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
+++ b/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
@@ -116,11 +116,11 @@ protected:
   {
     OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<float>,
                                typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<float>>(
-      std::integer_sequence<unsigned int, 4, 3, 2, 1>{});
+      typename FFTImageFilterTraits<TFFTImageFilter>::FilterDimensions{});
 
     OverrideFFTImageFilterType<typename FFTImageFilterTraits<TFFTImageFilter>::template InputPixelType<double>,
                                typename FFTImageFilterTraits<TFFTImageFilter>::template OutputPixelType<double>>(
-      std::integer_sequence<unsigned int, 4, 3, 2, 1>{});
+      typename FFTImageFilterTraits<TFFTImageFilter>::FilterDimensions{});
   }
 };
 

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
@@ -111,6 +111,7 @@ struct FFTImageFilterTraits<FFTWComplexToComplex1DFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.h
@@ -158,6 +158,7 @@ struct FFTImageFilterTraits<FFTWComplexToComplexFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
@@ -110,6 +110,7 @@ struct FFTImageFilterTraits<FFTWForward1DFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkFFTWForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWForwardFFTImageFilter.h
@@ -144,6 +144,7 @@ struct FFTImageFilterTraits<FFTWForwardFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.h
@@ -151,6 +151,7 @@ struct FFTImageFilterTraits<FFTWHalfHermitianToRealInverseFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
@@ -109,6 +109,7 @@ struct FFTImageFilterTraits<FFTWInverse1DFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.h
@@ -145,6 +145,7 @@ struct FFTImageFilterTraits<FFTWInverseFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkFFTWRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWRealToHalfHermitianForwardFFTImageFilter.h
@@ -144,6 +144,7 @@ struct FFTImageFilterTraits<FFTWRealToHalfHermitianForwardFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
@@ -74,6 +74,7 @@ struct FFTImageFilterTraits<VnlComplexToComplex1DFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // end namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.h
@@ -82,6 +82,7 @@ struct FFTImageFilterTraits<VnlComplexToComplexFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // end namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
@@ -75,6 +75,7 @@ struct FFTImageFilterTraits<VnlForward1DFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // end namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
@@ -101,6 +101,7 @@ struct FFTImageFilterTraits<VnlForwardFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 } // namespace itk
 

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.h
@@ -110,6 +110,7 @@ struct FFTImageFilterTraits<VnlHalfHermitianToRealInverseFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
@@ -76,6 +76,7 @@ struct FFTImageFilterTraits<VnlInverse1DFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // end namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
@@ -107,6 +107,7 @@ struct FFTImageFilterTraits<VnlInverseFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.h
@@ -105,6 +105,7 @@ struct FFTImageFilterTraits<VnlRealToHalfHermitianForwardFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 4, 3, 2, 1>;
 };
 
 } // namespace itk


### PR DESCRIPTION
Moves FFT filter image dimensions into existing trait objects in order
to decouple FFT factory overrides from fixed dimension lists. This will
allow other, external FFT implementations that may not be valid for
higher-dimension overrides to reuse the FFT factory class.

Future changes may replace the explicit dimension lists with CMake
variables to avoid registering unnecessary factories.

Motivation for these changes comes from developing accelerated FFT filter overrides in the [ITKVkFFTBackend](https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend) external module.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
