### PR TITLE
BUG: Fix code that treated `point1 - point2` as Point rather than Vector

### DIFF
--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1416,10 +1416,17 @@ RayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(const PointTyp
   ray.ZeroState();
   ray.Initialise();
 
-  PointType origin = this->m_Image->GetOrigin();
-  for (unsigned int i = 0; i < origin.Length; ++i)
-    origin[i] -= 0.5 * this->m_Image->GetSpacing()[i];
-  ray.SetRay(point - origin, direction);
+  const PointType origin = this->m_Image->GetOrigin();
+  const auto      spacing = this->m_Image->GetSpacing();
+
+  PointType rayPosition = point;
+
+  for (unsigned int i = 0; i < PointType::Length; ++i)
+  {
+    rayPosition[i] -= origin[i] - 0.5 * spacing[i];
+  }
+
+  ray.SetRay(rayPosition, direction);
   ray.IntegrateAboveThreshold(integral, m_Threshold);
 
   return (static_cast<OutputType>(integral));

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -185,7 +185,6 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
   // to an output pixel
   PointType outputPoint;       // Coordinates of output pixel
   PointType transformedPoint;  // Coordinates of transformed pixel
-  PointType displacementPoint; // the difference
   PixelType displacementPixel; // the difference, cast to pixel type
 
 
@@ -203,11 +202,11 @@ TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::Nonlinea
       // Compute corresponding input pixel position
       transformedPoint = transform->TransformPoint(outputPoint);
 
-      displacementPoint = transformedPoint - outputPoint;
+      const typename PointType::VectorType displacementVector = transformedPoint - outputPoint;
       // Cast PointType -> PixelType
       for (IndexValueType idx = 0; idx < ImageDimension; ++idx)
       {
-        displacementPixel[idx] = static_cast<typename PixelType::ValueType>(displacementPoint[idx]);
+        displacementPixel[idx] = static_cast<typename PixelType::ValueType>(displacementVector[idx]);
       }
       outIt.Set(displacementPixel);
       ++outIt;


### PR DESCRIPTION
An subtraction of the form `point1 - point2` yields a `Vector`, not a `Point`. Adjusted both `TransformToDisplacementFieldFilter::NonlinearThreadedGenerateData` and `RayCastInterpolateImageFunction::Evaluate` accordingly.

These two little flaws were found by locally (temporarily) declaring converting constructors of `Point` "explicit".