### PR TITLE
BUG: Limits, spacing, and direction in ComputeJacobianWithRespectToPosition

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -303,7 +303,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
       //      ( lpix - rpix )*space/(2.0*h); //2nd order centered difference
       for (unsigned int col = 0; col < NDimensions; ++col)
       {
-        TParametersValueType val = dPix[col] / spacing[col];
+        TParametersValueType val = dPix[col] / spacing[row];
         if (row == col)
         {
           val += 1.0;

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -223,7 +223,6 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   bool                   doInverseJacobian) const
 {
 
-  typename DisplacementFieldType::SizeType  size = this->m_DisplacementField->GetLargestPossibleRegion().GetSize();
   typename DisplacementFieldType::IndexType startingIndex =
     this->m_DisplacementField->GetLargestPossibleRegion().GetIndex();
   typename DisplacementFieldType::IndexType upperIndex =

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -224,6 +224,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
 {
 
   typename DisplacementFieldType::SizeType    size = this->m_DisplacementField->GetLargestPossibleRegion().GetSize();
+  typename DisplacementFieldType::IndexType   startingIndex = this->m_DisplacementField->GetLargestPossibleRegion().GetIndex();
   typename DisplacementFieldType::SpacingType spacing = this->m_DisplacementField->GetSpacing();
 
   IndexType ddrindex;
@@ -237,7 +238,7 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   TParametersValueType space = NumericTraits<TParametersValueType>::OneValue();
 
   // Minimum distance between neighbors
-  TParametersValueType mindist = NumericTraits<TParametersValueType>::OneValue();
+  IndexValueType mindist = NumericTraits<IndexValueType>::OneValue();
 
   // Flag indicating a valid location for Jacobian calculation
   bool isValidJacobianCalcLocat = true;
@@ -247,12 +248,12 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   dPixSign = doInverseJacobian ? -dPixSign : dPixSign;
   for (unsigned int row = 0; row < NDimensions; ++row)
   {
-    TParametersValueType dist = itk::Math::abs((float)index[row]);
+    IndexValueType dist = index[row] - startingIndex[row];
     if (dist < mindist)
     {
       isValidJacobianCalcLocat = false;
     }
-    dist = itk::Math::abs((TParametersValueType)size[row] - (TParametersValueType)index[row]);
+    dist = static_cast<IndexValueType>(size[row]) - dist;
     if (dist < mindist)
     {
       isValidJacobianCalcLocat = false;

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -223,9 +223,11 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   bool                   doInverseJacobian) const
 {
 
-  typename DisplacementFieldType::SizeType    size = this->m_DisplacementField->GetLargestPossibleRegion().GetSize();
-  typename DisplacementFieldType::IndexType   startingIndex = this->m_DisplacementField->GetLargestPossibleRegion().GetIndex();
-  typename DisplacementFieldType::IndexType   upperIndex = this->m_DisplacementField->GetLargestPossibleRegion().GetUpperIndex();
+  typename DisplacementFieldType::SizeType  size = this->m_DisplacementField->GetLargestPossibleRegion().GetSize();
+  typename DisplacementFieldType::IndexType startingIndex =
+    this->m_DisplacementField->GetLargestPossibleRegion().GetIndex();
+  typename DisplacementFieldType::IndexType upperIndex =
+    this->m_DisplacementField->GetLargestPossibleRegion().GetUpperIndex();
   typename DisplacementFieldType::SpacingType spacing = this->m_DisplacementField->GetSpacing();
 
   // Space between indices
@@ -237,9 +239,9 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   // Multiplier for getting inverse Jacobian
   TParametersValueType dPixSign = NumericTraits<TParametersValueType>::OneValue();
   dPixSign = doInverseJacobian ? -dPixSign : dPixSign;
-  for (unsigned int row = 0; row < NDimensions; ++row)
+  for (unsigned int i = 0; i < NDimensions; ++i)
   {
-    if (index[row] <= startingIndex[row] || index[row] >= upperIndex[row])
+    if (index[i] <= startingIndex[i] || index[i] >= upperIndex[i])
     {
       isValidJacobianCalcLocat = false;
       break;
@@ -250,45 +252,53 @@ DisplacementFieldTransform<TParametersValueType, NDimensions>::ComputeJacobianWi
   {
     // itkCentralDifferenceImageFunction does not support 4th order so
     // do manually here
-    for (unsigned int row = 0; row < NDimensions; ++row)
+    for (unsigned int col = 0; col < NDimensions; ++col)
     {
-      IndexType difIndex[4] = {index, index, index, index};
-      difIndex[0][row] -= 2;
-      difIndex[1][row] -= 1;
-      difIndex[2][row] += 1;
-      difIndex[3][row] += 2;
-      if (difIndex[0][row] < startingIndex[row])
+      IndexType difIndex[4] = { index, index, index, index };
+      difIndex[0][col] -= 2;
+      difIndex[1][col] -= 1;
+      difIndex[2][col] += 1;
+      difIndex[3][col] += 2;
+      if (difIndex[0][col] < startingIndex[col])
       {
-        difIndex[0][row] = startingIndex[row];
+        difIndex[0][col] = startingIndex[col];
       }
-      if (difIndex[3][row] > upperIndex[row])
+      if (difIndex[3][col] > upperIndex[col])
       {
-        difIndex[3][row] = upperIndex[row];
+        difIndex[3][col] = upperIndex[col];
       }
 
       OutputVectorType pixDisp[4];
-      for(unsigned int i = 0; i < 4; ++i)
+      for (unsigned int i = 0; i < 4; ++i)
       {
-        const OutputVectorType tempPix = m_DisplacementField->GetPixel(difIndex[i]);
-        pixDisp[i] = m_DisplacementField->TransformLocalVectorToPhysicalVector(tempPix);
+        pixDisp[i] = m_DisplacementField->GetPixel(difIndex[i]);
       }
 
       // 4th order centered difference
-      OutputVectorType dPix = (pixDisp[0] - pixDisp[1] * 8.0 + pixDisp[2] * 8.0 - pixDisp[3]) / (12.0 * space * spacing[row]) * dPixSign;
+      OutputVectorType dPix =
+        (pixDisp[0] - pixDisp[1] * 8.0 + pixDisp[2] * 8.0 - pixDisp[3]) / (12.0 * space * spacing[col]) * dPixSign;
 
-      dPix[row] += 1.0;
-      for (unsigned int col = 0; col < NDimensions; ++col)
+      for (unsigned int row = 0; row < NDimensions; ++row)
       {
-        jacobian(col, row) = dPix[col];
+        jacobian(row, col) = dPix[row];
         // Verify it's a real number
-        if (!itk::Math::isfinite(dPix[col]))
+        if (!itk::Math::isfinite(dPix[row]))
         {
           isValidJacobianCalcLocat = false;
           break;
         }
       }
-    } // for row
-  }   // if isValidJacobianCalcLocat
+    } // for col
+
+    for (unsigned int row = 0; row < NDimensions; ++row)
+    {
+      FixedArray<TParametersValueType, NDimensions> localComponentGrad(jacobian[row]);
+      FixedArray<TParametersValueType, NDimensions> physicalComponentGrad =
+        m_DisplacementField->TransformLocalVectorToPhysicalVector(localComponentGrad);
+      jacobian.set_row(row, physicalComponentGrad.data());
+      jacobian(row, row) += 1.;
+    }
+  } // if isValidJacobianCalcLocat
 
   if (!isValidJacobianCalcLocat)
   {

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -299,6 +299,14 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   anisotropicSpacing[1] = 0.8;
   field->SetSpacing(anisotropicSpacing);
 
+  /* and non-trivial image grid orientation */
+  FieldType::DirectionType gridDirection;
+  gridDirection(0, 0) = 3. / 5;
+  gridDirection(0, 1) = 4. / 5;
+  gridDirection(1, 0) = -4. / 5;
+  gridDirection(1, 1) = 3. / 5;
+  field->SetDirection(gridDirection);
+
   itk::ImageRegionIteratorWithIndex<FieldType> it(field, field->GetLargestPossibleRegion());
   it.GoToBegin();
 
@@ -319,8 +327,10 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(field, displacementTransform->GetDisplacementField());
 
   DisplacementTransformType::InputPointType testPoint;
-  testPoint[0] = 10;
-  testPoint[1] = 8;
+  testPoint[0] = 12;
+  testPoint[1] = 4;
+  /* With the anisotropicSpacing and gridDirection set above
+   * this point corresponds exactly to index = { 4, 15 }. */
 
   // Test LocalJacobian methods
   DisplacementTransformType::JacobianPositionType jacobian;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -293,6 +293,12 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
   fieldJTruth(0, 1) = 0.02;
   fieldJTruth(1, 1) = 1.1;
 
+  /* Test the correctness of the Jacobian computation with anisotropic spacing */
+  FieldType::SpacingType anisotropicSpacing;
+  anisotropicSpacing[0] = 1.0;
+  anisotropicSpacing[1] = 0.8;
+  field->SetSpacing(anisotropicSpacing);
+
   itk::ImageRegionIteratorWithIndex<FieldType> it(field, field->GetLargestPossibleRegion());
   it.GoToBegin();
 


### PR DESCRIPTION
In the previous version, the limits, spacing, and direction of the displacement field were incorrectly managed. This pull amends all of them, providing the correct behaviour.

The test itkDisplacementFieldTransformTest has been modified to include anisotropic spacing and non-trivial grid direction. The test is not passed by the previous version.