### PR TITLE
COMP: C++20 ambiguous overloaded operator

### DIFF
--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -205,13 +205,14 @@ itkWarpImageFilterTest(int, char *[])
   warper->SetOutputSpacing(array.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(array, warper->GetOutputSpacing());
 
-  array.Fill(-10.0);
-  warper->SetOutputOrigin(array.GetDataPointer());
-  ITK_TEST_SET_GET_VALUE(array, warper->GetOutputOrigin());
+  WarperType::PointType ptarray;
+  ptarray.Fill(-10.0);
+  warper->SetOutputOrigin(ptarray.GetDataPointer());
+  ITK_TEST_SET_GET_VALUE(ptarray, warper->GetOutputOrigin());
 
-  array.Fill(0.0);
-  warper->SetOutputOrigin(array.GetDataPointer());
-  ITK_TEST_SET_GET_VALUE(array, warper->GetOutputOrigin());
+  ptarray.Fill(0.0);
+  warper->SetOutputOrigin(ptarray.GetDataPointer());
+  ITK_TEST_SET_GET_VALUE(ptarray, warper->GetOutputOrigin());
 
   typename WarperType::DirectionType outputDirection;
   outputDirection.SetIdentity();

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -197,13 +197,14 @@ itkWarpVectorImageFilterTest(int, char *[])
   warper->SetOutputSpacing(array.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(array, warper->GetOutputSpacing());
 
-  array.Fill(-10.0);
-  warper->SetOutputOrigin(array.GetDataPointer());
-  ITK_TEST_SET_GET_VALUE(array, warper->GetOutputOrigin());
+  WarperType::PointType ptarray;
+  ptarray.Fill(-10.0);
+  warper->SetOutputOrigin(ptarray.GetDataPointer());
+  ITK_TEST_SET_GET_VALUE(ptarray, warper->GetOutputOrigin());
 
-  array.Fill(0.0);
-  warper->SetOutputOrigin(array.GetDataPointer());
-  ITK_TEST_SET_GET_VALUE(array, warper->GetOutputOrigin());
+  ptarray.Fill(0.0);
+  warper->SetOutputOrigin(ptarray.GetDataPointer());
+  ITK_TEST_SET_GET_VALUE(ptarray, warper->GetOutputOrigin());
 
   typename WarperType::DirectionType outputDirection;
   outputDirection.SetIdentity();


### PR DESCRIPTION
The != operator was ambiguously overloaded with C++20
CMAKE_CXX_STANDARD:STRING=20 build.

Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx:214:3: error: use of overloaded operator '!=' is ambiguous (with operand types 'itk::FixedArray<double, ImageDimension>' and 'const itk::WarpImageFilter<itk::Image<float, 2>, itk::Image<float, 2>, itk::Image<itk::Vector<float, 2>, 2> >::PointType' (aka 'const Point<double, Self::ImageDimension>'))
  ITK_TEST_SET_GET_VALUE(array, warper->GetOutputOrigin());
  ^                      ~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~
Modules/Core/TestKernel/include/itkTestingMacros.h:226:44: note: expanded from macro 'ITK_TEST_SET_GET_VALUE'
  CLANG_SUPPRESS_Wfloat_equal if (variable != command) CLANG_PRAGMA_POP \
                                  ~~~~~~~~ ^  ~~~~~~~
Modules/Core/Common/include/itkFixedArray.h:253:3: note: candidate function
  ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(FixedArray);
  ^
Modules/Core/Common/include/itkMacro.h:440:10: note: expanded from macro 'ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION'
    bool operator!=(const TypeName & other) const { return !(this->operator==(other)); } \
         ^
Modules/Core/Common/include/itkFixedArray.h:251:3: note: candidate function
  operator==(const FixedArray & r) const;
  ^
Modules/Core/Common/include/itkPoint.h:127:3: note: candidate function (with reversed parameter order)
  operator==(const Self & pt) const
  ^

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
