### PR TITLE
STYLE: Let assignment operators return a non-const reference

### DIFF
--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -115,10 +115,10 @@ public:
   }
 
   /** Copy operator */
-  const Self &
+  Self &
   operator=(const Self & rhs);
 
-  const Self &
+  Self &
   operator=(const VnlVectorType & rhs);
 
   /** Return the number of elements in the Array  */

--- a/Modules/Core/Common/include/itkArray.hxx
+++ b/Modules/Core/Common/include/itkArray.hxx
@@ -148,7 +148,7 @@ Array<TValue>::SetSize(SizeValueType sz)
 
 template <typename TValue>
 auto
-Array<TValue>::operator=(const Self & rhs) -> const Self &
+Array<TValue>::operator=(const Self & rhs) -> Self &
 {
   if (this != &rhs)
   {
@@ -167,7 +167,7 @@ Array<TValue>::operator=(const Self & rhs) -> const Self &
 
 template <typename TValue>
 auto
-Array<TValue>::operator=(const VnlVectorType & rhs) -> const Self &
+Array<TValue>::operator=(const VnlVectorType & rhs) -> Self &
 {
   if (this != &rhs)
   {

--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -55,10 +55,10 @@ public:
   Array2D(const Self & array);
   Array2D(const VnlMatrixType & matrix);
 
-  const Self &
+  Self &
   operator=(const Self & array);
 
-  const Self &
+  Self &
   operator=(const VnlMatrixType & matrix);
 
   void

--- a/Modules/Core/Common/include/itkArray2D.hxx
+++ b/Modules/Core/Common/include/itkArray2D.hxx
@@ -42,7 +42,7 @@ Array2D<TValue>::Array2D(const Self & array)
 
 /** Assignment Operator from Array */
 template <typename TValue>
-const Array2D<TValue> &
+Array2D<TValue> &
 Array2D<TValue>::operator=(const Self & array)
 {
   this->VnlMatrixType::operator=(array);
@@ -51,7 +51,7 @@ Array2D<TValue>::operator=(const Self & array)
 
 /** Assignment Operator from vnl_matrix */
 template <typename TValue>
-const Array2D<TValue> &
+Array2D<TValue> &
 Array2D<TValue>::operator=(const VnlMatrixType & matrix)
 {
   this->VnlMatrixType::operator=(matrix);

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -211,7 +211,7 @@ public:
   }
 
   /** Assignment operator. */
-  inline const Self &
+  inline Self &
   operator=(const vnl_matrix<T> & matrix)
   {
     m_Matrix = matrix;
@@ -247,7 +247,7 @@ public:
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
 
-  inline const Self &
+  inline Self &
   operator=(const InternalMatrixType & matrix)
   {
     this->m_Matrix = matrix;

--- a/Modules/Core/Common/include/itkOptimizerParameters.h
+++ b/Modules/Core/Common/include/itkOptimizerParameters.h
@@ -154,7 +154,7 @@ public:
    * TODO Determine behavior when copying from obj pointing to image parameters.
    *  By default should copy image param data into Array portion of new object,
    *  i.e. into data_block. Is that what we want? */
-  const Self &
+  Self &
   operator=(const Self & rhs)
   {
     // Note: there's no need to copy the OptimizerParametersHelper.
@@ -163,7 +163,7 @@ public:
     return *this;
   }
 
-  const Self &
+  Self &
   operator=(const ArrayType & rhs)
   {
     // Call the superclass implementation
@@ -171,7 +171,7 @@ public:
     return *this;
   }
 
-  const Self &
+  Self &
   operator=(const VnlVectorType & rhs)
   {
     // Call the superclass implementation

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.h
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.h
@@ -175,7 +175,7 @@ public:
   }
 
   /** Assignment operator. */
-  inline const Self &
+  inline Self &
   operator=(const vnl_matrix<T> & matrix)
   {
     m_Matrix = matrix;
@@ -189,7 +189,7 @@ public:
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
   /** Assignment operator. */
-  inline const Self &
+  inline Self &
   operator=(const Self & matrix)
   {
     m_Matrix = matrix.m_Matrix;

--- a/Modules/Core/Common/include/itkVersor.h
+++ b/Modules/Core/Common/include/itkVersor.h
@@ -116,7 +116,7 @@ public:
   Versor(const Self & v);
 
   /** Assignment operator =.  Copy the versor argument. */
-  const Self &
+  Self &
   operator=(const Self & v);
 
   /** Composition operator *=.  Compose the current versor

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -45,7 +45,7 @@ Versor<T>::Versor(const Self & v)
 
 /** Assignment Operator */
 template <typename T>
-const Versor<T> &
+Versor<T> &
 Versor<T>::operator=(const Self & v)
 {
   m_X = v.m_X;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -179,7 +179,7 @@ public:
     {
       m_Axis = axis;
     }
-    const AxisNodeType &
+    AxisNodeType &
     operator=(const NodeType & node)
     {
       this->NodeType::operator=(node);


### PR DESCRIPTION
Removed the "const" from `const Self &` return types of assignment
operators.

In accordance with C++ Core Guidelines, January 3, 2022: "Make copy
assignment non-virtual, take the parameter by const&, and return by
non-const&"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c60-make-copy-assignment-non-virtual-take-the-parameter-by-const-and-return-by-non-const

