### PR TITLE
BUG: Provide module name with ITK_WRAP_DOC enabled

### DIFF
--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -196,7 +196,7 @@ endmacro()
 macro(itk_end_wrap_submodule_castxml module)
   # write the wrap_*.cxx file
   #
-  # Global vars used: WRAPPER_INCLUDE_FILES WRAPPER_MODULE_NAME and WRAPPER_TYPEDEFS
+  # Global vars used: WRAPPER_INCLUDE_FILES and WRAPPER_TYPEDEFS
   # Global vars modified: none
 
   # Create the cxx file which will be given to castxml.

--- a/Wrapping/Generators/Doc/CMakeLists.txt
+++ b/Wrapping/Generators/Doc/CMakeLists.txt
@@ -92,23 +92,21 @@ endmacro()
 
 ###############################################################################
 # This macro is called once per module
-# Global variable WRAPPER_MODULE_NAME can be used
-# in the macro to current module name
 #
-macro(itk_end_wrap_submodule_DOC)
-    set(doxy2swig_config_file ${CMAKE_CURRENT_BINARY_DIR}/Doc/${WRAPPER_MODULE_NAME}.conf)
+macro(itk_end_wrap_submodule_DOC module_name)
+    set(doxy2swig_config_file ${CMAKE_CURRENT_BINARY_DIR}/Doc/${module_name}.conf)
     configure_file("${ITK_WRAP_DOC_SOURCE_DIR}/itk_doxy2swig.conf.in"
       "${doxy2swig_config_file}"
       @ONLY)
     # run itk_doxy2swig
     set(itk_doxy2swig_py "${ITK_WRAP_DOC_SOURCE_DIR}/itk_doxy2swig.py")
-    set(swig_doc_interface_file ${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${WRAPPER_MODULE_NAME}_doc.i)
+    set(swig_doc_interface_file ${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${module_name}_doc.i)
     add_custom_command(
       OUTPUT ${swig_doc_interface_file}
       COMMAND ${Python3_EXECUTABLE} ${itk_doxy2swig_py} ${doxy2swig_config_file} ${swig_doc_interface_file}
       #DEPENDS ${ITK_WRAP_DOC_DOXYGEN_XML_FILES} ${doxy2swig_config_file} ${itk_doxy2swig_py}
       DEPENDS ${WRAPPER_LIBRARY_NAME}Doxygen ${doxy2swig_config_file} ${itk_doxy2swig_py}
-  #    COMMENT "-- Wrapping library ${WRAPPER_MODULE_NAME}: Generating swig interface for inline documentation."
+  #    COMMENT "-- Wrapping library ${module_name}: Generating swig interface for inline documentation."
     )
     list(APPEND ITK_WRAP_DOC_DOCSTRING_FILES ${swig_doc_interface_file})
 endmacro()

--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -318,8 +318,8 @@ macro(itk_end_wrap_submodule_python group_name)
   # is there a docstring file?
   if(${module_prefix}_WRAP_DOC AND NOT ITK_WRAP_PYTHON_PROCESS_SWIG_INPUTS)
     # yes. Include the docstring file
-    set(doc_file "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${WRAPPER_MODULE_NAME}_doc.i")
-    set(ITK_WRAP_PYTHON_SWIG_EXT "%include ${WRAPPER_MODULE_NAME}_doc.i\n\n${ITK_WRAP_PYTHON_SWIG_EXT}")
+    set(doc_file "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}/${group_name}_doc.i")
+    set(ITK_WRAP_PYTHON_SWIG_EXT "%include ${group_name}_doc.i\n\n${ITK_WRAP_PYTHON_SWIG_EXT}")
   else()
     # no. Clear the doc_file var
     set(doc_file "")

--- a/Wrapping/TypedefMacros.cmake
+++ b/Wrapping/TypedefMacros.cmake
@@ -683,7 +683,7 @@ macro(itk_load_submodule module)
     itk_end_wrap_submodule_python("${module}")
   endif()
   if(${module_prefix}_WRAP_DOC)
-    itk_end_wrap_submodule_DOC()
+    itk_end_wrap_submodule_DOC("${module}")
   endif()
 
 endmacro()


### PR DESCRIPTION
WRAPPER_MODULE_NAME is no longer available with the recent wrapping
macro refactoring.

Addresses:

```
CMake Error:
  Running

   '/usr/bin/ninja' '-C' '/work/ITK-cp39-cp39-manylinux2014_x64' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:56497: multiple rules generate Wrapping/Typedefs/_doc.i [-w dupbuild=err]
```

that occurs when building the Python packages when ITK_WRAP_DOC is
enabled.
