### PR TITLE
Remove implicit conversion from a single scalar value to `itk::Vector`

### DIFF
--- a/Documentation/ITK5MigrationGuide.md
+++ b/Documentation/ITK5MigrationGuide.md
@@ -454,6 +454,12 @@ The namespece itself is only available in legacy mode. Some classes were renamed
 
 Enumeration member names (`ITK_COORDINATE_UNKNOWN`, `ITK_COORDINATE_Right`, `ITK_COORDINATE_PrimaryMinor`, `ITK_COORDINATE_ORIENTATION_RIP` etc) are unchanged.
 
+Implicit conversion of a single scalar value to a container (which would _fill_ the container by the
+scalar value) is discouraged. With ITK 5.3, when having `ITK_LEGACY_REMOVE=ON`, the constructors of
+`Point`, `RGBPixel`, `RGBAPixel`, and `Vector` that accept a single scalar value as argument are
+declared `explicit`. ITK 5.3 has included a preferable alternative to these constructors:
+`itk::MakeFilled<ContainerType>(value)`.
+
 Consolidated Vector Filter
 --------------------------
 

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -106,7 +106,7 @@ public:
    * \note The other five "special member functions" are defaulted implicitly, following the C++ "Rule of Zero". */
   Vector() = default;
 
-#if !defined(ITK_LEGACY_FUTURE_REMOVE)
+#if !defined(ITK_LEGACY_REMOVE)
   /** Constructor to initialize entire vector to one value.
    * \warning Not intended to convert a scalar value into
    * a Vector filled with that value.
@@ -116,6 +116,9 @@ public:
   /** Constructor to initialize entire vector to one value,
    * if explicitly invoked. */
   explicit Vector(const ValueType & r);
+
+  /** Prevents copy-initialization from `nullptr`, as well as from `0` (NULL). */
+  Vector(std::nullptr_t) = delete;
 #endif
 
   /** Pass-through constructor for the Array base class. */

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -318,7 +318,7 @@ public:
                             CovariantVectorType &        value,
                             unsigned int                 depth = 0,
                             const std::string &          name = "",
-                            const DerivativeOffsetType & offset = 1);
+                            const DerivativeOffsetType & offset = MakeFilled<DerivativeOffsetType>(1));
 
   /** Return the n-th order derivative value at the specified point. */
   virtual void
@@ -327,7 +327,7 @@ public:
                            CovariantVectorType &        value,
                            unsigned int                 depth = 0,
                            const std::string &          name = "",
-                           const DerivativeOffsetType & offset = 1);
+                           const DerivativeOffsetType & offset = MakeFilled<DerivativeOffsetType>(1));
 
 
   /*********************/

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
@@ -18,6 +18,7 @@
 #ifndef itkMahalanobisDistanceMembershipFunction_h
 #define itkMahalanobisDistanceMembershipFunction_h
 
+#include "itkNumericTraitsVectorPixel.h"
 #include "itkVariableSizeMatrix.h"
 
 #include "itkMembershipFunctionBase.h"

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -277,7 +277,7 @@ itkMeanSquaresImageToImageMetricv4VectorRegistrationTest(int argc, char * argv[]
   resample->SetOutputOrigin(fixedImage->GetOrigin());
   resample->SetOutputSpacing(fixedImage->GetSpacing());
   resample->SetOutputDirection(fixedImage->GetDirection());
-  resample->SetDefaultPixelValue(itk::NumericTraits<FixedImageType::PixelType::ValueType>::ZeroValue());
+  resample->SetDefaultPixelValue(itk::NumericTraits<FixedImageType::PixelType>::ZeroValue());
   resample->Update();
 
   // write out the displacement field


### PR DESCRIPTION
Follow-up to commit a8909625948547989f97385fd0b06c9f331606eb "ENH: Make Vector construction from scalar value explicit" by Brian Helba (@brianhelba), January 26, 2015

Analog to: pull request #3237 commit 8825834406356a66705437b74c843a54a47c57c3 "ENH: Declare converting `Point(v)` constructors `explicit`"
