### PR TITLE
BUG: Fix bug for remote AdaptiveDenoising

### DIFF
--- a/Modules/Remote/AdaptiveDenoising.remote.cmake
+++ b/Modules/Remote/AdaptiveDenoising.remote.cmake
@@ -56,5 +56,5 @@ itk_fetch_module(AdaptiveDenoising
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY ${git_protocol}://github.com/ntustison/ITKAdaptiveDenoising.git
-  GIT_TAG a31fc7dbed78260abb3832b908fd2b6a52cf189e
+  GIT_TAG 674218fae611184d4168bd0c7b027f1a0d1a8a18
 )


### PR DESCRIPTION
The AdaptiveDenoising project had a bug when processing images with small floating point
values (i.e. images with range of 0-1).

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
