### PR TITLE
COMP: Fix build against ITK install adding "expat_external.h" install rule

### DIFF
--- a/Modules/ThirdParty/Expat/src/expat/CMakeLists.txt
+++ b/Modules/ThirdParty/Expat/src/expat/CMakeLists.txt
@@ -196,6 +196,7 @@ INSTALL(FILES
   ${ITK3P_EXPAT_BINARY_DIR}/expatDllConfig.h
   ${ITK3P_EXPAT_SOURCE_DIR}/expat.h
   ${ITK3P_EXPAT_BINARY_DIR}/expat_config.h
+  ${ITK3P_EXPAT_SOURCE_DIR}/expat_external.h
   ${ITK3P_EXPAT_SOURCE_DIR}/itk_expat_mangle.h
   DESTINATION ${ITK3P_INSTALL_INCLUDE_DIR} # TODO: itk_expat.h #include "itkexpat/expat.h"
   COMPONENT Development)


### PR DESCRIPTION
This commit fixes a regression introduced in 9e337d3a2 (ENH: Update expat
files) by pull request #2755 on 2021-09-27.

ITK issue is #3186 and problem was first documented in
Slicer/SlicerExecutionModel#137
@hjmjohnson @dzenanz 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
