### PR TITLE
BUG: Fix `ColorTableTestSpecialConditionChecker` component/pixel mix-up

### DIFF
--- a/Modules/Core/Common/test/itkColorTableTest.cxx
+++ b/Modules/Core/Common/test/itkColorTableTest.cxx
@@ -108,23 +108,23 @@ ColorTableTestSpecialConditionChecker(typename itk::ColorTable<TComponent>::Poin
 
   char       rgb = 'r';
   TComponent zeroComponent(0);
-  pixel = colors->GetColorComponent(numberOfColors, rgb);
-  if (pixel != zeroComponent)
+  TComponent colorComponent = colors->GetColorComponent(numberOfColors, rgb);
+  if (colorComponent != zeroComponent)
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in itk::ColorTable::GetColorComponent" << std::endl;
     std::cerr << "Expected: 0 "
-              << ", but got: " << pixel << std::endl;
+              << ", but got: " << colorComponent << std::endl;
     return EXIT_FAILURE;
   }
   rgb = 'a';
-  pixel = colors->GetColorComponent(numberOfColors - 1, rgb);
-  if (pixel != zeroComponent)
+  colorComponent = colors->GetColorComponent(numberOfColors - 1, rgb);
+  if (colorComponent != zeroComponent)
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in itk::ColorTable::GetColorComponent" << std::endl;
     std::cerr << "Expected: 0 "
-              << ", but got: " << pixel << std::endl;
+              << ", but got: " << colorComponent << std::endl;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
It appears that `ColorTableTestSpecialConditionChecker<TComponent>()`
mixed up color component and pixel types, when it assigned the result of
two `GetColorComponent` calls to a `pixel` variable. `GetColorComponent`
returns a component value, rather than a pixel value.

This bug was found by declaring the `RGBPixel(const ComponentType &)`
constructor `explicit` (locally, temporarily), to detect accidental
implicit conversions from a component value to an `RGBPixel` value.

Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3221
commit 9cfaf8fbdaba802e3b6406db300581e25ddec9ff
"STYLE: Rename `ColorTable` template parameter `TPixel` to `TComponent`"