### PR TITLE
STYLE: Apply C++ "Rule of Zero" to `itk::FixedArray` and derived classes

### DIFF
--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -69,15 +69,9 @@ public:
   using Iterator = typename BaseArray::Iterator;
   using ConstIterator = typename BaseArray::ConstIterator;
 
-  /** Constructors */
+  /** Default-constructor.
+   * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   ContinuousIndex() = default;
-  ContinuousIndex(const ContinuousIndex &) = default;
-  ContinuousIndex(ContinuousIndex &&) = default;
-  ContinuousIndex &
-  operator=(const ContinuousIndex &) = default;
-  ContinuousIndex &
-  operator=(ContinuousIndex &&) = default;
-  ~ContinuousIndex() = default;
 
   /** Pass-through constructor to the Point base class. */
   ContinuousIndex(const ValueType r[IndexDimension])

--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -109,15 +109,9 @@ public:
   vnl_vector<T>
   GetVnlVector() const;
 
-  /** Default constructor. */
+  /** Default-constructor.
+   * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   CovariantVector() = default;
-  CovariantVector(const CovariantVector &) = default;
-  CovariantVector(CovariantVector &&) = default;
-  CovariantVector &
-  operator=(const CovariantVector &) = default;
-  CovariantVector &
-  operator=(CovariantVector &&) = default;
-  ~CovariantVector() = default;
 
   /**
    * Constructor to initialize entire vector to one value.

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -189,15 +189,9 @@ public:
   using SizeType = unsigned int;
 
 public:
-  /** Constructors */
+  /** Default-constructor.
+   * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   FixedArray() = default;
-  FixedArray(const FixedArray &) = default;
-  FixedArray &
-  operator=(const FixedArray &) = default;
-  FixedArray(FixedArray &&) = default;
-  FixedArray &
-  operator=(FixedArray &&) = default;
-  ~FixedArray() = default;
 
   /** Conversion constructors */
   FixedArray(const ValueType r[VLength]);

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -82,15 +82,10 @@ public:
   /** VectorType define the difference between two Points */
   using VectorType = Vector<ValueType, VPointDimension>;
 
-  /** Default constructor, assignments */
+  /** Default-constructor.
+   * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   Point() = default;
-  Point(const Point &) = default;
-  Point(Point &&) = default;
-  Point &
-  operator=(const Point &) = default;
-  Point &
-  operator=(Point &&) = default;
-  ~Point() = default;
+
   /** Pass-through constructors for different type points. */
   template <typename TPointValueType>
   Point(const Point<TPointValueType, VPointDimension> & r)

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -76,16 +76,9 @@ public:
   using ComponentType = TComponent;
   using LuminanceType = typename NumericTraits<ComponentType>::RealType;
 
-  /** Default constructors */
+  /** Default-constructor.
+   * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   RGBAPixel() { this->Fill(0); }
-  RGBAPixel(const RGBAPixel &) = default;
-  RGBAPixel &
-  operator=(const RGBAPixel &) = default;
-  RGBAPixel(RGBAPixel &&) = default;
-  RGBAPixel &
-  operator=(RGBAPixel &&) = default;
-  ~RGBAPixel() = default;
-
   /** Pass-through constructor for the Array base class. */
   template <typename TRGBAPixelValueType>
   RGBAPixel(const RGBAPixel<TRGBAPixelValueType> & r)

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -75,15 +75,9 @@ public:
   using ComponentType = TComponent;
   using LuminanceType = typename NumericTraits<ComponentType>::RealType;
 
-  /** Default constructors */
+  /** Default-constructor.
+   * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   RGBPixel() { this->Fill(0); }
-  RGBPixel(const RGBPixel &) = default;
-  RGBPixel(RGBPixel &&) = default;
-  RGBPixel &
-  operator=(const RGBPixel &) = default;
-  RGBPixel &
-  operator=(RGBPixel &&) = default;
-  ~RGBPixel() = default;
 
   /** Constructor to fill Red=Blug=Green= r. */
   RGBPixel(const ComponentType & r) { this->Fill(r); }

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
@@ -102,15 +102,9 @@ public:
   using SymmetricEigenAnalysisType =
     SymmetricEigenAnalysisFixedDimension<Dimension, MatrixType, EigenValuesArrayType, EigenVectorsMatrixType>;
 
-  /** Constructors */
+  /** Default-constructor.
+   * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   SymmetricSecondRankTensor() { this->Fill(0); }
-  SymmetricSecondRankTensor(const SymmetricSecondRankTensor &) = default;
-  SymmetricSecondRankTensor(SymmetricSecondRankTensor &&) = default;
-  SymmetricSecondRankTensor &
-  operator=(const SymmetricSecondRankTensor &) = default;
-  SymmetricSecondRankTensor &
-  operator=(SymmetricSecondRankTensor &&) = default;
-  ~SymmetricSecondRankTensor() = default;
 
   SymmetricSecondRankTensor(const ComponentType & r) { this->Fill(r); }
 

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -102,15 +102,9 @@ public:
   vnl_vector<T>
   GetVnlVector() const;
 
-  /** Default constructors, assignments and destructor */
+  /** Default-constructor.
+   * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   Vector() = default;
-  Vector(const Vector &) = default;
-  Vector(Vector &&) = default;
-  Vector &
-  operator=(const Vector &) = default;
-  Vector &
-  operator=(Vector &&) = default;
-  ~Vector() = default;
 
 #if !defined(ITK_LEGACY_FUTURE_REMOVE)
   /** Constructor to initialize entire vector to one value.


### PR DESCRIPTION
Removed the explicitly-defaulted definitions of the copy-constructor,
copy-assignment operator, move-constructor, move-assignment operator,
and destructor of `itk::FixedArray<TValue, VLength>` and derived classes,
as they might as well be defaulted implicitly.

Following previous commits that apply the "Rule of Zero", including:

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2896
commit 83f6cab3c4b8e87374147363bdf7f75f9cf7addf
"STYLE: Remove `TimeStamp` default-constructor, assignment (Rule of Zero)"

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2449
commit 59ebc33c6e835bd8ed52e54e40ee15a7fa24377e
"ENH: Make itk::Matrix trivially copyable, following Rule of Zero"

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/325
commit d36fbde0856cc3de684933f153f8be8cab5b5d8e
"ENH: Employ the rule of zero for aggregate types"