### PR TITLE
STYLE: Use direct-initialization for component-to-RGBPixel conversion

### DIFF
--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
@@ -39,7 +39,6 @@ itkResampleImageTest5(int argc, char * argv[])
   // Resample an RGB image
   constexpr unsigned int VDimension = 2;
 
-  using PixelType = unsigned char;
   using RGBPixelType = itk::RGBPixel<unsigned char>;
   using ImageType = itk::Image<RGBPixelType, 2>;
 
@@ -76,12 +75,11 @@ itkResampleImageTest5(int argc, char * argv[])
 
   // Fill image with a ramp
   itk::ImageRegionIteratorWithIndex<ImageType> iter(image, region);
-  PixelType                                    value;
   for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
   {
     index = iter.GetIndex();
-    value = index[0] + index[1];
-    iter.Set(value);
+    const RGBPixelType rgbPixel(index[0] + index[1]);
+    iter.Set(rgbPixel);
   }
 
   // Create an affine transformation

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -73,8 +73,9 @@ protected:
     itk::ImageRegionIteratorWithIndex<TOutputImage> it(out, out->GetRequestedRegion());
     for (it.GoToBegin(); !it.IsAtEnd(); ++it)
     {
-      typename TOutputImage::IndexType idx = it.GetIndex();
-      it.Set(idx[2] * 100 + idx[1] * 10 + idx[0]);
+      typename TOutputImage::IndexType       idx = it.GetIndex();
+      const typename TOutputImage::PixelType pixel(idx[2] * 100 + idx[1] * 10 + idx[0]);
+      it.Set(pixel);
     }
   };
 
@@ -188,11 +189,10 @@ HDF5ReadWriteTest2(const char * fileName)
   // Check image pixel values.
   itk::ImageRegionIterator<ImageType> it(image, image->GetLargestPossibleRegion());
   typename ImageType::IndexType       idx;
-  TPixel                              origValue;
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
   {
     idx = it.GetIndex();
-    origValue = idx[2] * 100 + idx[1] * 10 + idx[0];
+    const TPixel origValue(idx[2] * 100 + idx[1] * 10 + idx[0]);
     if (itk::Math::NotAlmostEquals(it.Get(), origValue))
     {
       std::cout << "Original Pixel (" << origValue << ") doesn't match read-in Pixel (" << it.Get() << std::endl;


### PR DESCRIPTION
Replaced cases of implicit conversion from RGB component value to
`RGBPixel` in unit tests by explicit pixel variable declarations,
direct-initializing them by the specified component value.

Aims to make clear that those conversions were really intended.
Especially because such a conversion may easily take place
unintentionally, implicitly, for example as addressed by pull request #3223
commit 490ef8ce90b44a61089a41054180ad203f36b2d4 "BUG: Fix `ColorTableTestSpecialConditionChecker` component/pixel mix-up"