### PR TITLE
ENH: Increase `itk::SumOfSquaresImageFunction` class coverage

### DIFF
--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -104,7 +104,7 @@ TestBasicObjectProperties()
 
   unsigned int radius = 1;
   imageFunction->SetNeighborhoodRadius(radius);
-  ITK_TEST_SET_GET_VALUE(radius, imageFunction->GetNeighborhoodRadius());
+  EXPECT_EQ(radius, imageFunction->GetNeighborhoodRadius());
 
   auto                                                                 size = TImage::SizeType::Filled(radius);
   const itk::RectangularImageNeighborhoodShape<TImage::ImageDimension> shape(size);

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -18,6 +18,7 @@
 
 // First include the header file to be tested:
 #include "itkSumOfSquaresImageFunction.h"
+#include "itkRectangularImageNeighborhoodShape.h"
 
 #include "itkImage.h"
 #include "itkImageBufferRange.h"
@@ -104,6 +105,11 @@ TestBasicObjectProperties()
   unsigned int radius = 1;
   imageFunction->SetNeighborhoodRadius(radius);
   ITK_TEST_SET_GET_VALUE(radius, imageFunction->GetNeighborhoodRadius());
+
+  auto                                                                 size = TImage::SizeType::Filled(radius);
+  const itk::RectangularImageNeighborhoodShape<TImage::ImageDimension> shape(size);
+  unsigned int                                                         neighborhoodSize = shape.GetNumberOfOffsets();
+  EXPECT_EQ(neighborhoodSize, imageFunction->GetNeighborhoodSize());
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -118,8 +118,11 @@ TestBasicObjectProperties()
 
 TEST(SumOfSquaresImageFunction, BasicObjectProperties)
 {
-  TestBasicObjectProperties<itk::Image<double, 2>>();
-  TestBasicObjectProperties<itk::Image<unsigned char, 3>>();
+  int testStatus = TestBasicObjectProperties<itk::Image<double, 2>>();
+  EXPECT_EQ(testStatus, EXIT_SUCCESS);
+
+  testStatus = TestBasicObjectProperties<itk::Image<unsigned char, 3>>();
+  EXPECT_EQ(testStatus, EXIT_SUCCESS);
 }
 
 


### PR DESCRIPTION
- ENH: Increase `itk::SumOfSquaresImageFunction` class coverage
- STYLE: Prefer using `EXPECT_EQ` in GTest value check
- ENH: Check GTest test method return value

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)