### PR TITLE
STYLE: Use MakeFilled, () or {}, instead of `Point(const ValueType &)`

### DIFF
--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -86,43 +86,43 @@ public:
   static const Self
   max(const Self &)
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self &)
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   max()
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min()
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   NonpositiveMin()
   {
-    return Self(NumericTraits<T>::NonpositiveMin());
+    return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
   static const Self
   ZeroValue()
   {
-    return Self(NumericTraits<T>::ZeroValue());
+    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
   }
 
   static const Self
   OneValue()
   {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -87,61 +87,61 @@ public:
   static const Self
   max(const Self &)
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self &)
   {
-    return Self(NumericTraits<T>::min());
-  }
-
-  static const Self
-  NonpositiveMin(const Self &)
-  {
-    return Self(NumericTraits<T>::NonpositiveMin());
-  }
-
-  static const Self
-  ZeroValue(const Self &)
-  {
-    return Self(NumericTraits<T>::ZeroValue());
-  }
-
-  static const Self
-  OneValue(const Self &)
-  {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   max()
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min()
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   NonpositiveMin()
   {
-    return Self(NumericTraits<T>::NonpositiveMin());
+    return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
   static const Self
   ZeroValue()
   {
-    return Self(NumericTraits<T>::ZeroValue());
+    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
   }
 
   static const Self
   OneValue()
   {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::OneValue());
+  }
+
+  static const Self
+  NonpositiveMin(const Self &)
+  {
+    return NonpositiveMin();
+  }
+
+  static const Self
+  ZeroValue(const Self &)
+  {
+    return ZeroValue();
+  }
+
+  static const Self
+  OneValue(const Self &)
+  {
+    return OneValue();
   }
 
   static constexpr bool IsSigned = std::is_signed<ValueType>::value;

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -86,43 +86,43 @@ public:
   static const Self
   max(const Self &)
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self &)
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   max()
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min()
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   NonpositiveMin()
   {
-    return Self(NumericTraits<T>::NonpositiveMin());
+    return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
   static const Self
   ZeroValue()
   {
-    return Self(NumericTraits<T>::ZeroValue());
+    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
   }
 
   static const Self
   OneValue()
   {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -73,43 +73,43 @@ public:
   static const Self
   max(const Self &)
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self &)
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   max()
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min()
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   NonpositiveMin()
   {
-    return Self(NumericTraits<T>::NonpositiveMin());
+    return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
   static const Self
   ZeroValue()
   {
-    return Self(NumericTraits<T>::ZeroValue());
+    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
   }
 
   static const Self
   OneValue()
   {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -85,43 +85,43 @@ public:
   static const Self
   max(const Self &)
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self &)
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   max()
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min()
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   NonpositiveMin()
   {
-    return Self(NumericTraits<ValueType>::NonpositiveMin());
+    return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
   static const Self
   ZeroValue()
   {
-    return Self(NumericTraits<T>::ZeroValue());
+    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
   }
 
   static const Self
   OneValue()
   {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -85,43 +85,43 @@ public:
   static const Self
   max(const Self &)
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self &)
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   max()
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min()
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   NonpositiveMin()
   {
-    return Self(NumericTraits<ValueType>::NonpositiveMin());
+    return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
   static const Self
   ZeroValue()
   {
-    return Self(NumericTraits<T>::ZeroValue());
+    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
   }
 
   static const Self
   OneValue()
   {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
   static const Self

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -86,43 +86,43 @@ public:
   static const Self
   max(const Self &)
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self &)
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   max()
   {
-    return Self(NumericTraits<T>::max());
+    return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
   static const Self
   min()
   {
-    return Self(NumericTraits<T>::min());
+    return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
   static const Self
   NonpositiveMin()
   {
-    return Self(NumericTraits<T>::NonpositiveMin());
+    return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
   static const Self
   ZeroValue()
   {
-    return Self(NumericTraits<T>::ZeroValue());
+    return MakeFilled<Self>(NumericTraits<T>::ZeroValue());
   }
 
   static const Self
   OneValue()
   {
-    return Self(NumericTraits<T>::OneValue());
+    return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
   static const Self

--- a/Modules/Core/Common/src/itkNumericTraitsDiffusionTensor3DPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsDiffusionTensor3DPixel.cxx
@@ -26,13 +26,12 @@ namespace itk
 // NumericTraits<>.
 //
 
-#define DIFFUSIONTENSOR3DPIXELSTATICTRAITSMACRO(T)                                        \
-  template <>                                                                             \
-  ITKCommon_EXPORT const DiffusionTensor3D<T> NumericTraits<DiffusionTensor3D<T>>::Zero = \
-    DiffusionTensor3D<T>(NumericTraits<T>::Zero);                                         \
-  template <>                                                                             \
-  ITKCommon_EXPORT const DiffusionTensor3D<T> NumericTraits<DiffusionTensor3D<T>>::One =  \
-    DiffusionTensor3D<T>(NumericTraits<T>::One);
+#define DIFFUSIONTENSOR3DPIXELSTATICTRAITSMACRO(T)                                         \
+  template <>                                                                              \
+  ITKCommon_EXPORT const DiffusionTensor3D<T> NumericTraits<DiffusionTensor3D<T>>::Zero{}; \
+  template <>                                                                              \
+  ITKCommon_EXPORT const DiffusionTensor3D<T> NumericTraits<DiffusionTensor3D<T>>::One =   \
+    MakeFilled<DiffusionTensor3D<T>>(1);
 
 //
 // List here the specializations of the Traits:

--- a/Modules/Core/Common/src/itkNumericTraitsRGBAPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsRGBAPixel.cxx
@@ -27,11 +27,11 @@ namespace itk
 // Helper macro for initializing the Zero and One static member of the
 // NumericTraits<>.
 //
-#define RGBAPIXELSTATICTRAITSMACRO(T)                                                                           \
-  template <>                                                                                                   \
-  ITKCommon_EXPORT const RGBAPixel<T> NumericTraits<RGBAPixel<T>>::Zero = RGBAPixel<T>(NumericTraits<T>::Zero); \
-  template <>                                                                                                   \
-  ITKCommon_EXPORT const RGBAPixel<T> NumericTraits<RGBAPixel<T>>::One = RGBAPixel<T>(NumericTraits<T>::One);
+#define RGBAPIXELSTATICTRAITSMACRO(T)                                      \
+  template <>                                                              \
+  ITKCommon_EXPORT const RGBAPixel<T> NumericTraits<RGBAPixel<T>>::Zero{}; \
+  template <>                                                              \
+  ITKCommon_EXPORT const RGBAPixel<T> NumericTraits<RGBAPixel<T>>::One = MakeFilled<RGBAPixel<T>>(1);
 
 //
 // List here the specializations of the Traits:

--- a/Modules/Core/Common/src/itkNumericTraitsRGBPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsRGBPixel.cxx
@@ -27,11 +27,11 @@ namespace itk
 // Helper macro for initializing the Zero and One static member of the
 // NumericTraits<>.
 //
-#define RGBPIXELSTATICTRAITSMACRO(T)                                                                         \
-  template <>                                                                                                \
-  ITKCommon_EXPORT const RGBPixel<T> NumericTraits<RGBPixel<T>>::Zero = RGBPixel<T>(NumericTraits<T>::Zero); \
-  template <>                                                                                                \
-  ITKCommon_EXPORT const RGBPixel<T> NumericTraits<RGBPixel<T>>::One = RGBPixel<T>(NumericTraits<T>::One);
+#define RGBPIXELSTATICTRAITSMACRO(T)                                     \
+  template <>                                                            \
+  ITKCommon_EXPORT const RGBPixel<T> NumericTraits<RGBPixel<T>>::Zero{}; \
+  template <>                                                            \
+  ITKCommon_EXPORT const RGBPixel<T> NumericTraits<RGBPixel<T>>::One = MakeFilled<RGBPixel<T>>(1);
 
 //
 // List here the specializations of the Traits:

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
@@ -128,7 +128,8 @@ Expect_Transform_member_functions_return_the_same_for_an_ImageAdapter_as_for_its
   const auto imageAdaptor = itk::ImageAdaptor<TImage, DummyPixelAccessor<typename TImage::PixelType>>::New();
   imageAdaptor->SetImage(&image);
 
-  for (const auto & point : { itk::Point<double, ImageDimension>(), itk::Point<double, ImageDimension>(1.0) })
+  for (const auto & point :
+       { itk::Point<double, ImageDimension>(), itk::MakeFilled<itk::Point<double, ImageDimension>>(1.0) })
   {
     Expect_TransformPhysicalPoint_member_functions_return_the_same_for_ImageAdapter_as_for_image(
       *imageAdaptor, image, point);

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -233,9 +233,9 @@ TEST(ImageMaskSpatialObject, IsInsideSingleZeroPixel)
   spatialObject->SetImage(image);
   spatialObject->Update();
 
-  EXPECT_FALSE(spatialObject->IsInside(PointType{ indexValue }));
-  EXPECT_FALSE(spatialObject->IsInside(PointType{ indexValue - 0.4999 }));
-  EXPECT_FALSE(spatialObject->IsInside(PointType{ indexValue + 0.4999 }));
+  EXPECT_FALSE(spatialObject->IsInside(itk::MakeFilled<PointType>(indexValue)));
+  EXPECT_FALSE(spatialObject->IsInside(itk::MakeFilled<PointType>(indexValue - 0.4999)));
+  EXPECT_FALSE(spatialObject->IsInside(itk::MakeFilled<PointType>(indexValue + 0.4999)));
 }
 
 
@@ -259,9 +259,9 @@ TEST(ImageMaskSpatialObject, IsInsideSingleNonZeroPixel)
   spatialObject->SetImage(image);
   spatialObject->Update();
 
-  EXPECT_TRUE(spatialObject->IsInside(PointType{ indexValue }));
-  EXPECT_TRUE(spatialObject->IsInside(PointType{ indexValue - 0.4999 }));
-  EXPECT_TRUE(spatialObject->IsInside(PointType{ indexValue + 0.4999 }));
+  EXPECT_TRUE(spatialObject->IsInside(itk::MakeFilled<PointType>(indexValue)));
+  EXPECT_TRUE(spatialObject->IsInside(itk::MakeFilled<PointType>(indexValue - 0.4999)));
+  EXPECT_TRUE(spatialObject->IsInside(itk::MakeFilled<PointType>(indexValue + 0.4999)));
 }
 
 
@@ -288,7 +288,7 @@ TEST(ImageMaskSpatialObject, IsInsideIndependentOfDistantPixels)
   spatialObject->Update();
 
   // Point of interest: a point close to the non-zero pixel.
-  const PointType pointOfInterest{ indexValue - 0.25 };
+  const auto pointOfInterest = itk::MakeFilled<PointType>(indexValue - 0.25);
 
   const bool isInsideBefore = spatialObject->IsInside(pointOfInterest);
 

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -238,7 +238,7 @@ KernelTransform<TParametersValueType, VDimension>::ComputeP()
   const PointIdentifier                  numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();
   const vnl_matrix<TParametersValueType> I{ IMatrixType().set_identity().as_matrix() };
 
-  InputPointType p{ NumericTraits<ScalarType>::ZeroValue() };
+  InputPointType p{};
 
   this->m_PMatrix.set_size(VDimension * numberOfLandmarks, VDimension * (VDimension + 1));
   this->m_PMatrix.fill(0.0);

--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -50,7 +50,7 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     covVector.Fill(1.0);
     ITK_TRY_EXPECT_EXCEPTION(transform->TransformCovariantVector(covVector));
 
-    typename TransformType::InputPointType       point{ 1.0 };
+    auto                                         point = itk::MakeFilled<typename TransformType::InputPointType>(1.0);
     typename TransformType::JacobianPositionType jacobianPosition;
     ITK_TRY_EXPECT_EXCEPTION(transform->ComputeJacobianWithRespectToPosition(point, jacobianPosition));
   }

--- a/Modules/Core/Transform/test/itkSimilarityTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarityTransformGTest.cxx
@@ -36,7 +36,7 @@ Test_SetCenterAndScale()
 
   for (double center{ -1.0 }; center <= 1.0; ++center)
   {
-    transform->SetCenter(PointType(center));
+    transform->SetCenter(itk::MakeFilled<PointType>(center));
 
     for (double scale{ 0.5 }; scale <= 2.0; scale *= 2.0)
     {
@@ -44,7 +44,8 @@ Test_SetCenterAndScale()
 
       for (double input{ -1.0 }; input <= 1.0; ++input)
       {
-        EXPECT_EQ(transform->TransformPoint(PointType(input)), PointType(center + (scale * (input - center))));
+        EXPECT_EQ(transform->TransformPoint(itk::MakeFilled<PointType>(input)),
+                  itk::MakeFilled<PointType>(center + (scale * (input - center))));
       }
     }
   }

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -44,8 +44,8 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PatchBasedDenoisingIm
   , // to avoid divide by zero
   m_SigmaUpdateDecimationFactor(
     static_cast<unsigned int>(Math::Round<double>(1.0 / m_KernelBandwidthFractionPixelsForEstimation)))
-  , m_NoiseSigma(0.0)
-  , m_NoiseSigmaSquared(0.0)
+  , m_NoiseSigma()
+  , m_NoiseSigmaSquared()
   , m_SearchSpaceList(ListAdaptorType::New())
 {
   // By default, turn off automatic kernel bandwidth sigma estimation

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -171,7 +171,7 @@ itkFastMarchingTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(outputDirection, marcher->GetOutputDirection());
 
   auto outputOriginValue = static_cast<typename FloatFMType::OutputPointType::ValueType>(std::stod(argv[7]));
-  typename FloatFMType::OutputPointType outputOrigin(outputOriginValue);
+  auto outputOrigin = itk::MakeFilled<typename FloatFMType::OutputPointType>(outputOriginValue);
   marcher->SetOutputOrigin(outputOrigin);
   ITK_TEST_SET_GET_VALUE(outputOrigin, marcher->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -40,7 +40,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   ResampleImageFilter()
   : m_Extrapolator(nullptr)
   , m_OutputSpacing(MakeFilled<SpacingType>(1.0))
-  , m_OutputOrigin(0.0)
+  , m_OutputOrigin()
 
 {
 

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
@@ -78,7 +78,7 @@ itkResampleImageTest5(int argc, char * argv[])
   for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
   {
     index = iter.GetIndex();
-    const RGBPixelType rgbPixel(index[0] + index[1]);
+    const auto rgbPixel = itk::MakeFilled<RGBPixelType>(index[0] + index[1]);
     iter.Set(rgbPixel);
   }
 

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -37,7 +37,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Polyline
   : m_ViewVector(MakeFilled<VectorType>(1))
   , m_UpVector(MakeFilled<VectorType>(1))
   , m_CameraCenterPoint(0)
-  , m_FocalPoint(0.0)
+  , m_FocalPoint()
 
 {
   this->SetNumberOfRequiredInputs(2);

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
@@ -25,7 +25,7 @@ namespace itk
 template <typename TOutputImage>
 GenerateImageSource<TOutputImage>::GenerateImageSource()
   : m_Spacing(MakeFilled<SpacingType>(1.0))
-  , m_Origin(0.0)
+  , m_Origin()
 
 {
   this->m_Size.Fill(64); // arbitrary default size

--- a/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
@@ -88,7 +88,7 @@ itkPhysicalPointImageSourceTest(int argc, char * argv[])
   size.Fill(64);
 
   auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  ImageType::PointType     origin(0.0);
+  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
@@ -144,7 +144,7 @@ PerformCompositeImageRegistration(int itkNotUsed(argc), char * argv[])
 
   // Change origins far from (0,0)
 
-  typename FixedImageType::PointType farOrigin(1000.0);
+  auto farOrigin = itk::MakeFilled<typename FixedImageType::PointType>(1000.0);
   fixedImage->SetOrigin(farOrigin);
   movingImage->SetOrigin(farOrigin);
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -142,7 +142,7 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
   {
     if (it.Get() == 0)
     {
-      cit.Set(RGBPixelType(itk::NumericTraits<unsigned char>::ZeroValue()));
+      cit.Set(RGBPixelType());
     }
     else
     {

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -121,7 +121,7 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
   {
     if (it.Get() == 0)
     {
-      cit.Set(RGBPixelType(itk::NumericTraits<unsigned char>::ZeroValue()));
+      cit.Set(RGBPixelType());
     }
     else
     {

--- a/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
@@ -181,7 +181,7 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
   {
     if (it.Get() == 0)
     {
-      cit.Set(RGBPixelType(static_cast<unsigned char>(0)));
+      cit.Set(RGBPixelType());
     }
     else
     {

--- a/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
@@ -172,7 +172,7 @@ itkScalarConnectedComponentImageFilterTest(int argc, char * argv[])
   {
     if (it.Get() == 0)
     {
-      cit.Set(RGBPixelType(static_cast<unsigned char>(0)));
+      cit.Set(RGBPixelType());
     }
     else
     {


### PR DESCRIPTION
Follow-up to:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3262
commit 82001f3024cbc879fce5a68b5f69f6bb5d5c9ea7
"STYLE: Use MakeFilled, () or {}, instead of `Vector(const ValueType &)`"