### PR TITLE
STYLE: Avoid `T var = elementValue` syntax to initialize a filled array

### DIFF
--- a/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
@@ -44,7 +44,7 @@ itkEllipseSpatialObjectTest(int, char *[])
 
   ITK_TEST_SET_GET_VALUE(radii, myEllipse->GetRadiusInObjectSpace());
 
-  EllipseType::ArrayType objectSpaceRadius = 3;
+  EllipseType::ArrayType objectSpaceRadius(3);
   myEllipse->SetRadiusInObjectSpace(objectSpaceRadius);
   myEllipse->Update();
 

--- a/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest.cxx
@@ -63,11 +63,11 @@ itkCannyEdgeDetectionImageFilterTest(int argc, char * argv[])
   filter->SetLowerThreshold(lowerThreshold);
   ITK_TEST_SET_GET_VALUE(lowerThreshold, filter->GetLowerThreshold());
 
-  CannyEdgeDetectionImageFilterType::ArrayType variance = 1.0f;
+  CannyEdgeDetectionImageFilterType::ArrayType variance(1.0f);
   filter->SetVariance(variance);
   ITK_TEST_SET_GET_VALUE(variance, filter->GetVariance());
 
-  CannyEdgeDetectionImageFilterType::ArrayType maximumError = .01f;
+  CannyEdgeDetectionImageFilterType::ArrayType maximumError(.01f);
   filter->SetMaximumError(maximumError);
   ITK_TEST_SET_GET_VALUE(maximumError, filter->GetMaximumError());
 

--- a/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest2.cxx
@@ -60,11 +60,11 @@ itkCannyEdgeDetectionImageFilterTest2(int argc, char * argv[])
   filter->SetLowerThreshold(lowerThreshold);
   ITK_TEST_SET_GET_VALUE(lowerThreshold, filter->GetLowerThreshold());
 
-  CannyEdgeDetectionImageFilterType::ArrayType variance = 1.0f;
+  CannyEdgeDetectionImageFilterType::ArrayType variance(1.0f);
   filter->SetVariance(variance);
   ITK_TEST_SET_GET_VALUE(variance, filter->GetVariance());
 
-  CannyEdgeDetectionImageFilterType::ArrayType maximumError = .01f;
+  CannyEdgeDetectionImageFilterType::ArrayType maximumError(.01f);
   filter->SetMaximumError(maximumError);
   ITK_TEST_SET_GET_VALUE(maximumError, filter->GetMaximumError());
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
@@ -65,7 +65,7 @@ BSpline(int argc, char * argv[])
   bspliner->SetCloseDimension(closeDimension);
   ITK_TEST_SET_GET_VALUE(closeDimension, bspliner->GetCloseDimension());
 
-  typename BSplinerType::ArrayType splineOrder = 3;
+  typename BSplinerType::ArrayType splineOrder(3);
   bspliner->SetSplineOrder(splineOrder);
   ITK_TEST_SET_GET_VALUE(splineOrder, bspliner->GetSplineOrder());
 

--- a/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
@@ -54,7 +54,7 @@ itkGaborImageSourceTestHelper(char * outputFilename, bool calculcateImaginaryPar
   gaborImage->SetSigma(sigma);
   ITK_TEST_SET_GET_VALUE(sigma, gaborImage->GetSigma());
 
-  typename GaborSourceType::ArrayType mean = 0.1;
+  typename GaborSourceType::ArrayType mean(0.1);
   gaborImage->SetMean(mean);
   ITK_TEST_SET_GET_VALUE(mean, gaborImage->GetMean());
 


### PR DESCRIPTION
The C++ copy-initialization syntax `T var = value` suggests that the
value at the right side is implicitly converted to the target type `T`.

When the target type `T` is a `FixedArray<TValue, VLength>`, or one of
its derived types, `T var = elementValue` _fills_ the variable with the
specified `elementValue`, by assigning the `elementValue` to each of its
elements. In this case, the C++ direct-initialization syntax
`T var(elementValue)` appears more appropriate.

Occurrences of `T var = elementValue` were found by locally temporarily
declaring the corresponding constructors `explicit`.