### PR TITLE
BUG: Limits, spacing, and direction in ComputeJacobianWithRespectToPosition

### DIFF
--- a/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
@@ -60,11 +60,19 @@ public:
   /** Enum of for spline order. */
   static constexpr unsigned int SplineOrder = VSplineOrder;
 
+  /** Evaluate the function. Faster than the `Evaluate` member function, because it is static (while `Evaluate` is
+   * virtual). */
+  static TRealValueType
+  FastEvaluate(const TRealValueType u)
+  {
+    return Self::Evaluate(Dispatch<VSplineOrder>(), u);
+  }
+
   /** Evaluate the function. */
   TRealValueType
   Evaluate(const TRealValueType & u) const override
   {
-    return this->Evaluate(Dispatch<VSplineOrder>(), u);
+    return Self::FastEvaluate(u);
   }
 
 protected:
@@ -87,15 +95,15 @@ private:
   {};
 
   /** Evaluate the function:  zeroth order spline. */
-  inline TRealValueType
-  Evaluate(const Dispatch<0> &, const TRealValueType & itkNotUsed(u)) const
+  inline static TRealValueType
+  Evaluate(const Dispatch<0> &, const TRealValueType & itkNotUsed(u))
   {
     return NumericTraits<TRealValueType>::ZeroValue();
   }
 
   /** Evaluate the function:  first order spline */
-  inline TRealValueType
-  Evaluate(const Dispatch<1> &, const TRealValueType & u) const
+  inline static TRealValueType
+  Evaluate(const Dispatch<1> &, const TRealValueType & u)
   {
     if (Math::ExactlyEquals(u, -NumericTraits<TRealValueType>::OneValue()))
     {
@@ -124,8 +132,8 @@ private:
   }
 
   /** Evaluate the function:  second order spline. */
-  inline TRealValueType
-  Evaluate(const Dispatch<2> &, const TRealValueType & u) const
+  inline static TRealValueType
+  Evaluate(const Dispatch<2> &, const TRealValueType & u)
   {
     if ((u > static_cast<TRealValueType>(-0.5)) && (u < static_cast<TRealValueType>(0.5)))
     {
@@ -146,8 +154,8 @@ private:
   }
 
   /** Evaluate the function:  third order spline. */
-  inline TRealValueType
-  Evaluate(const Dispatch<3> &, const TRealValueType & u) const
+  inline static TRealValueType
+  Evaluate(const Dispatch<3> &, const TRealValueType & u)
   {
     if ((u >= NumericTraits<TRealValueType>::ZeroValue()) && (u < NumericTraits<TRealValueType>::OneValue()))
     {
@@ -174,10 +182,10 @@ private:
   }
 
   /** Evaluate the function:  unimplemented spline order */
-  inline TRealValueType
-  Evaluate(const DispatchBase &, const TRealValueType &) const
+  inline static TRealValueType
+  Evaluate(const DispatchBase &, const TRealValueType &)
   {
-    itkExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
+    itkGenericExceptionMacro("Evaluate not implemented for spline order " << SplineOrder);
   }
 };
 } // end namespace itk

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -22,6 +22,7 @@
 #include "itkContinuousIndex.h"
 #include "itkArray.h"
 #include "itkArray2D.h"
+#include "itkMatrix.h"
 #include "itkMath.h"
 
 namespace itk
@@ -74,6 +75,9 @@ public:
   /** OutputType type alias support. */
   using WeightsType = typename Superclass::OutputType;
 
+  /** Weights for derivatives type alias support. */
+  using DerivativeWeightsType = Matrix<double, VSpaceDimension, Math::UnsignedPower(VSplineOrder + 1, VSpaceDimension)>;
+
   /** Number of weights. */
   static constexpr unsigned int NumberOfWeights{ WeightsType::Length };
 
@@ -102,6 +106,17 @@ public:
    */
   virtual void
   Evaluate(const ContinuousIndexType & index, WeightsType & weights, IndexType & startIndex) const;
+
+  /** Evaluate the weights for the derivatives with respect to the ContinuousIndex position
+   * (normalized position coordinates) and at specified ContinuousIndex position.  */
+  DerivativeWeightsType
+  EvaluateDerivatives(const ContinuousIndexType & index) const;
+
+  /** Compute the index with lower value in all dimensions in the support of the BSpline control points
+   * influencing the point indicated by a continuous index. */
+  static IndexType
+  StartIndex(const ContinuousIndexType & index);
+
 
 #if !defined(ITK_LEGACY_REMOVE)
   /** Get support region size. */

--- a/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
+++ b/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
@@ -303,6 +303,11 @@ public:
   {
     return VRows * VCols;
   }
+  static unsigned int
+  GetNumberOfComponents(const TargetType pixel)
+  {
+    return VRows * VCols;
+  }
   static void
   SetNthComponent(int i, TargetType & pixel, const ComponentType & v)
   {

--- a/Modules/Core/Common/include/itkNumericTraitsMatrixPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsMatrixPixel.h
@@ -1,0 +1,311 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkNumericTraitsMatrixPixel_h
+#define itkNumericTraitsMatrixPixel_h
+
+#include "itkNumericTraits.h"
+#include "itkMatrix.h"
+
+namespace itk
+{
+/** \brief NumericTraits for Matrix
+ * \tparam T Component type for Matrix
+ * \tparam Nrows Number of rows for the Matrix
+ * \tparam Ncols Number of columns for the Matrix
+ */
+template <typename T, unsigned int Nrows, unsigned int Ncols>
+class NumericTraits<Matrix<T, Nrows, Ncols>>
+{
+private:
+  using ElementAbsType = typename NumericTraits<T>::AbsType;
+  using ElementAccumulateType = typename NumericTraits<T>::AccumulateType;
+  using ElementFloatType = typename NumericTraits<T>::FloatType;
+  using ElementPrintType = typename NumericTraits<T>::PrintType;
+  using ElementRealType = typename NumericTraits<T>::RealType;
+
+public:
+  /** Return the type of the native component type. */
+  using ValueType = T;
+  using Self = Matrix<T, Nrows, Ncols>;
+
+  /** Unsigned component type */
+  using AbsType = Matrix<ElementAbsType, Nrows, Ncols>;
+
+  /** Accumulation of addition and multiplication. */
+  using AccumulateType = Matrix<ElementAccumulateType, Nrows, Ncols>;
+
+  /** Typedef for operations that use floating point instead of real precision
+   */
+  using FloatType = Matrix<ElementFloatType, Nrows, Ncols>;
+
+  /** Return the type that can be printed. */
+  using PrintType = Matrix<ElementPrintType, Nrows, Ncols>;
+
+  /** Type for real-valued scalar operations. */
+  using RealType = Matrix<ElementRealType, Nrows, Ncols>;
+
+  /** Type for real-valued scalar operations. */
+  using ScalarRealType = ElementRealType;
+
+  /** Measurement Matrix type */
+  using MeasurementMatrixType = Self;
+
+  static constexpr unsigned int NumRows = Nrows;
+  static constexpr unsigned int NumColumns = Ncols;
+
+  /** Component wise defined element
+   *
+   * \note minimum value for floating pointer types is defined as
+   * minimum positive normalize value.
+   */
+  static const Self
+  max(const Self &)
+  {
+    Self m;
+    m.Fill(NumericTraits<T>::max());
+    return m;
+  }
+
+  static const Self
+  min(const Self &)
+  {
+    Self m;
+    m.Fill(NumericTraits<T>::min());
+    return m;
+  }
+
+  static const Self
+  max()
+  {
+    Self m;
+    m.Fill(NumericTraits<T>::max());
+    return m;
+  }
+
+  static const Self
+  min()
+  {
+    Self m;
+    m.Fill(NumericTraits<T>::min());
+    return m;
+  }
+
+  static const Self
+  NonpositiveMin()
+  {
+    Self m;
+    m.Fill(NumericTraits<T>::NonpositiveMin());
+    return m;
+  }
+
+  static const Self
+  ZeroValue()
+  {
+    Self m;
+    m.Fill(NumericTraits<T>::ZeroValue());
+    return m;
+  }
+
+  static const Self
+  OneValue()
+  {
+    Self m;
+    m.Fill(NumericTraits<T>::OneValue());
+    return m;
+  }
+
+  static const Self
+  NonpositiveMin(const Self &)
+  {
+    return NonpositiveMin();
+  }
+
+  static const Self
+  ZeroValue(const Self &)
+  {
+    return ZeroValue();
+  }
+
+  static const Self
+  OneValue(const Self &)
+  {
+    return OneValue();
+  }
+
+  static bool
+  IsPositive(const Self & a)
+  {
+    bool flag = false;
+    for (unsigned int i = 0; i < a.NumRows; ++i)
+    {
+      for (unsigned int j = 0; j < a.NumColumns; ++j)
+      {
+        if (a[i][j] > NumericTraits<ValueType>::ZeroValue())
+        {
+          flag = true;
+        }
+      }
+    }
+    return flag;
+  }
+
+  static bool
+  IsNonpositive(const Self & a)
+  {
+    bool flag = false;
+    for (unsigned int i = 0; i < a.NumRows; ++i)
+    {
+      for (unsigned int j = 0; j < a.NumColumns; ++j)
+      {
+        if (!(a[i][j] > 0.0))
+        {
+          flag = true;
+        }
+      }
+    }
+    return flag;
+  }
+
+  static bool
+  IsNegative(const Self & a)
+  {
+    bool flag = false;
+    for (unsigned int i = 0; i < a.NumRows; ++i)
+    {
+      for (unsigned int j = 0; j < a.NumColumns; ++j)
+      {
+        if (a[i][j] < 0.0)
+        {
+          flag = true;
+        }
+      }
+    }
+    return flag;
+  }
+
+  static bool
+  IsNonnegative(const Self & a)
+  {
+    bool flag = false;
+    for (unsigned int i = 0; i < a.NumRows; ++i)
+    {
+      for (unsigned int j = 0; j < a.NumColumns; ++j)
+      {
+        if (!(a[i][j] < 0.0))
+        {
+          flag = true;
+        }
+      }
+    }
+    return flag;
+  }
+
+  static constexpr bool IsSigned = NumericTraits<ValueType>::IsSigned;
+  static constexpr bool IsInteger = NumericTraits<ValueType>::IsInteger;
+  static constexpr bool IsComplex = NumericTraits<ValueType>::IsComplex;
+
+  /** Fixed length Matrixs cannot be resized, so an exception will
+   *  be thrown if the input size is not valid.  If the size is valid
+   *  the Matrix will be filled with zeros. */
+  static void
+  SetLength(Matrix<T, Ncols, Nrows> & m, const unsigned int s)
+  {
+    if (s != Ncols * Nrows)
+    {
+      itkGenericExceptionMacro(<< "Cannot set the size of a Matrix of type " << Ncols << "x" << Nrows << " to " << s);
+    }
+    m.Fill(NumericTraits<T>::ZeroValue());
+  }
+
+  /** Return the size of the Matrix. */
+  static unsigned int
+  GetLength(const Matrix<T, Nrows, Ncols> &)
+  {
+    return Nrows * Ncols;
+  }
+
+  /** Return the size of the Matrix. */
+  static unsigned int
+  GetLength()
+  {
+    return Nrows * Ncols;
+  }
+
+  static void
+  AssignToArray(const Self & v, MeasurementMatrixType & mv)
+  {
+    mv = v;
+  }
+
+  template <typename TArray>
+  static void
+  AssignToArray(const Self & v, TArray & mv)
+  {
+    for (unsigned int i = 0, ij = 0; i < Nrows; ++i)
+    {
+      for (unsigned int j = 0; j < Ncols; ++j, ++ij)
+      {
+        mv[ij] = v[i][j];
+      }
+    }
+  }
+
+  /** \note: the functions are preferred over the member variables as
+   * they are defined for all partial specialization
+   */
+  static const Self ITKCommon_EXPORT Zero;
+  static const Self ITKCommon_EXPORT One;
+};
+
+// a macro to define and initialize static member variables,
+// NOTE: (T)(NumericTraits< T >::[Zero|One]) is needed to generate
+//       a temporary variable that is initialized from the
+//       constexpr [Zero|One] to be passed by const reference
+//       to the GENERIC_MATRIX<T,Nrows,Ncols> constructor.
+#define itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, Nrows, Ncols)                                      \
+  template <>                                                                                                          \
+  ITKCommon_EXPORT const GENERIC_MATRIX<T, Nrows, Ncols> NumericTraits<GENERIC_MATRIX<T, Nrows, Ncols>>::Zero =        \
+    GENERIC_MATRIX<T, Nrows, Ncols>((T)(NumericTraits<T>::Zero));                                                      \
+  template <>                                                                                                          \
+  ITKCommon_EXPORT const GENERIC_MATRIX<T, D> NumericTraits<GENERIC_MATRIX<T, D>>::One =                               \
+    GENERIC_MATRIX<T, D>((T)(NumericTraits<T>::One));
+
+//
+// List here the matrix dimension specializations of these static
+// Traits:
+//
+#define itkStaticNumericTraitsGenericMatrixDimensionsMacro(GENERIC_MATRIX, T)                                          \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 1, 1);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 1, 2);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 1, 3);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 1, 4);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 2, 1);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 2, 2);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 2, 3);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 2, 4);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 3, 1);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 3, 2);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 3, 3);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 3, 4);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 4, 1);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 4, 2);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 4, 3);                                                   \
+  itkStaticNumericTraitsGenericMatrixMacro(GENERIC_MATRIX, T, 4, 4);
+} // end namespace itk
+
+#endif // itkNumericTraitsMatrixPixel_h

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -353,5 +353,7 @@ MakeVector(const TValue firstValue, const TVariadic... otherValues)
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkVector.hxx"
 #endif
+#include "itkNumericTraitsVectorPixel.h"
+
 
 #endif

--- a/Modules/Core/Common/src/itkNumericTraitsMatrixPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsMatrixPixel.cxx
@@ -1,0 +1,36 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkNumericTraitsMatrixPixel.h"
+
+namespace itk
+{
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, char);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, unsigned char);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, signed char);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, short);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, unsigned short);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, int);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, unsigned int);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, long);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, unsigned long);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, float);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, double);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, long double);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, long long);
+itkStaticNumericTraitsGenericMatrixDimensionsMacro(Matrix, unsigned long long);
+} // end namespace itk

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -232,6 +232,7 @@ public:
   using WeightsFunctionType = BSplineInterpolationWeightFunction<ScalarType, Self::SpaceDimension, Self::SplineOrder>;
 
   using WeightsType = typename WeightsFunctionType::WeightsType;
+  using DerivativeWeightsType = typename WeightsFunctionType::DerivativeWeightsType;
   using ContinuousIndexType = typename WeightsFunctionType::ContinuousIndexType;
 
   /** Number of weights. */
@@ -294,15 +295,6 @@ public:
 
   void
   ComputeJacobianWithRespectToParameters(const InputPointType &, JacobianType &) const override = 0;
-
-  void
-  ComputeJacobianWithRespectToPosition(const InputPointType &, JacobianPositionType &) const override
-  {
-    itkExceptionMacro(<< "ComputeJacobianWithRespectToPosition not yet implemented "
-                         "for "
-                      << this->GetNameOfClass());
-  }
-  using Superclass::ComputeJacobianWithRespectToPosition;
 
   /** Return the number of parameters that completely define the Transfom */
   NumberOfParametersType

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -260,6 +260,15 @@ public:
   void
   ComputeJacobianWithRespectToParameters(const InputPointType &, JacobianType &) const override;
 
+  void
+  ComputeJacobianWithRespectToPosition(const InputPointType &, JacobianPositionType &) const override
+  {
+    itkExceptionMacro(<< "ComputeJacobianWithRespectToPosition not yet implemented "
+                         "for "
+                      << this->GetNameOfClass());
+  }
+  using Superclass::ComputeJacobianWithRespectToPosition;
+
   /** Return the number of parameters that completely define the Transfom */
   NumberOfParametersType
   GetNumberOfParameters() const override;

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -218,6 +218,7 @@ public:
   using WeightsFunctionType = typename Superclass::WeightsFunctionType;
 
   using WeightsType = typename Superclass::WeightsType;
+  using DerivativeWeightsType = typename Superclass::DerivativeWeightsType;
   using ContinuousIndexType = typename Superclass::ContinuousIndexType;
 
   /** Parameter index array type. */
@@ -242,6 +243,10 @@ public:
   /** Compute the Jacobian in one position. */
   void
   ComputeJacobianWithRespectToParameters(const InputPointType &, JacobianType &) const override;
+
+  void
+  ComputeJacobianWithRespectToPosition(const InputPointType &, JacobianPositionType &) const override;
+  using Superclass::ComputeJacobianWithRespectToPosition;
 
   /** Return the number of parameters that completely define the Transfom. */
   NumberOfParametersType

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -517,12 +517,12 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoin
                                                                                   bool & inside) const
 {
   inside = true;
+  outputPoint = point;
 
   if (this->m_CoefficientImages[0]->GetBufferPointer())
   {
     ContinuousIndexType index;
     this->m_CoefficientImages[0]->TransformPhysicalPointToContinuousIndex(point, index);
-    outputPoint = point;
 
     // NOTE: if the support region does not lie totally within the grid
     // we assume zero displacement and return the input point

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -522,13 +522,13 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoin
   {
     ContinuousIndexType index;
     this->m_CoefficientImages[0]->TransformPhysicalPointToContinuousIndex(point, index);
+    outputPoint = point;
 
     // NOTE: if the support region does not lie totally within the grid
     // we assume zero displacement and return the input point
     inside = this->InsideValidRegion(index);
     if (!inside)
     {
-      outputPoint = point;
       return;
     }
 
@@ -542,8 +542,6 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoin
     RegionType supportRegion;
     supportRegion.SetSize(supportSize);
     supportRegion.SetIndex(supportIndex);
-
-    outputPoint.Fill(NumericTraits<ScalarType>::ZeroValue());
 
     using IteratorType = ImageScanlineConstIterator<ImageType>;
     IteratorType                coeffIterator[SpaceDimension];
@@ -580,20 +578,10 @@ BSplineTransform<TParametersValueType, NDimensions, VSplineOrder>::TransformPoin
         coeffIterator[j].NextLine();
       }
     }
-
-    // Return results
-    for (unsigned int j = 0; j < SpaceDimension; ++j)
-    {
-      outputPoint[j] += point[j];
-    }
   }
   else
   {
     itkWarningMacro("B-spline coefficients have not been set");
-    for (unsigned int j = 0; j < SpaceDimension; ++j)
-    {
-      outputPoint[j] = point[j];
-    }
   }
 }
 

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -197,6 +197,11 @@ public:
   using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
   using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
+  using InverseTransformType = MatrixOffsetTransformBase<TParametersValueType, NOutputDimensions, NInputDimensions>;
+  /** InverseTransformType must be a friend to allow the generation of a transformation
+   * from its inverse (function GetInverse). */
+  friend class MatrixOffsetTransformBase<TParametersValueType, NOutputDimensions, NInputDimensions>;
+
   /** Set the transformation to an Identity
    *
    * This sets the matrix to identity and the Offset to null. */
@@ -471,7 +476,7 @@ public:
    *
    */
   bool
-  GetInverse(Self * inverse) const;
+  GetInverse(InverseTransformType * inverse) const;
 
   /** Return an inverse of this transform. */
   InverseTransformBasePointer

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -416,7 +416,8 @@ MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensi
 
 template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
 bool
-MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverse(Self * inverse) const
+MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverse(
+  InverseTransformType * inverse) const
 {
   if (!inverse)
   {
@@ -445,7 +446,7 @@ typename MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutp
   InverseTransformBasePointer
   MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::GetInverseTransform() const
 {
-  Pointer inv = New();
+  typename InverseTransformType::Pointer inv = InverseTransformType::New();
 
   return GetInverse(inv) ? inv.GetPointer() : nullptr;
 }

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -602,7 +602,7 @@ void
 MatrixOffsetTransformBase<TParametersValueType, NInputDimensions, NOutputDimensions>::
   ComputeInverseJacobianWithRespectToPosition(const InputPointType &, InverseJacobianPositionType & jac) const
 {
-  jac = this->GetMatrix().GetVnlMatrix();
+  jac = this->GetInverseMatrix().GetVnlMatrix();
 }
 
 

--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -599,7 +599,7 @@ itkAffineTransformTest(int, char *[])
     }
   }
 
-  /* Test ComputeInverseJacobianWithRespectToPosition. Should return the inverse Matrix. */
+  /* Test ComputeInverseJacobianWithRespectToPosition. Should return Matrix. */
   Matrix3Type matrix3invTruth;
   matrix3invTruth[0][0] = -8. / 3.;
   matrix3invTruth[0][1] = 8. / 3.;

--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -24,6 +24,7 @@
 
 using Matrix2Type = itk::Matrix<double, 2, 2>;
 using Vector2Type = itk::Vector<double, 2>;
+using Matrix3Type = itk::Matrix<double, 3, 3>;
 
 namespace
 {
@@ -126,7 +127,7 @@ itkAffineTransformTest(int, char *[])
 
   /* Create a 2D identity transformation and show its parameters */
   using Affine2DType = itk::AffineTransform<double, 2>;
-  Affine2DType::Pointer id2 = Affine2DType::New();
+  auto id2 = Affine2DType::New();
   matrix2 = id2->GetMatrix();
   vector2 = id2->GetOffset();
   std::cout << "Matrix from instantiating an identity transform:" << std::endl << matrix2;
@@ -155,7 +156,7 @@ itkAffineTransformTest(int, char *[])
   vector2[0] = 5;
   vector2[1] = 6;
 
-  Affine2DType::Pointer aff2 = Affine2DType::New();
+  auto aff2 = Affine2DType::New();
   aff2->SetMatrix(matrix2);
   aff2->SetOffset(vector2);
   for (unsigned int i = 0; i < 2; ++i)
@@ -170,7 +171,7 @@ itkAffineTransformTest(int, char *[])
   aff2->Print(std::cout);
 
   /* Get and test inverse of whole transform */
-  Affine2DType::Pointer affInv2 = Affine2DType::New();
+  auto affInv2 = Affine2DType::New();
   if (!aff2->GetInverse(affInv2))
   {
     std::cout << "Test transform does not have an inverse when expected." << std::endl;
@@ -475,7 +476,7 @@ itkAffineTransformTest(int, char *[])
   Affine3DType::MatrixType matrix3Truth;
 
   /* Create a 3D transform and rotate in 3D */
-  Affine3DType::Pointer  aff3 = Affine3DType::New();
+  auto                   aff3 = Affine3DType::New();
   itk::Vector<double, 3> axis;
   axis[0] = .707;
   axis[1] = .707;
@@ -501,7 +502,7 @@ itkAffineTransformTest(int, char *[])
   }
 
   /* Generate inverse transform */
-  Affine3DType::Pointer inv3 = Affine3DType::New();
+  auto inv3 = Affine3DType::New();
   if (!aff3->GetInverse(inv3))
   {
     std::cout << "Cannot compute inverse transformation" << std::endl;
@@ -542,7 +543,7 @@ itkAffineTransformTest(int, char *[])
   }
 
   /* Test output of ComputeJacobianWithRespectToParameters */
-  Affine3DType::Pointer jaff = Affine3DType::New();
+  auto jaff = Affine3DType::New();
 
   Affine3DType::InputPointType jpoint;
   jpoint[0] = 5.0;
@@ -571,25 +572,62 @@ itkAffineTransformTest(int, char *[])
   }
 
   /* Test ComputeJacobianWithRespectToPosition. Should return Matrix. */
-  const Affine3DType::MatrixType     jaffMatrix = jaff->GetMatrix();
+  matrix3Truth[0][0] = 1;
+  matrix3Truth[0][1] = 2;
+  matrix3Truth[0][2] = 3;
+  matrix3Truth[1][0] = 4;
+  matrix3Truth[1][1] = 5;
+  matrix3Truth[1][2] = 6;
+  matrix3Truth[2][0] = 7;
+  matrix3Truth[2][1] = 8;
+  matrix3Truth[2][2] = 8;
+
+  jaff->SetMatrix(matrix3Truth);
   Affine3DType::JacobianPositionType jaffJacobianPosition;
   jaff->ComputeJacobianWithRespectToPosition(jpoint, jaffJacobianPosition);
   for (unsigned int i = 0; i < Affine3DType::MatrixType::RowDimensions; ++i)
   {
     for (unsigned int j = 0; j < Affine3DType::MatrixType::ColumnDimensions; ++j)
     {
-      if (!testValue(jaffJacobianPosition[i][j], jaffMatrix[i][j]))
+      if (!testValue(jaffJacobianPosition[i][j], matrix3Truth[i][j]))
       {
         std::cout << "Failed ComputeJacobianWithRespectToPosition." << std::endl
                   << "jaffJacobianPosition: " << jaffJacobianPosition << std::endl
-                  << "jaffMatrix: " << jaffMatrix << std::endl;
+                  << "matrix3Truth: " << matrix3Truth << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+  }
+
+  /* Test ComputeInverseJacobianWithRespectToPosition. Should return the inverse Matrix. */
+  Matrix3Type matrix3invTruth;
+  matrix3invTruth[0][0] = -8. / 3.;
+  matrix3invTruth[0][1] = 8. / 3.;
+  matrix3invTruth[0][2] = -1;
+  matrix3invTruth[1][0] = 10. / 3.;
+  matrix3invTruth[1][1] = -13. / 3.;
+  matrix3invTruth[1][2] = 2;
+  matrix3invTruth[2][0] = -1;
+  matrix3invTruth[2][1] = 2;
+  matrix3invTruth[2][2] = -1;
+  Affine3DType::JacobianPositionType jaffInverseJacobianPosition;
+  jaff->ComputeInverseJacobianWithRespectToPosition(jpoint, jaffInverseJacobianPosition);
+  for (unsigned int i = 0; i < Affine3DType::MatrixType::RowDimensions; ++i)
+  {
+    for (unsigned int j = 0; j < Affine3DType::MatrixType::ColumnDimensions; ++j)
+    {
+      if (abs(jaffInverseJacobianPosition[i][j] - matrix3invTruth[i][j]) > 1e-13)
+      {
+        std::cout << "Failed ComputeInverseJacobianWithRespectToPosition." << std::endl
+                  << "jaffInverseJacobianPosition: " << jaffInverseJacobianPosition << std::endl
+                  << "matrix3invTruth: " << matrix3invTruth << std::endl;
         return EXIT_FAILURE;
       }
     }
   }
 
   /* Test SetParameters */
-  Affine3DType::Pointer paff = Affine3DType::New();
+  auto paff = Affine3DType::New();
   paff->Print(std::cout);
   Affine3DType::ParametersType parameters1(paff->GetNumberOfParameters());
   Affine3DType::ParametersType fixed_parameters = paff->GetFixedParameters();
@@ -619,9 +657,9 @@ itkAffineTransformTest(int, char *[])
   paff->Print(std::cout);
 
   // TEST INVERSE OF INVERSE
-  Affine3DType::Pointer paff_inv = Affine3DType::New();
+  auto paff_inv = Affine3DType::New();
   paff->GetInverse(paff_inv);
-  Affine3DType::Pointer paff_inv_inv = Affine3DType::New();
+  auto paff_inv_inv = Affine3DType::New();
   paff_inv->GetInverse(paff_inv_inv);
 
   std::cout << "TEST INVERSE" << std::endl;
@@ -729,7 +767,7 @@ itkAffineTransformTest(int, char *[])
   {
     // Test SetParameters and GetInverse
     using TransformType = itk::AffineTransform<double, 2>;
-    TransformType::Pointer transform = TransformType::New();
+    auto transform = TransformType::New();
 
     TransformType::ParametersType parameters2;
     TransformType::ParametersType expectedParameters;
@@ -782,7 +820,7 @@ itkAffineTransformTest(int, char *[])
 
     transform->SetParameters(expectedParameters);
 
-    TransformType::Pointer other = TransformType::New();
+    auto other = TransformType::New();
     transform->GetInverse(other);
 
     TransformType::Pointer otherbis = dynamic_cast<TransformType *>(transform->GetInverseTransform().GetPointer());
@@ -820,8 +858,8 @@ itkAffineTransformTest(int, char *[])
     }
 
     // Try to invert a singular transform
-    TransformType::Pointer singularTransform = TransformType::New();
-    TransformType::Pointer singularTransformInverse = TransformType::New();
+    auto singularTransform = TransformType::New();
+    auto singularTransformInverse = TransformType::New();
     singularTransform->Scale(0.0);
     if (!singularTransform->GetInverse(singularTransformInverse))
     {

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.h
@@ -144,6 +144,18 @@ public:
    */
   itkGetConstMacro(NumberOfIntegrationSteps, unsigned int);
 
+  /**
+   * Get/Set a flag to interpret LowerTimeBound and UpperTimeBound as rates
+   * in the velocity field time span. This is equivalent to consider that the velocity
+   * field is defined in the normalized time interval [0, 1], ignoring the input origin
+   * and spacing in the temporal dimension.
+   *
+   * The default is true for backwards compatibility.
+   */
+  itkSetMacro(TimeBoundsAsRates, bool);
+  itkGetConstMacro(TimeBoundsAsRates, bool);
+  itkBooleanMacro(TimeBoundsAsRates);
+
 protected:
   TimeVaryingVelocityFieldIntegrationImageFilter();
   ~TimeVaryingVelocityFieldIntegrationImageFilter() override = default;
@@ -174,6 +186,8 @@ protected:
   unsigned int m_NumberOfTimePoints;
 
   DisplacementFieldInterpolatorPointer m_DisplacementFieldInterpolator;
+
+  bool m_TimeBoundsAsRates{ true };
 
 private:
   VelocityFieldInterpolatorPointer m_VelocityFieldInterpolator;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -181,11 +181,6 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
     }
   }
 
-  if (this->m_UpperTimeBound == this->m_LowerTimeBound)
-  {
-    return displacement;
-  }
-
   // Perform the integration
   // Need to know how to map the time dimension of the input image to the
   // assumed domain of [0,1].

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -18,8 +18,6 @@
 #ifndef itkTimeVaryingVelocityFieldIntegrationImageFilter_hxx
 #define itkTimeVaryingVelocityFieldIntegrationImageFilter_hxx
 
-#include "itkTimeVaryingVelocityFieldIntegrationImageFilter.h"
-
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkVectorLinearInterpolateImageFunction.h"
 

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -137,11 +137,9 @@ void
 TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDisplacementField>::
   DynamicThreadedGenerateData(const OutputRegionType & region)
 {
-  if (Math::ExactlyEquals(this->m_LowerTimeBound, this->m_UpperTimeBound) ||
-      this->m_NumberOfIntegrationSteps == 0)
+  if (Math::ExactlyEquals(this->m_LowerTimeBound, this->m_UpperTimeBound) || this->m_NumberOfIntegrationSteps == 0)
   {
-    this->GetOutput()->FillBuffer(
-      itk::NumericTraits<typename DisplacementFieldType::PixelType>::Zero);
+    this->GetOutput()->FillBuffer(itk::NumericTraits<typename DisplacementFieldType::PixelType>::Zero);
     return;
   }
 
@@ -174,13 +172,18 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 
   // Initial conditions
 
-  PointType startingSpatialPoint = initialSpatialPoint;
+  VectorType displacement = zeroVector;
   if (!this->m_InitialDiffeomorphism.IsNull())
   {
-    if (this->m_DisplacementFieldInterpolator->IsInsideBuffer(startingSpatialPoint))
+    if (this->m_DisplacementFieldInterpolator->IsInsideBuffer(initialSpatialPoint))
     {
-      startingSpatialPoint += this->m_DisplacementFieldInterpolator->Evaluate(startingSpatialPoint);
+      displacement = this->m_DisplacementFieldInterpolator->Evaluate(initialSpatialPoint);
     }
+  }
+
+  if (this->m_UpperTimeBound == this->m_LowerTimeBound)
+  {
+    return displacement;
   }
 
   // Perform the integration
@@ -202,18 +205,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
   }
 
   typename TimeVaryingVelocityFieldType::PointType spaceTimeEnd;
-  typename TimeVaryingVelocityFieldType::PointType pointIn2;
-  typename TimeVaryingVelocityFieldType::PointType pointIn3;
   inputField->TransformIndexToPhysicalPoint(lastIndex, spaceTimeEnd);
-
-  // Calculate the delta time used for integration
-  const RealType deltaTime = itk::Math::abs(this->m_UpperTimeBound - this->m_LowerTimeBound) /
-                             static_cast<RealType>(this->m_NumberOfIntegrationSteps);
-
-  if (deltaTime == 0.0)
-  {
-    return zeroVector;
-  }
 
   const RealType timeOrigin = spaceTimeOrigin[InputImageDimension - 1];
   const RealType timeEnd = spaceTimeEnd[InputImageDimension - 1];
@@ -224,18 +216,12 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
     timeSign = -1.0;
   }
 
-  VectorType displacement = zeroVector;
+  RealType timePointInImage = timeOrigin + this->m_LowerTimeBound * timeSpan;
 
-  RealType timePoint = timeOrigin + this->m_LowerTimeBound * timeSpan;
-
-  RealType intervalTimePoint = (timePoint + 1.0) / static_cast<RealType>(this->m_NumberOfTimePoints);
-
-  /** Windows not registering + operation so use a loop explicitly */
-  PointType spatialPoint = startingSpatialPoint;
-  for (unsigned int d = 0; d < OutputImageDimension; ++d)
-  {
-    spatialPoint[d] += displacement[d];
-  }
+  // Calculate the delta time used for integration
+  const RealType deltaTime = timeSign * itk::Math::abs(this->m_UpperTimeBound - this->m_LowerTimeBound) /
+                             static_cast<RealType>(this->m_NumberOfIntegrationSteps);
+  const RealType deltaTimeInImage = timeSpan * deltaTime;
 
   for (unsigned int n = 0; n < this->m_NumberOfIntegrationSteps; ++n)
   {
@@ -244,40 +230,18 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
     typename TimeVaryingVelocityFieldType::PointType x3;
     typename TimeVaryingVelocityFieldType::PointType x4;
 
-    RealType intervalTimePointMinusDeltaTime = intervalTimePoint - timeSign * deltaTime;
-    RealType intervalTimePointMinusHalfDeltaTime = intervalTimePoint - timeSign * deltaTime * 0.5;
-    if (intervalTimePointMinusHalfDeltaTime < 0.0)
-    {
-      intervalTimePointMinusHalfDeltaTime = 0.0;
-    }
-    if (intervalTimePointMinusHalfDeltaTime > 1.0)
-    {
-      intervalTimePointMinusHalfDeltaTime = 1.0;
-    }
-    if (intervalTimePointMinusDeltaTime < 0.0)
-    {
-      intervalTimePointMinusDeltaTime = 0.0;
-    }
-    if (intervalTimePointMinusDeltaTime > 1.0)
-    {
-      intervalTimePointMinusDeltaTime = 1.0;
-    }
-
     for (unsigned int d = 0; d < OutputImageDimension; ++d)
     {
-      x1[d] = spatialPoint[d] + displacement[d];
-      x2[d] = spatialPoint[d] + displacement[d];
-      x3[d] = spatialPoint[d] + displacement[d];
-      x4[d] = spatialPoint[d] + displacement[d];
-      pointIn2[d] = spatialPoint[d] + displacement[d];
+      x1[d] = initialSpatialPoint[d] + displacement[d];
+      x2[d] = x1[d];
+      x3[d] = x1[d];
+      x4[d] = x1[d];
     }
 
-    x1[OutputImageDimension] = intervalTimePointMinusDeltaTime * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
-    x2[OutputImageDimension] =
-      intervalTimePointMinusHalfDeltaTime * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
-    x3[OutputImageDimension] =
-      intervalTimePointMinusHalfDeltaTime * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
-    x4[OutputImageDimension] = intervalTimePoint * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
+    x1[OutputImageDimension] = timePointInImage;
+    x2[OutputImageDimension] = timePointInImage + 0.5 * deltaTimeInImage;
+    x3[OutputImageDimension] = timePointInImage + 0.5 * deltaTimeInImage;
+    x4[OutputImageDimension] = timePointInImage + deltaTimeInImage;
 
     VectorType f1 = zeroVector;
     if (this->m_VelocityFieldInterpolator->IsInsideBuffer(x1))
@@ -317,12 +281,11 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 
     for (unsigned int jj = 0; jj < OutputImageDimension; ++jj)
     {
-      pointIn3[jj] = pointIn2[jj] + timeSign * deltaTime / 6.0 * (f1[jj] + 2.0 * f2[jj] + 2.0 * f3[jj] + f4[jj]);
-      displacement[jj] = pointIn3[jj] - startingSpatialPoint[jj];
+      x1[jj] += deltaTime / 6.0 * (f1[jj] + 2.0 * f2[jj] + 2.0 * f3[jj] + f4[jj]);
+      displacement[jj] = x1[jj] - initialSpatialPoint[jj];
     }
-    pointIn3[OutputImageDimension] = intervalTimePoint * static_cast<RealType>(this->m_NumberOfTimePoints - 1);
 
-    intervalTimePoint += deltaTime * timeSign;
+    timePointInImage += deltaTimeInImage;
   }
   return displacement;
 }

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -137,13 +137,11 @@ void
 TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDisplacementField>::
   DynamicThreadedGenerateData(const OutputRegionType & region)
 {
-  if (Math::ExactlyEquals(this->m_LowerTimeBound, this->m_UpperTimeBound))
+  if (Math::ExactlyEquals(this->m_LowerTimeBound, this->m_UpperTimeBound) ||
+      this->m_NumberOfIntegrationSteps == 0)
   {
-    return;
-  }
-
-  if (this->m_NumberOfIntegrationSteps == 0)
-  {
+    this->GetOutput()->FillBuffer(
+      itk::NumericTraits<typename DisplacementFieldType::PixelType>::Zero);
     return;
   }
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -40,7 +40,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   VectorType constantVelocity;
   constantVelocity.Fill(0.1);
 
-  TimeVaryingVelocityFieldType::Pointer constantVelocityField = TimeVaryingVelocityFieldType::New();
+  auto constantVelocityField = TimeVaryingVelocityFieldType::New();
 
   constantVelocityField->SetOrigin(origin);
   constantVelocityField->SetSpacing(spacing);
@@ -51,7 +51,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
 
   using IntegratorType =
     itk::TimeVaryingVelocityFieldIntegrationImageFilter<TimeVaryingVelocityFieldType, DisplacementFieldType>;
-  IntegratorType::Pointer integrator = IntegratorType::New();
+  auto integrator = IntegratorType::New();
   integrator->SetInput(constantVelocityField);
   integrator->SetLowerTimeBound(0.3);
   integrator->SetUpperTimeBound(0.75);
@@ -64,7 +64,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   index.Fill(0);
   VectorType displacement;
 
-  IntegratorType::Pointer inverseIntegrator = IntegratorType::New();
+  auto = IntegratorType::New();
   inverseIntegrator->SetInput(constantVelocityField);
   inverseIntegrator->SetLowerTimeBound(1.0);
   inverseIntegrator->SetUpperTimeBound(0.0);
@@ -115,7 +115,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
    */
   using ImportFilterType = itk::ImportImageFilter<VectorType, 4>;
 
-  ImportFilterType::Pointer importFilter = ImportFilterType::New();
+  auto importFilter = ImportFilterType::New();
 
   /* Size is made denser on the z and t coordinates, for which
    * the velocity field is rapidly changing.
@@ -174,6 +174,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   integrator->SetLowerTimeBound(0.2);
   integrator->SetUpperTimeBound(0.8);
   integrator->TimeBoundsAsRatesOff();
+
   integrator->SetNumberOfIntegrationSteps(50);
   integrator->Update();
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -173,6 +173,10 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   integrator->SetInput(timeVaryingVelocityField);
   integrator->SetLowerTimeBound(0.2);
   integrator->SetUpperTimeBound(0.8);
+  /* This time bounds are meant to be absolute
+   * for the velocity field original time span [0, 1.5].
+   * Thus, we need to switch off the default rescaling
+   * to the normalized time span [0, 1] */
   integrator->TimeBoundsAsRatesOff();
 
   integrator->SetNumberOfIntegrationSteps(50);

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -17,10 +17,13 @@
  *=========================================================================*/
 
 #include "itkTimeVaryingVelocityFieldIntegrationImageFilter.h"
+#include "itkImportImageFilter.h"
 
 int
 itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
 {
+  /* First test with homogeneous and constant velocity field
+   */
   using VectorType = itk::Vector<double, 3>;
   using DisplacementFieldType = itk::Image<VectorType, 3>;
   using TimeVaryingVelocityFieldType = itk::Image<VectorType, 4>;
@@ -34,25 +37,25 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   TimeVaryingVelocityFieldType::SizeType size;
   size.Fill(25);
 
-  VectorType displacement1;
-  displacement1.Fill(0.1);
+  VectorType constantVelocity;
+  constantVelocity.Fill(0.1);
 
-  TimeVaryingVelocityFieldType::Pointer timeVaryingVelocityField = TimeVaryingVelocityFieldType::New();
+  TimeVaryingVelocityFieldType::Pointer constantVelocityField = TimeVaryingVelocityFieldType::New();
 
-  timeVaryingVelocityField->SetOrigin(origin);
-  timeVaryingVelocityField->SetSpacing(spacing);
-  timeVaryingVelocityField->SetRegions(size);
-  timeVaryingVelocityField->Allocate();
-  timeVaryingVelocityField->FillBuffer(displacement1);
+  constantVelocityField->SetOrigin(origin);
+  constantVelocityField->SetSpacing(spacing);
+  constantVelocityField->SetRegions(size);
+  constantVelocityField->Allocate();
+  constantVelocityField->FillBuffer(constantVelocity);
 
 
   using IntegratorType =
     itk::TimeVaryingVelocityFieldIntegrationImageFilter<TimeVaryingVelocityFieldType, DisplacementFieldType>;
   IntegratorType::Pointer integrator = IntegratorType::New();
-  integrator->SetInput(timeVaryingVelocityField);
+  integrator->SetInput(constantVelocityField);
   integrator->SetLowerTimeBound(0.3);
   integrator->SetUpperTimeBound(0.75);
-  integrator->SetNumberOfIntegrationSteps(10);
+  integrator->SetNumberOfIntegrationSteps(100);
   integrator->Update();
 
   integrator->Print(std::cout, 3);
@@ -62,10 +65,10 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   VectorType displacement;
 
   IntegratorType::Pointer inverseIntegrator = IntegratorType::New();
-  inverseIntegrator->SetInput(timeVaryingVelocityField);
+  inverseIntegrator->SetInput(constantVelocityField);
   inverseIntegrator->SetLowerTimeBound(1.0);
   inverseIntegrator->SetUpperTimeBound(0.0);
-  inverseIntegrator->SetNumberOfIntegrationSteps(10);
+  inverseIntegrator->SetNumberOfIntegrationSteps(100);
   inverseIntegrator->Update();
 
   // This integration should result in a constant image of value
@@ -98,6 +101,114 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
     std::cerr << "Failed to produce the correct forward integration." << std::endl;
     return EXIT_FAILURE;
   }
+
+
+  /* Second test with inhomogeneous and time-varying velocity field
+   */
+
+  /* Generation of the velocity field defined by
+   *    v(x, y, z, t) = z/(1+t) * ( -sin(z), cos(z), 1 )
+   * which can be analytically integrated giving the motion
+   * corresponding to the displacement field:
+   *    Displacement(x0, y0, z0, t) =
+   *      ( cos(z0*(1+t)) - 1, sin(z0*(1+t)), z0*(1+t) )
+   */
+  using ImportFilterType = itk::ImportImageFilter<VectorType, 4>;
+
+  ImportFilterType::Pointer importFilter = ImportFilterType::New();
+
+  /* Size is made denser on the z and t coordinates, for which
+   * the velocity field is rapidly changing.
+   * The velocity field is homogeneous in the x-y plane.*/
+  size[0] = 3;
+  size[1] = 3;
+  size[2] = 401;
+  size[3] = 41;
+  ImportFilterType::IndexType start;
+  start.Fill(0);
+
+  ImportFilterType::RegionType region;
+  region.SetIndex(start);
+  region.SetSize(size);
+
+  importFilter->SetRegion(region);
+
+  origin.Fill(0.);
+  importFilter->SetOrigin(origin);
+
+  double spaceTimeSpan[4] = { 20., 20., 20., 1. };
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    spacing[i] = spaceTimeSpan[i] / (size[i] - 1);
+  }
+  importFilter->SetSpacing(spacing);
+
+  const unsigned int numberOfPixels = size[0] * size[1] * size[2] * size[3];
+  auto *             localBuffer = new VectorType[numberOfPixels];
+
+  VectorType * it = localBuffer;
+  for (unsigned int t = 0; t < size[3]; ++t)
+  {
+    for (unsigned int z = 0; z < size[2]; ++z)
+    {
+      const double zz = static_cast<double>(z) * spacing[2];
+      const double kappa = zz / (1 + t * spacing[3]);
+      for (unsigned int y = 0; y < size[1]; ++y)
+      {
+        for (unsigned int x = 0; x < size[0]; ++x, ++it)
+        {
+          (*it)[0] = -kappa * std::sin(zz);
+          (*it)[1] = kappa * std::cos(zz);
+          (*it)[2] = kappa;
+        }
+      }
+    }
+  }
+
+  const bool importImageFilterWillOwnTheBuffer = true;
+  importFilter->SetImportPointer(localBuffer, numberOfPixels, importImageFilterWillOwnTheBuffer);
+
+  TimeVaryingVelocityFieldType::Pointer timeVaryingVelocityField = importFilter->GetOutput();
+
+  integrator->SetInput(timeVaryingVelocityField);
+  integrator->SetLowerTimeBound(0.2);
+  integrator->SetUpperTimeBound(0.8);
+  integrator->SetNumberOfIntegrationSteps(50);
+  integrator->Update();
+
+  integrator->Print(std::cout, 3);
+
+  index[0] = (size[0] - 1) / 2;  // Corresponding to x = 10.
+  index[1] = (size[1] - 1) / 2;  // Corresponding to y = 10.
+  index[2] = (size[2] - 1) / 10; // Corresponding to z = 2.
+
+  displacementField = integrator->GetOutput();
+  displacement = displacementField->GetPixel(index);
+  // The analytic result is displacement = ( cos(3) - cos(2), sin(3) - sin(2), 3 - 2 )
+  std::cout << "Estimated forward displacement vector: " << displacement << std::endl;
+  if (itk::Math::abs(displacement[0] + 0.5738) > 0.0002 || itk::Math::abs(displacement[1] + 0.7682) > 0.0001 ||
+      itk::Math::abs(displacement[2] - 1.0000) > 0.0001)
+  {
+    std::cerr << "Failed to produce the correct forward integration." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  /* The same integrator is used backwards in time. */
+  integrator->SetLowerTimeBound(1.0);
+  integrator->SetUpperTimeBound(0.0);
+  integrator->Update();
+
+  inverseField = integrator->GetOutput();
+  displacement = inverseField->GetPixel(index);
+  // The analytic result is displacement = ( cos(1) - cos(2), sin(1) - sin(2), 1 - 2 )
+  std::cout << "Estimated inverse displacement vector: " << displacement << std::endl;
+  if (itk::Math::abs(displacement[0] - 0.9564) > 0.0001 || itk::Math::abs(displacement[1] + 0.0678) > 0.0003 ||
+      itk::Math::abs(displacement[2] + 1.0000) > 0.0001)
+  {
+    std::cerr << "Failed to produce the correct inverse integration." << std::endl;
+    return EXIT_FAILURE;
+  }
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -123,7 +123,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   size[0] = 3;
   size[1] = 3;
   size[2] = 401;
-  size[3] = 41;
+  size[3] = 61;
   ImportFilterType::IndexType start;
   start.Fill(0);
 
@@ -136,7 +136,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   origin.Fill(0.);
   importFilter->SetOrigin(origin);
 
-  double spaceTimeSpan[4] = { 20., 20., 20., 1. };
+  double spaceTimeSpan[4] = { 20., 20., 20., 1.5 };
   for (unsigned int i = 0; i < 4; i++)
   {
     spacing[i] = spaceTimeSpan[i] / (size[i] - 1);
@@ -151,8 +151,8 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   {
     for (unsigned int z = 0; z < size[2]; ++z)
     {
-      const double zz = static_cast<double>(z) * spacing[2];
-      const double kappa = zz / (1 + t * spacing[3]);
+      const double zz = spacing[2] * z;
+      const double kappa = zz / (1 + spacing[3] * t);
       for (unsigned int y = 0; y < size[1]; ++y)
       {
         for (unsigned int x = 0; x < size[0]; ++x, ++it)
@@ -173,6 +173,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   integrator->SetInput(timeVaryingVelocityField);
   integrator->SetLowerTimeBound(0.2);
   integrator->SetUpperTimeBound(0.8);
+  integrator->TimeBoundsAsRatesOff();
   integrator->SetNumberOfIntegrationSteps(50);
   integrator->Update();
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -64,7 +64,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int, char *[])
   index.Fill(0);
   VectorType displacement;
 
-  auto = IntegratorType::New();
+  auto inverseIntegrator = IntegratorType::New();
   inverseIntegrator->SetInput(constantVelocityField);
   inverseIntegrator->SetLowerTimeBound(1.0);
   inverseIntegrator->SetUpperTimeBound(0.0);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -328,15 +328,9 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Generat
     ImageRegionIterator<PointDataImageType> ItPhi(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
     for (ItPsi.GoToBegin(), ItPhi.GoToBegin(); !ItPsi.IsAtEnd(); ++ItPsi, ++ItPhi)
     {
-      ItPsi.Set(ItPhi.Get() + ItPsi.Get());
+      ItPhi.Set(ItPhi.Get() + ItPsi.Get());
     }
-
-    using ImageDuplicatorType = ImageDuplicator<PointDataImageType>;
-    typename ImageDuplicatorType::Pointer duplicator = ImageDuplicatorType::New();
-    duplicator->SetInputImage(this->m_PsiLattice);
-    duplicator->Update();
-    this->m_PhiLattice = duplicator->GetOutput();
-
+  
     this->UpdatePointSet();
   }
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -226,17 +226,6 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Generat
     }
   }
 
-  unsigned int maximumNumberOfSpans = 0;
-  for (unsigned int d = 0; d < ImageDimension; ++d)
-  {
-    unsigned int numberOfSpans = this->m_NumberOfControlPoints[d] - this->m_SplineOrder[d];
-    numberOfSpans <<= (this->m_NumberOfLevels[d] - 1);
-    if (numberOfSpans > maximumNumberOfSpans)
-    {
-      maximumNumberOfSpans = numberOfSpans;
-    }
-  }
-
   this->m_InputPointData->Initialize();
   this->m_OutputPointData->Initialize();
   if (inputPointSet->GetNumberOfPoints() > 0)

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -412,24 +412,4 @@ private:
 #  include "itkResampleImageFilter.hxx"
 #endif
 
-/*
-#include "itkNumericTraitsVectorPixel.h"
-#include "itkResampleImageFilter.hxx"
-auto prova()
-{
-  using InputPixelType = double;
-  using OutputPixelType = itk::Vector<double, 2>;
-  itk::Image<InputPixelType, 3>::Pointer t_inputImage = itk::Image<InputPixelType, 3>::New();
-  itk::ResampleImageFilter<itk::Image<InputPixelType, 3>, itk::Image<OutputPixelType, 2>>::Pointer resampler =
-    itk::ResampleImageFilter<itk::Image<InputPixelType, 3>, itk::Image<OutputPixelType, 2>>::New();
-  resampler->SetInput(t_inputImage);
-  resampler->Update();
-  double *arr;
-  OutputPixelType v = static_cast<OutputPixelType>(arr);
-  std::cout << "v[1]" << std::endl;
-  v[1] += 2.6;
-  return v;
-}
-*/
-
 #endif

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -18,6 +18,7 @@
 #ifndef itkResampleImageFilter_h
 #define itkResampleImageFilter_h
 
+#include <type_traits> // For std::enable_if
 #include "itkFixedArray.h"
 #include "itkTransform.h"
 #include "itkImageRegionIterator.h"
@@ -280,8 +281,8 @@ public:
    *  (scalar-wise) wrapping. If not set no transformation is performed (the default).
    *  Typically, this is required for the approprite tensorial transformation of
    *  (contravariant) vectors, covariant vectors, or symmetric rank-2 tensors. */
-  itkSetMacro(PixelTransformation, typename PixelTransformationType::Pointer);
-  itkGetConstMacro(PixelTransformation, typename PixelTransformationType::Pointer);
+  itkSetObjectMacro(PixelTransformation, PixelTransformationType);
+  itkGetConstObjectMacro(PixelTransformation, PixelTransformationType);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -63,7 +63,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   Self::AddRequiredInputName("Transform");
   this->InitializeTransform();
 
-  m_Interpolator = (LinearInterpolatorType::New().GetPointer());
+  m_Interpolator = dynamic_cast<InterpolatorType *>(LinearInterpolatorType::New().GetPointer());
 
   m_PixelTransformation = dynamic_cast<PixelTransformationType *>(
     IdentityPixelTransformation<InterpolatorOutputType, TransformType, InputPointType>::New().GetPointer());
@@ -454,10 +454,10 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
     if (m_Interpolator->IsInsideBuffer(inputIndex) && (!isSpecialCoordinatesImage || isInsideInput))
     {
       //      InterpolatorOutputType inputValue = m_Interpolator->EvaluateAtContinuousIndex(inputIndex);
-      //      InterpolatorOutputType transformedValue = m_PixelTransformation->Transform(inputValue, inputPoint,
-      //      outputPoint); value = Self::CastPixelWithBoundsChecking(transformedValue);
+      //      InterpolatorOutputType transformedValue = m_PixelTransformation->Transform(inputValue, outputPoint,
+      //      inputPoint); value = Self::CastPixelWithBoundsChecking(transformedValue);
       InterpolatorOutputType inputValue = m_Interpolator->EvaluateAtContinuousIndex(inputIndex);
-      value = Self::CastPixelWithBoundsChecking(m_PixelTransformation->Transform(inputValue, inputPoint, outputPoint));
+      value = Self::CastPixelWithBoundsChecking(m_PixelTransformation->Transform(inputValue, outputPoint, inputPoint));
       // TO DO (Jose): Check what to do with extrapolator.
     }
     else

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -63,7 +63,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   Self::AddRequiredInputName("Transform");
   this->InitializeTransform();
 
-  m_Interpolator = dynamic_cast<InterpolatorType *>(LinearInterpolatorType::New().GetPointer());
+  m_Interpolator = (LinearInterpolatorType::New().GetPointer());
 
   m_PixelTransformation = dynamic_cast<PixelTransformationType *>(
     IdentityPixelTransformation<InterpolatorOutputType, TransformType, InputPointType>::New().GetPointer());
@@ -552,7 +552,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
       // Evaluate input at right position and copy to the output
       if (m_Interpolator->IsInsideBuffer(inputIndex))
       {
-        outIt.Set(Self::CastPixelWithBoundsChecking(m_Interpolator->EvaluateAtContinuousIndex(inputIndex)));
+        outIt.Set(Self::CastPixelWithBoundsChecking(
+          m_PixelTransformation->Transform(m_Interpolator->EvaluateAtContinuousIndex(inputIndex))));
       }
       else
       {
@@ -562,7 +563,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
         }
         else
         {
-          outIt.Set(Self::CastPixelWithBoundsChecking(m_Extrapolator->EvaluateAtContinuousIndex(inputIndex)));
+          outIt.Set(Self::CastPixelWithBoundsChecking(
+            m_PixelTransformation->Transform(m_Extrapolator->EvaluateAtContinuousIndex(inputIndex))));
         }
       }
 

--- a/Modules/Filtering/ImageGrid/itk-module.cmake
+++ b/Modules/Filtering/ImageGrid/itk-module.cmake
@@ -6,6 +6,7 @@ shrinking, and changing its origin or spacing or orientation.")
 itk_module(ITKImageGrid
   COMPILE_DEPENDS
     ITKImageFunction
+    ITKPixelTransformation
   TEST_DEPENDS
     ITKTestKernel
     ITKSmoothing
@@ -18,3 +19,4 @@ itk_module(ITKImageGrid
 # ITKImageIntensity dependency introduced by itkBSplineScatteredDataPointSetToImageFilterTest4
 # ITKSmoothing dependency introduced by itkSliceBySliceImageFilterTest.
 # ITKIOImageBase dependency introduced by itkResampleImageFilter.
+# ITKPixelTransformation dependency introduced by itkResampleImageFilter.

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -143,7 +143,6 @@ itkResampleImageTest8(int, char *[])
 
   std::cout << "Input Image Type\n";
 
-#ifdef ddwid
   // Create and configure an image
   InputImagePointerType inputImage = InputImageType::New();
   InputImageIndexType   inputIndex = { { 0, 0 } };
@@ -177,6 +176,7 @@ itkResampleImageTest8(int, char *[])
   InterpolatorType::Pointer interp = InterpolatorType::New();
   interp->SetInputImage(inputImage);
 
+#ifdef ddwid
   // Create and configure a resampling filter
   itk::ResampleImageFilter<InputImageType, OutputImageType>::Pointer resample =
     itk::ResampleImageFilter<InputImageType, OutputImageType>::New();

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -143,6 +143,7 @@ itkResampleImageTest8(int, char *[])
 
   std::cout << "Input Image Type\n";
 
+#ifdef ddwid
   // Create and configure an image
   InputImagePointerType inputImage = InputImageType::New();
   InputImageIndexType   inputIndex = { { 0, 0 } };
@@ -264,7 +265,7 @@ itkResampleImageTest8(int, char *[])
     std::cout << "Resampling test failed" << std::endl;
     return EXIT_FAILURE;
   }
-
+#endif
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -176,7 +176,6 @@ itkResampleImageTest8(int, char *[])
   InterpolatorType::Pointer interp = InterpolatorType::New();
   interp->SetInputImage(inputImage);
 
-#ifdef ddwid
   // Create and configure a resampling filter
   itk::ResampleImageFilter<InputImageType, OutputImageType>::Pointer resample =
     itk::ResampleImageFilter<InputImageType, OutputImageType>::New();
@@ -265,7 +264,7 @@ itkResampleImageTest8(int, char *[])
     std::cout << "Resampling test failed" << std::endl;
     return EXIT_FAILURE;
   }
-#endif
+
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/PixelTransformation/CMakeLists.txt
+++ b/Modules/Filtering/PixelTransformation/CMakeLists.txt
@@ -1,0 +1,2 @@
+project(ITKPixelTransformation)
+itk_module_impl()

--- a/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.h
@@ -68,8 +68,8 @@ public:
   static constexpr unsigned int Dimension = TPixelType::Dimension;
   static_assert(Dimension == TransformType::InputPointType::Dimension &&
                   Dimension == TransformType::OutputPointType::Dimension,
-                "ContravariantVectorTransformation requires that PixelType and input and output images have all the "
-                "same dimension");
+                "ContravariantVectorTransformation requires that PixelType and input and output "
+                "transformation spaces have all the same dimension");
 
   PixelType
   Transform(const PixelType & value, const InputPointType & inputPoint, const OutputPointType & outputPoint) override;

--- a/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.h
@@ -57,12 +57,21 @@ public:
   /** Run-time type information (and related methods) */
   itkTypeMacro(ContravariantVectorTransformation, PixelTransformation);
 
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
   using TransformType = typename Superclass::TransformType;
   using PixelType = typename Superclass::PixelType;
   using InputPointType = typename Superclass::InputPointType;
   using OutputPointType = typename Superclass::OutputPointType;
 
-  PixelType &
+  static constexpr unsigned int Dimension = TPixelType::Dimension;
+  static_assert(Dimension == TransformType::InputPointType::Dimension &&
+                  Dimension == TransformType::OutputPointType::Dimension,
+                "ContravariantVectorTransformation requires that PixelType and input and output images have all the "
+                "same dimension");
+
+  PixelType
   Transform(const PixelType & value, const InputPointType & inputPoint, const OutputPointType & outputPoint) override;
 
 

--- a/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.h
@@ -1,0 +1,82 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkContravariantVectorTransformation_h
+#define itkContravariantVectorTransformation_h
+
+#include "itkPixelTransformation.h"
+
+namespace itk
+{
+/**
+ * \class ContravariantVectorTransformation
+ *
+ * This class is part of the pixel transformation hierarchy, whose base class is PixelTransformation.
+ * It defines the transformation for pixel values representing contravariant vectors due to the spatial
+ * transformation of the image (contravariant vector field).
+ * The natural appearance of contravariant vectors is as tangent vectors to a congruence of curves.
+ * A typical example of this type of vectors is a velocity field.
+ *
+ * \par
+ * These pixel transformations do not replace the ImageTransform but complement it.
+ * They have been introduced to be used by itkResampleImageFilter
+ * when the pixel type requires more complex transform than simply relocating it.
+ *
+ * \ingroup Filtering
+ * \ingroup PixelTransformation
+ */
+template <typename TPixelType,
+          typename TTransformType,
+          typename TOutputPointType = typename TTransformType::OutputPointType>
+class ITK_TEMPLATE_EXPORT ContravariantVectorTransformation
+  : public PixelTransformation<TPixelType, TTransformType, TOutputPointType>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(ContravariantVectorTransformation);
+
+  /** Standard class type aliases. */
+  using Self = ContravariantVectorTransformation;
+  using Superclass = PixelTransformation<TPixelType, TTransformType, TOutputPointType>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Run-time type information (and related methods) */
+  itkTypeMacro(ContravariantVectorTransformation, PixelTransformation);
+
+  using TransformType = typename Superclass::TransformType;
+  using PixelType = typename Superclass::PixelType;
+  using InputPointType = typename Superclass::InputPointType;
+  using OutputPointType = typename Superclass::OutputPointType;
+
+  PixelType &
+  Transform(const PixelType & value, const InputPointType & inputPoint, const OutputPointType & outputPoint) override;
+
+
+protected:
+  ContravariantVectorTransformation();
+  ~ContravariantVectorTransformation() override = default;
+
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+};
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "itkContravariantVectorTransformation.hxx"
+#endif
+
+#endif

--- a/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.hxx
@@ -37,9 +37,8 @@ ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>:
   const OutputPointType & outputPoint) -> PixelType
 {
   TransformType * inverseTransform = this->m_ImageTransform->GetInverseTransform();
-  if (false) // inverseTransform)
+  if (inverseTransform)
   {
-    std::cout << "C1" << std::endl;
     return inverseTransform->TransformVector(value, outputPoint);
   }
   else

--- a/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.hxx
@@ -1,0 +1,75 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkContravariantVectorTransformation_hxx
+#define itkContravariantVectorTransformation_hxx
+
+#include "itkContravariantVectorTransformation.h"
+namespace itk
+{
+/*
+template <typename TPixelType,
+          typename TTransformType,
+          typename TOutputPointType>
+ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::
+  ContravariantVectorTransformation()
+{
+  // initialize variables
+}
+*/
+
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+typename ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::PixelType &
+ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::Transform(
+  const PixelType &       value,
+  const InputPointType &  inputPoint,
+  const OutputPointType & outputPoint)
+{
+  TransformType * inverseTransform = m_ImageTransform->GetInverseTransform();
+  if (inverseTransform)
+  {
+    return inverseTransform->TransformVector(value, outputPoint);
+  }
+  else
+  {
+    typename TransformType::InverseJacobianPositionType jacobian;
+    m_ImageTransform->ComputeInverseJacobianWithRespectToPosition(inputPoint, jacobian);
+    PixelType result;
+
+    for (unsigned int i = 0; i < NOutputDimensions; ++i)
+    {
+      result[i] = NumericTraits<typename PixelType::ValueType>::ZeroValue();
+      for (unsigned int j = 0; j < NInputDimensions; ++j)
+      {
+        result[i] += jacobian[i][j] * vector[j];
+      }
+    }
+    return result;
+  }
+}
+
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+void
+ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::PrintSelf(std::ostream & os,
+                                                                                           Indent         indent) const
+{
+  Superclass::PrintSelf(os, indent);
+}
+
+} // end namespace itk
+
+#endif

--- a/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.hxx
@@ -36,7 +36,7 @@ ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>:
   const InputPointType &  inputPoint,
   const OutputPointType & outputPoint) -> PixelType
 {
-  TransformType * inverseTransform = this->m_ImageTransform->GetInverseTransform();
+  typename TransformType::Pointer inverseTransform = this->m_ImageTransform->GetInverseTransform();
   if (inverseTransform)
   {
     return inverseTransform->TransformVector(value, outputPoint);

--- a/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkContravariantVectorTransformation.hxx
@@ -21,41 +21,38 @@
 #include "itkContravariantVectorTransformation.h"
 namespace itk
 {
-/*
-template <typename TPixelType,
-          typename TTransformType,
-          typename TOutputPointType>
-ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::
-  ContravariantVectorTransformation()
+
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::ContravariantVectorTransformation()
 {
   // initialize variables
 }
-*/
+
 
 template <typename TPixelType, typename TTransformType, typename TOutputPointType>
-typename ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::PixelType &
+auto
 ContravariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::Transform(
   const PixelType &       value,
   const InputPointType &  inputPoint,
-  const OutputPointType & outputPoint)
+  const OutputPointType & outputPoint) -> PixelType
 {
-  TransformType * inverseTransform = m_ImageTransform->GetInverseTransform();
-  if (inverseTransform)
+  TransformType * inverseTransform = this->m_ImageTransform->GetInverseTransform();
+  if (false) // inverseTransform)
   {
+    std::cout << "C1" << std::endl;
     return inverseTransform->TransformVector(value, outputPoint);
   }
   else
   {
     typename TransformType::InverseJacobianPositionType jacobian;
-    m_ImageTransform->ComputeInverseJacobianWithRespectToPosition(inputPoint, jacobian);
+    this->m_ImageTransform->ComputeInverseJacobianWithRespectToPosition(inputPoint, jacobian);
     PixelType result;
-
-    for (unsigned int i = 0; i < NOutputDimensions; ++i)
+    for (unsigned int i = 0; i < Dimension; ++i)
     {
       result[i] = NumericTraits<typename PixelType::ValueType>::ZeroValue();
-      for (unsigned int j = 0; j < NInputDimensions; ++j)
+      for (unsigned int j = 0; j < Dimension; ++j)
       {
-        result[i] += jacobian[i][j] * vector[j];
+        result[i] += jacobian[i][j] * value[j];
       }
     }
     return result;

--- a/Modules/Filtering/PixelTransformation/include/itkCovariantVectorTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkCovariantVectorTransformation.h
@@ -68,8 +68,8 @@ public:
   static constexpr unsigned int Dimension = TPixelType::Dimension;
   static_assert(Dimension == TransformType::InputPointType::Dimension &&
                   Dimension == TransformType::OutputPointType::Dimension,
-                "ContravariantVectorTransformation requires that PixelType and input and output images have all the "
-                "same dimension");
+                "CovariantVectorTransformation requires that PixelType and input and output "
+                "transformation spaces have all the same dimension");
 
   PixelType
   Transform(const PixelType & value, const InputPointType & inputPoint, const OutputPointType & outputPoint) override;

--- a/Modules/Filtering/PixelTransformation/include/itkCovariantVectorTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkCovariantVectorTransformation.h
@@ -15,22 +15,21 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkIdentityPixelTransformation_h
-#define itkIdentityPixelTransformation_h
+#ifndef itkCovariantVectorTransformation_h
+#define itkCovariantVectorTransformation_h
 
 #include "itkPixelTransformation.h"
 
 namespace itk
 {
 /**
- * \class IdentityPixelTransformation
+ * \class CovariantVectorTransformation
  *
  * This class is part of the pixel transformation hierarchy, whose base class is PixelTransformation.
- * It defines the identity transformation of the pixel values after an image transformation.
- * This is the default pixel transformation used in the resampleImageFilter. And it is the typical
- * pixel transformation (no transformation) for geometrically scalar images, for which the
- * pixel values are intensities without directional or density information/dependency.
- * This is true also for non-geometrical (computational) vectors such as color RGB images.
+ * It defines the transformation for pixel values representing covariant vectors due to the spatial
+ * transformation of the image (covariant vector field).
+ * The natural appearance of covariant vectors is as differential of scalar fields, loosely identified with
+ * gradient vectors and with the normal vectors of the (hyper)-surfaces.
  *
  * \par
  * These pixel transformations do not replace the ImageTransform but complement it.
@@ -43,20 +42,20 @@ namespace itk
 template <typename TPixelType,
           typename TTransformType,
           typename TOutputPointType = typename TTransformType::OutputPointType>
-class ITK_TEMPLATE_EXPORT IdentityPixelTransformation
+class ITK_TEMPLATE_EXPORT CovariantVectorTransformation
   : public PixelTransformation<TPixelType, TTransformType, TOutputPointType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_MOVE(IdentityPixelTransformation);
+  ITK_DISALLOW_COPY_AND_MOVE(CovariantVectorTransformation);
 
   /** Standard class type aliases. */
-  using Self = IdentityPixelTransformation;
+  using Self = CovariantVectorTransformation;
   using Superclass = PixelTransformation<TPixelType, TTransformType, TOutputPointType>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(IdentityPixelTransformation, PixelTransformation);
+  itkTypeMacro(CovariantVectorTransformation, PixelTransformation);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -66,13 +65,19 @@ public:
   using InputPointType = typename Superclass::InputPointType;
   using OutputPointType = typename Superclass::OutputPointType;
 
+  static constexpr unsigned int Dimension = TPixelType::Dimension;
+  static_assert(Dimension == TransformType::InputPointType::Dimension &&
+                  Dimension == TransformType::OutputPointType::Dimension,
+                "ContravariantVectorTransformation requires that PixelType and input and output images have all the "
+                "same dimension");
+
   PixelType
   Transform(const PixelType & value, const InputPointType & inputPoint, const OutputPointType & outputPoint) override;
 
 
 protected:
-  IdentityPixelTransformation();
-  ~IdentityPixelTransformation() override = default;
+  CovariantVectorTransformation();
+  ~CovariantVectorTransformation() override = default;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -80,7 +85,7 @@ protected:
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkIdentityPixelTransformation.hxx"
+#  include "itkCovariantVectorTransformation.hxx"
 #endif
 
 #endif

--- a/Modules/Filtering/PixelTransformation/include/itkCovariantVectorTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkCovariantVectorTransformation.hxx
@@ -1,0 +1,67 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkCovariantVectorTransformation_hxx
+#define itkCovariantVectorTransformation_hxx
+
+#include "itkCovariantVectorTransformation.h"
+namespace itk
+{
+/*
+template <typename TPixelType,
+          typename TTransformType,
+          typename TOutputPointType>
+CovariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::
+  CovariantVectorTransformation()
+{
+  // initialize variables
+}
+*/
+
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+auto
+CovariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::Transform(
+  const PixelType &       value,
+  const InputPointType &  inputPoint,
+  const OutputPointType & outputPoint) -> PixelType
+{
+  typename TransformType::JacobianPositionType jacobian;
+  this->m_ImageTransform->ComputeJacobianWithRespectToPosition(inputPoint, jacobian);
+  PixelType result;
+
+  for (unsigned int i = 0; i < Dimension; ++i)
+  {
+    result[i] = NumericTraits<typename PixelType::ValueType>::ZeroValue();
+    for (unsigned int j = 0; j < Dimension; ++j)
+    {
+      result[i] += jacobian[j][i] * value[j];
+    }
+  }
+  return result;
+}
+
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+void
+CovariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::PrintSelf(std::ostream & os,
+                                                                                       Indent         indent) const
+{
+  Superclass::PrintSelf(os, indent);
+}
+
+} // end namespace itk
+
+#endif

--- a/Modules/Filtering/PixelTransformation/include/itkCovariantVectorTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkCovariantVectorTransformation.hxx
@@ -21,16 +21,11 @@
 #include "itkCovariantVectorTransformation.h"
 namespace itk
 {
-/*
-template <typename TPixelType,
-          typename TTransformType,
-          typename TOutputPointType>
-CovariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::
-  CovariantVectorTransformation()
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+CovariantVectorTransformation<TPixelType, TTransformType, TOutputPointType>::CovariantVectorTransformation()
 {
   // initialize variables
 }
-*/
 
 template <typename TPixelType, typename TTransformType, typename TOutputPointType>
 auto

--- a/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.h
@@ -75,9 +75,6 @@ protected:
   ~IdentityPixelTransformation() override = default;
 
   void
-  InitializeDefaultImageTransform() override{};
-
-  void
   PrintSelf(std::ostream & os, Indent indent) const override;
 };
 } // end namespace itk

--- a/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.h
@@ -75,6 +75,9 @@ protected:
   ~IdentityPixelTransformation() override = default;
 
   void
+  InitializeDefaultImageTransform() override{};
+
+  void
   PrintSelf(std::ostream & os, Indent indent) const override;
 };
 } // end namespace itk

--- a/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.h
@@ -1,0 +1,83 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkIdentityPixelTransformation_h
+#define itkIdentityPixelTransformation_h
+
+#include "itkPixelTransformation.h"
+
+namespace itk
+{
+/**
+ * \class IdentityPixelTransformation
+ *
+ * This class is part of the pixel transformation hierarchy, whose base class is PixelTransformation.
+ * It defines the identity transformation of the pixel values after an image transformation.
+ * This is the default pixel transformation used in the resampleImageFilter. And it is the typical
+ * pixel transformation (no transformation) for geometrically scalar images, for which the
+ * pixel values are intensities without directional or density information/dependency.
+ * This is true also for non-geometrical (computational) vectors such as color RGB images.
+ *
+ * \par
+ * These pixel transformations do not replace the ImageTransform but complement it.
+ * They have been introduced to be used by itkResampleImageFilter
+ * when the pixel type requires more complex transform than simply relocating it.
+ *
+ * \ingroup Filtering
+ * \ingroup PixelTransformation
+ */
+template <typename TPixelType,
+          typename TTransformType,
+          typename TOutputPointType = typename TTransformType::OutputPointType>
+class ITK_TEMPLATE_EXPORT IdentityPixelTransformation
+  : public PixelTransformation<TPixelType, TTransformType, TOutputPointType>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(IdentityPixelTransformation);
+
+  /** Standard class type aliases. */
+  using Self = IdentityPixelTransformation;
+  using Superclass = PixelTransformation<TPixelType, TTransformType, TOutputPointType>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Run-time type information (and related methods) */
+  itkTypeMacro(IdentityPixelTransformation, PixelTransformation);
+
+  using TransformType = typename Superclass::TransformType;
+  using PixelType = typename Superclass::PixelType;
+  using InputPointType = typename Superclass::InputPointType;
+  using OutputPointType = typename Superclass::OutputPointType;
+
+  PixelType &
+  Transform(const PixelType & value, const InputPointType & inputPoint, const OutputPointType & outputPoint) override;
+
+
+protected:
+  IdentityPixelTransformation();
+  ~IdentityPixelTransformation() override = default;
+
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+};
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "itkIdentityPixelTransformation.hxx"
+#endif
+
+#endif

--- a/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.hxx
@@ -21,23 +21,18 @@
 #include "itkIdentityPixelTransformation.h"
 namespace itk
 {
-/*
-template <typename TPixelType,
-          typename TTransformType,
-          typename TOutputPointType>
-IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::
-  IdentityPixelTransformation()
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::IdentityPixelTransformation()
 {
   // initialize variables
 }
-*/
 
 template <typename TPixelType, typename TTransformType, typename TOutputPointType>
-typename IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::PixelType &
+auto
 IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::Transform(
   const PixelType &       value,
   const InputPointType &  itkNotUsed(inputPoint),
-  const OutputPointType & itkNotUsed(outputPoint))
+  const OutputPointType & itkNotUsed(outputPoint)) -> PixelType
 {
   return value;
 }
@@ -47,7 +42,8 @@ void
 IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::PrintSelf(std::ostream & os,
                                                                                      Indent         indent) const
 {
-  Superclass::PrintSelf(os, indent);
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "Es un IdentityPixelTransformation." << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkIdentityPixelTransformation.hxx
@@ -1,0 +1,55 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkIdentityPixelTransformation_hxx
+#define itkIdentityPixelTransformation_hxx
+
+#include "itkIdentityPixelTransformation.h"
+namespace itk
+{
+/*
+template <typename TPixelType,
+          typename TTransformType,
+          typename TOutputPointType>
+IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::
+  IdentityPixelTransformation()
+{
+  // initialize variables
+}
+*/
+
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+typename IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::PixelType &
+IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::Transform(
+  const PixelType &       value,
+  const InputPointType &  itkNotUsed(inputPoint),
+  const OutputPointType & itkNotUsed(outputPoint))
+{
+  return value;
+}
+
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+void
+IdentityPixelTransformation<TPixelType, TTransformType, TOutputPointType>::PrintSelf(std::ostream & os,
+                                                                                     Indent         indent) const
+{
+  Superclass::PrintSelf(os, indent);
+}
+
+} // end namespace itk
+
+#endif

--- a/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.h
@@ -50,12 +50,12 @@ public:
 
   /** Standard class type aliases. */
   using Self = PixelTransformation;
-  using Superclass = LightObject;
+  using Superclass = Object;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(PixelTransformation, LightObject);
+  itkTypeMacro(PixelTransformation, Object);
 
   using TransformType = TTransformType;
   using PixelType = TPixelType;
@@ -64,10 +64,16 @@ public:
   using CoordValueType = typename InputPointType::CoordRepType;
 
   itkSetConstObjectMacro(ImageTransform, TransformType);
-  itkGetModifiableObjectMacro(ImageTransform, TransformType);
+  itkGetConstObjectMacro(ImageTransform, TransformType);
 
-  virtual PixelType &
-  Transform(const PixelType & value, const InputPointType & inputPoint, const OutputPointType & outputPoint) = 0;
+  /**
+   * The default values for the points are meant to be used for linear transformations,
+   * for which these points are irrelevant.
+   */
+  virtual PixelType
+  Transform(const PixelType &       value,
+            const InputPointType &  inputPoint = InputPointType(),
+            const OutputPointType & outputPoint = OutputPointType()) = 0;
 
 
 protected:

--- a/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.h
@@ -1,0 +1,88 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkPixelTransformation_h
+#define itkPixelTransformation_h
+
+#include "itkObject.h"
+
+namespace itk
+{
+/**
+ * \class PixelTransformation
+ *
+ * This class is the base for the pixel transformation hierarchy.
+ * It defines a generic interface for a transformation of the pixel values after
+ * an image transformation. Typical non-trivial cases are the transformation of
+ * images of geometric (contravariant) vectors, covariant vectors, or any more
+ * complex tensor. These pixel transformations do not replace the ImageTransform
+ * but complement it. They have been introduced to be used by itkResampleImageFilter
+ * when the pixel type requires more complex transform than simply relocating it.
+ *
+ * \par
+ * Each subclass of PixelTransformation defines the transformation for a particular
+ * type of object (pixel).
+ *
+ * \ingroup Filtering
+ * \ingroup PixelTransformation
+ */
+template <typename TPixelType,
+          typename TTransformType,
+          typename TOutputPointType = typename TTransformType::OutputPointType>
+class ITK_TEMPLATE_EXPORT PixelTransformation : public Object
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(PixelTransformation);
+
+  /** Standard class type aliases. */
+  using Self = PixelTransformation;
+  using Superclass = LightObject;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Run-time type information (and related methods) */
+  itkTypeMacro(PixelTransformation, LightObject);
+
+  using TransformType = TTransformType;
+  using PixelType = TPixelType;
+  using InputPointType = typename TransformType::InputPointType;
+  using OutputPointType = TOutputPointType;
+  using CoordValueType = typename InputPointType::CoordRepType;
+
+  itkSetConstObjectMacro(ImageTransform, TransformType);
+  itkGetModifiableObjectMacro(ImageTransform, TransformType);
+
+  virtual PixelType &
+  Transform(const PixelType & value, const InputPointType & inputPoint, const OutputPointType & outputPoint) = 0;
+
+
+protected:
+  PixelTransformation();
+  ~PixelTransformation() override = default;
+
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+
+  typename TransformType::ConstPointer m_ImageTransform;
+};
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "itkPixelTransformation.hxx"
+#endif
+
+#endif

--- a/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.h
@@ -80,7 +80,7 @@ protected:
   PixelTransformation();
   ~PixelTransformation() override = default;
 
-  virtual void
+  void
   InitializeDefaultImageTransform();
 
   void

--- a/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.h
+++ b/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.h
@@ -80,6 +80,9 @@ protected:
   PixelTransformation();
   ~PixelTransformation() override = default;
 
+  virtual void
+  InitializeDefaultImageTransform();
+
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.hxx
@@ -38,19 +38,19 @@ PixelTransformation<TPixelType, TTransformType, TOutputPointType>::PixelTransfor
   // than the output one is a projection ignoring the last coordinates.
   // The effect when the input dimension is smaller that the output one is
   // a linear embedding, where the additional coordinates are set to zero.
-  m_ImageTransform = dynamic_cast<TransformType *>(
+  auto defaultImageTransform =
     MatrixOffsetTransformBase<typename TransformType::ParametersValueType, // InputPointType::CoordRepType,
                               TransformType::InputSpaceDimension,
-                              TransformType::OutputSpaceDimension>::New()
-      .GetPointer());
-  m_ImageTransform->SetIdentity();
+                              TransformType::OutputSpaceDimension>::New();
+  defaultImageTransform->SetIdentity();
+  m_ImageTransform = dynamic_cast<TransformType *>(defaultImageTransform.GetPointer());
 }
 
 template <typename TPixelType, typename TTransformType, typename TOutputPointType>
 void
 PixelTransformation<TPixelType, TTransformType, TOutputPointType>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  Superclass::PrintSelf(os, indent);
+  this->Superclass::PrintSelf(os, indent);
 
   os << indent << "Transform: " << this->GetImageTransform() << std::endl;
 }

--- a/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.hxx
@@ -1,0 +1,60 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkPixelTransformation_hxx
+#define itkPixelTransformation_hxx
+
+#include "itkPixelTransformation.h"
+#include "itkMatrixOffsetTransformBase.h"
+namespace itk
+{
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+PixelTransformation<TPixelType, TTransformType, TOutputPointType>::PixelTransformation()
+{
+  // initialize variables
+
+  // The m_ImageTransform is meant to be set by the user.
+  // However, to avoid run-time error in case it has not been set, or having
+  // to check for every point, a default m_ImageTransform is initialized.
+  // The default m_ImageTransform is an affine transform set as identity.
+  // Note that itkIdentityTransform cannot be use because it requires input
+  // and output dimensions to coincide.
+  // In case they do not coincide AffineTransform assign 1 to the main
+  // diagonal and 0 elsewhere. The effect when the input dimension is larger
+  // than the output one is a projection ignoring the last coordinates.
+  // The effect when the input dimension is smaller that the output one is
+  // a linear embedding, where the additional coordinates are set to zero.
+  m_ImageTransform = dynamic_cast<TransformType *>(
+    MatrixOffsetTransformBase<typename TransformType::ParametersValueType, // InputPointType::CoordRepType,
+                              TransformType::InputSpaceDimension,
+                              TransformType::OutputSpaceDimension>::New()
+      .GetPointer());
+  m_ImageTransform->SetIdentity();
+}
+
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+void
+PixelTransformation<TPixelType, TTransformType, TOutputPointType>::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "Transform: " << this->GetImageTransform() << std::endl;
+}
+
+} // end namespace itk
+
+#endif

--- a/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.hxx
+++ b/Modules/Filtering/PixelTransformation/include/itkPixelTransformation.hxx
@@ -26,7 +26,13 @@ template <typename TPixelType, typename TTransformType, typename TOutputPointTyp
 PixelTransformation<TPixelType, TTransformType, TOutputPointType>::PixelTransformation()
 {
   // initialize variables
+  this->InitializeDefaultImageTransform();
+}
 
+template <typename TPixelType, typename TTransformType, typename TOutputPointType>
+void
+PixelTransformation<TPixelType, TTransformType, TOutputPointType>::InitializeDefaultImageTransform()
+{
   // The m_ImageTransform is meant to be set by the user.
   // However, to avoid run-time error in case it has not been set, or having
   // to check for every point, a default m_ImageTransform is initialized.
@@ -38,10 +44,10 @@ PixelTransformation<TPixelType, TTransformType, TOutputPointType>::PixelTransfor
   // than the output one is a projection ignoring the last coordinates.
   // The effect when the input dimension is smaller that the output one is
   // a linear embedding, where the additional coordinates are set to zero.
-  auto defaultImageTransform =
-    MatrixOffsetTransformBase<typename TransformType::ParametersValueType, // InputPointType::CoordRepType,
-                              TransformType::InputSpaceDimension,
-                              TransformType::OutputSpaceDimension>::New();
+
+  auto defaultImageTransform = MatrixOffsetTransformBase<typename TransformType::ParametersValueType,
+                                                         TransformType::InputSpaceDimension,
+                                                         TransformType::OutputSpaceDimension>::New();
   defaultImageTransform->SetIdentity();
   m_ImageTransform = dynamic_cast<TransformType *>(defaultImageTransform.GetPointer());
 }

--- a/Modules/Filtering/PixelTransformation/itk-module.cmake
+++ b/Modules/Filtering/PixelTransformation/itk-module.cmake
@@ -1,0 +1,17 @@
+set(DOCUMENTATION "This module groups transformations of pixel values due to
+image transform. The trivial case is the identity transformation for scalar
+images. But typical non-trivial cases are the transformation of images of
+geometric (contravariant) vectors, covariant vectors, or any more complex
+tensor. These pixel transformations do not replace the ImageTransform but
+complement it. They have been introduced to be used by itkResampleImageFilter
+when the pixel type requires more complex transform than simply relocating it.")
+
+itk_module(ITKPixelTransformation
+  COMPILE_DEPENDS
+    ITKImageFunction
+  TEST_DEPENDS
+  DESCRIPTION
+    "${DOCUMENTATION}"
+)
+
+# ITKIOImageBase dependency introduced by itkResampleImageFilter.

--- a/Utilities/GitSetup/config
+++ b/Utilities/GitSetup/config
@@ -1,7 +1,9 @@
 [hooks]
-	url = https://github.com/InsightSoftwareConsortium/ITK.git
+#	url = https://github.com/InsightSoftwareConsortium/ITK.git
+	url = https://github.com/josempozo/ITK.git
 [upstream]
-	url = https://github.com/InsightSoftwareConsortium/ITK.git
+#	url = https://github.com/InsightSoftwareConsortium/ITK.git
+	url = https://github.com/josempozo/ITK.git
 	remote = upstream
 [github]
 	organization-name = InsightSoftwareConsortium


### PR DESCRIPTION
In the previous version, the limits, spacing, and direction of the displacement field were incorrectly managed. This pull amends all of them, providing the correct behaviour.

The test itkDisplacementFieldTransformTest has been modified to include anisotropic spacing and non-trivial grid direction. The test is not passed by the previous version.