### PR TITLE
COMP: Revert "ENH: Declare converting `Point(v)` constructors `explicit`"

### DIFF
--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -99,22 +99,7 @@ public:
   Point(const ValueType r[VPointDimension])
     : BaseArray(r)
   {}
-
-#if defined(ITK_LEGACY_REMOVE)
-  /** Prevents copy-initialization from `nullptr`, as well as from `0` (NULL). */
-  Point(std::nullptr_t) = delete;
-
-  /** Explicit constructors for single values */
-  template <typename TPointValueType>
-  explicit Point(const TPointValueType & v)
-    : BaseArray(v)
-  {}
-  explicit Point(const ValueType & v)
-    : BaseArray(v)
-  {}
-#else
-  /** Pass-through constructors for single values
-   * \note ITK_LEGACY_REMOVE=ON will disallow implicit conversion from a single value. */
+  /** Pass-through constructors for single values */
   template <typename TPointValueType>
   Point(const TPointValueType & v)
     : BaseArray(v)
@@ -122,7 +107,6 @@ public:
   Point(const ValueType & v)
     : BaseArray(v)
   {}
-#endif
 
   /** Explicit constructor for std::array. */
   explicit Point(const std::array<ValueType, VPointDimension> & stdArray)


### PR DESCRIPTION
This reverts commit 8825834406356a66705437b74c843a54a47c57c3.

To address:

```
FAILED: test/CMakeFiles/WebAssemblyInterfaceTestDriver.dir/itkPipelineTest.cxx.o
ccache /usr/bin/c++  -I/home/matt/bin/ITK2-Wrap-Release/Modules/ThirdParty/Eigen3/src -I/home/matt/src/ITK2/Modules/ThirdParty/VNL/src/vxl/core -I/home/matt/bin/ITK2-Wrap-Release/Modules/ThirdParty/VNL/src/vxl/v3p/netlib -I/home/matt/bin/ITK2-Wrap-Release/Modules/ThirdParty/VNL/src/vxl/vcl -I/home/matt/bin/ITK2-Wrap-Release/Modules/ThirdParty/VNL/src/vxl/core -I/home/matt/bin/ITK2-Wrap-Release/Modules/Core/Common -I/home/matt/src/ITK2/Modules/Core/Common/include -I/home/matt/bin/ITK2-Wrap-Release/Modules/IO/ImageBase -I/home/matt/src/ITK2/Modules/IO/ImageBase/include -I/home/matt/src/ITK2/Modules/Filtering/ImageFilterBase/include -I/home/matt/bin/ITK2-Wrap-Release/Modules/ThirdParty/Netlib -I/home/matt/src/ITK2/Modules/Numerics/Statistics/include -I/home/matt/src/ITK2/Modules/Core/Transform/include -I/home/matt/src/ITK2/Modules/Core/Mesh/include -I/home/matt/src/ITK2/Modules/Core/QuadEdgeMesh/include -I/home/matt/src/ITK2/Modules/Segmentation/Voronoi/include -I/home/matt/src/ITK2/Modules/IO/MeshBase/include -I/home/matt/src/ITK2/Modules/Core/ImageAdaptors/include -I/home/matt/src/ITK2/Modules/Core/ImageFunction/include -I/home/matt/src/ITKMeshToPolyData/include -I/home/matt/bin/ITKMeshToPolyData-Wrap-Release/include -I/home/matt/bin/ITKWebAssemblyInterface-Wrap-Release/_deps/rapidjson_lib-src/include -I/home/matt/bin/ITKWebAssemblyInterface-Wrap-Release/_deps/cli11-src/include -I/home/matt/bin/ITKWebAssemblyInterface-Wrap-Release/_deps/rang-src/include -I/home/matt/bin/ITKWebAssemblyInterface-Wrap-Release/_deps/libcbor-src/src -I/home/matt/bin/ITKWebAssemblyInterface-Wrap-Release/_deps/libcbor-build/src -I/home/matt/bin/ITKWebAssemblyInterface-Wrap-Release/_deps/libcbor-build -I/home/matt/src/itk-wasm/include -I/home/matt/bin/ITKWebAssemblyInterface-Wrap-Release/include -I/home/matt/src/ITK2/Modules/ThirdParty/DoubleConversion/src -I/home/matt/bin/ITK2-Wrap-Release/Modules/ThirdParty/DoubleConversion/src/double-conversion -I/home/matt/src/ITK2/Modules/Core/TestKernel/include -isystem /home/matt/src/ITK2/Modules/ThirdParty/Eigen3/src/itkeigen/.. -isystem /home/matt/bin/ITK2-Wrap-Release/Modules/ThirdParty/KWSys/src -isystem /home/matt/src/ITK2/Modules/ThirdParty/VNL/src/vxl/v3p/netlib -isystem /home/matt/src/ITK2/Modules/ThirdParty/VNL/src/vxl/vcl -isystem /home/matt/src/ITK2/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo -isystem /home/matt/src/ITK2/Modules/ThirdParty/VNL/src/vxl/core/vnl -isystem /home/matt/bin/ITK2-Wrap-Release/Modules/ThirdParty/VNL/src/vxl/core/vnl -msse2 -O2 -g -DNDEBUG -fPIE -std=c++17 -MD -MT test/CMakeFiles/WebAssemblyInterfaceTestDriver.dir/itkPipelineTest.cxx.o -MF test/CMakeFiles/WebAssemblyInterfaceTestDriver.dir/itkPipelineTest.cxx.o.d -o test/CMakeFiles/WebAssemblyInterfaceTestDriver.dir/itkPipelineTest.cxx.o -c /home/matt/src/itk-wasm/test/itkPipelineTest.cxx
In file included from /usr/include/c++/9/bits/char_traits.h:39,
                 from /usr/include/c++/9/string:40,
                 from /home/matt/src/ITK2/Modules/Core/Common/include/itkMacro.h:47,
                 from /home/matt/src/ITK2/Modules/Core/TestKernel/include/itkTestingMacros.h:22,
                 from /home/matt/src/itk-wasm/test/itkPipelineTest.cxx:18:
/usr/include/c++/9/bits/stl_algobase.h: In instantiation of ‘static _OI std::__copy_move<false, false, std::random_access_iterator_tag>::__copy_m(_II, _II, _OI) [with _II = float*; _OI = itk::Point<float, 3>*]’:
/usr/include/c++/9/bits/stl_algobase.h:404:30:   required from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = float*; _OI = itk::Point<float, 3>*]’
/usr/include/c++/9/bits/stl_algobase.h:441:30:   required from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = float*; _OI = itk::Point<float, 3>*]’
/usr/include/c++/9/bits/stl_algobase.h:474:7:   required from ‘_OI std::copy(_II, _II, _OI) [with _II = float*; _OI = itk::Point<float, 3>*]’
/usr/include/c++/9/bits/vector.tcc:321:29:   required from ‘void std::vector<_Tp, _Alloc>::_M_assign_aux(_ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = float*; _Tp = itk::Point<float, 3>; _Alloc = std::allocator<itk::Point<float, 3> >]’
/usr/include/c++/9/bits/stl_vector.h:1625:4:   required from ‘void std::vector<_Tp, _Alloc>::_M_assign_dispatch(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = float*; _Tp = itk::Point<float, 3>; _Alloc = std::allocator<itk::Point<float, 3> >]’
/usr/include/c++/9/bits/stl_vector.h:766:4:   required from ‘void std::vector<_Tp, _Alloc>::assign(_InputIterator, _InputIterator) [with _InputIterator = float*; <template-parameter-2-2> = void; _Tp = itk::Point<float, 3>; _Alloc = std::allocator<itk::Point<float, 3> >]’
/home/matt/src/itk-wasm/include/itkWASMPolyDataToPolyDataFilter.hxx:193:5:   required from ‘void itk::WASMPolyDataToPolyDataFilter<TPolyData>::GenerateData() [with TPolyData = itk::PolyData<float>]’
/home/matt/src/itk-wasm/include/itkWASMPolyDataToPolyDataFilter.hxx:139:1:   required from here
/usr/include/c++/9/bits/stl_algobase.h:342:18: error: no match for ‘operator=’ (operand types are ‘itk::Point<float, 3>’ and ‘float’)
  342 |        *__result = *__first;
      |        ~~~~~~~~~~^~~~~~~~~~
In file included from /home/matt/src/ITK2/Modules/Core/Common/include/itkPoint.h:385,
                 from /home/matt/src/ITK2/Modules/Core/Common/include/itkContinuousIndex.h:21,
                 from /home/matt/src/ITK2/Modules/Core/Common/include/itkImageRegion.h:34,
                 from /home/matt/src/ITK2/Modules/Core/Common/include/itkImage.h:21,
                 from /home/matt/src/itk-wasm/test/itkPipelineTest.cxx:21:
/home/matt/src/ITK2/Modules/Core/Common/include/itkPoint.hxx:31:1: note: candidate: ‘itk::Point<T, VPointDimension>& itk::Point<TCoordRep, VPointDimension>::operator=(const ValueType*) [with TCoordRep = float; unsigned int VPointDimension = 3; itk::Point<TCoordRep, VPointDimension>::ValueType = float]’
   31 | Point<T, TPointDimension>::operator=(const ValueType r[TPointDimension])
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/matt/src/ITK2/Modules/Core/Common/include/itkPoint.hxx:31:54: note:   no known conversion for argument 1 from ‘float’ to ‘const ValueType*’ {aka ‘const float*’}
   31 | Point<T, TPointDimension>::operator=(const ValueType r[TPointDimension])
      |                                      ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
In file included from /home/matt/src/ITK2/Modules/Core/Common/include/itkContinuousIndex.h:21,
                 from /home/matt/src/ITK2/Modules/Core/Common/include/itkImageRegion.h:34,
                 from /home/matt/src/ITK2/Modules/Core/Common/include/itkImage.h:21,
                 from /home/matt/src/itk-wasm/test/itkPipelineTest.cxx:21:
/home/matt/src/ITK2/Modules/Core/Common/include/itkPoint.h:53:27: note: candidate: ‘constexpr itk::Point<float, 3>& itk::Point<float, 3>::operator=(const itk::Point<float, 3>&)’
   53 | class ITK_TEMPLATE_EXPORT Point : public FixedArray<TCoordRep, VPointDimension>
      |                           ^~~~~
/home/matt/src/ITK2/Modules/Core/Common/include/itkPoint.h:53:27: note:   no known conversion for argument 1 from ‘float’ to ‘const itk::Point<float, 3>&’
/home/matt/src/ITK2/Modules/Core/Common/include/itkPoint.h:53:27: note: candidate: ‘constexpr itk::Point<float, 3>& itk::Point<float, 3>::operator=(itk::Point<float, 3>&&)’
/home/matt/src/ITK2/Modules/Core/Common/include/itkPoint.h:53:27: note:   no known conversion for argument 1 from ‘float’ to ‘itk::Point<float, 3>&&’
```

with GCC 9.4 on Linux, building the itkwasm/WebAssemblyInterface Python wrapping.
