### PR TITLE
ENH: Declare converting `Point(v)` constructors `explicit`

### DIFF
--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -99,7 +99,22 @@ public:
   Point(const ValueType r[VPointDimension])
     : BaseArray(r)
   {}
-  /** Pass-through constructors for single values */
+
+#if defined(ITK_LEGACY_REMOVE)
+  /** Prevents copy-initialization from `nullptr`, as well as from `0` (NULL). */
+  Point(std::nullptr_t) = delete;
+
+  /** Explicit constructors for single values */
+  template <typename TPointValueType>
+  explicit Point(const TPointValueType & v)
+    : BaseArray(v)
+  {}
+  explicit Point(const ValueType & v)
+    : BaseArray(v)
+  {}
+#else
+  /** Pass-through constructors for single values
+   * \note ITK_LEGACY_REMOVE=ON will disallow implicit conversion from a single value. */
   template <typename TPointValueType>
   Point(const TPointValueType & v)
     : BaseArray(v)
@@ -107,6 +122,7 @@ public:
   Point(const ValueType & v)
     : BaseArray(v)
   {}
+#endif
 
   /** Explicit constructor for std::array. */
   explicit Point(const std::array<ValueType, VPointDimension> & stdArray)


### PR DESCRIPTION
Prevented implicit conversion of a value to `Point`. Aims to avoid
possible flaws, like the ones addressed by:

Pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3225
commit 5b71d63a88cc80547e8584eae59e945fbbf51e5d
"BUG: Quick-fix ContourSpatialObject::Update(), LINEAR_INTERPOLATION case"

Pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3228
commit 12a501cddc3f4c4c93190cb2e64bb2b9c1f558c0
"BUG: Fix `SetCenterInObjectSpace` calls in Registration test"

Pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3231
commit e4841aaba2fd67dabda95189bc1a93da4fa146c3
"STYLE: Clarify estimation ray position `RayCastInterpolateImageFunction`"

Deleted `Point(nullptr_t)`, especially to avoid `PointType p = 0`.