### PR TITLE
BUG: Quick-fix ContourSpatialObject::Update(), LINEAR_INTERPOLATION case

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -214,13 +214,18 @@ ContourSpatialObject<TDimension>::Update()
         {
           step[d] = (pnt2[d] - pnt[d]) / m_InterpolationFactor;
         }
+
+        // TODO There is an issue regarding this code, from 24 February 2022:
+        // "`ContourSpatialObject<TDimension>::Update()` LINEAR_INTERPOLATION case may need some adjustment"
+        // https://github.com/InsightSoftwareConsortium/ITK/issues/3222
+
         PointType newPoint;
         newPoint.Fill(NumericTraits<double>::max());
         for (unsigned int i = 0; i < m_InterpolationFactor; ++i)
         {
           for (unsigned int d = 0; d < TDimension; ++d)
           {
-            newPoint = pnt[d] + i * step[d];
+            newPoint[d] = pnt[d] + i * step[d];
           }
         }
         typename Superclass::SpatialObjectPointType newSOPoint;


### PR DESCRIPTION
`ContourSpatialObject::Update()` appears to have an assignment to
`newPoint`, in the `case InterpolationMethodEnum::LINEAR_INTERPOLATION`
section, which was meant to assign just a single element `newPoint[d]`.

As was confirmed by Stephen Aylward (@aylward) at issue https://github.com/InsightSoftwareConsortium/ITK/issues/3222,
"`ContourSpatialObject<TDimension>::Update()` LINEAR_INTERPOLATION case
may need some adjustment".

Some more adjustment may still be needed, as `newPoint` now still gets
modified multiply times (rather than just once), before it eventually
gets used.