### PR TITLE
STYLE: Use MakeFilled, () or {}, instead of `Vector(const ValueType &)`

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -248,7 +248,7 @@ private:
   PixelType   m_InteriorValue{ NumericTraits<PixelType>::ZeroValue() };
   PixelType   m_AnnulusValue{ NumericTraits<PixelType>::OneValue() };
   PixelType   m_ExteriorValue{ NumericTraits<PixelType>::ZeroValue() };
-  SpacingType m_Spacing{ 1.0 };
+  SpacingType m_Spacing{ MakeFilled<SpacingType>(1.0) };
 };
 } // namespace itk
 

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -810,7 +810,7 @@ protected:
   /** Origin, spacing, and direction in physical coordinates. This variables are
    * protected for efficiency.  They are referenced frequently by
    * inner loop calculations. */
-  SpacingType   m_Spacing{ 1.0 };
+  SpacingType   m_Spacing{ MakeFilled<SpacingType>(1.0) };
   PointType     m_Origin{};
   DirectionType m_Direction{ DirectionType::GetIdentity() };
   DirectionType m_InverseDirection{ DirectionType::GetIdentity() };

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -201,10 +201,10 @@ public:
 #define itkStaticNumericTraitsGenericArrayMacro(GENERIC_ARRAY, T, D)                    \
   template <>                                                                           \
   ITKCommon_EXPORT const GENERIC_ARRAY<T, D> NumericTraits<GENERIC_ARRAY<T, D>>::Zero = \
-    GENERIC_ARRAY<T, D>((T)(NumericTraits<T>::Zero));                                   \
+    MakeFilled<GENERIC_ARRAY<T, D>>(NumericTraits<T>::Zero);                            \
   template <>                                                                           \
   ITKCommon_EXPORT const GENERIC_ARRAY<T, D> NumericTraits<GENERIC_ARRAY<T, D>>::One =  \
-    GENERIC_ARRAY<T, D>((T)(NumericTraits<T>::One));
+    MakeFilled<GENERIC_ARRAY<T, D>>(NumericTraits<T>::One);
 
 //
 // List here the array dimension specializations of these static

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -72,43 +72,43 @@ public:
   static const Self
   max(const Self &)
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self &)
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   max()
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min()
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   NonpositiveMin()
   {
-    return Self(NumericTraits<T>::NonpositiveMin());
+    return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
   static const Self
   ZeroValue()
   {
-    return Self(NumericTraits<T>::ZeroValue());
+    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
   }
 
   static const Self
   OneValue()
   {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
   static const Self

--- a/Modules/Core/Common/test/itkImageBaseGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBaseGTest.cxx
@@ -130,8 +130,8 @@ CheckInvalidSpacingExceptions()
 
   // Test exceptions
   const SpacingType initialSpacing = imageBase->GetSpacing();
-  const SpacingType negativeSpacing(-1.0);
-  const SpacingType zeroSpacing(0.0);
+  const auto        negativeSpacing = itk::MakeFilled<SpacingType>(-1.0);
+  const SpacingType zeroSpacing{};
 
 #if !defined(ITK_LEGACY_REMOVE)
   // Only a warning is displayed

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -152,7 +152,7 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussianKernel()
   else
   {
     using SpacingType = typename TInputImage::SpacingType;
-    const SpacingType spacing = m_UseImageSpacing ? inputImage->GetSpacing() : SpacingType(1);
+    const SpacingType spacing = m_UseImageSpacing ? inputImage->GetSpacing() : MakeFilled<SpacingType>(1);
 
     for (unsigned int direction = 0; direction < Self::ImageDimension; ++direction)
     {

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -215,7 +215,7 @@ RunLinearInterpolateTest()
 
                     const InterpolatedVectorType & vectorpixel = vectorinterpolator->Evaluate(point);
 
-                    const InterpolatedVectorType expectedvector(expectedValue);
+                    const auto expectedvector = itk::MakeFilled<InterpolatedVectorType>(expectedValue);
 
                     const AccumulatorType & errornorm = (expectedvector - vectorpixel).GetNorm();
 

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -179,7 +179,7 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
 
             // test image of vectors
             const InterpolatedVectorType vectorpixel = vectorinterpolator->Evaluate(point);
-            const InterpolatedVectorType expectedvector(expectedValue);
+            const auto                   expectedvector = itk::MakeFilled<InterpolatedVectorType>(expectedValue);
             const double                 errornorm = (expectedvector - vectorpixel).GetNorm();
 
             if (errornorm > 0)

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -75,7 +75,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBox()
     typename Superclass::ContinuousIndexType maxContinuousIndex{ minIndex + boundingBoxInIndexSpace.GetSize() };
 
     // Allow a margin of half a pixel in each direction.
-    const typename SpatialObject<TDimension>::VectorType half_pixel_size{ 0.5 };
+    const auto half_pixel_size = MakeFilled<typename SpatialObject<TDimension>::VectorType>(0.5);
     minContinuousIndex -= half_pixel_size;
     maxContinuousIndex -= half_pixel_size;
 

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -82,7 +82,7 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
   std::cout << "Sample mean = " << calculator->GetMean() << std::endl;
   std::cout << "Sample covariance = " << calculator->GetCovarianceMatrix();
 
-  if (calculator->GetMean() != CalculatorType::VectorType(255) ||
+  if (calculator->GetMean() != itk::MakeFilled<CalculatorType::VectorType>(255) ||
       itk::Math::NotAlmostEquals(calculator->GetCovarianceMatrix()[0][0],
                                  itk::NumericTraits<CalculatorType::MatrixType::ValueType>::ZeroValue()))
   {

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -171,7 +171,7 @@ BSplineTransformInitializer<TTransform, TImage>::InitializeTransform() const
   {
     minAngle[d] = NumericTraits<double>::max();
 
-    VectorType vectorAxis(0.0);
+    VectorType vectorAxis{};
     vectorAxis[d] = 1.0;
 
     for (unsigned int i = 0; i < SpaceDimension; ++i)

--- a/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
@@ -62,7 +62,7 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    VectorType axis(1.5);
+    auto axis = itk::MakeFilled<VectorType>(1.5);
 
     ValueType angle = 120.0 * std::atan(1.0) / 45.0;
 
@@ -109,7 +109,7 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
 
     auto rotation = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 120.0; // turn 120 degrees
 
@@ -267,7 +267,7 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -343,7 +343,7 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
     std::cout << " Exercise the SetIdentity() method " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -396,8 +396,8 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
     std::cout << " Exercise the Scaling methods " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
-    const double           angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
+    auto         axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
+    const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
     transform->SetRotation(axis, angle);
 
     TransformType::InputPointType center;

--- a/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
@@ -68,7 +68,7 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    VectorType axis(1.5);
+    auto axis = itk::MakeFilled<VectorType>(1.5);
 
     ValueType angle = 120.0 * std::atan(1.0) / 45.0;
 
@@ -112,7 +112,7 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
 
     auto rotation = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 120.0; // turn 120 degrees
 
@@ -270,7 +270,7 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -409,7 +409,7 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
     std::cout << " Exercise the SetIdentity() method " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -464,7 +464,7 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
     std::cout << " Exercise the Scaling methods " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 

--- a/Modules/Core/Transform/test/itkScaleVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleVersor3DTransformTest.cxx
@@ -63,7 +63,7 @@ itkScaleVersor3DTransformTest(int, char *[])
 
     transform->Print(std::cout);
 
-    VectorType axis(1.5);
+    auto axis = itk::MakeFilled<VectorType>(1.5);
 
     ValueType angle = 120.0 * std::atan(1.0) / 45.0;
 
@@ -126,7 +126,7 @@ itkScaleVersor3DTransformTest(int, char *[])
 
     auto rotation = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 120.0; // turn 120 degrees
 
@@ -284,7 +284,7 @@ itkScaleVersor3DTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -421,7 +421,7 @@ itkScaleVersor3DTransformTest(int, char *[])
     std::cout << " Exercise the SetIdentity() method " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -470,7 +470,7 @@ itkScaleVersor3DTransformTest(int, char *[])
     std::cout << " Exercise the Scaling methods " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 

--- a/Modules/Core/Transform/test/itkSimilarity3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity3DTransformTest.cxx
@@ -74,7 +74,7 @@ itkSimilarity3DTransformTest(int, char *[])
       return EXIT_FAILURE;
     }
 
-    VectorType axis(1.5);
+    auto axis = itk::MakeFilled<VectorType>(1.5);
 
     ValueType angle = 120.0 * std::atan(1.0) / 45.0;
 
@@ -114,7 +114,7 @@ itkSimilarity3DTransformTest(int, char *[])
 
     auto rotation = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 120.0; // turn 120 degrees
 
@@ -270,7 +270,7 @@ itkSimilarity3DTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -396,7 +396,7 @@ itkSimilarity3DTransformTest(int, char *[])
     std::cout << " Exercise the SetIdentity() method " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -443,7 +443,7 @@ itkSimilarity3DTransformTest(int, char *[])
     std::cout << " Exercise the Scaling methods " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 

--- a/Modules/Core/Transform/test/itkVersorRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorRigid3DTransformTest.cxx
@@ -65,7 +65,7 @@ itkVersorRigid3DTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    VectorType axis(1.5);
+    auto axis = itk::MakeFilled<VectorType>(1.5);
 
     ValueType angle = 120.0 * std::atan(1.0) / 45.0;
 
@@ -106,7 +106,7 @@ itkVersorRigid3DTransformTest(int, char *[])
 
     auto rotation = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 120.0; // turn 120 degrees
 
@@ -264,7 +264,7 @@ itkVersorRigid3DTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 
@@ -385,7 +385,7 @@ itkVersorRigid3DTransformTest(int, char *[])
     std::cout << " Exercise the SetIdentity() method " << std::endl;
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 

--- a/Modules/Core/Transform/test/itkVersorTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorTransformTest.cxx
@@ -65,7 +65,7 @@ itkVersorTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    VectorType axis(1.5);
+    auto axis = itk::MakeFilled<VectorType>(1.5);
 
     ValueType angle = 120.0 * std::atan(1.0) / 45.0;
 
@@ -103,7 +103,7 @@ itkVersorTransformTest(int, char *[])
 
     auto rotation = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 120.0; // turn 120 degrees
 
@@ -261,7 +261,7 @@ itkVersorTransformTest(int, char *[])
 
     auto transform = TransformType::New();
 
-    itk::Vector<double, 3> axis(1);
+    auto axis = itk::MakeFilled<itk::Vector<double, 3>>(1);
 
     const double angle = (std::atan(1.0) / 45.0) * 30.0; // turn 30 degrees
 

--- a/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.hxx
@@ -60,7 +60,7 @@ template <typename InputImage, typename TOutputImage>
 void
 ComposeDisplacementFieldsImageFilter<InputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   this->GetOutput()->FillBuffer(zeroVector);
 
@@ -97,7 +97,7 @@ ComposeDisplacementFieldsImageFilter<InputImage, TOutputImage>::DynamicThreadedG
       pointIn2[d] = pointIn1[d] + warpVector[d];
     }
 
-    typename InterpolatorType::OutputType displacement(0.0);
+    typename InterpolatorType::OutputType displacement{};
     if (this->m_Interpolator->IsInsideBuffer(pointIn2))
     {
       displacement = this->m_Interpolator->Evaluate(pointIn2);

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -184,7 +184,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
       }
       if (isOnStationaryBoundary)
       {
-        VectorType                            data(0.0);
+        VectorType                            data{};
         typename InputPointSetType::PointType point;
 
         bsplineParametricDomainField->TransformIndexToPhysicalPoint(index, point);

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -141,11 +141,11 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::SetIdentity()
 {
   if (!this->m_DisplacementField.IsNull())
   {
-    this->m_DisplacementField->FillBuffer(OutputVectorType(0.0));
+    this->m_DisplacementField->FillBuffer(OutputVectorType());
   }
   if (!this->m_InverseDisplacementField.IsNull())
   {
-    this->m_InverseDisplacementField->FillBuffer(OutputVectorType(0.0));
+    this->m_InverseDisplacementField->FillBuffer(OutputVectorType());
   }
 }
 

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -180,7 +180,7 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Gau
     smoothField->DisconnectPipeline();
   }
 
-  const DisplacementVectorType zeroVector(0.0);
+  const DisplacementVectorType zeroVector{};
 
   // make sure boundary does not move
   ScalarType weight1 = 1.0;

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -173,7 +173,7 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimen
     smoothField->DisconnectPipeline();
   }
 
-  const DisplacementVectorType zeroVector(0.0);
+  const DisplacementVectorType zeroVector{};
 
   // make sure boundary does not move
   ScalarType weight1 = 1.0;

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
@@ -187,7 +187,7 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
 
   // make sure boundary does not move
 
-  const DisplacementVectorType zeroVector(0.0);
+  const DisplacementVectorType zeroVector{};
 
   ScalarType weight1 = 1.0;
   if (spatialVariance < 0.5)

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -70,7 +70,7 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
   this->UpdateProgress(0.0f);
   this->AllocateOutputs();
 
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   typename DisplacementFieldType::ConstPointer displacementField = this->GetInput();
 
@@ -171,7 +171,7 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
   const typename DisplacementFieldType::RegionType fullRegion = this->m_ComposedField->GetRequestedRegion();
   const typename DisplacementFieldType::SizeType   size = fullRegion.GetSize();
   const typename DisplacementFieldType::IndexType  startIndex = fullRegion.GetIndex();
-  const typename DisplacementFieldType::PixelType  zeroVector(0.0);
+  const typename DisplacementFieldType::PixelType  zeroVector{};
 
   ImageRegionIterator<DisplacementFieldType> ItE(this->m_ComposedField, region);
   ImageRegionIterator<RealImageType>         ItS(this->m_ScaledNormImage, region);

--- a/Modules/Filtering/DisplacementField/test/itkComposeDisplacementFieldsImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkComposeDisplacementFieldsImageFilterTest.cxx
@@ -38,7 +38,7 @@ itkComposeDisplacementFieldsImageFilterTest(int, char *[])
   spacing.Fill(0.5);
   size.Fill(100);
 
-  VectorType ones(1);
+  auto ones = itk::MakeFilled<VectorType>(1);
 
   auto field = DisplacementFieldType::New();
   field->SetOrigin(origin);

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
@@ -39,7 +39,7 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   spacing.Fill(0.5);
   size.Fill(100);
 
-  VectorType ones(1);
+  auto ones = itk::MakeFilled<VectorType>(1);
 
   auto field = DisplacementFieldType::New();
   field->SetOrigin(origin);
@@ -61,7 +61,7 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   auto pointSet = PointSetType::New();
   pointSet->Initialize();
 
-  VectorType ones_points(1.0);
+  auto ones_points = itk::MakeFilled<VectorType>(1.0);
 
   // Assign some random points within the b-spline domain
   PointSetType::PointType point1;

--- a/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
@@ -47,7 +47,7 @@ itkInvertDisplacementFieldImageFilterTest(int argc, char * argv[])
   spacing.Fill(0.5);
   size.Fill(100);
 
-  VectorType ones(1);
+  auto ones = itk::MakeFilled<VectorType>(1);
 
   auto field = DisplacementFieldType::New();
   field->SetOrigin(origin);
@@ -57,7 +57,7 @@ itkInvertDisplacementFieldImageFilterTest(int argc, char * argv[])
   field->Allocate();
   field->FillBuffer(ones);
 
-  const VectorType zeroVector(0.0);
+  const VectorType zeroVector{};
 
   // make sure boundary does not move
   float weight1 = 1.0;

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -33,7 +33,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::SignedMaurerDistanceMapImageFilter()
   : m_BackgroundValue(NumericTraits<InputPixelType>::ZeroValue())
-  , m_Spacing(0.0)
+  , m_Spacing()
   , m_InputCache(nullptr)
 {
   this->DynamicMultiThreadingOff();

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -161,7 +161,7 @@ itkFastMarchingTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(outputRegion, marcher->GetOutputRegion());
 
   auto outputSpacingValue = static_cast<typename FloatFMType::OutputSpacingType::ValueType>(std::stod(argv[6]));
-  typename FloatFMType::OutputSpacingType outputSpacing(outputSpacingValue);
+  auto outputSpacing = itk::MakeFilled<typename FloatFMType::OutputSpacingType>(outputSpacingValue);
   marcher->SetOutputSpacing(outputSpacing);
   ITK_TEST_SET_GET_VALUE(outputSpacing, marcher->GetOutputSpacing());
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -466,7 +466,7 @@ BSplineControlPointImageFilter<TInputPointImage, TOutputImage>::RefineControlPoi
       }
       for (unsigned int i = 0; i < (2 << (ImageDimension - 1)); ++i)
       {
-        PixelType sum(0.0);
+        PixelType sum{};
 
         PixelType val;
         off = this->NumberToIndex(i, size);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -275,7 +275,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Generat
   {
     this->m_PsiLattice->SetRegions(this->m_PhiLattice->GetLargestPossibleRegion());
     this->m_PsiLattice->Allocate();
-    PointDataType P(0.0);
+    PointDataType P{};
     this->m_PsiLattice->FillBuffer(P);
   }
 
@@ -825,8 +825,8 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::RefineC
 
     for (unsigned int i = 0; i < (2 << (ImageDimension - 1)); ++i)
     {
-      PointDataType sum(0.0);
-      PointDataType val(0.0);
+      PointDataType sum{};
+      PointDataType val{};
       off = this->NumberToIndex(i, size);
 
       bool outOfBoundary = false;

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -39,7 +39,7 @@ template <typename TInputImage,
 ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTransformPrecisionType>::
   ResampleImageFilter()
   : m_Extrapolator(nullptr)
-  , m_OutputSpacing(1.0)
+  , m_OutputSpacing(MakeFilled<SpacingType>(1.0))
   , m_OutputOrigin(0.0)
 
 {

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
@@ -46,7 +46,7 @@ itkBSplineControlPointImageFunctionTest(int, char *[])
   phiLattice->SetSpacing(spacing);
   phiLattice->SetRegions(size);
   phiLattice->Allocate();
-  phiLattice->FillBuffer(VectorType(0.0));
+  phiLattice->FillBuffer(VectorType{});
 
   // To create the specified function, the first and last control points have
   // a value of 1.0;

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
@@ -75,7 +75,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest(int argc, char * argv[])
       unsigned long i = pointSet->GetNumberOfPoints();
       pointSet->SetPoint(i, point);
 
-      PointSetType::PixelType V(DataDimension);
+      auto V = itk::MakeFilled<PointSetType::PixelType>(DataDimension);
       V[0] = static_cast<RealType>(It.Get());
       pointSet->SetPointData(i, V);
     }

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -34,8 +34,8 @@ namespace itk
 
 template <typename TInputImage, typename TPolyline, typename TVector, typename TOutputImage>
 PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::PolylineMaskImageFilter()
-  : m_ViewVector(1)
-  , m_UpVector(1)
+  : m_ViewVector(MakeFilled<VectorType>(1))
+  , m_UpVector(MakeFilled<VectorType>(1))
   , m_CameraCenterPoint(0)
   , m_FocalPoint(0.0)
 

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
@@ -24,7 +24,7 @@ namespace itk
 {
 template <typename TOutputImage>
 GenerateImageSource<TOutputImage>::GenerateImageSource()
-  : m_Spacing(1.0)
+  : m_Spacing(MakeFilled<SpacingType>(1.0))
   , m_Origin(0.0)
 
 {

--- a/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
@@ -87,7 +87,7 @@ itkPhysicalPointImageSourceTest(int argc, char * argv[])
   itk::Size<ImageDimension> size;
   size.Fill(64);
 
-  ImageType::SpacingType   spacing(1.0);
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType     origin(0.0);
   ImageType::DirectionType direction;
   direction.SetIdentity();

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -263,7 +263,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
       output->TransformIndexToPhysicalPoint(idx, physicalPosition);
 
       const typename ImageType::DirectionType & direction = output->GetDirection();
-      VectorType                                scale(output->GetSpacing()[0]);
+      auto                                      scale = MakeFilled<VectorType>(output->GetSpacing()[0]);
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         scale[i] *= direction(i, 0);

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -159,7 +159,7 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
       // set up vectors normal to the faces - only put in 3 points for
       // each face:
       // face 1
-      LType3     PP(0.0);
+      LType3     PP{};
       FacetType3 Fc;
       b /= 2.0;
       c /= 2.0;
@@ -414,7 +414,7 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
       // set up vectors normal to the faces - only put in 3 points for
       // each face:
       // face 1
-      LType3     PP(0.0);
+      LType3     PP{};
       FacetType3 Fc;
 
       PP[0] = 0;
@@ -733,7 +733,7 @@ void FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringEle
       FacetArray.resize(facets);
 
       // original corners of octahedron
-      LType3 P0(0.0), P1(0.0), P2(0.0), P3(0.0), P4(0.0), P5(0.0);
+      LType3 P0{}, P1{}, P2{}, P3{}, P4{}, P5{};
       P0[0] = 0;
       P0[1] = 0;
       P0[2] = 1;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
@@ -70,7 +70,7 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
   CoefficientType coeff;
   filter->SetCoefficientsMethod(&coeff);
 
-  MeshType::VectorType nullVector(0.);
+  MeshType::VectorType nullVector{};
 
   std::map<MeshType::PointIdentifier, MeshType::VectorType> constraints;
   constraints[150] = nullVector;
@@ -81,13 +81,13 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
   constraints[183] = nullVector;
   constraints[226] = nullVector;
 
-  MeshType::VectorType d(0.);
+  MeshType::VectorType d{};
   d[2] = -0.1;
 
   constraints[729] = d;
   constraints[938] = d;
 
-  MeshType::VectorType e(0.);
+  MeshType::VectorType e{};
   e[1] = 0.1;
   e[2] = -0.1;
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
@@ -75,7 +75,7 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest(int argc, char 
   CoefficientType coeff;
   filter->SetCoefficientsMethod(&coeff);
 
-  MeshType::VectorType nullVector(0.);
+  MeshType::VectorType nullVector{};
 
   std::map<MeshType::PointIdentifier, MeshType::VectorType> constraints;
   constraints[150] = nullVector;
@@ -86,13 +86,13 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest(int argc, char 
   constraints[183] = nullVector;
   constraints[226] = nullVector;
 
-  MeshType::VectorType d(0.);
+  MeshType::VectorType d{};
   d[2] = -0.1;
 
   constraints[729] = d;
   constraints[938] = d;
 
-  MeshType::VectorType e(0.);
+  MeshType::VectorType e{};
   e[1] = 0.1;
   e[2] = -0.1;
 

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -50,7 +50,7 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
   // RecursiveGaussianImageFilter and compare a few filtered pixels.
   //
   // Create ON and OFF vectors
-  PixelType vector0(0.0);
+  PixelType vector0{};
   PixelType vector1;
   vector1[0] = 1.0;
   vector1[1] = 2.0;

--- a/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
@@ -267,7 +267,7 @@ TimeVaryingBSplineVelocityFieldTransformParametersAdaptor<TTransform>::AdaptTran
   using UpsampleFilterType = ResampleImageFilter<ComponentImageType, ComponentImageType, ParametersValueType>;
   using DecompositionFilterType = BSplineDecompositionImageFilter<ComponentImageType, ComponentImageType>;
 
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   TimeVaryingVelocityFieldControlPointLatticePointer requiredLattice =
     TimeVaryingVelocityFieldControlPointLatticeType::New();

--- a/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
@@ -243,7 +243,7 @@ typename BSplineSyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTra
 
   if (this->m_Metric->GetMetricCategory() == ObjectToObjectMetricBaseTemplateEnums::MetricCategory::POINT_SET_METRIC)
   {
-    const DisplacementVectorType zeroVector(0.0);
+    const DisplacementVectorType zeroVector{};
 
     VirtualImageBaseConstPointer virtualDomainImage = this->GetCurrentLevelVirtualDomainImage();
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -72,7 +72,7 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
 
       VirtualImageBaseConstPointer virtualDomainImage = this->GetCurrentLevelVirtualDomainImage();
 
-      const DisplacementVectorType zeroVector(0.0);
+      const DisplacementVectorType zeroVector{};
 
       auto fixedDisplacementField = DisplacementFieldType::New();
       fixedDisplacementField->CopyInformation(virtualDomainImage);
@@ -572,7 +572,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   if (this->m_DownsampleImagesForMetricDerivatives &&
       this->m_Metric->GetMetricCategory() != ObjectToObjectMetricBaseTemplateEnums::MetricCategory::POINT_SET_METRIC)
   {
-    const DisplacementVectorType zeroVector(0.0);
+    const DisplacementVectorType zeroVector{};
 
     auto identityField = DisplacementFieldType::New();
     identityField->CopyInformation(virtualDomainImage);
@@ -780,7 +780,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
     smoothField->DisconnectPipeline();
   }
 
-  const DisplacementVectorType zeroVector(0.0);
+  const DisplacementVectorType zeroVector{};
 
   // make sure boundary does not move
   RealType weight1 = 1.0;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -127,7 +127,7 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
     }
   }
 
-  const DisplacementVectorType zeroVector(0.0);
+  const DisplacementVectorType zeroVector{};
 
   auto identityField = DisplacementFieldType::New();
   identityField->CopyInformation(virtualDomainImage);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
@@ -218,7 +218,7 @@ PerformBSplineExpImageRegistration(int argc, char * argv[])
   compositeTransform->AddTransform(affineSimple->GetModifiableTransform());
 
   using VectorType = itk::Vector<RealType, VImageDimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
   using DisplacementFieldType = itk::Image<VectorType, VImageDimension>;
   auto displacementField = DisplacementFieldType::New();
   displacementField->CopyInformation(fixedImage);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
@@ -161,7 +161,7 @@ PerformBSplineSyNImageRegistration(int itkNotUsed(argc), char * argv[])
   affineWriter->Update();
 
   using VectorType = itk::Vector<RealType, ImageDimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   // Create the SyN deformable registration method
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNPointSetRegistrationTest.cxx
@@ -112,7 +112,7 @@ itkBSplineSyNPointSetRegistrationTest(int itkNotUsed(argc), char * itkNotUsed(ar
   // Create the SyN deformable registration method
 
   using VectorType = itk::Vector<double, Dimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   using DisplacementFieldType = itk::Image<VectorType, Dimension>;
   auto displacementField = DisplacementFieldType::New();

--- a/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
@@ -232,7 +232,7 @@ PerformExpImageRegistration(int argc, char * argv[])
   compositeTransform->AddTransform(affineSimple->GetModifiableTransform());
 
   using VectorType = itk::Vector<RealType, VImageDimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
   using DisplacementFieldType = itk::Image<VectorType, VImageDimension>;
   using ConstantVelocityFieldType = itk::Image<VectorType, VImageDimension>;
   auto displacementField = ConstantVelocityFieldType::New();

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -237,7 +237,7 @@ PerformSimpleImageRegistration(int argc, char * argv[])
   using RealType = typename AffineRegistrationType::RealType;
 
   using VectorType = itk::Vector<RealType, VImageDimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
   using DisplacementFieldType = itk::Image<VectorType, VImageDimension>;
   auto displacementField = DisplacementFieldType::New();
   displacementField->CopyInformation(fixedImage);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
@@ -254,7 +254,7 @@ PerformSimpleImageRegistrationWithMaskAndSampling(int argc, char * argv[])
   using RealType = typename AffineRegistrationType::RealType;
 
   using VectorType = itk::Vector<RealType, VImageDimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
   using DisplacementFieldType = itk::Image<VectorType, VImageDimension>;
   auto displacementField = DisplacementFieldType::New();
   displacementField->CopyInformation(fixedImage);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -194,7 +194,7 @@ PerformDisplacementFieldImageRegistration(int itkNotUsed(argc), char * argv[])
   affineWriter->Update();
 
   using VectorType = itk::Vector<RealType, ImageDimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   // Create the SyN deformable registration method
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNPointSetRegistrationTest.cxx
@@ -112,7 +112,7 @@ itkSyNPointSetRegistrationTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   // Create the SyN deformable registration method
 
   using VectorType = itk::Vector<double, Dimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   using DisplacementFieldType = itk::Image<VectorType, Dimension>;
   auto displacementField = DisplacementFieldType::New();

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
@@ -301,7 +301,7 @@ PerformTimeVaryingBSplineVelocityFieldImageRegistration(int argc, char * argv[])
   initialFieldTransformAdaptor->SetRequiredTransformDomainDirection(transformDomainDirection);
   ITK_TEST_SET_GET_VALUE(transformDomainDirection, initialFieldTransformAdaptor->GetRequiredTransformDomainDirection());
 
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   velocityFieldLattice->SetOrigin(initialFieldTransformAdaptor->GetRequiredControlPointLatticeOrigin());
   velocityFieldLattice->SetSpacing(initialFieldTransformAdaptor->GetRequiredControlPointLatticeSpacing());

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
@@ -188,7 +188,7 @@ itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest(int itkNotUsed(argc),
   initialFieldTransformAdaptor->SetRequiredTransformDomainMeshSize(transformDomainMeshSize);
   initialFieldTransformAdaptor->SetRequiredTransformDomainDirection(transformDomainDirection);
 
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   velocityFieldLattice->SetOrigin(initialFieldTransformAdaptor->GetRequiredControlPointLatticeOrigin());
   velocityFieldLattice->SetSpacing(initialFieldTransformAdaptor->GetRequiredControlPointLatticeSpacing());

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
@@ -186,7 +186,7 @@ PerformTimeVaryingVelocityFieldImageRegistration(int argc, char * argv[])
   affineWriter->Update();
 
   using VectorType = itk::Vector<RealType, ImageDimension>;
-  VectorType zeroVector(0.0);
+  VectorType zeroVector{};
 
   // Determine the parameters (size, spacing, etc) for the time-varying velocity field
   // Here we use 10 time index points.

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -133,7 +133,7 @@ test_RegionGrowKLMExceptionHandling()
   image5D->SetLargestPossibleRegion(region5D);
   image5D->SetBufferedRegion(region5D);
   image5D->Allocate();
-  itk::Vector<double, NUMBANDS2> pixel(0.0);
+  itk::Vector<double, NUMBANDS2> pixel{};
   image5D->FillBuffer(pixel);
 
   // Set the filter with valid inputs


### PR DESCRIPTION
A call to `MakeFilled<VectorType>(value)` expresses more clearly than
`Vector(const ValueType &)` that an _entire_ Vector is to be filled by
the specific scalar value.

Zero-initialization of a Vector is achieved in the most generic way, by
an empty pair of parentheses `()` or an empty pair of braces `{}`,
rather than by passing 0.0 to the explicit `Vector(const ValueType &)`
constructor.