### PR TITLE
ENH: bug #3241: Add qfac and qto_xyz to itkNiftiImageIO metadata

### DIFF
--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -994,6 +994,20 @@ NiftiImageIO::SetImageIOMetadataFromNIfTI()
   std::ostringstream intent_name;
   intent_name << nim->intent_name;
   EncapsulateMetaData<std::string>(thisDic, "intent_name", intent_name.str());
+
+  // The below were added after ITK 5.3rc2.
+
+  EncapsulateMetaData<float>(thisDic, "qfac", nim->qfac);
+
+  std::vector<float> qto_xyz;
+  for (int row = 0; row < 4; ++row)
+  {
+    for (int column = 0; column < 4; ++column)
+    {
+      qto_xyz.push_back(nim->qto_xyz.m[row][column]);
+    }
+  }
+  EncapsulateMetaData<std::vector<float>>(thisDic, "qto_xyz", qto_xyz);
 }
 
 void


### PR DESCRIPTION
bug #3241: In f38b1dd I accidentally changed some behaviour. Specifically, the value of pixdim[0] in itk::NiftiImageIO metadata is different before and after the change.

Previous to the change, SetImageIOMetadataFromNIfTI() was populated from the nifti_1_header structure. After the change, it is populated from the nifti_image structure. The latter is created from the former with nifti_convert_nhdr2nim(). Most of the fields used in SetImageIOMetadataFromNIfTI() have 1-to-1 correspondences in these two structures. I expected all 8 elements of the pixdim array were the same in both structures, but in fact no; element 0 is special. nifti_convert_nhdr2nim() unconditionally sets pixdim[0] to 0.0 (by virtue of allocating the structure with calloc).

In my own app, I was using pixdim[0] (retrieved from itk::NiftiImageIO) as the last parameter to nifti_quatern_to_mat44(). I see now looking at niftilib itself that I should be passing qfac as the last parameter.  But the itk::MetaDataObject doesn't include it, so this commit adds qfac to the metadata dictionary.

Additionally, we now include the whole qto_xyz matrix, so that ITK clients that call nifti_quatern_to_mat44() don't even need to.  This plugs a leaky abstraction and allows my own app for example to not even know that ITK is implemented via niftilib, and never need to call down to it.

Note that the behaviour change of f38b1dd is not being reverted, because it's been four years now, no one else has noticed, and some people may be relying on this behaviour now.