### PR TITLE
Replace `std::vector<bool>` with `std::unique_ptr<bool[]>`, remove `EnabledArrayType = std::vector<bool>`

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -21,6 +21,8 @@
 #include "itkMath.h"
 #include "itkSphereSpatialFunction.h"
 
+#include <memory> // For make_unique.
+
 namespace itk
 {
 /** Create the operator */
@@ -105,7 +107,7 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
 
   const typename SizeType::SizeValueType w = this->Size();
 
-  std::vector<bool>              outside(w);
+  const auto                     outside = std::make_unique<bool[]>(w);
   CoefficientVector              coeffP(w);
   OffsetType                     offset;
   typename SphereType::InputType point;

--- a/Modules/Core/Common/test/itkTimeStampTest.cxx
+++ b/Modules/Core/Common/test/itkTimeStampTest.cxx
@@ -20,6 +20,7 @@
 #include "itkMultiThreaderBase.h"
 
 #include <iostream>
+#include <memory> // For make_unique.
 #include <type_traits>
 
 static_assert(std::is_nothrow_default_constructible<itk::TimeStamp>::value, "Check TimeStamp default-constructibility");
@@ -89,7 +90,7 @@ itkTimeStampTest(int, char *[])
 
     // Declare an array to test whether the all modified times have
     // been used
-    std::vector<bool> istimestamped(numberOfWorkUnits);
+    const auto istimestamped = std::make_unique<bool[]>(numberOfWorkUnits);
 
     // Call Modified once  on any object to make it up-to-date
     multithreader->Modified();

--- a/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
@@ -53,7 +53,6 @@ public:
 
   using typename Superclass::ParametersValueType;
   using typename Superclass::ParametersType;
-  using EnabledArrayType = std::vector<bool>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);


### PR DESCRIPTION
Replaced `std::vector<bool>` by `std::unique_ptr<bool[]>` in two cases as it appears preferable to avoid using `std::vector<bool>`, when there is a convenient alternative.

In general, `std::vector<bool>` appears troublesome, as it may not prevent data races, and its support for random access may be suboptimal. On the other hand, an `std::unique_ptr<bool[]>` offers fast random access and prevents data races when accessing different elements in the same array.

Follow-up to pull request #3166 commit 915b8e48d8ff7d9f5b943eb673826ad85bf74a8c "BUG: fixed threading bug, don't use vector<bool> from multiple threads" by Sean McBride (merged on 8 February 2022).

Also removed an unused type alias, `EnabledArrayType = std::vector<bool>`.