### PR TITLE
COMP: Add #include "itkNumericTraitsVectorPixel.h"

### DIFF
--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetImageFilter.h
@@ -18,6 +18,7 @@
 #ifndef itkVectorThresholdSegmentationLevelSetImageFilter_h
 #define itkVectorThresholdSegmentationLevelSetImageFilter_h
 
+#include "itkNumericTraitsVectorPixel.h"
 #include "itkSegmentationLevelSetImageFilter.h"
 #include "itkVectorThresholdSegmentationLevelSetFunction.h"
 


### PR DESCRIPTION
For VectorThresholdSegmentationLevelSetImageFilter.  Otherwise the VectorType is set to `double` rather than `itk::Vector<double, N>`.

Similar to c679de253e80e2512fa0c072911414c9068f33e3.