### PR TITLE
COMP: FEM module was not compiling after renames in 4b43536

### DIFF
--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
@@ -57,7 +57,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ImageToRectilinearFEMObjectFilter, ProcessObject);
 
-  static constexpr unsigned int NDimensions = TInputImage::ImageDimension;
+  static constexpr unsigned int VDimension = TInputImage::ImageDimension;
 
   /** Typedefs for Input Image */
   using InputImageType = TInputImage;


### PR DESCRIPTION
4b43536c8b22bb716a4f0b76a0582a99d6d8911d did a lot of renames.
This one was somehow overlooked.
It causes compile errors when Module_ITKFEMRegistration is enabled:
```
96>------ Build started: Project: ITKFEMRegistration, Configuration: Debug x64 ------
96>itkFEMRegistrationFilter.cxx
96>C:\Dev\ITK-git\Modules\Numerics\FEM\include\itkImageToRectilinearFEMObjectFilter.h(72,54): error C2065: 'VDimension': undeclared identifier
96>C:\Dev\ITK-git\Modules\Numerics\FEM\include\itkImageToRectilinearFEMObjectFilter.h(175): message : see reference to class template instantiation 'itk::fem::ImageToRectilinearFEMObjectFilter<TInputImage>' being compiled
96>C:\Dev\ITK-git\Modules\Numerics\FEM\include\itkImageToRectilinearFEMObjectFilter.h(72,1): error C2975: 'VDimension': invalid template argument for 'itk::fem::FEMObject', expected compile-time constant expression
96>C:\Dev\ITK-git\Modules\Numerics\FEM\include\itkFEMObject.h(74): message : see declaration of 'VDimension'
95>ITKIOHDF5.vcxproj -> C:\Dev\ITK-vs19\lib\Debug\ITKIOHDF5-5.3.lib
96>Done building project "ITKFEMRegistration.vcxproj" -- FAILED.
```
