### PR TITLE
ENH: Add metadata_dict option to itk.imwrite

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -142,6 +142,12 @@ assert itk.range(reader.GetOutput()) == (0, 255)
 itk.imwrite(reader, sys.argv[4])
 itk.imwrite(reader, sys.argv[4], imageio=itk.PNGImageIO.New())
 itk.imwrite(reader, sys.argv[4], True)
+# exercise metadata_dict
+metadata_dict = itk.MetaDataDictionary.New()
+metadata_str = itk.MetaDataObject[str].New()
+metadata_str.Set("A custom name")
+metadata_dict.Set("Segment0_Name", metadata_str)
+itk.imwrite(reader, sys.argv[4], True, metadata_dict=metadata_dict)
 
 # test read
 image = itk.imread(pathlib.Path(filename))

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -876,6 +876,7 @@ def imwrite(
     filename: fileiotype,
     compression: bool = False,
     imageio: Optional["itkt.ImageIOBase"] = None,
+    metadata_dict: Optional["itkt.MetaDataDictionary"] = None,
 ) -> None:
     """Write a image or the output image of a filter to a file.
 
@@ -894,6 +895,9 @@ def imwrite(
     imageio :
         Use the provided itk.ImageIOBase derived instance to write the file.
 
+    metadata_dict :
+        Save the provided itk.MetaDataDictionary extra headers to the file.
+
     The writer is instantiated with the image type of the image in
     parameter (or, again, with the output image of the filter in parameter).
     """
@@ -910,6 +914,8 @@ def imwrite(
     auto_pipeline.current = tmp_auto_pipeline
     if imageio:
         writer.SetImageIO(imageio)
+    if metadata_dict:
+        writer.SetMetaDataDict(metadata_dict)
     writer.Update()
 
 


### PR DESCRIPTION
For adding extra metadata to headers.

The most common user case would be adding Slicer headers to `.seg.nrrd`
files.

See the following references for slicer details:
[1](https://apidocs.slicer.org/master/classvtkMRMLSegmentationStorageNode.html#details)
[2](https://slicer.readthedocs.io/en/latest/developer_guide/modules/segmentations.html)

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)

