### PR TITLE
ENH: Declare RGBPixel, RGBAPixel constructors from component `explicit`

### DIFF
--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -87,7 +87,16 @@ public:
   RGBAPixel(const ComponentType r[4])
     : BaseArray(r)
   {}
+
+#if defined(ITK_LEGACY_REMOVE)
+  /** Prevents copy-initialization from `nullptr`, as well as from `0` (NULL). */
+  RGBAPixel(std::nullptr_t) = delete;
+
+  /** Explicit constructor */
+  explicit RGBAPixel(const ComponentType & r) { this->Fill(r); }
+#else
   RGBAPixel(const ComponentType & r) { this->Fill(r); }
+#endif
 
   /** Pass-through assignment operator for the Array base class. */
   RGBAPixel &

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -79,8 +79,17 @@ public:
    * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   RGBPixel() { this->Fill(0); }
 
-  /** Constructor to fill Red=Blug=Green= r. */
+#if defined(ITK_LEGACY_REMOVE)
+  /** Explicit constructor to fill Red=Blug=Green= r. */
+  explicit RGBPixel(const ComponentType & r) { this->Fill(r); }
+
+  /** Prevents copy-initialization from `nullptr`, as well as from `0` (NULL). */
+  RGBPixel(std::nullptr_t) = delete;
+#else
+  /** Constructor to fill Red=Blug=Green= r.
+   * \note ITK_LEGACY_REMOVE=ON will disallow implicit conversion from a component value. */
   RGBPixel(const ComponentType & r) { this->Fill(r); }
+#endif
 
   /** Pass-through constructor for the Array base class. */
   template <typename TRGBPixelValueType>


### PR DESCRIPTION
Prevents implicit conversion of a component value to `RGBPixel` or
`RGBAPixel`. Aims to avoid possible flaws, like the one addressed by:

Pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3223
commit 490ef8ce90b44a61089a41054180ad203f36b2d4
"BUG: Fix `ColorTableTestSpecialConditionChecker` component/pixel mix-up"

Added _deleted_ `RGBPixel(nullptr_t)` and `RGBAPixel(nullptr_t)`
constructors, especially to avoid erroneous user code like
`RGBPixel pixel = 0`.