### PR TITLE
STYLE: Replace type aliases with `using`-declarations, in itkIntTypes.h

### DIFF
--- a/Modules/Core/Common/include/itkIntTypes.h
+++ b/Modules/Core/Common/include/itkIntTypes.h
@@ -25,38 +25,38 @@
 
 namespace itk
 {
-using int8_t = std::int8_t;
-using uint8_t = std::uint8_t;
-using int16_t = std::int16_t;
-using uint16_t = std::uint16_t;
-using int32_t = std::int32_t;
-using uint32_t = std::uint32_t;
-using int64_t = std::int64_t;
-using uint64_t = std::uint64_t;
+using std::int8_t;
+using std::uint8_t;
+using std::int16_t;
+using std::uint16_t;
+using std::int32_t;
+using std::uint32_t;
+using std::int64_t;
+using std::uint64_t;
 
-using int_least8_t = std::int_least8_t;
-using uint_least8_t = std::uint_least8_t;
-using int_least16_t = std::int_least16_t;
-using uint_least16_t = std::uint_least16_t;
-using int_least32_t = std::int_least32_t;
-using uint_least32_t = std::uint_least32_t;
-using int_least64_t = std::int_least64_t;
-using uint_least64_t = std::uint_least64_t;
+using std::int_least8_t;
+using std::uint_least8_t;
+using std::int_least16_t;
+using std::uint_least16_t;
+using std::int_least32_t;
+using std::uint_least32_t;
+using std::int_least64_t;
+using std::uint_least64_t;
 
-using int_fast8_t = std::int_fast8_t;
-using uint_fast8_t = std::uint_fast8_t;
-using int_fast16_t = std::int_fast16_t;
-using uint_fast16_t = std::uint_fast16_t;
-using int_fast32_t = std::int_fast32_t;
-using uint_fast32_t = std::uint_fast32_t;
-using int_fast64_t = std::int_fast64_t;
-using uint_fast64_t = std::uint_fast64_t;
+using std::int_fast8_t;
+using std::uint_fast8_t;
+using std::int_fast16_t;
+using std::uint_fast16_t;
+using std::int_fast32_t;
+using std::uint_fast32_t;
+using std::int_fast64_t;
+using std::uint_fast64_t;
 
-using intmax_t = std::intmax_t;
-using uintmax_t = std::uintmax_t;
+using std::intmax_t;
+using std::uintmax_t;
 
-using intptr_t = std::intptr_t;
-using uintptr_t = std::uintptr_t;
+using std::intptr_t;
+using std::uintptr_t;
 
 
 #if defined(ITK_USE_64BITS_IDS) && ((ULLONG_MAX != ULONG_MAX) || (LLONG_MAX != LONG_MAX))


### PR DESCRIPTION
Reduced code redundancy by replacing type alias declarations of the form
`using` _type_ `= std::`_type_ with the equivalent `using`-declarations.