### PR TITLE
wasm fixes

### DIFF
--- a/CMake/ITKExternalData.cmake
+++ b/CMake/ITKExternalData.cmake
@@ -43,7 +43,7 @@ if(NOT ITK_FORBID_DOWNLOADS)
 endif()
 
 # Emscripten currently has difficulty reading symlinks.
-if(EMSCRIPTEN)
+if(EMSCRIPTEN OR WASI)
   set(ExternalData_NO_SYMLINKS 1)
 endif()
 

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -217,7 +217,7 @@ function(check_compiler_optimization_flags c_optimization_flags_var cxx_optimiza
          list(APPEND InstructionSetOptimizationFlags
               /arch:SSE /arch:SSE2)
       endif()
-    elseif(NOT EMSCRIPTEN)
+    elseif(NOT EMSCRIPTEN OR WASI)
       if (${CMAKE_C_COMPILER} MATCHES "icc.*$")
         set(USING_INTEL_ICC_COMPILER TRUE)
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,11 @@ endif()
 option(BUILD_SHARED_LIBS "Build ITK with shared libraries." OFF)
 set(ITK_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 
-option(ITK_DYNAMIC_LOADING "Support run-time loading of shared libraries" ON)
+set(ITK_DYNAMIC_LOADING_DEFAULT ON)
+if(WASI OR EMSCRIPTEN)
+  set(ITK_DYNAMIC_LOADING_DEFAULT OFF)
+endif()
+option(ITK_DYNAMIC_LOADING "Support run-time loading of shared libraries" ${ITK_DYNAMIC_LOADING_DEFAULT})
 mark_as_advanced(ITK_DYNAMIC_LOADING)
 
 #-----------------------------------------------------------------------------

--- a/Modules/Core/TestKernel/src/CMakeLists.txt
+++ b/Modules/Core/TestKernel/src/CMakeLists.txt
@@ -1,12 +1,14 @@
-add_executable(itkTestDriver itkTestDriver.cxx)
-target_link_libraries(itkTestDriver
-  LINK_PRIVATE ${ITK_MODULE_ITKTestKernel_PRIVATE_DEPENDS}
-  LINK_PUBLIC ${ITK_MODULE_ITKTestKernel_PUBLIC_DEPENDS} ${ITKTestKernel_LIBRARIES})
-itk_module_target_label(itkTestDriver)
-itk_module_target_export(itkTestDriver)
+if(NOT DO_NOT_BUILD_ITK_TEST_DRIVER)
+  add_executable(itkTestDriver itkTestDriver.cxx)
+  target_link_libraries(itkTestDriver
+    LINK_PRIVATE ${ITK_MODULE_ITKTestKernel_PRIVATE_DEPENDS}
+    LINK_PUBLIC ${ITK_MODULE_ITKTestKernel_PUBLIC_DEPENDS} ${ITKTestKernel_LIBRARIES})
+  itk_module_target_label(itkTestDriver)
+  itk_module_target_export(itkTestDriver)
 
-if(NOT DO_NOT_INSTALL_ITK_TEST_DRIVER) # used only by vcpkg
-  itk_module_target_install(itkTestDriver)
+  if(NOT DO_NOT_INSTALL_ITK_TEST_DRIVER) # used only by vcpkg
+    itk_module_target_install(itkTestDriver)
+  endif()
 endif()
 
 set(ITKTestKernel_SRCS


### PR DESCRIPTION
- COMP: Add an option to not build the itkTestDriver executable
- COMP: Do not enable ITK_DYNAMIC_LOADING by default with Emscripten, WASI
