### PR TITLE
DOC: Specify ```language in markdown.  Clang-format code examples.

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -154,24 +154,24 @@ how to remove dependence on barrier by using ParallelizeImageRegion.
 ```cpp
 ThreadedGenerateData()
 {
-  //code1 (parallel)
+  // code1 (parallel)
   myBarrier->Wait();
-  if (threadId==0)
-    {
-    //code2 single-threaded
-    }
-  //code3 (parallel)
+  if (threadId == 0)
+  {
+    // code2 single-threaded
+  }
+  // code3 (parallel)
 }
 ```
 
 after refactoring to not use barrier:
 ```cpp
-GenerateData() //Not Threaded
+GenerateData() // Not Threaded
 {
   this->AllocateOutputs();
   this->BeforeThreadedGenerateData();
   ParallelizeImageRegion(code1 as lambda)
-  //code2 single-threaded
+  // code2 single-threaded
   ParallelizeImageRegion(code3 as lambda)
   this->AfterThreadedGenerateData();
 }
@@ -212,7 +212,7 @@ An external module example that demonstrates this can be found in
 [this commit](https://github.com/InsightSoftwareConsortium/ITKBoneMorphometry/pull/32/commits/a8014c186ac53837362a0cb9db46ae224b8e9584).
 
 Before, using `itk::Array`:
-```C++
+```cpp
 // Members:
 Array<SizeValueType> m_NumVoxelsInsideMask;
 BeforeThreadedGenerateData()
@@ -222,8 +222,7 @@ BeforeThreadedGenerateData()
   m_NumVoxelsInsideMask.Fill(0);
 }
 
-ThreadedGenerateData(const RegionType & outputRegionForThread,
-                     ThreadIdType threadId)
+ThreadedGenerateData(const RegionType & outputRegionForThread, ThreadIdType threadId)
 {
   // Do algorithm per threadId
   // Store the results per thread at the end
@@ -233,17 +232,16 @@ ThreadedGenerateData(const RegionType & outputRegionForThread,
 AfterThreadedGenerateData()
 {
   // Retrieve and sum all the results per thread.
-  ThreadIdType numberOfThreads = this->GetNumberOfThreads();
+  ThreadIdType  numberOfThreads = this->GetNumberOfThreads();
   SizeValueType numVoxelsInsideMask = 0;
-  for (unsigned int i = 0; i < numberOfThreads; ++i )
-    {
+  for (unsigned int i = 0; i < numberOfThreads; ++i)
+  {
     numVoxelsInsideMask += m_NumVoxelsInsideMask[i];
-    }
+  }
 }
-
 ```
 After, using `std::atomic`:
-```C++
+```cpp
 // Members:
 std::atomic<SizeValueType> m_NumVoxelsInsideMask;
 BeforeThreadedGenerateData()
@@ -296,7 +294,7 @@ an external module that transitioned to the new threading model can be found in
 The variables `ITK_MAX_THREADS` and `ITK_DEFAULT_THREAD_ID` are now in the `itk::` namespace.
 Backwards compatibility is currently supported by exposing these to the global namespace
 with
-```C++
+```cpp
   using itk::ITK_MAX_THREADS;
   using itk::ITK_DEFAULT_THREAD_ID;
 ```
@@ -508,7 +506,7 @@ scoping, provide clean, readable code, facilitate wrapping in languages such
 as Python, and enable printing enum values to `std::ostream` with
 `operator<<`, and support templates, enums that we previously declared as:
 
-```
+```cpp
 // itkClassName.h
 namespace itk
 {
@@ -516,21 +514,20 @@ namespace itk
 class ClassName
 {
 public:
-
   enum Choices
   {
-     One,
-     Two,
-     Three
+    One,
+    Two,
+    Three
   };
 };
 
-}
+} // namespace itk
 ```
 
 are now declared as:
 
-```
+```cpp
 // itkClassName.h
 namespace itk
 {
@@ -538,7 +535,7 @@ namespace itk
 class ClassNameEnums
 {
 public:
-  enum class Choices: uint8_t
+  enum class Choices : uint8_t
   {
     One,
     Two,
@@ -551,7 +548,6 @@ operator<<(std::ostream & out, const ClassNameEnums::Choices value);
 class ClassName
 {
 public:
-
   using ChoicesEnum = ClassNameEnums::Choices;
 #if !defined(ITK_LEGACY_REMOVE)
   using Choices = ChoicesEnum;
@@ -561,7 +557,7 @@ public:
 #endif
 };
 
-}
+} // namespace itk
 
 // itkClassName.cxx
 namespace itk

--- a/Documentation/Maintenance/Release.md
+++ b/Documentation/Maintenance/Release.md
@@ -477,7 +477,7 @@ cd ..
 
 For Linux ARM builds, the steps are similar, but the wheel build step is:
 
-```
+```sh
 docker run --privileged --rm tonistiigi/binfmt --install all
 docker run -it -v $(pwd):/work/ quay.io/pypa/manylinux2014_aarch64:latest bash
 # In the container
@@ -645,7 +645,7 @@ update the guide and make it available:
 To create `ItkSoftwareGuide.pdf` to deposit at itk.org/ItkSoftwareGuide.pdf from
 `InsightSoftwareGuide-Book{1,2}-5.X.0.pdf`, use `pdftk`:
 
-```
+```sh
    pdftk ITKSoftwareGuideSinglePDFCoverPage.pdf ITKSoftwareGuide-Book1.pdf ITKSoftwareGuide-Book2.pdf cat output /tmp/ItkSoftwareGuide.pdf
 ```
 
@@ -809,7 +809,7 @@ Release Notes Posts
 To get started with the release notes, first use the download link
 cookiecutter to generate Markdown and webpage Download page HTML:
 
-```
+```sh
 pip install cookiecutter
 cookiecutter ~/src/ITK/Utilities/Maintenance/DownloadLinksCookieCutter/
 ```

--- a/Modules/Remote/README.md
+++ b/Modules/Remote/README.md
@@ -47,7 +47,7 @@ core developers in maintaining the core ITK code base.  There are currently (202
 
 ## Documenting the Compliance Level of a remote module
 Use the following template to document the compliance level of the modules.
-```
+```cmake
 #-- # Grading Level Criteria Report
 #-- EVALUATION DATE: 2020-03-01
 #-- EVALUATORS: [<<NO EVALUATOR>>,<<NO EVALUATOR>>]

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ pay for developer time, professional services, travel, workshops, and a variety 
 
 ITK is distributed in binary Python packages. To install:
 
-```
+```sh
 pip install itk
 ```
 
 or
 
-```
+```sh
 conda install -c conda-forge itk
 ```
 

--- a/Utilities/Maintenance/DownloadLinksCookieCutter/{{cookiecutter.output_directory}}/ReleaseDownloadLinks.md
+++ b/Utilities/Maintenance/DownloadLinksCookieCutter/{{cookiecutter.output_directory}}/ReleaseDownloadLinks.md
@@ -2,13 +2,13 @@
 
 Install [ITK Python packages](https://itkpythonpackage.readthedocs.io/en/latest/Quick_start_guide.html) with:
 
-```
+```sh
 pip install --upgrade itk
 ```
 
 or:
 
-```
+```sh
 conda install -c conda-forge itk
 ```
 


### PR DESCRIPTION
DOC: Change some displayed code examples from the obsolete coding style for ITK to our current clang-format style.
STYLE: Note the language (e.g., cpp, sh, cmake) after ``` markup so that `markdown` viewers can use language-specific formatting.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
