### PR TITLE
BUG: FEM module has incorrect public member name

### DIFF
--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
@@ -69,7 +69,7 @@ public:
   using ImageIndexType = typename InputImageType::IndexType;
 
   /** Typedefs for Output FEMObject */
-  using FEMObjectType = typename itk::fem::FEMObject<VDimension>;
+  using FEMObjectType = typename itk::fem::FEMObject<NDimensions>;
   using FEMObjectPointer = typename FEMObjectType::Pointer;
   using FEMObjectConstPointer = typename FEMObjectType::ConstPointer;
   using DataObjectPointer = typename DataObject::Pointer;

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -32,9 +32,9 @@ namespace fem
 template <typename TInputImage>
 ImageToRectilinearFEMObjectFilter<TInputImage>::ImageToRectilinearFEMObjectFilter()
 {
-  this->m_NumberOfElements.set_size(VDimension);
+  this->m_NumberOfElements.set_size(NDimensions);
   this->m_NumberOfElements.fill(0);
-  this->m_PixelsPerElement.set_size(VDimension);
+  this->m_PixelsPerElement.set_size(NDimensions);
   this->m_PixelsPerElement.fill(1);
   this->m_Material = nullptr;
   this->m_Element = nullptr;
@@ -137,7 +137,7 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::GenerateData()
     itkWarningMacro(<< "GenerateData() found no input objects");
   }
 
-  if (VDimension == 2)
+  if (NDimensions == 2)
   {
     Generate2DRectilinearMesh();
   }

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
@@ -509,7 +509,7 @@ MetaFEMObjectConverter<VDimension>::SpatialObjectToMetaObject(const SpatialObjec
 
       Load->m_GN = SOLoadCast->GetGlobalNumber();
 
-      const auto numLoadElements = static_cast<const int>(SOLoadCast->GetElementArray().size());
+      const int numLoadElements = static_cast<int>(SOLoadCast->GetElementArray().size());
       Load->m_NumElements = numLoadElements;
       for (int i = 0; i < numLoadElements; ++i)
       {


### PR DESCRIPTION
Commit 4b43536c8b22bb716a4f0b76a0582a99d6d8911d "STYLE: Change template parameter name prefix N to V" intended to change template parameter names but mistakenly changed a member variable's name.  This commit fixes that.

I don't have permission to push to #3201, so this pull request is intended to replace it.