### PR TITLE
BUG: fixed threading bug, don't use vector<bool> from multiple threads

### DIFF
--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
@@ -151,8 +151,11 @@ protected:
   /** The Hessian with local support */
   HessianArrayType m_HessianArray;
 
-  /** Valid flag for the Quasi-Newton steps */
-  std::vector<bool> m_NewtonStepValidFlags;
+  /** Valid flag for the Quasi-Newton steps.
+   * NB: although semantically boolean, vector<bool> is not thread safe due to the possibility of multiple bits being
+   * packed together in the same memory location.
+   */
+  std::vector<uint8_t> m_NewtonStepValidFlags;
 
   /** Estimate a Newton step */
   virtual void


### PR DESCRIPTION
vector<bool> is not thread safe due to the possibility of multiple bits being packed together in the same memory location.   Found by TSan.
