### PR TITLE
Add a type alias, `BooleanStdVectorType`, for `std::vector<uint8_t>`

### DIFF
--- a/Modules/Core/Common/include/itkBooleanStdVector.h
+++ b/Modules/Core/Common/include/itkBooleanStdVector.h
@@ -1,0 +1,41 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkBooleanStdVector_h
+#define itkBooleanStdVector_h
+
+#include "itkIntTypes.h"
+#include <vector>
+
+namespace itk
+{
+
+/** The type alias `BooleanStdVectorType` provides an alternative to `std::vector<bool>`. `std::vector<bool>` is not
+ * thread safe due to the possibility of multiple bits being packed together in the same memory location.
+ * BooleanStdVectorType does not have such a space optimization. BooleanStdVectorType is semantically like
+ * `std::vector<bool>`, but unlike `std::vector<bool>`, it does "avoid data races when the contents of the contained
+ * object in different elements in the same container [...] are modified concurrently", according to the C++ Standard,
+ * section [container.requirements.dataraces], "Container data races".
+ *
+ * \note BooleanStdVectorType is only intended to be used for the storage of Boolean values (true and false), not for
+ * arbitrary integer values.
+ */
+using BooleanStdVectorType = std::vector<uint8_t>;
+
+} // namespace itk
+
+#endif

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -605,6 +605,7 @@ endif()
 
 set(ITKCommonGTests
       itkAggregateTypesGTest.cxx
+      itkBooleanStdVectorGTest.cxx
       itkBuildInformationGTest.cxx
       itkConnectedImageNeighborhoodShapeGTest.cxx
       itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx

--- a/Modules/Core/Common/test/itkBooleanStdVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkBooleanStdVectorGTest.cxx
@@ -1,0 +1,43 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkBooleanStdVector.h"
+
+#include <type_traits>
+
+namespace
+{
+using ValueType = itk::BooleanStdVectorType::value_type;
+
+static_assert(sizeof(ValueType) <= sizeof(bool),
+              "The value type of BooleanStdVectorType should not be larger than the built-in C++ bool type.");
+static_assert(
+  ValueType{ false } == false,
+  "The value type of BooleanStdVectorType should be allowed as a conditional expression, evaluating to false.");
+static_assert(
+  ValueType{ true } == true,
+  "The value type of BooleanStdVectorType should be allowed as a conditional expression, evaluating to true.");
+static_assert(bool{ ValueType{ false } } == false,
+              "The value type of BooleanStdVectorType should support a lossless round-trip from bool value false.");
+static_assert(bool{ ValueType{ true } } == true,
+              "The value type of BooleanStdVectorType should support a lossless round-trip from bool value true.");
+static_assert(std::is_same<decltype(*itk::BooleanStdVectorType{}.data()), ValueType &>::value,
+              "BooleanStdVectorType should have a valid data() member function (unlike std::vector<bool>).");
+
+} // namespace

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h
@@ -18,6 +18,7 @@
 #ifndef itkDenseFiniteDifferenceImageFilter_h
 #define itkDenseFiniteDifferenceImageFilter_h
 
+#include "itkBooleanStdVector.h"
 #include "itkFiniteDifferenceImageFilter.h"
 #include "itkMultiThreaderBase.h"
 
@@ -173,9 +174,7 @@ private:
     TimeStepType                       TimeStep;
     std::vector<TimeStepType>          TimeStepList;
 
-    // NB: although semantically boolean, vector<bool> is not thread safe due to the possibility of multiple bits being
-    // packed together in the same memory location.
-    std::vector<uint8_t> ValidTimeStepList;
+    BooleanStdVectorType ValidTimeStepList;
   };
 
   /** This callback method uses ImageSource::SplitRequestedRegion to acquire an

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -18,6 +18,7 @@
 #ifndef itkFiniteDifferenceImageFilter_h
 #define itkFiniteDifferenceImageFilter_h
 
+#include "itkBooleanStdVector.h"
 #include "itkInPlaceImageFilter.h"
 #include "itkFiniteDifferenceFunction.h"
 
@@ -331,11 +332,11 @@ protected:
    * \param timeStepList The set of time changes compiled from all the threaded calls
    * to ThreadedGenerateData.
    * \param valid The set of flags indicating which of "timeStepList" elements are
-   *  valid. Although they are uint8_t, they should be treated like bools.
+   *  valid.
    *
    * The default is to return the minimum value in the list. */
   virtual TimeStepType
-  ResolveTimeStep(const std::vector<TimeStepType> & timeStepList, const std::vector<uint8_t> & valid) const;
+  ResolveTimeStep(const std::vector<TimeStepType> & timeStepList, const BooleanStdVectorType & valid) const;
 
   /** Set the number of elapsed iterations of the filter. */
   itkSetMacro(ElapsedIterations, IdentifierType);

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -167,7 +167,7 @@ FiniteDifferenceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRe
 template <typename TInputImage, typename TOutputImage>
 typename FiniteDifferenceImageFilter<TInputImage, TOutputImage>::TimeStepType
 FiniteDifferenceImageFilter<TInputImage, TOutputImage>::ResolveTimeStep(const std::vector<TimeStepType> & timeStepList,
-                                                                        const std::vector<uint8_t> &      valid) const
+                                                                        const BooleanStdVectorType &      valid) const
 {
   TimeStepType oMin = NumericTraits<TimeStepType>::ZeroValue();
   bool         flag = false;

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.h
@@ -18,6 +18,7 @@
 #ifndef itkFiniteDifferenceSparseImageFilter_h
 #define itkFiniteDifferenceSparseImageFilter_h
 
+#include "itkBooleanStdVector.h"
 #include "itkFiniteDifferenceSparseImageFunction.h"
 #include "itkFiniteDifferenceImageFilter.h"
 #include "itkMultiThreaderBase.h"
@@ -197,10 +198,7 @@ protected:
     FiniteDifferenceSparseImageFilter * Filter;
     TimeStepType                        TimeStep;
     std::vector<TimeStepType>           TimeStepList;
-
-    // NB: although semantically boolean, vector<bool> is not thread safe due to the possibility of multiple bits being
-    // packed together in the same memory location.
-    std::vector<uint8_t> ValidTimeStepList;
+    BooleanStdVectorType                ValidTimeStepList;
   };
 
 private:

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
@@ -241,11 +241,11 @@ protected:
    * \param timeStepList The set of time changes compiled from all the threaded calls
    * to ThreadedGenerateData.
    * \param valid The set of flags indicating which of "timeStepList" elements are
-   *  valid. Although they are uint8_t, they should be treated like bools.
+   *  valid.
    *
    * The default is to return the minimum value in the list. */
   TimeStepType
-  ResolveTimeStep(const std::vector<TimeStepType> & timeStepList, const std::vector<uint8_t> & valid) const override;
+  ResolveTimeStep(const std::vector<TimeStepType> & timeStepList, const BooleanStdVectorType & valid) const override;
 
   /** This method is called after the solution has been generated to allow
    * subclasses to apply some further processing to the output. */

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -183,7 +183,7 @@ template <typename TInputImage, typename TOutputImage, typename TParentImageFilt
 typename GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::TimeStepType
 GPUFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilter>::ResolveTimeStep(
   const std::vector<TimeStepType> & timeStepList,
-  const std::vector<uint8_t> &      valid) const
+  const BooleanStdVectorType &      valid) const
 {
   TimeStepType oMin = NumericTraits<TimeStepType>::ZeroValue();
   bool         flag = false;

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
@@ -18,6 +18,7 @@
 #ifndef itkNarrowBandImageFilterBase_h
 #define itkNarrowBandImageFilterBase_h
 
+#include "itkBooleanStdVector.h"
 #include "itkFiniteDifferenceImageFilter.h"
 #include "itkMultiThreaderBase.h"
 #include "itkNarrowBand.h"
@@ -292,9 +293,7 @@ protected:
 
   bool m_Touched;
 
-  // NB: although semantically boolean, vector<bool> is not thread safe due to the possibility of multiple bits being
-  // packed together in the same memory location.
-  std::vector<uint8_t> m_TouchedForThread;
+  BooleanStdVectorType m_TouchedForThread;
 
   ValueType m_IsoSurfaceValue;
 

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
@@ -86,7 +86,7 @@ NarrowBandImageFilterBase<TInputImage, TOutputImage>::GenerateData()
 
   TimeStepType              timeStep;
   std::vector<TimeStepType> timeStepList(numberOfWorkUnits, NumericTraits<TimeStepType>::ZeroValue());
-  std::vector<uint8_t>      validTimeStepList(numberOfWorkUnits, true);
+  BooleanStdVectorType      validTimeStepList(numberOfWorkUnits, true);
 
   // Implement iterative loop in thread function
   // ThreadedApplyUpdate and ThreadedCalculateChanged

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
@@ -19,6 +19,7 @@
 #define itkQuasiNewtonOptimizerv4_h
 
 #include "itkArray2D.h"
+#include "itkBooleanStdVector.h"
 #include "itkGradientDescentOptimizerv4.h"
 
 #include "vnl/algo/vnl_matrix_inverse.h"
@@ -152,10 +153,8 @@ protected:
   HessianArrayType m_HessianArray;
 
   /** Valid flag for the Quasi-Newton steps.
-   * NB: although semantically boolean, vector<bool> is not thread safe due to the possibility of multiple bits being
-   * packed together in the same memory location.
    */
-  std::vector<uint8_t> m_NewtonStepValidFlags;
+  BooleanStdVectorType m_NewtonStepValidFlags;
 
   /** Estimate a Newton step */
   virtual void

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -18,6 +18,7 @@
 #ifndef itkParallelSparseFieldLevelSetImageFilter_h
 #define itkParallelSparseFieldLevelSetImageFilter_h
 
+#include "itkBooleanStdVector.h"
 #include "itkFiniteDifferenceImageFilter.h"
 #include "itkSparseFieldLayer.h"
 #include "itkObjectStore.h"
@@ -712,10 +713,8 @@ protected:
 
   /** Thread-specific data */
   std::vector<TimeStepType> m_TimeStepList;
-  // NB: although semantically boolean, vector<bool> is not thread safe due to the possibility of multiple bits being
-  // packed together in the same memory location.
-  std::vector<uint8_t> m_ValidTimeStepList;
-  TimeStepType         m_TimeStep;
+  BooleanStdVectorType      m_ValidTimeStepList;
+  TimeStepType              m_TimeStep;
 
   /** The number of work units to use. */
   ThreadIdType m_NumOfWorkUnits{ 0 };


### PR DESCRIPTION
Follow-up to pull request #3166 commit 915b8e48d8ff7d9f5b943eb673826ad85bf74a8c "BUG: fixed threading bug, don't use vector<bool> from multiple threads", by Sean McBride (@seanm) (merged on 8 February 2022).
