### PR TITLE
STYLE: Remove `std::` prefix from types that work without it

### DIFF
--- a/Examples/IO/DicomSeriesReadSeriesWrite.cxx
+++ b/Examples/IO/DicomSeriesReadSeriesWrite.cxx
@@ -143,7 +143,7 @@ main(int argc, char * argv[])
     namesGenerator->GetInputFileNames();
   // Software Guide : EndCodeSnippet
 
-  std::size_t numberOfFileNames = filenames.size();
+  size_t numberOfFileNames = filenames.size();
   std::cout << numberOfFileNames << std::endl;
   for (unsigned int fni = 0; fni < numberOfFileNames; ++fni)
   {

--- a/Examples/IO/IOFactoryRegistration.cxx
+++ b/Examples/IO/IOFactoryRegistration.cxx
@@ -26,7 +26,7 @@ main()
 {
   const std::list<itk::ObjectFactoryBase *> & factories =
     itk::ObjectFactoryBase::GetRegisteredFactories();
-  const std::size_t numFactories = factories.size();
+  const size_t numFactories = factories.size();
 
   std::cout << numFactories << " Image IO factories registered:" << std::endl;
 

--- a/Examples/IO/IOPlugin.cxx
+++ b/Examples/IO/IOPlugin.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   // List all registered factories
   std::list<itk::ObjectFactoryBase *> factories =
     itk::ObjectFactoryBase::GetRegisteredFactories();
-  const std::size_t numFactories = factories.size();
+  const size_t numFactories = factories.size();
 
   std::cout << "----- Registered factories -----" << std::endl;
   std::cout << "Count: " << numFactories << std::endl;

--- a/Modules/Compatibility/Deprecated/include/itkAtomicInt.h
+++ b/Modules/Compatibility/Deprecated/include/itkAtomicInt.h
@@ -203,13 +203,13 @@ public:
   }
 
   T *
-  operator+=(std::ptrdiff_t val)
+  operator+=(ptrdiff_t val)
   {
     return reinterpret_cast<T *>(m_Object += val * sizeof(T));
   }
 
   T *
-  operator-=(std::ptrdiff_t val)
+  operator-=(ptrdiff_t val)
   {
     return reinterpret_cast<T *>(m_Object -= val * sizeof(T));
   }

--- a/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
@@ -57,7 +57,7 @@ namespace itk
  * neighborhood shape, including the center pixel, and asserts that the result
  * is as expected:
    \code
-   std::size_t maximumCityblockDistance = 2;
+   size_t maximumCityblockDistance = 2;
    bool includeCenterPixel = true;
    ConnectedImageNeighborhoodShape<3> shape{ maximumCityblockDistance, includeCenterPixel };
    std::vector<Offset<3>> offsets = GenerateImageNeighborhoodOffsets(shape);
@@ -110,8 +110,8 @@ public:
    * The parameter 'includeCenterPixel' specifies whether or not the center
    * pixel (offset zero) should be included with the offsets for this shape.
    */
-  constexpr explicit ConnectedImageNeighborhoodShape(const std::size_t maximumCityblockDistance,
-                                                     const bool        includeCenterPixel) noexcept
+  constexpr explicit ConnectedImageNeighborhoodShape(const size_t maximumCityblockDistance,
+                                                     const bool   includeCenterPixel) noexcept
     : m_MaximumCityblockDistance{ maximumCityblockDistance }
     , m_IncludeCenterPixel{ includeCenterPixel }
     , m_NumberOfOffsets{ CalculateNumberOfOffsets(maximumCityblockDistance, includeCenterPixel) }
@@ -119,7 +119,7 @@ public:
 
 
   /** Returns the number of offsets needed for this shape. */
-  constexpr std::size_t
+  constexpr size_t
   GetNumberOfOffsets() const noexcept
   {
     return m_NumberOfOffsets;
@@ -136,12 +136,12 @@ public:
       Offset<ImageDimension> offset;
       std::fill_n(offset.begin(), ImageDimension, -1);
 
-      std::size_t i = 0;
+      size_t i = 0;
 
       while (i < m_NumberOfOffsets)
       {
-        const std::size_t numberOfNonZeroOffsetValues =
-          ImageDimension - static_cast<std::size_t>(std::count(offset.begin(), offset.end(), 0));
+        const size_t numberOfNonZeroOffsetValues =
+          ImageDimension - static_cast<size_t>(std::count(offset.begin(), offset.end(), 0));
 
         if ((m_IncludeCenterPixel || (numberOfNonZeroOffsetValues > 0)) &&
             (numberOfNonZeroOffsetValues <= m_MaximumCityblockDistance))
@@ -170,20 +170,20 @@ public:
 private:
   // The maximum city-block distance (Manhattan distance) between the center
   // pixel and each connected neighbor pixel.
-  std::size_t m_MaximumCityblockDistance;
+  size_t m_MaximumCityblockDistance;
 
   // Specifies whether or not the center pixel (offset zero) should be included
   // with the offsets for this shape.
   bool m_IncludeCenterPixel;
 
   // The number of offsets needed to represent this shape.
-  std::size_t m_NumberOfOffsets;
+  size_t m_NumberOfOffsets;
 
 
   // Calculates a + b. Numeric overflow triggers a compilation error in
   // "constexpr context" and a debug assert failure at run-time.
-  static constexpr std::uintmax_t
-  CalculateSum(const std::uintmax_t a, const std::uintmax_t b) noexcept
+  static constexpr uintmax_t
+  CalculateSum(const uintmax_t a, const uintmax_t b) noexcept
   {
     return ((a + b) >= a) && ((a + b) >= b) ? (a + b) : (ITK_X_ASSERT(!"CalculateSum overflow!"), 0);
   }
@@ -191,11 +191,11 @@ private:
 
   // Calculates 2 ^ n. Numeric overflow triggers a compilation error in
   // "constexpr context" and a debug assert failure at run-time.
-  static constexpr std::uintmax_t
-  CalculatePowerOfTwo(const std::size_t n) noexcept
+  static constexpr uintmax_t
+  CalculatePowerOfTwo(const size_t n) noexcept
   {
-    return (n < std::numeric_limits<std::uintmax_t>::digits) ? (std::uintmax_t{ 1 } << n)
-                                                             : (ITK_X_ASSERT(!"CalculatePowerOfTwo overflow!"), 0);
+    return (n < std::numeric_limits<uintmax_t>::digits) ? (uintmax_t{ 1 } << n)
+                                                        : (ITK_X_ASSERT(!"CalculatePowerOfTwo overflow!"), 0);
   }
 
 
@@ -203,8 +203,8 @@ private:
   // Inspired by the 'binom' function from Walter, June 23, 2017:
   // https://stackoverflow.com/questions/44718971/calculate-binomial-coffeficient-very-reliable/44719165#44719165
   // Optimized for small values of 'k' (k <= n/2).
-  static constexpr std::uintmax_t
-  CalculateBinomialCoefficient(const std::uintmax_t n, const std::uintmax_t k) noexcept
+  static constexpr uintmax_t
+  CalculateBinomialCoefficient(const uintmax_t n, const uintmax_t k) noexcept
   {
     return (k > n) ? (ITK_X_ASSERT(!"Out of range!"), 0)
                    : (k == 0) ? 1 : Math::UnsignedProduct(n, CalculateBinomialCoefficient(n - 1, k - 1)) / k;
@@ -214,8 +214,8 @@ private:
   // Calculates the number of m-dimensional hypercubes on the boundary of an
   // n-cube, as described at https://en.wikipedia.org/wiki/Hypercube#Elements
   // (Which refers to H.S.M. Coxeter, Regular polytopes, 3rd ed., 1973, p.120.)
-  static constexpr std::size_t
-  CalculateNumberOfHypercubesOnBoundaryOfCube(const std::size_t m, const std::size_t n) noexcept
+  static constexpr size_t
+  CalculateNumberOfHypercubesOnBoundaryOfCube(const size_t m, const size_t n) noexcept
   {
     // Calculate 2^(n-m) * BinomialCoefficient(n, m)
     return Math::UnsignedProduct(CalculatePowerOfTwo(n - m),
@@ -229,8 +229,8 @@ private:
 
 
   // Iterates recursively from i = ImageDimension-1 down to m (inclusive).
-  static constexpr std::size_t
-  CalculateSumOfNumberOfHypercubesOnBoundaryOfCube(const std::size_t i, const std::size_t m) noexcept
+  static constexpr size_t
+  CalculateSumOfNumberOfHypercubesOnBoundaryOfCube(const size_t i, const size_t m) noexcept
   {
     return ITK_X_ASSERT(i >= m),
            CalculateSum(CalculateNumberOfHypercubesOnBoundaryOfCube(i, ImageDimension),
@@ -239,8 +239,8 @@ private:
 
 
   /** Calculates the number of neighbors connected to the center pixel. */
-  static constexpr std::size_t
-  CalculateNumberOfConnectedNeighbors(const std::size_t maximumCityblockDistance) noexcept
+  static constexpr size_t
+  CalculateNumberOfConnectedNeighbors(const size_t maximumCityblockDistance) noexcept
   {
     return (((maximumCityblockDistance == 0) || (ImageDimension == 0))
               ? 0
@@ -252,8 +252,8 @@ private:
 
 
   /** Calculates the number of offsets needed for this shape. */
-  static constexpr std::size_t
-  CalculateNumberOfOffsets(const std::size_t maximumCityblockDistance, const bool includeCenterPixel) noexcept
+  static constexpr size_t
+  CalculateNumberOfOffsets(const size_t maximumCityblockDistance, const bool includeCenterPixel) noexcept
   {
     return (includeCenterPixel ? 1 : 0) + CalculateNumberOfConnectedNeighbors(maximumCityblockDistance);
   }
@@ -261,7 +261,7 @@ private:
 
 
 /** Generates the offsets for a connected image neighborhood shape. */
-template <unsigned int VImageDimension, std::size_t VMaximumCityblockDistance, bool VIncludeCenterPixel>
+template <unsigned int VImageDimension, size_t VMaximumCityblockDistance, bool VIncludeCenterPixel>
 auto
 GenerateConnectedImageNeighborhoodShapeOffsets() noexcept
 {

--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -289,7 +289,7 @@ private:
 
   public:
     // Types conforming the iterator requirements of the C++ standard library:
-    using difference_type = std::ptrdiff_t;
+    using difference_type = ptrdiff_t;
     using value_type = PixelType;
     using reference = std::conditional_t<SupportsDirectPixelAccess, QualifiedPixelType &, PixelProxy<IsImageTypeConst>>;
     using pointer = QualifiedPixelType *;
@@ -635,7 +635,7 @@ public:
 
 
   /** Returns the size of the range, that is the number of pixels. */
-  std::size_t
+  size_t
   size() const noexcept
   {
     return m_NumberOfPixels;
@@ -654,12 +654,12 @@ public:
    * \note The return type QualifiedIterator<false>::reference is equivalent to
    * iterator::reference.
    */
-  typename QualifiedIterator<false>::reference operator[](const std::size_t n) const noexcept
+  typename QualifiedIterator<false>::reference operator[](const size_t n) const noexcept
   {
     assert(n < this->size());
-    assert(n <= static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max()));
+    assert(n <= static_cast<size_t>(std::numeric_limits<ptrdiff_t>::max()));
 
-    return this->begin()[static_cast<std::ptrdiff_t>(n)];
+    return this->begin()[static_cast<ptrdiff_t>(n)];
   }
 };
 

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -145,7 +145,7 @@ private:
       , m_IterationRegionSize(regionSize)
     {}
 
-    template <std::size_t VIndex>
+    template <size_t VIndex>
     void Increment(std::true_type) noexcept
     {
       static_assert(VIndex < (ImageDimension - 1), "For a larger index value, the other overload should be picked");
@@ -160,7 +160,7 @@ private:
       }
     }
 
-    template <std::size_t VIndex>
+    template <size_t VIndex>
     void Increment(std::false_type) noexcept
     {
       static_assert(VIndex == (ImageDimension - 1), "For a smaller index value, the other overload should be picked");
@@ -170,7 +170,7 @@ private:
     }
 
 
-    template <std::size_t VIndex>
+    template <size_t VIndex>
     void Decrement(std::true_type) noexcept
     {
       static_assert(VIndex < (ImageDimension - 1), "For a larger index value, the other overload should be picked");
@@ -185,7 +185,7 @@ private:
       }
     }
 
-    template <std::size_t VIndex>
+    template <size_t VIndex>
     void Decrement(std::false_type) noexcept
     {
       static_assert(VIndex == (ImageDimension - 1), "For a smaller index value, the other overload should be picked");
@@ -197,7 +197,7 @@ private:
 
   public:
     // Types conforming the iterator requirements of the C++ standard library:
-    using difference_type = std::ptrdiff_t;
+    using difference_type = ptrdiff_t;
     using value_type = typename std::iterator_traits<QualifiedBufferIteratorType>::value_type;
     using reference = typename std::iterator_traits<QualifiedBufferIteratorType>::reference;
     using pointer = typename std::iterator_traits<QualifiedBufferIteratorType>::pointer;
@@ -439,11 +439,11 @@ public:
 
 
   /** Returns the size of the range, that is the number of pixels in the region. */
-  std::size_t
+  size_t
   size() const noexcept
   {
     return std::accumulate(
-      m_IterationRegionSize.begin(), m_IterationRegionSize.end(), std::size_t{ 1 }, std::multiplies<std::size_t>{});
+      m_IterationRegionSize.begin(), m_IterationRegionSize.end(), size_t{ 1 }, std::multiplies<size_t>{});
   }
 
 

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -326,7 +326,7 @@ public:
   using iterator = value_type *;
   using const_iterator = const value_type *;
   using size_type = unsigned int;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = ptrdiff_t;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 

--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -86,7 +86,7 @@ public:
   {
   public:
     // Types conforming the iterator requirements of the C++ standard library:
-    using difference_type = std::ptrdiff_t;
+    using difference_type = ptrdiff_t;
     using value_type = IndexType;
     using reference = const IndexType &;
     using pointer = const IndexType *;
@@ -386,10 +386,10 @@ public:
 
 
   /** Returns the size of the range, that is the number of indices. */
-  std::size_t
+  size_t
   size() const noexcept
   {
-    std::size_t result = 1;
+    size_t result = 1;
 
     for (unsigned int i = 0; i < VDimension; ++i)
     {

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -772,9 +772,9 @@ GreatestPrimeFactor(unsigned long long n);
 /**  Returns `a * b`. Numeric overflow triggers a compilation error in
  * "constexpr context" and a debug assert failure at run-time.
  */
-template <typename TReturnType = std::uintmax_t>
+template <typename TReturnType = uintmax_t>
 constexpr TReturnType
-UnsignedProduct(const std::uintmax_t a, const std::uintmax_t b) noexcept
+UnsignedProduct(const uintmax_t a, const uintmax_t b) noexcept
 {
   static_assert(std::is_unsigned<TReturnType>::value, "UnsignedProduct only supports unsigned return types");
 
@@ -789,14 +789,14 @@ UnsignedProduct(const std::uintmax_t a, const std::uintmax_t b) noexcept
 
 /** Calculates base ^ exponent. Numeric overflow triggers a compilation error in
  * "constexpr context" and a debug assert failure at run-time. Otherwise equivalent to
- * C++11 `static_cast<std::uintmax_t>(std::pow(base, exponent))`
+ * C++11 `static_cast<uintmax_t>(std::pow(base, exponent))`
  *
  * \note `UnsignedPower(0, 0)` is not supported, as zero to the power of zero has
  * no agreed-upon value: https://en.wikipedia.org/wiki/Zero_to_the_power_of_zero
  */
-template <typename TReturnType = std::uintmax_t>
+template <typename TReturnType = uintmax_t>
 constexpr TReturnType
-UnsignedPower(const std::uintmax_t base, const std::uintmax_t exponent) noexcept
+UnsignedPower(const uintmax_t base, const uintmax_t exponent) noexcept
 {
   static_assert(std::is_unsigned<TReturnType>::value, "UnsignedPower only supports unsigned return types");
 

--- a/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
@@ -125,7 +125,7 @@ public:
   }
 
   /** Get the length of the input array. */
-  static std::size_t
+  static size_t
   GetLength(const Array<T> & m)
   {
     return m.GetSize();

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -279,7 +279,7 @@ public:
   using iterator = value_type *;
   using const_iterator = const value_type *;
   using size_type = unsigned int;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = ptrdiff_t;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 

--- a/Modules/Core/Common/include/itkRectangularImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkRectangularImageNeighborhoodShape.h
@@ -63,7 +63,7 @@ public:
 
 
   /** Returns the number of offsets needed to represent this shape. */
-  constexpr std::size_t
+  constexpr size_t
   GetNumberOfOffsets() const noexcept
   {
     return m_NumberOfOffsets;
@@ -83,7 +83,7 @@ public:
         return -static_cast<OffsetValueType>(radiusValue);
       });
 
-      for (std::size_t i = 0; i < m_NumberOfOffsets; ++i)
+      for (size_t i = 0; i < m_NumberOfOffsets; ++i)
       {
         offsets[i] = offset;
 
@@ -108,12 +108,12 @@ private:
   Size<ImageDimension> m_Radius;
 
   // The number of offsets needed to represent this shape.
-  std::size_t m_NumberOfOffsets;
+  size_t m_NumberOfOffsets;
 
 
   // Private helper function to calculate the number of Offsets by a recursive
   // function call. Recursion is necessary for C++11 constexpr.
-  constexpr std::size_t
+  constexpr size_t
   CalculateNumberOfOffsets(const unsigned int dimension) const noexcept
   {
     return (dimension == 0)

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -369,7 +369,7 @@ private:
 
   public:
     // Types conforming the iterator requirements of the C++ standard library:
-    using difference_type = std::ptrdiff_t;
+    using difference_type = ptrdiff_t;
     using value_type = PixelType;
     using reference = PixelProxy<IsImageTypeConst>;
     using pointer = QualifiedPixelType *;
@@ -627,7 +627,7 @@ private:
   const OffsetType * m_ShapeOffsets{ nullptr };
 
   // The number of neighborhood pixels.
-  std::size_t m_NumberOfNeighborhoodPixels{ 0 };
+  size_t m_NumberOfNeighborhoodPixels{ 0 };
 
   OptionalPixelAccessParameterType m_OptionalPixelAccessParameter{};
 
@@ -654,7 +654,7 @@ public:
   ShapedImageNeighborhoodRange(ImageType &                            image,
                                const IndexType &                      location,
                                const OffsetType * const               shapeOffsets,
-                               const std::size_t                      numberOfNeigborhoodPixels,
+                               const size_t                           numberOfNeigborhoodPixels,
                                const OptionalPixelAccessParameterType optionalPixelAccessParameter = {})
     : m_ImageBufferPointer{ image.ImageType::GetBufferPointer() }
     ,
@@ -764,7 +764,7 @@ public:
 
 
   /** Returns the size of the range, that is the number of neighborhood pixels. */
-  std::size_t
+  size_t
   size() const noexcept
   {
     return m_NumberOfNeighborhoodPixels;
@@ -784,12 +784,12 @@ public:
    * iterator::reference. The return value is a proxy object that behaves like a
    * reference to the pixel.
    */
-  typename QualifiedIterator<false>::reference operator[](const std::size_t n) const noexcept
+  typename QualifiedIterator<false>::reference operator[](const size_t n) const noexcept
   {
     assert(n < this->size());
-    assert(n <= static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max()));
+    assert(n <= static_cast<size_t>(std::numeric_limits<ptrdiff_t>::max()));
 
-    return this->begin()[static_cast<std::ptrdiff_t>(n)];
+    return this->begin()[static_cast<ptrdiff_t>(n)];
   }
 
 

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -238,7 +238,7 @@ public:
   using iterator = value_type *;
   using const_iterator = const value_type *;
   using size_type = unsigned int;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = ptrdiff_t;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 

--- a/Modules/Core/Common/include/itkThreadSupport.h
+++ b/Modules/Core/Common/include/itkThreadSupport.h
@@ -44,7 +44,7 @@ namespace itk
 /** Platform specific type alias for simple types
  */
 #if defined(ITK_USE_PTHREADS)
-constexpr std::size_t ITK_MAX_THREADS = ITK_DEFAULT_MAX_THREADS;
+constexpr size_t ITK_MAX_THREADS = ITK_DEFAULT_MAX_THREADS;
 using MutexType = pthread_mutex_t;
 using FastMutexType = pthread_mutex_t;
 using ThreadFunctionType = void * (*)(void *);
@@ -59,7 +59,7 @@ using itk::ITK_THREAD_RETURN_DEFAULT_VALUE; // We need this out of the itk names
 using ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION = itk::ITK_THREAD_RETURN_TYPE;
 #elif defined(ITK_USE_WIN32_THREADS)
 
-constexpr std::size_t ITK_MAX_THREADS = ITK_DEFAULT_MAX_THREADS;
+constexpr size_t ITK_MAX_THREADS = ITK_DEFAULT_MAX_THREADS;
 using MutexType = HANDLE;
 using FastMutexType = CRITICAL_SECTION;
 using ThreadFunctionType = unsigned int(__stdcall *)(void *);
@@ -74,7 +74,7 @@ constexpr ITK_THREAD_RETURN_TYPE ITK_THREAD_RETURN_DEFAULT_VALUE = 0;
 #  define ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION itk::ITK_THREAD_RETURN_TYPE __stdcall
 #else
 
-constexpr std::size_t ITK_MAX_THREADS = 1;
+constexpr size_t ITK_MAX_THREADS = 1;
 using MutexType = int;
 using FastMutexType = int;
 using ThreadFunctionType = void (*)(void *);

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -272,7 +272,7 @@ public:
     operator()(unsigned int newSize, unsigned int oldSize, TValue2 * oldBuffer, TValue2 * newBuffer) const
     {
       itkAssertInDebugAndIgnoreInReleaseMacro(newBuffer);
-      const std::size_t nb = std::min(newSize, oldSize);
+      const size_t nb = std::min(newSize, oldSize);
       itkAssertInDebugAndIgnoreInReleaseMacro(nb == 0 || (nb > 0 && oldBuffer != nullptr));
       std::copy_n(oldBuffer, nb, newBuffer);
     }

--- a/Modules/Core/Common/src/itkArrayOutputSpecialization.cxx
+++ b/Modules/Core/Common/src/itkArrayOutputSpecialization.cxx
@@ -26,11 +26,11 @@ std::ostream & operator<<<double>(std::ostream & os, const Array<double> & arr)
 {
   NumberToString<double> convert;
   os << "[";
-  const std::size_t length = arr.size();
+  const size_t length = arr.size();
   if (length >= 1)
   {
-    const std::size_t last = length - 1;
-    for (std::size_t i = 0; i < last; ++i)
+    const size_t last = length - 1;
+    for (size_t i = 0; i < last; ++i)
     {
       os << convert(arr[i]) << ", ";
     }
@@ -45,11 +45,11 @@ std::ostream & operator<<<float>(std::ostream & os, const Array<float> & arr)
 {
   NumberToString<float> convert;
   os << "[";
-  const std::size_t length = arr.size();
+  const size_t length = arr.size();
   if (length >= 1)
   {
-    const std::size_t last = length - 1;
-    for (std::size_t i = 0; i < last; ++i)
+    const size_t last = length - 1;
+    for (size_t i = 0; i < last; ++i)
     {
       os << convert(static_cast<float>(arr[i])) << ", ";
     }

--- a/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
+++ b/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
@@ -35,9 +35,9 @@
 namespace
 {
 template <unsigned int VImageDimension,
-          std::size_t  VMaximumCityblockDistance,
+          size_t       VMaximumCityblockDistance,
           bool         VIncludeCenterPixel,
-          std::size_t  VExpectedNumberOfOffsets>
+          size_t       VExpectedNumberOfOffsets>
 void
 Assert_GetNumberOfOffsets_returns_expected_number()
 {
@@ -55,8 +55,8 @@ Assert_GetNumberOfOffsets_returns_expected_number()
 
 
 template <unsigned int VImageDimension,
-          std::size_t  VMaximumCityblockDistance,
-          std::size_t  VExpectedNumberOfOffsetsExcludingCenterPixel>
+          size_t       VMaximumCityblockDistance,
+          size_t       VExpectedNumberOfOffsetsExcludingCenterPixel>
 void
 Assert_GetNumberOfOffsets_returns_expected_number()
 {
@@ -75,7 +75,7 @@ Assert_GetNumberOfOffsets_returns_expected_number()
 
 // Asserts that GenerateImageNeighborhoodOffsets(shape) returns the expected
 // result for a shape with the specified ImageDimension and MaximumCityblockDistance,
-template <unsigned int VImageDimension, std::size_t VMaximumCityblockDistance>
+template <unsigned int VImageDimension, size_t VMaximumCityblockDistance>
 void
 Assert_GenerateImageNeighborhoodOffsets_returns_expected_offsets_excluding_center_pixel(
   const std::vector<itk::Offset<VImageDimension>> & expectedOffsets)
@@ -103,7 +103,7 @@ Assert_The_middle_offset_is_all_zero_when_center_pixel_is_included()
        ++maximumCityblockDistance)
   {
     const ShapeType               shape{ maximumCityblockDistance, includeCenterPixel };
-    const std::size_t             numberOfOffsets = shape.GetNumberOfOffsets();
+    const size_t                  numberOfOffsets = shape.GetNumberOfOffsets();
     const std::vector<OffsetType> offsets = GenerateImageNeighborhoodOffsets(shape);
 
     ASSERT_FALSE(offsets.empty());
@@ -288,8 +288,8 @@ TEST(ConnectedImageNeighborhoodShape, SupportsConstShapedNeighborhoodIterator)
 
   // Define a shape that should generate the same offsets as in the
   // previous ActivateOffset(offset) calls.
-  constexpr std::size_t cityBlockDistance = 1;
-  constexpr bool        includeCenterPixel = false;
+  constexpr size_t cityBlockDistance = 1;
+  constexpr bool   includeCenterPixel = false;
 
   shapedNeighborhoodIterator.ActivateOffsets(
     itk::GenerateConnectedImageNeighborhoodShapeOffsets<ImageDimension, cityBlockDistance, includeCenterPixel>());

--- a/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
@@ -138,7 +138,7 @@ TEST(ConstantBoundaryImageNeighborhoodPixelAccessPolicy, YieldsSpecifiedConstant
     ASSERT_EQ(range.size(), numberOfExpectedNeighbors);
 
     // Test by using RangeType::operator[]:
-    for (std::size_t i = 0; i < numberOfExpectedNeighbors; ++i)
+    for (size_t i = 0; i < numberOfExpectedNeighbors; ++i)
     {
       const PixelType pixel = range[i];
       EXPECT_EQ(pixel, constantValue);

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -458,13 +458,13 @@ TEST(ImageBufferRange, DistanceBetweenIteratorsCanBeObtainedBySubtraction)
 
   ImageBufferRange<ImageType>::iterator it1 = range.begin();
 
-  const std::size_t numberOfPixels = range.size();
+  const size_t numberOfPixels = range.size();
 
-  for (std::size_t i1 = 0; i1 < numberOfPixels; ++i1, ++it1)
+  for (size_t i1 = 0; i1 < numberOfPixels; ++i1, ++it1)
   {
     ImageBufferRange<ImageType>::iterator it2 = it1;
 
-    for (std::size_t i2 = 0; i2 < numberOfPixels; ++i2, ++it2)
+    for (size_t i2 = 0; i2 < numberOfPixels; ++i2, ++it2)
     {
       EXPECT_EQ(it2 - it1, std::distance(it1, it2));
     }
@@ -784,11 +784,11 @@ TEST(ImageBufferRange, SupportsSubscript)
 
   RangeType range{ *image };
 
-  const std::size_t numberOfNeighbors = range.size();
+  const size_t numberOfNeighbors = range.size();
 
   RangeType::iterator it = range.begin();
 
-  for (std::size_t i = 0; i < numberOfNeighbors; ++i)
+  for (size_t i = 0; i < numberOfNeighbors; ++i)
   {
     std::iterator_traits<RangeType::iterator>::reference neighbor = range[i];
     EXPECT_EQ(neighbor, *it);

--- a/Modules/Core/Common/test/itkImageNeighborhoodOffsetsGTest.cxx
+++ b/Modules/Core/Common/test/itkImageNeighborhoodOffsetsGTest.cxx
@@ -39,7 +39,7 @@ public:
   static constexpr unsigned int ImageDimension = VImageDimension;
 
   // Returns the number of offsets needed to represent this shape.
-  constexpr std::size_t
+  constexpr size_t
   GetNumberOfOffsets() const noexcept
   {
     return 0;

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -40,7 +40,7 @@ template class itk::ImageRegionRange<itk::Image<short, 4>>;
 template class itk::ImageRegionRange<const itk::Image<short>>;
 template class itk::ImageRegionRange<itk::VectorImage<short>>;
 template class itk::ImageRegionRange<const itk::VectorImage<short>>;
-template class itk::ImageRegionRange<itk::Image<itk::RGBPixel<std::uint8_t>>>;
+template class itk::ImageRegionRange<itk::Image<itk::RGBPixel<uint8_t>>>;
 template class itk::ImageRegionRange<itk::Image<itk::Vector<long, 11>>>;
 
 using itk::ImageRegionRange;

--- a/Modules/Core/Common/test/itkMathTest.cxx
+++ b/Modules/Core/Common/test/itkMathTest.cxx
@@ -25,7 +25,7 @@
 #include <limits>
 #include <type_traits> // For is_same.
 
-constexpr auto maxUnsignedValue = std::numeric_limits<std::uintmax_t>::max();
+constexpr auto maxUnsignedValue = std::numeric_limits<uintmax_t>::max();
 
 using itk::Math::UnsignedPower;
 using itk::Math::UnsignedProduct;
@@ -41,15 +41,15 @@ static_assert((UnsignedPower(2, 1) == 2) && (UnsignedPower(3, 1) == 3) &&
               "Check one as exponent");
 static_assert((UnsignedPower(2, 2) == 4) && (UnsignedPower(2, 3) == 8), "Check powers of two");
 static_assert((UnsignedPower(3, 2) == 9) && (UnsignedPower(3, 3) == 27), "Check powers of three");
-static_assert(UnsignedPower(2, std::numeric_limits<std::uintmax_t>::digits - 1) ==
-                (std::uintmax_t{ 1 } << (std::numeric_limits<std::uintmax_t>::digits - 1)),
+static_assert(UnsignedPower(2, std::numeric_limits<uintmax_t>::digits - 1) ==
+                (uintmax_t{ 1 } << (std::numeric_limits<uintmax_t>::digits - 1)),
               "Check 2^63 (at least when uintmax_t is 64 bits)");
 
-static_assert(std::is_same<decltype(UnsignedPower(1, 1)), std::uintmax_t>::value,
+static_assert(std::is_same<decltype(UnsignedPower(1, 1)), uintmax_t>::value,
               "The return type of UnsignedPower should be uintmax_t by default.");
-static_assert(std::is_same<decltype(UnsignedPower<std::uint8_t>(1, 1)), std::uint8_t>::value &&
-                std::is_same<decltype(UnsignedPower<std::uint16_t>(1, 1)), std::uint16_t>::value &&
-                std::is_same<decltype(UnsignedPower<std::uint32_t>(1, 1)), std::uint32_t>::value,
+static_assert(std::is_same<decltype(UnsignedPower<uint8_t>(1, 1)), uint8_t>::value &&
+                std::is_same<decltype(UnsignedPower<uint16_t>(1, 1)), uint16_t>::value &&
+                std::is_same<decltype(UnsignedPower<uint32_t>(1, 1)), uint32_t>::value,
               "UnsignedPower allows specifying the return type by its template argument.");
 
 static_assert((UnsignedProduct(0, 0) == 0) && (UnsignedProduct(0, 1) == 0) && (UnsignedProduct(1, 0) == 0) &&

--- a/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
@@ -43,7 +43,7 @@ Expect_data_returns_pointer_to_first_element(T & container)
 class ObjectCounter
 {
 private:
-  static std::size_t m_Count;
+  static size_t m_Count;
 
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ObjectCounter);
@@ -52,14 +52,14 @@ public:
 
   ~ObjectCounter() { --m_Count; }
 
-  static std::size_t
+  static size_t
   GetCount()
   {
     return m_Count;
   }
 };
 
-std::size_t ObjectCounter::m_Count{};
+size_t ObjectCounter::m_Count{};
 
 
 } // namespace

--- a/Modules/Core/Common/test/itkNumberToStringGTest.cxx
+++ b/Modules/Core/Common/test/itkNumberToStringGTest.cxx
@@ -79,7 +79,7 @@ Test_decimal_notation_supports_up_to_twentyone_digits()
 {
   const itk::NumberToString<TValue> numberToString{};
 
-  for (std::int8_t exponent{ 20 }; exponent > 0; --exponent)
+  for (int8_t exponent{ 20 }; exponent > 0; --exponent)
   {
     const auto power_of_ten = std::pow(TValue{ 10 }, static_cast<TValue>(exponent));
 
@@ -88,7 +88,7 @@ Test_decimal_notation_supports_up_to_twentyone_digits()
     EXPECT_EQ(numberToString(-power_of_ten), "-1" + std::string(exponent, '0'));
   }
 
-  for (std::int8_t exponent{ -6 }; exponent < 0; ++exponent)
+  for (int8_t exponent{ -6 }; exponent < 0; ++exponent)
   {
     const auto power_of_ten = std::pow(TValue{ 10 }, static_cast<TValue>(exponent));
 

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -405,7 +405,7 @@ itkNumericTraitsTest(int, char *[])
   // Check not fundamental types which we need
 
   CheckTraits("size_t", static_cast<size_t>(0));
-  CheckTraits("std::ptrdiff_t", static_cast<std::ptrdiff_t>(0));
+  CheckTraits("ptrdiff_t", static_cast<ptrdiff_t>(0));
   using VectorSizeType = std::vector<int>::size_type;
   CheckTraits("std::vector<int>::size_type", static_cast<VectorSizeType>(0));
 

--- a/Modules/Core/Common/test/itkOptimizerParametersGTest.cxx
+++ b/Modules/Core/Common/test/itkOptimizerParametersGTest.cxx
@@ -34,7 +34,7 @@ TEST(OptimizerParameters, ConstructWithSpecifiedSizeAndInitialValue)
   {
     EXPECT_EQ(OptimizerParametersType(0, initialValue).size(), 0);
 
-    for (std::size_t size{ 1 }; size <= 4; ++size)
+    for (size_t size{ 1 }; size <= 4; ++size)
     {
       const OptimizerParametersType optimizerParameters(size, initialValue);
 

--- a/Modules/Core/Common/test/itkSTLThreadTest.cxx
+++ b/Modules/Core/Common/test/itkSTLThreadTest.cxx
@@ -35,7 +35,7 @@ int
 itkSTLThreadTest(int argc, char * argv[])
 {
   // Choose a number of threads.
-  std::size_t numWorkUnits = 10;
+  size_t numWorkUnits = 10;
   if (argc > 1)
   {
     int nt = std::stoi(argv[1]);
@@ -74,7 +74,7 @@ itkSTLThreadTest(int argc, char * argv[])
 
   // Create result array.  Assume failure.
   auto * results = new int[numWorkUnits];
-  for (std::size_t i = 0; i < numWorkUnits; ++i)
+  for (size_t i = 0; i < numWorkUnits; ++i)
   {
     results[i] = 0;
   }
@@ -87,7 +87,7 @@ itkSTLThreadTest(int argc, char * argv[])
 
   // Report results.
   int result = 0;
-  for (std::size_t i = 0; i < numWorkUnits; ++i)
+  for (size_t i = 0; i < numWorkUnits; ++i)
   {
     if (!results[i])
     {

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -502,13 +502,13 @@ TEST(ShapedImageNeighborhoodRange, DistanceBetweenIteratorsCanBeObtainedBySubtra
 
   itk::ShapedImageNeighborhoodRange<ImageType>::iterator it1 = range.begin();
 
-  const std::size_t numberOfNeighborhoodPixels = range.size();
+  const size_t numberOfNeighborhoodPixels = range.size();
 
-  for (std::size_t i1 = 0; i1 < numberOfNeighborhoodPixels; ++i1, ++it1)
+  for (size_t i1 = 0; i1 < numberOfNeighborhoodPixels; ++i1, ++it1)
   {
     itk::ShapedImageNeighborhoodRange<ImageType>::iterator it2 = it1;
 
-    for (std::size_t i2 = 0; i2 < numberOfNeighborhoodPixels; ++i2, ++it2)
+    for (size_t i2 = 0; i2 < numberOfNeighborhoodPixels; ++i2, ++it2)
     {
       EXPECT_EQ(it2 - it1, std::distance(it1, it2));
     }
@@ -892,11 +892,11 @@ TEST(ShapedImageNeighborhoodRange, SupportsSubscript)
     itk::GenerateRectangularImageNeighborhoodOffsets(radius);
   RangeType range{ *image, location, offsets };
 
-  const std::size_t numberOfNeighbors = range.size();
+  const size_t numberOfNeighbors = range.size();
 
   RangeType::iterator it = range.begin();
 
-  for (std::size_t i = 0; i < numberOfNeighbors; ++i)
+  for (size_t i = 0; i < numberOfNeighbors; ++i)
   {
     RangeType::iterator::reference neighbor = range[i];
     EXPECT_EQ(neighbor, *it);

--- a/Modules/Core/Common/test/itkVectorContainerGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerGTest.cxx
@@ -24,7 +24,7 @@
 #include <string>
 
 // The tested ElementIdentifier type.
-using TestedElementIdentifierType = std::size_t;
+using TestedElementIdentifierType = size_t;
 
 // Test template instantiations for various TElement template arguments:
 template class itk::VectorContainer<TestedElementIdentifierType, int>;

--- a/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest2.cxx
+++ b/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest2.cxx
@@ -37,7 +37,7 @@ itkConnectedRegionsMeshFilterTest2(int argc, char * argv[])
 
   // Check if input file is a mesh file or image file by checking presence of .vtk
   std::string fileName(argv[1]);
-  std::size_t found = fileName.find(".vtk");
+  size_t      found = fileName.find(".vtk");
   bool        imageSource = true;
 
   if (found != std::string::npos)

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -88,9 +88,9 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBox()
     boundingBoxInObjectSpace->SetMaximum(firstPoint);
 
     // The total number of corner points of the bounding box.
-    constexpr auto numberOfCorners = std::uintmax_t{ 1 } << TDimension;
+    constexpr auto numberOfCorners = uintmax_t{ 1 } << TDimension;
 
-    for (std::uintmax_t cornerNumber{ 1 }; cornerNumber < numberOfCorners; ++cornerNumber)
+    for (uintmax_t cornerNumber{ 1 }; cornerNumber < numberOfCorners; ++cornerNumber)
     {
       // For each corner, estimate the n-dimensional index.
 
@@ -98,7 +98,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBox()
 
       for (unsigned int dim{}; dim < TDimension; ++dim)
       {
-        const std::uintmax_t bitMask{ std::uintmax_t{ 1 } << dim };
+        const uintmax_t bitMask{ uintmax_t{ 1 } << dim };
 
         if ((cornerNumber & bitMask) != 0)
         {

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
@@ -412,7 +412,7 @@ private:
    * bias field estimate.
    */
   RealImagePointer
-  UpdateBiasFieldEstimate(RealImageType *, std::size_t);
+  UpdateBiasFieldEstimate(RealImageType *, size_t);
 
   /**
    * Convergence is determined by the coefficient of variation of the difference

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -121,12 +121,12 @@ CLANG_SUPPRESS_Wfloat_equal
     const bool          useMaskLabel = this->GetUseMaskLabel();
 
     const ImageBufferRange<RealImageType> logInputImageBufferRange{ *logInputImage };
-    const std::size_t                     numberOfPixels = logInputImageBufferRange.size();
+    const size_t                          numberOfPixels = logInputImageBufferRange.size();
 
     // Number of pixels of the input image that are included with the filter.
-    std::size_t numberOfIncludedPixels = 0;
+    size_t numberOfIncludedPixels = 0;
 
-    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
            (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
@@ -272,10 +272,10 @@ CLANG_SUPPRESS_Wfloat_equal
     RealType binMaximum = NumericTraits<RealType>::NonpositiveMin();
     RealType binMinimum = NumericTraits<RealType>::max();
 
-    const auto        unsharpenedImageBufferRange = MakeImageBufferRange(unsharpenedImage);
-    const std::size_t numberOfPixels = unsharpenedImageBufferRange.size();
+    const auto   unsharpenedImageBufferRange = MakeImageBufferRange(unsharpenedImage);
+    const size_t numberOfPixels = unsharpenedImageBufferRange.size();
 
-    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
            (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
@@ -299,7 +299,7 @@ CLANG_SUPPRESS_Wfloat_equal
 
     vnl_vector<RealType> H(this->m_NumberOfHistogramBins, 0.0);
 
-    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
            (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
@@ -447,7 +447,7 @@ CLANG_SUPPRESS_Wfloat_equal
 
     const ImageBufferRange<RealImageType> sharpenedImageBufferRange{ *sharpenedImage };
 
-    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
            (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
@@ -473,7 +473,7 @@ CLANG_SUPPRESS_Wfloat_equal
   template <typename TInputImage, typename TMaskImage, typename TOutputImage>
   typename N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::RealImagePointer
   N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::UpdateBiasFieldEstimate(
-    RealImageType * fieldEstimate, const std::size_t numberOfIncludedPixels)
+    RealImageType * fieldEstimate, const size_t numberOfIncludedPixels)
   {
     // Temporarily set the direction cosine to identity since the B-spline
     // approximation algorithm works in parametric space and not physical
@@ -516,7 +516,7 @@ CLANG_SUPPRESS_Wfloat_equal
     ImageRegionConstIteratorWithIndex<RealImageType> It(parametricFieldEstimate,
                                                         parametricFieldEstimate->GetRequestedRegion());
 
-    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue, ++It)
+    for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue, ++It)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
            (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
@@ -660,10 +660,10 @@ CLANG_SUPPRESS_Wfloat_equal
     const MaskPixelType maskLabel = this->GetMaskLabel();
     const bool          useMaskLabel = this->GetUseMaskLabel();
 
-    const auto        subtracterImageBufferRange = MakeImageBufferRange(subtracter->GetOutput());
-    const std::size_t numberOfPixels = subtracterImageBufferRange.size();
+    const auto   subtracterImageBufferRange = MakeImageBufferRange(subtracter->GetOutput());
+    const size_t numberOfPixels = subtracterImageBufferRange.size();
 
-    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
     {
       if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
            (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&

--- a/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
@@ -22,7 +22,7 @@ namespace itk
 CompositeValleyFunction::CompositeValleyFunction(const MeasureArrayType & classMeans,
                                                  const MeasureArrayType & classSigmas)
 {
-  const std::size_t length = classMeans.size();
+  const size_t length = classMeans.size();
 
   if (length != classSigmas.size())
   {
@@ -40,7 +40,7 @@ CompositeValleyFunction::CompositeValleyFunction(const MeasureArrayType & classM
     throw ex;
   }
 
-  for (std::size_t i = 0; i < length; ++i)
+  for (size_t i = 0; i < length; ++i)
   {
     this->AddNewClass(classMeans[i], classSigmas[i]);
   }

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
@@ -144,9 +144,9 @@ TEST(ResampleImageFilter, FilterPreservesAnyDoublePixelValueByDefault)
   std::default_random_engine randomEngine;
 
   // The number of iterations is arbitrarily chosen.
-  const std::size_t numberOfIterations = 11;
+  const size_t numberOfIterations = 11;
 
-  for (std::size_t i = 0; i < numberOfIterations; ++i)
+  for (size_t i = 0; i < numberOfIterations; ++i)
   {
     const double randomNumber1 = std::uniform_real_distribution<>{}(randomEngine);
     const double randomNumber2 = std::uniform_real_distribution<>{ 0.0, NumericLimits::max() }(randomEngine);
@@ -161,10 +161,10 @@ TEST(ResampleImageFilter, FilterPreservesAnyDoublePixelValueByDefault)
 
 TEST(ResampleImageFilter, FilterPreservesMinAndMaxInt64PixelValuesByDefault)
 {
-  Expect_ResampleImageFilter_preserves_pixel_value(std::numeric_limits<std::int64_t>::min());
+  Expect_ResampleImageFilter_preserves_pixel_value(std::numeric_limits<int64_t>::min());
 
   // Note: The following expectation would fail on ITK version <= 4.13.1:
-  Expect_ResampleImageFilter_preserves_pixel_value(std::numeric_limits<std::int64_t>::max());
+  Expect_ResampleImageFilter_preserves_pixel_value(std::numeric_limits<int64_t>::max());
 }
 
 

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -265,7 +265,7 @@ private:
   struct VertexHash
   {
     using CoordinateType = typename VertexType::CoordRepType;
-    inline std::size_t
+    inline size_t
     operator()(const VertexType & v) const noexcept
     {
       return std::hash<CoordinateType>{}(v[0]) ^ (std::hash<CoordinateType>{}(v[1]) << 1);

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -569,7 +569,7 @@ ContourExtractor2DImageFilter<TInputImage>::FillOutputs(
     allContours.splice(allContours.end(), labelsContoursOutput[label]);
   }
   this->SetNumberOfIndexedOutputs(allContours.size());
-  std::size_t NumberOutputsWritten{ 0 };
+  size_t NumberOutputsWritten{ 0 };
 
   for (ContourContainerConstIterator it{ allContours.cbegin() }; it != allContours.cend(); ++it, ++NumberOutputsWritten)
   {

--- a/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
@@ -182,8 +182,7 @@ itkMetaImageIOMetaDataTest(int argc, char * argv[])
   }
 
   const auto maxSupportedStringSize = (MET_MAX_NUMBER_OF_FIELD_VALUES * sizeof(double)) - 1;
-  static_assert(maxSupportedStringSize == std::numeric_limits<std::int16_t>::max(),
-                "Assert that this max value is 32767");
+  static_assert(maxSupportedStringSize == std::numeric_limits<int16_t>::max(), "Assert that this max value is 32767");
 
   {
     // Add string of the maximum supported size.

--- a/Modules/IO/XML/include/itkDOMNode.h
+++ b/Modules/IO/XML/include/itkDOMNode.h
@@ -80,7 +80,7 @@ public:
   /** Container to return the attributes of a DOM node. */
   using AttributesListType = std::list<AttributeItemType>;
 
-  using SizeType = std::size_t;
+  using SizeType = size_t;
   using IdentifierType = int;
   using OffsetType = int;
 

--- a/Modules/IO/XML/src/itkDOMNode.cxx
+++ b/Modules/IO/XML/src/itkDOMNode.cxx
@@ -478,7 +478,7 @@ DOMNode::Find(const std::string & path)
 
   std::string rpath;
   {
-    std::size_t pos = path.find_first_of('/');
+    size_t pos = path.find_first_of('/');
     if (pos == std::string::npos)
     {
       s = path;
@@ -573,7 +573,7 @@ DOMNode::Find(const std::string & path)
   // <tag>[:n]
   else
   {
-    std::size_t pos = s.find_first_of(':');
+    size_t pos = s.find_first_of(':');
     if (pos != std::string::npos)
     {
       std::string s2 = s.substr(pos + 1);

--- a/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
+++ b/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
@@ -139,13 +139,13 @@ public:
   class CoefficientVectorSizeMismatch
   {
   public:
-    CoefficientVectorSizeMismatch(const std::size_t given, const std::size_t required)
+    CoefficientVectorSizeMismatch(const size_t given, const size_t required)
       : m_Required{ required }
       , m_Given{ given }
     {}
 
-    std::size_t m_Required;
-    std::size_t m_Given;
+    size_t m_Required;
+    size_t m_Given;
   };
 
   /** \brief Sets the Legendre polynomials' parameters.

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -55,7 +55,7 @@ public:
   using TotalAbsoluteFrequencyType = NumericTraits<AbsoluteFrequencyType>::AccumulateType;
   using TotalRelativeFrequencyType = NumericTraits<RelativeFrequencyType>::AccumulateType;
 
-  using MeasurementVectorLength = std::size_t;
+  using MeasurementVectorLength = size_t;
 
   template <typename TVectorType>
   static bool


### PR DESCRIPTION
This is accomplished with
```sh
cd git/ITK
find * -type f |
  egrep '\.(c|cc|cxx|cpp|h|hh|hxx|hpp)$' |
  fgrep -v ThirdParty |
  fgrep -v itkIntTypes.h |
  xargs sed -i -r -e \
    's/std::((size|ptrdiff|max_align|u?int(_fast|_least|max|ptr)?[0-9]*)_t)/\1/g'
```
Closes #3248.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
