### PR TITLE
STYLE: Change template parameter name prefix N to V

### DIFF
--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -33,7 +33,7 @@ namespace itk
  * type held at each pixel in an Image or at each vertex of an Mesh.
  * The template parameter T can be any data type that behaves like a
  * primitive (or atomic) data type (int, short, float, complex).
- * The NVectorDimension defines the number of components in the vector array.
+ * The VVectorDimension defines the number of components in the vector array.
  *
  * CovariantVector is not a dynamically extendible array like std::vector. It is
  * intended to be used like a mathematical vector.
@@ -65,13 +65,13 @@ namespace itk
  * \endsphinx
  */
 
-template <typename T, unsigned int NVectorDimension = 3>
-class ITK_TEMPLATE_EXPORT CovariantVector : public FixedArray<T, NVectorDimension>
+template <typename T, unsigned int VVectorDimension = 3>
+class ITK_TEMPLATE_EXPORT CovariantVector : public FixedArray<T, VVectorDimension>
 {
 public:
   /** Standard class type aliases. */
   using Self = CovariantVector;
-  using Superclass = FixedArray<T, NVectorDimension>;
+  using Superclass = FixedArray<T, VVectorDimension>;
 
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an CovariantVector.   */
@@ -82,19 +82,19 @@ public:
   using ComponentType = T;
 
   /** Dimension of the Space */
-  static constexpr unsigned int Dimension = NVectorDimension;
+  static constexpr unsigned int Dimension = VVectorDimension;
 
   /** I am a covariant vector. */
   using CovariantVectorType = Self;
 
   /** The Array type from which this CovariantVector is derived. */
-  using BaseArray = FixedArray<T, NVectorDimension>;
+  using BaseArray = FixedArray<T, VVectorDimension>;
 
   /** Get the dimension (size) of the vector. */
   static unsigned int
   GetCovariantVectorDimension()
   {
-    return NVectorDimension;
+    return VVectorDimension;
   }
 
   /** Set a vnl_vector_ref referencing the same memory block. */
@@ -127,7 +127,7 @@ public:
   /** Pass-through constructor for the Array base class. Implicit casting is
    * performed to initialize constructor from any another one of datatype. */
   template <typename TVectorValueType>
-  CovariantVector(const CovariantVector<TVectorValueType, NVectorDimension> & r)
+  CovariantVector(const CovariantVector<TVectorValueType, VVectorDimension> & r)
     : BaseArray(r)
   {}
   CovariantVector(const ValueType r[Dimension])
@@ -137,7 +137,7 @@ public:
   /** Assignment operator with implicit casting from another data type */
   template <typename TCovariantVectorValueType>
   Self &
-  operator=(const CovariantVector<TCovariantVectorValueType, NVectorDimension> & r)
+  operator=(const CovariantVector<TCovariantVectorValueType, VVectorDimension> & r)
   {
     BaseArray::operator=(r);
     return *this;
@@ -145,14 +145,14 @@ public:
 
   /** Pass-through assignment operator for the Array base class. */
   CovariantVector &
-  operator=(const ValueType r[NVectorDimension]);
+  operator=(const ValueType r[VVectorDimension]);
 
   /** Scalar operator*=.  Scales elements by a scalar. */
   template <typename Tt>
   inline const Self &
   operator*=(const Tt & value)
   {
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       (*this)[i] = static_cast<ValueType>((*this)[i] * value);
     }
@@ -164,7 +164,7 @@ public:
   const Self &
   operator/=(const Tt & value)
   {
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       (*this)[i] = static_cast<ValueType>((*this)[i] / value);
     }
@@ -200,7 +200,7 @@ public:
 
   /** operator*.  Performs the scalar product with a vector (contravariant).
    * This scalar product is invariant under affine transformations */
-  ValueType operator*(const Vector<T, NVectorDimension> & other) const;
+  ValueType operator*(const Vector<T, VVectorDimension> & other) const;
 
   /** Scalar operator*. Scale the elements of a vector by a scalar.
    * Return a new vector. */
@@ -208,7 +208,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       result[i] = static_cast<ValueType>((*this)[i] * val);
     }
@@ -223,7 +223,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       result[i] = static_cast<ValueType>((*this)[i] / val);
     }
@@ -238,7 +238,7 @@ public:
   static unsigned int
   GetNumberOfComponents()
   {
-    return NVectorDimension;
+    return VVectorDimension;
   }
 
   /** Divides the covariant vector components by the norm and return the norm */
@@ -253,9 +253,9 @@ public:
    *  Casting is done with C-Like rules  */
   template <typename TCoordRepB>
   void
-  CastFrom(const CovariantVector<TCoordRepB, NVectorDimension> & pa)
+  CastFrom(const CovariantVector<TCoordRepB, VVectorDimension> & pa)
   {
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       (*this)[i] = static_cast<T>(pa[i]);
     }
@@ -264,17 +264,17 @@ public:
 
 /** Premultiply Operator for product of a vector and a scalar.
  *  CovariantVector< T, N >  =  T * CovariantVector< T,N > */
-template <typename T, unsigned int NVectorDimension>
-inline CovariantVector<T, NVectorDimension> operator*(const T & scalar, const CovariantVector<T, NVectorDimension> & v)
+template <typename T, unsigned int VVectorDimension>
+inline CovariantVector<T, VVectorDimension> operator*(const T & scalar, const CovariantVector<T, VVectorDimension> & v)
 {
   return v.operator*(scalar);
 }
 
 /** Performs the scalar product of a covariant with a contravariant.
  * This scalar product is invariant under affine transformations */
-template <typename T, unsigned int NVectorDimension>
-inline T operator*(const Vector<T, NVectorDimension> &          contravariant,
-                   const CovariantVector<T, NVectorDimension> & covariant)
+template <typename T, unsigned int VVectorDimension>
+inline T operator*(const Vector<T, VVectorDimension> &          contravariant,
+                   const CovariantVector<T, VVectorDimension> & covariant)
 {
   return covariant.operator*(contravariant);
 }
@@ -289,9 +289,9 @@ ITKCommon_EXPORT void
 CrossProduct(CovariantVector<int, 3>, const Vector<int, 3> &, const Vector<int, 3> &);
 
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 inline void
-swap(CovariantVector<T, NVectorDimension> & a, CovariantVector<T, NVectorDimension> & b)
+swap(CovariantVector<T, VVectorDimension> & a, CovariantVector<T, VVectorDimension> & b)
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -28,106 +28,106 @@ CovariantVector<T, TVectorDimension>::CovariantVector(const ValueType & r)
   : Superclass{ r }
 {}
 
-template <typename T, unsigned int NVectorDimension>
-CovariantVector<T, NVectorDimension> &
-CovariantVector<T, NVectorDimension>::operator=(const ValueType r[NVectorDimension])
+template <typename T, unsigned int VVectorDimension>
+CovariantVector<T, VVectorDimension> &
+CovariantVector<T, VVectorDimension>::operator=(const ValueType r[VVectorDimension])
 {
   BaseArray::operator=(r);
   return *this;
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 auto
-CovariantVector<T, NVectorDimension>::operator+=(const Self & vec) -> const Self &
+CovariantVector<T, VVectorDimension>::operator+=(const Self & vec) -> const Self &
 {
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     (*this)[i] += vec[i];
   }
   return *this;
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 auto
-CovariantVector<T, NVectorDimension>::operator-=(const Self & vec) -> const Self &
+CovariantVector<T, VVectorDimension>::operator-=(const Self & vec) -> const Self &
 {
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     (*this)[i] -= vec[i];
   }
   return *this;
 }
 
-template <typename T, unsigned int NVectorDimension>
-CovariantVector<T, NVectorDimension>
-CovariantVector<T, NVectorDimension>::operator-() const
+template <typename T, unsigned int VVectorDimension>
+CovariantVector<T, VVectorDimension>
+CovariantVector<T, VVectorDimension>::operator-() const
 {
   Self result;
 
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     result[i] = -(*this)[i];
   }
   return result;
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 auto
-CovariantVector<T, NVectorDimension>::operator+(const Self & vec) const -> Self
+CovariantVector<T, VVectorDimension>::operator+(const Self & vec) const -> Self
 {
   Self result;
 
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     result[i] = (*this)[i] + vec[i];
   }
   return result;
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 auto
-CovariantVector<T, NVectorDimension>::operator-(const Self & vec) const -> Self
+CovariantVector<T, VVectorDimension>::operator-(const Self & vec) const -> Self
 {
   Self result;
 
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     result[i] = (*this)[i] - vec[i];
   }
   return result;
 }
 
-template <typename T, unsigned int NVectorDimension>
-typename CovariantVector<T, NVectorDimension>::ValueType CovariantVector<T, NVectorDimension>::operator*(
+template <typename T, unsigned int VVectorDimension>
+typename CovariantVector<T, VVectorDimension>::ValueType CovariantVector<T, VVectorDimension>::operator*(
   const Self & other) const
 {
   typename NumericTraits<T>::AccumulateType value = NumericTraits<T>::ZeroValue();
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];
   }
   return static_cast<ValueType>(value);
 }
 
-template <typename T, unsigned int NVectorDimension>
-typename CovariantVector<T, NVectorDimension>::ValueType CovariantVector<T, NVectorDimension>::operator*(
-  const Vector<T, NVectorDimension> & other) const
+template <typename T, unsigned int VVectorDimension>
+typename CovariantVector<T, VVectorDimension>::ValueType CovariantVector<T, VVectorDimension>::operator*(
+  const Vector<T, VVectorDimension> & other) const
 {
   typename NumericTraits<T>::AccumulateType value = NumericTraits<T>::ZeroValue();
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];
   }
   return value;
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 auto
-CovariantVector<T, NVectorDimension>::GetSquaredNorm() const -> RealValueType
+CovariantVector<T, VVectorDimension>::GetSquaredNorm() const -> RealValueType
 {
   RealValueType sum = NumericTraits<RealValueType>::ZeroValue();
 
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     const RealValueType value = (*this)[i];
     sum += value * value;
@@ -135,20 +135,20 @@ CovariantVector<T, NVectorDimension>::GetSquaredNorm() const -> RealValueType
   return sum;
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 auto
-CovariantVector<T, NVectorDimension>::GetNorm() const -> RealValueType
+CovariantVector<T, VVectorDimension>::GetNorm() const -> RealValueType
 {
   return std::sqrt(this->GetSquaredNorm());
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 auto
-CovariantVector<T, NVectorDimension>::Normalize() -> RealValueType
+CovariantVector<T, VVectorDimension>::Normalize() -> RealValueType
 {
   const RealValueType norm = this->GetNorm();
 
-  for (unsigned int i = 0; i < NVectorDimension; ++i)
+  for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     (*this)[i] /= norm;
   }
@@ -156,9 +156,9 @@ CovariantVector<T, NVectorDimension>::Normalize() -> RealValueType
   return norm;
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 void
-CovariantVector<T, NVectorDimension>::SetVnlVector(const vnl_vector<T> & v)
+CovariantVector<T, VVectorDimension>::SetVnlVector(const vnl_vector<T> & v)
 {
   for (unsigned int i = 0; i < v.size(); ++i)
   {
@@ -166,22 +166,22 @@ CovariantVector<T, NVectorDimension>::SetVnlVector(const vnl_vector<T> & v)
   }
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 vnl_vector_ref<T>
-CovariantVector<T, NVectorDimension>::GetVnlVector()
+CovariantVector<T, VVectorDimension>::GetVnlVector()
 {
-  return vnl_vector_ref<T>(NVectorDimension, this->GetDataPointer());
+  return vnl_vector_ref<T>(VVectorDimension, this->GetDataPointer());
 }
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 vnl_vector<T>
-CovariantVector<T, NVectorDimension>::GetVnlVector() const
+CovariantVector<T, VVectorDimension>::GetVnlVector() const
 {
   // Return a vector_ref<>.  This will be automatically converted to a
   // vnl_vector<>.  We have to use a const_cast<> which would normally
   // be prohibited in a const method, but it is safe to do here
   // because the cast to vnl_vector<> will ultimately copy the data.
-  return vnl_vector_ref<T>(NVectorDimension, const_cast<T *>(this->GetDataPointer()));
+  return vnl_vector_ref<T>(VVectorDimension, const_cast<T *>(this->GetDataPointer()));
 }
 
 } // end namespace itk

--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -173,15 +173,15 @@ public:
    *
    * \deprecated Use RebindImageType instead
    */
-  template <typename UPixelType, unsigned int NUImageDimension = VImageDimension>
+  template <typename UPixelType, unsigned int VUImageDimension = VImageDimension>
   struct Rebind
   {
-    using Type = itk::Image<UPixelType, NUImageDimension>;
+    using Type = itk::Image<UPixelType, VUImageDimension>;
   };
 
 
-  template <typename UPixelType, unsigned int NUImageDimension = VImageDimension>
-  using RebindImageType = itk::Image<UPixelType, NUImageDimension>;
+  template <typename UPixelType, unsigned int VUImageDimension = VImageDimension>
+  using RebindImageType = itk::Image<UPixelType, VUImageDimension>;
 
 
   /** Allocate the image memory. The size of the image must

--- a/Modules/Core/Common/include/itkImageHelper.h
+++ b/Modules/Core/Common/include/itkImageHelper.h
@@ -47,14 +47,14 @@ namespace itk
  */
 
 // Forward reference because of circular dependencies
-template <unsigned int NImageDimension>
+template <unsigned int VImageDimension>
 class ITK_TEMPLATE_EXPORT ImageBase;
 
-template <unsigned int NImageDimension, unsigned int NLoop>
+template <unsigned int VImageDimension, unsigned int VLoop>
 class ImageHelper
 {
 public:
-  using ImageType = ImageBase<NImageDimension>;
+  using ImageType = ImageBase<VImageDimension>;
   using IndexType = typename ImageType::IndexType;
   using OffsetType = typename ImageType::OffsetType;
   using OffsetValueType = typename ImageType::OffsetValueType;
@@ -67,8 +67,8 @@ public:
                const OffsetValueType offsetTable[],
                IndexType &           index)
   {
-    ImageHelper<NImageDimension, NLoop - 1>::ComputeIndexInner(
-      bufferedRegionIndex, offset, offsetTable, index, std::integral_constant<bool, NLoop == 1>{});
+    ImageHelper<VImageDimension, VLoop - 1>::ComputeIndexInner(
+      bufferedRegionIndex, offset, offsetTable, index, std::integral_constant<bool, VLoop == 1>{});
   }
 
   inline static void
@@ -78,11 +78,11 @@ public:
                     IndexType &           index,
                     std::false_type)
   {
-    index[NLoop] = static_cast<IndexValueType>(offset / offsetTable[NLoop]);
-    offset -= (index[NLoop] * offsetTable[NLoop]);
-    index[NLoop] += bufferedRegionIndex[NLoop];
-    ImageHelper<NImageDimension, NLoop - 1>::ComputeIndexInner(
-      bufferedRegionIndex, offset, offsetTable, index, std::integral_constant<bool, NLoop == 1>{});
+    index[VLoop] = static_cast<IndexValueType>(offset / offsetTable[VLoop]);
+    offset -= (index[VLoop] * offsetTable[VLoop]);
+    index[VLoop] += bufferedRegionIndex[VLoop];
+    ImageHelper<VImageDimension, VLoop - 1>::ComputeIndexInner(
+      bufferedRegionIndex, offset, offsetTable, index, std::integral_constant<bool, VLoop == 1>{});
   }
 
   inline static void
@@ -104,8 +104,8 @@ public:
                 const OffsetValueType offsetTable[],
                 OffsetValueType &     offset)
   {
-    ImageHelper<NImageDimension, NLoop - 1>::ComputeOffsetInner(
-      bufferedRegionIndex, index, offsetTable, offset, std::integral_constant<bool, NLoop == 1>{});
+    ImageHelper<VImageDimension, VLoop - 1>::ComputeOffsetInner(
+      bufferedRegionIndex, index, offsetTable, offset, std::integral_constant<bool, VLoop == 1>{});
   }
 
   inline static void
@@ -115,9 +115,9 @@ public:
                      OffsetValueType &     offset,
                      std::false_type)
   {
-    offset += (index[NLoop] - bufferedRegionIndex[NLoop]) * offsetTable[NLoop];
-    ImageHelper<NImageDimension, NLoop - 1>::ComputeOffsetInner(
-      bufferedRegionIndex, index, offsetTable, offset, std::integral_constant<bool, NLoop == 1>{});
+    offset += (index[VLoop] - bufferedRegionIndex[VLoop]) * offsetTable[VLoop];
+    ImageHelper<VImageDimension, VLoop - 1>::ComputeOffsetInner(
+      bufferedRegionIndex, index, offsetTable, offset, std::integral_constant<bool, VLoop == 1>{});
   }
 
   inline static void

--- a/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.h
+++ b/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.h
@@ -32,8 +32,8 @@ namespace itk
  */
 
 /* Can we template of Image type instead, but require that Image be of type
- * Image< Vector< TValue, NVectorDimension >, VImageDimension > ? */
-template <typename TValue, unsigned int NVectorDimension, unsigned int VImageDimension>
+ * Image< Vector< TValue, VVectorDimension >, VImageDimension > ? */
+template <typename TValue, unsigned int VVectorDimension, unsigned int VImageDimension>
 class ITK_TEMPLATE_EXPORT ImageVectorOptimizerParametersHelper : public OptimizerParametersHelper<TValue>
 {
 public:
@@ -43,7 +43,7 @@ public:
   using Superclass = OptimizerParametersHelper<TValue>;
 
   /** Image type that this class expects. */
-  using ParameterImageType = Image<Vector<TValue, NVectorDimension>, VImageDimension>;
+  using ParameterImageType = Image<Vector<TValue, VVectorDimension>, VImageDimension>;
   using ParameterImagePointer = typename ParameterImageType::Pointer;
 
   /** Type of the common data object used in OptimizerParameters */

--- a/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.hxx
+++ b/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.hxx
@@ -23,16 +23,16 @@
 namespace itk
 {
 /** Default contstructor */
-template <typename TValue, unsigned int NVectorDimension, unsigned int VImageDimension>
-ImageVectorOptimizerParametersHelper<TValue, NVectorDimension, VImageDimension>::ImageVectorOptimizerParametersHelper()
+template <typename TValue, unsigned int VVectorDimension, unsigned int VImageDimension>
+ImageVectorOptimizerParametersHelper<TValue, VVectorDimension, VImageDimension>::ImageVectorOptimizerParametersHelper()
 {
   m_ParameterImage = nullptr;
 }
 
 /** Move the data pointer */
-template <typename TValue, unsigned int NVectorDimension, unsigned int VImageDimension>
+template <typename TValue, unsigned int VVectorDimension, unsigned int VImageDimension>
 void
-ImageVectorOptimizerParametersHelper<TValue, NVectorDimension, VImageDimension>::MoveDataPointer(
+ImageVectorOptimizerParametersHelper<TValue, VVectorDimension, VImageDimension>::MoveDataPointer(
   CommonContainerType * container,
   TValue *              pointer)
 {
@@ -53,9 +53,9 @@ ImageVectorOptimizerParametersHelper<TValue, NVectorDimension, VImageDimension>:
 }
 
 /** Set parameter image */
-template <typename TValue, unsigned int NVectorDimension, unsigned int VImageDimension>
+template <typename TValue, unsigned int VVectorDimension, unsigned int VImageDimension>
 void
-ImageVectorOptimizerParametersHelper<TValue, NVectorDimension, VImageDimension>::SetParametersObject(
+ImageVectorOptimizerParametersHelper<TValue, VVectorDimension, VImageDimension>::SetParametersObject(
   CommonContainerType * container,
   LightObject *         object)
 {
@@ -77,7 +77,7 @@ ImageVectorOptimizerParametersHelper<TValue, NVectorDimension, VImageDimension>:
     // The PixelContainer for Image<Vector> points to type Vector, so we have
     // to determine the number of raw elements of type TValue in the buffer
     // and cast a pointer to it for assignment to the Array data pointer.
-    typename CommonContainerType::SizeValueType sz = image->GetPixelContainer()->Size() * NVectorDimension;
+    typename CommonContainerType::SizeValueType sz = image->GetPixelContainer()->Size() * VVectorDimension;
     auto * valuePointer = reinterpret_cast<TValue *>(image->GetPixelContainer()->GetBufferPointer());
     // Set the Array's pointer to the image data buffer. By default it will
     // not manage the memory.

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -47,7 +47,7 @@ namespace itk
  * \endsphinx
  */
 
-template <typename T, unsigned int NRows = 3, unsigned int NColumns = 3>
+template <typename T, unsigned int VRows = 3, unsigned int VColumns = 3>
 class ITK_TEMPLATE_EXPORT Matrix
 {
 public:
@@ -59,36 +59,36 @@ public:
   using ComponentType = T;
 
   /** Number Of Columns and Rows. */
-  static constexpr unsigned int RowDimensions = NRows;
-  static constexpr unsigned int ColumnDimensions = NColumns;
+  static constexpr unsigned int RowDimensions = VRows;
+  static constexpr unsigned int ColumnDimensions = VColumns;
 
   /** Internal matrix type */
-  using InternalMatrixType = vnl_matrix_fixed<T, NRows, NColumns>;
+  using InternalMatrixType = vnl_matrix_fixed<T, VRows, VColumns>;
 
   /** Compatible square matrix. This is currently used by operator* to help
    * with wrapping.  \todo In the future, the method should be templated to allow
-   * multiplication by NColumns by XRows.*/
-  using CompatibleSquareMatrixType = Matrix<T, NColumns, NColumns>;
+   * multiplication by VColumns by XRows.*/
+  using CompatibleSquareMatrixType = Matrix<T, VColumns, VColumns>;
 
   /** Matrix by Vector multiplication.  */
-  Vector<T, NRows> operator*(const Vector<T, NColumns> & vect) const;
+  Vector<T, VRows> operator*(const Vector<T, VColumns> & vect) const;
 
   /** Matrix by Point multiplication.  */
-  Point<T, NRows> operator*(const Point<T, NColumns> & pnt) const;
+  Point<T, VRows> operator*(const Point<T, VColumns> & pnt) const;
 
   /** Matrix by CovariantVector multiplication.  */
-  CovariantVector<T, NRows> operator*(const CovariantVector<T, NColumns> & covect) const;
+  CovariantVector<T, VRows> operator*(const CovariantVector<T, VColumns> & covect) const;
 
   /** Matrix by vnl_vector_fixed multiplication.  */
-  vnl_vector_fixed<T, NRows> operator*(const vnl_vector_fixed<T, NColumns> & inVNLvect) const;
+  vnl_vector_fixed<T, VRows> operator*(const vnl_vector_fixed<T, VColumns> & inVNLvect) const;
 
   /** Matrix by Matrix multiplication.  */
   Self operator*(const CompatibleSquareMatrixType & matrix) const;
 
   template <unsigned int OuterDim>
-  Matrix<T, NRows, OuterDim> operator*(const vnl_matrix_fixed<T, NRows, OuterDim> & matrix) const
+  Matrix<T, VRows, OuterDim> operator*(const vnl_matrix_fixed<T, VRows, OuterDim> & matrix) const
   {
-    const Matrix<T, NRows, OuterDim> result(m_Matrix * matrix);
+    const Matrix<T, VRows, OuterDim> result(m_Matrix * matrix);
     return result;
   }
 
@@ -230,9 +230,9 @@ public:
   {
     bool equal = true;
 
-    for (unsigned int r = 0; r < NRows; ++r)
+    for (unsigned int r = 0; r < VRows; ++r)
     {
-      for (unsigned int c = 0; c < NColumns; ++c)
+      for (unsigned int c = 0; c < VColumns; ++c)
       {
         if (Math::NotExactlyEquals(m_Matrix(r, c), matrix.m_Matrix(r, c)))
         {
@@ -260,7 +260,7 @@ public:
   {}
 
   /** Return the inverse matrix. */
-  inline vnl_matrix_fixed<T, NColumns, NRows>
+  inline vnl_matrix_fixed<T, VColumns, VRows>
   GetInverse() const
   {
     if (vnl_determinant(m_Matrix) == NumericTraits<T>::ZeroValue())
@@ -268,14 +268,14 @@ public:
       itkGenericExceptionMacro(<< "Singular matrix. Determinant is 0.");
     }
     vnl_matrix_inverse<T> inverse(m_Matrix.as_ref());
-    return vnl_matrix_fixed<T, NColumns, NRows>{ inverse.as_matrix() };
+    return vnl_matrix_fixed<T, VColumns, VRows>{ inverse.as_matrix() };
   }
 
   /** Return the transposed matrix. */
-  inline vnl_matrix_fixed<T, NColumns, NRows>
+  inline vnl_matrix_fixed<T, VColumns, VRows>
   GetTranspose() const
   {
-    return vnl_matrix_fixed<T, NColumns, NRows>{ m_Matrix.transpose().as_matrix() };
+    return vnl_matrix_fixed<T, VColumns, VRows>{ m_Matrix.transpose().as_matrix() };
   }
 
   /** Defaulted default-constructor. Zero-initializes all of its elements.
@@ -297,18 +297,18 @@ private:
   InternalMatrixType m_Matrix{};
 };
 
-template <typename T, unsigned int NRows, unsigned int NColumns>
+template <typename T, unsigned int VRows, unsigned int VColumns>
 std::ostream &
-operator<<(std::ostream & os, const Matrix<T, NRows, NColumns> & v)
+operator<<(std::ostream & os, const Matrix<T, VRows, VColumns> & v)
 {
   os << v.GetVnlMatrix();
   return os;
 }
 
 
-template <typename T, unsigned int NRows, unsigned int NColumns>
+template <typename T, unsigned int VRows, unsigned int VColumns>
 inline void
-swap(const Matrix<T, NRows, NColumns> & a, const Matrix<T, NRows, NColumns> & b)
+swap(const Matrix<T, VRows, VColumns> & a, const Matrix<T, VRows, VColumns> & b)
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkMatrix.hxx
+++ b/Modules/Core/Common/include/itkMatrix.hxx
@@ -25,14 +25,14 @@ namespace itk
 /**
  *  Product by a Vector
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-Vector<T, NRows> Matrix<T, NRows, NColumns>::operator*(const Vector<T, NColumns> & vect) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+Vector<T, VRows> Matrix<T, VRows, VColumns>::operator*(const Vector<T, VColumns> & vect) const
 {
-  Vector<T, NRows> result;
-  for (unsigned int r = 0; r < NRows; ++r)
+  Vector<T, VRows> result;
+  for (unsigned int r = 0; r < VRows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < NColumns; ++c)
+    for (unsigned int c = 0; c < VColumns; ++c)
     {
       sum += m_Matrix(r, c) * vect[c];
     }
@@ -44,14 +44,14 @@ Vector<T, NRows> Matrix<T, NRows, NColumns>::operator*(const Vector<T, NColumns>
 /**
  *  Product by a Point
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-Point<T, NRows> Matrix<T, NRows, NColumns>::operator*(const Point<T, NColumns> & pnt) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+Point<T, VRows> Matrix<T, VRows, VColumns>::operator*(const Point<T, VColumns> & pnt) const
 {
-  Point<T, NRows> result;
-  for (unsigned int r = 0; r < NRows; ++r)
+  Point<T, VRows> result;
+  for (unsigned int r = 0; r < VRows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < NColumns; ++c)
+    for (unsigned int c = 0; c < VColumns; ++c)
     {
       sum += m_Matrix(r, c) * pnt[c];
     }
@@ -63,14 +63,14 @@ Point<T, NRows> Matrix<T, NRows, NColumns>::operator*(const Point<T, NColumns> &
 /**
  *  Product by a vnl_vector_fixed
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-vnl_vector_fixed<T, NRows> Matrix<T, NRows, NColumns>::operator*(const vnl_vector_fixed<T, NColumns> & inVNLvect) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+vnl_vector_fixed<T, VRows> Matrix<T, VRows, VColumns>::operator*(const vnl_vector_fixed<T, VColumns> & inVNLvect) const
 {
-  vnl_vector_fixed<T, NRows> result;
-  for (unsigned int r = 0; r < NRows; ++r)
+  vnl_vector_fixed<T, VRows> result;
+  for (unsigned int r = 0; r < VRows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < NColumns; ++c)
+    for (unsigned int c = 0; c < VColumns; ++c)
     {
       sum += m_Matrix(r, c) * inVNLvect[c];
     }
@@ -82,14 +82,14 @@ vnl_vector_fixed<T, NRows> Matrix<T, NRows, NColumns>::operator*(const vnl_vecto
 /**
  *  Product by a CovariantVector
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-CovariantVector<T, NRows> Matrix<T, NRows, NColumns>::operator*(const CovariantVector<T, NColumns> & covect) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+CovariantVector<T, VRows> Matrix<T, VRows, VColumns>::operator*(const CovariantVector<T, VColumns> & covect) const
 {
-  CovariantVector<T, NRows> result;
-  for (unsigned int r = 0; r < NRows; ++r)
+  CovariantVector<T, VRows> result;
+  for (unsigned int r = 0; r < VRows; ++r)
   {
     T sum = NumericTraits<T>::ZeroValue();
-    for (unsigned int c = 0; c < NColumns; ++c)
+    for (unsigned int c = 0; c < VColumns; ++c)
     {
       sum += m_Matrix(r, c) * covect[c];
     }
@@ -101,8 +101,8 @@ CovariantVector<T, NRows> Matrix<T, NRows, NColumns>::operator*(const CovariantV
 /**
  *  Product by a matrix
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-Matrix<T, NRows, NColumns> Matrix<T, NRows, NColumns>::operator*(const CompatibleSquareMatrixType & matrix) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+Matrix<T, VRows, VColumns> Matrix<T, VRows, VColumns>::operator*(const CompatibleSquareMatrixType & matrix) const
 {
   const Self result(m_Matrix * matrix.GetVnlMatrix());
   return result;
@@ -111,15 +111,15 @@ Matrix<T, NRows, NColumns> Matrix<T, NRows, NColumns>::operator*(const Compatibl
 /**
  *  Matrix Addition
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-Matrix<T, NRows, NColumns>
-Matrix<T, NRows, NColumns>::operator+(const Self & matrix) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+Matrix<T, VRows, VColumns>
+Matrix<T, VRows, VColumns>::operator+(const Self & matrix) const
 {
   Self result;
 
-  for (unsigned int r = 0; r < NRows; ++r)
+  for (unsigned int r = 0; r < VRows; ++r)
   {
-    for (unsigned int c = 0; c < NColumns; ++c)
+    for (unsigned int c = 0; c < VColumns; ++c)
     {
       result.m_Matrix(r, c) = m_Matrix(r, c) + matrix.m_Matrix(r, c);
     }
@@ -130,13 +130,13 @@ Matrix<T, NRows, NColumns>::operator+(const Self & matrix) const
 /**
  *  Matrix Addition in-place
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-const Matrix<T, NRows, NColumns> &
-Matrix<T, NRows, NColumns>::operator+=(const Self & matrix)
+template <typename T, unsigned int VRows, unsigned int VColumns>
+const Matrix<T, VRows, VColumns> &
+Matrix<T, VRows, VColumns>::operator+=(const Self & matrix)
 {
-  for (unsigned int r = 0; r < NRows; ++r)
+  for (unsigned int r = 0; r < VRows; ++r)
   {
-    for (unsigned int c = 0; c < NColumns; ++c)
+    for (unsigned int c = 0; c < VColumns; ++c)
     {
       m_Matrix(r, c) += matrix.m_Matrix(r, c);
     }
@@ -147,15 +147,15 @@ Matrix<T, NRows, NColumns>::operator+=(const Self & matrix)
 /**
  *  Matrix Subtraction
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-Matrix<T, NRows, NColumns>
-Matrix<T, NRows, NColumns>::operator-(const Self & matrix) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+Matrix<T, VRows, VColumns>
+Matrix<T, VRows, VColumns>::operator-(const Self & matrix) const
 {
   Self result;
 
-  for (unsigned int r = 0; r < NRows; ++r)
+  for (unsigned int r = 0; r < VRows; ++r)
   {
-    for (unsigned int c = 0; c < NColumns; ++c)
+    for (unsigned int c = 0; c < VColumns; ++c)
     {
       result.m_Matrix(r, c) = m_Matrix(r, c) - matrix.m_Matrix(r, c);
     }
@@ -166,13 +166,13 @@ Matrix<T, NRows, NColumns>::operator-(const Self & matrix) const
 /**
  *  Matrix subtraction in-place
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-const Matrix<T, NRows, NColumns> &
-Matrix<T, NRows, NColumns>::operator-=(const Self & matrix)
+template <typename T, unsigned int VRows, unsigned int VColumns>
+const Matrix<T, VRows, VColumns> &
+Matrix<T, VRows, VColumns>::operator-=(const Self & matrix)
 {
-  for (unsigned int r = 0; r < NRows; ++r)
+  for (unsigned int r = 0; r < VRows; ++r)
   {
-    for (unsigned int c = 0; c < NColumns; ++c)
+    for (unsigned int c = 0; c < VColumns; ++c)
     {
       m_Matrix(r, c) -= matrix.m_Matrix(r, c);
     }
@@ -183,8 +183,8 @@ Matrix<T, NRows, NColumns>::operator-=(const Self & matrix)
 /**
  *  Product by a vnl_matrix
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-vnl_matrix<T> Matrix<T, NRows, NColumns>::operator*(const vnl_matrix<T> & matrix) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+vnl_matrix<T> Matrix<T, VRows, VColumns>::operator*(const vnl_matrix<T> & matrix) const
 {
   return m_Matrix * matrix;
 }
@@ -192,9 +192,9 @@ vnl_matrix<T> Matrix<T, NRows, NColumns>::operator*(const vnl_matrix<T> & matrix
 /**
  *  Product by a matrix
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
+template <typename T, unsigned int VRows, unsigned int VColumns>
 void
-Matrix<T, NRows, NColumns>::operator*=(const CompatibleSquareMatrixType & matrix)
+Matrix<T, VRows, VColumns>::operator*=(const CompatibleSquareMatrixType & matrix)
 {
   m_Matrix *= matrix.GetVnlMatrix();
 }
@@ -202,9 +202,9 @@ Matrix<T, NRows, NColumns>::operator*=(const CompatibleSquareMatrixType & matrix
 /**
  *  Product by a vnl_matrix
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
+template <typename T, unsigned int VRows, unsigned int VColumns>
 void
-Matrix<T, NRows, NColumns>::operator*=(const vnl_matrix<T> & matrix)
+Matrix<T, VRows, VColumns>::operator*=(const vnl_matrix<T> & matrix)
 {
   m_Matrix *= matrix;
 }
@@ -212,8 +212,8 @@ Matrix<T, NRows, NColumns>::operator*=(const vnl_matrix<T> & matrix)
 /**
  *  Product by a vnl_vector
  */
-template <typename T, unsigned int NRows, unsigned int NColumns>
-vnl_vector<T> Matrix<T, NRows, NColumns>::operator*(const vnl_vector<T> & vc) const
+template <typename T, unsigned int VRows, unsigned int VColumns>
+vnl_vector<T> Matrix<T, VRows, VColumns>::operator*(const vnl_vector<T> & vc) const
 {
   return m_Matrix * vc;
 }

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
@@ -58,13 +58,13 @@ printnb(const TIteratorType & nb, bool full)
   }
 }
 
-template <unsigned int N>
+template <unsigned int VDimension>
 void
-FillImage(itk::Image<itk::Index<N>, N> * img)
+FillImage(itk::Image<itk::Index<VDimension>, VDimension> * img)
 {
-  using IndexType = itk::Index<N>;
-  using ImageType = itk::Image<IndexType, N>;
-  const itk::Size<N> size = img->GetRequestedRegion().GetSize();
+  using IndexType = itk::Index<VDimension>;
+  using ImageType = itk::Image<IndexType, VDimension>;
+  const itk::Size<VDimension> size = img->GetRequestedRegion().GetSize();
 
   unsigned int i;
   IndexType    loop;
@@ -74,7 +74,7 @@ FillImage(itk::Image<itk::Index<N>, N> * img)
   while (!it.IsAtEnd())
   {
     it.Value() = loop;
-    for (i = 0; i < N; ++i)
+    for (i = 0; i < VDimension; ++i)
     {
       loop[i]++;
       if ((unsigned int)(loop[i]) == size[i])

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -35,7 +35,7 @@ namespace itk
  * Point can be used as the data type held at each pixel in
  * an Image or at each vertex of an Mesh. The template parameter T can
  * be any data type that behaves like a primitive (or atomic) data type (int,
- * short, float, complex).  The NPointDimension defines the number of
+ * short, float, complex).  The VPointDimension defines the number of
  * components in the point array.
  *
  * \ingroup Geometry
@@ -49,13 +49,13 @@ namespace itk
  * \sphinxexample{Core/Common/DistanceBetweenIndices,Distance between two indices}
  * \endsphinx
  */
-template <typename TCoordRep, unsigned int NPointDimension = 3>
-class ITK_TEMPLATE_EXPORT Point : public FixedArray<TCoordRep, NPointDimension>
+template <typename TCoordRep, unsigned int VPointDimension = 3>
+class ITK_TEMPLATE_EXPORT Point : public FixedArray<TCoordRep, VPointDimension>
 {
 public:
   /** Standard class type aliases. */
   using Self = Point;
-  using Superclass = FixedArray<TCoordRep, NPointDimension>;
+  using Superclass = FixedArray<TCoordRep, VPointDimension>;
 
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an Point.   */
@@ -65,10 +65,10 @@ public:
   using RealType = typename NumericTraits<ValueType>::RealType;
 
   /** Dimension of the Space */
-  static constexpr unsigned int PointDimension = NPointDimension;
+  static constexpr unsigned int PointDimension = VPointDimension;
 
   /** The Array type from which this Vector is derived. */
-  using BaseArray = FixedArray<TCoordRep, NPointDimension>;
+  using BaseArray = FixedArray<TCoordRep, VPointDimension>;
   using Iterator = typename BaseArray::Iterator;
   using ConstIterator = typename BaseArray::ConstIterator;
 
@@ -76,11 +76,11 @@ public:
   static unsigned int
   GetPointDimension()
   {
-    return NPointDimension;
+    return VPointDimension;
   }
 
   /** VectorType define the difference between two Points */
-  using VectorType = Vector<ValueType, NPointDimension>;
+  using VectorType = Vector<ValueType, VPointDimension>;
 
   /** Default constructor, assignments */
   Point() = default;
@@ -93,15 +93,15 @@ public:
   ~Point() = default;
   /** Pass-through constructors for different type points. */
   template <typename TPointValueType>
-  Point(const Point<TPointValueType, NPointDimension> & r)
+  Point(const Point<TPointValueType, VPointDimension> & r)
     : BaseArray(r)
   {}
   /** Pass-through constructors for plain arrays. */
   template <typename TPointValueType>
-  Point(const TPointValueType r[NPointDimension])
+  Point(const TPointValueType r[VPointDimension])
     : BaseArray(r)
   {}
-  Point(const ValueType r[NPointDimension])
+  Point(const ValueType r[VPointDimension])
     : BaseArray(r)
   {}
   /** Pass-through constructors for single values */
@@ -114,13 +114,13 @@ public:
   {}
 
   /** Explicit constructor for std::array. */
-  explicit Point(const std::array<ValueType, NPointDimension> & stdArray)
+  explicit Point(const std::array<ValueType, VPointDimension> & stdArray)
     : BaseArray(stdArray)
   {}
 
   /** Pass-through assignment operator for a plain array. */
   Point &
-  operator=(const ValueType r[NPointDimension]);
+  operator=(const ValueType r[VPointDimension]);
 
   /** Compare two points for equality. */
   bool
@@ -128,7 +128,7 @@ public:
   {
     bool same = true;
 
-    for (unsigned int i = 0; i < NPointDimension && same; ++i)
+    for (unsigned int i = 0; i < VPointDimension && same; ++i)
     {
       same = (Math::ExactlyEquals((*this)[i], pt[i]));
     }
@@ -249,9 +249,9 @@ public:
    *  Casting is done with C-Like rules  */
   template <typename TCoordRepB>
   void
-  CastFrom(const Point<TCoordRepB, NPointDimension> & pa)
+  CastFrom(const Point<TCoordRepB, VPointDimension> & pa)
   {
-    for (unsigned int i = 0; i < NPointDimension; ++i)
+    for (unsigned int i = 0; i < VPointDimension; ++i)
     {
       (*this)[i] = static_cast<TCoordRep>(pa[i]);
     }
@@ -263,11 +263,11 @@ public:
 
   template <typename TCoordRepB>
   RealType
-  SquaredEuclideanDistanceTo(const Point<TCoordRepB, NPointDimension> & pa) const
+  SquaredEuclideanDistanceTo(const Point<TCoordRepB, VPointDimension> & pa) const
   {
     RealType sum = NumericTraits<RealType>::ZeroValue();
 
-    for (unsigned int i = 0; i < NPointDimension; ++i)
+    for (unsigned int i = 0; i < VPointDimension; ++i)
     {
       const auto     component = static_cast<RealType>(pa[i]);
       const RealType difference = static_cast<RealType>((*this)[i]) - component;
@@ -281,7 +281,7 @@ public:
    * C-Like rules */
   template <typename TCoordRepB>
   RealType
-  EuclideanDistanceTo(const Point<TCoordRepB, NPointDimension> & pa) const
+  EuclideanDistanceTo(const Point<TCoordRepB, VPointDimension> & pa) const
   {
     const double distance = std::sqrt(static_cast<double>(this->SquaredEuclideanDistanceTo(pa)));
 
@@ -289,13 +289,13 @@ public:
   }
 };
 
-template <typename T, unsigned int NPointDimension>
+template <typename T, unsigned int VPointDimension>
 std::ostream &
-operator<<(std::ostream & os, const Point<T, NPointDimension> & vct);
+operator<<(std::ostream & os, const Point<T, VPointDimension> & vct);
 
-template <typename T, unsigned int NPointDimension>
+template <typename T, unsigned int VPointDimension>
 std::istream &
-operator>>(std::istream & is, Point<T, NPointDimension> & vct);
+operator>>(std::istream & is, Point<T, VPointDimension> & vct);
 
 /**
  *\class BarycentricCombination
@@ -341,9 +341,9 @@ public:
 };
 
 
-template <typename TCoordRep, unsigned int NPointDimension>
+template <typename TCoordRep, unsigned int VPointDimension>
 inline void
-swap(Point<TCoordRep, NPointDimension> & a, Point<TCoordRep, NPointDimension> & b)
+swap(Point<TCoordRep, VPointDimension> & a, Point<TCoordRep, VPointDimension> & b)
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkPromoteType.h
+++ b/Modules/Core/Common/include/itkPromoteType.h
@@ -37,17 +37,17 @@ namespace Details
  * \ingroup MetaProgrammingLibrary
  * \ingroup ITKCommon
  */
-template <int N, typename TA, typename TB>
+template <int VTypeEnum, typename TA, typename TB>
 struct SizeToType;
 
 /** Helper class to implement \c itk::PromoteType<>.
  * \ingroup MetaProgrammingLibrary
  * \ingroup ITKCommon
  */
-template <int N>
+template <int VCharacters>
 struct Identity
 {
-  using Type = char[N];
+  using Type = char[VCharacters];
 };
 
 /** Helper macro to implement \c itk::PromoteType<>.
@@ -55,11 +55,11 @@ struct Identity
  * \ingroup MetaProgrammingLibrary
  * \ingroup ITKCommon
  */
-#define ITK_ASSOCIATE(N, Typed)       \
-  template <typename TA, typename TB> \
-  struct SizeToType<N, TA, TB>        \
-  {                                   \
-    using Type = Typed;               \
+#define ITK_ASSOCIATE(VTypeEnum, Typed) \
+  template <typename TA, typename TB>   \
+  struct SizeToType<VTypeEnum, TA, TB>  \
+  {                                     \
+    using Type = Typed;                 \
   };
 
 ITK_ASSOCIATE(1, TA);

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -33,9 +33,9 @@ namespace itk
 namespace detail
 {
 /* Helper functions returning pointer to matrix data for different types.  */
-template <typename TValueType, unsigned int NRows, unsigned int NCols>
+template <typename TValueType, unsigned int VRows, unsigned int VColumns>
 const TValueType *
-GetPointerToMatrixData(const vnl_matrix_fixed<TValueType, NRows, NCols> & inputMatrix)
+GetPointerToMatrixData(const vnl_matrix_fixed<TValueType, VRows, VColumns> & inputMatrix)
 {
   return inputMatrix.data_block();
 };
@@ -46,9 +46,9 @@ GetPointerToMatrixData(const vnl_matrix<TValueType> & inputMatrix)
   return inputMatrix.data_block();
 };
 
-template <typename TValueType, unsigned int NRows, unsigned int NCols>
+template <typename TValueType, unsigned int VRows, unsigned int VColumns>
 const TValueType *
-GetPointerToMatrixData(const itk::Matrix<TValueType, NRows, NCols> & inputMatrix)
+GetPointerToMatrixData(const itk::Matrix<TValueType, VRows, VColumns> & inputMatrix)
 {
   return inputMatrix.GetVnlMatrix().data_block();
 };

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
@@ -71,27 +71,27 @@ namespace itk
  * \ingroup ITKCommon
  */
 
-template <typename TComponent, unsigned int NDimension = 3>
-class ITK_TEMPLATE_EXPORT SymmetricSecondRankTensor : public FixedArray<TComponent, NDimension *(NDimension + 1) / 2>
+template <typename TComponent, unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT SymmetricSecondRankTensor : public FixedArray<TComponent, VDimension *(VDimension + 1) / 2>
 {
 public:
   /** Standard class type aliases. */
   using Self = SymmetricSecondRankTensor;
-  using Superclass = FixedArray<TComponent, NDimension *(NDimension + 1) / 2>;
+  using Superclass = FixedArray<TComponent, VDimension *(VDimension + 1) / 2>;
 
   /** Dimension of the vector space. */
-  static constexpr unsigned int Dimension = NDimension;
-  static constexpr unsigned int InternalDimension = NDimension * (NDimension + 1) / 2;
+  static constexpr unsigned int Dimension = VDimension;
+  static constexpr unsigned int InternalDimension = VDimension * (VDimension + 1) / 2;
 
   /** Convenience type alias. */
   using BaseArray = FixedArray<TComponent, Self::InternalDimension>;
 
   /** Array of eigen-values. */
-  using EigenValuesArrayType = FixedArray<TComponent, NDimension>;
+  using EigenValuesArrayType = FixedArray<TComponent, VDimension>;
 
   /** Matrix of eigen-vectors. */
-  using MatrixType = Matrix<TComponent, NDimension, NDimension>;
-  using EigenVectorsMatrixType = Matrix<TComponent, NDimension, NDimension>;
+  using MatrixType = Matrix<TComponent, VDimension, VDimension>;
+  using EigenVectorsMatrixType = Matrix<TComponent, VDimension, VDimension>;
 
   /**  Define the component type. */
   using ComponentType = TComponent;
@@ -116,7 +116,7 @@ public:
 
   /** Constructor to enable casting...  */
   template <typename TCoordRepB>
-  SymmetricSecondRankTensor(const SymmetricSecondRankTensor<TCoordRepB, NDimension> & pa)
+  SymmetricSecondRankTensor(const SymmetricSecondRankTensor<TCoordRepB, VDimension> & pa)
     : BaseArray(pa)
   {}
 
@@ -130,7 +130,7 @@ public:
   /** Templated Pass-through assignment  for the Array base class. */
   template <typename TCoordRepB>
   Self &
-  operator=(const SymmetricSecondRankTensor<TCoordRepB, NDimension> & pa)
+  operator=(const SymmetricSecondRankTensor<TCoordRepB, VDimension> & pa)
   {
     BaseArray::operator=(pa);
     return *this;
@@ -220,12 +220,12 @@ public:
    */
   template <typename TMatrixValueType>
   Self
-  Rotate(const Matrix<TMatrixValueType, NDimension, NDimension> & m) const;
+  Rotate(const Matrix<TMatrixValueType, VDimension, VDimension> & m) const;
   template <typename TMatrixValueType>
   Self
-  Rotate(const vnl_matrix_fixed<TMatrixValueType, NDimension, NDimension> & m) const
+  Rotate(const vnl_matrix_fixed<TMatrixValueType, VDimension, VDimension> & m) const
   {
-    return this->Rotate(static_cast<Matrix<TMatrixValueType, NDimension, NDimension>>(m));
+    return this->Rotate(static_cast<Matrix<TMatrixValueType, VDimension, VDimension>>(m));
   }
   template <typename TMatrixValueType>
   Self
@@ -250,13 +250,13 @@ private:
 using OutputStreamType = std::ostream;
 using InputStreamType = std::istream;
 
-template <typename TComponent, unsigned int NDimension>
+template <typename TComponent, unsigned int VDimension>
 OutputStreamType &
-operator<<(OutputStreamType & os, const SymmetricSecondRankTensor<TComponent, NDimension> & c);
+operator<<(OutputStreamType & os, const SymmetricSecondRankTensor<TComponent, VDimension> & c);
 
-template <typename TComponent, unsigned int NDimension>
+template <typename TComponent, unsigned int VDimension>
 InputStreamType &
-operator>>(InputStreamType & is, SymmetricSecondRankTensor<TComponent, NDimension> & dt);
+operator>>(InputStreamType & is, SymmetricSecondRankTensor<TComponent, VDimension> & dt);
 
 template <typename T>
 inline void

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
@@ -25,9 +25,9 @@ namespace itk
 /**
  * Assignment Operator from a scalar constant
  */
-template <typename T, unsigned int NDimension>
-SymmetricSecondRankTensor<T, NDimension> &
-SymmetricSecondRankTensor<T, NDimension>::operator=(const ComponentType & r)
+template <typename T, unsigned int VDimension>
+SymmetricSecondRankTensor<T, VDimension> &
+SymmetricSecondRankTensor<T, VDimension>::operator=(const ComponentType & r)
 {
   BaseArray::operator=(&r);
   return *this;
@@ -36,9 +36,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator=(const ComponentType & r)
 /**
  * Assigment from a plain array
  */
-template <typename T, unsigned int NDimension>
-SymmetricSecondRankTensor<T, NDimension> &
-SymmetricSecondRankTensor<T, NDimension>::operator=(const ComponentArrayType r)
+template <typename T, unsigned int VDimension>
+SymmetricSecondRankTensor<T, VDimension> &
+SymmetricSecondRankTensor<T, VDimension>::operator=(const ComponentArrayType r)
 {
   BaseArray::operator=(r);
   return *this;
@@ -47,9 +47,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator=(const ComponentArrayType r)
 /**
  * Returns a temporary copy of a vector
  */
-template <typename T, unsigned int NDimension>
-SymmetricSecondRankTensor<T, NDimension>
-SymmetricSecondRankTensor<T, NDimension>::operator+(const Self & r) const
+template <typename T, unsigned int VDimension>
+SymmetricSecondRankTensor<T, VDimension>
+SymmetricSecondRankTensor<T, VDimension>::operator+(const Self & r) const
 {
   Self result;
 
@@ -63,9 +63,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator+(const Self & r) const
 /**
  * Returns a temporary copy of a vector
  */
-template <typename T, unsigned int NDimension>
-SymmetricSecondRankTensor<T, NDimension>
-SymmetricSecondRankTensor<T, NDimension>::operator-(const Self & r) const
+template <typename T, unsigned int VDimension>
+SymmetricSecondRankTensor<T, VDimension>
+SymmetricSecondRankTensor<T, VDimension>::operator-(const Self & r) const
 {
   Self result;
 
@@ -79,9 +79,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator-(const Self & r) const
 /**
  * Performs addition in place
  */
-template <typename T, unsigned int NDimension>
-const SymmetricSecondRankTensor<T, NDimension> &
-SymmetricSecondRankTensor<T, NDimension>::operator+=(const Self & r)
+template <typename T, unsigned int VDimension>
+const SymmetricSecondRankTensor<T, VDimension> &
+SymmetricSecondRankTensor<T, VDimension>::operator+=(const Self & r)
 {
   for (unsigned int i = 0; i < InternalDimension; ++i)
   {
@@ -93,9 +93,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator+=(const Self & r)
 /**
  * Performs subtraction in place
  */
-template <typename T, unsigned int NDimension>
-const SymmetricSecondRankTensor<T, NDimension> &
-SymmetricSecondRankTensor<T, NDimension>::operator-=(const Self & r)
+template <typename T, unsigned int VDimension>
+const SymmetricSecondRankTensor<T, VDimension> &
+SymmetricSecondRankTensor<T, VDimension>::operator-=(const Self & r)
 {
   for (unsigned int i = 0; i < InternalDimension; ++i)
   {
@@ -107,9 +107,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator-=(const Self & r)
 /**
  * Performs multiplication by a scalar, in place
  */
-template <typename T, unsigned int NDimension>
-const SymmetricSecondRankTensor<T, NDimension> &
-SymmetricSecondRankTensor<T, NDimension>::operator*=(const RealValueType & r)
+template <typename T, unsigned int VDimension>
+const SymmetricSecondRankTensor<T, VDimension> &
+SymmetricSecondRankTensor<T, VDimension>::operator*=(const RealValueType & r)
 {
   for (unsigned int i = 0; i < InternalDimension; ++i)
   {
@@ -121,9 +121,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator*=(const RealValueType & r)
 /**
  * Performs division by a scalar, in place
  */
-template <typename T, unsigned int NDimension>
-const SymmetricSecondRankTensor<T, NDimension> &
-SymmetricSecondRankTensor<T, NDimension>::operator/=(const RealValueType & r)
+template <typename T, unsigned int VDimension>
+const SymmetricSecondRankTensor<T, VDimension> &
+SymmetricSecondRankTensor<T, VDimension>::operator/=(const RealValueType & r)
 {
   for (unsigned int i = 0; i < InternalDimension; ++i)
   {
@@ -135,8 +135,8 @@ SymmetricSecondRankTensor<T, NDimension>::operator/=(const RealValueType & r)
 /**
  * Performs multiplication with a scalar
  */
-template <typename T, unsigned int NDimension>
-SymmetricSecondRankTensor<T, NDimension> SymmetricSecondRankTensor<T, NDimension>::operator*(
+template <typename T, unsigned int VDimension>
+SymmetricSecondRankTensor<T, VDimension> SymmetricSecondRankTensor<T, VDimension>::operator*(
   const RealValueType & r) const
 {
   Self result;
@@ -151,9 +151,9 @@ SymmetricSecondRankTensor<T, NDimension> SymmetricSecondRankTensor<T, NDimension
 /**
  * Performs division by a scalar
  */
-template <typename T, unsigned int NDimension>
-SymmetricSecondRankTensor<T, NDimension>
-SymmetricSecondRankTensor<T, NDimension>::operator/(const RealValueType & r) const
+template <typename T, unsigned int VDimension>
+SymmetricSecondRankTensor<T, VDimension>
+SymmetricSecondRankTensor<T, VDimension>::operator/(const RealValueType & r) const
 {
   Self result;
 
@@ -167,9 +167,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator/(const RealValueType & r) con
 /**
  * Matrix notation access to elements
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 auto
-SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned int col) const -> const ValueType &
+SymmetricSecondRankTensor<T, VDimension>::operator()(unsigned int row, unsigned int col) const -> const ValueType &
 {
   unsigned int k;
 
@@ -193,9 +193,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned 
 /**
  * Matrix notation access to elements
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 auto
-SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned int col) -> ValueType &
+SymmetricSecondRankTensor<T, VDimension>::operator()(unsigned int row, unsigned int col) -> ValueType &
 {
   unsigned int k;
 
@@ -220,9 +220,9 @@ SymmetricSecondRankTensor<T, NDimension>::operator()(unsigned int row, unsigned 
  * Set the Tensor to an Identity.
  * Set ones in the diagonal and zeroes every where else.
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 void
-SymmetricSecondRankTensor<T, NDimension>::SetIdentity()
+SymmetricSecondRankTensor<T, VDimension>::SetIdentity()
 {
   this->Fill(NumericTraits<T>::ZeroValue());
   for (unsigned int i = 0; i < Dimension; ++i)
@@ -234,9 +234,9 @@ SymmetricSecondRankTensor<T, NDimension>::SetIdentity()
 /**
  * Get the Trace
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 auto
-SymmetricSecondRankTensor<T, NDimension>::GetTrace() const -> AccumulateValueType
+SymmetricSecondRankTensor<T, VDimension>::GetTrace() const -> AccumulateValueType
 {
   AccumulateValueType trace = NumericTraits<AccumulateValueType>::ZeroValue();
   unsigned int        k = 0;
@@ -252,9 +252,9 @@ SymmetricSecondRankTensor<T, NDimension>::GetTrace() const -> AccumulateValueTyp
 /**
  * Compute Eigen Values
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 void
-SymmetricSecondRankTensor<T, NDimension>::ComputeEigenValues(EigenValuesArrayType & eigenValues) const
+SymmetricSecondRankTensor<T, VDimension>::ComputeEigenValues(EigenValuesArrayType & eigenValues) const
 {
   SymmetricEigenAnalysisType symmetricEigenSystem;
 
@@ -275,9 +275,9 @@ SymmetricSecondRankTensor<T, NDimension>::ComputeEigenValues(EigenValuesArrayTyp
  * Compute Eigen analysis, it returns an array with eigen values
  * and a Matrix with eigen vectors
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 void
-SymmetricSecondRankTensor<T, NDimension>::ComputeEigenAnalysis(EigenValuesArrayType &   eigenValues,
+SymmetricSecondRankTensor<T, VDimension>::ComputeEigenAnalysis(EigenValuesArrayType &   eigenValues,
                                                                EigenVectorsMatrixType & eigenVectors) const
 {
   SymmetricEigenAnalysisType symmetricEigenSystem;
@@ -300,20 +300,20 @@ SymmetricSecondRankTensor<T, NDimension>::ComputeEigenAnalysis(EigenValuesArrayT
  * matrix * self * Transpose(matrix)
  *
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 template <typename TMatrixValueType>
-SymmetricSecondRankTensor<T, NDimension>
-SymmetricSecondRankTensor<T, NDimension>::Rotate(const Matrix<TMatrixValueType, NDimension, NDimension> & m) const
+SymmetricSecondRankTensor<T, VDimension>
+SymmetricSecondRankTensor<T, VDimension>::Rotate(const Matrix<TMatrixValueType, VDimension, VDimension> & m) const
 {
   Self result;
-  using RotationMatrixType = Matrix<double, NDimension, NDimension>;
+  using RotationMatrixType = Matrix<double, VDimension, VDimension>;
   RotationMatrixType SCT; // self * Transpose(m)
-  for (unsigned int r = 0; r < NDimension; ++r)
+  for (unsigned int r = 0; r < VDimension; ++r)
   {
-    for (unsigned int c = 0; c < NDimension; ++c)
+    for (unsigned int c = 0; c < VDimension; ++c)
     {
       double sum = 0.0;
-      for (unsigned int t = 0; t < NDimension; ++t)
+      for (unsigned int t = 0; t < VDimension; ++t)
       {
         sum += (*this)(r, t) * m(c, t);
       }
@@ -321,12 +321,12 @@ SymmetricSecondRankTensor<T, NDimension>::Rotate(const Matrix<TMatrixValueType, 
     }
   }
   // self = m * sct;
-  for (unsigned int r = 0; r < NDimension; ++r)
+  for (unsigned int r = 0; r < VDimension; ++r)
   {
-    for (unsigned int c = 0; c < NDimension; ++c)
+    for (unsigned int c = 0; c < VDimension; ++c)
     {
       double sum = 0.0;
-      for (unsigned int t = 0; t < NDimension; ++t)
+      for (unsigned int t = 0; t < VDimension; ++t)
       {
         sum += m(r, t) * SCT(t, c);
       }
@@ -339,19 +339,19 @@ SymmetricSecondRankTensor<T, NDimension>::Rotate(const Matrix<TMatrixValueType, 
 /**
  * Pre-multiply the Tensor by a Matrix
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 auto
-SymmetricSecondRankTensor<T, NDimension>::PreMultiply(const MatrixType & m) const -> MatrixType
+SymmetricSecondRankTensor<T, VDimension>::PreMultiply(const MatrixType & m) const -> MatrixType
 {
   MatrixType result;
 
   using AccumulateType = typename NumericTraits<T>::AccumulateType;
-  for (unsigned int r = 0; r < NDimension; ++r)
+  for (unsigned int r = 0; r < VDimension; ++r)
   {
-    for (unsigned int c = 0; c < NDimension; ++c)
+    for (unsigned int c = 0; c < VDimension; ++c)
     {
       AccumulateType sum = NumericTraits<AccumulateType>::ZeroValue();
-      for (unsigned int t = 0; t < NDimension; ++t)
+      for (unsigned int t = 0; t < VDimension; ++t)
       {
         sum += m(r, t) * (*this)(t, c);
       }
@@ -364,19 +364,19 @@ SymmetricSecondRankTensor<T, NDimension>::PreMultiply(const MatrixType & m) cons
 /**
  * Post-multiply the Tensor by a Matrix
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 auto
-SymmetricSecondRankTensor<T, NDimension>::PostMultiply(const MatrixType & m) const -> MatrixType
+SymmetricSecondRankTensor<T, VDimension>::PostMultiply(const MatrixType & m) const -> MatrixType
 {
   MatrixType result;
 
   using AccumulateType = typename NumericTraits<T>::AccumulateType;
-  for (unsigned int r = 0; r < NDimension; ++r)
+  for (unsigned int r = 0; r < VDimension; ++r)
   {
-    for (unsigned int c = 0; c < NDimension; ++c)
+    for (unsigned int c = 0; c < VDimension; ++c)
     {
       AccumulateType sum = NumericTraits<AccumulateType>::ZeroValue();
-      for (unsigned int t = 0; t < NDimension; ++t)
+      for (unsigned int t = 0; t < VDimension; ++t)
       {
         sum += (*this)(r, t) * m(t, c);
       }
@@ -389,9 +389,9 @@ SymmetricSecondRankTensor<T, NDimension>::PostMultiply(const MatrixType & m) con
 /**
  * Print content to an ostream
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 std::ostream &
-operator<<(std::ostream & os, const SymmetricSecondRankTensor<T, NDimension> & c)
+operator<<(std::ostream & os, const SymmetricSecondRankTensor<T, VDimension> & c)
 {
   for (unsigned int i = 0; i < c.GetNumberOfComponents(); ++i)
   {
@@ -403,9 +403,9 @@ operator<<(std::ostream & os, const SymmetricSecondRankTensor<T, NDimension> & c
 /**
  * Read content from an istream
  */
-template <typename T, unsigned int NDimension>
+template <typename T, unsigned int VDimension>
 std::istream &
-operator>>(std::istream & is, SymmetricSecondRankTensor<T, NDimension> & dt)
+operator>>(std::istream & is, SymmetricSecondRankTensor<T, VDimension> & dt)
 {
   for (unsigned int i = 0; i < dt.GetNumberOfComponents(); ++i)
   {

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -31,7 +31,7 @@ namespace itk
  * of values).  Vector can be used as the data type held at each pixel in
  * an Image or at each vertex of an Mesh. The template parameter T can
  * be any data type that behaves like a primitive (or atomic) data type (int,
- * short, float, complex).  The NVectorDimension defines the number of
+ * short, float, complex).  The VVectorDimension defines the number of
  * components in the vector array.
  *
  * Vector is not a dynamically extendible array like std::vector. It is
@@ -58,13 +58,13 @@ namespace itk
  * \sphinxexample{Core/Common/VectorDotProduct,Dot product (inner product) of two vectors}
  * \endsphinx
  */
-template <typename T, unsigned int NVectorDimension = 3>
-class ITK_TEMPLATE_EXPORT Vector : public FixedArray<T, NVectorDimension>
+template <typename T, unsigned int VVectorDimension = 3>
+class ITK_TEMPLATE_EXPORT Vector : public FixedArray<T, VVectorDimension>
 {
 public:
   /** Standard class type aliases. */
   using Self = Vector;
-  using Superclass = FixedArray<T, NVectorDimension>;
+  using Superclass = FixedArray<T, VVectorDimension>;
 
   /** ValueType can be used to declare a variable that is the same type
    * as a data element held in an Vector.   */
@@ -72,7 +72,7 @@ public:
   using RealValueType = typename NumericTraits<ValueType>::RealType;
 
   /** Dimension of the vector space. */
-  static constexpr unsigned int Dimension = NVectorDimension;
+  static constexpr unsigned int Dimension = VVectorDimension;
 
   /** I am a vector type. */
   using VectorType = Self;
@@ -81,13 +81,13 @@ public:
   using ComponentType = T;
 
   /** The Array type from which this vector is derived. */
-  using BaseArray = FixedArray<T, NVectorDimension>;
+  using BaseArray = FixedArray<T, VVectorDimension>;
 
   /** Get the dimension (size) of the vector. */
   static unsigned int
   GetVectorDimension()
   {
-    return NVectorDimension;
+    return VVectorDimension;
   }
 
   /** Set a vnl_vector_ref referencing the same memory block. */
@@ -126,7 +126,7 @@ public:
 
   /** Pass-through constructor for the Array base class. */
   template <typename TVectorValueType>
-  Vector(const Vector<TVectorValueType, NVectorDimension> & r)
+  Vector(const Vector<TVectorValueType, VVectorDimension> & r)
     : BaseArray(r)
   {}
   Vector(const ValueType r[Dimension])
@@ -138,28 +138,28 @@ public:
   {}
 
   /** Explicit constructor for std::array. */
-  explicit Vector(const std::array<ValueType, NVectorDimension> & stdArray)
+  explicit Vector(const std::array<ValueType, VVectorDimension> & stdArray)
     : BaseArray(stdArray)
   {}
 
   /** Pass-through assignment operator for the Array base class. */
   template <typename TVectorValueType>
   Vector &
-  operator=(const Vector<TVectorValueType, NVectorDimension> & r)
+  operator=(const Vector<TVectorValueType, VVectorDimension> & r)
   {
     BaseArray::operator=(r);
     return *this;
   }
 
   Vector &
-  operator=(const ValueType r[NVectorDimension]);
+  operator=(const ValueType r[VVectorDimension]);
 
   /** Scalar operator*=.  Scales elements by a scalar. */
   template <typename Tt>
   inline const Self &
   operator*=(const Tt & value)
   {
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       (*this)[i] = static_cast<ValueType>((*this)[i] * value);
     }
@@ -171,7 +171,7 @@ public:
   inline const Self &
   operator/=(const Tt & value)
   {
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       (*this)[i] = static_cast<ValueType>((*this)[i] / value);
     }
@@ -209,7 +209,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       result[i] = static_cast<ValueType>((*this)[i] * value);
     }
@@ -224,7 +224,7 @@ public:
   {
     Self result;
 
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       result[i] = static_cast<ValueType>((*this)[i] / value);
     }
@@ -255,7 +255,7 @@ public:
   static unsigned int
   GetNumberOfComponents()
   {
-    return NVectorDimension;
+    return VVectorDimension;
   }
 
   /** Divides the vector components by the vector norm (when the norm is not
@@ -273,19 +273,19 @@ public:
    *  Casting is done with C-Like rules  */
   template <typename TCoordRepB>
   void
-  CastFrom(const Vector<TCoordRepB, NVectorDimension> & pa)
+  CastFrom(const Vector<TCoordRepB, VVectorDimension> & pa)
   {
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       (*this)[i] = static_cast<T>(pa[i]);
     }
   }
 
   template <typename TCoordRepB>
-  operator Vector<TCoordRepB, NVectorDimension>()
+  operator Vector<TCoordRepB, VVectorDimension>()
   {
-    Vector<TCoordRepB, NVectorDimension> r;
-    for (unsigned int i = 0; i < NVectorDimension; ++i)
+    Vector<TCoordRepB, VVectorDimension> r;
+    for (unsigned int i = 0; i < VVectorDimension; ++i)
     {
       r[i] = static_cast<TCoordRepB>((*this)[i]);
     }
@@ -295,21 +295,21 @@ public:
 
 /** Premultiply Operator for product of a vector and a scalar.
  *  Vector< T, N >  =  T * Vector< T,N > */
-template <typename T, unsigned int NVectorDimension>
-inline Vector<T, NVectorDimension> operator*(const T & scalar, const Vector<T, NVectorDimension> & v)
+template <typename T, unsigned int VVectorDimension>
+inline Vector<T, VVectorDimension> operator*(const T & scalar, const Vector<T, VVectorDimension> & v)
 {
   return v.operator*(scalar);
 }
 
 /** Print content to an ostream */
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 std::ostream &
-operator<<(std::ostream & os, const Vector<T, NVectorDimension> & vct);
+operator<<(std::ostream & os, const Vector<T, VVectorDimension> & vct);
 
 /** Read content from an istream */
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 std::istream &
-operator>>(std::istream & is, Vector<T, NVectorDimension> & vct);
+operator>>(std::istream & is, Vector<T, VVectorDimension> & vct);
 
 ITKCommon_EXPORT Vector<double, 3>
                  CrossProduct(const Vector<double, 3> &, const Vector<double, 3> &);
@@ -321,9 +321,9 @@ ITKCommon_EXPORT Vector<int, 3>
                  CrossProduct(const Vector<int, 3> &, const Vector<int, 3> &);
 
 
-template <typename T, unsigned int NVectorDimension>
+template <typename T, unsigned int VVectorDimension>
 inline void
-swap(Vector<T, NVectorDimension> & a, Vector<T, NVectorDimension> & b)
+swap(Vector<T, VVectorDimension> & a, Vector<T, VVectorDimension> & b)
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkVectorImage.h
+++ b/Modules/Core/Common/include/itkVectorImage.h
@@ -183,22 +183,22 @@ public:
    * \sa Image::Rebind
    * \deprecated Use template alias RebindImageType instead
    */
-  template <typename UPixelType, unsigned int NUImageDimension = VImageDimension>
+  template <typename UPixelType, unsigned int VUImageDimension = VImageDimension>
   struct Rebind
   {
-    using Type = itk::VectorImage<UPixelType, NUImageDimension>;
+    using Type = itk::VectorImage<UPixelType, VUImageDimension>;
   };
 
   /// \cond HIDE_SPECIALIZATION_DOCUMENTATION
-  template <typename UElementType, unsigned int NUImageDimension>
-  struct Rebind<VariableLengthVector<UElementType>, NUImageDimension>
+  template <typename UElementType, unsigned int VUImageDimension>
+  struct Rebind<VariableLengthVector<UElementType>, VUImageDimension>
   {
-    using Type = itk::VectorImage<UElementType, NUImageDimension>;
+    using Type = itk::VectorImage<UElementType, VUImageDimension>;
   };
   /// \endcond
 
-  template <typename UPixelType, unsigned int NUImageDimension = VImageDimension>
-  using RebindImageType = typename Rebind<UPixelType, NUImageDimension>::Type;
+  template <typename UPixelType, unsigned int VUImageDimension = VImageDimension>
+  using RebindImageType = typename Rebind<UPixelType, VUImageDimension>::Type;
 
   /** Allocate the image memory. The size of the image must
    * already be set, e.g. by calling SetRegions(). */

--- a/Modules/Core/Common/test/itkSizeGTest.cxx
+++ b/Modules/Core/Common/test/itkSizeGTest.cxx
@@ -25,8 +25,8 @@
 
 namespace
 {
-template <unsigned int NDimension>
-constexpr std::integral_constant<unsigned int, NDimension> DimensionConstant{};
+template <unsigned int VDimension>
+constexpr std::integral_constant<unsigned int, VDimension> DimensionConstant{};
 
 
 template <unsigned int VDimension>

--- a/Modules/Core/Common/test/itkSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkSliceIteratorTest.cxx
@@ -21,21 +21,21 @@
 #include "itkNeighborhoodIterator.h"
 #include <iostream>
 
-template <typename T, unsigned int N>
+template <typename TPixelType, unsigned int VDimension>
 void
-FillRegionSequential(itk::SmartPointer<itk::Image<T, N>> I)
+FillRegionSequential(itk::SmartPointer<itk::Image<TPixelType, VDimension>> I)
 {
-  unsigned int      iDim, ArrayLength, i;
-  itk::Size<N>      Index;
-  unsigned long int Location[N];
-  unsigned int      mult;
-  T                 value;
+  unsigned int          iDim, ArrayLength, i;
+  itk::Size<VDimension> Index;
+  unsigned long int     Location[VDimension];
+  unsigned int          mult;
+  TPixelType            value;
 
-  itk::ImageRegionIterator<itk::Image<T, N>> data(I, I->GetRequestedRegion());
+  itk::ImageRegionIterator<itk::Image<TPixelType, VDimension>> data(I, I->GetRequestedRegion());
 
   Index = (I->GetRequestedRegion()).GetSize();
 
-  for (ArrayLength = 1, iDim = 0; iDim < N; ++iDim)
+  for (ArrayLength = 1, iDim = 0; iDim < VDimension; ++iDim)
   {
     Location[iDim] = 0;
     ArrayLength *= Index[iDim];
@@ -43,18 +43,18 @@ FillRegionSequential(itk::SmartPointer<itk::Image<T, N>> I)
 
   for (i = 0; i < ArrayLength; ++i, ++data)
   {
-    for (iDim = 0, mult = 1, value = 0; iDim < N; ++iDim, mult *= 10)
+    for (iDim = 0, mult = 1, value = 0; iDim < VDimension; ++iDim, mult *= 10)
     {
-      value += mult * Location[N - iDim - 1];
+      value += mult * Location[VDimension - iDim - 1];
     }
     data.Set(value);
 
-    iDim = N - 1;
+    iDim = VDimension - 1;
     bool done = false;
     while (!done)
     {
       ++Location[iDim];
-      if (Location[iDim] == Index[(N - 1) - iDim])
+      if (Location[iDim] == Index[(VDimension - 1) - iDim])
       {
         Location[iDim] = 0;
       }
@@ -74,9 +74,9 @@ FillRegionSequential(itk::SmartPointer<itk::Image<T, N>> I)
   }
 }
 
-template <typename T, unsigned int VDimension>
+template <typename TPixelType, unsigned int VDimension>
 void
-PrintRegion(itk::SmartPointer<itk::Image<T, VDimension>> I)
+PrintRegion(itk::SmartPointer<itk::Image<TPixelType, VDimension>> I)
 {
   unsigned int iDim;
   long         rsz[VDimension];
@@ -94,7 +94,7 @@ PrintRegion(itk::SmartPointer<itk::Image<T, VDimension>> I)
     std::cout << "\tRegionStartIndex = " << I->GetRequestedRegion().GetIndex()[iDim] << std::endl;
   }
 
-  itk::ImageRegionIterator<itk::Image<T, VDimension>> iter(I, I->GetRequestedRegion());
+  itk::ImageRegionIterator<itk::Image<TPixelType, VDimension>> iter(I, I->GetRequestedRegion());
 
   for (; !iter.IsAtEnd(); ++iter)
   {

--- a/Modules/Core/GPUCommon/include/itkGPUImage.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImage.h
@@ -293,11 +293,11 @@ public:
   using Type = T;
 };
 
-template <typename TPixelType, unsigned int NDimension>
-class ITK_TEMPLATE_EXPORT GPUTraits<Image<TPixelType, NDimension>>
+template <typename TPixelType, unsigned int VDimension>
+class ITK_TEMPLATE_EXPORT GPUTraits<Image<TPixelType, VDimension>>
 {
 public:
-  using Type = GPUImage<TPixelType, NDimension>;
+  using Type = GPUImage<TPixelType, VDimension>;
 };
 
 } // end namespace itk

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h
@@ -30,7 +30,7 @@
 
 namespace itk
 {
-template <typename TPixel, unsigned int NDimension>
+template <typename TPixel, unsigned int VDimension>
 class GPUImage;
 
 /**

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -140,8 +140,8 @@ public:
     using Type = Image<UPixelType, UImageDimension>;
   };
 
-  template <typename UPixelType, unsigned int NUImageDimension = TImage::ImageDimension>
-  using RebindImageType = itk::Image<UPixelType, NUImageDimension>;
+  template <typename UPixelType, unsigned int VUImageDimension = TImage::ImageDimension>
+  using RebindImageType = itk::Image<UPixelType, VUImageDimension>;
 
 
   /** Set the region object that defines the size and starting index

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -31,7 +31,7 @@ namespace itk
  * This class contains all the functions necessary to define a point
  * that can be used to build lines.
  * This Class derives from SpatialObjectPoint.
- * A LineSpatialObjectPoint has NDimension-1 normals.
+ * A LineSpatialObjectPoint has VDimension-1 normals.
  * \ingroup ITKSpatialObjects
  *
  * \sphinx

--- a/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaArrowConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaArrowConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaArrowConverter);
 
   /** Standard class type aliases */
   using Self = MetaArrowConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using ArrowSpatialObjectType = ArrowSpatialObject<NDimensions>;
+  using ArrowSpatialObjectType = ArrowSpatialObject<VDimension>;
   using ArrowSpatialObjectPointer = typename ArrowSpatialObjectType::Pointer;
   using ArrowSpatialObjectConstPointer = typename ArrowSpatialObjectType::ConstPointer;
   using ArrowMetaObjectType = MetaArrow;

--- a/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
@@ -22,17 +22,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaArrowConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaArrowConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new ArrowMetaObjectType);
 }
 
 /** Convert a metaArrow into an arrow SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaArrowConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaArrowConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * metaArrow = dynamic_cast<const MetaArrow *>(mo);
   if (metaArrow == nullptr)
@@ -48,7 +48,7 @@ MetaArrowConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType 
   const double *                         metaDirection = metaArrow->Direction();
   typename SpatialObjectType::PointType  positionInObjectSpace;
   typename SpatialObjectType::VectorType directionInObjectSpace;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     positionInObjectSpace[i] = metaPosition[i];
     directionInObjectSpace[i] = metaDirection[i];
@@ -70,9 +70,9 @@ MetaArrowConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType 
 }
 
 /** Convert an arrow SpatialObject into a metaArrow */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaArrowConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
+MetaArrowConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   ArrowSpatialObjectConstPointer arrowSO = dynamic_cast<const ArrowSpatialObjectType *>(spatialObject);
   if (arrowSO.IsNull())
@@ -80,7 +80,7 @@ MetaArrowConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTy
     itkExceptionMacro(<< "Can't downcast SpatialObject to ArrowSpatialObject");
   }
 
-  auto * mo = new MetaArrow(NDimensions);
+  auto * mo = new MetaArrow(VDimension);
 
   float metaLength = arrowSO->GetLengthInObjectSpace();
 
@@ -90,11 +90,11 @@ MetaArrowConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTy
   }
 
   // convert position and direction
-  double                                 metaPosition[NDimensions];
-  double                                 metaDirection[NDimensions];
+  double                                 metaPosition[VDimension];
+  double                                 metaDirection[VDimension];
   typename SpatialObjectType::PointType  spPositionInObjectSpace = arrowSO->GetPositionInObjectSpace();
   typename SpatialObjectType::VectorType spDirectionInObjectSpace = arrowSO->GetDirectionInObjectSpace();
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     metaPosition[i] = spPositionInObjectSpace[i];
     metaDirection[i] = spDirectionInObjectSpace[i];

--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaBlobConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaBlobConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaBlobConverter);
 
   /** Standard class type aliases */
   using Self = MetaBlobConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using BlobSpatialObjectType = BlobSpatialObject<NDimensions>;
+  using BlobSpatialObjectType = BlobSpatialObject<VDimension>;
   using BlobSpatialObjectPointer = typename BlobSpatialObjectType::Pointer;
   using BlobSpatialObjectConstPointer = typename BlobSpatialObjectType::ConstPointer;
   using BlobMetaObjectType = MetaBlob;

--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
@@ -22,17 +22,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaBlobConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaBlobConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new BlobMetaObjectType);
 }
 
 /** Convert a metaBlob into an Blob SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaBlobConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaBlobConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * Blob = dynamic_cast<const BlobMetaObjectType *>(mo);
   if (Blob == nullptr)
@@ -50,11 +50,11 @@ MetaBlobConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
   blob->GetProperty().SetBlue(Blob->Color()[2]);
   blob->GetProperty().SetAlpha(Blob->Color()[3]);
 
-  using BlobPointType = itk::SpatialObjectPoint<NDimensions>;
+  using BlobPointType = itk::SpatialObjectPoint<VDimension>;
 
   auto it2 = Blob->GetPoints().begin();
 
-  vnl_vector<double> v(NDimensions);
+  vnl_vector<double> v(VDimension);
 
   for (unsigned int identifier = 0; identifier < Blob->GetPoints().size(); ++identifier)
   {
@@ -63,7 +63,7 @@ MetaBlobConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
     using PointType = typename BlobSpatialObjectType::PointType;
     PointType point;
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       point[ii] = (*it2)->m_X[ii] * Blob->ElementSpacing(ii);
     }
@@ -83,9 +83,9 @@ MetaBlobConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
 }
 
 /** Convert a Blob SpatialObject into a metaBlob */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaBlobConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
+MetaBlobConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   BlobSpatialObjectConstPointer blobSO = dynamic_cast<const BlobSpatialObjectType *>(spatialObject);
   if (blobSO.IsNull())
@@ -93,15 +93,15 @@ MetaBlobConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTyp
     itkExceptionMacro(<< "Can't downcast SpatialObject to BlobSpatialObject");
   }
 
-  auto * Blob = new MetaBlob(NDimensions);
+  auto * Blob = new MetaBlob(VDimension);
 
   // fill in the Blob information
   typename BlobSpatialObjectType::BlobPointListType::const_iterator it;
   for (it = blobSO->GetPoints().begin(); it != blobSO->GetPoints().end(); ++it)
   {
-    auto * pnt = new BlobPnt(NDimensions);
+    auto * pnt = new BlobPnt(VDimension);
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
     }
@@ -114,7 +114,7 @@ MetaBlobConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTyp
     Blob->GetPoints().push_back(pnt);
   }
 
-  if (NDimensions == 2)
+  if (VDimension == 2)
   {
     Blob->PointDim("x y red green blue alpha");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.h
@@ -32,15 +32,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaContourConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaContourConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaContourConverter);
 
   /** Standard class type aliases */
   using Self = MetaContourConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -55,7 +55,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using ContourSpatialObjectType = ContourSpatialObject<NDimensions>;
+  using ContourSpatialObjectType = ContourSpatialObject<VDimension>;
   using ContourSpatialObjectPointer = typename ContourSpatialObjectType::Pointer;
   using ContourSpatialObjectConstPointer = typename ContourSpatialObjectType::ConstPointer;
   using ContourMetaObjectType = MetaContour;

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
@@ -22,17 +22,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaContourConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaContourConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new ContourMetaObjectType);
 }
 
 /** Convert a metaContour into an Contour SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaContourConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaContourConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * contourMO = dynamic_cast<const MetaContour *>(mo);
   if (contourMO == nullptr)
@@ -68,17 +68,17 @@ MetaContourConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
     using CovariantVectorType = typename ControlPointType::CovariantVectorType;
     CovariantVectorType normal;
 
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       point[i] = (*itCP)->m_X[i] * contourMO->ElementSpacing(i);
     }
 
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       pickedPoint[i] = (*itCP)->m_XPicked[i] * contourMO->ElementSpacing(i);
     }
 
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       normal[i] = (*itCP)->m_V[i];
     }
@@ -108,7 +108,7 @@ MetaContourConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
     using PointType = typename ControlPointType::PointType;
     PointType point;
 
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       point[i] = (*itI)->m_X[i];
     }
@@ -128,16 +128,16 @@ MetaContourConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 }
 
 /** Convert a Contour SpatialObject into a metaContour */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaContourConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
+MetaContourConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   ContourSpatialObjectConstPointer contourSO = dynamic_cast<const ContourSpatialObjectType *>(so);
   if (contourSO.IsNull())
   {
     itkExceptionMacro(<< "Can't downcast SpatialObject to ContourSpatialObject");
   }
-  auto * contourMO = new MetaContour(NDimensions);
+  auto * contourMO = new MetaContour(VDimension);
 
 
   // fill in the control points information
@@ -145,21 +145,21 @@ MetaContourConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
 
   for (itCP = contourSO->GetControlPoints().begin(); itCP != contourSO->GetControlPoints().end(); ++itCP)
   {
-    auto * pnt = new ContourControlPnt(NDimensions);
+    auto * pnt = new ContourControlPnt(VDimension);
 
     pnt->m_Id = (*itCP).GetId();
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*itCP).GetPositionInObjectSpace()[d];
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_XPicked[d] = (*itCP).GetPickedPointInObjectSpace()[d];
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_V[d] = (*itCP).GetNormalInObjectSpace()[d];
     }
@@ -172,11 +172,11 @@ MetaContourConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     contourMO->GetControlPoints().push_back(pnt);
   }
 
-  if (NDimensions == 2)
+  if (VDimension == 2)
   {
     contourMO->ControlPointDim("id x y xp yp v1 v2 r g b a");
   }
-  else if (NDimensions == 3)
+  else if (VDimension == 3)
   {
     contourMO->ControlPointDim("id x y z xp yp zp v1 v2 v3 r gn be a");
   }
@@ -185,10 +185,10 @@ MetaContourConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
   typename ContourSpatialObjectType::ContourPointListType::const_iterator itI;
   for (itI = contourSO->GetPoints().begin(); itI != contourSO->GetPoints().end(); ++itI)
   {
-    auto * pnt = new ContourInterpolatedPnt(NDimensions);
+    auto * pnt = new ContourInterpolatedPnt(VDimension);
 
     pnt->m_Id = (*itI).GetId();
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*itI).GetPositionInObjectSpace()[d];
     }
@@ -201,11 +201,11 @@ MetaContourConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     contourMO->GetInterpolatedPoints().push_back(pnt);
   }
 
-  if (NDimensions == 2)
+  if (VDimension == 2)
   {
     contourMO->InterpolatedPointDim("id x y r g b a");
   }
-  else if (NDimensions == 3)
+  else if (VDimension == 3)
   {
     contourMO->InterpolatedPointDim("id x y z r g b a");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaDTITubeConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaDTITubeConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaDTITubeConverter);
 
   /** Standard class type aliases */
   using Self = MetaDTITubeConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using DTITubeSpatialObjectType = DTITubeSpatialObject<NDimensions>;
+  using DTITubeSpatialObjectType = DTITubeSpatialObject<VDimension>;
   using DTITubeSpatialObjectPointer = typename DTITubeSpatialObjectType::Pointer;
   using DTITubeSpatialObjectConstPointer = typename DTITubeSpatialObjectType::ConstPointer;
   using DTITubeMetaObjectType = MetaDTITube;

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -23,17 +23,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaDTITubeConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaDTITubeConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new DTITubeMetaObjectType);
 }
 
 /** Convert a MetaDTITube into an Tube SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaDTITubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * tube = dynamic_cast<const MetaDTITube *>(mo);
   if (tube == nullptr)
@@ -52,13 +52,13 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
   tubeSO->GetProperty().SetBlue(tube->Color()[2]);
   tubeSO->GetProperty().SetAlpha(tube->Color()[3]);
 
-  using TubePointType = itk::DTITubeSpatialObjectPoint<NDimensions>;
+  using TubePointType = itk::DTITubeSpatialObjectPoint<VDimension>;
 
   auto it2 = tube->GetPoints().begin();
 
-  itk::CovariantVector<double, NDimensions> v;
+  itk::CovariantVector<double, VDimension> v;
   v.Fill(0.0);
-  itk::Vector<double, NDimensions> t;
+  itk::Vector<double, VDimension> t;
   t.Fill(0.0);
 
   for (unsigned int identifier = 0; identifier < tube->GetPoints().size(); ++identifier)
@@ -68,7 +68,7 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
     using PointType = typename DTITubeSpatialObjectType::PointType;
     PointType point;
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       point[ii] = (*it2)->m_X[ii] * tube->ElementSpacing(ii);
     }
@@ -112,7 +112,7 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
     if (Math::NotExactlyEquals((*it2)->GetField(vnd), -1))
     {
       v[0] = (*it2)->GetField(vnd);
-      for (unsigned int ii = 1; ii < NDimensions; ++ii)
+      for (unsigned int ii = 1; ii < VDimension; ++ii)
       {
         ++(vnd[2]); // x -> y -> z
         v[ii] = (*it2)->GetField(vnd);
@@ -125,7 +125,7 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
     if (Math::NotExactlyEquals((*it2)->GetField(vnd), -1))
     {
       v[0] = (*it2)->GetField(vnd);
-      for (unsigned int ii = 1; ii < NDimensions; ++ii)
+      for (unsigned int ii = 1; ii < VDimension; ++ii)
       {
         ++(vnd[2]); // x -> y -> z
         v[ii] = (*it2)->GetField(vnd);
@@ -137,7 +137,7 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
     if (Math::NotExactlyEquals((*it2)->GetField(td), -1))
     {
       t[0] = (*it2)->GetField(td);
-      for (unsigned int ii = 1; ii < NDimensions; ++ii)
+      for (unsigned int ii = 1; ii < VDimension; ++ii)
       {
         ++(td[1]); // x -> y -> z
         t[ii] = (*it2)->GetField(td);
@@ -178,10 +178,9 @@ MetaDTITubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 }
 
 /** Convert a Tube SpatialObject into a MetaDTITube */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaDTITubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject)
-  -> MetaObjectType *
+MetaDTITubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   DTITubeSpatialObjectConstPointer DTITubeSO = dynamic_cast<const DTITubeSpatialObjectType *>(spatialObject);
   if (DTITubeSO.IsNull())
@@ -189,7 +188,7 @@ MetaDTITubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     itkExceptionMacro(<< "Can't downcast SpatialObject to DTITubeSpatialObject");
   }
 
-  auto * tube = new MetaDTITube(NDimensions);
+  auto * tube = new MetaDTITube(VDimension);
 
   // Check what are the fields to be written
   bool writeNormal1 = false;
@@ -215,7 +214,7 @@ MetaDTITubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     }
 
     unsigned int d;
-    for (d = 0; d < NDimensions; ++d)
+    for (d = 0; d < VDimension; ++d)
     {
       if (Math::NotExactlyEquals((*it).GetNormal1InObjectSpace()[d], 0))
       {
@@ -246,9 +245,9 @@ MetaDTITubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
   // fill in the tube information
   for (it = DTITubeSO->GetPoints().begin(); it != DTITubeSO->GetPoints().end(); ++it)
   {
-    auto * pnt = new DTITubePnt(NDimensions);
+    auto * pnt = new DTITubePnt(VDimension);
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
     }
@@ -281,7 +280,7 @@ MetaDTITubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     {
       pnt->AddField("v1x", (*it).GetNormal1InObjectSpace()[0]);
       pnt->AddField("v1y", (*it).GetNormal1InObjectSpace()[1]);
-      if (NDimensions == 3)
+      if (VDimension == 3)
       {
         pnt->AddField("v1z", (*it).GetNormal1InObjectSpace()[2]);
       }
@@ -291,7 +290,7 @@ MetaDTITubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     {
       pnt->AddField("v2x", (*it).GetNormal2InObjectSpace()[0]);
       pnt->AddField("v2y", (*it).GetNormal2InObjectSpace()[1]);
-      if (NDimensions == 3)
+      if (VDimension == 3)
       {
         pnt->AddField("v2z", (*it).GetNormal2InObjectSpace()[2]);
       }
@@ -301,7 +300,7 @@ MetaDTITubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     {
       pnt->AddField("tx", (*it).GetTangentInObjectSpace()[0]);
       pnt->AddField("ty", (*it).GetTangentInObjectSpace()[1]);
-      if (NDimensions == 3)
+      if (VDimension == 3)
       {
         pnt->AddField("tz", (*it).GetTangentInObjectSpace()[2]);
       }

--- a/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaEllipseConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaEllipseConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaEllipseConverter);
 
   /** Standard class type aliases */
   using Self = MetaEllipseConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using EllipseSpatialObjectType = EllipseSpatialObject<NDimensions>;
+  using EllipseSpatialObjectType = EllipseSpatialObject<VDimension>;
   using EllipseSpatialObjectPointer = typename EllipseSpatialObjectType::Pointer;
   using EllipseSpatialObjectConstPointer = typename EllipseSpatialObjectType::ConstPointer;
   using EllipseMetaObjectType = MetaEllipse;

--- a/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
@@ -22,17 +22,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaEllipseConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaEllipseConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new EllipseMetaObjectType);
 }
 
 /** Convert a metaEllipse into an ellipse SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaEllipseConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaEllipseConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * ellipseMO = dynamic_cast<const EllipseMetaObjectType *>(mo);
   if (ellipseMO == nullptr)
@@ -43,7 +43,7 @@ MetaEllipseConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
   EllipseSpatialObjectPointer ellipseSO = EllipseSpatialObjectType::New();
 
   typename EllipseSpatialObjectType::ArrayType radii;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     radii[i] = ellipseMO->Radius()[i];
   }
@@ -61,9 +61,9 @@ MetaEllipseConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 }
 
 /** Convert an ellipse SpatialObject into a metaEllipse */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaEllipseConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
+MetaEllipseConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   EllipseSpatialObjectConstPointer ellipseSO = dynamic_cast<const EllipseSpatialObjectType *>(so);
   if (ellipseSO.IsNull())
@@ -71,11 +71,11 @@ MetaEllipseConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     itkExceptionMacro(<< "Can't downcast SpatialObject to EllipseSpatialObject");
   }
 
-  auto * ellipseMO = new EllipseMetaObjectType(NDimensions);
+  auto * ellipseMO = new EllipseMetaObjectType(VDimension);
 
-  auto * radii = new float[NDimensions];
+  auto * radii = new float[VDimension];
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     radii[i] = ellipseSO->GetRadiusInObjectSpace()[i];
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaGaussianConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaGaussianConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaGaussianConverter);
 
   /** Standard class type aliases */
   using Self = MetaGaussianConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using GaussianSpatialObjectType = GaussianSpatialObject<NDimensions>;
+  using GaussianSpatialObjectType = GaussianSpatialObject<VDimension>;
   using GaussianSpatialObjectPointer = typename GaussianSpatialObjectType::Pointer;
   using GaussianSpatialObjectConstPointer = typename GaussianSpatialObjectType::ConstPointer;
   using GaussianMetaObjectType = MetaGaussian;

--- a/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.hxx
@@ -22,17 +22,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaGaussianConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaGaussianConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new GaussianMetaObjectType);
 }
 
 /** Convert a metaGaussian into a gaussian SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaGaussianConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaGaussianConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * metaGaussian = dynamic_cast<const GaussianMetaObjectType *>(mo);
   if (metaGaussian == nullptr)
@@ -57,9 +57,9 @@ MetaGaussianConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTy
 }
 
 /** Convert a gaussian SpatialObject into a metaGaussian */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaGaussianConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
+MetaGaussianConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   GaussianSpatialObjectConstPointer gaussianSO = dynamic_cast<const GaussianSpatialObjectType *>(so);
   auto *                            metaGaussian = new GaussianMetaObjectType;

--- a/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaGroupConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaGroupConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaGroupConverter);
 
   /** Standard class type aliases */
   using Self = MetaGroupConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using GroupSpatialObjectType = GroupSpatialObject<NDimensions>;
+  using GroupSpatialObjectType = GroupSpatialObject<VDimension>;
   using GroupSpatialObjectPointer = typename GroupSpatialObjectType::Pointer;
   using GroupSpatialObjectConstPointer = typename GroupSpatialObjectType::ConstPointer;
   using GroupMetaObjectType = MetaGroup;

--- a/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.hxx
@@ -21,17 +21,17 @@
 
 namespace itk
 {
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaGroupConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaGroupConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new GroupMetaObjectType);
 }
 
 /** Convert a metaGroup into an group SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaGroupConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaGroupConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * group = dynamic_cast<const GroupMetaObjectType *>(mo);
   if (group == nullptr)
@@ -52,9 +52,9 @@ MetaGroupConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType 
 }
 
 /** Convert a group SpatialObject into a metaGroup */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaGroupConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
+MetaGroupConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   GroupSpatialObjectConstPointer groupSO = dynamic_cast<const GroupSpatialObjectType *>(so);
   if (groupSO.IsNull())
@@ -62,7 +62,7 @@ MetaGroupConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTy
     itkExceptionMacro(<< "Can't downcast SpatialObject to GroupSpatialObject");
   }
 
-  auto * group = new GroupMetaObjectType(NDimensions);
+  auto * group = new GroupMetaObjectType(VDimension);
 
   float color[4];
 

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.h
@@ -34,17 +34,17 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3,
+template <unsigned int VDimension = 3,
           typename TPixel = unsigned char,
-          typename TSpatialObjectType = ImageSpatialObject<NDimensions, TPixel>>
-class ITK_TEMPLATE_EXPORT MetaImageConverter : public MetaConverterBase<NDimensions>
+          typename TSpatialObjectType = ImageSpatialObject<VDimension, TPixel>>
+class ITK_TEMPLATE_EXPORT MetaImageConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaImageConverter);
 
   /** Standard class type aliases */
   using Self = MetaImageConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -63,7 +63,7 @@ public:
   using ImageSpatialObjectPointer = typename ImageSpatialObjectType::Pointer;
   using ImageSpatialObjectConstPointer = typename ImageSpatialObjectType::ConstPointer;
   using ImageMetaObjectType = MetaImage;
-  using ImageType = Image<TPixel, NDimensions>;
+  using ImageType = Image<TPixel, VDimension>;
   /** Convert the MetaObject to Spatial Object */
   SpatialObjectPointer
   MetaObjectToSpatialObject(const MetaObjectType * mo) override;

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -24,23 +24,23 @@
 
 namespace itk
 {
-template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
+template <unsigned int VDimension, typename PixelType, typename TSpatialObjectType>
 auto
-MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::CreateMetaObject() -> MetaObjectType *
+MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new ImageMetaObjectType);
 }
 
-template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
+template <unsigned int VDimension, typename PixelType, typename TSpatialObjectType>
 const char *
-MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::GetMetaObjectSubType()
+MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::GetMetaObjectSubType()
 {
   return "Image";
 }
 
-template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
+template <unsigned int VDimension, typename PixelType, typename TSpatialObjectType>
 auto
-MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(const ImageMetaObjectType * image) ->
+MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::AllocateImage(const ImageMetaObjectType * image) ->
   typename ImageType::Pointer
 {
   auto rval = ImageType::New();
@@ -52,7 +52,7 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(co
   SizeType    size;
   SpacingType spacing;
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     size[i] = image->DimSize()[i];
     if (Math::ExactlyEquals(image->ElementSpacing()[i], NumericTraits<typename SpacingType::ValueType>::ZeroValue()))
@@ -75,9 +75,9 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::AllocateImage(co
 }
 
 /** Convert a metaImage into an ImageMaskSpatialObject  */
-template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
+template <unsigned int VDimension, typename PixelType, typename TSpatialObjectType>
 auto
-MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::MetaObjectToSpatialObject(const MetaObjectType * mo)
   -> SpatialObjectPointer
 {
   const auto * imageMO = dynamic_cast<const ImageMetaObjectType *>(mo);
@@ -108,9 +108,9 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::MetaObjectToSpat
 
 
 /** Convert an Image SpatialObject into a metaImage */
-template <unsigned int NDimensions, typename PixelType, typename TSpatialObjectType>
+template <unsigned int VDimension, typename PixelType, typename TSpatialObjectType>
 auto
-MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::SpatialObjectToMetaObject(const SpatialObjectType * so)
   -> MetaObjectType *
 {
   const ImageSpatialObjectConstPointer imageSO = dynamic_cast<const ImageSpatialObjectType *>(so);
@@ -123,16 +123,16 @@ MetaImageConverter<NDimensions, PixelType, TSpatialObjectType>::SpatialObjectToM
 
   ImageConstPointer SOImage = imageSO->GetImage();
 
-  float spacing[NDimensions];
-  int   size[NDimensions];
+  float spacing[VDimension];
+  int   size[VDimension];
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     size[i] = SOImage->GetLargestPossibleRegion().GetSize()[i];
     spacing[i] = SOImage->GetSpacing()[i];
   }
 
-  auto * imageMO = new MetaImage(NDimensions, size, spacing, MET_GetPixelType(typeid(PixelType)));
+  auto * imageMO = new MetaImage(VDimension, size, spacing, MET_GetPixelType(typeid(PixelType)));
 
   itk::ImageRegionConstIterator<ImageType> it(SOImage, SOImage->GetLargestPossibleRegion());
   for (unsigned int i = 0; !it.IsAtEnd(); i++, ++it)

--- a/Modules/Core/SpatialObjects/include/itkMetaImageMaskConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageMaskConverter.h
@@ -34,16 +34,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class MetaImageMaskConverter
-  : public MetaImageConverter<NDimensions, unsigned char, ImageMaskSpatialObject<NDimensions>>
+template <unsigned int VDimension = 3>
+class MetaImageMaskConverter : public MetaImageConverter<VDimension, unsigned char, ImageMaskSpatialObject<VDimension>>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaImageMaskConverter);
 
   /** Standard class type aliases */
   using Self = MetaImageMaskConverter;
-  using Superclass = MetaImageConverter<NDimensions, unsigned char>;
+  using Superclass = MetaImageConverter<VDimension, unsigned char>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaLandmarkConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaLandmarkConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaLandmarkConverter);
 
   /** Standard class type aliases */
   using Self = MetaLandmarkConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using LandmarkSpatialObjectType = LandmarkSpatialObject<NDimensions>;
+  using LandmarkSpatialObjectType = LandmarkSpatialObject<VDimension>;
   using LandmarkSpatialObjectPointer = typename LandmarkSpatialObjectType::Pointer;
   using LandmarkSpatialObjectConstPointer = typename LandmarkSpatialObjectType::ConstPointer;
   using LandmarkMetaObjectType = MetaLandmark;

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
@@ -22,17 +22,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaLandmarkConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaLandmarkConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new LandmarkMetaObjectType);
 }
 
 /** Convert a metaLandmark into an Landmark SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaLandmarkConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaLandmarkConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * landmarkMO = dynamic_cast<const LandmarkMetaObjectType *>(mo);
   if (landmarkMO == nullptr)
@@ -50,7 +50,7 @@ MetaLandmarkConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTy
   landmarkSO->GetProperty().SetBlue(landmarkMO->Color()[2]);
   landmarkSO->GetProperty().SetAlpha(landmarkMO->Color()[3]);
 
-  using LandmarkPointType = itk::SpatialObjectPoint<NDimensions>;
+  using LandmarkPointType = itk::SpatialObjectPoint<VDimension>;
 
   auto it2 = landmarkMO->GetPoints().begin();
 
@@ -61,7 +61,7 @@ MetaLandmarkConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTy
     using PointType = typename LandmarkSpatialObjectType::PointType;
     PointType point;
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       point[ii] = (*it2)->m_X[ii] * landmarkMO->ElementSpacing(ii);
     }
@@ -81,9 +81,9 @@ MetaLandmarkConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTy
 }
 
 /** Convert a Landmark SpatialObject into a metaLandmark */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaLandmarkConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
+MetaLandmarkConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   const LandmarkSpatialObjectConstPointer landmarkSO = dynamic_cast<const LandmarkSpatialObjectType *>(so);
 
@@ -92,15 +92,15 @@ MetaLandmarkConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjec
     itkExceptionMacro(<< "Can't downcast SpatialObject to LandmarkSpatialObject");
   }
 
-  auto * landmarkMO = new MetaLandmark(NDimensions);
+  auto * landmarkMO = new MetaLandmark(VDimension);
 
   // fill in the Landmark information
   typename LandmarkSpatialObjectType::LandmarkPointListType::const_iterator it;
   for (it = landmarkSO->GetPoints().begin(); it != landmarkSO->GetPoints().end(); ++it)
   {
-    auto * pnt = new LandmarkPnt(NDimensions);
+    auto * pnt = new LandmarkPnt(VDimension);
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
     }
@@ -112,7 +112,7 @@ MetaLandmarkConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjec
     landmarkMO->GetPoints().push_back(pnt);
   }
 
-  if (NDimensions == 2)
+  if (VDimension == 2)
   {
     landmarkMO->PointDim("x y red green blue alpha");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaLineConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaLineConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaLineConverter);
 
   /** Standard class type aliases */
   using Self = MetaLineConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using LineSpatialObjectType = LineSpatialObject<NDimensions>;
+  using LineSpatialObjectType = LineSpatialObject<VDimension>;
   using LineSpatialObjectPointer = typename LineSpatialObjectType::Pointer;
   using LineSpatialObjectConstPointer = typename LineSpatialObjectType::ConstPointer;
   using LineMetaObjectType = MetaLine;

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
@@ -22,17 +22,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaLineConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaLineConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new LineMetaObjectType);
 }
 
 /** Convert a metaLine into an Line SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaLineConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaLineConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * lineMO = dynamic_cast<const LineMetaObjectType *>(mo);
   if (lineMO == nullptr)
@@ -50,7 +50,7 @@ MetaLineConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
   lineSO->GetProperty().SetBlue(lineMO->Color()[2]);
   lineSO->GetProperty().SetAlpha(lineMO->Color()[3]);
 
-  using LinePointType = itk::LineSpatialObjectPoint<NDimensions>;
+  using LinePointType = itk::LineSpatialObjectPoint<VDimension>;
 
   auto it2 = lineMO->GetPoints().begin();
 
@@ -62,17 +62,17 @@ MetaLineConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
     PointType point;
     using NormalType = typename LinePointType::CovariantVectorType;
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       point[ii] = (*it2)->m_X[ii] * lineMO->ElementSpacing(ii);
     }
 
     pnt.SetPositionInObjectSpace(point);
 
-    for (unsigned int ii = 0; ii < NDimensions - 1; ++ii)
+    for (unsigned int ii = 0; ii < VDimension - 1; ++ii)
     {
       NormalType normal;
-      for (unsigned int jj = 0; jj < NDimensions; ++jj)
+      for (unsigned int jj = 0; jj < VDimension; ++jj)
       {
         normal[jj] = (*it2)->m_V[ii][jj];
       }
@@ -91,9 +91,9 @@ MetaLineConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
 }
 
 /** Convert a Line SpatialObject into a metaLine */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaLineConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
+MetaLineConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   LineSpatialObjectConstPointer lineSO = dynamic_cast<const LineSpatialObjectType *>(spatialObject);
   if (lineSO.IsNull())
@@ -101,7 +101,7 @@ MetaLineConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTyp
     itkExceptionMacro(<< "Can't downcast SpatialObject to LineSpatialObject");
   }
 
-  auto * lineMO = new MetaLine(NDimensions);
+  auto * lineMO = new MetaLine(VDimension);
 
   // due to a Visual Studio stupidity, can't seem to define
   // a const method to return the points list.
@@ -111,16 +111,16 @@ MetaLineConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTyp
   typename LineSpatialObjectType::LinePointListType::const_iterator it;
   for (it = linePoints.begin(); it != linePoints.end(); ++it)
   {
-    auto * pnt = new LinePnt(NDimensions);
+    auto * pnt = new LinePnt(VDimension);
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
     }
 
-    for (unsigned int n = 0; n < NDimensions - 1; ++n)
+    for (unsigned int n = 0; n < VDimension - 1; ++n)
     {
-      for (unsigned int d = 0; d < NDimensions; ++d)
+      for (unsigned int d = 0; d < VDimension; ++d)
       {
         pnt->m_V[n][d] = ((*it).GetNormalInObjectSpace(n))[d];
       }
@@ -134,11 +134,11 @@ MetaLineConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTyp
     lineMO->GetPoints().push_back(pnt);
   }
 
-  if (NDimensions == 2)
+  if (VDimension == 2)
   {
     lineMO->PointDim("x y v1x v1y v2x v2y red green blue alpha");
   }
-  else if (NDimensions == 3)
+  else if (VDimension == 3)
   {
     lineMO->PointDim("x y z v1x v1y v1z v2x v2y v2z red green blue alpha");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.h
@@ -31,17 +31,17 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3,
+template <unsigned int VDimension = 3,
           typename PixelType = unsigned char,
-          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, NDimensions, NDimensions>>
-class ITK_TEMPLATE_EXPORT MetaMeshConverter : public MetaConverterBase<NDimensions>
+          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, VDimension, VDimension>>
+class ITK_TEMPLATE_EXPORT MetaMeshConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaMeshConverter);
 
   /** Standard class type aliases */
   using Self = MetaMeshConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -56,7 +56,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using MeshType = itk::Mesh<PixelType, NDimensions, TMeshTraits>;
+  using MeshType = itk::Mesh<PixelType, VDimension, TMeshTraits>;
   using MeshSpatialObjectType = MeshSpatialObject<MeshType>;
   using MeshSpatialObjectPointer = typename MeshSpatialObjectType::Pointer;
   using MeshSpatialObjectConstPointer = typename MeshSpatialObjectType::ConstPointer;

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -27,17 +27,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 auto
-MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaObject() -> MetaObjectType *
+MetaMeshConverter<VDimension, PixelType, TMeshTraits>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new MeshMetaObjectType);
 }
 
 /** Convert a metaMesh into an Mesh SpatialObject  */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 auto
-MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectToSpatialObject(const MetaObjectType * mo)
+MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject(const MetaObjectType * mo)
   -> SpatialObjectPointer
 {
   const auto * _mesh = dynamic_cast<const MeshMetaObjectType *>(mo);
@@ -67,7 +67,7 @@ MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectToSpatialObjec
   while (it_points != points.end())
   {
     typename MeshType::PointType pt;
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       pt[i] = ((*it_points)->m_X)[i] * _mesh->ElementSpacing(i);
     }
@@ -201,9 +201,9 @@ MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::MetaObjectToSpatialObjec
 }
 
 /** Convert a Mesh SpatialObject into a metaMesh */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 auto
-MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::SpatialObjectToMetaObject(const SpatialObjectType * so)
+MetaMeshConverter<VDimension, PixelType, TMeshTraits>::SpatialObjectToMetaObject(const SpatialObjectType * so)
   -> MetaObjectType *
 {
   const MeshSpatialObjectConstPointer meshSO = dynamic_cast<const MeshSpatialObjectType *>(so);
@@ -212,7 +212,7 @@ MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::SpatialObjectToMetaObjec
   {
     itkExceptionMacro(<< "Can't downcast SpatialObject to MeshSpatialObject");
   }
-  auto * metamesh = new MeshMetaObjectType(NDimensions);
+  auto * metamesh = new MeshMetaObjectType(VDimension);
 
   typename MeshType::ConstPointer mesh = meshSO->GetMesh();
 
@@ -232,8 +232,8 @@ MetaMeshConverter<NDimensions, PixelType, TMeshTraits>::SpatialObjectToMetaObjec
 
   while (it_points != points->End())
   {
-    auto * pnt = new MeshPoint(NDimensions);
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    auto * pnt = new MeshPoint(VDimension);
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       pnt->m_X[i] = (*it_points)->Value()[i];
     }

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -42,9 +42,9 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3,
+template <unsigned int VDimension = 3,
           typename PixelType = unsigned char,
-          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, NDimensions, NDimensions>>
+          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, VDimension, VDimension>>
 class ITK_TEMPLATE_EXPORT MetaSceneConverter : public Object
 {
 public:
@@ -60,12 +60,12 @@ public:
   itkTypeMacro(MetaSceneConverter, Object);
 
   /** SpatialObject Scene types */
-  using SpatialObjectType = itk::SpatialObject<NDimensions>;
+  using SpatialObjectType = itk::SpatialObject<VDimension>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
   using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
 
   /** Typedef for auxiliary conversion classes */
-  using MetaConverterBaseType = MetaConverterBase<NDimensions>;
+  using MetaConverterBaseType = MetaConverterBase<VDimension>;
   using MetaConverterPointer = typename MetaConverterBaseType::Pointer;
   using ConverterMapType = std::map<std::string, MetaConverterPointer>;
 

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -40,8 +40,8 @@
 namespace itk
 {
 /** Constructor */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::MetaSceneConverter()
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+MetaSceneConverter<VDimension, PixelType, TMeshTraits>::MetaSceneConverter()
 {
   // default behaviour of scene converter is not to save transform
   // with each spatial object.
@@ -51,24 +51,24 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::MetaSceneConverter()
   m_WriteImagesInSeparateFile = false;
 }
 
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::SetTransform(MetaObject * obj, const TransformType * transform)
+MetaSceneConverter<VDimension, PixelType, TMeshTraits>::SetTransform(MetaObject * obj, const TransformType * transform)
 {
   typename SpatialObjectType::TransformType::InputPointType center = transform->GetCenter();
   typename SpatialObjectType::TransformType::MatrixType     matrix = transform->GetMatrix();
   typename SpatialObjectType::TransformType::OffsetType     offset = transform->GetOffset();
 
   unsigned int p = 0;
-  for (unsigned int row = 0; row < NDimensions; ++row)
+  for (unsigned int row = 0; row < VDimension; ++row)
   {
-    for (unsigned int col = 0; col < NDimensions; ++col)
+    for (unsigned int col = 0; col < VDimension; ++col)
     {
       m_Orientation[p++] = matrix[row][col];
     }
   }
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     m_Position[i] = offset[i];
     m_CenterOfRotation[i] = center[i];
@@ -80,24 +80,24 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::SetTransform(MetaObject
   obj->SetDoublePrecision(m_TransformPrecision);
 }
 
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::SetTransform(SpatialObjectType * so, const MetaObject * meta)
+MetaSceneConverter<VDimension, PixelType, TMeshTraits>::SetTransform(SpatialObjectType * so, const MetaObject * meta)
 {
   typename SpatialObjectType::TransformType::InputPointType center;
   typename SpatialObjectType::TransformType::MatrixType     matrix;
   typename SpatialObjectType::TransformType::OffsetType     offset;
 
   unsigned int p = 0;
-  for (unsigned int row = 0; row < NDimensions; ++row)
+  for (unsigned int row = 0; row < VDimension; ++row)
   {
-    for (unsigned int col = 0; col < NDimensions; ++col)
+    for (unsigned int col = 0; col < VDimension; ++col)
     {
       matrix[row][col] = (meta->Orientation())[p++];
     }
   }
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     offset[i] = (meta->Position())[i];
     center[i] = (meta->CenterOfRotation())[i];
@@ -110,9 +110,9 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::SetTransform(SpatialObj
 
 /** Convert a metaScene into a Composite Spatial Object
  *  Also Managed Composite Spatial Object to keep a hierarchy */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 auto
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateSpatialObjectScene(MetaScene * mScene)
+MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateSpatialObjectScene(MetaScene * mScene)
   -> SpatialObjectPointer
 {
   SpatialObjectPointer soScene = nullptr;
@@ -134,68 +134,68 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateSpatialObjectScen
       // If there is the subtype is a vessel
       if (objectSubTypeName == "Vessel")
       {
-        currentSO = this->MetaObjectToSpatialObject<MetaVesselTubeConverter<NDimensions>>(*it);
+        currentSO = this->MetaObjectToSpatialObject<MetaVesselTubeConverter<VDimension>>(*it);
       }
       else if (objectSubTypeName == "DTI")
       {
-        currentSO = this->MetaObjectToSpatialObject<MetaDTITubeConverter<NDimensions>>(*it);
+        currentSO = this->MetaObjectToSpatialObject<MetaDTITubeConverter<VDimension>>(*it);
       }
       else
       {
-        currentSO = this->MetaObjectToSpatialObject<MetaTubeConverter<NDimensions>>(*it);
+        currentSO = this->MetaObjectToSpatialObject<MetaTubeConverter<VDimension>>(*it);
       }
     }
     else if (objectTypeName == "Group")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaGroupConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaGroupConverter<VDimension>>(*it);
     }
     else if (objectTypeName == "Ellipse")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaEllipseConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaEllipseConverter<VDimension>>(*it);
     }
     else if (objectTypeName == "Arrow")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaArrowConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaArrowConverter<VDimension>>(*it);
     }
     else if (objectTypeName == "Image")
     {
       // If there is the subtype is a mask
       if (objectSubTypeName == "Mask")
       {
-        currentSO = this->MetaObjectToSpatialObject<MetaImageMaskConverter<NDimensions>>(*it);
+        currentSO = this->MetaObjectToSpatialObject<MetaImageMaskConverter<VDimension>>(*it);
       }
       else
       {
-        currentSO = this->MetaObjectToSpatialObject<MetaImageConverter<NDimensions, PixelType>>(*it);
+        currentSO = this->MetaObjectToSpatialObject<MetaImageConverter<VDimension, PixelType>>(*it);
       }
     }
     else if (objectTypeName == "Blob")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaBlobConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaBlobConverter<VDimension>>(*it);
     }
     else if (objectTypeName == "Gaussian")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaGaussianConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaGaussianConverter<VDimension>>(*it);
     }
     else if (objectTypeName == "Landmark")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaLandmarkConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaLandmarkConverter<VDimension>>(*it);
     }
     else if (objectTypeName == "Surface")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaSurfaceConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaSurfaceConverter<VDimension>>(*it);
     }
     else if (objectTypeName == "Line")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaLineConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaLineConverter<VDimension>>(*it);
     }
     else if (objectTypeName == "Mesh")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaMeshConverter<NDimensions, PixelType, TMeshTraits>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaMeshConverter<VDimension, PixelType, TMeshTraits>>(*it);
     }
     else if (objectTypeName == "Contour")
     {
-      currentSO = this->MetaObjectToSpatialObject<MetaContourConverter<NDimensions>>(*it);
+      currentSO = this->MetaObjectToSpatialObject<MetaContourConverter<VDimension>>(*it);
     }
     else
     {
@@ -231,9 +231,9 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateSpatialObjectScen
 }
 
 /** Read a meta file give the type */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 auto
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::ReadMeta(const std::string & name) -> SpatialObjectPointer
+MetaSceneConverter<VDimension, PixelType, TMeshTraits>::ReadMeta(const std::string & name) -> SpatialObjectPointer
 {
   auto * mScene = new MetaScene;
 
@@ -248,18 +248,18 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::ReadMeta(const std::str
 }
 
 /** Write a meta file give the type */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 MetaScene *
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(const SpatialObjectType * soScene,
-                                                                         unsigned int              depth,
-                                                                         const std::string &       name)
+MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateMetaScene(const SpatialObjectType * soScene,
+                                                                        unsigned int              depth,
+                                                                        const std::string &       name)
 {
-  auto * metaScene = new MetaScene(NDimensions);
+  auto * metaScene = new MetaScene(VDimension);
 
   metaScene->BinaryData(m_BinaryPoints);
 
-  auto * spacing = new float[NDimensions];
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  auto * spacing = new float[VDimension];
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     spacing[i] = 1;
   }
@@ -282,63 +282,63 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(const S
     std::string spatialObjectTypeName((*it)->GetTypeName());
     if (spatialObjectTypeName == "GroupSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaGroupConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaGroupConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "TubeSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaTubeConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaTubeConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "VesselTubeSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaVesselTubeConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaVesselTubeConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "DTITubeSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaDTITubeConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaDTITubeConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "EllipseSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaEllipseConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaEllipseConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "ArrowSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaArrowConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaArrowConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "ImageSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaImageConverter<NDimensions, PixelType>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaImageConverter<VDimension, PixelType>>(*it);
     }
     else if (spatialObjectTypeName == "ImageMaskSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaImageMaskConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaImageMaskConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "BlobSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaBlobConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaBlobConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "GaussianSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaGaussianConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaGaussianConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "LandmarkSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaLandmarkConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaLandmarkConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "ContourSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaContourConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaContourConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "SurfaceSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaSurfaceConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaSurfaceConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "LineSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaLineConverter<NDimensions>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaLineConverter<VDimension>>(*it);
     }
     else if (spatialObjectTypeName == "MeshSpatialObject")
     {
-      currentMeta = this->SpatialObjectToMetaObject<MetaMeshConverter<NDimensions, PixelType, TMeshTraits>>(*it);
+      currentMeta = this->SpatialObjectToMetaObject<MetaMeshConverter<VDimension, PixelType, TMeshTraits>>(*it);
     }
     else
     {
@@ -371,12 +371,12 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::CreateMetaScene(const S
 }
 
 /** Write a meta file give the type */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 bool
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::WriteMeta(const SpatialObjectType * soScene,
-                                                                   const std::string &       fileName,
-                                                                   unsigned int              depth,
-                                                                   const std::string &       soName)
+MetaSceneConverter<VDimension, PixelType, TMeshTraits>::WriteMeta(const SpatialObjectType * soScene,
+                                                                  const std::string &       fileName,
+                                                                  unsigned int              depth,
+                                                                  const std::string &       soName)
 {
   MetaScene * metaScene = this->CreateMetaScene(soScene, depth, soName);
 
@@ -387,12 +387,11 @@ MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::WriteMeta(const Spatial
   return true;
 }
 
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void
-MetaSceneConverter<NDimensions, PixelType, TMeshTraits>::RegisterMetaConverter(
-  const std::string &     metaTypeName,
-  const std::string &     spatialObjectTypeName,
-  MetaConverterBaseType * converter)
+MetaSceneConverter<VDimension, PixelType, TMeshTraits>::RegisterMetaConverter(const std::string & metaTypeName,
+                                                                              const std::string & spatialObjectTypeName,
+                                                                              MetaConverterBaseType * converter)
 {
   this->m_ConverterMap[metaTypeName] = converter;
   this->m_ConverterMap[spatialObjectTypeName] = converter;

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaSurfaceConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaSurfaceConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaSurfaceConverter);
 
   /** Standard class type aliases */
   using Self = MetaSurfaceConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using SurfaceSpatialObjectType = SurfaceSpatialObject<NDimensions>;
+  using SurfaceSpatialObjectType = SurfaceSpatialObject<VDimension>;
   using SurfaceSpatialObjectPointer = typename SurfaceSpatialObjectType::Pointer;
   using SurfaceSpatialObjectConstPointer = typename SurfaceSpatialObjectType::ConstPointer;
   using SurfaceMetaObjectType = MetaSurface;

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
@@ -21,17 +21,17 @@
 
 namespace itk
 {
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaSurfaceConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaSurfaceConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new SurfaceMetaObjectType);
 }
 
 /** Convert a metaSurface into an Surface SpatialObject */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaSurfaceConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaSurfaceConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * surfaceMO = dynamic_cast<const SurfaceMetaObjectType *>(mo);
   if (surfaceMO == nullptr)
@@ -61,12 +61,12 @@ MetaSurfaceConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
     using CovariantVectorType = typename SurfacePointType::CovariantVectorType;
     CovariantVectorType normal;
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       point[ii] = (*it2)->m_X[ii] * surfaceMO->ElementSpacing(ii);
     }
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       normal[ii] = (*it2)->m_V[ii];
     }
@@ -87,9 +87,9 @@ MetaSurfaceConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectTyp
 }
 
 /** Convert a Surface SpatialObject into a metaSurface */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaSurfaceConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
+MetaSurfaceConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   SurfaceSpatialObjectConstPointer surfaceSO = dynamic_cast<const SurfaceSpatialObjectType *>(so);
 
@@ -97,20 +97,20 @@ MetaSurfaceConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
   {
     itkExceptionMacro(<< "Can't downcast SpatialObject to SurfaceSpatialObject");
   }
-  auto * surfaceMO = new MetaSurface(NDimensions);
+  auto * surfaceMO = new MetaSurface(VDimension);
 
   // fill in the Surface information
   typename SurfaceSpatialObjectType::SurfacePointListType::const_iterator it;
   for (it = surfaceSO->GetPoints().begin(); it != surfaceSO->GetPoints().end(); ++it)
   {
-    auto * pnt = new SurfacePnt(NDimensions);
+    auto * pnt = new SurfacePnt(VDimension);
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_V[d] = (*it).GetNormalInObjectSpace()[d];
     }
@@ -123,11 +123,11 @@ MetaSurfaceConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObject
     surfaceMO->GetPoints().push_back(pnt);
   }
 
-  if (NDimensions == 2)
+  if (VDimension == 2)
   {
     surfaceMO->PointDim("x y v1 v2 red green blue alpha");
   }
-  else if (NDimensions == 3)
+  else if (VDimension == 3)
   {
     surfaceMO->PointDim("x y z v1 v2 v3 red green blue alpha");
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaTubeConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaTubeConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaTubeConverter);
 
   /** Standard class type aliases */
   using Self = MetaTubeConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using TubeSpatialObjectType = TubeSpatialObject<NDimensions>;
+  using TubeSpatialObjectType = TubeSpatialObject<VDimension>;
   using TubeSpatialObjectPointer = typename TubeSpatialObjectType::Pointer;
   using TubeSpatialObjectConstPointer = typename TubeSpatialObjectType::ConstPointer;
   using TubeMetaObjectType = MetaTube;

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
@@ -21,17 +21,17 @@
 
 namespace itk
 {
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaTubeConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaTubeConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new TubeMetaObjectType);
 }
 
 /** Convert a metaTube into an Tube SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaTubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * tubeMO = dynamic_cast<const TubeMetaObjectType *>(mo);
   if (tubeMO == nullptr)
@@ -50,19 +50,19 @@ MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
   tubeSO->GetProperty().SetBlue(tubeMO->Color()[2]);
   tubeSO->GetProperty().SetAlpha(tubeMO->Color()[3]);
 
-  using TubePointType = itk::TubeSpatialObjectPoint<NDimensions>;
+  using TubePointType = itk::TubeSpatialObjectPoint<VDimension>;
 
   auto it2 = tubeMO->GetPoints().begin();
 
-  itk::CovariantVector<double, NDimensions> v;
-  itk::Vector<double, NDimensions>          t;
+  itk::CovariantVector<double, VDimension> v;
+  itk::Vector<double, VDimension>          t;
 
   for (unsigned int identifier = 0; identifier < tubeMO->GetPoints().size(); ++identifier)
   {
     TubePointType pnt;
 
     typename TubePointType::PointType pos;
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pos[d] = (*it2)->m_X[d] * tubeMO->ElementSpacing(d);
     }
@@ -76,19 +76,19 @@ MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
     pnt.SetRoundness((*it2)->m_Roundness);
     pnt.SetIntensity((*it2)->m_Intensity);
 
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       v[i] = (*it2)->m_V1[i];
     }
     pnt.SetNormal1InObjectSpace(v);
 
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       v[i] = (*it2)->m_V2[i];
     }
     pnt.SetNormal2InObjectSpace(v);
 
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       t[i] = (*it2)->m_T[i];
     }
@@ -121,9 +121,9 @@ MetaTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType *
 }
 
 /** Convert a Tube SpatialObject into a metaTube */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
+MetaTubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * spatialObject) -> MetaObjectType *
 {
   TubeSpatialObjectConstPointer tubeSO = dynamic_cast<const TubeSpatialObjectType *>(spatialObject);
   if (tubeSO.IsNull())
@@ -131,15 +131,15 @@ MetaTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTyp
     itkExceptionMacro(<< "Can't downcast SpatialObject to TubeSpatialObject");
   }
 
-  auto * tubeMO = new MetaTube(NDimensions);
+  auto * tubeMO = new MetaTube(VDimension);
 
   // fill in the tube information
   typename TubeSpatialObjectType::TubePointListType::const_iterator it;
   for (it = tubeSO->GetPoints().begin(); it != tubeSO->GetPoints().end(); ++it)
   {
-    auto * pnt = new TubePnt(NDimensions);
+    auto * pnt = new TubePnt(VDimension);
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*it).GetPositionInObjectSpace()[d];
     }
@@ -164,17 +164,17 @@ MetaTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectTyp
       ++iter;
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_V1[d] = (*it).GetNormal1InObjectSpace()[d];
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_V2[d] = (*it).GetNormal2InObjectSpace()[d];
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_T[d] = (*it).GetTangentInObjectSpace()[d];
     }

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.h
@@ -31,15 +31,15 @@ namespace itk
  *  \sa MetaConverterBase
  *  \ingroup ITKSpatialObjects
  */
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaVesselTubeConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaVesselTubeConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaVesselTubeConverter);
 
   /** Standard class type aliases */
   using Self = MetaVesselTubeConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -54,7 +54,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using VesselTubeSpatialObjectType = TubeSpatialObject<NDimensions>;
+  using VesselTubeSpatialObjectType = TubeSpatialObject<VDimension>;
   using VesselTubeSpatialObjectPointer = typename VesselTubeSpatialObjectType::Pointer;
   using VesselTubeSpatialObjectConstPointer = typename VesselTubeSpatialObjectType::ConstPointer;
   using VesselTubeMetaObjectType = MetaVesselTube;

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
@@ -22,17 +22,17 @@
 namespace itk
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaVesselTubeConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaVesselTubeConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new VesselTubeMetaObjectType);
 }
 
 /** Convert a MetaVesselTube into an Tube SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaVesselTubeConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * vesselTubeMO = dynamic_cast<const VesselTubeMetaObjectType *>(mo);
   if (vesselTubeMO == nullptr)
@@ -61,19 +61,19 @@ MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObject
     vesselTubeSO->GetProperty().SetTagStringValue("Artery", "False");
   }
 
-  using VesselTubePointType = itk::TubeSpatialObjectPoint<NDimensions>;
+  using VesselTubePointType = itk::TubeSpatialObjectPoint<VDimension>;
 
   auto it2 = vesselTubeMO->GetPoints().begin();
 
-  itk::CovariantVector<double, NDimensions> v;
-  itk::Vector<double, NDimensions>          t;
+  itk::CovariantVector<double, VDimension> v;
+  itk::Vector<double, VDimension>          t;
 
   for (unsigned int identifier = 0; identifier < vesselTubeMO->GetPoints().size(); ++identifier)
   {
     VesselTubePointType pnt;
 
     typename VesselTubePointType::PointType pos;
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pos[d] = (*it2)->m_X[d] * vesselTubeMO->ElementSpacing(d);
     }
@@ -87,19 +87,19 @@ MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObject
     pnt.SetRoundness((*it2)->m_Roundness);
     pnt.SetIntensity((*it2)->m_Intensity);
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       v[ii] = (*it2)->m_V1[ii];
     }
     pnt.SetNormal1InObjectSpace(v);
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       v[ii] = (*it2)->m_V2[ii];
     }
     pnt.SetNormal2InObjectSpace(v);
 
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       t[ii] = (*it2)->m_T[ii];
     }
@@ -132,9 +132,9 @@ MetaVesselTubeConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObject
 }
 
 /** Convert a Tube SpatialObject into a MetaVesselTube */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaVesselTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
+MetaVesselTubeConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   const typename VesselTubeSpatialObjectType::ConstPointer vesselTubeSO =
     dynamic_cast<const VesselTubeSpatialObjectType *>(so);
@@ -143,16 +143,16 @@ MetaVesselTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObj
   {
     itkExceptionMacro(<< "Can't downcast SpatialObject to VesselTubeSpatialObject");
   }
-  auto * vesselTubeMO = new MetaVesselTube(NDimensions);
+  auto * vesselTubeMO = new MetaVesselTube(VDimension);
 
   // fill in the tube information
 
   typename VesselTubeSpatialObjectType::TubePointListType::const_iterator i;
   for (i = vesselTubeSO->GetPoints().begin(); i != vesselTubeSO->GetPoints().end(); ++i)
   {
-    auto * pnt = new VesselTubePnt(NDimensions);
+    auto * pnt = new VesselTubePnt(VDimension);
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_X[d] = (*i).GetPositionInObjectSpace()[d];
     }
@@ -177,17 +177,17 @@ MetaVesselTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObj
       ++iter;
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_V1[d] = (*i).GetNormal1InObjectSpace()[d];
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_V2[d] = (*i).GetNormal2InObjectSpace()[d];
     }
 
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       pnt->m_T[d] = (*i).GetTangentInObjectSpace()[d];
     }
@@ -227,7 +227,7 @@ MetaVesselTubeConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObj
   vesselTubeMO->ParentPoint(vesselTubeSO->GetParentPoint());
   vesselTubeMO->NPoints(static_cast<int>(vesselTubeMO->GetPoints().size()));
 
-  for (unsigned int ii = 0; ii < NDimensions; ++ii)
+  for (unsigned int ii = 0; ii < VDimension; ++ii)
   {
     vesselTubeMO->ElementSpacing(ii, 1);
     // Spacing is no longer used

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
@@ -34,9 +34,9 @@
 int
 itkImageMaskSpatialObjectTest(int, char *[])
 {
-  constexpr unsigned int NDimensions = 3;
+  constexpr unsigned int VDimension = 3;
 
-  using ImageMaskSpatialObject = itk::ImageMaskSpatialObject<NDimensions>;
+  using ImageMaskSpatialObject = itk::ImageMaskSpatialObject<VDimension>;
   using PixelType = ImageMaskSpatialObject::PixelType;
   using ImageType = ImageMaskSpatialObject::ImageType;
   using Iterator = itk::ImageRegionIterator<ImageType>;

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -38,12 +38,12 @@
 int
 itkImageMaskSpatialObjectTest2(int, char *[])
 {
-  constexpr unsigned int NDimensions = 3;
+  constexpr unsigned int VDimension = 3;
   int                    retval = EXIT_SUCCESS;
 
-  using ImageMaskSpatialObject = itk::ImageMaskSpatialObject<NDimensions>;
+  using ImageMaskSpatialObject = itk::ImageMaskSpatialObject<VDimension>;
   using PixelType = ImageMaskSpatialObject::PixelType;
-  using ImageType = itk::Image<PixelType, NDimensions>;
+  using ImageType = itk::Image<PixelType, VDimension>;
   using Iterator = itk::ImageRegionIterator<ImageType>;
 
   // Direction was not taken into account in the image spatial object

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -36,11 +36,11 @@
 int
 itkImageMaskSpatialObjectTest3(int, char *[])
 {
-  constexpr unsigned int NDimensions = 3;
+  constexpr unsigned int VDimension = 3;
 
-  using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<NDimensions>;
+  using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<VDimension>;
   using PixelType = ImageMaskSpatialObjectType::PixelType;
-  using ImageType = itk::Image<PixelType, NDimensions>;
+  using ImageType = itk::Image<PixelType, VDimension>;
 
   auto                 image = ImageType::New();
   ImageType::SizeType  size = { { 5, 5, 5 } };
@@ -81,7 +81,7 @@ itkImageMaskSpatialObjectTest3(int, char *[])
 
   ImageMaskSpatialObjectType::RegionType::SizeType regionSize;
   ImageMaskSpatialObjectType::IndexType::IndexType regionIndex;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     regionIndex[i] = bndMinI[i];
     regionSize[i] = bndMaxI[i] - bndMinI[i];

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -35,14 +35,14 @@
 int
 itkImageSpatialObjectTest(int, char *[])
 {
-#define NDimensions 3
+#define VDimension 3
 
   using ScalarType = double;
   using Pixel = unsigned short;
-  using ImageType = itk::Image<Pixel, NDimensions>;
-  using ImageSpatialObject = itk::ImageSpatialObject<NDimensions, Pixel>;
+  using ImageType = itk::Image<Pixel, VDimension>;
+  using ImageSpatialObject = itk::ImageSpatialObject<VDimension, Pixel>;
   using Iterator = itk::ImageRegionIterator<ImageType>;
-  using PointType = itk::Point<ScalarType, NDimensions>;
+  using PointType = itk::Point<ScalarType, VDimension>;
 
   auto                  image = ImageType::New();
   ImageType::SizeType   size = { { 10, 10, 10 } };

--- a/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
@@ -130,15 +130,15 @@ private:
  *\class MetaConverterBase
  *  Dummy converter class
  */
-template <unsigned int NDimensions = 3>
-class MetaDummyConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class MetaDummyConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaDummyConverter);
 
   /** Standard class type aliases */
   using Self = MetaDummyConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -153,7 +153,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using DummySpatialObjectType = DummySpatialObject<NDimensions>;
+  using DummySpatialObjectType = DummySpatialObject<VDimension>;
   using DummySpatialObjectPointer = typename DummySpatialObjectType::Pointer;
   using DummySpatialObjectConstPointer = typename DummySpatialObjectType::ConstPointer;
   using DummyMetaObjectType = MetaDummy;

--- a/Modules/Core/Transform/include/itkAffineTransform.h
+++ b/Modules/Core/Transform/include/itkAffineTransform.h
@@ -77,15 +77,15 @@ namespace itk
  * TParametersValueType The type to be used for scalar numeric
  *                      values.  Either float or double.
  *
- * NDimensions   The number of dimensions of the vector space.
+ * VDimension   The number of dimensions of the vector space.
  *
  * This class provides several methods for setting the matrix and vector
  * defining the transform. To support the registration framework, the
  * transform parameters can also be set as an Array<double> of size
- * (NDimension + 1) * NDimension using method SetParameters().
- * The first (NDimension x NDimension) parameters defines the matrix in
+ * (VDimension + 1) * VDimension using method SetParameters().
+ * The first (VDimension x VDimension) parameters defines the matrix in
  * row-major order (where the column index varies the fastest).
- * The last NDimension parameters defines the translation
+ * The last VDimension parameters defines the translation
  * in each dimensions.
  *
  * This class also supports the specification of a center of rotation (center)
@@ -95,17 +95,17 @@ namespace itk
  * \ingroup ITKTransform
  */
 
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
 // Number of dimensions in the input space
 class ITK_TEMPLATE_EXPORT AffineTransform
-  : public MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>
+  : public MatrixOffsetTransformBase<TParametersValueType, VDimension, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AffineTransform);
 
   /** Standard type alias   */
   using Self = AffineTransform;
-  using Superclass = MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>;
+  using Superclass = MatrixOffsetTransformBase<TParametersValueType, VDimension, VDimension>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -117,10 +117,10 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int InputSpaceDimension = NDimensions;
-  static constexpr unsigned int OutputSpaceDimension = NDimensions;
-  static constexpr unsigned int SpaceDimension = NDimensions;
-  static constexpr unsigned int ParametersDimension = NDimensions * (NDimensions + 1);
+  static constexpr unsigned int InputSpaceDimension = VDimension;
+  static constexpr unsigned int OutputSpaceDimension = VDimension;
+  static constexpr unsigned int SpaceDimension = VDimension;
+  static constexpr unsigned int ParametersDimension = VDimension * (VDimension + 1);
 
   /** Parameters Type   */
   using typename Superclass::ParametersType;
@@ -204,7 +204,7 @@ public:
    * \warning Only to be use in two dimensions
    *
    * \todo Find a way to generate a compile-time error
-   *       is this is used with NDimensions != 2. */
+   *       is this is used with VDimension != 2. */
   void
   Rotate2D(TParametersValueType angle, bool pre = false);
 
@@ -220,7 +220,7 @@ public:
    * \warning Only to be used in dimension 3
    *
    * \todo Find a way to generate a compile-time error
-   * is this is used with NDimensions != 3. */
+   * is this is used with VDimension != 3. */
   void
   Rotate3D(const OutputVectorType & axis, TParametersValueType angle, bool pre = false);
 

--- a/Modules/Core/Transform/include/itkAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkAffineTransform.hxx
@@ -24,36 +24,36 @@
 namespace itk
 {
 /** Constructor with default arguments */
-template <typename TParametersValueType, unsigned int NDimensions>
-AffineTransform<TParametersValueType, NDimensions>::AffineTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+AffineTransform<TParametersValueType, VDimension>::AffineTransform()
   : Superclass(ParametersDimension)
 {}
 
 /** Constructor with default arguments */
-template <typename TParametersValueType, unsigned int NDimensions>
-AffineTransform<TParametersValueType, NDimensions>::AffineTransform(unsigned int parametersDimension)
+template <typename TParametersValueType, unsigned int VDimension>
+AffineTransform<TParametersValueType, VDimension>::AffineTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {}
 
 /** Constructor with explicit arguments */
-template <typename TParametersValueType, unsigned int NDimensions>
-AffineTransform<TParametersValueType, NDimensions>::AffineTransform(const MatrixType &       matrix,
-                                                                    const OutputVectorType & offset)
+template <typename TParametersValueType, unsigned int VDimension>
+AffineTransform<TParametersValueType, VDimension>::AffineTransform(const MatrixType &       matrix,
+                                                                   const OutputVectorType & offset)
   : Superclass(matrix, offset)
 {}
 
 /** Print self */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AffineTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+AffineTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }
 
 /** Compose with a translation */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AffineTransform<TParametersValueType, NDimensions>::Translate(const OutputVectorType & trans, bool pre)
+AffineTransform<TParametersValueType, VDimension>::Translate(const OutputVectorType & trans, bool pre)
 {
   OutputVectorType newTranslation = this->GetTranslation();
 
@@ -71,9 +71,9 @@ AffineTransform<TParametersValueType, NDimensions>::Translate(const OutputVector
 }
 
 /** Compose with isotropic scaling */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AffineTransform<TParametersValueType, NDimensions>::Scale(const TParametersValueType & factor, bool pre)
+AffineTransform<TParametersValueType, VDimension>::Scale(const TParametersValueType & factor, bool pre)
 {
   if (pre)
   {
@@ -97,16 +97,16 @@ AffineTransform<TParametersValueType, NDimensions>::Scale(const TParametersValue
 }
 
 /** Compose with anisotropic scaling */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AffineTransform<TParametersValueType, NDimensions>::Scale(const OutputVectorType & factor, bool pre)
+AffineTransform<TParametersValueType, VDimension>::Scale(const OutputVectorType & factor, bool pre)
 {
   MatrixType   trans;
   unsigned int i, j;
 
-  for (i = 0; i < NDimensions; ++i)
+  for (i = 0; i < VDimension; ++i)
   {
-    for (j = 0; j < NDimensions; ++j)
+    for (j = 0; j < VDimension; ++j)
     {
       trans[i][j] = 0.0;
     }
@@ -127,16 +127,16 @@ AffineTransform<TParametersValueType, NDimensions>::Scale(const OutputVectorType
 }
 
 /** Compose with elementary rotation */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AffineTransform<TParametersValueType, NDimensions>::Rotate(int axis1, int axis2, TParametersValueType angle, bool pre)
+AffineTransform<TParametersValueType, VDimension>::Rotate(int axis1, int axis2, TParametersValueType angle, bool pre)
 {
   MatrixType   trans;
   unsigned int i, j;
 
-  for (i = 0; i < NDimensions; ++i)
+  for (i = 0; i < VDimension; ++i)
   {
-    for (j = 0; j < NDimensions; ++j)
+    for (j = 0; j < VDimension; ++j)
     {
       trans[i][j] = 0.0;
     }
@@ -162,10 +162,10 @@ AffineTransform<TParametersValueType, NDimensions>::Rotate(int axis1, int axis2,
 
 /** Compose with 2D rotation
  * \todo Find a way to generate a compile-time error
- * is this is used with NDimensions != 2. */
-template <typename TParametersValueType, unsigned int NDimensions>
+ * is this is used with VDimension != 2. */
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AffineTransform<TParametersValueType, NDimensions>::Rotate2D(TParametersValueType angle, bool pre)
+AffineTransform<TParametersValueType, VDimension>::Rotate2D(TParametersValueType angle, bool pre)
 {
   MatrixType trans;
 
@@ -189,12 +189,12 @@ AffineTransform<TParametersValueType, NDimensions>::Rotate2D(TParametersValueTyp
 
 /** Compose with 3D rotation
  *  \todo Find a way to generate a compile-time error
- *  is this is used with NDimensions != 3. */
-template <typename TParametersValueType, unsigned int NDimensions>
+ *  is this is used with VDimension != 3. */
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AffineTransform<TParametersValueType, NDimensions>::Rotate3D(const OutputVectorType & axis,
-                                                             TParametersValueType     angle,
-                                                             bool                     pre)
+AffineTransform<TParametersValueType, VDimension>::Rotate3D(const OutputVectorType & axis,
+                                                            TParametersValueType     angle,
+                                                            bool                     pre)
 {
   MatrixType trans;
   ScalarType r, x1, x2, x3;
@@ -239,16 +239,16 @@ AffineTransform<TParametersValueType, NDimensions>::Rotate3D(const OutputVectorT
 }
 
 /** Compose with elementary rotation */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AffineTransform<TParametersValueType, NDimensions>::Shear(int axis1, int axis2, TParametersValueType coef, bool pre)
+AffineTransform<TParametersValueType, VDimension>::Shear(int axis1, int axis2, TParametersValueType coef, bool pre)
 {
   MatrixType   trans;
   unsigned int i, j;
 
-  for (i = 0; i < NDimensions; ++i)
+  for (i = 0; i < VDimension; ++i)
   {
-    for (j = 0; j < NDimensions; ++j)
+    for (j = 0; j < VDimension; ++j)
     {
       trans[i][j] = 0.0;
     }
@@ -270,17 +270,17 @@ AffineTransform<TParametersValueType, NDimensions>::Shear(int axis1, int axis2, 
 }
 
 /** Get an inverse of this transform. */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-AffineTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+AffineTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   return this->Superclass::GetInverse(inverse);
 }
 
 /** Return an inverse of this transform. */
-template <typename TParametersValueType, unsigned int NDimensions>
-typename AffineTransform<TParametersValueType, NDimensions>::InverseTransformBasePointer
-AffineTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+template <typename TParametersValueType, unsigned int VDimension>
+typename AffineTransform<TParametersValueType, VDimension>::InverseTransformBasePointer
+AffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const
 {
   Pointer inv = New();
 
@@ -288,15 +288,15 @@ AffineTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
 }
 
 /** Compute a distance between two affine transforms */
-template <typename TParametersValueType, unsigned int NDimensions>
-typename AffineTransform<TParametersValueType, NDimensions>::ScalarType
-AffineTransform<TParametersValueType, NDimensions>::Metric(const Self * other) const
+template <typename TParametersValueType, unsigned int VDimension>
+typename AffineTransform<TParametersValueType, VDimension>::ScalarType
+AffineTransform<TParametersValueType, VDimension>::Metric(const Self * other) const
 {
   ScalarType result = 0.0, term;
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    for (unsigned int j = 0; j < NDimensions; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       term = this->GetMatrix()[i][j] - other->GetMatrix()[i][j];
       result += term * term;
@@ -308,15 +308,15 @@ AffineTransform<TParametersValueType, NDimensions>::Metric(const Self * other) c
 }
 
 /** Compute a distance between self and the identity transform */
-template <typename TParametersValueType, unsigned int NDimensions>
-typename AffineTransform<TParametersValueType, NDimensions>::ScalarType
-AffineTransform<TParametersValueType, NDimensions>::Metric() const
+template <typename TParametersValueType, unsigned int VDimension>
+typename AffineTransform<TParametersValueType, VDimension>::ScalarType
+AffineTransform<TParametersValueType, VDimension>::Metric() const
 {
   ScalarType result = 0.0, term;
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    for (unsigned int j = 0; j < NDimensions; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       if (i == j)
       {

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
@@ -65,7 +65,7 @@ r = std::sqrt(x^2 + y^2 + z^2)
  * TParametersValueType  The type to be used for scalar numeric
  *                       values.  Either float or double.
  *
- * NDimensions   The number of dimensions of the vector space (must be >=3).
+ * VDimension   The number of dimensions of the vector space (must be >=3).
  *
  * \todo Is there any real value in allowing the user to template
  * over the scalar type?  Perhaps it should always be double, unless
@@ -84,22 +84,22 @@ r = std::sqrt(x^2 + y^2 + z^2)
  * \sphinxexample{Core/Transform/CartesianToAzimuthElevation,Cartesian To Azimuth Elevation}
  * \endsphinx
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
 class ITK_TEMPLATE_EXPORT AzimuthElevationToCartesianTransform
-  : public AffineTransform<TParametersValueType, NDimensions>
+  : public AffineTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AzimuthElevationToCartesianTransform);
 
   /** Standard class type aliases.   */
   using Self = AzimuthElevationToCartesianTransform;
-  using Superclass = AffineTransform<TParametersValueType, NDimensions>;
+  using Superclass = AffineTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
-  static constexpr unsigned int ParametersDimension = NDimensions * (NDimensions + 1);
+  static constexpr unsigned int SpaceDimension = VDimension;
+  static constexpr unsigned int ParametersDimension = VDimension * (VDimension + 1);
 
   /** Run-time type information (and related methods).   */
   itkTypeMacro(AzimuthElevationToCartesianTransform, AffineTransform);

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
@@ -22,8 +22,8 @@
 namespace itk
 {
 // Constructor with default arguments
-template <typename TParametersValueType, unsigned int NDimensions>
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::AzimuthElevationToCartesianTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::AzimuthElevationToCartesianTransform()
 // add this construction call when deriving from itk::Transform
 // :Superclass(ParametersDimension)
 {
@@ -37,10 +37,10 @@ AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::Azimuth
 }
 
 // Print self
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os,
-                                                                                   Indent         indent) const
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,
+                                                                                  Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -66,9 +66,9 @@ AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::PrintSe
   os << indent << std::endl;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::OutputPointType
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::TransformPoint(
+template <typename TParametersValueType, unsigned int VDimension>
+typename AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::OutputPointType
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::TransformPoint(
   const InputPointType & point) const
 {
   OutputPointType result;
@@ -85,9 +85,9 @@ AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::Transfo
 }
 
 /** Transform a point, from azimuth-elevation to cartesian */
-template <typename TParametersValueType, unsigned int NDimensions>
-typename AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::OutputPointType
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::TransformAzElToCartesian(
+template <typename TParametersValueType, unsigned int VDimension>
+typename AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::OutputPointType
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::TransformAzElToCartesian(
   const InputPointType & point) const
 {
   OutputPointType result;
@@ -106,9 +106,9 @@ AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::Transfo
   return result;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::OutputPointType
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::TransformCartesianToAzEl(
+template <typename TParametersValueType, unsigned int VDimension>
+typename AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::OutputPointType
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::TransformCartesianToAzEl(
   const OutputPointType & point) const
 {
   InputPointType result; // Converted point
@@ -121,9 +121,9 @@ AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::Transfo
 }
 
 // Set parameters
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::SetAzimuthElevationToCartesianParameters(
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::SetAzimuthElevationToCartesianParameters(
   const double sampleSize,
   const double firstSampleDistance,
   const long   maxAzimuth,
@@ -139,9 +139,9 @@ AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::SetAzim
   SetFirstSampleDistance(firstSampleDistance / sampleSize);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::SetAzimuthElevationToCartesianParameters(
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::SetAzimuthElevationToCartesianParameters(
   const double sampleSize,
   const double firstSampleDistance,
   const long   maxAzimuth,
@@ -150,16 +150,16 @@ AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::SetAzim
   SetAzimuthElevationToCartesianParameters(sampleSize, firstSampleDistance, maxAzimuth, maxElevation, 1.0, 1.0);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::SetForwardAzimuthElevationToCartesian()
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::SetForwardAzimuthElevationToCartesian()
 {
   m_ForwardAzimuthElevationToPhysical = true;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-AzimuthElevationToCartesianTransform<TParametersValueType, NDimensions>::SetForwardCartesianToAzimuthElevation()
+AzimuthElevationToCartesianTransform<TParametersValueType, VDimension>::SetForwardCartesianToAzimuthElevation()
 {
   m_ForwardAzimuthElevationToPhysical = false;
 }

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -30,15 +30,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3, unsigned int VSplineOrder = 3>
-class ITK_TEMPLATE_EXPORT BSplineBaseTransform : public Transform<TParametersValueType, NDimensions, NDimensions>
+template <typename TParametersValueType = double, unsigned int VDimension = 3, unsigned int VSplineOrder = 3>
+class ITK_TEMPLATE_EXPORT BSplineBaseTransform : public Transform<TParametersValueType, VDimension, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineBaseTransform);
 
   /** Standard class type aliases. */
   using Self = BSplineBaseTransform;
-  using Superclass = Transform<TParametersValueType, NDimensions, NDimensions>;
+  using Superclass = Transform<TParametersValueType, VDimension, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -46,7 +46,7 @@ public:
   itkTypeMacro(BSplineBaseTransform, Transform);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
+  static constexpr unsigned int SpaceDimension = VDimension;
 
   /** The BSpline order. */
   static constexpr unsigned int SplineOrder = VSplineOrder;
@@ -177,7 +177,7 @@ public:
   using ParametersValueType = typename ParametersType::ValueType;
   using ImageType = Image<ParametersValueType, Self::SpaceDimension>;
   using ImagePointer = typename ImageType::Pointer;
-  using CoefficientImageArray = FixedArray<ImagePointer, NDimensions>;
+  using CoefficientImageArray = FixedArray<ImagePointer, VDimension>;
 
   /** Set the array of coefficient images.
    *

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -27,8 +27,8 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::BSplineBaseTransform()
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::BSplineBaseTransform()
   : Superclass(0)
   , m_CoefficientImages(Self::ArrayOfImagePointerGeneratorHelper())
 {
@@ -39,9 +39,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::BSplineBa
 }
 
 // Set the parameters
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::SetIdentity()
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::SetIdentity()
 {
   if (this->m_InternalParametersBuffer.Size() != this->GetNumberOfParameters())
   {
@@ -54,9 +54,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::SetIdenti
 }
 
 // Set the parameters
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::SetParameters(const ParametersType & parameters)
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::SetParameters(const ParametersType & parameters)
 {
   // check if the number of parameters match the
   // expected number of parameters
@@ -86,9 +86,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::SetParame
 }
 
 // Set the parameters by value
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::SetParametersByValue(
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::SetParametersByValue(
   const ParametersType & parameters)
 {
   // check if the number of parameters match the
@@ -105,19 +105,19 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::SetParame
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::
-  SetFixedParametersFromTransformDomainInformation() const
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::SetFixedParametersFromTransformDomainInformation()
+  const
 {
   //  Fixed Parameters store the following information:
   //  Grid Size
   //  Grid Origin
   //  Grid Spacing
   //  Grid Direction
-  //  The size of each of these is equal to NDimensions
+  //  The size of each of these is equal to VDimension
 
-  this->m_FixedParameters.SetSize(NDimensions * (NDimensions + 3));
+  this->m_FixedParameters.SetSize(VDimension * (VDimension + 3));
 
   this->SetFixedParametersGridSizeFromTransformDomainInformation();
   this->SetFixedParametersGridOriginFromTransformDomainInformation();
@@ -130,9 +130,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::
 /**
  * UpdateTransformParameters
  */
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::UpdateTransformParameters(
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::UpdateTransformParameters(
   const DerivativeType & update,
   TParametersValueType   factor)
 {
@@ -185,9 +185,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::UpdateTra
 }
 
 // Wrap flat parameters as images
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::WrapAsImages()
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::WrapAsImages()
 {
   /**
    * Wrap flat parameters array into SpaceDimension number of ITK images
@@ -205,17 +205,17 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::WrapAsIma
 }
 
 // Get the parameters
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetParameters() const -> const ParametersType &
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::GetParameters() const -> const ParametersType &
 {
   return this->m_InternalParametersBuffer;
 }
 
 // Get the parameters
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetFixedParameters() const
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::GetFixedParameters() const
   -> const FixedParametersType &
 {
   // HACK:  This should not be necessary if the
@@ -225,9 +225,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetFixedP
 }
 
 // Print self
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::PrintSelf(std::ostream & os, Indent indent) const
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 
@@ -241,9 +241,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::PrintSelf
 
 
 /** Get Jacobian at a point. A very specialized function just for BSplines */
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::
   ComputeJacobianFromBSplineWeightsWithRespectToPosition(const InputPointType &    point,
                                                          WeightsType &             weights,
                                                          ParameterIndexArrayType & indexes) const
@@ -284,18 +284,18 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 unsigned int
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfAffectedWeights() const
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::GetNumberOfAffectedWeights() const
 {
   return WeightsFunctionType::NumberOfWeights;
 }
 
 // This helper class is used to work around a race condition where the dynamically
 // generated images must exist before the references to the sub-sections are created.
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::ArrayOfImagePointerGeneratorHelper()
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::ArrayOfImagePointerGeneratorHelper()
   -> CoefficientImageArray
 {
   CoefficientImageArray tempArrayOfPointers;
@@ -308,10 +308,9 @@ BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::ArrayOfIm
 }
 
 // Transform a point
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-typename BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::OutputPointType
-BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoint(
-  const InputPointType & point) const
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
+typename BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::OutputPointType
+BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::TransformPoint(const InputPointType & point) const
 {
   WeightsType             weights;
   ParameterIndexArrayType indices;

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -109,16 +109,16 @@ outputPoint = transform->TransformPoint( inputPoint );
  * \sphinxexample{Core/Transform/GlobalRegistrationTwoImagesBSpline,Global Registration Of Two Images (BSpline)}
  * \endsphinx
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3, unsigned int VSplineOrder = 3>
+template <typename TParametersValueType = double, unsigned int VDimension = 3, unsigned int VSplineOrder = 3>
 class ITK_TEMPLATE_EXPORT BSplineDeformableTransform
-  : public BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>
+  : public BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineDeformableTransform);
 
   /** Standard class type aliases. */
   using Self = BSplineDeformableTransform;
-  using Superclass = BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>;
+  using Superclass = BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -146,7 +146,7 @@ public:
   itkTypeMacro(BSplineDeformableTransform, BSplineBaseTransform);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
+  static constexpr unsigned int SpaceDimension = VDimension;
 
   /** The BSpline order. */
   static constexpr unsigned int SplineOrder = VSplineOrder;

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -27,8 +27,8 @@ namespace itk
 {
 
 // Constructor with default arguments
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::BSplineDeformableTransform()
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::BSplineDeformableTransform()
   : m_GridRegion(Superclass::m_CoefficientImages[0]->GetLargestPossibleRegion())
   , m_GridOrigin(Superclass::m_CoefficientImages[0]->GetOrigin())
   , m_GridSpacing(Superclass::m_CoefficientImages[0]->GetSpacing())
@@ -73,9 +73,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::BSp
 }
 
 // Get the number of parameters
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfParameters() const
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::GetNumberOfParameters() const
   -> NumberOfParametersType
 {
   // The number of parameters equal SpaceDimension * number of
@@ -84,9 +84,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Get
 }
 
 // Get the number of parameters per dimension
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfParametersPerDimension() const
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::GetNumberOfParametersPerDimension() const
   -> NumberOfParametersType
 {
   // The number of parameters per dimension equal number of
@@ -95,9 +95,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Get
 }
 
 // Set the grid region
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::UpdateValidGridRegion()
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::UpdateValidGridRegion()
 {
   // Set the valid region
   // If the grid spans the interval [start, last].
@@ -110,7 +110,7 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Upd
   // with odd spline orders.
   typename RegionType::SizeType  size;
   typename RegionType::IndexType index;
-  for (unsigned int j = 0; j < NDimensions; ++j)
+  for (unsigned int j = 0; j < VDimension; ++j)
   {
     index[j] = this->m_GridRegion.GetIndex()[j];
     size[j] = this->m_GridRegion.GetSize()[j];
@@ -124,9 +124,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Upd
 }
 
 // Set the grid region
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::SetGridRegion(const RegionType & region)
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::SetGridRegion(const RegionType & region)
 {
   if (this->m_GridRegion != region)
   {
@@ -156,9 +156,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Set
 }
 
 // Set the grid spacing
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::SetGridSpacing(const SpacingType & spacing)
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::SetGridSpacing(const SpacingType & spacing)
 {
   if (this->m_GridSpacing != spacing)
   {
@@ -174,9 +174,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Set
 }
 
 // Set the grid direction
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::SetGridDirection(
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::SetGridDirection(
   const DirectionType & direction)
 {
   if (this->m_GridDirection != direction)
@@ -193,9 +193,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Set
 }
 
 // Set the grid origin
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::SetGridOrigin(const OriginType & origin)
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::SetGridOrigin(const OriginType & origin)
 {
   if (this->m_GridOrigin != origin)
   {
@@ -210,9 +210,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Set
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::
   SetCoefficientImageInformationFromFixedParameters()
 {
 
@@ -225,7 +225,7 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
   {
     // set the grid size parameters
     SizeType gridSize;
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       gridSize[i] = static_cast<int>(this->m_FixedParameters[i]);
     }
@@ -237,9 +237,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
   {
     // Set the origin parameters
     OriginType origin;
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
-      origin[i] = this->m_FixedParameters[NDimensions + i];
+      origin[i] = this->m_FixedParameters[VDimension + i];
     }
     this->SetGridOrigin(origin);
   }
@@ -247,9 +247,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
   {
     // Set the spacing parameters
     SpacingType spacing;
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
-      spacing[i] = this->m_FixedParameters[2 * NDimensions + i];
+      spacing[i] = this->m_FixedParameters[2 * VDimension + i];
     }
     this->SetGridSpacing(spacing);
   }
@@ -257,70 +257,70 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
   {
     // Set the direction parameters
     DirectionType direction;
-    for (unsigned int di = 0; di < NDimensions; ++di)
+    for (unsigned int di = 0; di < VDimension; ++di)
     {
-      for (unsigned int dj = 0; dj < NDimensions; ++dj)
+      for (unsigned int dj = 0; dj < VDimension; ++dj)
       {
-        direction[di][dj] = this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)];
+        direction[di][dj] = this->m_FixedParameters[3 * VDimension + (di * VDimension + dj)];
       }
     }
     this->SetGridDirection(direction);
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::
   SetFixedParametersGridSizeFromTransformDomainInformation() const
 {
   // Set the grid size parameters
   const SizeType & gridSize = this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetSize();
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     this->m_FixedParameters[i] = static_cast<FixedParametersValueType>(gridSize[i]);
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::
   SetFixedParametersGridOriginFromTransformDomainInformation() const
 {
   // Set the origin parameters
 
   const OriginType & origin = this->m_CoefficientImages[0]->GetOrigin();
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    this->m_FixedParameters[NDimensions + i] = static_cast<FixedParametersValueType>(origin[i]);
+    this->m_FixedParameters[VDimension + i] = static_cast<FixedParametersValueType>(origin[i]);
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::
   SetFixedParametersGridSpacingFromTransformDomainInformation() const
 {
   // Set the spacing parameters
   const SpacingType & spacing = this->m_CoefficientImages[0]->GetSpacing();
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    this->m_FixedParameters[2 * NDimensions + i] = static_cast<FixedParametersValueType>(spacing[i]);
+    this->m_FixedParameters[2 * VDimension + i] = static_cast<FixedParametersValueType>(spacing[i]);
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::
   SetFixedParametersGridDirectionFromTransformDomainInformation() const
 {
   /** Set the direction parameters */
   const DirectionType & direction = this->m_CoefficientImages[0]->GetDirection();
-  for (unsigned int di = 0; di < NDimensions; ++di)
+  for (unsigned int di = 0; di < VDimension; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; ++dj)
+    for (unsigned int dj = 0; dj < VDimension; ++dj)
     {
-      this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)] =
+      this->m_FixedParameters[3 * VDimension + (di * VDimension + dj)] =
         static_cast<FixedParametersValueType>(direction[di][dj]);
     }
   }
@@ -328,21 +328,21 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::
 
 
 // Set the Fixed Parameters
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::SetFixedParameters(
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::SetFixedParameters(
   const FixedParametersType & passedParameters)
 {
   // check if the number of passedParameters match the
   // expected number of this->m_FixedParameters
   if (passedParameters.Size() == this->m_FixedParameters.Size())
   {
-    for (unsigned int i = 0; i < NDimensions * (3 + NDimensions); ++i)
+    for (unsigned int i = 0; i < VDimension * (3 + VDimension); ++i)
     {
       this->m_FixedParameters[i] = passedParameters[i];
     }
   }
-  else if (passedParameters.Size() == NDimensions * 3)
+  else if (passedParameters.Size() == VDimension * 3)
   {
     // This option was originally valid for backwards compatibility
     // with BSplines saved to disk from before image orientation was used.
@@ -361,9 +361,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Set
 }
 
 // Set the B-Spline coefficients using input images
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::SetCoefficientImages(
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::SetCoefficientImages(
   const CoefficientImageArray & images)
 {
   bool validArrayOfImages = true;
@@ -408,10 +408,10 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Set
 }
 
 // Print self
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::PrintSelf(std::ostream & os,
-                                                                                       Indent         indent) const
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::PrintSelf(std::ostream & os,
+                                                                                      Indent         indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 
@@ -431,9 +431,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Pri
   os << indent << "GridRegion: " << this->m_GridRegion << std::endl;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 bool
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::InsideValidRegion(
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::InsideValidRegion(
   ContinuousIndexType & index) const
 {
   bool inside = true;
@@ -458,9 +458,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Ins
   return inside;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoint(
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::TransformPoint(
   const InputPointType &    inputPoint,
   OutputPointType &         outputPoint,
   WeightsType &             weights,
@@ -546,9 +546,9 @@ BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::Tra
 }
 
 // Compute the Jacobian in one position
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineDeformableTransform<TParametersValueType, NDimensions, VSplineOrder>::ComputeJacobianWithRespectToParameters(
+BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::ComputeJacobianWithRespectToParameters(
   const InputPointType & point,
   JacobianType &         jacobian) const
 {

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -99,16 +99,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3, unsigned int VSplineOrder = 3>
-class ITK_TEMPLATE_EXPORT BSplineTransform
-  : public BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>
+template <typename TParametersValueType = double, unsigned int VDimension = 3, unsigned int VSplineOrder = 3>
+class ITK_TEMPLATE_EXPORT BSplineTransform : public BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineTransform);
 
   /** Standard class type aliases. */
   using Self = BSplineTransform;
-  using Superclass = BSplineBaseTransform<TParametersValueType, NDimensions, VSplineOrder>;
+  using Superclass = BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -119,7 +118,7 @@ public:
   itkTypeMacro(BSplineTransform, BSplineBaseTransform);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
+  static constexpr unsigned int SpaceDimension = VDimension;
 
   /** The BSpline order. */
   static constexpr unsigned int SplineOrder = VSplineOrder;

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -26,8 +26,8 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::BSplineTransform()
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::BSplineTransform()
   : Superclass()
 {
 
@@ -57,7 +57,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::BSplineTransf
   MeshSizeType meshSize;
   meshSize.Fill(1);
 
-  this->m_FixedParameters.SetSize(NDimensions * (NDimensions + 3));
+  this->m_FixedParameters.SetSize(VDimension * (VDimension + 3));
 
   this->SetFixedParametersFromTransformDomainInformation(meshOrigin, meshPhysical, meshDirection, meshSize);
 
@@ -65,9 +65,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::BSplineTransf
   this->SetCoefficientImageInformationFromFixedParameters();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 std::string
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformTypeAsString() const
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::GetTransformTypeAsString() const
 {
   if (VSplineOrder != 3)
   {
@@ -79,9 +79,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformT
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfParameters() const
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::GetNumberOfParameters() const
   -> NumberOfParametersType
 {
   // The number of parameters equals SpaceDimension * number of
@@ -90,9 +90,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfPa
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfParametersPerDimension() const
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::GetNumberOfParametersPerDimension() const
   -> NumberOfParametersType
 {
   // The number of parameters per dimension equals the number of
@@ -107,9 +107,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetNumberOfPa
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetTransformDomainOrigin(const OriginType & origin)
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetTransformDomainOrigin(const OriginType & origin)
 {
   if (this->GetTransformDomainOrigin() != origin)
   {
@@ -124,30 +124,30 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetTransformD
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformDomainOrigin() const -> OriginType
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::GetTransformDomainOrigin() const -> OriginType
 {
   OriginType origin;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    const ScalarType spacing = this->m_FixedParameters[2 * NDimensions + i];
+    const ScalarType spacing = this->m_FixedParameters[2 * VDimension + i];
     origin[i] = spacing * 0.5 * (SplineOrder - 1);
   }
 
   origin = this->GetTransformDomainDirection() * origin;
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    const ScalarType grid_origin = this->m_FixedParameters[NDimensions + i];
+    const ScalarType grid_origin = this->m_FixedParameters[VDimension + i];
     origin[i] += grid_origin;
   }
   return origin;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetTransformDomainPhysicalDimensions(
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetTransformDomainPhysicalDimensions(
   const PhysicalDimensionsType & dims)
 {
   if (this->GetTransformDomainPhysicalDimensions() != dims)
@@ -161,24 +161,24 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetTransformD
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformDomainPhysicalDimensions() const
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::GetTransformDomainPhysicalDimensions() const
   -> PhysicalDimensionsType
 {
   const MeshSizeType     size = this->GetTransformDomainMeshSize();
   PhysicalDimensionsType physicalDim;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    ScalarType spacing = this->m_FixedParameters[2 * NDimensions + i];
+    ScalarType spacing = this->m_FixedParameters[2 * VDimension + i];
     physicalDim[i] = size[i] * spacing;
   }
   return physicalDim;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetTransformDomainDirection(
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetTransformDomainDirection(
   const DirectionType & direction)
 {
   if (this->GetTransformDomainDirection() != direction)
@@ -194,26 +194,26 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetTransformD
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformDomainDirection() const -> DirectionType
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::GetTransformDomainDirection() const -> DirectionType
 {
   DirectionType direction;
 
-  for (unsigned int di = 0; di < NDimensions; ++di)
+  for (unsigned int di = 0; di < VDimension; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; ++dj)
+    for (unsigned int dj = 0; dj < VDimension; ++dj)
     {
-      const FixedParametersValueType v = this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)];
+      const FixedParametersValueType v = this->m_FixedParameters[3 * VDimension + (di * VDimension + dj)];
       direction[di][dj] = static_cast<typename DirectionType::ValueType>(v);
     }
   }
   return direction;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetTransformDomainMeshSize(
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetTransformDomainMeshSize(
   const MeshSizeType & meshSize)
 {
   if (this->GetTransformDomainMeshSize() != meshSize)
@@ -229,13 +229,13 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetTransformD
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 auto
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformDomainMeshSize() const -> MeshSizeType
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::GetTransformDomainMeshSize() const -> MeshSizeType
 {
   MeshSizeType meshSize;
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     using ValueType = typename MeshSizeType::SizeValueType;
     meshSize[i] = static_cast<ValueType>(this->m_FixedParameters[i]) - SplineOrder;
@@ -243,9 +243,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::GetTransformD
   return meshSize;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetFixedParametersFromCoefficientImageInformation()
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetFixedParametersFromCoefficientImageInformation()
 {
   // Fixed Parameters store the following information:
   //  grid size
@@ -255,41 +255,41 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetFixedParam
 
   // Set the grid size parameters
   const SizeType & gridSize = this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetSize();
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     this->m_FixedParameters[i] = static_cast<FixedParametersValueType>(gridSize[i]);
   }
 
   const OriginType & origin = this->m_CoefficientImages[0]->GetOrigin();
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    this->m_FixedParameters[NDimensions + i] = static_cast<FixedParametersValueType>(origin[i]);
+    this->m_FixedParameters[VDimension + i] = static_cast<FixedParametersValueType>(origin[i]);
   }
 
   // Set the spacing parameters
   const SpacingType & spacing = this->m_CoefficientImages[0]->GetSpacing();
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    this->m_FixedParameters[2 * NDimensions + i] = static_cast<FixedParametersValueType>(spacing[i]);
+    this->m_FixedParameters[2 * VDimension + i] = static_cast<FixedParametersValueType>(spacing[i]);
   }
 
   // Set the direction parameters
   const DirectionType & direction = this->m_CoefficientImages[0]->GetDirection();
-  for (unsigned int di = 0; di < NDimensions; ++di)
+  for (unsigned int di = 0; di < VDimension; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; ++dj)
+    for (unsigned int dj = 0; dj < VDimension; ++dj)
     {
-      this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)] =
+      this->m_FixedParameters[3 * VDimension + (di * VDimension + dj)] =
         static_cast<FixedParametersValueType>(direction[di][dj]);
     }
   }
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetFixedParametersFromTransformDomainInformation(
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetFixedParametersFromTransformDomainInformation(
   const OriginType &             meshOrigin,
   const PhysicalDimensionsType & meshPhysical,
   const DirectionType &          meshDirection,
@@ -297,7 +297,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetFixedParam
 {
 
   // Set the grid size parameters
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     this->m_FixedParameters[i] = static_cast<FixedParametersValueType>(meshSize[i] + SplineOrder);
   }
@@ -307,41 +307,41 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetFixedParam
   using PointType = typename ImageType::PointType;
   PointType origin;
   origin.Fill(0.0);
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     ScalarType gridSpacing = meshPhysical[i] / static_cast<ScalarType>(meshSize[i]);
     origin[i] = -0.5 * gridSpacing * (SplineOrder - 1);
   }
 
   origin = meshDirection * origin;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    this->m_FixedParameters[NDimensions + i] = static_cast<FixedParametersValueType>(origin[i] + meshOrigin[i]);
+    this->m_FixedParameters[VDimension + i] = static_cast<FixedParametersValueType>(origin[i] + meshOrigin[i]);
   }
 
   // Set the spacing parameters
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     ScalarType gridSpacing = meshPhysical[i] / static_cast<ScalarType>(meshSize[i]);
 
-    this->m_FixedParameters[2 * NDimensions + i] = static_cast<FixedParametersValueType>(gridSpacing);
+    this->m_FixedParameters[2 * VDimension + i] = static_cast<FixedParametersValueType>(gridSpacing);
   }
 
   // Set the direction parameters
-  for (unsigned int di = 0; di < NDimensions; ++di)
+  for (unsigned int di = 0; di < VDimension; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; ++dj)
+    for (unsigned int dj = 0; dj < VDimension; ++dj)
     {
-      this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)] =
+      this->m_FixedParameters[3 * VDimension + (di * VDimension + dj)] =
         static_cast<FixedParametersValueType>(meshDirection[di][dj]);
     }
   }
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetCoefficientImageInformationFromFixedParameters()
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetCoefficientImageInformationFromFixedParameters()
 {
   // Fixed Parameters store the following information:
   //  grid size
@@ -352,7 +352,7 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetCoefficien
 
   // set the grid size parameters
   SizeType gridSize;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     gridSize[i] = static_cast<SizeValueType>(this->m_FixedParameters[i]);
   }
@@ -360,27 +360,27 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetCoefficien
 
   // Set the origin parameters
   OriginType origin;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    origin[i] = this->m_FixedParameters[NDimensions + i];
+    origin[i] = this->m_FixedParameters[VDimension + i];
   }
   this->m_CoefficientImages[0]->SetOrigin(origin);
 
   // Set the spacing parameters
   SpacingType spacing;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    spacing[i] = this->m_FixedParameters[2 * NDimensions + i];
+    spacing[i] = this->m_FixedParameters[2 * VDimension + i];
   }
   this->m_CoefficientImages[0]->SetSpacing(spacing);
 
   // Set the direction parameters
   DirectionType direction;
-  for (unsigned int di = 0; di < NDimensions; ++di)
+  for (unsigned int di = 0; di < VDimension; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; ++dj)
+    for (unsigned int dj = 0; dj < VDimension; ++dj)
     {
-      direction[di][dj] = this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)];
+      direction[di][dj] = this->m_FixedParameters[3 * VDimension + (di * VDimension + dj)];
     }
   }
   this->m_CoefficientImages[0]->SetDirection(direction);
@@ -404,16 +404,16 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetCoefficien
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetFixedParameters(
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetFixedParameters(
   const FixedParametersType & passedParameters)
 {
   // Check if the number of passedParameters match the
   // expected number of this->m_FixedParameters
   if (passedParameters.Size() == this->m_FixedParameters.Size())
   {
-    for (unsigned int i = 0; i < NDimensions * (3 + NDimensions); ++i)
+    for (unsigned int i = 0; i < VDimension * (3 + VDimension); ++i)
     {
       this->m_FixedParameters[i] = passedParameters[i];
     }
@@ -429,9 +429,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetFixedParam
   this->SetCoefficientImageInformationFromFixedParameters();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetCoefficientImages(
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::SetCoefficientImages(
   const CoefficientImageArray & images)
 {
   bool validArrayOfImages = true;
@@ -477,9 +477,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::SetCoefficien
   this->SetParameters(this->m_InternalParametersBuffer);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 bool
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::InsideValidRegion(ContinuousIndexType & index) const
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::InsideValidRegion(ContinuousIndexType & index) const
 {
   const SizeType gridSize = this->m_CoefficientImages[0]->GetLargestPossibleRegion().GetSize();
 
@@ -509,13 +509,13 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::InsideValidRe
   return inside;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoint(const InputPointType &    point,
-                                                                                  OutputPointType &         outputPoint,
-                                                                                  WeightsType &             weights,
-                                                                                  ParameterIndexArrayType & indices,
-                                                                                  bool & inside) const
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::TransformPoint(const InputPointType &    point,
+                                                                                 OutputPointType &         outputPoint,
+                                                                                 WeightsType &             weights,
+                                                                                 ParameterIndexArrayType & indices,
+                                                                                 bool &                    inside) const
 {
   inside = true;
 
@@ -597,9 +597,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoin
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::ComputeJacobianWithRespectToParameters(
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::ComputeJacobianWithRespectToParameters(
   const InputPointType & point,
   JacobianType &         jacobian) const
 {
@@ -661,9 +661,9 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::ComputeJacobi
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::PrintSelf(std::ostream & os, Indent indent) const
+BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/Transform/include/itkCenteredAffineTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredAffineTransform.h
@@ -30,15 +30,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT CenteredAffineTransform : public AffineTransform<TParametersValueType, NDimensions>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT CenteredAffineTransform : public AffineTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(CenteredAffineTransform);
 
   /** Standard type alias   */
   using Self = CenteredAffineTransform;
-  using Superclass = AffineTransform<TParametersValueType, NDimensions>;
+  using Superclass = AffineTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -49,8 +49,8 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
-  static constexpr unsigned int ParametersDimension = NDimensions * (NDimensions + 2);
+  static constexpr unsigned int SpaceDimension = VDimension;
+  static constexpr unsigned int ParametersDimension = VDimension * (VDimension + 2);
 
   /** Types taken from the Superclass */
   using typename Superclass::ParametersType;
@@ -82,7 +82,7 @@ public:
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set/Get the transformation from a container of parameters.
-   * The first (NDimension x NDimension) parameters define the
+   * The first (VDimension x VDimension) parameters define the
    * matrix, the next N parameters define the center of rotation
    * and the last N parameters define the translation to be applied
    * after the coordinate system has been restored to the rotation center.

--- a/Modules/Core/Transform/include/itkCenteredAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredAffineTransform.hxx
@@ -24,23 +24,23 @@
 namespace itk
 {
 // Constructor with default arguments
-template <typename TParametersValueType, unsigned int NDimensions>
-CenteredAffineTransform<TParametersValueType, NDimensions>::CenteredAffineTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+CenteredAffineTransform<TParametersValueType, VDimension>::CenteredAffineTransform()
   : Superclass(ParametersDimension)
 {}
 
 // Get parameters
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CenteredAffineTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
+CenteredAffineTransform<TParametersValueType, VDimension>::GetParameters() const -> const ParametersType &
 {
   // Transfer the linear part
   unsigned int par = 0;
 
   const MatrixType & matrix = this->GetMatrix();
-  for (unsigned int row = 0; row < NDimensions; ++row)
+  for (unsigned int row = 0; row < VDimension; ++row)
   {
-    for (unsigned int col = 0; col < NDimensions; ++col)
+    for (unsigned int col = 0; col < VDimension; ++col)
     {
       this->m_Parameters[par] = matrix[row][col];
       ++par;
@@ -49,7 +49,7 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::GetParameters() cons
 
   // Transfer the rotation center
   InputPointType center = this->GetCenter();
-  for (unsigned int j = 0; j < NDimensions; ++j)
+  for (unsigned int j = 0; j < VDimension; ++j)
   {
     this->m_Parameters[par] = center[j];
     ++par;
@@ -57,7 +57,7 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::GetParameters() cons
 
   // Transfer the translation
   OutputVectorType translation = this->GetTranslation();
-  for (unsigned int k = 0; k < NDimensions; ++k)
+  for (unsigned int k = 0; k < VDimension; ++k)
   {
     this->m_Parameters[par] = translation[k];
     ++par;
@@ -67,9 +67,9 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::GetParameters() cons
 }
 
 /** Set the parameters */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CenteredAffineTransform<TParametersValueType, NDimensions>::SetParameters(const ParametersType & parameters)
+CenteredAffineTransform<TParametersValueType, VDimension>::SetParameters(const ParametersType & parameters)
 {
   // Transfer the linear part
   unsigned int par = 0;
@@ -81,9 +81,9 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::SetParameters(const 
   }
 
   MatrixType matrix;
-  for (unsigned int row = 0; row < NDimensions; ++row)
+  for (unsigned int row = 0; row < VDimension; ++row)
   {
-    for (unsigned int col = 0; col < NDimensions; ++col)
+    for (unsigned int col = 0; col < VDimension; ++col)
     {
       matrix[row][col] = this->m_Parameters[par];
       ++par;
@@ -94,7 +94,7 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::SetParameters(const 
 
   // Transfer the rotation center
   InputPointType center;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     center[i] = this->m_Parameters[par];
     ++par;
@@ -103,7 +103,7 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::SetParameters(const 
 
   // Transfer the translation
   OutputVectorType translation;
-  for (unsigned int k = 0; k < NDimensions; ++k)
+  for (unsigned int k = 0; k < VDimension; ++k)
   {
     translation[k] = this->m_Parameters[par];
     ++par;
@@ -115,9 +115,9 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::SetParameters(const 
   this->Modified();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CenteredAffineTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToParameters(
+CenteredAffineTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToParameters(
   const InputPointType & p,
   JacobianType &         jacobian) const
 {
@@ -126,7 +126,7 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::ComputeJacobianWithR
   // a constant value in the diagonal.
   // The block corresponding to the center parameters is
   // composed by ( Identity matrix - Rotation Matrix).
-  jacobian.SetSize(NDimensions, this->GetNumberOfLocalParameters());
+  jacobian.SetSize(VDimension, this->GetNumberOfLocalParameters());
   jacobian.Fill(0.0);
 
   unsigned int blockOffset = 0;
@@ -158,17 +158,17 @@ CenteredAffineTransform<TParametersValueType, NDimensions>::ComputeJacobianWithR
 }
 
 // Get an inverse of this transform
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-CenteredAffineTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+CenteredAffineTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   return this->Superclass::GetInverse(inverse);
 }
 
 // Return an inverse of this transform
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CenteredAffineTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
+CenteredAffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 

--- a/Modules/Core/Transform/include/itkCompositeTransform.h
+++ b/Modules/Core/Transform/include/itkCompositeTransform.h
@@ -83,15 +83,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT CompositeTransform : public MultiTransform<TParametersValueType, NDimensions, NDimensions>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT CompositeTransform : public MultiTransform<TParametersValueType, VDimension, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(CompositeTransform);
 
   /** Standard class type aliases. */
   using Self = CompositeTransform;
-  using Superclass = MultiTransform<TParametersValueType, NDimensions, NDimensions>;
+  using Superclass = MultiTransform<TParametersValueType, VDimension, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -153,8 +153,8 @@ public:
   using TransformsToOptimizeFlagsType = std::deque<bool>;
 
   /** Dimension of the domain spaces. */
-  static constexpr unsigned int InputDimension = NDimensions;
-  static constexpr unsigned int OutputDimension = NDimensions;
+  static constexpr unsigned int InputDimension = VDimension;
+  static constexpr unsigned int OutputDimension = VDimension;
 
   /** Active Transform state manipulation */
 
@@ -398,7 +398,7 @@ public:
    * transform using Jacobian rule. This version takes in temporary
    * variables to avoid excessive constructions and memory allocations.
    * NOTE: outJacobian MUST be sized correctly prior to the call;
-   * outJacobian's size should be [NDimensions, this->GetNumberOfLocalParameters() ]
+   * outJacobian's size should be [VDimension, this->GetNumberOfLocalParameters() ]
    * jacobianCache may be resized internally and will be reused between calls
    */
   void

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -23,17 +23,17 @@ namespace itk
 {
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-CompositeTransform<TParametersValueType, NDimensions>::CompositeTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+CompositeTransform<TParametersValueType, VDimension>::CompositeTransform()
 {
   this->m_TransformsToOptimizeFlags.clear();
   this->m_TransformsToOptimizeQueue.clear();
   this->m_PreviousTransformsToOptimizeUpdateTime = 0;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::GetTransformCategory() const -> TransformCategoryEnum
+CompositeTransform<TParametersValueType, VDimension>::GetTransformCategory() const -> TransformCategoryEnum
 {
   // Check if linear
   bool isLinearTransform = this->IsLinear();
@@ -65,9 +65,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetTransformCategory() co
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & inputPoint) const
+CompositeTransform<TParametersValueType, VDimension>::TransformPoint(const InputPointType & inputPoint) const
   -> OutputPointType
 {
 
@@ -81,9 +81,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformPoint(const Inpu
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorType & inputVector) const
+CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVectorType & inputVector) const
   -> OutputVectorType
 {
   OutputVectorType outputVector(inputVector);
@@ -99,10 +99,10 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorType
-CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorType & inputVector,
-                                                                       const InputPointType &  inputPoint) const
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorType
+CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVectorType & inputVector,
+                                                                      const InputPointType &  inputPoint) const
 {
   OutputVectorType outputVector(inputVector);
   OutputPointType  outputPoint(inputPoint);
@@ -118,10 +118,10 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVnlVectorType
-CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVnlVectorType & inputVector,
-                                                                       const InputPointType &     inputPoint) const
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVnlVectorType
+CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVnlVectorType & inputVector,
+                                                                      const InputPointType &     inputPoint) const
 {
   OutputVnlVectorType outputVector(inputVector);
   OutputPointType     outputPoint(inputPoint);
@@ -137,9 +137,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVnlVectorType & inputVector) const
+CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVnlVectorType & inputVector) const
   -> OutputVnlVectorType
 {
   OutputVnlVectorType outputVector(inputVector);
@@ -154,9 +154,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorPixelType & inputVector) const
+CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVectorPixelType & inputVector) const
   -> OutputVectorPixelType
 {
   OutputVectorPixelType outputVector(inputVector);
@@ -171,10 +171,10 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorPixelType
-CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorPixelType & inputVector,
-                                                                       const InputPointType &       inputPoint) const
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+CompositeTransform<TParametersValueType, VDimension>::TransformVector(const InputVectorPixelType & inputVector,
+                                                                      const InputPointType &       inputPoint) const
 {
   OutputVectorPixelType outputVector(inputVector);
   OutputPointType       outputPoint(inputPoint);
@@ -190,9 +190,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformVector(const Inp
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputCovariantVectorType
-CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputCovariantVectorType
+CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
   const InputCovariantVectorType & inputVector) const
 {
   OutputCovariantVectorType outputVector(inputVector);
@@ -207,9 +207,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputCovariantVectorType
-CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputCovariantVectorType
+CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
   const InputCovariantVectorType & inputVector,
   const InputPointType &           inputPoint) const
 {
@@ -227,9 +227,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorPixelType
-CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(
   const InputVectorPixelType & inputVector) const
 {
   OutputVectorPixelType outputVector(inputVector);
@@ -244,11 +244,10 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorPixelType
-CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
-  const InputVectorPixelType & inputVector,
-  const InputPointType &       inputPoint) const
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+CompositeTransform<TParametersValueType, VDimension>::TransformCovariantVector(const InputVectorPixelType & inputVector,
+                                                                               const InputPointType & inputPoint) const
 {
   OutputVectorPixelType outputVector(inputVector);
   OutputPointType       outputPoint(inputPoint);
@@ -264,9 +263,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputDiffusionTensor3DType
-CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3D(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputDiffusionTensor3DType
+CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D(
   const InputDiffusionTensor3DType & inputTensor,
   const InputPointType &             inputPoint) const
 {
@@ -284,9 +283,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorPixelType
-CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3D(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D(
   const InputVectorPixelType & inputTensor,
   const InputPointType &       inputPoint) const
 {
@@ -304,9 +303,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputDiffusionTensor3DType
-CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3D(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputDiffusionTensor3DType
+CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D(
   const InputDiffusionTensor3DType & inputTensor) const
 {
   OutputDiffusionTensor3DType outputTensor(inputTensor);
@@ -321,9 +320,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorPixelType
-CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3D(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+CompositeTransform<TParametersValueType, VDimension>::TransformDiffusionTensor3D(
   const InputVectorPixelType & inputTensor) const
 {
   OutputVectorPixelType outputTensor(inputTensor);
@@ -338,9 +337,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformDiffusionTensor3
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputSymmetricSecondRankTensorType
-CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondRankTensor(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputSymmetricSecondRankTensorType
+CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRankTensor(
   const InputSymmetricSecondRankTensorType & inputTensor,
   const InputPointType &                     inputPoint) const
 {
@@ -358,9 +357,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondR
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorPixelType
-CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondRankTensor(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRankTensor(
   const InputVectorPixelType & inputTensor,
   const InputPointType &       inputPoint) const
 {
@@ -378,9 +377,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondR
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputSymmetricSecondRankTensorType
-CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondRankTensor(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputSymmetricSecondRankTensorType
+CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRankTensor(
   const InputSymmetricSecondRankTensorType & inputTensor) const
 {
   OutputSymmetricSecondRankTensorType outputTensor(inputTensor);
@@ -395,9 +394,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondR
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename CompositeTransform<TParametersValueType, NDimensions>::OutputVectorPixelType
-CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondRankTensor(
+template <typename TParametersValueType, unsigned int VDimension>
+typename CompositeTransform<TParametersValueType, VDimension>::OutputVectorPixelType
+CompositeTransform<TParametersValueType, VDimension>::TransformSymmetricSecondRankTensor(
   const InputVectorPixelType & inputTensor) const
 {
   OutputVectorPixelType outputTensor(inputTensor);
@@ -412,9 +411,9 @@ CompositeTransform<TParametersValueType, NDimensions>::TransformSymmetricSecondR
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-CompositeTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+CompositeTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   typename TransformQueueType::const_iterator it;
 
@@ -448,9 +447,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
+CompositeTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   /* This method can't be defined in Superclass because of the call to New() */
   Pointer inverseTransform = New();
@@ -466,9 +465,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetInverseTransform() con
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CompositeTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToParameters(
+CompositeTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToParameters(
   const InputPointType & p,
   JacobianType &         outJacobian) const
 {
@@ -477,20 +476,20 @@ CompositeTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespec
    * as that in which they're applied, i.e. reverse order.
    * M rows = dimensionality of the transforms
    * N cols = total number of parameters in the selected sub transforms. */
-  outJacobian.SetSize(NDimensions, this->GetNumberOfLocalParameters());
+  outJacobian.SetSize(VDimension, this->GetNumberOfLocalParameters());
   JacobianType jacobianWithRespectToPosition;
   this->ComputeJacobianWithRespectToParametersCachedTemporaries(p, outJacobian, jacobianWithRespectToPosition);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CompositeTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToParametersCachedTemporaries(
+CompositeTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToParametersCachedTemporaries(
   const InputPointType & p,
   JacobianType &         outJacobian,
   JacobianType &         cacheJacobian) const
 {
-  // NOTE: This must have been done outside of outJacobian.SetSize( NDimensions, this->GetNumberOfLocalParameters() );
-  assert(outJacobian.rows() == NDimensions && outJacobian.cols() == this->GetNumberOfLocalParameters());
+  // NOTE: This must have been done outside of outJacobian.SetSize( VDimension, this->GetNumberOfLocalParameters() );
+  assert(outJacobian.rows() == VDimension && outJacobian.cols() == this->GetNumberOfLocalParameters());
 
   if (this->GetNumberOfTransforms() == 1)
   {
@@ -558,7 +557,7 @@ CompositeTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespec
 
       const NumberOfParametersType numberOfLocalParameters = transform->GetNumberOfLocalParameters();
 
-      cacheJacobian.SetSize(NDimensions, numberOfLocalParameters);
+      cacheJacobian.SetSize(VDimension, numberOfLocalParameters);
       transform->ComputeJacobianWithRespectToParameters(transformedPoint, cacheJacobian);
       outJacobian.update(cacheJacobian, 0, offset);
       offset += numberOfLocalParameters;
@@ -584,22 +583,22 @@ CompositeTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespec
       transform->ComputeJacobianWithRespectToPosition(transformedPoint, jacobianWithRespectToPosition);
 
       // Perform the following matrix multiplication in-place:
-      // outJacobian[0:NDimensions,0:offsetLast] = jacobianWithRespectToPosition*outJacobian[0:NDimensions,0:offsetLast]
-      assert(jacobianWithRespectToPosition.rows() == NDimensions);
-      double temp[NDimensions];
+      // outJacobian[0:VDimension,0:offsetLast] = jacobianWithRespectToPosition*outJacobian[0:VDimension,0:offsetLast]
+      assert(jacobianWithRespectToPosition.rows() == VDimension);
+      double temp[VDimension];
       for (unsigned int c = 0; c < offsetLast; ++c)
       {
-        for (unsigned int r = 0; r < NDimensions; ++r)
+        for (unsigned int r = 0; r < VDimension; ++r)
         {
           temp[r] = 0.0;
           // update_j[r][c] = 0.0;
-          for (unsigned int k = 0; k < NDimensions; ++k)
+          for (unsigned int k = 0; k < VDimension; ++k)
           {
             // update_j[r][c]
             temp[r] += jacobianWithRespectToPosition[r][k] * outJacobian[k][c];
           }
         }
-        for (unsigned int r = 0; r < NDimensions; ++r)
+        for (unsigned int r = 0; r < VDimension; ++r)
         {
           outJacobian[r][c] = temp[r];
         }
@@ -612,9 +611,9 @@ CompositeTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespec
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
+CompositeTransform<TParametersValueType, VDimension>::GetParameters() const -> const ParametersType &
 {
   const TransformQueueType & transforms = this->GetTransformsToOptimizeQueue();
   if (transforms.size() == 1)
@@ -644,9 +643,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetParameters() const -> 
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CompositeTransform<TParametersValueType, NDimensions>::SetParameters(const ParametersType & inputParameters)
+CompositeTransform<TParametersValueType, VDimension>::SetParameters(const ParametersType & inputParameters)
 {
   /* We do not copy inputParameters into m_Parameters,
    * to avoid unnecessary copying. */
@@ -705,9 +704,9 @@ CompositeTransform<TParametersValueType, NDimensions>::SetParameters(const Param
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::GetFixedParameters() const -> const FixedParametersType &
+CompositeTransform<TParametersValueType, VDimension>::GetFixedParameters() const -> const FixedParametersType &
 {
   TransformQueueType transforms = this->GetTransformsToOptimizeQueue();
   /* Resize destructively. But if it's already this size, nothing is done so
@@ -728,9 +727,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetFixedParameters() cons
   return this->m_FixedParameters;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CompositeTransform<TParametersValueType, NDimensions>::SetFixedParameters(const FixedParametersType & inputParameters)
+CompositeTransform<TParametersValueType, VDimension>::SetFixedParameters(const FixedParametersType & inputParameters)
 {
   /* Assumes input params are concatenation of the parameters of the
    * sub transforms currently selected for optimization. */
@@ -757,9 +756,9 @@ CompositeTransform<TParametersValueType, NDimensions>::SetFixedParameters(const 
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfParameters() const -> NumberOfParametersType
+CompositeTransform<TParametersValueType, VDimension>::GetNumberOfParameters() const -> NumberOfParametersType
 {
   /* Returns to total number of params in all transforms currently
    * set to be used for optimized.
@@ -783,9 +782,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfParameters() c
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfLocalParameters() const -> NumberOfParametersType
+CompositeTransform<TParametersValueType, VDimension>::GetNumberOfLocalParameters() const -> NumberOfParametersType
 {
   if (this->GetMTime() == this->m_LocalParametersUpdateTime)
   {
@@ -813,9 +812,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfLocalParameter
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfFixedParameters() const -> NumberOfParametersType
+CompositeTransform<TParametersValueType, VDimension>::GetNumberOfFixedParameters() const -> NumberOfParametersType
 {
   /* Returns to total number of params in all transforms currently
    * set to be used for optimized.
@@ -835,10 +834,10 @@ CompositeTransform<TParametersValueType, NDimensions>::GetNumberOfFixedParameter
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CompositeTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(const DerivativeType & update,
-                                                                                 ScalarType             factor)
+CompositeTransform<TParametersValueType, VDimension>::UpdateTransformParameters(const DerivativeType & update,
+                                                                                ScalarType             factor)
 {
   /* Update parameters within the sub-transforms set to be optimized. */
   /* NOTE: We might want to thread this over each sub-transform, if we
@@ -887,10 +886,9 @@ CompositeTransform<TParametersValueType, NDimensions>::UpdateTransformParameters
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-CompositeTransform<TParametersValueType, NDimensions>::GetTransformsToOptimizeQueue() const
-  -> const TransformQueueType &
+CompositeTransform<TParametersValueType, VDimension>::GetTransformsToOptimizeQueue() const -> const TransformQueueType &
 {
   /* Update the list of transforms to use for optimization only if
    the selection of transforms to optimize may have changed */
@@ -912,9 +910,9 @@ CompositeTransform<TParametersValueType, NDimensions>::GetTransformsToOptimizeQu
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CompositeTransform<TParametersValueType, NDimensions>::FlattenTransformQueue()
+CompositeTransform<TParametersValueType, VDimension>::FlattenTransformQueue()
 {
   TransformQueueType            transformQueue;
   TransformQueueType            transformsToOptimizeQueue;
@@ -961,9 +959,9 @@ CompositeTransform<TParametersValueType, NDimensions>::FlattenTransformQueue()
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-CompositeTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+CompositeTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -992,9 +990,9 @@ CompositeTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & 
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 typename LightObject::Pointer
-CompositeTransform<TParametersValueType, NDimensions>::InternalClone() const
+CompositeTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   // This class doesn't use its superclass implementation
   // TODO: is it really the right behavior?

--- a/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.h
@@ -34,16 +34,16 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
 class ITK_TEMPLATE_EXPORT ElasticBodyReciprocalSplineKernelTransform
-  : public KernelTransform<TParametersValueType, NDimensions>
+  : public KernelTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ElasticBodyReciprocalSplineKernelTransform);
 
   /** Standard class type aliases. */
   using Self = ElasticBodyReciprocalSplineKernelTransform;
-  using Superclass = KernelTransform<TParametersValueType, NDimensions>;
+  using Superclass = KernelTransform<TParametersValueType, VDimension>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
@@ -20,24 +20,24 @@
 
 namespace itk
 {
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 ElasticBodyReciprocalSplineKernelTransform<TParametersValueType,
-                                           NDimensions>::ElasticBodyReciprocalSplineKernelTransform()
+                                           VDimension>::ElasticBodyReciprocalSplineKernelTransform()
 {
   // Alpha = 8 ( 1 - \nu ) - 1
   m_Alpha = 8.0 * (1.0 - .25) - 1;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ElasticBodyReciprocalSplineKernelTransform<TParametersValueType, NDimensions>::ComputeG(const InputVectorType & x,
-                                                                                        GMatrixType & gmatrix) const
+ElasticBodyReciprocalSplineKernelTransform<TParametersValueType, VDimension>::ComputeG(const InputVectorType & x,
+                                                                                       GMatrixType & gmatrix) const
 {
   const TParametersValueType r = x.GetNorm();
   const TParametersValueType factor = (r > 1e-8) ? (-1.0 / r) : NumericTraits<TParametersValueType>::ZeroValue();
   const TParametersValueType radial = m_Alpha * r;
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     const typename InputVectorType::ValueType xi = x[i] * factor;
     // G is symmetric
@@ -51,10 +51,10 @@ ElasticBodyReciprocalSplineKernelTransform<TParametersValueType, NDimensions>::C
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ElasticBodyReciprocalSplineKernelTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os,
-                                                                                         Indent         indent) const
+ElasticBodyReciprocalSplineKernelTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,
+                                                                                        Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "m_Alpha: " << m_Alpha << std::endl;

--- a/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.h
@@ -36,15 +36,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT ElasticBodySplineKernelTransform : public KernelTransform<TParametersValueType, NDimensions>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT ElasticBodySplineKernelTransform : public KernelTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ElasticBodySplineKernelTransform);
 
   /** Standard class type aliases. */
   using Self = ElasticBodySplineKernelTransform;
-  using Superclass = KernelTransform<TParametersValueType, NDimensions>;
+  using Superclass = KernelTransform<TParametersValueType, VDimension>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;

--- a/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.hxx
@@ -20,23 +20,23 @@
 
 namespace itk
 {
-template <typename TParametersValueType, unsigned int NDimensions>
-ElasticBodySplineKernelTransform<TParametersValueType, NDimensions>::ElasticBodySplineKernelTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+ElasticBodySplineKernelTransform<TParametersValueType, VDimension>::ElasticBodySplineKernelTransform()
 {
   // Alpha = 12 ( 1 - \nu ) - 1
   m_Alpha = 12.0 * (1.0 - .25) - 1;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ElasticBodySplineKernelTransform<TParametersValueType, NDimensions>::ComputeG(const InputVectorType & x,
-                                                                              GMatrixType &           gmatrix) const
+ElasticBodySplineKernelTransform<TParametersValueType, VDimension>::ComputeG(const InputVectorType & x,
+                                                                             GMatrixType &           gmatrix) const
 {
   const TParametersValueType r = x.GetNorm();
   const TParametersValueType factor = -3.0 * r;
   const TParametersValueType radial = m_Alpha * (r * r) * r;
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     const typename InputVectorType::ValueType xi = x[i] * factor;
     // G is symmetric
@@ -50,9 +50,9 @@ ElasticBodySplineKernelTransform<TParametersValueType, NDimensions>::ComputeG(co
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ElasticBodySplineKernelTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+ElasticBodySplineKernelTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "m_Alpha: " << m_Alpha << std::endl;

--- a/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.h
+++ b/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.h
@@ -30,17 +30,17 @@ namespace itk
  * \ingroup ITKTransform
  */
 
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
 // Number of dimensions in the input space
 class ITK_TEMPLATE_EXPORT FixedCenterOfRotationAffineTransform
-  : public ScalableAffineTransform<TParametersValueType, NDimensions>
+  : public ScalableAffineTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FixedCenterOfRotationAffineTransform);
 
   /** Standard type alias   */
   using Self = FixedCenterOfRotationAffineTransform;
-  using Superclass = ScalableAffineTransform<TParametersValueType, NDimensions>;
+  using Superclass = ScalableAffineTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -51,10 +51,10 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int InputSpaceDimension = NDimensions;
-  static constexpr unsigned int OutputSpaceDimension = NDimensions;
-  static constexpr unsigned int SpaceDimension = NDimensions;
-  static constexpr unsigned int ParametersDimension = NDimensions * (NDimensions + 2);
+  static constexpr unsigned int InputSpaceDimension = VDimension;
+  static constexpr unsigned int OutputSpaceDimension = VDimension;
+  static constexpr unsigned int SpaceDimension = VDimension;
+  static constexpr unsigned int ParametersDimension = VDimension * (VDimension + 2);
 
   /** Types taken from the Superclass */
   using typename Superclass::ParametersType;

--- a/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.hxx
@@ -25,20 +25,20 @@
 namespace itk
 {
 /** Constructor with default arguments */
-template <typename TParametersValueType, unsigned int NDimensions>
-FixedCenterOfRotationAffineTransform<TParametersValueType, NDimensions>::FixedCenterOfRotationAffineTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+FixedCenterOfRotationAffineTransform<TParametersValueType, VDimension>::FixedCenterOfRotationAffineTransform()
   : Superclass(ParametersDimension)
 {}
 
-template <typename TParametersValueType, unsigned int NDimensions>
-FixedCenterOfRotationAffineTransform<TParametersValueType, NDimensions>::FixedCenterOfRotationAffineTransform(
+template <typename TParametersValueType, unsigned int VDimension>
+FixedCenterOfRotationAffineTransform<TParametersValueType, VDimension>::FixedCenterOfRotationAffineTransform(
   unsigned int outputSpaceDims,
   unsigned int paramsDims)
   : Superclass(outputSpaceDims, paramsDims)
 {}
 
-template <typename TParametersValueType, unsigned int NDimensions>
-FixedCenterOfRotationAffineTransform<TParametersValueType, NDimensions>::FixedCenterOfRotationAffineTransform(
+template <typename TParametersValueType, unsigned int VDimension>
+FixedCenterOfRotationAffineTransform<TParametersValueType, VDimension>::FixedCenterOfRotationAffineTransform(
   const MatrixType &       matrix,
   const OutputVectorType & offset)
   : Superclass(matrix, offset)

--- a/Modules/Core/Transform/include/itkIdentityTransform.h
+++ b/Modules/Core/Transform/include/itkIdentityTransform.h
@@ -46,15 +46,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType, unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT IdentityTransform : public Transform<TParametersValueType, NDimensions, NDimensions>
+template <typename TParametersValueType, unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT IdentityTransform : public Transform<TParametersValueType, VDimension, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(IdentityTransform);
 
   /** Standard class type aliases. */
   using Self = IdentityTransform;
-  using Superclass = Transform<TParametersValueType, NDimensions, NDimensions>;
+  using Superclass = Transform<TParametersValueType, VDimension, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -65,8 +65,8 @@ public:
   itkTypeMacro(IdentityTransform, Transform);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int InputSpaceDimension = NDimensions;
-  static constexpr unsigned int OutputSpaceDimension = NDimensions;
+  static constexpr unsigned int InputSpaceDimension = VDimension;
+  static constexpr unsigned int OutputSpaceDimension = VDimension;
 
   /** Type of the input parameters. */
   using typename Superclass::ParametersType;
@@ -174,7 +174,7 @@ public:
   void
   ComputeJacobianWithRespectToParameters(const InputPointType &, JacobianType & jacobian) const override
   {
-    jacobian.SetSize(NDimensions, 0);
+    jacobian.SetSize(VDimension, 0);
   }
 
 

--- a/Modules/Core/Transform/include/itkKernelTransform.h
+++ b/Modules/Core/Transform/include/itkKernelTransform.h
@@ -57,15 +57,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType, unsigned int NDimensions>
-class ITK_TEMPLATE_EXPORT KernelTransform : public Transform<TParametersValueType, NDimensions, NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
+class ITK_TEMPLATE_EXPORT KernelTransform : public Transform<TParametersValueType, VDimension, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(KernelTransform);
 
   /** Standard class type aliases. */
   using Self = KernelTransform;
-  using Superclass = Transform<TParametersValueType, NDimensions, NDimensions>;
+  using Superclass = Transform<TParametersValueType, VDimension, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -76,7 +76,7 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
+  static constexpr unsigned int SpaceDimension = VDimension;
 
   /** Scalar type. */
   using typename Superclass::ScalarType;
@@ -115,8 +115,8 @@ public:
   /** PointList type alias. This type is used for maintaining lists of points,
    * specifically, the source and target landmark lists. */
   using PointSetTraitsType =
-    DefaultStaticMeshTraits<TParametersValueType, NDimensions, NDimensions, TParametersValueType, TParametersValueType>;
-  using PointSetType = PointSet<InputPointType, NDimensions, PointSetTraitsType>;
+    DefaultStaticMeshTraits<TParametersValueType, VDimension, VDimension, TParametersValueType, TParametersValueType>;
+  using PointSetType = PointSet<InputPointType, VDimension, PointSetTraitsType>;
 
   using PointSetPointer = typename PointSetType::Pointer;
   using PointsContainer = typename PointSetType::PointsContainer;
@@ -174,7 +174,7 @@ public:
   }
 
   /** 'I' (identity) matrix type alias. */
-  using IMatrixType = vnl_matrix_fixed<TParametersValueType, NDimensions, NDimensions>;
+  using IMatrixType = vnl_matrix_fixed<TParametersValueType, VDimension, VDimension>;
 
   /** Compute the Jacobian Matrix of the transformation at one point */
   void
@@ -191,7 +191,7 @@ public:
 
   /** Set the Transformation Parameters and update the internal transformation.
    * The parameters represent the source landmarks. Each landmark point is
-   * represented by NDimensions doubles. All the landmarks are concatenated to
+   * represented by VDimension doubles. All the landmarks are concatenated to
    * form one flat Array<double>. */
   void
   SetParameters(const ParametersType &) override;
@@ -246,7 +246,7 @@ protected:
 
 public:
   /** 'G' matrix type alias. */
-  using GMatrixType = vnl_matrix_fixed<TParametersValueType, NDimensions, NDimensions>;
+  using GMatrixType = vnl_matrix_fixed<TParametersValueType, VDimension, VDimension>;
 
   /** 'L' matrix type alias. */
   using LMatrixType = vnl_matrix<TParametersValueType>;
@@ -267,16 +267,16 @@ public:
   using DMatrixType = vnl_matrix<TParametersValueType>;
 
   /** 'A' matrix type alias. Rotational part of the Affine component */
-  using AMatrixType = vnl_matrix_fixed<TParametersValueType, NDimensions, NDimensions>;
+  using AMatrixType = vnl_matrix_fixed<TParametersValueType, VDimension, VDimension>;
 
   /** 'B' matrix type alias. Translational part of the Affine component */
-  using BMatrixType = vnl_vector_fixed<TParametersValueType, NDimensions>;
+  using BMatrixType = vnl_vector_fixed<TParametersValueType, VDimension>;
 
   /** Row matrix type alias. */
-  using RowMatrixType = vnl_matrix_fixed<TParametersValueType, 1, NDimensions>;
+  using RowMatrixType = vnl_matrix_fixed<TParametersValueType, 1, VDimension>;
 
   /** Column matrix type alias. */
-  using ColumnMatrixType = vnl_matrix_fixed<TParametersValueType, NDimensions, 1>;
+  using ColumnMatrixType = vnl_matrix_fixed<TParametersValueType, VDimension, 1>;
 
 protected:
   /** Compute G(x)

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -21,14 +21,14 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
-KernelTransform<TParametersValueType, NDimensions>::KernelTransform()
-  : Superclass(NDimensions)
-// the second NDimensions is associated is provided as
+template <typename TParametersValueType, unsigned int VDimension>
+KernelTransform<TParametersValueType, VDimension>::KernelTransform()
+  : Superclass(VDimension)
+// the second VDimension is associated is provided as
 // a tentative number for initializing the Jacobian.
 // The matrix can be resized at run time so this number
 // here is irrelevant. The correct size of the Jacobian
-// will be NDimension X NDimension.NumberOfLandMarks.
+// will be VDimension X VDimension.NumberOfLandMarks.
 {
   this->m_I.set_identity();
   this->m_SourceLandmarks = PointSetType::New();
@@ -39,9 +39,9 @@ KernelTransform<TParametersValueType, NDimensions>::KernelTransform()
   this->m_Stiffness = 0.0;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::SetSourceLandmarks(PointSetType * landmarks)
+KernelTransform<TParametersValueType, VDimension>::SetSourceLandmarks(PointSetType * landmarks)
 {
   itkDebugMacro("setting SourceLandmarks to " << landmarks);
   if (this->m_SourceLandmarks != landmarks)
@@ -53,9 +53,9 @@ KernelTransform<TParametersValueType, NDimensions>::SetSourceLandmarks(PointSetT
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::SetTargetLandmarks(PointSetType * landmarks)
+KernelTransform<TParametersValueType, VDimension>::SetTargetLandmarks(PointSetType * landmarks)
 {
   itkDebugMacro("setting TargetLandmarks to " << landmarks);
   if (this->m_TargetLandmarks != landmarks)
@@ -67,19 +67,19 @@ KernelTransform<TParametersValueType, NDimensions>::SetTargetLandmarks(PointSetT
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeG(const InputVectorType &,
-                                                             GMatrixType & itkNotUsed(gmatrix)) const
+KernelTransform<TParametersValueType, VDimension>::ComputeG(const InputVectorType &,
+                                                            GMatrixType & itkNotUsed(gmatrix)) const
 {
   itkExceptionMacro(<< "ComputeG(vector,gmatrix) must be reimplemented"
                     << " in subclasses of KernelTransform.");
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-const typename KernelTransform<TParametersValueType, NDimensions>::GMatrixType &
-  KernelTransform<TParametersValueType, NDimensions>::ComputeReflexiveG(PointsIterator) const
+template <typename TParametersValueType, unsigned int VDimension>
+const typename KernelTransform<TParametersValueType, VDimension>::GMatrixType &
+  KernelTransform<TParametersValueType, VDimension>::ComputeReflexiveG(PointsIterator) const
 {
   m_GMatrix.fill(NumericTraits<TParametersValueType>::ZeroValue());
   m_GMatrix.fill_diagonal(m_Stiffness);
@@ -88,10 +88,10 @@ const typename KernelTransform<TParametersValueType, NDimensions>::GMatrixType &
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeDeformationContribution(const InputPointType & thisPoint,
-                                                                                   OutputPointType &      result) const
+KernelTransform<TParametersValueType, VDimension>::ComputeDeformationContribution(const InputPointType & thisPoint,
+                                                                                  OutputPointType &      result) const
 {
   /*
    * Default implementation of the the method. This can be overloaded
@@ -106,9 +106,9 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeDeformationContributi
   for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
   {
     this->ComputeG(thisPoint - sp->Value(), Gmatrix);
-    for (unsigned int dim = 0; dim < NDimensions; ++dim)
+    for (unsigned int dim = 0; dim < VDimension; ++dim)
     {
-      for (unsigned int odim = 0; odim < NDimensions; ++odim)
+      for (unsigned int odim = 0; odim < VDimension; ++odim)
       {
         result[odim] += Gmatrix(dim, odim) * m_DMatrix(dim, lnd);
       }
@@ -118,9 +118,9 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeDeformationContributi
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeD()
+KernelTransform<TParametersValueType, VDimension>::ComputeD()
 {
   PointIdentifier numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
 
@@ -141,9 +141,9 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeD()
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeWMatrix()
+KernelTransform<TParametersValueType, VDimension>::ComputeWMatrix()
 {
   using SVDSolverType = vnl_svd<TParametersValueType>;
 
@@ -156,19 +156,19 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeWMatrix()
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeL()
+KernelTransform<TParametersValueType, VDimension>::ComputeL()
 {
   PointIdentifier numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
 
-  vnl_matrix<TParametersValueType> O2(NDimensions * (NDimensions + 1), NDimensions * (NDimensions + 1), 0);
+  vnl_matrix<TParametersValueType> O2(VDimension * (VDimension + 1), VDimension * (VDimension + 1), 0);
 
   this->ComputeP();
   this->ComputeK();
 
-  this->m_LMatrix.set_size(NDimensions * (numberOfLandmarks + NDimensions + 1),
-                           NDimensions * (numberOfLandmarks + NDimensions + 1));
+  this->m_LMatrix.set_size(VDimension * (numberOfLandmarks + VDimension + 1),
+                           VDimension * (numberOfLandmarks + VDimension + 1));
 
   this->m_LMatrix.fill(0.0);
 
@@ -179,16 +179,16 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeL()
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeK()
+KernelTransform<TParametersValueType, VDimension>::ComputeK()
 {
   PointIdentifier numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
 
 
   this->ComputeD();
 
-  this->m_KMatrix.set_size(NDimensions * numberOfLandmarks, NDimensions * numberOfLandmarks);
+  this->m_KMatrix.set_size(VDimension * numberOfLandmarks, VDimension * numberOfLandmarks);
 
   this->m_KMatrix.fill(0.0);
 
@@ -210,7 +210,7 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeK()
       G.as_ref()
     }; // different interfaces require different representations of values.
     this->m_KMatrix.update(
-      G_reference_alias, i * NDimensions, i * NDimensions); // update only accepts `const vnl_matrix<T> &`
+      G_reference_alias, i * VDimension, i * VDimension); // update only accepts `const vnl_matrix<T> &`
     ++p2;
     ++j;
 
@@ -220,8 +220,8 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeK()
       const InputVectorType s = p1.Value() - p2.Value();
       this->ComputeG(s, G);
       // write value in upper and lower triangle of matrix
-      this->m_KMatrix.update(G_reference_alias, i * NDimensions, j * NDimensions);
-      this->m_KMatrix.update(G_reference_alias, j * NDimensions, i * NDimensions);
+      this->m_KMatrix.update(G_reference_alias, i * VDimension, j * VDimension);
+      this->m_KMatrix.update(G_reference_alias, j * VDimension, i * VDimension);
       ++p2;
       ++j;
     }
@@ -231,83 +231,83 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeK()
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeP()
+KernelTransform<TParametersValueType, VDimension>::ComputeP()
 {
   const PointIdentifier                  numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
   const vnl_matrix<TParametersValueType> I{ IMatrixType().set_identity().as_matrix() };
 
   InputPointType p{ NumericTraits<ScalarType>::ZeroValue() };
 
-  this->m_PMatrix.set_size(NDimensions * numberOfLandmarks, NDimensions * (NDimensions + 1));
+  this->m_PMatrix.set_size(VDimension * numberOfLandmarks, VDimension * (VDimension + 1));
   this->m_PMatrix.fill(0.0);
   for (unsigned long i = 0; i < numberOfLandmarks; ++i)
   {
     this->m_SourceLandmarks->GetPoint(i, &p);
-    for (unsigned int j = 0; j < NDimensions; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       const vnl_matrix<TParametersValueType> temp_matrix{ I * p[j] }; // be explicit about conversions that occur.
       this->m_PMatrix.update(
-        temp_matrix, i * NDimensions, j * NDimensions); // update only takes 'const vnl_matrix<T> &' as input
+        temp_matrix, i * VDimension, j * VDimension); // update only takes 'const vnl_matrix<T> &' as input
     }
-    this->m_PMatrix.update(I, i * NDimensions, NDimensions * NDimensions);
+    this->m_PMatrix.update(I, i * VDimension, VDimension * VDimension);
   }
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeY()
+KernelTransform<TParametersValueType, VDimension>::ComputeY()
 {
   PointIdentifier numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
 
   typename VectorSetType::ConstIterator displacement = this->m_Displacements->Begin();
 
-  this->m_YMatrix.set_size(NDimensions * (numberOfLandmarks + NDimensions + 1), 1);
+  this->m_YMatrix.set_size(VDimension * (numberOfLandmarks + VDimension + 1), 1);
 
   this->m_YMatrix.fill(0.0);
   for (unsigned int i = 0; i < numberOfLandmarks; ++i)
   {
-    for (unsigned int j = 0; j < NDimensions; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
-      this->m_YMatrix.put(i * NDimensions + j, 0, displacement.Value()[j]);
+      this->m_YMatrix.put(i * VDimension + j, 0, displacement.Value()[j]);
     }
     ++displacement;
   }
-  for (unsigned int i = 0; i < NDimensions * (NDimensions + 1); ++i)
+  for (unsigned int i = 0; i < VDimension * (VDimension + 1); ++i)
   {
-    this->m_YMatrix.put(numberOfLandmarks * NDimensions + i, 0, 0);
+    this->m_YMatrix.put(numberOfLandmarks * VDimension + i, 0, 0);
   }
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ReorganizeW()
+KernelTransform<TParametersValueType, VDimension>::ReorganizeW()
 {
   PointIdentifier numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
 
   // The deformable (non-affine) part of the registration goes here
-  this->m_DMatrix.set_size(NDimensions, numberOfLandmarks);
+  this->m_DMatrix.set_size(VDimension, numberOfLandmarks);
   unsigned int ci = 0;
   for (unsigned int lnd = 0; lnd < numberOfLandmarks; ++lnd)
   {
-    for (unsigned int dim = 0; dim < NDimensions; ++dim)
+    for (unsigned int dim = 0; dim < VDimension; ++dim)
     {
       this->m_DMatrix(dim, lnd) = this->m_WMatrix(ci++, 0);
     }
   }
   // This matrix holds the rotational part of the Affine component
-  for (unsigned int j = 0; j < NDimensions; ++j)
+  for (unsigned int j = 0; j < VDimension; ++j)
   {
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       this->m_AMatrix(i, j) = this->m_WMatrix(ci++, 0);
     }
   }
   // This vector holds the translational part of the Affine component
-  for (unsigned int k = 0; k < NDimensions; ++k)
+  for (unsigned int k = 0; k < VDimension; ++k)
   {
     this->m_BVector(k) = this->m_WMatrix(ci++, 0);
   }
@@ -317,9 +317,9 @@ KernelTransform<TParametersValueType, NDimensions>::ReorganizeW()
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-KernelTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & thisPoint) const
+KernelTransform<TParametersValueType, VDimension>::TransformPoint(const InputPointType & thisPoint) const
   -> OutputPointType
 {
   OutputPointType result;
@@ -332,15 +332,15 @@ KernelTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPo
   this->ComputeDeformationContribution(thisPoint, result);
 
   // Add the rotational part of the Affine component
-  for (unsigned int j = 0; j < NDimensions; ++j)
+  for (unsigned int j = 0; j < VDimension; ++j)
   {
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       result[i] += this->m_AMatrix(i, j) * thisPoint[j];
     }
   }
   // This vector holds the translational part of the Affine component
-  for (unsigned int k = 0; k < NDimensions; ++k)
+  for (unsigned int k = 0; k < VDimension; ++k)
   {
     result[k] += this->m_BVector(k) + thisPoint[k];
   }
@@ -349,11 +349,10 @@ KernelTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPo
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToParameters(
-  const InputPointType &,
-  JacobianType & jacobian) const
+KernelTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToParameters(const InputPointType &,
+                                                                                          JacobianType & jacobian) const
 {
   jacobian.Fill(0.0);
 
@@ -365,9 +364,9 @@ KernelTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectTo
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::SetParameters(const ParametersType & parameters)
+KernelTransform<TParametersValueType, VDimension>::SetParameters(const ParametersType & parameters)
 {
   // Set the parameters
   // NOTE that in this transformation both the Source and Target
@@ -385,7 +384,7 @@ KernelTransform<TParametersValueType, NDimensions>::SetParameters(const Paramete
   }
 
   auto               landmarks = PointsContainer::New();
-  const unsigned int numberOfLandmarks = parameters.Size() / NDimensions;
+  const unsigned int numberOfLandmarks = parameters.Size() / VDimension;
   landmarks->Reserve(numberOfLandmarks);
 
   PointsIterator itr = landmarks->Begin();
@@ -396,7 +395,7 @@ KernelTransform<TParametersValueType, NDimensions>::SetParameters(const Paramete
   unsigned int pcounter = 0;
   while (itr != end)
   {
-    for (unsigned int dim = 0; dim < NDimensions; ++dim)
+    for (unsigned int dim = 0; dim < VDimension; ++dim)
     {
       landMark[dim] = parameters[pcounter];
       ++pcounter;
@@ -413,9 +412,9 @@ KernelTransform<TParametersValueType, NDimensions>::SetParameters(const Paramete
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::SetFixedParameters(const FixedParametersType & parameters)
+KernelTransform<TParametersValueType, VDimension>::SetFixedParameters(const FixedParametersType & parameters)
 {
   // Set the fixed parameters
   // Since the API of the SetParameters() function sets the
@@ -424,7 +423,7 @@ KernelTransform<TParametersValueType, NDimensions>::SetFixedParameters(const Fix
   // I/O mechanism to be supported.
 
   auto               landmarks = PointsContainer::New();
-  const unsigned int numberOfLandmarks = parameters.Size() / NDimensions;
+  const unsigned int numberOfLandmarks = parameters.Size() / VDimension;
 
   landmarks->Reserve(numberOfLandmarks);
 
@@ -436,7 +435,7 @@ KernelTransform<TParametersValueType, NDimensions>::SetFixedParameters(const Fix
   unsigned int pcounter = 0;
   while (itr != end)
   {
-    for (unsigned int dim = 0; dim < NDimensions; ++dim)
+    for (unsigned int dim = 0; dim < VDimension; ++dim)
     {
       landMark[dim] = parameters[pcounter];
       ++pcounter;
@@ -449,11 +448,11 @@ KernelTransform<TParametersValueType, NDimensions>::SetFixedParameters(const Fix
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::UpdateParameters() const
+KernelTransform<TParametersValueType, VDimension>::UpdateParameters() const
 {
-  this->m_Parameters = ParametersType(this->m_SourceLandmarks->GetNumberOfPoints() * NDimensions);
+  this->m_Parameters = ParametersType(this->m_SourceLandmarks->GetNumberOfPoints() * VDimension);
 
   PointsIterator itr = this->m_SourceLandmarks->GetPoints()->Begin();
   PointsIterator end = this->m_SourceLandmarks->GetPoints()->End();
@@ -462,7 +461,7 @@ KernelTransform<TParametersValueType, NDimensions>::UpdateParameters() const
   while (itr != end)
   {
     InputPointType landmark = itr.Value();
-    for (unsigned int dim = 0; dim < NDimensions; ++dim)
+    for (unsigned int dim = 0; dim < VDimension; ++dim)
     {
       this->m_Parameters[pcounter] = landmark[dim];
       ++pcounter;
@@ -472,23 +471,23 @@ KernelTransform<TParametersValueType, NDimensions>::UpdateParameters() const
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-KernelTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
+KernelTransform<TParametersValueType, VDimension>::GetParameters() const -> const ParametersType &
 {
   this->UpdateParameters();
   return this->m_Parameters;
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-KernelTransform<TParametersValueType, NDimensions>::GetFixedParameters() const -> const FixedParametersType &
+KernelTransform<TParametersValueType, VDimension>::GetFixedParameters() const -> const FixedParametersType &
 {
   // Get the fixed parameters
   // This returns the target landmark locations
   // This was added to support the Transform Reader/Writer mechanism
-  this->m_FixedParameters = ParametersType(this->m_TargetLandmarks->GetNumberOfPoints() * NDimensions);
+  this->m_FixedParameters = ParametersType(this->m_TargetLandmarks->GetNumberOfPoints() * VDimension);
 
   PointsIterator itr = this->m_TargetLandmarks->GetPoints()->Begin();
   PointsIterator end = this->m_TargetLandmarks->GetPoints()->End();
@@ -497,7 +496,7 @@ KernelTransform<TParametersValueType, NDimensions>::GetFixedParameters() const -
   while (itr != end)
   {
     InputPointType landmark = itr.Value();
-    for (unsigned int dim = 0; dim < NDimensions; ++dim)
+    for (unsigned int dim = 0; dim < VDimension; ++dim)
     {
       this->m_FixedParameters[pcounter] = landmark[dim];
       ++pcounter;
@@ -509,9 +508,9 @@ KernelTransform<TParametersValueType, NDimensions>::GetFixedParameters() const -
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-KernelTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+KernelTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   if (this->m_SourceLandmarks)

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -86,32 +86,32 @@ public:
  * \tparam TParametersValueType The type to be used for scalar numeric values.  Either
  *    float or double.
  *
- * \tparam NInputDimensions   The number of dimensions of the input vector space.
+ * \tparam VInputDimension   The number of dimensions of the input vector space.
  *
- * \tparam NOutputDimensions  The number of dimensions of the output vector space.
+ * \tparam VOutputDimension  The number of dimensions of the output vector space.
  *
  * This class provides several methods for setting the matrix and offset
  * defining the transform. To support the registration framework, the
  * transform parameters can also be set as an Array<TParametersValueType> of size
- * (NInputDimension + 1) * NOutputDimension using method SetParameters().
- * The first (NOutputDimension x NInputDimension) parameters defines the
+ * (VInputDimension + 1) * VOutputDimension using method SetParameters().
+ * The first (VOutputDimension x VInputDimension) parameters defines the
  * matrix in row-major order (where the column index varies the fastest).
- * The last NOutputDimension parameters defines the translation
+ * The last VOutputDimension parameters defines the translation
  * in each dimensions.
  *
  * \ingroup ITKTransform
  */
 
-template <typename TParametersValueType = double, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
+template <typename TParametersValueType = double, unsigned int VInputDimension = 3, unsigned int VOutputDimension = 3>
 class ITK_TEMPLATE_EXPORT MatrixOffsetTransformBase
-  : public Transform<TParametersValueType, NInputDimensions, NOutputDimensions>
+  : public Transform<TParametersValueType, VInputDimension, VOutputDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MatrixOffsetTransformBase);
 
   /** Standard type alias   */
   using Self = MatrixOffsetTransformBase;
-  using Superclass = Transform<TParametersValueType, NInputDimensions, NOutputDimensions>;
+  using Superclass = Transform<TParametersValueType, VInputDimension, VOutputDimension>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -123,9 +123,9 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int InputSpaceDimension = NInputDimensions;
-  static constexpr unsigned int OutputSpaceDimension = NOutputDimensions;
-  static constexpr unsigned int ParametersDimension = NOutputDimensions * (NInputDimensions + 1);
+  static constexpr unsigned int InputSpaceDimension = VInputDimension;
+  static constexpr unsigned int OutputSpaceDimension = VOutputDimension;
+  static constexpr unsigned int ParametersDimension = VOutputDimension * (VInputDimension + 1);
 
   /** Parameters Type   */
   using typename Superclass::FixedParametersType;
@@ -197,10 +197,10 @@ public:
   using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
-  using InverseTransformType = MatrixOffsetTransformBase<TParametersValueType, NOutputDimensions, NInputDimensions>;
+  using InverseTransformType = MatrixOffsetTransformBase<TParametersValueType, VOutputDimension, VInputDimension>;
   /** InverseTransformType must be a friend to allow the generation of a transformation
    * from its inverse (function GetInverse). */
-  friend class MatrixOffsetTransformBase<TParametersValueType, NOutputDimensions, NInputDimensions>;
+  friend class MatrixOffsetTransformBase<TParametersValueType, VOutputDimension, VInputDimension>;
 
   /** Set the transformation to an Identity
    *
@@ -351,8 +351,8 @@ public:
   }
 
   /** Set the transformation from a container of parameters.
-   * The first (NOutputDimension x NInputDimension) parameters define the
-   * matrix and the last NOutputDimension parameters the translation.
+   * The first (VOutputDimension x VInputDimension) parameters define the
+   * matrix and the last VOutputDimension parameters the translation.
    * Offset is updated based on current center. */
   void
   SetParameters(const ParametersType & parameters) override;

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -26,44 +26,44 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::MatrixOffsetTransformBase(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::MatrixOffsetTransformBase(
   unsigned int paramDims)
   : Superclass(paramDims)
 {
   m_MatrixMTime.Modified();
   m_InverseMatrixMTime = m_MatrixMTime;
-  this->m_FixedParameters.SetSize(NInputDimensions);
+  this->m_FixedParameters.SetSize(VInputDimension);
   this->m_FixedParameters.Fill(0.0);
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::MatrixOffsetTransformBase(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::MatrixOffsetTransformBase(
   const MatrixType &       matrix,
   const OutputVectorType & offset)
   : m_Matrix(matrix)
   , m_Offset(offset)
 {
   m_MatrixMTime.Modified();
-  std::copy_n(offset.begin(), NOutputDimensions, m_Translation.begin());
+  std::copy_n(offset.begin(), VOutputDimension, m_Translation.begin());
   this->ComputeMatrixParameters();
 }
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::PrintSelf(std::ostream & os,
-                                                                                                Indent indent) const
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::PrintSelf(std::ostream & os,
+                                                                                              Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
   unsigned int i, j;
 
   os << indent << "Matrix: " << std::endl;
-  for (i = 0; i < NInputDimensions; ++i)
+  for (i = 0; i < VInputDimension; ++i)
   {
     os << indent.GetNextIndent();
-    for (j = 0; j < NOutputDimensions; ++j)
+    for (j = 0; j < VOutputDimension; ++j)
     {
       os << m_Matrix[i][j] << " ";
     }
@@ -75,10 +75,10 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
   os << indent << "Translation: " << m_Translation << std::endl;
 
   os << indent << "Inverse: " << std::endl;
-  for (i = 0; i < NInputDimensions; ++i)
+  for (i = 0; i < VInputDimension; ++i)
   {
     os << indent.GetNextIndent();
-    for (j = 0; j < NOutputDimensions; ++j)
+    for (j = 0; j < VOutputDimension; ++j)
     {
       os << this->GetInverseMatrix()[i][j] << " ";
     }
@@ -88,9 +88,9 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::SetIdentity()
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::SetIdentity()
 {
   m_Matrix.SetIdentity();
   m_MatrixMTime.Modified();
@@ -104,10 +104,10 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::Compose(const Self * other,
-                                                                                              bool         pre)
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::Compose(const Self * other,
+                                                                                            bool         pre)
 {
   if (pre)
   {
@@ -128,36 +128,36 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputPointType
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformPoint(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputPointType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformPoint(
   const InputPointType & point) const
 {
   return m_Matrix * point + m_Offset;
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorType
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformVector(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(
   const InputVectorType & vect) const
 {
   return m_Matrix * vect;
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVnlVectorType
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformVector(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVnlVectorType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(
   const InputVnlVectorType & vect) const
 {
   return m_Matrix.GetVnlMatrix() * vect;
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorPixelType
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformVector(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(
   const InputVectorPixelType & vect) const
 {
   const unsigned int vectorDim = vect.Size();
@@ -169,7 +169,7 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
     vnl_vect[i] = vect[i];
     for (unsigned int j = 0; j < vectorDim; ++j)
     {
-      if ((i < NInputDimensions) && (j < NInputDimensions))
+      if ((i < VInputDimension) && (j < VInputDimension))
       {
         vnl_mat(i, j) = m_Matrix(i, j);
       }
@@ -192,17 +192,17 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputCovariantVectorType
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformCovariantVector(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputCovariantVectorType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformCovariantVector(
   const InputCovariantVectorType & vec) const
 {
   OutputCovariantVectorType result; // Converted vector
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     result[i] = NumericTraits<ScalarType>::ZeroValue();
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += this->GetInverseMatrix()[j][i] * vec[j]; // Inverse
                                                             // transposed
@@ -212,9 +212,9 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorPixelType
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformCovariantVector(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformCovariantVector(
   const InputVectorPixelType & vect) const
 {
 
@@ -227,7 +227,7 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
     vnl_vect[i] = vect[i];
     for (unsigned int j = 0; j < vectorDim; ++j)
     {
-      if ((i < NInputDimensions) && (j < NInputDimensions))
+      if ((i < VInputDimension) && (j < VInputDimension))
       {
         vnl_mat(i, j) = this->GetInverseMatrix()(j, i);
       }
@@ -250,11 +250,10 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
-  OutputDiffusionTensor3DType
-  MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformDiffusionTensor3D(
-    const InputDiffusionTensor3DType & tensor) const
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputDiffusionTensor3DType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformDiffusionTensor3D(
+  const InputDiffusionTensor3DType & tensor) const
 {
 
   JacobianType jacobian;
@@ -274,9 +273,9 @@ typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutp
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorPixelType
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformDiffusionTensor3D(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformDiffusionTensor3D(
   const InputVectorPixelType & tensor) const
 {
   OutputVectorPixelType result(InputDiffusionTensor3DType::InternalDimension); // Converted tensor
@@ -300,30 +299,31 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
-  OutputSymmetricSecondRankTensorType
-  MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
-    TransformSymmetricSecondRankTensor(const InputSymmetricSecondRankTensorType & inputTensor) const
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType,
+                                   VInputDimension,
+                                   VOutputDimension>::OutputSymmetricSecondRankTensorType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformSymmetricSecondRankTensor(
+  const InputSymmetricSecondRankTensorType & inputTensor) const
 {
   JacobianType jacobian;
-  jacobian.SetSize(NOutputDimensions, NInputDimensions);
+  jacobian.SetSize(VOutputDimension, VInputDimension);
   JacobianType invJacobian;
-  invJacobian.SetSize(NInputDimensions, NOutputDimensions);
+  invJacobian.SetSize(VInputDimension, VOutputDimension);
   JacobianType tensor;
-  tensor.SetSize(NInputDimensions, NInputDimensions);
+  tensor.SetSize(VInputDimension, VInputDimension);
 
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       tensor(i, j) = inputTensor(i, j);
     }
   }
 
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NOutputDimensions; ++j)
+    for (unsigned int j = 0; j < VOutputDimension; ++j)
     {
       jacobian(j, i) = this->GetMatrix()(j, i);
       invJacobian(i, j) = this->GetInverseMatrix()(i, j);
@@ -333,9 +333,9 @@ typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutp
   JacobianType                        outTensor = jacobian * tensor * invJacobian;
   OutputSymmetricSecondRankTensorType outputTensor;
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NOutputDimensions; ++j)
+    for (unsigned int j = 0; j < VOutputDimension; ++j)
     {
       outputTensor(i, j) = outTensor(i, j);
     }
@@ -345,29 +345,29 @@ typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutp
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorPixelType
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
-  TransformSymmetricSecondRankTensor(const InputVectorPixelType & inputTensor) const
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::TransformSymmetricSecondRankTensor(
+  const InputVectorPixelType & inputTensor) const
 {
   JacobianType jacobian;
-  jacobian.SetSize(NOutputDimensions, NInputDimensions);
+  jacobian.SetSize(VOutputDimension, VInputDimension);
   JacobianType invJacobian;
-  invJacobian.SetSize(NInputDimensions, NOutputDimensions);
+  invJacobian.SetSize(VInputDimension, VOutputDimension);
   JacobianType tensor;
-  tensor.SetSize(NInputDimensions, NInputDimensions);
+  tensor.SetSize(VInputDimension, VInputDimension);
 
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
-      tensor(i, j) = inputTensor[j + NInputDimensions * i];
+      tensor(i, j) = inputTensor[j + VInputDimension * i];
     }
   }
 
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NOutputDimensions; ++j)
+    for (unsigned int j = 0; j < VOutputDimension; ++j)
     {
       jacobian(j, i) = this->GetMatrix()(j, i);
       invJacobian(i, j) = this->GetInverseMatrix()(i, j);
@@ -378,11 +378,11 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 
   OutputVectorPixelType outputTensor;
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NOutputDimensions; ++j)
+    for (unsigned int j = 0; j < VOutputDimension; ++j)
     {
-      outputTensor[j + NOutputDimensions * i] = outTensor(i, j);
+      outputTensor[j + VOutputDimension * i] = outTensor(i, j);
     }
   }
 
@@ -390,9 +390,9 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 auto
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverseMatrix() const
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::GetInverseMatrix() const
   -> const InverseMatrixType &
 {
   // If the transform has been modified we recompute the inverse
@@ -414,9 +414,9 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 bool
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverse(
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::GetInverse(
   InverseTransformType * inverse) const
 {
   if (!inverse)
@@ -441,10 +441,9 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
-  InverseTransformBasePointer
-  MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverseTransform() const
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::InverseTransformBasePointer
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::GetInverseTransform() const
 {
   auto inv = InverseTransformType::New();
 
@@ -452,19 +451,19 @@ typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutp
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::SetFixedParameters(
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::SetFixedParameters(
   const FixedParametersType & fp)
 {
-  if (fp.size() < NInputDimensions)
+  if (fp.size() < VInputDimension)
   {
     itkExceptionMacro(<< "Error setting fixed parameters: parameters array size (" << fp.size()
-                      << ") is less than expected  (NInputDimensions = " << NInputDimensions << ")");
+                      << ") is less than expected  (VInputDimension = " << VInputDimension << ")");
   }
   this->m_FixedParameters = fp;
   InputPointType c;
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
     c[i] = this->m_FixedParameters[i];
   }
@@ -472,12 +471,11 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-const typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
-  FixedParametersType &
-  MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetFixedParameters() const
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+const typename MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::FixedParametersType &
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::GetFixedParameters() const
 {
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
     this->m_FixedParameters[i] = this->m_Center[i];
   }
@@ -485,23 +483,23 @@ const typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions,
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 auto
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetParameters() const
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::GetParameters() const
   -> const ParametersType &
 {
   // Transfer the linear part
   unsigned int par = 0;
-  for (unsigned int row = 0; row < NOutputDimensions; ++row)
+  for (unsigned int row = 0; row < VOutputDimension; ++row)
   {
-    for (unsigned int col = 0; col < NInputDimensions; ++col)
+    for (unsigned int col = 0; col < VInputDimension; ++col)
     {
       this->m_Parameters[par] = m_Matrix[row][col];
       ++par;
     }
   }
   // Transfer the constant part
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     this->m_Parameters[par] = m_Translation[i];
     ++par;
@@ -511,18 +509,18 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::SetParameters(
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::SetParameters(
   const ParametersType & parameters)
 {
-  if (parameters.Size() < (NOutputDimensions * NInputDimensions + NOutputDimensions))
+  if (parameters.Size() < (VOutputDimension * VInputDimension + VOutputDimension))
   {
     itkExceptionMacro(<< "Error setting parameters: parameters array size (" << parameters.Size()
                       << ") is less than expected "
-                      << " (NInputDimensions * NOutputDimensions + NOutputDimensions) "
-                      << " (" << NInputDimensions << " * " << NOutputDimensions << " + " << NOutputDimensions << " = "
-                      << NInputDimensions * NOutputDimensions + NOutputDimensions << ")");
+                      << " (VInputDimension * VOutputDimension + VOutputDimension) "
+                      << " (" << VInputDimension << " * " << VOutputDimension << " + " << VOutputDimension << " = "
+                      << VInputDimension * VOutputDimension + VOutputDimension << ")");
   }
 
   unsigned int par = 0;
@@ -532,16 +530,16 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
   {
     this->m_Parameters = parameters;
   }
-  for (unsigned int row = 0; row < NOutputDimensions; ++row)
+  for (unsigned int row = 0; row < VOutputDimension; ++row)
   {
-    for (unsigned int col = 0; col < NInputDimensions; ++col)
+    for (unsigned int col = 0; col < VInputDimension; ++col)
     {
       m_Matrix[row][col] = this->m_Parameters[par];
       ++par;
     }
   }
   // Transfer the constant part
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     m_Translation[i] = this->m_Parameters[par];
     ++par;
@@ -558,14 +556,14 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
   this->Modified();
 }
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::
   ComputeJacobianWithRespectToParameters(const InputPointType & p, JacobianType & jacobian) const
 {
   // This will not reallocate memory if the dimensions are equal
   // to the matrix's current dimensions.
-  jacobian.SetSize(NOutputDimensions, this->GetNumberOfLocalParameters());
+  jacobian.SetSize(VOutputDimension, this->GetNumberOfLocalParameters());
   jacobian.Fill(0.0);
 
   // The Jacobian of the affine transform is composed of
@@ -574,52 +572,52 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
   const InputVectorType v = p - this->GetCenter();
 
   unsigned int blockOffset = 0;
-  for (unsigned int block = 0; block < NInputDimensions; ++block)
+  for (unsigned int block = 0; block < VInputDimension; ++block)
   {
-    for (unsigned int dim = 0; dim < NOutputDimensions; ++dim)
+    for (unsigned int dim = 0; dim < VOutputDimension; ++dim)
     {
       jacobian(block, blockOffset + dim) = v[dim];
     }
 
-    blockOffset += NInputDimensions;
+    blockOffset += VInputDimension;
   }
-  for (unsigned int dim = 0; dim < NOutputDimensions; ++dim)
+  for (unsigned int dim = 0; dim < VOutputDimension; ++dim)
   {
     jacobian(dim, blockOffset + dim) = 1.0;
   }
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::
   ComputeJacobianWithRespectToPosition(const InputPointType &, JacobianPositionType & jac) const
 {
   jac = this->GetMatrix().GetVnlMatrix();
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::
   ComputeInverseJacobianWithRespectToPosition(const InputPointType &, InverseJacobianPositionType & jac) const
 {
   jac = this->GetInverseMatrix().GetVnlMatrix();
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::ComputeOffset()
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::ComputeOffset()
 {
   const MatrixType & matrix = this->GetMatrix();
 
   OffsetType offset;
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     offset[i] = m_Translation[i] + m_Center[i];
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       offset[i] -= matrix[i][j] * m_Center[j];
     }
@@ -629,18 +627,18 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::ComputeTranslation()
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::ComputeTranslation()
 {
   const MatrixType & matrix = this->GetMatrix();
 
   OffsetType translation;
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     translation[i] = m_Offset[i] - m_Center[i];
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       translation[i] += matrix[i][j] * m_Center[j];
     }
@@ -649,9 +647,9 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
   m_Translation = translation;
 }
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::ComputeMatrix()
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::ComputeMatrix()
 {
   // Since parameters explicitly define the matrix in this base class, this
   // function does nothing.  Normally used to compute a matrix when
@@ -659,9 +657,9 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::ComputeMatrixParameters()
+MatrixOffsetTransformBase<TParametersValueType, VInputDimension, VOutputDimension>::ComputeMatrixParameters()
 {
   // Since parameters explicitly define the matrix in this base class, this
   // function does nothing.  Normally used to update the parameterization

--- a/Modules/Core/Transform/include/itkMultiTransform.h
+++ b/Modules/Core/Transform/include/itkMultiTransform.h
@@ -59,17 +59,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType = double,
-          unsigned int NDimensions = 3,
-          unsigned int NSubDimensions = NDimensions>
-class ITK_TEMPLATE_EXPORT MultiTransform : public Transform<TParametersValueType, NDimensions, NSubDimensions>
+template <typename TParametersValueType = double, unsigned int VDimension = 3, unsigned int VSubDimensions = VDimension>
+class ITK_TEMPLATE_EXPORT MultiTransform : public Transform<TParametersValueType, VDimension, VSubDimensions>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MultiTransform);
 
   /** Standard class type aliases. */
   using Self = MultiTransform;
-  using Superclass = Transform<TParametersValueType, NDimensions, NSubDimensions>;
+  using Superclass = Transform<TParametersValueType, VDimension, VSubDimensions>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -77,7 +75,7 @@ public:
   itkTypeMacro(MultiTransform, Transform);
 
   /** Sub transform type **/
-  using TransformType = Transform<TParametersValueType, NSubDimensions, NSubDimensions>;
+  using TransformType = Transform<TParametersValueType, VSubDimensions, VSubDimensions>;
   using TransformTypePointer = typename TransformType::Pointer;
 
   /* Types common to both container and sub transforms */
@@ -136,11 +134,11 @@ public:
   using typename Superclass::NumberOfParametersType;
 
   /** Dimension of the domain spaces. */
-  static constexpr unsigned int InputDimension = NDimensions;
-  static constexpr unsigned int OutputDimension = NDimensions;
+  static constexpr unsigned int InputDimension = VDimension;
+  static constexpr unsigned int OutputDimension = VDimension;
 
-  static constexpr unsigned int SubInputDimension = NSubDimensions;
-  static constexpr unsigned int SubOutputDimension = NSubDimensions;
+  static constexpr unsigned int SubInputDimension = VSubDimensions;
+  static constexpr unsigned int SubOutputDimension = VSubDimensions;
 
   /** Functionality for sub transforms */
 

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -23,8 +23,8 @@ namespace itk
 {
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::MultiTransform()
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::MultiTransform()
   : Superclass(0)
 {
   this->m_NumberOfLocalParameters = NumericTraits<NumberOfParametersType>::ZeroValue();
@@ -32,9 +32,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::MultiTransfor
   this->m_TransformQueue.clear();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 auto
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetTransformCategory() const -> TransformCategoryEnum
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetTransformCategory() const -> TransformCategoryEnum
 {
   // If all sub-transforms are the same, return that type. Otherwise
   // return Unknown.
@@ -61,9 +61,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetTransformC
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 bool
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::IsLinear() const
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::IsLinear() const
 {
   // If all sub-transforms are linear, return true.
   for (SizeValueType tind = 0; tind < this->GetNumberOfTransforms(); ++tind)
@@ -77,9 +77,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::IsLinear() co
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 auto
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetParameters() const -> const ParametersType &
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetParameters() const -> const ParametersType &
 {
   /* Resize destructively. But if it's already this size, nothing is done so
    * it's efficient. */
@@ -102,9 +102,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetParameters
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 void
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::SetParameters(const ParametersType & inputParameters)
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::SetParameters(const ParametersType & inputParameters)
 {
   /* We do not copy inputParameters into m_Parameters,
    * to avoid unnecessary copying. */
@@ -146,9 +146,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::SetParameters
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 auto
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetFixedParameters() const
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetFixedParameters() const
   -> const FixedParametersType &
 {
   /* Resize destructively. But if it's already this size, nothing is done so
@@ -174,9 +174,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetFixedParam
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 void
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::SetFixedParameters(
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::SetFixedParameters(
   const FixedParametersType & inputParameters)
 {
   /* Verify proper input size. */
@@ -206,9 +206,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::SetFixedParam
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 auto
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfParameters() const
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetNumberOfParameters() const
   -> NumberOfParametersType
 {
   /* Returns to total number of params in all transforms currently
@@ -231,9 +231,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfPa
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 auto
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfLocalParameters() const
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetNumberOfLocalParameters() const
   -> NumberOfParametersType
 {
   if (this->GetMTime() == this->m_LocalParametersUpdateTime)
@@ -258,9 +258,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfLo
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 auto
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfFixedParameters() const
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetNumberOfFixedParameters() const
   -> NumberOfParametersType
 {
   NumberOfParametersType result = NumericTraits<NumberOfParametersType>::ZeroValue();
@@ -274,9 +274,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetNumberOfFi
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 void
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::UpdateTransformParameters(
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::UpdateTransformParameters(
   const DerivativeType & update,
   ScalarType             factor)
 {
@@ -324,9 +324,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::UpdateTransfo
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 bool
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetInverse(Self * inverse) const
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetInverse(Self * inverse) const
 {
   typename TransformQueueType::const_iterator it;
 
@@ -353,9 +353,9 @@ MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::GetInverse(Se
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int NSubDimensions>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSubDimensions>
 void
-MultiTransform<TParametersValueType, NDimensions, NSubDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+MultiTransform<TParametersValueType, VDimension, VSubDimensions>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.h
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.h
@@ -30,15 +30,15 @@ namespace itk
  * \ingroup ITKTransform
  */
 
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT ScalableAffineTransform : public AffineTransform<TParametersValueType, NDimensions>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT ScalableAffineTransform : public AffineTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ScalableAffineTransform);
 
   /** Standard type alias   */
   using Self = ScalableAffineTransform;
-  using Superclass = AffineTransform<TParametersValueType, NDimensions>;
+  using Superclass = AffineTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -49,10 +49,10 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int InputSpaceDimension = NDimensions;
-  static constexpr unsigned int OutputSpaceDimension = NDimensions;
-  static constexpr unsigned int SpaceDimension = NDimensions;
-  static constexpr unsigned int ParametersDimension = NDimensions * (NDimensions + 1);
+  static constexpr unsigned int InputSpaceDimension = VDimension;
+  static constexpr unsigned int OutputSpaceDimension = VDimension;
+  static constexpr unsigned int SpaceDimension = VDimension;
+  static constexpr unsigned int ParametersDimension = VDimension * (VDimension + 1);
 
   /** Types taken from the Superclass */
   using typename Superclass::ParametersType;
@@ -101,10 +101,10 @@ public:
 
   /** Set the scale of the transform */
   virtual void
-  SetScale(const double scale[NDimensions]);
+  SetScale(const double scale[VDimension]);
 
   virtual void
-  SetScaleComponent(const double scale[NDimensions])
+  SetScaleComponent(const double scale[VDimension])
   {
     this->SetScale(scale);
   }
@@ -162,7 +162,7 @@ protected:
   }
 
 private:
-  double          m_Scale[NDimensions];
+  double          m_Scale[VDimension];
   InputVectorType m_MatrixScale;
 }; // class ScalableAffineTransform
 } // namespace itk

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
@@ -26,11 +26,11 @@
 namespace itk
 {
 /** Constructor with default arguments */
-template <typename TParametersValueType, unsigned int NDimensions>
-ScalableAffineTransform<TParametersValueType, NDimensions>::ScalableAffineTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+ScalableAffineTransform<TParametersValueType, VDimension>::ScalableAffineTransform()
   : Superclass(Self::ParametersDimension)
 {
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     m_Scale[i] = 1;
     m_MatrixScale[i] = 1;
@@ -38,23 +38,23 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::ScalableAffineTransf
 }
 
 /** Constructor with default arguments */
-template <typename TParametersValueType, unsigned int NDimensions>
-ScalableAffineTransform<TParametersValueType, NDimensions>::ScalableAffineTransform(unsigned int,
-                                                                                    unsigned int parametersDimension)
+template <typename TParametersValueType, unsigned int VDimension>
+ScalableAffineTransform<TParametersValueType, VDimension>::ScalableAffineTransform(unsigned int,
+                                                                                   unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     m_Scale[i] = 1;
     m_MatrixScale[i] = 1;
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
-ScalableAffineTransform<TParametersValueType, NDimensions>::ScalableAffineTransform(unsigned int parametersDimension)
+template <typename TParametersValueType, unsigned int VDimension>
+ScalableAffineTransform<TParametersValueType, VDimension>::ScalableAffineTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
 {
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     m_Scale[i] = 1;
     m_MatrixScale[i] = 1;
@@ -62,12 +62,12 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::ScalableAffineTransf
 }
 
 /** Constructor with default arguments */
-template <typename TParametersValueType, unsigned int NDimensions>
-ScalableAffineTransform<TParametersValueType, NDimensions>::ScalableAffineTransform(const MatrixType &       matrix,
-                                                                                    const OutputVectorType & offset)
+template <typename TParametersValueType, unsigned int VDimension>
+ScalableAffineTransform<TParametersValueType, VDimension>::ScalableAffineTransform(const MatrixType &       matrix,
+                                                                                   const OutputVectorType & offset)
   : Superclass(matrix, offset)
 {
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     m_Scale[i] = 1;
     m_MatrixScale[i] = 1;
@@ -75,22 +75,22 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::ScalableAffineTransf
 }
 
 /** Print self */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScalableAffineTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+ScalableAffineTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
   unsigned int i;
 
   os << indent << "Scale : ";
-  for (i = 0; i < NDimensions; ++i)
+  for (i = 0; i < VDimension; ++i)
   {
     os << m_Scale[i] << " ";
   }
   os << std::endl;
   os << indent << "MatrixScale : ";
-  for (i = 0; i < NDimensions; ++i)
+  for (i = 0; i < VDimension; ++i)
   {
     os << m_MatrixScale[i] << " ";
   }
@@ -98,11 +98,11 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostre
 }
 
 // Set the parameters in order to fit an Identity transform
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScalableAffineTransform<TParametersValueType, NDimensions>::SetIdentity()
+ScalableAffineTransform<TParametersValueType, VDimension>::SetIdentity()
 {
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     m_Scale[i] = 1;
     m_MatrixScale[i] = 1;
@@ -111,13 +111,13 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::SetIdentity()
 }
 
 /** Set the scale of the transformation */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScalableAffineTransform<TParametersValueType, NDimensions>::SetScale(const InputVectorType & scale)
+ScalableAffineTransform<TParametersValueType, VDimension>::SetScale(const InputVectorType & scale)
 {
   unsigned int i;
 
-  for (i = 0; i < NDimensions; ++i)
+  for (i = 0; i < VDimension; ++i)
   {
     m_Scale[i] = scale[i];
   }
@@ -125,13 +125,13 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::SetScale(const Input
   this->Modified();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScalableAffineTransform<TParametersValueType, NDimensions>::SetScale(const double scale[NDimensions])
+ScalableAffineTransform<TParametersValueType, VDimension>::SetScale(const double scale[VDimension])
 {
   unsigned int i;
 
-  for (i = 0; i < NDimensions; ++i)
+  for (i = 0; i < VDimension; ++i)
   {
     m_Scale[i] = scale[i];
   }
@@ -140,17 +140,17 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::SetScale(const doubl
 }
 
 // Get an inverse of this transform
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-ScalableAffineTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+ScalableAffineTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   return this->Superclass::GetInverse(inverse);
 }
 
 // Return an inverse of this transform
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ScalableAffineTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
+ScalableAffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 
@@ -158,12 +158,12 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::GetInverseTransform(
 }
 
 /** Set the scale of the transformation */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScalableAffineTransform<TParametersValueType, NDimensions>::ComputeMatrix()
+ScalableAffineTransform<TParametersValueType, VDimension>::ComputeMatrix()
 {
   bool scaleChanged = false;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     if (Math::NotExactlyEquals(m_Scale[i], m_MatrixScale[i]))
     {
@@ -174,7 +174,7 @@ ScalableAffineTransform<TParametersValueType, NDimensions>::ComputeMatrix()
   {
     MatrixType                                mat;
     typename MatrixType::InternalMatrixType & imat = mat.GetVnlMatrix();
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       if (Math::NotAlmostEquals(m_MatrixScale[i],
                                 NumericTraits<typename NumericTraits<InputVectorType>::ValueType>::ZeroValue()) &&

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.h
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.h
@@ -31,15 +31,15 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType = float, unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT ScaleLogarithmicTransform : public ScaleTransform<TParametersValueType, NDimensions>
+template <typename TParametersValueType = float, unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT ScaleLogarithmicTransform : public ScaleTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ScaleLogarithmicTransform);
 
   /** Standard class type aliases.   */
   using Self = ScaleLogarithmicTransform;
-  using Superclass = ScaleTransform<TParametersValueType, NDimensions>;
+  using Superclass = ScaleTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -50,8 +50,8 @@ public:
   itkTypeMacro(ScaleLogarithmicTransform, ScaleTransform);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
-  static constexpr unsigned int ParametersDimension = NDimensions;
+  static constexpr unsigned int SpaceDimension = VDimension;
+  static constexpr unsigned int ParametersDimension = VDimension;
 
   /** Scalar type. */
   using typename Superclass::ScalarType;

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
@@ -22,9 +22,9 @@
 namespace itk
 {
 // Set the parameters
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleLogarithmicTransform<TParametersValueType, NDimensions>::SetParameters(const ParametersType & parameters)
+ScaleLogarithmicTransform<TParametersValueType, VDimension>::SetParameters(const ParametersType & parameters)
 {
   ScaleType scales;
 
@@ -45,9 +45,9 @@ ScaleLogarithmicTransform<TParametersValueType, NDimensions>::SetParameters(cons
 }
 
 // Get Parameters
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ScaleLogarithmicTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
+ScaleLogarithmicTransform<TParametersValueType, VDimension>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
 
@@ -64,16 +64,16 @@ ScaleLogarithmicTransform<TParametersValueType, NDimensions>::GetParameters() co
 }
 
 // Print self
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleLogarithmicTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+ScaleLogarithmicTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleLogarithmicTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToParameters(
+ScaleLogarithmicTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToParameters(
   const InputPointType & p,
   JacobianType &         jacobian) const
 {

--- a/Modules/Core/Transform/include/itkScaleTransform.h
+++ b/Modules/Core/Transform/include/itkScaleTransform.h
@@ -37,16 +37,16 @@ namespace itk
  * \sphinxexample{Core/Transform/ScaleAnImage,Scale An Image}
  * \endsphinx
  */
-template <typename TParametersValueType = float, unsigned int NDimensions = 3>
+template <typename TParametersValueType = float, unsigned int VDimension = 3>
 class ITK_TEMPLATE_EXPORT ScaleTransform
-  : public MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>
+  : public MatrixOffsetTransformBase<TParametersValueType, VDimension, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ScaleTransform);
 
   /** Standard class type aliases.   */
   using Self = ScaleTransform;
-  using Superclass = MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>;
+  using Superclass = MatrixOffsetTransformBase<TParametersValueType, VDimension, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -57,8 +57,8 @@ public:
   itkTypeMacro(ScaleTransform, Transform);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
-  static constexpr unsigned int ParametersDimension = NDimensions;
+  static constexpr unsigned int SpaceDimension = VDimension;
+  static constexpr unsigned int ParametersDimension = VDimension;
 
   /** Scalar type. */
   using typename Superclass::ScalarType;
@@ -73,23 +73,23 @@ public:
   using typename Superclass::InverseJacobianPositionType;
 
   /** Standard vector type for this class. */
-  using ScaleType = FixedArray<TParametersValueType, NDimensions>;
+  using ScaleType = FixedArray<TParametersValueType, VDimension>;
 
   /** Standard vector type for this class. */
-  using InputVectorType = Vector<TParametersValueType, NDimensions>;
-  using OutputVectorType = Vector<TParametersValueType, NDimensions>;
+  using InputVectorType = Vector<TParametersValueType, VDimension>;
+  using OutputVectorType = Vector<TParametersValueType, VDimension>;
 
   /** Standard covariant vector type for this class. */
-  using InputCovariantVectorType = CovariantVector<TParametersValueType, NDimensions>;
-  using OutputCovariantVectorType = CovariantVector<TParametersValueType, NDimensions>;
+  using InputCovariantVectorType = CovariantVector<TParametersValueType, VDimension>;
+  using OutputCovariantVectorType = CovariantVector<TParametersValueType, VDimension>;
 
   /** Standard vnl_vector type for this class. */
-  using InputVnlVectorType = vnl_vector_fixed<TParametersValueType, NDimensions>;
-  using OutputVnlVectorType = vnl_vector_fixed<TParametersValueType, NDimensions>;
+  using InputVnlVectorType = vnl_vector_fixed<TParametersValueType, VDimension>;
+  using OutputVnlVectorType = vnl_vector_fixed<TParametersValueType, VDimension>;
 
   /** Standard coordinate point type for this class. */
-  using InputPointType = Point<TParametersValueType, NDimensions>;
-  using OutputPointType = Point<TParametersValueType, NDimensions>;
+  using InputPointType = Point<TParametersValueType, VDimension>;
+  using OutputPointType = Point<TParametersValueType, VDimension>;
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost.*/

--- a/Modules/Core/Transform/include/itkScaleTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleTransform.hxx
@@ -23,16 +23,16 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
-ScaleTransform<TParametersValueType, NDimensions>::ScaleTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+ScaleTransform<TParametersValueType, VDimension>::ScaleTransform()
   : Superclass(ParametersDimension)
 {
   m_Scale.Fill(NumericTraits<ScalarType>::OneValue());
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::SetParameters(const ParametersType & parameters)
+ScaleTransform<TParametersValueType, VDimension>::SetParameters(const ParametersType & parameters)
 {
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
@@ -53,9 +53,9 @@ ScaleTransform<TParametersValueType, NDimensions>::SetParameters(const Parameter
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ScaleTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
+ScaleTransform<TParametersValueType, VDimension>::GetParameters() const -> const ParametersType &
 {
   itkDebugMacro(<< "Getting parameters ");
   // Transfer the translation part
@@ -70,9 +70,9 @@ ScaleTransform<TParametersValueType, NDimensions>::GetParameters() const -> cons
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+ScaleTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -80,9 +80,9 @@ ScaleTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, 
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::Compose(const Self * other, bool)
+ScaleTransform<TParametersValueType, VDimension>::Compose(const Self * other, bool)
 {
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
@@ -91,9 +91,9 @@ ScaleTransform<TParametersValueType, NDimensions>::Compose(const Self * other, b
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::Scale(const ScaleType & scale, bool)
+ScaleTransform<TParametersValueType, VDimension>::Scale(const ScaleType & scale, bool)
 {
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
@@ -102,9 +102,9 @@ ScaleTransform<TParametersValueType, NDimensions>::Scale(const ScaleType & scale
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ScaleTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & point) const -> OutputPointType
+ScaleTransform<TParametersValueType, VDimension>::TransformPoint(const InputPointType & point) const -> OutputPointType
 {
   OutputPointType        result;
   const InputPointType & center = this->GetCenter();
@@ -117,9 +117,9 @@ ScaleTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPoi
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ScaleTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorType & vect) const
+ScaleTransform<TParametersValueType, VDimension>::TransformVector(const InputVectorType & vect) const
   -> OutputVectorType
 {
   OutputVectorType result;
@@ -132,9 +132,9 @@ ScaleTransform<TParametersValueType, NDimensions>::TransformVector(const InputVe
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ScaleTransform<TParametersValueType, NDimensions>::TransformVector(const InputVnlVectorType & vect) const
+ScaleTransform<TParametersValueType, VDimension>::TransformVector(const InputVnlVectorType & vect) const
   -> OutputVnlVectorType
 {
   OutputVnlVectorType result;
@@ -147,9 +147,9 @@ ScaleTransform<TParametersValueType, NDimensions>::TransformVector(const InputVn
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ScaleTransform<TParametersValueType, NDimensions>::TransformCovariantVector(const InputCovariantVectorType & vect) const
+ScaleTransform<TParametersValueType, VDimension>::TransformCovariantVector(const InputCovariantVectorType & vect) const
   -> OutputCovariantVectorType
 {
   // Covariant Vectors are scaled by the inverse
@@ -163,9 +163,9 @@ ScaleTransform<TParametersValueType, NDimensions>::TransformCovariantVector(cons
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-ScaleTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+ScaleTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   if (!inverse)
   {
@@ -181,9 +181,9 @@ ScaleTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) co
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ScaleTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
+ScaleTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 
@@ -194,9 +194,9 @@ ScaleTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -
   return nullptr;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::SetIdentity()
+ScaleTransform<TParametersValueType, VDimension>::SetIdentity()
 {
   Superclass::SetIdentity();
   ScaleType i;
@@ -205,10 +205,10 @@ ScaleTransform<TParametersValueType, NDimensions>::SetIdentity()
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToParameters(const InputPointType & p,
-                                                                                          JacobianType & j) const
+ScaleTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToParameters(const InputPointType & p,
+                                                                                         JacobianType &         j) const
 {
   j.SetSize(SpaceDimension, this->GetNumberOfLocalParameters());
   j.Fill(0.0);
@@ -220,22 +220,21 @@ ScaleTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToP
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToPosition(
-  const InputPointType &,
-  JacobianPositionType & jac) const
+ScaleTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToPosition(const InputPointType &,
+                                                                                       JacobianPositionType & jac) const
 {
   jac.fill(0.0);
-  for (unsigned int dim = 0; dim < NDimensions; ++dim)
+  for (unsigned int dim = 0; dim < VDimension; ++dim)
   {
     jac[dim][dim] = m_Scale[dim];
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::SetScale(const ScaleType & scale)
+ScaleTransform<TParametersValueType, VDimension>::SetScale(const ScaleType & scale)
 {
   m_Scale = scale;
   this->ComputeMatrix();
@@ -243,9 +242,9 @@ ScaleTransform<TParametersValueType, NDimensions>::SetScale(const ScaleType & sc
   this->Modified();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ScaleTransform<TParametersValueType, NDimensions>::ComputeMatrix()
+ScaleTransform<TParametersValueType, VDimension>::ComputeMatrix()
 {
 
   MatrixType matrix;
@@ -261,9 +260,9 @@ ScaleTransform<TParametersValueType, NDimensions>::ComputeMatrix()
 
 
 // Back transform a point
-template <typename TParametersValueType, unsigned int NDimensions>
-inline typename ScaleTransform<TParametersValueType, NDimensions>::InputPointType
-ScaleTransform<TParametersValueType, NDimensions>::BackTransform(const OutputPointType & point) const
+template <typename TParametersValueType, unsigned int VDimension>
+inline typename ScaleTransform<TParametersValueType, VDimension>::InputPointType
+ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputPointType & point) const
 {
   InputPointType         result;
   const InputPointType & center = this->GetCenter();
@@ -276,9 +275,9 @@ ScaleTransform<TParametersValueType, NDimensions>::BackTransform(const OutputPoi
 }
 
 // Back transform a vector
-template <typename TParametersValueType, unsigned int NDimensions>
-inline typename ScaleTransform<TParametersValueType, NDimensions>::InputVectorType
-ScaleTransform<TParametersValueType, NDimensions>::BackTransform(const OutputVectorType & vect) const
+template <typename TParametersValueType, unsigned int VDimension>
+inline typename ScaleTransform<TParametersValueType, VDimension>::InputVectorType
+ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputVectorType & vect) const
 {
   InputVectorType result;
 
@@ -290,9 +289,9 @@ ScaleTransform<TParametersValueType, NDimensions>::BackTransform(const OutputVec
 }
 
 // Back transform a vnl_vector
-template <typename TParametersValueType, unsigned int NDimensions>
-inline typename ScaleTransform<TParametersValueType, NDimensions>::InputVnlVectorType
-ScaleTransform<TParametersValueType, NDimensions>::BackTransform(const OutputVnlVectorType & vect) const
+template <typename TParametersValueType, unsigned int VDimension>
+inline typename ScaleTransform<TParametersValueType, VDimension>::InputVnlVectorType
+ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputVnlVectorType & vect) const
 {
   InputVnlVectorType result;
 
@@ -304,9 +303,9 @@ ScaleTransform<TParametersValueType, NDimensions>::BackTransform(const OutputVnl
 }
 
 // Back Transform a CovariantVector
-template <typename TParametersValueType, unsigned int NDimensions>
-inline typename ScaleTransform<TParametersValueType, NDimensions>::InputCovariantVectorType
-ScaleTransform<TParametersValueType, NDimensions>::BackTransform(const OutputCovariantVectorType & vect) const
+template <typename TParametersValueType, unsigned int VDimension>
+inline typename ScaleTransform<TParametersValueType, VDimension>::InputCovariantVectorType
+ScaleTransform<TParametersValueType, VDimension>::BackTransform(const OutputCovariantVectorType & vect) const
 {
   // Covariant Vectors are scaled by the inverse
   InputCovariantVectorType result;

--- a/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.h
@@ -32,17 +32,17 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType, unsigned int NDimensions = 3>
+template <typename TParametersValueType, unsigned int VDimension = 3>
 // Number of dimensions
 class ITK_TEMPLATE_EXPORT ThinPlateR2LogRSplineKernelTransform
-  : public KernelTransform<TParametersValueType, NDimensions>
+  : public KernelTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ThinPlateR2LogRSplineKernelTransform);
 
   /** Standard class type aliases. */
   using Self = ThinPlateR2LogRSplineKernelTransform;
-  using Superclass = KernelTransform<TParametersValueType, NDimensions>;
+  using Superclass = KernelTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.hxx
@@ -20,10 +20,10 @@
 
 namespace itk
 {
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ThinPlateR2LogRSplineKernelTransform<TParametersValueType, NDimensions>::ComputeG(const InputVectorType & x,
-                                                                                  GMatrixType &           gmatrix) const
+ThinPlateR2LogRSplineKernelTransform<TParametersValueType, VDimension>::ComputeG(const InputVectorType & x,
+                                                                                 GMatrixType &           gmatrix) const
 {
   const TParametersValueType r = x.GetNorm();
 
@@ -34,9 +34,9 @@ ThinPlateR2LogRSplineKernelTransform<TParametersValueType, NDimensions>::Compute
   gmatrix.fill_diagonal(R2logR);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ThinPlateR2LogRSplineKernelTransform<TParametersValueType, NDimensions>::ComputeDeformationContribution(
+ThinPlateR2LogRSplineKernelTransform<TParametersValueType, VDimension>::ComputeDeformationContribution(
   const InputPointType & thisPoint,
   OutputPointType &      result) const
 {
@@ -50,7 +50,7 @@ ThinPlateR2LogRSplineKernelTransform<TParametersValueType, NDimensions>::Compute
     const TParametersValueType r = position.GetNorm();
     const TParametersValueType R2logR =
       (r > 1e-8) ? r * r * std::log(r) : NumericTraits<TParametersValueType>::ZeroValue();
-    for (unsigned int odim = 0; odim < NDimensions; ++odim)
+    for (unsigned int odim = 0; odim < VDimension; ++odim)
     {
       result[odim] += R2logR * this->m_DMatrix(odim, lnd);
     }

--- a/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.h
@@ -30,16 +30,16 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType, unsigned int NDimensions = 3>
+template <typename TParametersValueType, unsigned int VDimension = 3>
 // Number of dimensions
-class ITK_TEMPLATE_EXPORT ThinPlateSplineKernelTransform : public KernelTransform<TParametersValueType, NDimensions>
+class ITK_TEMPLATE_EXPORT ThinPlateSplineKernelTransform : public KernelTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ThinPlateSplineKernelTransform);
 
   /** Standard class type aliases. */
   using Self = ThinPlateSplineKernelTransform;
-  using Superclass = KernelTransform<TParametersValueType, NDimensions>;
+  using Superclass = KernelTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.hxx
@@ -20,23 +20,23 @@
 
 namespace itk
 {
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ThinPlateSplineKernelTransform<TParametersValueType, NDimensions>::ComputeG(const InputVectorType & x,
-                                                                            GMatrixType &           gmatrix) const
+ThinPlateSplineKernelTransform<TParametersValueType, VDimension>::ComputeG(const InputVectorType & x,
+                                                                           GMatrixType &           gmatrix) const
 {
   const TParametersValueType r = x.GetNorm();
 
   gmatrix.fill(NumericTraits<TParametersValueType>::ZeroValue());
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     gmatrix[i][i] = r;
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ThinPlateSplineKernelTransform<TParametersValueType, NDimensions>::ComputeDeformationContribution(
+ThinPlateSplineKernelTransform<TParametersValueType, VDimension>::ComputeDeformationContribution(
   const InputPointType & thisPoint,
   OutputPointType &      result) const
 {
@@ -49,7 +49,7 @@ ThinPlateSplineKernelTransform<TParametersValueType, NDimensions>::ComputeDeform
     InputVectorType            position = thisPoint - sp->Value();
     const TParametersValueType r = position.GetNorm();
 
-    for (unsigned int odim = 0; odim < NDimensions; ++odim)
+    for (unsigned int odim = 0; odim < VDimension; ++odim)
     {
       result[odim] += r * this->m_DMatrix(odim, lnd);
     }

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -79,7 +79,7 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
+template <typename TParametersValueType, unsigned int VInputDimension = 3, unsigned int VOutputDimension = 3>
 class ITK_TEMPLATE_EXPORT Transform : public TransformBaseTemplate<TParametersValueType>
 {
 public:
@@ -95,8 +95,8 @@ public:
   itkTypeMacro(Transform, TransformBaseTemplate);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int InputSpaceDimension = NInputDimensions;
-  static constexpr unsigned int OutputSpaceDimension = NOutputDimensions;
+  static constexpr unsigned int InputSpaceDimension = VInputDimension;
+  static constexpr unsigned int OutputSpaceDimension = VOutputDimension;
 
   /** define the Clone method */
   itkCloneMacro(Self);
@@ -105,14 +105,14 @@ public:
   unsigned int
   GetInputSpaceDimension() const override
   {
-    return NInputDimensions;
+    return VInputDimension;
   }
 
   /** Get the size of the output space */
   unsigned int
   GetOutputSpaceDimension() const override
   {
-    return NOutputDimensions;
+    return VOutputDimension;
   }
 
   /** Type of the input parameters. */
@@ -127,12 +127,12 @@ public:
 
   /** Type of the Jacobian matrix. */
   using JacobianType = Array2D<ParametersValueType>;
-  using JacobianPositionType = vnl_matrix_fixed<ParametersValueType, NOutputDimensions, NInputDimensions>;
-  using InverseJacobianPositionType = vnl_matrix_fixed<ParametersValueType, NInputDimensions, NOutputDimensions>;
+  using JacobianPositionType = vnl_matrix_fixed<ParametersValueType, VOutputDimension, VInputDimension>;
+  using InverseJacobianPositionType = vnl_matrix_fixed<ParametersValueType, VInputDimension, VOutputDimension>;
 
   /** Standard vector type for this class. */
-  using InputVectorType = Vector<TParametersValueType, NInputDimensions>;
-  using OutputVectorType = Vector<TParametersValueType, NOutputDimensions>;
+  using InputVectorType = Vector<TParametersValueType, VInputDimension>;
+  using OutputVectorType = Vector<TParametersValueType, VOutputDimension>;
 
   /** Standard variable length vector type for this class
    *  this provides an interface for the VectorImage class */
@@ -140,28 +140,28 @@ public:
   using OutputVectorPixelType = VariableLengthVector<TParametersValueType>;
 
   /* Standard symmetric second rank tenosr type for this class */
-  using InputSymmetricSecondRankTensorType = SymmetricSecondRankTensor<TParametersValueType, NInputDimensions>;
-  using OutputSymmetricSecondRankTensorType = SymmetricSecondRankTensor<TParametersValueType, NOutputDimensions>;
+  using InputSymmetricSecondRankTensorType = SymmetricSecondRankTensor<TParametersValueType, VInputDimension>;
+  using OutputSymmetricSecondRankTensorType = SymmetricSecondRankTensor<TParametersValueType, VOutputDimension>;
 
   /* Standard tensor type for this class */
   using InputDiffusionTensor3DType = DiffusionTensor3D<TParametersValueType>;
   using OutputDiffusionTensor3DType = DiffusionTensor3D<TParametersValueType>;
 
   /** Standard covariant vector type for this class */
-  using InputCovariantVectorType = CovariantVector<TParametersValueType, NInputDimensions>;
-  using OutputCovariantVectorType = CovariantVector<TParametersValueType, NOutputDimensions>;
+  using InputCovariantVectorType = CovariantVector<TParametersValueType, VInputDimension>;
+  using OutputCovariantVectorType = CovariantVector<TParametersValueType, VOutputDimension>;
 
   /** Standard vnl_vector type for this class. */
-  using InputVnlVectorType = vnl_vector_fixed<TParametersValueType, NInputDimensions>;
-  using OutputVnlVectorType = vnl_vector_fixed<TParametersValueType, NOutputDimensions>;
+  using InputVnlVectorType = vnl_vector_fixed<TParametersValueType, VInputDimension>;
+  using OutputVnlVectorType = vnl_vector_fixed<TParametersValueType, VOutputDimension>;
 
   /** Standard coordinate point type for this class */
-  using InputPointType = Point<TParametersValueType, NInputDimensions>;
-  using OutputPointType = Point<TParametersValueType, NOutputDimensions>;
+  using InputPointType = Point<TParametersValueType, VInputDimension>;
+  using OutputPointType = Point<TParametersValueType, VOutputDimension>;
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  using InverseTransformBaseType = Transform<TParametersValueType, NOutputDimensions, NInputDimensions>;
+  using InverseTransformBaseType = Transform<TParametersValueType, VOutputDimension, VInputDimension>;
 
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
@@ -553,10 +553,10 @@ public:
    * The image parameter may be either a SmartPointer or a raw pointer.
    * */
   template <typename TImage>
-  std::enable_if_t<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions, void>
+  std::enable_if_t<TImage::ImageDimension == VInputDimension && TImage::ImageDimension == VOutputDimension, void>
   ApplyToImageMetadata(TImage * image) const;
   template <typename TImage>
-  std::enable_if_t<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions, void>
+  std::enable_if_t<TImage::ImageDimension == VInputDimension && TImage::ImageDimension == VOutputDimension, void>
   ApplyToImageMetadata(SmartPointer<TImage> image) const
   {
     this->ApplyToImageMetadata(image.GetPointer()); // Delegate to the raw pointer signature

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -25,17 +25,16 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::Transform(
-  NumberOfParametersType numberOfParameters)
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::Transform(NumberOfParametersType numberOfParameters)
   : m_Parameters(numberOfParameters)
   , m_FixedParameters()
 {}
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 std::string
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::GetTransformTypeAsString() const
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::GetTransformTypeAsString() const
 {
   std::ostringstream n;
 
@@ -47,9 +46,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::GetTransfo
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 typename LightObject::Pointer
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::InternalClone() const
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
@@ -66,9 +65,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::InternalCl
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::UpdateTransformParameters(
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::UpdateTransformParameters(
   const DerivativeType & update,
   ParametersValueType    factor)
 {
@@ -122,19 +121,18 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::UpdateTran
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformVector(
-  const InputVectorType & vector,
-  const InputPointType &  point) const
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(const InputVectorType & vector,
+                                                                                    const InputPointType &  point) const
 {
   JacobianPositionType jacobian;
   this->ComputeJacobianWithRespectToPosition(point, jacobian);
   OutputVectorType result;
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     result[i] = NumericTraits<TParametersValueType>::ZeroValue();
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[i][j] * vector[j];
     }
@@ -144,19 +142,18 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformV
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVnlVectorType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformVector(
-  const InputVnlVectorType & vector,
-  const InputPointType &     point) const
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVnlVectorType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(const InputVnlVectorType & vector,
+                                                                                    const InputPointType & point) const
 {
   JacobianPositionType jacobian;
   this->ComputeJacobianWithRespectToPosition(point, jacobian);
   OutputVnlVectorType result;
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     result[i] = NumericTraits<ParametersValueType>::ZeroValue();
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[i][j] * vector[j];
     }
@@ -166,28 +163,27 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformV
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorPixelType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformVector(
-  const InputVectorPixelType & vector,
-  const InputPointType &       point) const
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVector(const InputVectorPixelType & vector,
+                                                                                    const InputPointType & point) const
 {
 
-  if (vector.GetSize() != NInputDimensions)
+  if (vector.GetSize() != VInputDimension)
   {
-    itkExceptionMacro("Input Vector is not of size NInputDimensions = " << NInputDimensions << std::endl);
+    itkExceptionMacro("Input Vector is not of size VInputDimension = " << VInputDimension << std::endl);
   }
 
   JacobianPositionType jacobian;
   this->ComputeJacobianWithRespectToPosition(point, jacobian);
 
   OutputVectorPixelType result;
-  result.SetSize(NOutputDimensions);
+  result.SetSize(VOutputDimension);
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     result[i] = NumericTraits<ParametersValueType>::ZeroValue();
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[i][j] * vector[j];
     }
@@ -197,19 +193,19 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformV
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputCovariantVectorType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformCovariantVector(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputCovariantVectorType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCovariantVector(
   const InputCovariantVectorType & vector,
   const InputPointType &           point) const
 {
   InverseJacobianPositionType jacobian;
   this->ComputeInverseJacobianWithRespectToPosition(point, jacobian);
   OutputCovariantVectorType result;
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     result[i] = NumericTraits<TParametersValueType>::ZeroValue();
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[j][i] * vector[j];
     }
@@ -219,28 +215,28 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformC
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorPixelType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformCovariantVector(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCovariantVector(
   const InputVectorPixelType & vector,
   const InputPointType &       point) const
 {
 
-  if (vector.GetSize() != NInputDimensions)
+  if (vector.GetSize() != VInputDimension)
   {
-    itkExceptionMacro("Input Vector is not of size NInputDimensions = " << NInputDimensions << std::endl);
+    itkExceptionMacro("Input Vector is not of size VInputDimension = " << VInputDimension << std::endl);
   }
 
   InverseJacobianPositionType jacobian;
   this->ComputeInverseJacobianWithRespectToPosition(point, jacobian);
 
   OutputVectorPixelType result;
-  result.SetSize(NOutputDimensions);
+  result.SetSize(VOutputDimension);
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
     result[i] = NumericTraits<ParametersValueType>::ZeroValue();
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       result[i] += jacobian[j][i] * vector[j];
     }
@@ -250,9 +246,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformC
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputDiffusionTensor3DType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformDiffusionTensor3D(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputDiffusionTensor3DType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformDiffusionTensor3D(
   const InputDiffusionTensor3DType & inputTensor,
   const InputPointType &             point) const
 {
@@ -266,9 +262,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformD
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorPixelType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformDiffusionTensor3D(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformDiffusionTensor3D(
   const InputVectorPixelType & inputTensor,
   const InputPointType &       point) const
 {
@@ -296,9 +292,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformD
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputDiffusionTensor3DType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputDiffusionTensor3DType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::
   PreservationOfPrincipalDirectionDiffusionTensor3DReorientation(const InputDiffusionTensor3DType &  inputTensor,
                                                                  const InverseJacobianPositionType & jacobian) const
 {
@@ -310,9 +306,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::
     matrix(i, i) = 1.0;
   }
 
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NOutputDimensions; ++j)
+    for (unsigned int j = 0; j < VOutputDimension; ++j)
     {
       if ((i < 3) && (j < 3))
       {
@@ -380,9 +376,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputSymmetricSecondRankTensorType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformSymmetricSecondRankTensor(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputSymmetricSecondRankTensorType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformSymmetricSecondRankTensor(
   const InputSymmetricSecondRankTensorType & inputTensor,
   const InputPointType &                     point) const
 {
@@ -391,11 +387,11 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformS
   InverseJacobianPositionType invJacobian;
   this->ComputeInverseJacobianWithRespectToPosition(point, invJacobian);
   JacobianType tensor;
-  tensor.SetSize(NInputDimensions, NInputDimensions);
+  tensor.SetSize(VInputDimension, VInputDimension);
 
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
       tensor(i, j) = inputTensor(i, j);
     }
@@ -404,9 +400,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformS
   JacobianType                        outTensor = jacobian * tensor * invJacobian;
   OutputSymmetricSecondRankTensorType outputTensor;
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NOutputDimensions; ++j)
+    for (unsigned int j = 0; j < VOutputDimension; ++j)
     {
       outputTensor(i, j) = outTensor(i, j);
     }
@@ -416,16 +412,16 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformS
 }
 
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-typename Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::OutputVectorPixelType
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformSymmetricSecondRankTensor(
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+typename Transform<TParametersValueType, VInputDimension, VOutputDimension>::OutputVectorPixelType
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformSymmetricSecondRankTensor(
   const InputVectorPixelType & inputTensor,
   const InputPointType &       point) const
 {
 
-  if (inputTensor.GetSize() != (NInputDimensions * NInputDimensions))
+  if (inputTensor.GetSize() != (VInputDimension * VInputDimension))
   {
-    itkExceptionMacro("Input DiffusionTensor3D does not have " << NInputDimensions * NInputDimensions << " elements"
+    itkExceptionMacro("Input DiffusionTensor3D does not have " << VInputDimension * VInputDimension << " elements"
                                                                << std::endl);
   }
 
@@ -434,36 +430,36 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::TransformS
   InverseJacobianPositionType invJacobian;
   this->ComputeInverseJacobianWithRespectToPosition(point, invJacobian);
   JacobianType tensor;
-  tensor.SetSize(NInputDimensions, NInputDimensions);
+  tensor.SetSize(VInputDimension, VInputDimension);
 
-  for (unsigned int i = 0; i < NInputDimensions; ++i)
+  for (unsigned int i = 0; i < VInputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NInputDimensions; ++j)
+    for (unsigned int j = 0; j < VInputDimension; ++j)
     {
-      tensor(i, j) = inputTensor[j + NInputDimensions * i];
+      tensor(i, j) = inputTensor[j + VInputDimension * i];
     }
   }
 
   JacobianType outTensor = jacobian * tensor * invJacobian;
 
   OutputVectorPixelType outputTensor;
-  outputTensor.SetSize(NOutputDimensions * NOutputDimensions);
+  outputTensor.SetSize(VOutputDimension * VOutputDimension);
 
-  for (unsigned int i = 0; i < NOutputDimensions; ++i)
+  for (unsigned int i = 0; i < VOutputDimension; ++i)
   {
-    for (unsigned int j = 0; j < NOutputDimensions; ++j)
+    for (unsigned int j = 0; j < VOutputDimension; ++j)
     {
-      outputTensor[j + NOutputDimensions * i] = outTensor(i, j);
+      outputTensor[j + VOutputDimension * i] = outTensor(i, j);
     }
   }
 
   return outputTensor;
 }
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 template <typename TImage>
-std::enable_if_t<TImage::ImageDimension == NInputDimensions && TImage::ImageDimension == NOutputDimensions, void>
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::ApplyToImageMetadata(TImage * image) const
+std::enable_if_t<TImage::ImageDimension == VInputDimension && TImage::ImageDimension == VOutputDimension, void>
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::ApplyToImageMetadata(TImage * image) const
 {
   using ImageType = TImage;
 
@@ -506,34 +502,34 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::ApplyToIma
 
 
 #if !defined(ITK_LEGACY_REMOVE)
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::ComputeJacobianWithRespectToPosition(
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::ComputeJacobianWithRespectToPosition(
   const InputPointType & pnt,
   JacobianType &         jacobian) const
 {
   JacobianPositionType jacobian_fixed;
   this->ComputeJacobianWithRespectToPosition(pnt, jacobian_fixed);
-  jacobian.SetSize(NOutputDimensions, NInputDimensions);
+  jacobian.SetSize(VOutputDimension, VInputDimension);
   jacobian.set(jacobian_fixed.data_block());
 }
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::ComputeInverseJacobianWithRespectToPosition(
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::ComputeInverseJacobianWithRespectToPosition(
   const InputPointType & pnt,
   JacobianType &         jacobian) const
 {
   InverseJacobianPositionType jacobian_fixed;
   this->ComputeInverseJacobianWithRespectToPosition(pnt, jacobian_fixed);
-  jacobian.SetSize(NInputDimensions, NOutputDimensions);
+  jacobian.SetSize(VInputDimension, VOutputDimension);
   jacobian.set(jacobian_fixed.data_block());
 }
 #endif
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::ComputeInverseJacobianWithRespectToPosition(
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::ComputeInverseJacobianWithRespectToPosition(
   const InputPointType &        pnt,
   InverseJacobianPositionType & jacobian) const
 {
@@ -541,14 +537,14 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::ComputeInv
   this->ComputeJacobianWithRespectToPosition(pnt, forward_jacobian);
 
   using SVDAlgorithmType =
-    vnl_svd_fixed<typename JacobianPositionType::element_type, NOutputDimensions, NInputDimensions>;
+    vnl_svd_fixed<typename JacobianPositionType::element_type, VOutputDimension, VInputDimension>;
   SVDAlgorithmType svd(forward_jacobian);
   jacobian.set(svd.inverse().data_block());
 }
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::CopyInParameters(
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::CopyInParameters(
   const ParametersValueType * const begin,
   const ParametersValueType * const end)
 {
@@ -566,9 +562,9 @@ Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::CopyInPara
   this->SetParameters(this->m_Parameters);
 }
 
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
 void
-Transform<TParametersValueType, NInputDimensions, NOutputDimensions>::CopyInFixedParameters(
+Transform<TParametersValueType, VInputDimension, VOutputDimension>::CopyInFixedParameters(
   const FixedParametersValueType * const begin,
   const FixedParametersValueType * const end)
 {

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -39,15 +39,15 @@ namespace itk
  * \sphinxexample{Registration/Common/MutualInformation,Mutual Information}
  * \endsphinx
  */
-template <typename TParametersValueType = double, unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT TranslationTransform : public Transform<TParametersValueType, NDimensions, NDimensions>
+template <typename TParametersValueType = double, unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT TranslationTransform : public Transform<TParametersValueType, VDimension, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TranslationTransform);
 
   /** Standard class type aliases. */
   using Self = TranslationTransform;
-  using Superclass = Transform<TParametersValueType, NDimensions, NDimensions>;
+  using Superclass = Transform<TParametersValueType, VDimension, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -58,8 +58,8 @@ public:
   itkTypeMacro(TranslationTransform, Transform);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int SpaceDimension = NDimensions;
-  static constexpr unsigned int ParametersDimension = NDimensions;
+  static constexpr unsigned int SpaceDimension = VDimension;
+  static constexpr unsigned int ParametersDimension = VDimension;
 
   /** Standard scalar type for this class. */
   using typename Superclass::ScalarType;
@@ -77,20 +77,20 @@ public:
   using typename Superclass::NumberOfParametersType;
 
   /** Standard vector type for this class. */
-  using InputVectorType = Vector<TParametersValueType, NDimensions>;
-  using OutputVectorType = Vector<TParametersValueType, NDimensions>;
+  using InputVectorType = Vector<TParametersValueType, VDimension>;
+  using OutputVectorType = Vector<TParametersValueType, VDimension>;
 
   /** Standard covariant vector type for this class. */
-  using InputCovariantVectorType = CovariantVector<TParametersValueType, NDimensions>;
-  using OutputCovariantVectorType = CovariantVector<TParametersValueType, NDimensions>;
+  using InputCovariantVectorType = CovariantVector<TParametersValueType, VDimension>;
+  using OutputCovariantVectorType = CovariantVector<TParametersValueType, VDimension>;
 
   /** Standard vnl_vector type for this class. */
-  using InputVnlVectorType = vnl_vector_fixed<TParametersValueType, NDimensions>;
-  using OutputVnlVectorType = vnl_vector_fixed<TParametersValueType, NDimensions>;
+  using InputVnlVectorType = vnl_vector_fixed<TParametersValueType, VDimension>;
+  using OutputVnlVectorType = vnl_vector_fixed<TParametersValueType, VDimension>;
 
   /** Standard coordinate point type for this class. */
-  using InputPointType = Point<TParametersValueType, NDimensions>;
-  using OutputPointType = Point<TParametersValueType, NDimensions>;
+  using InputPointType = Point<TParametersValueType, VDimension>;
+  using OutputPointType = Point<TParametersValueType, VDimension>;
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost.*/
@@ -203,7 +203,7 @@ public:
   NumberOfParametersType
   GetNumberOfParameters() const override
   {
-    return NDimensions;
+    return VDimension;
   }
 
   /** Indicates that this transform is linear. That is, given two
@@ -256,33 +256,33 @@ private:
 };                           // class TranslationTransform
 
 // Back transform a point
-template <typename TParametersValueType, unsigned int NDimensions>
-inline typename TranslationTransform<TParametersValueType, NDimensions>::InputPointType
-TranslationTransform<TParametersValueType, NDimensions>::BackTransform(const OutputPointType & point) const
+template <typename TParametersValueType, unsigned int VDimension>
+inline typename TranslationTransform<TParametersValueType, VDimension>::InputPointType
+TranslationTransform<TParametersValueType, VDimension>::BackTransform(const OutputPointType & point) const
 {
   return point - m_Offset;
 }
 
 // Back transform a vector
-template <typename TParametersValueType, unsigned int NDimensions>
-inline typename TranslationTransform<TParametersValueType, NDimensions>::InputVectorType
-TranslationTransform<TParametersValueType, NDimensions>::BackTransform(const OutputVectorType & vect) const
+template <typename TParametersValueType, unsigned int VDimension>
+inline typename TranslationTransform<TParametersValueType, VDimension>::InputVectorType
+TranslationTransform<TParametersValueType, VDimension>::BackTransform(const OutputVectorType & vect) const
 {
   return vect;
 }
 
 // Back transform a vnl_vector
-template <typename TParametersValueType, unsigned int NDimensions>
-inline typename TranslationTransform<TParametersValueType, NDimensions>::InputVnlVectorType
-TranslationTransform<TParametersValueType, NDimensions>::BackTransform(const OutputVnlVectorType & vect) const
+template <typename TParametersValueType, unsigned int VDimension>
+inline typename TranslationTransform<TParametersValueType, VDimension>::InputVnlVectorType
+TranslationTransform<TParametersValueType, VDimension>::BackTransform(const OutputVnlVectorType & vect) const
 {
   return vect;
 }
 
 // Back Transform a CovariantVector
-template <typename TParametersValueType, unsigned int NDimensions>
-inline typename TranslationTransform<TParametersValueType, NDimensions>::InputCovariantVectorType
-TranslationTransform<TParametersValueType, NDimensions>::BackTransform(const OutputCovariantVectorType & vect) const
+template <typename TParametersValueType, unsigned int VDimension>
+inline typename TranslationTransform<TParametersValueType, VDimension>::InputCovariantVectorType
+TranslationTransform<TParametersValueType, VDimension>::BackTransform(const OutputCovariantVectorType & vect) const
 {
   return vect;
 }

--- a/Modules/Core/Transform/include/itkTranslationTransform.hxx
+++ b/Modules/Core/Transform/include/itkTranslationTransform.hxx
@@ -24,10 +24,10 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
-TranslationTransform<TParametersValueType, NDimensions>::TranslationTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+TranslationTransform<TParametersValueType, VDimension>::TranslationTransform()
   : Superclass(ParametersDimension)
-  , m_IdentityJacobian(NDimensions, NDimensions)
+  , m_IdentityJacobian(VDimension, VDimension)
 {
   m_Offset.Fill(0);
 
@@ -35,15 +35,15 @@ TranslationTransform<TParametersValueType, NDimensions>::TranslationTransform()
   // Therefore the m_IdentityJacobian variable can be
   // initialized here and be shared among all the threads.
   this->m_IdentityJacobian.Fill(0.0);
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     this->m_IdentityJacobian(i, i) = 1.0;
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TranslationTransform<TParametersValueType, NDimensions>::SetParameters(const ParametersType & parameters)
+TranslationTransform<TParametersValueType, VDimension>::SetParameters(const ParametersType & parameters)
 {
   if (parameters.Size() < SpaceDimension)
   {
@@ -73,9 +73,9 @@ TranslationTransform<TParametersValueType, NDimensions>::SetParameters(const Par
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-TranslationTransform<TParametersValueType, NDimensions>::GetParameters() const -> const ParametersType &
+TranslationTransform<TParametersValueType, VDimension>::GetParameters() const -> const ParametersType &
 {
   for (unsigned int i = 0; i < SpaceDimension; ++i)
   {
@@ -85,9 +85,9 @@ TranslationTransform<TParametersValueType, NDimensions>::GetParameters() const -
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TranslationTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+TranslationTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
@@ -95,17 +95,17 @@ TranslationTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream 
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TranslationTransform<TParametersValueType, NDimensions>::Compose(const Self * other, bool)
+TranslationTransform<TParametersValueType, VDimension>::Compose(const Self * other, bool)
 {
   this->Translate(other->m_Offset);
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TranslationTransform<TParametersValueType, NDimensions>::Translate(const OutputVectorType & offset, bool)
+TranslationTransform<TParametersValueType, VDimension>::Translate(const OutputVectorType & offset, bool)
 {
   ParametersType newOffset(SpaceDimension);
 
@@ -117,45 +117,45 @@ TranslationTransform<TParametersValueType, NDimensions>::Translate(const OutputV
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-TranslationTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & point) const
+TranslationTransform<TParametersValueType, VDimension>::TransformPoint(const InputPointType & point) const
   -> OutputPointType
 {
   return point + m_Offset;
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-TranslationTransform<TParametersValueType, NDimensions>::TransformVector(const InputVectorType & vect) const
+TranslationTransform<TParametersValueType, VDimension>::TransformVector(const InputVectorType & vect) const
   -> OutputVectorType
 {
   return vect;
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-TranslationTransform<TParametersValueType, NDimensions>::TransformVector(const InputVnlVectorType & vect) const
+TranslationTransform<TParametersValueType, VDimension>::TransformVector(const InputVnlVectorType & vect) const
   -> OutputVnlVectorType
 {
   return vect;
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename TranslationTransform<TParametersValueType, NDimensions>::OutputCovariantVectorType
-TranslationTransform<TParametersValueType, NDimensions>::TransformCovariantVector(
+template <typename TParametersValueType, unsigned int VDimension>
+typename TranslationTransform<TParametersValueType, VDimension>::OutputCovariantVectorType
+TranslationTransform<TParametersValueType, VDimension>::TransformCovariantVector(
   const InputCovariantVectorType & vect) const
 {
   return vect;
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-TranslationTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+TranslationTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   if (!inverse)
   {
@@ -168,9 +168,9 @@ TranslationTransform<TParametersValueType, NDimensions>::GetInverse(Self * inver
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-TranslationTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
+TranslationTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inv = New();
 
@@ -178,9 +178,9 @@ TranslationTransform<TParametersValueType, NDimensions>::GetInverseTransform() c
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TranslationTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToParameters(
+TranslationTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToParameters(
   const InputPointType &,
   JacobianType & jacobian) const
 {
@@ -190,9 +190,9 @@ TranslationTransform<TParametersValueType, NDimensions>::ComputeJacobianWithResp
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TranslationTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToPosition(
+TranslationTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToPosition(
   const InputPointType &,
   JacobianPositionType & jac) const
 {
@@ -200,9 +200,9 @@ TranslationTransform<TParametersValueType, NDimensions>::ComputeJacobianWithResp
 }
 
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TranslationTransform<TParametersValueType, NDimensions>::SetIdentity()
+TranslationTransform<TParametersValueType, VDimension>::SetIdentity()
 {
   m_Offset.Fill(0.0);
 }

--- a/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.h
@@ -30,16 +30,16 @@ namespace itk
  *
  * \ingroup ITKTransform
  */
-template <typename TParametersValueType, unsigned int NDimensions = 3>
+template <typename TParametersValueType, unsigned int VDimension = 3>
 // Number of dimensions
-class ITK_TEMPLATE_EXPORT VolumeSplineKernelTransform : public KernelTransform<TParametersValueType, NDimensions>
+class ITK_TEMPLATE_EXPORT VolumeSplineKernelTransform : public KernelTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VolumeSplineKernelTransform);
 
   /** Standard class type aliases. */
   using Self = VolumeSplineKernelTransform;
-  using Superclass = KernelTransform<TParametersValueType, NDimensions>;
+  using Superclass = KernelTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.hxx
@@ -20,24 +20,24 @@
 
 namespace itk
 {
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-VolumeSplineKernelTransform<TParametersValueType, NDimensions>::ComputeG(const InputVectorType & x,
-                                                                         GMatrixType &           gmatrix) const
+VolumeSplineKernelTransform<TParametersValueType, VDimension>::ComputeG(const InputVectorType & x,
+                                                                        GMatrixType &           gmatrix) const
 {
   const TParametersValueType r = x.GetNorm();
 
   gmatrix.fill(NumericTraits<TParametersValueType>::ZeroValue());
   const TParametersValueType r3 = r * r * r;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     gmatrix[i][i] = r3;
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-VolumeSplineKernelTransform<TParametersValueType, NDimensions>::ComputeDeformationContribution(
+VolumeSplineKernelTransform<TParametersValueType, VDimension>::ComputeDeformationContribution(
   const InputPointType & thisPoint,
   OutputPointType &      result) const
 {
@@ -51,7 +51,7 @@ VolumeSplineKernelTransform<TParametersValueType, NDimensions>::ComputeDeformati
     const TParametersValueType r = position.GetNorm();
     const TParametersValueType r3 = r * r * r;
 
-    for (unsigned int odim = 0; odim < NDimensions; ++odim)
+    for (unsigned int odim = 0; odim < VDimension; ++odim)
     {
       result[odim] += r3 * this->m_DMatrix(odim, lnd);
     }

--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -27,14 +27,14 @@ namespace
 
 
 // Method which checks that two BSpline are exactly equal
-template <typename TParametersValueType, unsigned int NDimensions, unsigned int VSplineOrder>
+template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
 void
-bspline_eq(const itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder> * bspline1,
-           const itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder> * bspline2,
-           const std::string &                                                            description = "",
-           double                                                                         tolerance = 1e-15)
+bspline_eq(const itk::BSplineTransform<TParametersValueType, VDimension, VSplineOrder> * bspline1,
+           const itk::BSplineTransform<TParametersValueType, VDimension, VSplineOrder> * bspline2,
+           const std::string &                                                           description = "",
+           double                                                                        tolerance = 1e-15)
 {
-  using BSplineType = itk::BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>;
+  using BSplineType = itk::BSplineTransform<TParametersValueType, VDimension, VSplineOrder>;
   // Compare Transform Domain interface
 
   EXPECT_EQ(bspline1->GetNumberOfFixedParameters(), bspline2->GetNumberOfFixedParameters()) << description;
@@ -50,10 +50,10 @@ bspline_eq(const itk::BSplineTransform<TParametersValueType, NDimensions, VSplin
   ITK_EXPECT_VECTOR_NEAR(bspline1->GetParameters(), bspline2->GetParameters(), tolerance) << description;
   ITK_EXPECT_VECTOR_NEAR(bspline1->GetFixedParameters(), bspline2->GetFixedParameters(), tolerance) << description;
 
-  ASSERT_EQ(bspline1->GetCoefficientImages().Size(), NDimensions) << description;
-  ASSERT_EQ(bspline2->GetCoefficientImages().Size(), NDimensions) << description;
+  ASSERT_EQ(bspline1->GetCoefficientImages().Size(), VDimension) << description;
+  ASSERT_EQ(bspline2->GetCoefficientImages().Size(), VDimension) << description;
 
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     using ImageType = typename BSplineType::ImageType;
     using ImageConstIterator = typename itk::ImageRegionConstIterator<ImageType>;

--- a/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
@@ -108,10 +108,10 @@ testVectorArray(const TVector & v1, const TVector & v2)
 int
 itkCompositeTransformTest(int, char *[])
 {
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   /* Create composite transform */
-  using CompositeType = itk::CompositeTransform<double, NDimensions>;
+  using CompositeType = itk::CompositeTransform<double, VDimension>;
   using ScalarType = CompositeType::ScalarType;
 
   auto compositeTransform = CompositeType::New();
@@ -119,8 +119,8 @@ itkCompositeTransformTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(compositeTransform, CompositeTransform, MultiTransform);
 
   /* Test obects */
-  using Matrix2Type = itk::Matrix<ScalarType, NDimensions, NDimensions>;
-  using Vector2Type = itk::Vector<ScalarType, NDimensions>;
+  using Matrix2Type = itk::Matrix<ScalarType, VDimension, VDimension>;
+  using Vector2Type = itk::Vector<ScalarType, VDimension>;
 
 
   /* Test that we have an empty the queue */
@@ -159,7 +159,7 @@ itkCompositeTransformTest(int, char *[])
 
 
   /* Add an affine transform */
-  using AffineType = itk::AffineTransform<ScalarType, NDimensions>;
+  using AffineType = itk::AffineTransform<ScalarType, VDimension>;
   auto        affine = AffineType::New();
   Matrix2Type matrix2;
   Vector2Type vector2;
@@ -841,14 +841,14 @@ itkCompositeTransformTest(int, char *[])
   auto compositeTransform3 = CompositeType::New();
   auto compositeTransform4 = CompositeType::New();
 
-  using TranslationTransformType = itk::TranslationTransform<double, NDimensions>;
+  using TranslationTransformType = itk::TranslationTransform<double, VDimension>;
   using TranslationTransformPointer = TranslationTransformType::Pointer;
   using TranslationTransformVector = std::vector<TranslationTransformPointer>;
   TranslationTransformVector translationTransformVector(12);
   for (itk::SizeValueType n = 0; n < 12; ++n)
   {
     translationTransformVector[n] = TranslationTransformType::New();
-    TranslationTransformType::ParametersType params(NDimensions);
+    TranslationTransformType::ParametersType params(VDimension);
     params.Fill(n);
     translationTransformVector[n]->SetParameters(params);
   }

--- a/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
+++ b/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
@@ -25,11 +25,11 @@
 namespace
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
 Check_New_MatrixOffsetTransformBase()
 {
-  using MatrixOffsetTransformBaseType = itk::MatrixOffsetTransformBase<TParametersValueType, NDimensions, NDimensions>;
+  using MatrixOffsetTransformBaseType = itk::MatrixOffsetTransformBase<TParametersValueType, VDimension, VDimension>;
 
   const auto transformBase = MatrixOffsetTransformBaseType::New();
 
@@ -45,13 +45,13 @@ Check_New_MatrixOffsetTransformBase()
 }
 
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 void
 Assert_SetFixedParameters_throws_when_size_is_less_than_NDimensions()
 {
-  for (unsigned int size{}; size < NDimensions; ++size)
+  for (unsigned int size{}; size < VDimension; ++size)
   {
-    using TransformBaseType = itk::MatrixOffsetTransformBase<double, NDimensions, NDimensions>;
+    using TransformBaseType = itk::MatrixOffsetTransformBase<double, VDimension, VDimension>;
     using FixedParametersType = typename TransformBaseType::FixedParametersType;
 
     const auto                transformBase = TransformBaseType::New();

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -71,15 +71,15 @@ testVectorArray(const TVector & v1, const TVector & v2)
 
 constexpr unsigned int itkMultiTransformTestNDimensions = 2;
 
-template <class TScalar = double, unsigned int NDimensions = itkMultiTransformTestNDimensions>
-class MultiTransformTestTransform : public itk::MultiTransform<TScalar, NDimensions>
+template <class TScalar = double, unsigned int VDimension = itkMultiTransformTestNDimensions>
+class MultiTransformTestTransform : public itk::MultiTransform<TScalar, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MultiTransformTestTransform);
 
   /** Standard class type aliases. */
   using Self = MultiTransformTestTransform;
-  using Superclass = itk::MultiTransform<TScalar, NDimensions, NDimensions>;
+  using Superclass = itk::MultiTransform<TScalar, VDimension, VDimension>;
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
 
@@ -122,18 +122,18 @@ protected:
 int
 itkMultiTransformTest(int, char *[])
 {
-  const unsigned int NDimensions = itkMultiTransformTestNDimensions;
+  const unsigned int VDimension = itkMultiTransformTestNDimensions;
 
   /* Create multi-transform */
-  using MultiTransformType = MultiTransformTestTransform<double, NDimensions>;
+  using MultiTransformType = MultiTransformTestTransform<double, VDimension>;
   using Superclass = MultiTransformType::Superclass;
   using ScalarType = Superclass::ScalarType;
 
   auto multiTransform = MultiTransformType::New();
 
   /* Test obects */
-  using Matrix2Type = itk::Matrix<ScalarType, NDimensions, NDimensions>;
-  using Vector2Type = itk::Vector<ScalarType, NDimensions>;
+  using Matrix2Type = itk::Matrix<ScalarType, VDimension, VDimension>;
+  using Vector2Type = itk::Vector<ScalarType, VDimension>;
 
   /* Test that we have an empty the queue */
   if (multiTransform->GetNumberOfTransforms() != 0)
@@ -149,7 +149,7 @@ itkMultiTransformTest(int, char *[])
   }
 
   /* Add an affine transform */
-  using AffineType = itk::AffineTransform<ScalarType, NDimensions>;
+  using AffineType = itk::AffineTransform<ScalarType, VDimension>;
   auto        affine = AffineType::New();
   Matrix2Type matrix2;
   Vector2Type vector2;
@@ -320,7 +320,7 @@ itkMultiTransformTest(int, char *[])
    */
 
   /* Create a displacement field transform */
-  using DisplacementTransformType = itk::DisplacementFieldTransform<double, NDimensions>;
+  using DisplacementTransformType = itk::DisplacementFieldTransform<double, VDimension>;
   auto displacementTransform = DisplacementTransformType::New();
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   auto field = FieldType::New(); // This is based on itk::Image

--- a/Modules/Core/Transform/test/itkTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGTest.cxx
@@ -23,14 +23,14 @@
 
 namespace
 {
-template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-class DerivedTransform : public itk::Transform<TParametersValueType, NInputDimensions, NOutputDimensions>
+template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
+class DerivedTransform : public itk::Transform<TParametersValueType, VInputDimension, VOutputDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DerivedTransform);
 
   using Self = DerivedTransform;
-  using Superclass = itk::Transform<TParametersValueType, NInputDimensions, NOutputDimensions>;
+  using Superclass = itk::Transform<TParametersValueType, VInputDimension, VOutputDimension>;
   using Pointer = itk::SmartPointer<Self>;
 
   itkNewMacro(Self);

--- a/Modules/Core/Transform/test/itkTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformTest.cxx
@@ -26,12 +26,12 @@ namespace itk
 namespace itkTransformTestHelpers
 {
 
-template <typename TScalar, unsigned int NInputDimensions, unsigned int NOutputDimensions>
-class TransformTestHelper : public Transform<TScalar, NInputDimensions, NOutputDimensions>
+template <typename TScalar, unsigned int VInputDimension, unsigned int VOutputDimension>
+class TransformTestHelper : public Transform<TScalar, VInputDimension, VOutputDimension>
 {
 public:
   using Self = TransformTestHelper;
-  using Superclass = Transform<TScalar, NInputDimensions, NOutputDimensions>;
+  using Superclass = Transform<TScalar, VInputDimension, VOutputDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -165,13 +165,13 @@ public:
   }
 };
 
-template <typename TScalar, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+template <typename TScalar, unsigned int VInputDimension, unsigned int VOutputDimension>
 class TransformTester
 {
 public:
   using Self = TransformTester;
 
-  using TransformType = TransformTestHelper<double, NInputDimensions, NOutputDimensions>;
+  using TransformType = TransformTestHelper<double, VInputDimension, VOutputDimension>;
 
   using JacobianType = typename TransformType::JacobianType;
   using ParametersType = typename TransformType::ParametersType;
@@ -195,7 +195,7 @@ public:
   bool
   RunTests()
   {
-    std::cout << "Testing itkTransform<" << NInputDimensions << "," << NOutputDimensions << ">" << std::endl;
+    std::cout << "Testing itkTransform<" << VInputDimension << "," << VOutputDimension << ">" << std::endl;
     auto transform = TransformType::New();
 
     InputPointType pnt;
@@ -209,7 +209,7 @@ public:
     transform->TransformVector(vec, pnt);
 
     InputVectorPixelType vecpix;
-    vecpix.SetSize(NInputDimensions);
+    vecpix.SetSize(VInputDimension);
     vecpix.Fill(1.7);
     transform->TransformVector(vecpix);
     transform->TransformVector(vecpix, pnt);
@@ -236,7 +236,7 @@ public:
     std::cout << "TransformDiffusionTensor3D()                  OK" << std::endl;
 
     InputSymmetricSecondRankTensorType ssrten;
-    vecpix.SetSize(NInputDimensions * NInputDimensions);
+    vecpix.SetSize(VInputDimension * VInputDimension);
     vecpix.Fill(0);
     transform->TransformSymmetricSecondRankTensor(ssrten);
     transform->TransformSymmetricSecondRankTensor(ssrten, pnt);

--- a/Modules/Core/Transform/test/itkTranslationTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkTranslationTransformGTest.cxx
@@ -28,11 +28,11 @@
 namespace
 {
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 void
 Expect_SetParameters_throws_when_size_is_less_than_SpaceDimension()
 {
-  using TransformType = itk::TranslationTransform<double, NDimensions>;
+  using TransformType = itk::TranslationTransform<double, VDimension>;
   const auto transform = TransformType::New();
 
   for (unsigned int size{}; size < TransformType::SpaceDimension; ++size)
@@ -43,21 +43,21 @@ Expect_SetParameters_throws_when_size_is_less_than_SpaceDimension()
 }
 
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 void
 Expect_SetParameters_sets_translation_offset()
 {
-  using TransformType = itk::TranslationTransform<double, NDimensions>;
+  using TransformType = itk::TranslationTransform<double, VDimension>;
   using ParametersType = typename TransformType::ParametersType;
 
   const auto transform = TransformType::New();
 
   // Check setting the offset to (0, 0, 0, ...).
-  transform->SetParameters(ParametersType(NDimensions, 0.0));
+  transform->SetParameters(ParametersType(VDimension, 0.0));
   EXPECT_EQ(transform->GetOffset(), typename TransformType::OutputVectorType());
 
   // Check setting the offset to (1, 2, 3, ...).
-  ParametersType parameters(NDimensions);
+  ParametersType parameters(VDimension);
   std::iota(parameters.begin(), parameters.end(), 1.0);
   transform->SetParameters(parameters);
   EXPECT_TRUE(std::equal(parameters.begin(), parameters.end(), transform->GetOffset().begin()));

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.h
@@ -52,16 +52,16 @@ namespace itk
  *
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT BSplineExponentialDiffeomorphicTransform
-  : public ConstantVelocityFieldTransform<TParametersValueType, NDimensions>
+  : public ConstantVelocityFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineExponentialDiffeomorphicTransform);
 
   /** Standard class type aliases. */
   using Self = BSplineExponentialDiffeomorphicTransform;
-  using Superclass = ConstantVelocityFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = ConstantVelocityFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -72,10 +72,10 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the velocity field . */
-  static constexpr unsigned int ConstantVelocityFieldDimension = NDimensions;
+  static constexpr unsigned int ConstantVelocityFieldDimension = VDimension;
 
   /** Dimension of the vector spaces. */
-  static constexpr unsigned int Dimension = NDimensions;
+  static constexpr unsigned int Dimension = VDimension;
 
   /** Types from superclass */
   using typename Superclass::ScalarType;

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -30,8 +30,8 @@ namespace itk
 /**
  * Constructor
  */
-template <typename TParametersValueType, unsigned int NDimensions>
-BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::BSplineExponentialDiffeomorphicTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::BSplineExponentialDiffeomorphicTransform()
 
 {
   this->m_NumberOfControlPointsForTheConstantVelocityField.Fill(4);
@@ -41,9 +41,9 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::BSp
 /**
  * set mesh size for update field
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::SetMeshSizeForTheUpdateField(
+BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::SetMeshSizeForTheUpdateField(
   const ArrayType & meshSize)
 {
   ArrayType numberOfControlPoints;
@@ -57,9 +57,9 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Set
 /**
  * set mesh size for update field
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::SetMeshSizeForTheConstantVelocityField(
+BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::SetMeshSizeForTheConstantVelocityField(
   const ArrayType & meshSize)
 {
   ArrayType numberOfControlPoints;
@@ -70,9 +70,9 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Set
   this->SetNumberOfControlPointsForTheConstantVelocityField(numberOfControlPoints);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(
+BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
   const DerivativeType & update,
   ScalarType             factor)
 {
@@ -102,7 +102,7 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Upd
   auto * updateFieldPointer =
     reinterpret_cast<DisplacementVectorType *>(const_cast<DerivativeType &>(update).data_block());
 
-  using ImporterType = ImportImageFilter<DisplacementVectorType, NDimensions>;
+  using ImporterType = ImportImageFilter<DisplacementVectorType, VDimension>;
   const bool importFilterWillReleaseMemory = false;
 
   auto importer = ImporterType::New();
@@ -126,7 +126,7 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Upd
     updateField = updateSmoothField;
   }
 
-  using RealImageType = Image<ScalarType, NDimensions>;
+  using RealImageType = Image<ScalarType, VDimension>;
 
   using MultiplierType = MultiplyImageFilter<ConstantVelocityFieldType, RealImageType, ConstantVelocityFieldType>;
   auto multiplier = MultiplierType::New();
@@ -174,9 +174,9 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Upd
   this->IntegrateVelocityField();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::ConstantVelocityFieldPointer
-BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::BSplineSmoothConstantVelocityField(
+template <typename TParametersValueType, unsigned int VDimension>
+typename BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::ConstantVelocityFieldPointer
+BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::BSplineSmoothConstantVelocityField(
   const ConstantVelocityFieldType * field,
   const ArrayType &                 numberOfControlPoints)
 {
@@ -198,10 +198,10 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::BSp
 /**
  * Standard "PrintSelf" method
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-BSplineExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os,
-                                                                                       Indent         indent) const
+BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,
+                                                                                      Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
@@ -48,16 +48,16 @@ namespace itk
  *
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT BSplineSmoothingOnUpdateDisplacementFieldTransform
-  : public DisplacementFieldTransform<TParametersValueType, NDimensions>
+  : public DisplacementFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BSplineSmoothingOnUpdateDisplacementFieldTransform);
 
   /** Standard class type aliases. */
   using Self = BSplineSmoothingOnUpdateDisplacementFieldTransform;
-  using Superclass = DisplacementFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = DisplacementFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -68,7 +68,7 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the domain spaces. */
-  static constexpr unsigned int Dimension = NDimensions;
+  static constexpr unsigned int Dimension = VDimension;
 
   /** Types from superclass */
   using typename Superclass::ScalarType;
@@ -78,7 +78,7 @@ public:
   using typename Superclass::DisplacementFieldPointer;
   using typename Superclass::DisplacementFieldConstPointer;
 
-  using TransformPointer = typename Transform<TParametersValueType, NDimensions, NDimensions>::Pointer;
+  using TransformPointer = typename Transform<TParametersValueType, VDimension, VDimension>::Pointer;
 
   /**
    * type alias for projecting the input displacement field onto a

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -30,9 +30,9 @@ namespace itk
 /**
  * Constructor
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType,
-                                                   NDimensions>::BSplineSmoothingOnUpdateDisplacementFieldTransform()
+                                                   VDimension>::BSplineSmoothingOnUpdateDisplacementFieldTransform()
 
 {
   this->m_NumberOfControlPointsForTheUpdateField.Fill(4);
@@ -42,9 +42,9 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType,
 /**
  * set mesh size for update field
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::SetMeshSizeForTheUpdateField(
+BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::SetMeshSizeForTheUpdateField(
   const ArrayType & meshSize)
 {
   ArrayType numberOfControlPoints;
@@ -58,9 +58,9 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimens
 /**
  * set mesh size for total field
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::SetMeshSizeForTheTotalField(
+BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::SetMeshSizeForTheTotalField(
   const ArrayType & meshSize)
 {
   ArrayType numberOfControlPoints;
@@ -71,9 +71,9 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimens
   this->SetNumberOfControlPointsForTheTotalField(numberOfControlPoints);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(
+BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
   const DerivativeType & update,
   ScalarType             factor)
 {
@@ -172,9 +172,9 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimens
 /**
  * set displacement field and project it onto the space of b-spline transforms
  */
-template <typename TParametersValueType, unsigned int NDimensions>
-typename BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::DisplacementFieldPointer
-BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::BSplineSmoothDisplacementField(
+template <typename TParametersValueType, unsigned int VDimension>
+typename BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::DisplacementFieldPointer
+BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::BSplineSmoothDisplacementField(
   const DisplacementFieldType * field,
   const ArrayType &             numberOfControlPoints)
 {
@@ -193,9 +193,9 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimens
   return smoothField;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 typename LightObject::Pointer
-BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::InternalClone() const
+BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   LightObject::Pointer loPtr = Superclass::InternalClone();
 
@@ -219,10 +219,10 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimens
   return loPtr;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os,
-                                                                                                 Indent indent) const
+BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,
+                                                                                                Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
@@ -32,16 +32,16 @@ namespace itk
  *
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT ConstantVelocityFieldTransform
-  : public DisplacementFieldTransform<TParametersValueType, NDimensions>
+  : public DisplacementFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ConstantVelocityFieldTransform);
 
   /** Standard class type aliases. */
   using Self = ConstantVelocityFieldTransform;
-  using Superclass = DisplacementFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = DisplacementFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -84,10 +84,10 @@ public:
   using typename Superclass::DerivativeType;
 
   /** Dimension of the constant velocity field . */
-  static constexpr unsigned int ConstantVelocityFieldDimension = NDimensions;
+  static constexpr unsigned int ConstantVelocityFieldDimension = VDimension;
 
   /** Dimension of the vector spaces. */
-  static constexpr unsigned int Dimension = NDimensions;
+  static constexpr unsigned int Dimension = VDimension;
 
   /** Define the displacement field type and corresponding interpolator type. */
   using typename Superclass::DisplacementFieldType;

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -30,8 +30,8 @@ namespace itk
 /**
  * Constructor
  */
-template <typename TParametersValueType, unsigned int NDimensions>
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::ConstantVelocityFieldTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::ConstantVelocityFieldTransform()
   : m_ConstantVelocityField(nullptr)
 
 {
@@ -56,9 +56,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::ConstantVeloc
   this->m_Parameters.SetHelper(helper);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
   const DerivativeType & update,
   ScalarType             factor)
 {
@@ -72,9 +72,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::UpdateTransfo
 /**
  * return an inverse transformation
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   if (!inverse || !this->m_ConstantVelocityField)
   {
@@ -95,9 +95,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::GetInverse(Se
 }
 
 // Return an inverse of this transform
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::GetInverseTransform() const
   -> InverseTransformBasePointer
 {
   Pointer inverseTransform = New();
@@ -111,9 +111,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::GetInverseTra
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::SetConstantVelocityField(
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::SetConstantVelocityField(
   ConstantVelocityFieldType * field)
 {
   itkDebugMacro("setting VelocityField to " << field);
@@ -136,9 +136,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::SetConstantVe
   this->SetFixedParametersFromConstantVelocityField();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::SetConstantVelocityFieldInterpolator(
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::SetConstantVelocityFieldInterpolator(
   ConstantVelocityFieldInterpolatorType * interpolator)
 {
   itkDebugMacro("setting ConstantVelocityFieldInterpolator to " << interpolator);
@@ -153,9 +153,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::SetConstantVe
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::SetFixedParameters(
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::SetFixedParameters(
   const FixedParametersType & fixedParameters)
 {
   if (fixedParameters.Size() != ConstantVelocityFieldDimension * (ConstantVelocityFieldDimension + 3))
@@ -205,9 +205,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::SetFixedParam
   this->SetConstantVelocityField(velocityField);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::SetFixedParametersFromConstantVelocityField() const
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::SetFixedParametersFromConstantVelocityField() const
 {
   this->m_FixedParameters.SetSize(ConstantVelocityFieldDimension * (ConstantVelocityFieldDimension + 3));
 
@@ -248,9 +248,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::SetFixedParam
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::IntegrateVelocityField()
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::IntegrateVelocityField()
 {
   using ExponentiatorType =
     ExponentialDisplacementFieldImageFilter<ConstantVelocityFieldType, ConstantVelocityFieldType>;
@@ -313,9 +313,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::IntegrateVelo
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::DisplacementFieldType::Pointer
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::CopyDisplacementField(
+template <typename TParametersValueType, unsigned int VDimension>
+typename ConstantVelocityFieldTransform<TParametersValueType, VDimension>::DisplacementFieldType::Pointer
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplacementField(
   const DisplacementFieldType * toCopy) const
 {
   auto rval = DisplacementFieldType::New();
@@ -335,9 +335,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::CopyDisplacem
   return rval;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 typename LightObject::Pointer
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::InternalClone() const
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   // create a new instance
   LightObject::Pointer   loPtr = Superclass::InternalClone();
@@ -389,9 +389,9 @@ ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::InternalClone
   return loPtr;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-ConstantVelocityFieldTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+ConstantVelocityFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
@@ -33,7 +33,7 @@ namespace itk
  * a displacement field.
  *
  * The displacement field stores vectors of displacements, with
- * dimension \c NDimensions. Transformation is performed at a given
+ * dimension \c VDimension. Transformation is performed at a given
  * point by adding the displacement at that point to the input point.
  *
  * T(x, p), x is the position, p is the local parameter at position x.
@@ -51,8 +51,8 @@ namespace itk
  * The displacement field is defined using an itkImage, and must be set
  * before use by the user, using \c SetDisplacementField. The image has
  * the same dimensionality as the input and output spaces, defined by
- * template parameter \c NDimensions, and is an image of vectors of
- * type \c OutputVectorType, with dimensionality NDimensions as well.
+ * template parameter \c VDimension, and is an image of vectors of
+ * type \c OutputVectorType, with dimensionality VDimension as well.
  *
  * An interpolator of type \c VectorInterpolateImageFunction is used with
  * the displacement field image. By default,
@@ -82,15 +82,15 @@ namespace itk
  *
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
-class ITK_TEMPLATE_EXPORT DisplacementFieldTransform : public Transform<TParametersValueType, NDimensions, NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
+class ITK_TEMPLATE_EXPORT DisplacementFieldTransform : public Transform<TParametersValueType, VDimension, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(DisplacementFieldTransform);
 
   /** Standard class type aliases. */
   using Self = DisplacementFieldTransform;
-  using Superclass = Transform<TParametersValueType, NDimensions, NDimensions>;
+  using Superclass = Transform<TParametersValueType, VDimension, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -153,7 +153,7 @@ public:
   using typename Superclass::DerivativeType;
 
   /** Dimension of the domain spaces. */
-  static constexpr unsigned int Dimension = NDimensions;
+  static constexpr unsigned int Dimension = VDimension;
 
   /** Define the displacement field type and corresponding interpolator type. */
   using DisplacementFieldType = Image<OutputVectorType, Dimension>;
@@ -296,7 +296,7 @@ public:
 
   /**
    * Compute the jacobian with respect to the parameters at a point.
-   * Simply returns identity matrix, sized [NDimensions, NDimensions].
+   * Simply returns identity matrix, sized [VDimension, VDimension].
    *
    * T(x, p), x is the position, p is the local parameter at position x.
    * Take a 2D example, x = (x0, x1), p = (p0, p1) and T(x, p) is defined as:
@@ -323,7 +323,7 @@ public:
 
   /**
    * Compute the jacobian with respect to the parameters at an index.
-   * Simply returns identity matrix, sized [NDimensions, NDimensions].
+   * Simply returns identity matrix, sized [VDimension, VDimension].
    * See \c ComputeJacobianWithRespectToParameters( InputPointType, ... )
    * for rationale.
    */

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -28,13 +28,13 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
-DisplacementFieldTransform<TParametersValueType, NDimensions>::DisplacementFieldTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+DisplacementFieldTransform<TParametersValueType, VDimension>::DisplacementFieldTransform()
   : Superclass(0)
   , m_CoordinateTolerance(ImageToImageFilterCommon::GetGlobalDefaultCoordinateTolerance())
   , m_DirectionTolerance(ImageToImageFilterCommon::GetGlobalDefaultDirectionTolerance())
 {
-  this->m_FixedParameters.SetSize(NDimensions * (NDimensions + 3));
+  this->m_FixedParameters.SetSize(VDimension * (VDimension + 3));
   this->m_FixedParameters.Fill(0.0);
 
   // Setup and assign default interpolator
@@ -53,17 +53,17 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::DisplacementField
   this->m_Parameters.SetHelper(helper);
 
   /* Initialize the identity jacobian. */
-  m_IdentityJacobian.SetSize(NDimensions, NDimensions);
+  m_IdentityJacobian.SetSize(VDimension, VDimension);
   m_IdentityJacobian.Fill(0.0);
-  for (unsigned int dim = 0; dim < NDimensions; ++dim)
+  for (unsigned int dim = 0; dim < VDimension; ++dim)
   {
     m_IdentityJacobian[dim][dim] = 1.0;
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-DisplacementFieldTransform<TParametersValueType, NDimensions>::TransformPoint(const InputPointType & inputPoint) const
+DisplacementFieldTransform<TParametersValueType, VDimension>::TransformPoint(const InputPointType & inputPoint) const
   -> OutputPointType
 {
   if (!this->m_DisplacementField)
@@ -88,7 +88,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::TransformPoint(co
         ->template TransformPhysicalPointToContinuousIndex<typename InterpolatorType::ContinuousIndexType::ValueType>(
           point);
     typename InterpolatorType::OutputType displacement = this->m_Interpolator->EvaluateAtContinuousIndex(cidx);
-    for (unsigned int ii = 0; ii < NDimensions; ++ii)
+    for (unsigned int ii = 0; ii < VDimension; ++ii)
     {
       outputPoint[ii] += displacement[ii];
     }
@@ -99,9 +99,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::TransformPoint(co
   return outputPoint;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   if (!inverse || !this->m_InverseDisplacementField)
   {
@@ -119,10 +119,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverse(Self *
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverseTransform() const
-  -> InverseTransformBasePointer
+DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inverseTransform = New();
 
@@ -136,9 +135,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverseTransfo
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::SetIdentity()
+DisplacementFieldTransform<TParametersValueType, VDimension>::SetIdentity()
 {
   if (!this->m_DisplacementField.IsNull())
   {
@@ -150,9 +149,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::SetIdentity()
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToPosition(
+DisplacementFieldTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToPosition(
   const InputPointType & point,
   JacobianPositionType & jacobian) const
 {
@@ -160,18 +159,18 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   this->ComputeJacobianWithRespectToPosition(idx, jacobian);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToPosition(
+DisplacementFieldTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToPosition(
   const IndexType &      index,
   JacobianPositionType & jacobian) const
 {
   this->ComputeJacobianWithRespectToPositionInternal(index, jacobian, false);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeInverseJacobianWithRespectToPosition(
+DisplacementFieldTransform<TParametersValueType, VDimension>::ComputeInverseJacobianWithRespectToPosition(
   const InputPointType &        point,
   InverseJacobianPositionType & jacobian) const
 {
@@ -179,9 +178,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeInverseJac
   this->ComputeJacobianWithRespectToPositionInternal(idx, jacobian, true);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverseJacobianOfForwardFieldWithRespectToPosition(
+DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverseJacobianOfForwardFieldWithRespectToPosition(
   const InputPointType & point,
   JacobianPositionType & jacobian,
   bool                   useSVD) const
@@ -190,9 +189,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverseJacobia
   this->GetInverseJacobianOfForwardFieldWithRespectToPosition(idx, jacobian, useSVD);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverseJacobianOfForwardFieldWithRespectToPosition(
+DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverseJacobianOfForwardFieldWithRespectToPosition(
   const IndexType &      index,
   JacobianPositionType & jacobian,
   bool                   useSVD) const
@@ -215,9 +214,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::GetInverseJacobia
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWithRespectToPositionInternal(
+DisplacementFieldTransform<TParametersValueType, VDimension>::ComputeJacobianWithRespectToPositionInternal(
   const IndexType &      index,
   JacobianPositionType & jacobian,
   bool                   doInverseJacobian) const
@@ -238,7 +237,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   // Multiplier for getting inverse Jacobian
   TParametersValueType dPixSign = NumericTraits<TParametersValueType>::OneValue();
   dPixSign = doInverseJacobian ? -dPixSign : dPixSign;
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     if (index[i] <= startingIndex[i] || index[i] >= upperIndex[i])
     {
@@ -251,7 +250,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   {
     // itkCentralDifferenceImageFunction does not support 4th order so
     // do manually here
-    for (unsigned int col = 0; col < NDimensions; ++col)
+    for (unsigned int col = 0; col < VDimension; ++col)
     {
       IndexType difIndex[4] = { index, index, index, index };
       difIndex[0][col] -= 2;
@@ -277,7 +276,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
       OutputVectorType dPix =
         (pixDisp[0] - pixDisp[1] * 8.0 + pixDisp[2] * 8.0 - pixDisp[3]) / (12.0 * space * spacing[col]) * dPixSign;
 
-      for (unsigned int row = 0; row < NDimensions; ++row)
+      for (unsigned int row = 0; row < VDimension; ++row)
       {
         jacobian(row, col) = dPix[row];
         // Verify it's a real number
@@ -289,10 +288,10 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
       }
     } // for col
 
-    for (unsigned int row = 0; row < NDimensions; ++row)
+    for (unsigned int row = 0; row < VDimension; ++row)
     {
-      FixedArray<TParametersValueType, NDimensions> localComponentGrad(jacobian[row]);
-      FixedArray<TParametersValueType, NDimensions> physicalComponentGrad =
+      FixedArray<TParametersValueType, VDimension> localComponentGrad(jacobian[row]);
+      FixedArray<TParametersValueType, VDimension> physicalComponentGrad =
         m_DisplacementField->TransformLocalVectorToPhysicalVector(localComponentGrad);
       jacobian.set_row(row, physicalComponentGrad.data());
       jacobian(row, row) += 1.;
@@ -305,19 +304,19 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(const DerivativeType & update,
-                                                                                         ScalarType             factor)
+DisplacementFieldTransform<TParametersValueType, VDimension>::UpdateTransformParameters(const DerivativeType & update,
+                                                                                        ScalarType             factor)
 {
   // This simply adds the values.
   // TODO: This should be multi-threaded probably, via image add filter.
   Superclass::UpdateTransformParameters(update, factor);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::SetDisplacementField(DisplacementFieldType * field)
+DisplacementFieldTransform<TParametersValueType, VDimension>::SetDisplacementField(DisplacementFieldType * field)
 {
   if (this->m_DisplacementField != field)
   {
@@ -343,9 +342,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::SetDisplacementFi
   this->SetFixedParametersFromDisplacementField();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::SetInverseDisplacementField(
+DisplacementFieldTransform<TParametersValueType, VDimension>::SetInverseDisplacementField(
   DisplacementFieldType * inverseField)
 {
   if (this->m_InverseDisplacementField != inverseField)
@@ -363,9 +362,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::SetInverseDisplac
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::VerifyFixedParametersInformation()
+DisplacementFieldTransform<TParametersValueType, VDimension>::VerifyFixedParametersInformation()
 {
   if (!this->m_DisplacementField.IsNull() && !this->m_InverseDisplacementField.IsNull())
   {
@@ -431,9 +430,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::VerifyFixedParame
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::SetInterpolator(InterpolatorType * interpolator)
+DisplacementFieldTransform<TParametersValueType, VDimension>::SetInterpolator(InterpolatorType * interpolator)
 {
   if (this->m_Interpolator != interpolator)
   {
@@ -446,9 +445,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::SetInterpolator(I
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::SetInverseInterpolator(InterpolatorType * interpolator)
+DisplacementFieldTransform<TParametersValueType, VDimension>::SetInverseInterpolator(InterpolatorType * interpolator)
 {
   if (this->m_InverseInterpolator != interpolator)
   {
@@ -461,12 +460,12 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::SetInverseInterpo
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::SetFixedParameters(
+DisplacementFieldTransform<TParametersValueType, VDimension>::SetFixedParameters(
   const FixedParametersType & fixedParameters)
 {
-  if (fixedParameters.Size() != NDimensions * (NDimensions + 3))
+  if (fixedParameters.Size() != VDimension * (VDimension + 3))
   {
     itkExceptionMacro("The fixed parameters are not the right size.");
   }
@@ -484,29 +483,29 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::SetFixedParameter
   }
 
   SizeType size;
-  for (unsigned int d = 0; d < NDimensions; ++d)
+  for (unsigned int d = 0; d < VDimension; ++d)
   {
     size[d] = static_cast<SizeValueType>(fixedParameters[d]);
   }
 
   PointType origin;
-  for (unsigned int d = 0; d < NDimensions; ++d)
+  for (unsigned int d = 0; d < VDimension; ++d)
   {
-    origin[d] = fixedParameters[d + NDimensions];
+    origin[d] = fixedParameters[d + VDimension];
   }
 
   SpacingType spacing;
-  for (unsigned int d = 0; d < NDimensions; ++d)
+  for (unsigned int d = 0; d < VDimension; ++d)
   {
-    spacing[d] = fixedParameters[d + 2 * NDimensions];
+    spacing[d] = fixedParameters[d + 2 * VDimension];
   }
 
   DirectionType direction;
-  for (unsigned int di = 0; di < NDimensions; ++di)
+  for (unsigned int di = 0; di < VDimension; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; ++dj)
+    for (unsigned int dj = 0; dj < VDimension; ++dj)
     {
-      direction[di][dj] = fixedParameters[3 * NDimensions + (di * NDimensions + dj)];
+      direction[di][dj] = fixedParameters[3 * VDimension + (di * VDimension + dj)];
     }
   }
 
@@ -537,11 +536,11 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::SetFixedParameter
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::SetFixedParametersFromDisplacementField() const
+DisplacementFieldTransform<TParametersValueType, VDimension>::SetFixedParametersFromDisplacementField() const
 {
-  this->m_FixedParameters.SetSize(NDimensions * (NDimensions + 3));
+  this->m_FixedParameters.SetSize(VDimension * (VDimension + 3));
 
   if (this->m_DisplacementField.IsNull())
   {
@@ -554,40 +553,40 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::SetFixedParameter
 
   // Set the field size parameters
   SizeType fieldSize = fieldRegion.GetSize();
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     this->m_FixedParameters[i] = static_cast<FixedParametersValueType>(fieldSize[i]);
   }
 
   // Set the origin parameters
   PointType fieldOrigin = this->m_DisplacementField->GetOrigin();
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    this->m_FixedParameters[NDimensions + i] = fieldOrigin[i];
+    this->m_FixedParameters[VDimension + i] = fieldOrigin[i];
   }
 
   // Set the spacing parameters
   SpacingType fieldSpacing = this->m_DisplacementField->GetSpacing();
-  for (unsigned int i = 0; i < NDimensions; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
-    this->m_FixedParameters[2 * NDimensions + i] = static_cast<FixedParametersValueType>(fieldSpacing[i]);
+    this->m_FixedParameters[2 * VDimension + i] = static_cast<FixedParametersValueType>(fieldSpacing[i]);
   }
 
   // Set the direction parameters
   DirectionType fieldDirection = this->m_DisplacementField->GetDirection();
-  for (unsigned int di = 0; di < NDimensions; ++di)
+  for (unsigned int di = 0; di < VDimension; ++di)
   {
-    for (unsigned int dj = 0; dj < NDimensions; ++dj)
+    for (unsigned int dj = 0; dj < VDimension; ++dj)
     {
-      this->m_FixedParameters[3 * NDimensions + (di * NDimensions + dj)] =
+      this->m_FixedParameters[3 * VDimension + (di * VDimension + dj)] =
         static_cast<FixedParametersValueType>(fieldDirection[di][dj]);
     }
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-DisplacementFieldTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+DisplacementFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.h
@@ -52,16 +52,16 @@ namespace itk
  *
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT GaussianExponentialDiffeomorphicTransform
-  : public ConstantVelocityFieldTransform<TParametersValueType, NDimensions>
+  : public ConstantVelocityFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GaussianExponentialDiffeomorphicTransform);
 
   /** Standard class type aliases. */
   using Self = GaussianExponentialDiffeomorphicTransform;
-  using Superclass = ConstantVelocityFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = ConstantVelocityFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -72,10 +72,10 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the velocity field . */
-  static constexpr unsigned int ConstantVelocityFieldDimension = NDimensions;
+  static constexpr unsigned int ConstantVelocityFieldDimension = VDimension;
 
   /** Dimension of the vector spaces. */
-  static constexpr unsigned int Dimension = NDimensions;
+  static constexpr unsigned int Dimension = VDimension;
 
   /** Types from superclass */
   using typename Superclass::ScalarType;
@@ -121,7 +121,7 @@ protected:
 
   /** Type of Gaussian Operator used during smoothing. Define here
    * so we can use a member var during the operation. */
-  using GaussianSmoothingOperatorType = GaussianOperator<ScalarType, NDimensions>;
+  using GaussianSmoothingOperatorType = GaussianOperator<ScalarType, VDimension>;
 
   using GaussianSmoothingSmootherType =
     VectorNeighborhoodOperatorImageFilter<ConstantVelocityFieldType, ConstantVelocityFieldType>;

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -27,16 +27,15 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
-GaussianExponentialDiffeomorphicTransform<TParametersValueType,
-                                          NDimensions>::GaussianExponentialDiffeomorphicTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::GaussianExponentialDiffeomorphicTransform()
   : m_GaussianSmoothingVarianceForTheUpdateField(0.5)
   , m_GaussianSmoothingVarianceForTheConstantVelocityField(0.5)
 {}
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-GaussianExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(
+GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
   const DerivativeType & update,
   ScalarType             factor)
 {
@@ -62,7 +61,7 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Up
   auto * updateFieldPointer =
     reinterpret_cast<DisplacementVectorType *>(const_cast<DerivativeType &>(update).data_block());
 
-  using ImporterType = ImportImageFilter<DisplacementVectorType, NDimensions>;
+  using ImporterType = ImportImageFilter<DisplacementVectorType, VDimension>;
   const bool importFilterWillReleaseMemory = false;
 
   auto importer = ImporterType::New();
@@ -86,7 +85,7 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Up
     updateField = updateSmoothField;
   }
 
-  using RealImageType = Image<ScalarType, NDimensions>;
+  using RealImageType = Image<ScalarType, VDimension>;
 
   using MultiplierType = MultiplyImageFilter<ConstantVelocityFieldType, RealImageType, ConstantVelocityFieldType>;
   auto multiplier = MultiplierType::New();
@@ -133,9 +132,9 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Up
   this->IntegrateVelocityField();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename GaussianExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::ConstantVelocityFieldPointer
-GaussianExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::GaussianSmoothConstantVelocityField(
+template <typename TParametersValueType, unsigned int VDimension>
+typename GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::ConstantVelocityFieldPointer
+GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::GaussianSmoothConstantVelocityField(
   ConstantVelocityFieldType * field,
   ScalarType                  variance)
 {
@@ -227,10 +226,10 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::Ga
 /**
  * Standard "PrintSelf" method
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-GaussianExponentialDiffeomorphicTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os,
-                                                                                        Indent         indent) const
+GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,
+                                                                                       Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.h
@@ -42,16 +42,16 @@ namespace itk
  *
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT GaussianSmoothingOnUpdateDisplacementFieldTransform
-  : public DisplacementFieldTransform<TParametersValueType, NDimensions>
+  : public DisplacementFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GaussianSmoothingOnUpdateDisplacementFieldTransform);
 
   /** Standard class type aliases. */
   using Self = GaussianSmoothingOnUpdateDisplacementFieldTransform;
-  using Superclass = DisplacementFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = DisplacementFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -69,7 +69,7 @@ public:
   using typename Superclass::DisplacementFieldPointer;
   using DisplacementVectorType = typename DisplacementFieldType::PixelType;
 
-  using TransformPointer = typename Transform<TParametersValueType, NDimensions, NDimensions>::Pointer;
+  using TransformPointer = typename Transform<TParametersValueType, VDimension, VDimension>::Pointer;
 
   /**
    * Get/Set the Gaussian smoothing standard deviation for the update field.

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -31,17 +31,17 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType,
-                                                    NDimensions>::GaussianSmoothingOnUpdateDisplacementFieldTransform()
+                                                    VDimension>::GaussianSmoothingOnUpdateDisplacementFieldTransform()
 {
   this->m_GaussianSmoothingVarianceForTheUpdateField = 3.0;
   this->m_GaussianSmoothingVarianceForTheTotalField = 0.5;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(
+GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
   const DerivativeType & update,
   ScalarType             factor)
 {
@@ -50,7 +50,7 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimen
   const typename DisplacementFieldType::RegionType & bufferedRegion = displacementField->GetBufferedRegion();
   const SizeValueType                                numberOfPixels = bufferedRegion.GetNumberOfPixels();
 
-  using ImporterType = ImportImageFilter<DisplacementVectorType, NDimensions>;
+  using ImporterType = ImportImageFilter<DisplacementVectorType, VDimension>;
   const bool importFilterWillReleaseMemory = false;
 
   //
@@ -125,10 +125,9 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimen
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType,
-                                                             NDimensions>::DisplacementFieldPointer
-GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::GaussianSmoothDisplacementField(
+template <typename TParametersValueType, unsigned int VDimension>
+typename GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::DisplacementFieldPointer
+GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::GaussianSmoothDisplacementField(
   DisplacementFieldType * field,
   ScalarType              variance)
 {
@@ -217,9 +216,9 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimen
   return field;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 typename LightObject::Pointer
-GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::InternalClone() const
+GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   LightObject::Pointer loPtr = Superclass::InternalClone();
 
@@ -240,10 +239,10 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimen
   return loPtr;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os,
-                                                                                                  Indent indent) const
+GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,
+                                                                                                 Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
@@ -35,16 +35,16 @@ namespace itk
  *
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform
-  : public TimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>
+  : public TimeVaryingVelocityFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform);
 
   /** Standard class type aliases. */
   using Self = GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform;
-  using Superclass = TimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = TimeVaryingVelocityFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -55,7 +55,7 @@ public:
   itkNewMacro(Self);
 
   /** Dimension of the time varying velocity field. */
-  static constexpr unsigned int TimeVaryingVelocityFieldDimension = NDimensions + 1;
+  static constexpr unsigned int TimeVaryingVelocityFieldDimension = VDimension + 1;
 
   /** Types from superclass */
   using typename Superclass::ScalarType;

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
@@ -30,8 +30,8 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
-GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>::
+template <typename TParametersValueType, unsigned int VDimension>
+GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, VDimension>::
   GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform()
   : m_GaussianSpatialSmoothingVarianceForTheUpdateField(3.0)
   , m_GaussianSpatialSmoothingVarianceForTheTotalField(0.5)
@@ -39,17 +39,18 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
   , m_GaussianTemporalSmoothingVarianceForTheTotalField(0.0)
 {}
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>::
-  UpdateTransformParameters(const DerivativeType & update, ScalarType factor)
+GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
+  const DerivativeType & update,
+  ScalarType             factor)
 {
   TimeVaryingVelocityFieldPointer velocityField = this->GetModifiableVelocityField();
 
   const typename VelocityFieldType::RegionType & bufferedRegion = velocityField->GetBufferedRegion();
   const SizeValueType                            numberOfPixels = bufferedRegion.GetNumberOfPixels();
 
-  using ImporterType = ImportImageFilter<DisplacementVectorType, NDimensions + 1>;
+  using ImporterType = ImportImageFilter<DisplacementVectorType, VDimension + 1>;
   const bool importFilterWillReleaseMemory = false;
 
   //
@@ -132,10 +133,10 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
   this->IntegrateVelocityField();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 typename GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
-                                                                    NDimensions>::TimeVaryingVelocityFieldPointer
-GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>::
+                                                                    VDimension>::TimeVaryingVelocityFieldPointer
+GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, VDimension>::
   GaussianSmoothTimeVaryingVelocityField(VelocityFieldType * field,
                                          ScalarType          spatialVariance,
                                          ScalarType          temporalVariance)
@@ -157,9 +158,9 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
 
   for (unsigned int d = 0; d < TimeVaryingVelocityFieldDimension; ++d)
   {
-    using GaussianType = GaussianOperator<DisplacementVectorValueType, NDimensions + 1>;
+    using GaussianType = GaussianOperator<DisplacementVectorValueType, VDimension + 1>;
     GaussianType gaussian;
-    if (d < NDimensions)
+    if (d < VDimension)
     {
       gaussian.SetVariance(spatialVariance);
     }
@@ -209,7 +210,7 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
     TimeVaryingVelocityFieldIndexType index = fieldIt.GetIndex();
 
     bool isOnBoundary = false;
-    for (unsigned int d = 0; d < NDimensions; ++d)
+    for (unsigned int d = 0; d < VDimension; ++d)
     {
       if (index[d] == startIndex[d] || index[d] == static_cast<IndexValueType>(size[d]) - startIndex[d] - 1)
       {
@@ -230,9 +231,9 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
   return field;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>::PrintSelf(
+GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType, VDimension>::PrintSelf(
   std::ostream & os,
   Indent         indent) const
 {

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.h
@@ -64,16 +64,16 @@ namespace itk
  * \ingroup Transforms
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT TimeVaryingBSplineVelocityFieldTransform
-  : public VelocityFieldTransform<TParametersValueType, NDimensions>
+  : public VelocityFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TimeVaryingBSplineVelocityFieldTransform);
 
   /** Standard class type aliases. */
   using Self = TimeVaryingBSplineVelocityFieldTransform;
-  using Superclass = VelocityFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = VelocityFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -108,10 +108,10 @@ public:
   using typename Superclass::DerivativeType;
 
   /** Dimension of the domain spaces. */
-  static constexpr unsigned int Dimension = NDimensions;
+  static constexpr unsigned int Dimension = VDimension;
 
   /** Dimension of the time varying velocity field. */
-  static constexpr unsigned int VelocityFieldDimension = NDimensions + 1;
+  static constexpr unsigned int VelocityFieldDimension = VDimension + 1;
 
   using VelocityFieldPointType = typename VelocityFieldType::PointType;
   using VelocityFieldSizeType = typename VelocityFieldType::SizeType;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
@@ -32,8 +32,8 @@ namespace itk
 /**
  * Constructor
  */
-template <typename TParametersValueType, unsigned int NDimensions>
-TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::TimeVaryingBSplineVelocityFieldTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, VDimension>::TimeVaryingBSplineVelocityFieldTransform()
 {
   this->m_SplineOrder = 3;
   this->m_TemporalPeriodicity = false;
@@ -44,9 +44,9 @@ TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::Tim
   this->m_VelocityFieldDirection.SetIdentity();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::IntegrateVelocityField()
+TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, VDimension>::IntegrateVelocityField()
 {
   if (!this->GetVelocityField())
   {
@@ -59,7 +59,7 @@ TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::Int
   closeDimensions.Fill(0);
   if (this->m_TemporalPeriodicity)
   {
-    closeDimensions[NDimensions] = 1;
+    closeDimensions[VDimension] = 1;
   }
 
   auto bspliner = BSplineFilterType::New();
@@ -115,9 +115,9 @@ TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::Int
   this->SetInverseDisplacementField(inverseDisplacementField);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(
+TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
   const DerivativeType & update,
   ScalarType             factor)
 {
@@ -132,12 +132,12 @@ TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::Upd
   DerivativeType scaledUpdate = update;
   scaledUpdate *= factor;
 
-  const auto numberOfPixels = static_cast<SizeValueType>(scaledUpdate.Size() / NDimensions);
+  const auto numberOfPixels = static_cast<SizeValueType>(scaledUpdate.Size() / VDimension);
   const bool importFilterWillReleaseMemory = false;
 
   auto * updateFieldPointer = reinterpret_cast<DisplacementVectorType *>(scaledUpdate.data_block());
 
-  using ImporterType = ImportImageFilter<DisplacementVectorType, NDimensions + 1>;
+  using ImporterType = ImportImageFilter<DisplacementVectorType, VDimension + 1>;
   auto importer = ImporterType::New();
   importer->SetImportPointer(updateFieldPointer, numberOfPixels, importFilterWillReleaseMemory);
   importer->SetRegion(this->GetTimeVaryingVelocityFieldControlPointLattice()->GetBufferedRegion());
@@ -158,10 +158,10 @@ TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::Upd
   this->IntegrateVelocityField();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os,
-                                                                                       Indent         indent) const
+TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os,
+                                                                                      Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.h
@@ -50,16 +50,16 @@ namespace itk
  * \ingroup Transforms
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 class ITK_TEMPLATE_EXPORT TimeVaryingVelocityFieldTransform
-  : public VelocityFieldTransform<TParametersValueType, NDimensions>
+  : public VelocityFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TimeVaryingVelocityFieldTransform);
 
   /** Standard class type aliases. */
   using Self = TimeVaryingVelocityFieldTransform;
-  using Superclass = VelocityFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = VelocityFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -96,7 +96,7 @@ public:
   /** Derivative type */
   using typename Superclass::DerivativeType;
 
-  using TransformPointer = typename Transform<TParametersValueType, NDimensions, NDimensions>::Pointer;
+  using TransformPointer = typename Transform<TParametersValueType, VDimension, VDimension>::Pointer;
 
   /** Get the time-varying velocity field. */
 #if !defined(ITK_LEGACY_REMOVE)

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.hxx
@@ -24,9 +24,9 @@
 namespace itk
 {
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-TimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>::IntegrateVelocityField()
+TimeVaryingVelocityFieldTransform<TParametersValueType, VDimension>::IntegrateVelocityField()
 {
   if (this->GetVelocityField())
   {

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -32,15 +32,15 @@ namespace itk
  *
  * \ingroup ITKDisplacementField
  */
-template <typename TParametersValueType, unsigned int NDimensions>
-class ITK_TEMPLATE_EXPORT VelocityFieldTransform : public DisplacementFieldTransform<TParametersValueType, NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
+class ITK_TEMPLATE_EXPORT VelocityFieldTransform : public DisplacementFieldTransform<TParametersValueType, VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VelocityFieldTransform);
 
   /** Standard class type aliases. */
   using Self = VelocityFieldTransform;
-  using Superclass = DisplacementFieldTransform<TParametersValueType, NDimensions>;
+  using Superclass = DisplacementFieldTransform<TParametersValueType, VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -83,10 +83,10 @@ public:
   using typename Superclass::DerivativeType;
 
   /** Dimension of the velocity field . */
-  static constexpr unsigned int VelocityFieldDimension = NDimensions + 1;
+  static constexpr unsigned int VelocityFieldDimension = VDimension + 1;
 
   /** Dimension of the vector spaces. */
-  static constexpr unsigned int Dimension = NDimensions;
+  static constexpr unsigned int Dimension = VDimension;
 
   /** Define the displacement field type and corresponding interpolator type. */
   using typename Superclass::DisplacementFieldType;

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -29,8 +29,8 @@ namespace itk
 /**
  * Constructor
  */
-template <typename TParametersValueType, unsigned int NDimensions>
-VelocityFieldTransform<TParametersValueType, NDimensions>::VelocityFieldTransform()
+template <typename TParametersValueType, unsigned int VDimension>
+VelocityFieldTransform<TParametersValueType, VDimension>::VelocityFieldTransform()
 {
   this->m_FixedParameters.SetSize(VelocityFieldDimension * (VelocityFieldDimension + 3));
   this->m_FixedParameters.Fill(0.0);
@@ -55,10 +55,10 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::VelocityFieldTransfor
   this->m_VelocityFieldSetTime = 0;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-VelocityFieldTransform<TParametersValueType, NDimensions>::UpdateTransformParameters(const DerivativeType & update,
-                                                                                     ScalarType             factor)
+VelocityFieldTransform<TParametersValueType, VDimension>::UpdateTransformParameters(const DerivativeType & update,
+                                                                                    ScalarType             factor)
 {
   // This simply adds the values.
   // TODO: This should be multi-threaded probably, via image add filter.
@@ -70,9 +70,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::UpdateTransformParame
 /**
  * return an inverse transformation
  */
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 bool
-VelocityFieldTransform<TParametersValueType, NDimensions>::GetInverse(Self * inverse) const
+VelocityFieldTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse) const
 {
   if (!inverse || !this->m_VelocityField)
   {
@@ -93,9 +93,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::GetInverse(Self * inv
 }
 
 // Return an inverse of this transform
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 auto
-VelocityFieldTransform<TParametersValueType, NDimensions>::GetInverseTransform() const -> InverseTransformBasePointer
+VelocityFieldTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
 {
   Pointer inverseTransform = New();
   if (this->GetInverse(inverseTransform))
@@ -108,9 +108,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::GetInverseTransform()
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-VelocityFieldTransform<TParametersValueType, NDimensions>::SetVelocityField(VelocityFieldType * field)
+VelocityFieldTransform<TParametersValueType, VDimension>::SetVelocityField(VelocityFieldType * field)
 {
   itkDebugMacro("setting VelocityField to " << field);
   if (this->m_VelocityField != field)
@@ -132,9 +132,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::SetVelocityField(Velo
   this->SetFixedParametersFromVelocityField();
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-VelocityFieldTransform<TParametersValueType, NDimensions>::SetVelocityFieldInterpolator(
+VelocityFieldTransform<TParametersValueType, VDimension>::SetVelocityFieldInterpolator(
   VelocityFieldInterpolatorType * interpolator)
 {
   itkDebugMacro("setting VelocityFieldInterpolator to " << interpolator);
@@ -149,9 +149,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::SetVelocityFieldInter
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-VelocityFieldTransform<TParametersValueType, NDimensions>::SetFixedParameters(
+VelocityFieldTransform<TParametersValueType, VDimension>::SetFixedParameters(
   const FixedParametersType & fixedParameters)
 {
   if (fixedParameters.Size() != VelocityFieldDimension * (VelocityFieldDimension + 3))
@@ -200,9 +200,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::SetFixedParameters(
   this->SetVelocityField(velocityField);
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-VelocityFieldTransform<TParametersValueType, NDimensions>::SetFixedParametersFromVelocityField() const
+VelocityFieldTransform<TParametersValueType, VDimension>::SetFixedParametersFromVelocityField() const
 {
   this->m_FixedParameters.SetSize(VelocityFieldDimension * (VelocityFieldDimension + 3));
 
@@ -241,9 +241,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::SetFixedParametersFro
   }
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
-typename VelocityFieldTransform<TParametersValueType, NDimensions>::DisplacementFieldType::Pointer
-VelocityFieldTransform<TParametersValueType, NDimensions>::CopyDisplacementField(
+template <typename TParametersValueType, unsigned int VDimension>
+typename VelocityFieldTransform<TParametersValueType, VDimension>::DisplacementFieldType::Pointer
+VelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplacementField(
   const DisplacementFieldType * toCopy) const
 {
   auto rval = DisplacementFieldType::New();
@@ -263,9 +263,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::CopyDisplacementField
   return rval;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 typename LightObject::Pointer
-VelocityFieldTransform<TParametersValueType, NDimensions>::InternalClone() const
+VelocityFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   // create a new instance
   LightObject::Pointer   loPtr = Superclass::InternalClone();
@@ -322,9 +322,9 @@ VelocityFieldTransform<TParametersValueType, NDimensions>::InternalClone() const
   return loPtr;
 }
 
-template <typename TParametersValueType, unsigned int NDimensions>
+template <typename TParametersValueType, unsigned int VDimension>
 void
-VelocityFieldTransform<TParametersValueType, NDimensions>::PrintSelf(std::ostream & os, Indent indent) const
+VelocityFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -235,9 +235,9 @@ private:
     it.Set(correctedGradient);
   }
 
-  template <template <typename, unsigned int> class P, class T, unsigned int N>
+  template <template <typename, unsigned int> class P, class T, unsigned int VDimension>
   void
-  TransformOutputPixel(ImageRegionIterator<Image<P<T, N>, N>> & it)
+  TransformOutputPixel(ImageRegionIterator<Image<P<T, VDimension>, VDimension>> & it)
   {
     const OutputPixelType gradient = it.Get();
     // This uses the more efficient set by reference method

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
@@ -28,17 +28,17 @@ int
 itkResampleImageTest(int, char *[])
 {
 
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   using PixelType = float;
-  using ImageType = itk::Image<PixelType, NDimensions>;
+  using ImageType = itk::Image<PixelType, VDimension>;
   using ImageIndexType = ImageType::IndexType;
   using ImagePointerType = ImageType::Pointer;
   using ImageRegionType = ImageType::RegionType;
   using ImageSizeType = ImageType::SizeType;
   using CoordRepType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
+  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
 
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
@@ -33,13 +33,13 @@
 namespace
 {
 
-template <typename TCoordRepType, unsigned int NDimensions>
-class NonlinearAffineTransform : public itk::AffineTransform<TCoordRepType, NDimensions>
+template <typename TCoordRepType, unsigned int VDimension>
+class NonlinearAffineTransform : public itk::AffineTransform<TCoordRepType, VDimension>
 {
 public:
   /** Standard class type aliases.   */
   using Self = NonlinearAffineTransform;
-  using Superclass = itk::AffineTransform<TCoordRepType, NDimensions>;
+  using Superclass = itk::AffineTransform<TCoordRepType, VDimension>;
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
 
@@ -77,14 +77,14 @@ itkResampleImageTest2(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image<PixelType, NDimensions>;
+  using ImageType = itk::Image<PixelType, VDimension>;
   using CoordRepType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
-  using NonlinearAffineTransformType = NonlinearAffineTransform<CoordRepType, NDimensions>;
+  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
+  using NonlinearAffineTransformType = NonlinearAffineTransform<CoordRepType, VDimension>;
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
   using ExtrapolatorType = itk::NearestNeighborExtrapolateImageFunction<ImageType, CoordRepType>;
 
@@ -160,7 +160,7 @@ itkResampleImageTest2(int argc, char * argv[])
     }
 
     typename ImageType::SpacingType outputSpacing;
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       outputSpacing[i] = outputSpacingValue;
     }
@@ -171,7 +171,7 @@ itkResampleImageTest2(int argc, char * argv[])
     typename ImageType::SizeType outputSize;
 
     using SizeValueType = typename ImageType::SizeType::SizeValueType;
-    for (unsigned int i = 0; i < NDimensions; ++i)
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
       outputSize[i] = itk::Math::Ceil<SizeValueType>((double)inputSize[i] * inputSpacing[i] / outputSpacing[i]);
     }

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -34,13 +34,13 @@
 namespace
 {
 
-template <typename TCoordRepType, unsigned int NDimensions>
-class NonlinearAffineTransform : public itk::AffineTransform<TCoordRepType, NDimensions>
+template <typename TCoordRepType, unsigned int VDimension>
+class NonlinearAffineTransform : public itk::AffineTransform<TCoordRepType, VDimension>
 {
 public:
   /** Standard class type aliases.   */
   using Self = NonlinearAffineTransform;
-  using Superclass = itk::AffineTransform<TCoordRepType, NDimensions>;
+  using Superclass = itk::AffineTransform<TCoordRepType, VDimension>;
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
 
@@ -74,14 +74,14 @@ itkResampleImageTest2Streaming(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image<PixelType, NDimensions>;
+  using ImageType = itk::Image<PixelType, VDimension>;
   using CoordRepType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
-  using NonlinearAffineTransformType = NonlinearAffineTransform<CoordRepType, NDimensions>;
+  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
+  using NonlinearAffineTransformType = NonlinearAffineTransform<CoordRepType, VDimension>;
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
   using ExtrapolatorType = itk::NearestNeighborExtrapolateImageFunction<ImageType, CoordRepType>;
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest3.cxx
@@ -43,13 +43,13 @@ itkResampleImageTest3(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image<PixelType, NDimensions>;
+  using ImageType = itk::Image<PixelType, VDimension>;
   using CoordRepType = double;
 
-  using TransformType = itk::IdentityTransform<CoordRepType, NDimensions>;
+  using TransformType = itk::IdentityTransform<CoordRepType, VDimension>;
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
 
   using ReaderType = itk::ImageFileReader<ImageType>;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
@@ -27,11 +27,11 @@ int
 itkResampleImageTest4(int argc, char * argv[])
 {
 
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   using PixelType = float;
 
-  using ImageType = itk::Image<PixelType, NDimensions>;
+  using ImageType = itk::Image<PixelType, VDimension>;
   using ImageIndexType = ImageType::IndexType;
   using ImagePointerType = ImageType::Pointer;
   using ImageRegionType = ImageType::RegionType;
@@ -39,7 +39,7 @@ itkResampleImageTest4(int argc, char * argv[])
 
   using CoordRepType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
+  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
 
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
@@ -37,7 +37,7 @@ itkResampleImageTest5(int argc, char * argv[])
   }
 
   // Resample an RGB image
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   using PixelType = unsigned char;
   using RGBPixelType = itk::RGBPixel<unsigned char>;
@@ -50,7 +50,7 @@ itkResampleImageTest5(int argc, char * argv[])
 
   using CoordRepType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
+  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
@@ -38,7 +38,7 @@ itkResampleImageTest6(int argc, char * argv[])
 
 
   // Resample a Vector image
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   using ValueType = unsigned char;
 
@@ -52,7 +52,7 @@ itkResampleImageTest6(int argc, char * argv[])
 
   using CoordRepType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
+  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -31,11 +31,11 @@ int
 itkResampleImageTest7(int, char *[])
 {
 
-  constexpr unsigned int NDimensions = 2;
+  constexpr unsigned int VDimension = 2;
 
   using PixelType = float;
 
-  using ImageType = itk::Image<PixelType, NDimensions>;
+  using ImageType = itk::Image<PixelType, VDimension>;
   using ImageIndexType = ImageType::IndexType;
   using ImagePointerType = ImageType::Pointer;
   using ImageRegionType = ImageType::RegionType;
@@ -43,7 +43,7 @@ itkResampleImageTest7(int, char *[])
 
   using CoordRepType = double;
 
-  using AffineTransformType = itk::AffineTransform<CoordRepType, NDimensions>;
+  using AffineTransformType = itk::AffineTransform<CoordRepType, VDimension>;
 
   using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordRepType>;
 

--- a/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -26,12 +26,12 @@
 
 enum
 {
-  NDimensions = 3
+  VDimension = 3
 };
 
 using PixelType = float;
 using InputImageType = itk::PhasedArray3DSpecialCoordinatesImage<PixelType>;
-using ImageType = itk::Image<PixelType, NDimensions>;
+using ImageType = itk::Image<PixelType, VDimension>;
 using InputImagePointerType = InputImageType::Pointer;
 using ImagePointerType = ImageType::Pointer;
 using ImageRegionType = ImageType::RegionType;

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -37,9 +37,9 @@ class VanHerkGilWermanDilateImageFilter;
 namespace itk
 {
 
-template <unsigned int NDimension>
-FlatStructuringElement<NDimension>
-FlatStructuringElement<NDimension>::Polygon(RadiusType radius, unsigned int lines)
+template <unsigned int VDimension>
+FlatStructuringElement<VDimension>
+FlatStructuringElement<VDimension>::Polygon(RadiusType radius, unsigned int lines)
 {
   Self res = Self();
   GeneratePolygon(res, radius, lines);
@@ -1013,9 +1013,9 @@ FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParamet
   return res;
 }
 
-template <unsigned int NDimension>
-FlatStructuringElement<NDimension>
-FlatStructuringElement<NDimension>::Annulus(RadiusType   radius,
+template <unsigned int VDimension>
+FlatStructuringElement<VDimension>
+FlatStructuringElement<VDimension>::Annulus(RadiusType   radius,
                                             unsigned int thickness,
                                             bool         includeCenter,
                                             bool         radiusIsParametric)
@@ -1031,7 +1031,7 @@ FlatStructuringElement<NDimension>::Annulus(RadiusType   radius,
   auto                           kernelImage = ImageType::New();
   typename ImageType::RegionType region;
   RadiusType                     size = radius;
-  for (unsigned int i = 0; i < NDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     size[i] = 2 * size[i] + 1;
   }
@@ -1053,7 +1053,7 @@ FlatStructuringElement<NDimension>::Annulus(RadiusType   radius,
   //
 
   // Ellipsoid spatial function typedef
-  using EllipsoidType = EllipsoidInteriorExteriorSpatialFunction<NDimension>;
+  using EllipsoidType = EllipsoidInteriorExteriorSpatialFunction<VDimension>;
 
   // Create an ellipsoid spatial function for the source image
   auto ellipsoidOuter = EllipsoidType::New();
@@ -1062,7 +1062,7 @@ FlatStructuringElement<NDimension>::Annulus(RadiusType   radius,
   // Define and set the axes lengths for the ellipsoid
   typename EllipsoidType::InputType axesOuter;
   typename EllipsoidType::InputType axesInner;
-  for (unsigned int i = 0; i < NDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     if (result.GetRadiusIsParametric())
     {
@@ -1080,7 +1080,7 @@ FlatStructuringElement<NDimension>::Annulus(RadiusType   radius,
 
   // Define and set the center of the ellipsoid in physical space
   typename EllipsoidType::InputType center;
-  for (unsigned int i = 0; i < NDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     // put the center of ellipse in the middle of the center pixel
     center[i] = result.GetRadius(i) + 0.5;
@@ -1098,7 +1098,7 @@ FlatStructuringElement<NDimension>::Annulus(RadiusType   radius,
 
   // Create the starting seed
   typename ImageType::IndexType seed;
-  for (unsigned int i = 0; i < NDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     seed[i] = result.GetRadius(i);
   }

--- a/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.h
+++ b/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.h
@@ -58,7 +58,7 @@ namespace itk
  *
  * \ingroup ITKIOCSV
  */
-template <typename TValue, unsigned int NRows = 0, unsigned int NColumns = 0>
+template <typename TValue, unsigned int VRows = 0, unsigned int VColumns = 0>
 class ITK_TEMPLATE_EXPORT CSVNumericObjectFileWriter : public LightProcessObject
 {
 public:
@@ -78,8 +78,8 @@ public:
 
   // Matrix types
   using vnlMatrixType = vnl_matrix<TValue>;
-  using vnlFixedMatrixType = vnl_matrix_fixed<TValue, NRows, NColumns>;
-  using itkMatrixType = itk::Matrix<TValue, NRows, NColumns>;
+  using vnlFixedMatrixType = vnl_matrix_fixed<TValue, VRows, VColumns>;
+  using itkMatrixType = itk::Matrix<TValue, VRows, VColumns>;
 
   using StringVectorType = std::vector<std::string>;
 

--- a/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
+++ b/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
@@ -26,71 +26,71 @@
 
 namespace itk
 {
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::CSVNumericObjectFileWriter()
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::CSVNumericObjectFileWriter()
 {
   this->m_FieldDelimiterCharacter = ',';
   this->m_InputObject = nullptr;
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::SetInput(const vnlMatrixType * obj)
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::SetInput(const vnlMatrixType * obj)
 {
   this->m_InputObject = const_cast<TValue *>(obj->data_block());
   this->m_Rows = obj->rows();
   this->m_Columns = obj->cols();
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::SetInput(const vnlFixedMatrixType * obj)
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::SetInput(const vnlFixedMatrixType * obj)
 {
   this->m_InputObject = const_cast<TValue *>(obj->data_block());
   this->m_Rows = obj->rows();
   this->m_Columns = obj->cols();
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::SetInput(const itkMatrixType * obj)
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::SetInput(const itkMatrixType * obj)
 {
   this->m_InputObject = const_cast<TValue *>(obj->GetVnlMatrix().data_block());
   this->m_Rows = obj->RowDimensions;
   this->m_Columns = obj->ColumnDimensions;
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::ColumnHeadersPushBack(const std::string & header)
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::ColumnHeadersPushBack(const std::string & header)
 {
   this->m_ColumnHeaders.push_back(header);
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::RowHeadersPushBack(const std::string & header)
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::RowHeadersPushBack(const std::string & header)
 {
   this->m_RowHeaders.push_back(header);
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::SetColumnHeaders(const StringVectorType & columnheaders)
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::SetColumnHeaders(const StringVectorType & columnheaders)
 {
   this->m_ColumnHeaders = columnheaders;
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::SetRowHeaders(const StringVectorType & rowheaders)
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::SetRowHeaders(const StringVectorType & rowheaders)
 {
   this->m_RowHeaders = rowheaders;
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::PrepareForWriting()
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::PrepareForWriting()
 {
   // throw an exception if no filename is provided
   if (this->m_FileName.empty())
@@ -129,9 +129,9 @@ CSVNumericObjectFileWriter<TValue, NRows, NColumns>::PrepareForWriting()
   }
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::Write()
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::Write()
 {
   this->PrepareForWriting();
 
@@ -194,16 +194,16 @@ CSVNumericObjectFileWriter<TValue, NRows, NColumns>::Write()
   outputStream.close();
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::Update()
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::Update()
 {
   this->Write();
 }
 
-template <typename TValue, unsigned int NRows, unsigned int NColumns>
+template <typename TValue, unsigned int VRows, unsigned int VColumns>
 void
-CSVNumericObjectFileWriter<TValue, NRows, NColumns>::PrintSelf(std::ostream & os, Indent indent) const
+CSVNumericObjectFileWriter<TValue, VRows, VColumns>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "File name: " << this->m_FileName << std::endl;

--- a/Modules/IO/CSV/test/itkCSVNumericObjectFileWriterTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVNumericObjectFileWriterTest.cxx
@@ -166,10 +166,10 @@ itkCSVNumericObjectFileWriterTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  constexpr unsigned int NRows = 3;
-  constexpr unsigned int NCols = 3;
+  constexpr unsigned int VRows = 3;
+  constexpr unsigned int VColumns = 3;
 
-  using fixedMatrixType = itk::Matrix<double, NRows, NCols>;
+  using fixedMatrixType = itk::Matrix<double, VRows, VColumns>;
   fixedMatrixType fixedmatrix;
   fixedmatrix[0][0] = nan;
   fixedmatrix[0][1] = 1e+09;
@@ -191,7 +191,7 @@ itkCSVNumericObjectFileWriterTest(int argc, char * argv[])
   RowHeaders.emplace_back("Row2");
   RowHeaders.emplace_back("Row3");
 
-  using fixedMatrixWriterType = itk::CSVNumericObjectFileWriter<double, NRows, NCols>;
+  using fixedMatrixWriterType = itk::CSVNumericObjectFileWriter<double, VRows, VColumns>;
   auto fixed_matrix_writer = fixedMatrixWriterType::New();
 
   fixed_matrix_writer->SetFileName(filename);

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -595,11 +595,11 @@ public:
     this->SetPixelType(IOPixelEnum::VECTOR);
     this->SetComponentType(MapPixelType<TPixel>::CType);
   }
-  template <typename TCoordRep, unsigned int NPointDimension>
+  template <typename TCoordRep, unsigned int VPointDimension>
   void
-  SetPixelTypeInfo(const Point<TCoordRep, NPointDimension> *)
+  SetPixelTypeInfo(const Point<TCoordRep, VPointDimension> *)
   {
-    this->SetNumberOfComponents(NPointDimension);
+    this->SetNumberOfComponents(VPointDimension);
     this->SetPixelType(IOPixelEnum::POINT);
     this->SetComponentType(MapPixelType<TCoordRep>::CType);
   }

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -346,19 +346,19 @@ public:
     }
   }
 
-  template <typename T, unsigned int NR, unsigned int NC>
+  template <typename T, unsigned int VRows, unsigned int VColumns>
   void
-  SetPixelType(const Matrix<T, NR, NC> & itkNotUsed(dummy), bool UsePointPixel = true)
+  SetPixelType(const Matrix<T, VRows, VColumns> & itkNotUsed(dummy), bool UsePointPixel = true)
   {
     if (UsePointPixel)
     {
-      SetNumberOfPointPixelComponents(NR * NC);
+      SetNumberOfPointPixelComponents(VRows * VColumns);
       SetPointPixelComponentType(MapComponentType<T>::CType);
       SetPointPixelType(IOPixelEnum::MATRIX);
     }
     else
     {
-      SetNumberOfCellPixelComponents(NR * NC);
+      SetNumberOfCellPixelComponents(VRows * VColumns);
       SetCellPixelComponentType(MapComponentType<T>::CType);
       SetCellPixelType(IOPixelEnum::MATRIX);
     }

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.h
@@ -30,9 +30,9 @@ namespace itk
  *
  * \ingroup ITKIOSpatialObjects
  */
-template <unsigned int NDimensions = 3,
+template <unsigned int VDimension = 3,
           typename PixelType = unsigned char,
-          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, NDimensions, NDimensions>>
+          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, VDimension, VDimension>>
 class ITK_TEMPLATE_EXPORT SpatialObjectReader : public Object
 {
 public:
@@ -41,16 +41,16 @@ public:
   /** SmartPointer type alias support */
   using Self = SpatialObjectReader;
   using Pointer = SmartPointer<Self>;
-  using SpatialObjectType = SpatialObject<NDimensions>;
+  using SpatialObjectType = SpatialObject<VDimension>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
-  using GroupType = GroupSpatialObject<NDimensions>;
+  using GroupType = GroupSpatialObject<VDimension>;
   using GroupPointer = typename GroupType::Pointer;
 
   /** base type for MetaConverters -- bidirections conversion btw
    *  SpatialObject & MetaObject
    */
-  using MetaConverterBaseType = MetaConverterBase<NDimensions>;
-  using MetaSceneConverterType = MetaSceneConverter<NDimensions, PixelType, TMeshTraits>;
+  using MetaConverterBaseType = MetaConverterBase<VDimension>;
+  using MetaSceneConverterType = MetaSceneConverter<VDimension, PixelType, TMeshTraits>;
 
   /** Method for creation through the object factory */
   itkNewMacro(Self);

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.hxx
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.hxx
@@ -21,8 +21,8 @@
 
 namespace itk
 {
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-SpatialObjectReader<NDimensions, PixelType, TMeshTraits>::SpatialObjectReader()
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+SpatialObjectReader<VDimension, PixelType, TMeshTraits>::SpatialObjectReader()
 {
   m_FileName = "";
   m_SpatialObject = nullptr;
@@ -30,9 +30,9 @@ SpatialObjectReader<NDimensions, PixelType, TMeshTraits>::SpatialObjectReader()
   m_MetaToSpatialConverter = MetaSceneConverterType::New();
 }
 
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void
-SpatialObjectReader<NDimensions, PixelType, TMeshTraits>::Update()
+SpatialObjectReader<VDimension, PixelType, TMeshTraits>::Update()
 {
   m_SpatialObject = m_MetaToSpatialConverter->ReadMeta(m_FileName.c_str());
   m_Group = nullptr;
@@ -44,11 +44,11 @@ SpatialObjectReader<NDimensions, PixelType, TMeshTraits>::Update()
 }
 
 /** Add a converter for a new MetaObject/SpatialObject type */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void
-SpatialObjectReader<NDimensions, PixelType, TMeshTraits>::RegisterMetaConverter(const char * metaTypeName,
-                                                                                const char * spatialObjectTypeName,
-                                                                                MetaConverterBaseType * converter)
+SpatialObjectReader<VDimension, PixelType, TMeshTraits>::RegisterMetaConverter(const char * metaTypeName,
+                                                                               const char * spatialObjectTypeName,
+                                                                               MetaConverterBaseType * converter)
 {
   this->m_MetaToSpatialConverter->RegisterMetaConverter(metaTypeName, spatialObjectTypeName, converter);
 }

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
@@ -29,9 +29,9 @@ namespace itk
  * \brief TODO
  * \ingroup ITKIOSpatialObjects
  */
-template <unsigned int NDimensions = 3,
+template <unsigned int VDimension = 3,
           typename PixelType = unsigned char,
-          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, NDimensions, NDimensions>>
+          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, VDimension, VDimension>>
 class ITK_TEMPLATE_EXPORT SpatialObjectWriter : public Object
 {
 public:
@@ -44,16 +44,16 @@ public:
   /** Run-time type information (and related methods). */
   using Superclass = Object;
 
-  using SpatialObjectType = SpatialObject<NDimensions>;
+  using SpatialObjectType = SpatialObject<VDimension>;
   using SpatialObjectPointer = typename SpatialObjectType::Pointer;
   using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
 
   /** base type for MetaConverters -- bidirections conversion btw
    *  SpatialObject & MetaObject
    */
-  using MetaConverterBaseType = MetaConverterBase<NDimensions>;
+  using MetaConverterBaseType = MetaConverterBase<VDimension>;
 
-  using MetaSceneConverterType = MetaSceneConverter<NDimensions, PixelType, TMeshTraits>;
+  using MetaSceneConverterType = MetaSceneConverter<VDimension, PixelType, TMeshTraits>;
 
   /** Method for creation through the object factory */
   itkNewMacro(Self);

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.hxx
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.hxx
@@ -21,8 +21,8 @@
 
 namespace itk
 {
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>::SpatialObjectWriter()
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::SpatialObjectWriter()
 {
   m_FileName = "";
   m_SpatialObject = nullptr;
@@ -32,24 +32,24 @@ SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>::SpatialObjectWriter()
 }
 
 /** Set the precision at which the transform should be written */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void
-SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>::SetTransformPrecision(unsigned int precision)
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::SetTransformPrecision(unsigned int precision)
 {
   m_MetaToSpatialConverter->SetTransformPrecision(precision);
 }
 
 /** Get the precision at which the transform should be written */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 unsigned int
-SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>::GetTransformPrecision()
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::GetTransformPrecision()
 {
   return m_MetaToSpatialConverter->GetTransformPrecision();
 }
 
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void
-SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>::Update()
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::Update()
 {
   m_MetaToSpatialConverter->SetBinaryPoints(m_BinaryPoints);
   m_MetaToSpatialConverter->SetWriteImagesInSeparateFile(m_WriteImagesInSeparateFile);
@@ -62,11 +62,11 @@ SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>::Update()
 }
 
 /** Add a converter for a new MetaObject/SpatialObject type */
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
 void
-SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>::RegisterMetaConverter(const char * metaTypeName,
-                                                                                const char * spatialObjectTypeName,
-                                                                                MetaConverterBaseType * converter)
+SpatialObjectWriter<VDimension, PixelType, TMeshTraits>::RegisterMetaConverter(const char * metaTypeName,
+                                                                               const char * spatialObjectTypeName,
+                                                                               MetaConverterBaseType * converter)
 {
   this->m_MetaToSpatialConverter->RegisterMetaConverter(metaTypeName, spatialObjectTypeName, converter);
 }

--- a/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
@@ -44,9 +44,9 @@ namespace itk
  *         Brain Imaging Center, Montreal Neurological Institute, McGill University, Montreal Canada 2012
  * \ingroup ITKIOTransformMINC
  */
-template <typename TParametersValueType = double, unsigned int NInputDimensions = 3, unsigned int NOutputDimensions = 3>
+template <typename TParametersValueType = double, unsigned int VInputDimension = 3, unsigned int VOutputDimension = 3>
 class ITK_TEMPLATE_EXPORT MINCTransformAdapter
-  : public Transform<TParametersValueType, NInputDimensions, NOutputDimensions>
+  : public Transform<TParametersValueType, VInputDimension, VOutputDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MINCTransformAdapter);
@@ -54,7 +54,7 @@ public:
   /** Standard class type aliases. */
   using Self = MINCTransformAdapter;
 
-  using Superclass = Transform<TParametersValueType, NInputDimensions, NOutputDimensions>;
+  using Superclass = Transform<TParametersValueType, VInputDimension, VOutputDimension>;
 
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -68,8 +68,8 @@ public:
   itkTypeMacro(MINCTransformAdapter, Transform);
 
   /** Dimension of the domain space. */
-  static constexpr unsigned int InputSpaceDimension = NInputDimensions;
-  static constexpr unsigned int OutputSpaceDimension = NOutputDimensions;
+  static constexpr unsigned int InputSpaceDimension = VInputDimension;
+  static constexpr unsigned int OutputSpaceDimension = VOutputDimension;
 
   /** Type of the input parameters. */
   using ScalarType = double;
@@ -96,12 +96,12 @@ public:
   using OutputCovariantVectorType = CovariantVector<TParametersValueType, Self::OutputSpaceDimension>;
 
   /** Standard coordinate point type for this class */
-  using InputPointType = Point<TParametersValueType, NInputDimensions>;
-  using OutputPointType = Point<TParametersValueType, NInputDimensions>;
+  using InputPointType = Point<TParametersValueType, VInputDimension>;
+  using OutputPointType = Point<TParametersValueType, VInputDimension>;
 
   /** Standard vnl_vector type for this class. */
-  using InputVnlVectorType = vnl_vector_fixed<TParametersValueType, NInputDimensions>;
-  using OutputVnlVectorType = vnl_vector_fixed<TParametersValueType, NOutputDimensions>;
+  using InputVnlVectorType = vnl_vector_fixed<TParametersValueType, VInputDimension>;
+  using OutputVnlVectorType = vnl_vector_fixed<TParametersValueType, VOutputDimension>;
 
   /**  Method to transform a point. */
   OutputPointType
@@ -287,7 +287,7 @@ public:
 protected:
   MINCTransformAdapter()
   {
-    if (NInputDimensions != 3 || NOutputDimensions != 3)
+    if (VInputDimension != 3 || VOutputDimension != 3)
       itkExceptionMacro(<< "Sorry, only 3D to 3d minc xfm transform is currently implemented");
   }
 

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -35,11 +35,11 @@ namespace
 //
 // Private Helper functions
 //
-template <unsigned int NDimension>
+template <unsigned int VDimension>
 vnl_matrix<double> inline CalculateRotationMatrix(const vnl_symmetric_eigensystem<double> & eig)
 {
-  vnl_matrix<double> rotationMatrix(NDimension, NDimension, 0);
-  for (unsigned int i = 0; i < NDimension; ++i)
+  vnl_matrix<double> rotationMatrix(VDimension, VDimension, 0);
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     rotationMatrix.set_column(i, eig.get_eigenvector(i));
   }
@@ -53,11 +53,11 @@ vnl_matrix<double> inline CalculateRotationMatrix(const vnl_symmetric_eigensyste
   // can fix this by making one of them negative.  Make the last
   // eigenvector (with smallest eigenvalue) negative.
   float matrixDet;
-  if (NDimension == 2)
+  if (VDimension == 2)
   {
     matrixDet = vnl_det(rotationMatrix[0], rotationMatrix[1]);
   }
-  else if (NDimension == 3)
+  else if (VDimension == 3)
   {
     matrixDet = vnl_det(rotationMatrix[0], rotationMatrix[1], rotationMatrix[2]);
   }
@@ -69,7 +69,7 @@ vnl_matrix<double> inline CalculateRotationMatrix(const vnl_symmetric_eigensyste
 
   if (matrixDet < 0)
   {
-    rotationMatrix.set_column(NDimension - 1, -rotationMatrix.get_column(NDimension - 1));
+    rotationMatrix.set_column(VDimension - 1, -rotationMatrix.get_column(VDimension - 1));
   }
 
   // Transpose the matrix to yield the rotation matrix.

--- a/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
@@ -26,7 +26,7 @@
 #include "itkTestingMacros.h"
 
 // Helper function declaration.
-template <const unsigned int NDimension>
+template <const unsigned int VDimension>
 int
 LabelGeometryImageFilterTest(std::string labelImageName,
                              std::string intensityImageName,
@@ -83,7 +83,7 @@ itkLabelGeometryImageFilterTest(int argc, char * argv[])
   return EXIT_SUCCESS;
 }
 
-template <const unsigned int NDimension>
+template <const unsigned int VDimension>
 int
 LabelGeometryImageFilterTest(std::string labelImageName,
                              std::string intensityImageName,
@@ -97,8 +97,8 @@ LabelGeometryImageFilterTest(std::string labelImageName,
   using LabelPixelType = unsigned short;
   using IntensityPixelType = unsigned char;
 
-  using LabelImageType = itk::Image<LabelPixelType, NDimension>;
-  using IntensityImageType = itk::Image<IntensityPixelType, NDimension>;
+  using LabelImageType = itk::Image<LabelPixelType, VDimension>;
+  using IntensityImageType = itk::Image<IntensityPixelType, VDimension>;
 
   // Read the label image.
   using LabelReaderType = itk::ImageFileReader<LabelImageType>;
@@ -166,7 +166,7 @@ LabelGeometryImageFilterTest(std::string labelImageName,
 
     matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetCentroid(labelValue)[0];
     matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetCentroid(labelValue)[1];
-    if (NDimension == 3)
+    if (VDimension == 3)
     {
       matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetCentroid(labelValue)[2];
     }
@@ -176,7 +176,7 @@ LabelGeometryImageFilterTest(std::string labelImageName,
     }
     matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetWeightedCentroid(labelValue)[0];
     matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetWeightedCentroid(labelValue)[1];
-    if (NDimension == 3)
+    if (VDimension == 3)
     {
       matrix(rowIndex, columnIndex++) = labelGeometryFilter->GetWeightedCentroid(labelValue)[2];
     }

--- a/Modules/Nonunit/Review/test/itkRegionBasedLevelSetFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRegionBasedLevelSetFunctionTest.cxx
@@ -77,7 +77,7 @@ protected:
   ~RegionBasedLevelSetFunctionTestHelper() override = default;
 };
 
-template <unsigned int NDimension>
+template <unsigned int VDimension>
 class RegionBasedLevelSetFunctionSharedDataHelper : public DataObject
 {
 public:
@@ -94,7 +94,7 @@ public:
 
   unsigned long m_FunctionCount;
 
-  using IndexType = Index<NDimension>;
+  using IndexType = Index<VDimension>;
 
   struct SingleData
   {

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest1.cxx
@@ -73,7 +73,7 @@ protected:
   ~ScalarChanAndVeseLevelSetFunctionTestHelper() override = default;
 };
 
-template <unsigned int NDimension>
+template <unsigned int VDimension>
 class ScalarChanAndVeseLevelSetFunctionSharedDataHelper : public DataObject
 {
 public:
@@ -90,14 +90,14 @@ public:
 
   unsigned long m_FunctionCount;
 
-  using IndexType = Index<NDimension>;
+  using IndexType = Index<VDimension>;
   using ListPixelType = std::list<unsigned int>;
-  using ImageType = Image<ListPixelType, NDimension>;
+  using ImageType = Image<ListPixelType, VDimension>;
 
   typename ImageType::Pointer m_NearestNeighborListImage;
 
   using PixelType = double;
-  using InputImageType = Image<PixelType, NDimension>;
+  using InputImageType = Image<PixelType, VDimension>;
 
   struct SingleData
   {

--- a/Modules/Nonunit/Review/test/itkScalarRegionBasedLevelSetFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarRegionBasedLevelSetFunctionTest.cxx
@@ -86,7 +86,7 @@ protected:
   ~ScalarRegionBasedLevelSetFunctionTestHelper() override = default;
 };
 
-template <unsigned int NDimension>
+template <unsigned int VDimension>
 class ScalarRegionBasedLevelSetFunctionSharedDataHelper : public DataObject
 {
 public:
@@ -103,14 +103,14 @@ public:
 
   unsigned long m_FunctionCount;
 
-  using IndexType = Index<NDimension>;
+  using IndexType = Index<VDimension>;
   using ListPixelType = std::list<unsigned int>;
 
-  using ImageType = Image<ListPixelType, NDimension>;
+  using ImageType = Image<ListPixelType, VDimension>;
   typename ImageType::Pointer m_NearestNeighborListImage;
 
   using PixelType = double;
-  using InputImageType = Image<PixelType, NDimension>;
+  using InputImageType = Image<PixelType, VDimension>;
 
   struct SingleData
   {

--- a/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
@@ -25,7 +25,7 @@
 namespace StochasticFractalDimensionImageFilterTest
 {
 
-template <unsigned int NDimension>
+template <unsigned int VDimension>
 class Helper
 {
 public:
@@ -33,7 +33,7 @@ public:
   Run(int argc, char * argv[])
   {
     using PixelType = float;
-    using ImageType = itk::Image<PixelType, NDimension>;
+    using ImageType = itk::Image<PixelType, VDimension>;
 
     using ReaderType = itk::ImageFileReader<ImageType>;
     auto imageReader = ReaderType::New();

--- a/Modules/Numerics/FEM/include/itkFEMSpatialObjectReader.h
+++ b/Modules/Numerics/FEM/include/itkFEMSpatialObjectReader.h
@@ -29,16 +29,16 @@ namespace itk
  *
  * \ingroup ITKFEM
  */
-template <unsigned int NDimensions = 3,
+template <unsigned int VDimension = 3,
           typename PixelType = unsigned char,
-          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, NDimensions, NDimensions>>
-class ITK_TEMPLATE_EXPORT FEMSpatialObjectReader : public SpatialObjectReader<NDimensions, PixelType, TMeshTraits>
+          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, VDimension, VDimension>>
+class ITK_TEMPLATE_EXPORT FEMSpatialObjectReader : public SpatialObjectReader<VDimension, PixelType, TMeshTraits>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FEMSpatialObjectReader);
 
   using Self = FEMSpatialObjectReader;
-  using Superclass = SpatialObjectReader<NDimensions, PixelType, TMeshTraits>;
+  using Superclass = SpatialObjectReader<VDimension, PixelType, TMeshTraits>;
   using Pointer = SmartPointer<Self>;
 
   /** Run-time type information (and related methods). */
@@ -54,10 +54,10 @@ protected:
   ~FEMSpatialObjectReader() override = default;
 };
 
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-FEMSpatialObjectReader<NDimensions, PixelType, TMeshTraits>::FEMSpatialObjectReader()
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+FEMSpatialObjectReader<VDimension, PixelType, TMeshTraits>::FEMSpatialObjectReader()
 {
-  this->RegisterMetaConverter("FEMObject", "FEMObjectSpatialObject", MetaFEMObjectConverter<NDimensions>::New());
+  this->RegisterMetaConverter("FEMObject", "FEMObjectSpatialObject", MetaFEMObjectConverter<VDimension>::New());
 }
 
 } // namespace itk

--- a/Modules/Numerics/FEM/include/itkFEMSpatialObjectWriter.h
+++ b/Modules/Numerics/FEM/include/itkFEMSpatialObjectWriter.h
@@ -29,16 +29,16 @@ namespace itk
  *
  * \ingroup ITKFEM
  */
-template <unsigned int NDimensions = 3,
+template <unsigned int VDimension = 3,
           typename PixelType = unsigned char,
-          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, NDimensions, NDimensions>>
-class ITK_TEMPLATE_EXPORT FEMSpatialObjectWriter : public SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>
+          typename TMeshTraits = DefaultStaticMeshTraits<PixelType, VDimension, VDimension>>
+class ITK_TEMPLATE_EXPORT FEMSpatialObjectWriter : public SpatialObjectWriter<VDimension, PixelType, TMeshTraits>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FEMSpatialObjectWriter);
 
   using Self = FEMSpatialObjectWriter;
-  using Superclass = SpatialObjectWriter<NDimensions, PixelType, TMeshTraits>;
+  using Superclass = SpatialObjectWriter<VDimension, PixelType, TMeshTraits>;
   using Pointer = SmartPointer<Self>;
 
   /** Run-time type information (and related methods). */
@@ -54,10 +54,10 @@ protected:
   ~FEMSpatialObjectWriter() override = default;
 };
 
-template <unsigned int NDimensions, typename PixelType, typename TMeshTraits>
-FEMSpatialObjectWriter<NDimensions, PixelType, TMeshTraits>::FEMSpatialObjectWriter()
+template <unsigned int VDimension, typename PixelType, typename TMeshTraits>
+FEMSpatialObjectWriter<VDimension, PixelType, TMeshTraits>::FEMSpatialObjectWriter()
 {
-  this->RegisterMetaConverter("FEMObject", "FEMObjectSpatialObject", MetaFEMObjectConverter<NDimensions>::New());
+  this->RegisterMetaConverter("FEMObject", "FEMObjectSpatialObject", MetaFEMObjectConverter<VDimension>::New());
 }
 
 } // namespace itk

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
@@ -69,7 +69,7 @@ public:
   using ImageIndexType = typename InputImageType::IndexType;
 
   /** Typedefs for Output FEMObject */
-  using FEMObjectType = typename itk::fem::FEMObject<NDimensions>;
+  using FEMObjectType = typename itk::fem::FEMObject<VDimension>;
   using FEMObjectPointer = typename FEMObjectType::Pointer;
   using FEMObjectConstPointer = typename FEMObjectType::ConstPointer;
   using DataObjectPointer = typename DataObject::Pointer;
@@ -85,7 +85,7 @@ public:
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
 //  itkConceptMacro(SameDimensionOrMinusOne,
-//    (Concept::SameDimensionOrMinusOne<NDimensions, 3>));
+//    (Concept::SameDimensionOrMinusOne<VDimension, 3>));
 // End concept checking
 #endif
 

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -32,9 +32,9 @@ namespace fem
 template <typename TInputImage>
 ImageToRectilinearFEMObjectFilter<TInputImage>::ImageToRectilinearFEMObjectFilter()
 {
-  this->m_NumberOfElements.set_size(NDimensions);
+  this->m_NumberOfElements.set_size(VDimension);
   this->m_NumberOfElements.fill(0);
-  this->m_PixelsPerElement.set_size(NDimensions);
+  this->m_PixelsPerElement.set_size(VDimension);
   this->m_PixelsPerElement.fill(1);
   this->m_Material = nullptr;
   this->m_Element = nullptr;
@@ -137,7 +137,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GenerateData()
     itkWarningMacro(<< "GenerateData() found no input objects");
   }
 
-  if (NDimensions == 2)
+  if (VDimension == 2)
   {
     Generate2DRectilinearMesh();
   }

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.h
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.h
@@ -40,15 +40,15 @@ namespace itk
  * \ingroup ITKFEM
  */
 
-template <unsigned int NDimensions = 3>
-class ITK_TEMPLATE_EXPORT MetaFEMObjectConverter : public MetaConverterBase<NDimensions>
+template <unsigned int VDimension = 3>
+class ITK_TEMPLATE_EXPORT MetaFEMObjectConverter : public MetaConverterBase<VDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MetaFEMObjectConverter);
 
   /** Standard class type aliases */
   using Self = MetaFEMObjectConverter;
-  using Superclass = MetaConverterBase<NDimensions>;
+  using Superclass = MetaConverterBase<VDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
@@ -63,7 +63,7 @@ public:
   using typename Superclass::MetaObjectType;
 
   /** Specific class types for conversion */
-  using FEMObjectSpatialObjectType = FEMObjectSpatialObject<NDimensions>;
+  using FEMObjectSpatialObjectType = FEMObjectSpatialObject<VDimension>;
   using FEMObjectSpatialObjectPointer = typename FEMObjectSpatialObjectType::Pointer;
   using FEMObjectSpatialObjectConstPointer = typename FEMObjectSpatialObjectType::ConstPointer;
   using FEMObjectMetaObjectType = MetaFEMObject;

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
@@ -30,20 +30,20 @@ namespace itk
 {
 
 /** Constructor */
-template <unsigned int NDimensions>
-MetaFEMObjectConverter<NDimensions>::MetaFEMObjectConverter() = default;
+template <unsigned int VDimension>
+MetaFEMObjectConverter<VDimension>::MetaFEMObjectConverter() = default;
 
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaFEMObjectConverter<NDimensions>::CreateMetaObject() -> MetaObjectType *
+MetaFEMObjectConverter<VDimension>::CreateMetaObject() -> MetaObjectType *
 {
   return dynamic_cast<MetaObjectType *>(new FEMObjectMetaObjectType);
 }
 
 /** Convert a metaFEMObject into an FEMObject SpatialObject  */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaFEMObjectConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
+MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectType * mo) -> SpatialObjectPointer
 {
   const auto * FEMmo = dynamic_cast<const MetaFEMObject *>(mo);
   if (FEMmo == nullptr)
@@ -53,7 +53,7 @@ MetaFEMObjectConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectT
 
   FEMObjectSpatialObjectPointer FEMSO = FEMObjectSpatialObjectType::New();
 
-  using FEMObjectType = fem::FEMObject<NDimensions>;
+  using FEMObjectType = fem::FEMObject<VDimension>;
   using FEMObjectPointer = typename FEMObjectType::Pointer;
 
   FEMObjectPointer myFEMObject = FEMObjectType::New();
@@ -313,9 +313,9 @@ MetaFEMObjectConverter<NDimensions>::MetaObjectToSpatialObject(const MetaObjectT
 }
 
 /** Convert an FEMObject SpatialObject into a metaFEMObject */
-template <unsigned int NDimensions>
+template <unsigned int VDimension>
 auto
-MetaFEMObjectConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
+MetaFEMObjectConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjectType * so) -> MetaObjectType *
 {
   FEMObjectSpatialObjectConstPointer FEMSO = dynamic_cast<const FEMObjectSpatialObjectType *>(so);
   if (FEMSO.IsNull())
@@ -323,12 +323,12 @@ MetaFEMObjectConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObje
     itkExceptionMacro(<< "Can't downcast SpatialObject to FEMObjectSpatialObject");
   }
 
-  using FEMObjectType = fem::FEMObject<NDimensions>;
+  using FEMObjectType = fem::FEMObject<VDimension>;
   using FEMObjectConstPointer = typename FEMObjectType::ConstPointer;
 
   FEMObjectConstPointer curFEMObject = FEMSO->GetFEMObject();
 
-  auto * FEMmo = new MetaFEMObject(NDimensions);
+  auto * FEMmo = new MetaFEMObject(VDimension);
 
   // copy the relevant info from spatial object to femobject
 
@@ -336,12 +336,12 @@ MetaFEMObjectConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObje
   const int numSONodes = curFEMObject->GetNumberOfNodes();
   for (int i = 0; i < numSONodes; ++i)
   {
-    auto *                           Node = new FEMObjectNode(NDimensions);
+    auto *                           Node = new FEMObjectNode(VDimension);
     fem::Element::Node::ConstPointer SONode = curFEMObject->GetNode(i);
     fem::Element::VectorType         pt = SONode->GetCoordinates();
 
     Node->m_GN = SONode->GetGlobalNumber();
-    for (unsigned int j = 0; j < NDimensions; ++j)
+    for (unsigned int j = 0; j < VDimension; ++j)
     {
       Node->m_X[j] = pt[j];
     }
@@ -383,7 +383,7 @@ MetaFEMObjectConverter<NDimensions>::SpatialObjectToMetaObject(const SpatialObje
     auto *                     Element = new FEMObjectElement(numNodes);
 
     Element->m_GN = SOElement->GetGlobalNumber();
-    Element->m_Dim = NDimensions;
+    Element->m_Dim = VDimension;
     Element->m_NumNodes = numNodes;
 
     std::string element_name = SOElement->GetNameOfClass();

--- a/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
@@ -37,7 +37,7 @@ namespace itk
 namespace testhelper
 {
 
-template <typename TFixedPixelType, typename TMovingPixelType, unsigned int NDimension>
+template <typename TFixedPixelType, typename TMovingPixelType, unsigned int VDimension>
 class ImageRegistrationMethodImageSource : public itk::Object
 {
 public:
@@ -54,8 +54,8 @@ public:
   itkTypeMacro(Image, Object);
 
 
-  using MovingImageType = itk::Image<TMovingPixelType, NDimension>;
-  using FixedImageType = itk::Image<TFixedPixelType, NDimension>;
+  using MovingImageType = itk::Image<TMovingPixelType, VDimension>;
+  using FixedImageType = itk::Image<TFixedPixelType, VDimension>;
 
   const MovingImageType *
   GetMovingImage() const

--- a/Modules/Registration/Metricsv4/include/itkVectorImageToImageMetricTraitsv4.h
+++ b/Modules/Registration/Metricsv4/include/itkVectorImageToImageMetricTraitsv4.h
@@ -42,7 +42,7 @@ namespace itk
 template <typename TFixedImageType,
           typename TMovingImageType,
           typename TVirtualImageType,
-          unsigned int NumberOfComponents,
+          unsigned int VNumberOfComponents,
           typename TCoordRep = typename ObjectToObjectMetricBase::CoordinateRepresentationType>
 class VectorImageToImageMetricTraitsv4
 {
@@ -65,9 +65,9 @@ public:
   static constexpr ImageDimensionType MovingImageDimension = MovingImageType::ImageDimension;
   static constexpr ImageDimensionType VirtualImageDimension = VirtualImageType::ImageDimension;
 
-  using FixedImageGradientType = Vector<CoordinateRepresentationType, FixedImageDimension * NumberOfComponents>;
-  using MovingImageGradientType = Vector<CoordinateRepresentationType, MovingImageDimension * NumberOfComponents>;
-  using VirtualImageGradientType = Vector<CoordinateRepresentationType, VirtualImageDimension * NumberOfComponents>;
+  using FixedImageGradientType = Vector<CoordinateRepresentationType, FixedImageDimension * VNumberOfComponents>;
+  using MovingImageGradientType = Vector<CoordinateRepresentationType, MovingImageDimension * VNumberOfComponents>;
+  using VirtualImageGradientType = Vector<CoordinateRepresentationType, VirtualImageDimension * VNumberOfComponents>;
 
   using FixedImageGradientConvertType = DefaultConvertPixelTraits<FixedImageGradientType>;
   using MovingImageGradientConvertType = DefaultConvertPixelTraits<MovingImageGradientType>;

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVBasicTypeBridge.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVBasicTypeBridge.h
@@ -167,11 +167,11 @@ struct OpenCVBasicTypeBridge<itk::Size<2>, cv::Size>
   }
 };
 
-template <typename T, unsigned int NRows, unsigned int NColumns>
-struct OpenCVBasicTypeBridge<itk::Matrix<T, NRows, NColumns>, cv::Matx<T, NRows, NColumns>>
+template <typename T, unsigned int VRows, unsigned int VColumns>
+struct OpenCVBasicTypeBridge<itk::Matrix<T, VRows, VColumns>, cv::Matx<T, VRows, VColumns>>
 {
-  using ITKDataType = itk::Matrix<T, NRows, NColumns>;
-  using OpenCVDataType = cv::Matx<T, NRows, NColumns>;
+  using ITKDataType = itk::Matrix<T, VRows, VColumns>;
+  using OpenCVDataType = cv::Matx<T, VRows, VColumns>;
 
   static ITKDataType
   FromOpenCVToITK(const OpenCVDataType & iP)

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVBasicTypeBridgeTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVBasicTypeBridgeTest.cxx
@@ -169,16 +169,16 @@ Size2ConversionTest()
 int
 MatrixConversionTest()
 {
-  constexpr unsigned int NRows = 2;
-  constexpr unsigned int NColumns = 3;
-  using ITKMatrixType = itk::Matrix<double, NRows, NColumns>;
-  using CVMatrixType = cv::Matx<double, NRows, NColumns>;
+  constexpr unsigned int NumberOfRows = 2;
+  constexpr unsigned int NumberOfColumns = 3;
+  using ITKMatrixType = itk::Matrix<double, NumberOfRows, NumberOfColumns>;
+  using CVMatrixType = cv::Matx<double, NumberOfRows, NumberOfColumns>;
 
   CVMatrixType cvA;
   int          k = 1;
-  for (unsigned int i = 0; i < NRows; ++i)
+  for (unsigned int i = 0; i < NumberOfRows; ++i)
   {
-    for (unsigned int j = 0; j < NColumns; ++j)
+    for (unsigned int j = 0; j < NumberOfColumns; ++j)
     {
       cvA(i, j) = static_cast<double>(k++);
     }
@@ -188,9 +188,9 @@ MatrixConversionTest()
 
   int oResult = EXIT_SUCCESS;
 
-  for (unsigned int i = 0; i < NRows; ++i)
+  for (unsigned int i = 0; i < NumberOfRows; ++i)
   {
-    for (unsigned int j = 0; j < NColumns; ++j)
+    for (unsigned int j = 0; j < NumberOfColumns; ++j)
     {
       if (cvA(i, j) != ITKA[i][j])
       {
@@ -442,16 +442,16 @@ Size2ConversionTest()
 int
 MatrixConversionTest()
 {
-  constexpr unsigned int NRows = 2;
-  constexpr unsigned int NColumns = 3;
-  using ITKMatrixType = itk::Matrix<double, NRows, NColumns>;
-  using CVMatrixType = cv::Matx<double, NRows, NColumns>;
+  constexpr unsigned int NumberOfRows = 2;
+  constexpr unsigned int NumberOfColumns = 3;
+  using ITKMatrixType = itk::Matrix<double, NumberOfRows, NumberOfColumns>;
+  using CVMatrixType = cv::Matx<double, NumberOfRows, NumberOfColumns>;
 
   ITKMatrixType itkA;
   int           k = 1;
-  for (unsigned int i = 0; i < NRows; ++i)
+  for (unsigned int i = 0; i < NumberOfRows; ++i)
   {
-    for (unsigned int j = 0; j < NColumns; ++j)
+    for (unsigned int j = 0; j < NumberOfColumns; ++j)
     {
       itkA[i][j] = static_cast<double>(k++);
     }
@@ -461,9 +461,9 @@ MatrixConversionTest()
 
   int oResult = EXIT_SUCCESS;
 
-  for (unsigned int i = 0; i < NRows; ++i)
+  for (unsigned int i = 0; i < NumberOfRows; ++i)
   {
-    for (unsigned int j = 0; j < NColumns; ++j)
+    for (unsigned int j = 0; j < NumberOfColumns; ++j)
     {
       if (cvA(i, j) != itkA[i][j])
       {

--- a/Utilities/ITKv5Preparation/Move_DISALLOW_COPY_to_public_section.cpp
+++ b/Utilities/ITKv5Preparation/Move_DISALLOW_COPY_to_public_section.cpp
@@ -108,15 +108,15 @@ GoToFirstNonSpace(const char * ptr)
   return ptr;
 }
 
-template <unsigned int N>
+template <unsigned int VLength>
 bool
-StringStartsWithPrefix(const char *& str, const char (&prefix)[N])
+StringStartsWithPrefix(const char *& str, const char (&prefix)[VLength])
 {
-  assert(prefix[N - 1] == '\0');
-  if ((std::strlen(str) + 1 >= N) && (std::memcmp(str, prefix, N - 1) == 0))
+  assert(prefix[VLength - 1] == '\0');
+  if ((std::strlen(str) + 1 >= VLength) && (std::memcmp(str, prefix, VLength - 1) == 0))
   {
     // Move the 'str' pointer beyond the prefix.
-    str += N - 1;
+    str += VLength - 1;
     return true;
   }
   return false;

--- a/Utilities/KWStyle/ITK.kws.xml
+++ b/Utilities/KWStyle/ITK.kws.xml
@@ -14,7 +14,7 @@
 <NameOfClass>[NameOfClass],itk</NameOfClass>
 <IfNDefDefine>[NameOfClass]_[Extension]</IfNDefDefine>
 <EmptyLines>2</EmptyLines>
-<Template>([TNV]|D|unsigned int|int|bool|QMatrix|B[12]|typename|class|U|R|InputImage|Arguments|Function|vecLength|Output)</Template>
+<Template>([TV]|D|unsigned int|int|bool|QMatrix|B[12]|typename|class|U|R|InputImage|Arguments|Function|vecLength|Output)</Template>
 <Operator>1,1</Operator>
 <Header>Utilities/KWStyle/ITKHeader.h,false,true</Header>
 </Description>


### PR DESCRIPTION
Template parameters that are of `typename` have names that start with `T`, but for template parameters that are values (e.g., `unsigned int`) rather than types, both `N` and `V` have been used as a prefix for their names.  This pull request changes instances with prefix `N` to have a `V` prefix.  Additionally `NDimensions` (plural) is changed to `VDimension` (singular).

Note that class members (typically `static const(expr)` members) are sometimes named with an `N` or `V` prefix.  Perhaps neither of these prefixes is appropriate by the ITK Style Guide.  Nonetheless, these are not changed because outside code, such as ITK modules, might refer to them by their current names. 

Thanks to @N-Dekker for discovering this issue.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
