### PR TITLE
BUG: Limits, spacing, and direction in ComputeJacobianWithRespectToPosition

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -303,7 +303,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
       //      ( lpix - rpix )*space/(2.0*h); //2nd order centered difference
       for (unsigned int col = 0; col < NDimensions; ++col)
       {
-        TParametersValueType val = dPix[col] / spacing[col];
+        TParametersValueType val = dPix[col] / spacing[row];
         if (row == col)
         {
           val += 1.0;

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -224,6 +224,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
 {
 
   typename DisplacementFieldType::SizeType    size = this->m_DisplacementField->GetLargestPossibleRegion().GetSize();
+  typename DisplacementFieldType::IndexType   startingIndex = this->m_DisplacementField->GetLargestPossibleRegion().GetIndex();
   typename DisplacementFieldType::SpacingType spacing = this->m_DisplacementField->GetSpacing();
 
   IndexType ddrindex;
@@ -237,7 +238,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   TParametersValueType space = NumericTraits<TParametersValueType>::OneValue();
 
   // Minimum distance between neighbors
-  TParametersValueType mindist = NumericTraits<TParametersValueType>::OneValue();
+  IndexValueType mindist = NumericTraits<IndexValueType>::OneValue();
 
   // Flag indicating a valid location for Jacobian calculation
   bool isValidJacobianCalcLocat = true;
@@ -247,12 +248,12 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   dPixSign = doInverseJacobian ? -dPixSign : dPixSign;
   for (unsigned int row = 0; row < NDimensions; ++row)
   {
-    TParametersValueType dist = itk::Math::abs((float)index[row]);
+    IndexValueType dist = index[row] - startingIndex[row];
     if (dist < mindist)
     {
       isValidJacobianCalcLocat = false;
     }
-    dist = itk::Math::abs((TParametersValueType)size[row] - (TParametersValueType)index[row]);
+    dist = static_cast<IndexValueType>(size[row]) - dist;
     if (dist < mindist)
     {
       isValidJacobianCalcLocat = false;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -299,6 +299,14 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   anisotropicSpacing[1] = 0.8;
   field->SetSpacing(anisotropicSpacing);
 
+  /* and non-trivial image grid orientation */
+  FieldType::DirectionType gridDirection;
+  gridDirection(0, 0) = 3./5;
+  gridDirection(0, 1) = 4./5;
+  gridDirection(1, 0) = -4./5;
+  gridDirection(1, 1) = 3./5;
+  field->SetDirection(gridDirection);
+
   itk::ImageRegionIteratorWithIndex<FieldType> it(field, field->GetLargestPossibleRegion());
   it.GoToBegin();
 
@@ -319,8 +327,10 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(field, displacementTransform->GetDisplacementField());
 
   DisplacementTransformType::InputPointType testPoint;
-  testPoint[0] = 10;
-  testPoint[1] = 8;
+  testPoint[0] = 12;
+  testPoint[1] = 4;
+  /* With the anisotropicSpacing and gridDirection set above
+   * this point corresponds exactly to index = { 4, 15 }. */
 
   // Test LocalJacobian methods
   DisplacementTransformType::JacobianPositionType jacobian;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -293,6 +293,12 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   fieldJTruth(0, 1) = 0.02;
   fieldJTruth(1, 1) = 1.1;
 
+  /* Test the correctness of the Jacobian computation with anisotropic spacing */
+  FieldType::SpacingType anisotropicSpacing;
+  anisotropicSpacing[0] = 1.0;
+  anisotropicSpacing[1] = 0.8;
+  field->SetSpacing(anisotropicSpacing);
+
   itk::ImageRegionIteratorWithIndex<FieldType> it(field, field->GetLargestPossibleRegion());
   it.GoToBegin();
 


### PR DESCRIPTION
In the previous version, the limits, spacing, and direction of the displacement field were incorrectly managed. This pull amends all of them, providing the correct behaviour.

The test itkDisplacementFieldTransformTest has been modified to include anisotropic spacing and non-trivial grid direction. The test is not passed by the previous version.